### PR TITLE
lomiri.lomiri-system-settings{,-unwrapped,-security-privacy}: init at 1.0.2

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -497,6 +497,7 @@ in {
   lxd = pkgs.recurseIntoAttrs (handleTest ./lxd { inherit handleTestOn; });
   lxd-image-server = handleTest ./lxd-image-server.nix {};
   #logstash = handleTest ./logstash.nix {};
+  lomiri-system-settings = handleTest ./lomiri-system-settings.nix {};
   lorri = handleTest ./lorri/default.nix {};
   maddy = discoverTests (import ./maddy { inherit handleTest; });
   maestral = handleTest ./maestral.nix {};

--- a/nixos/tests/lomiri-system-settings.nix
+++ b/nixos/tests/lomiri-system-settings.nix
@@ -1,0 +1,99 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "lomiri-system-settings-standalone";
+  meta.maintainers = lib.teams.lomiri.members;
+
+  nodes.machine = { config, pkgs, ... }: {
+    imports = [
+      ./common/x11.nix
+    ];
+
+    services.xserver.enable = true;
+
+    environment = {
+      systemPackages = with pkgs.lomiri; [
+        suru-icon-theme
+        lomiri-system-settings
+      ];
+      variables = {
+        UITK_ICON_THEME = "suru";
+      };
+    };
+
+    i18n.supportedLocales = [ "all" ];
+
+    fonts.packages = with pkgs; [
+      # Intended font & helps with OCR
+      ubuntu_font_family
+    ];
+
+    services.upower.enable = true;
+  };
+
+  enableOCR = true;
+
+  testScript = let
+    settingsPages = [
+      # Base pages
+      { name = "wifi"; type = "internal"; element = "networks"; }
+      { name = "bluetooth"; type = "internal"; element = "discoverable|None detected"; }
+      # only text we can really look for with VPN is on a button, OCR on CI struggles with it
+      { name = "vpn"; type = "internal"; element = "Add|Manual|Configuration"; skipOCR = true; }
+      { name = "appearance"; type = "internal"; element = "Background image|blur effects"; }
+      { name = "desktop"; type = "internal"; element = "workspaces|Icon size"; }
+      { name = "sound"; type = "internal"; element = "Silent Mode|Message sound"; }
+      { name = "language"; type = "internal"; element = "Display language|External keyboard"; }
+      { name = "notification"; type = "internal"; element = "Apps that notify"; }
+      { name = "gestures"; type = "internal"; element = "Edge drag"; }
+      { name = "mouse"; type = "internal"; element = "Cursor speed|Wheel scrolling speed"; }
+      { name = "timedate"; type = "internal"; element = "Time zone|Set the time and date"; }
+
+      # External plugins
+      { name = "security-privacy"; type = "external"; element = "Locking|unlocking|permissions"; elementLocalised = "Sperren|Entsperren|Berechtigungen"; }
+    ];
+  in
+  ''
+    machine.wait_for_x()
+
+    with subtest("lomiri system settings launches"):
+        machine.execute("lomiri-system-settings >&2 &")
+        machine.wait_for_text("System Settings")
+        machine.screenshot("lss_open")
+
+    # Move focus to start of plugins list for following list of tests
+    machine.send_key("tab")
+    machine.send_key("tab")
+    machine.screenshot("lss_focus")
+
+    # tab through & open all sub-menus, to make sure none of them fail
+  '' + (lib.strings.concatMapStringsSep "\n" (page: ''
+    machine.send_key("tab")
+    machine.send_key("kp_enter")
+  ''
+  + lib.optionalString (!(page.skipOCR or false)) ''
+    with subtest("lomiri system settings ${page.name} works"):
+        machine.wait_for_text(r"(${page.element})")
+        machine.screenshot("lss_page_${page.name}")
+  '') settingsPages) + ''
+
+    machine.execute("pkill -f lomiri-system-settings")
+
+    with subtest("lomiri system settings localisation works"):
+        machine.execute("env LANG=de_DE.UTF-8 lomiri-system-settings >&2 &")
+        machine.wait_for_text("Systemeinstellungen")
+        machine.screenshot("lss_localised_open")
+
+    # Move focus to start of plugins list for following list of tests
+    machine.send_key("tab")
+    machine.send_key("tab")
+    machine.screenshot("lss_focus_localised")
+
+  '' + (lib.strings.concatMapStringsSep "\n" (page: ''
+    machine.send_key("tab")
+    machine.send_key("kp_enter")
+  '' + lib.optionalString (page.type == "external") ''
+    with subtest("lomiri system settings ${page.name} localisation works"):
+        machine.wait_for_text(r"(${page.elementLocalised})")
+        machine.screenshot("lss_localised_page_${page.name}")
+  '') settingsPages) + ''
+  '';
+})

--- a/pkgs/desktops/lomiri/applications/lomiri-system-settings/2000-Support-wrapping-for-Nixpkgs.patch
+++ b/pkgs/desktops/lomiri/applications/lomiri-system-settings/2000-Support-wrapping-for-Nixpkgs.patch
@@ -1,0 +1,160 @@
+From 8e21cf46551091c884014985d3e0dd9704d6dc04 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Wed, 14 Feb 2024 16:00:24 +0100
+Subject: [PATCH] Support wrapping for Nixpkgs
+
+---
+ src/CMakeLists.txt   | 24 +++++++++++++++++++-----
+ src/main.cpp         |  8 +++++---
+ src/plugin.cpp       | 19 +++++++++++++++++--
+ tests/CMakeLists.txt | 18 ++++++++++++++----
+ 4 files changed, 55 insertions(+), 14 deletions(-)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index cd3131d0..fcd78bdf 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -1,13 +1,27 @@
+ include_directories(${GLIB_INCLUDE_DIRS})
+ 
+-add_definitions(-DI18N_DIRECTORY="${CMAKE_INSTALL_FULL_LOCALEDIR}")
+ add_definitions(-DI18N_DOMAIN="lomiri-system-settings")
+-add_definitions(-DPLUGIN_PRIVATE_MODULE_DIR="${PLUGIN_PRIVATE_MODULE_DIR}")
++
++add_definitions(-DNIX_FALLBACK_PREFIX="${CMAKE_INSTALL_PREFIX}")
++
++set(I18N_DIRECTORY "${CMAKE_INSTALL_FULL_LOCALEDIR}")
++
++list(APPEND NIX_LOCATION_VARIABLES
++    I18N_DIRECTORY
++    PLUGIN_PRIVATE_MODULE_DIR
++    PLUGIN_MANIFEST_DIR
++    PLUGIN_QML_DIR
++    PLUGIN_MODULE_DIR
++)
++
++foreach(locvar IN LISTS NIX_LOCATION_VARIABLES)
++    string(REPLACE "${CMAKE_INSTALL_PREFIX}" "" NIX_${locvar}_RELATIVE "${${locvar}}")
++    add_definitions(-D${locvar}=do_not_use_me)
++    add_definitions(-DNIX_${locvar}_RELATIVE="${NIX_${locvar}_RELATIVE}")
++endforeach()
++
+ add_definitions(-DMANIFEST_DIR="${MANIFEST_DIR}")
+-add_definitions(-DPLUGIN_MANIFEST_DIR="${PLUGIN_MANIFEST_DIR}")
+ add_definitions(-DQML_DIR="${QML_DIR}")
+-add_definitions(-DPLUGIN_QML_DIR="${PLUGIN_QML_DIR}")
+-add_definitions(-DPLUGIN_MODULE_DIR="${PLUGIN_MODULE_DIR}")
+ 
+ add_subdirectory(SystemSettings)
+ 
+diff --git a/src/main.cpp b/src/main.cpp
+index 64441da3..cfcabe42 100644
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -42,6 +42,8 @@ int main(int argc, char **argv)
+     QByteArray mountPoint = qEnvironmentVariableIsSet("SNAP") ? qgetenv("SNAP") : "";
+     bool isSnap = !mountPoint.isEmpty();
+ 
++    QByteArray dataPrefix = qEnvironmentVariableIsSet("NIX_LSS_PREFIX") ? qgetenv("NIX_LSS_PREFIX") : NIX_FALLBACK_PREFIX;
++
+     // Ensure printing environment is correct.
+     qputenv("QT_PRINTER_MODULE", "cupsprintersupport");
+ 
+@@ -78,12 +80,12 @@ int main(int argc, char **argv)
+     qmlRegisterType<LomiriSystemSettings::PluginManager>("SystemSettings", 1, 0, "PluginManager");
+     view.engine()->rootContext()->setContextProperty("Utilities", &utils);
+     view.setResizeMode(QQuickView::SizeRootObjectToView);
+-    view.engine()->addImportPath(mountPoint + PLUGIN_PRIVATE_MODULE_DIR);
+-    view.engine()->addImportPath(mountPoint + PLUGIN_QML_DIR);
++    view.engine()->addImportPath(mountPoint + dataPrefix + "/" + NIX_PLUGIN_PRIVATE_MODULE_DIR_RELATIVE);
++    view.engine()->addImportPath(mountPoint + dataPrefix + "/" + NIX_PLUGIN_QML_DIR_RELATIVE);
+     view.rootContext()->setContextProperty("defaultPlugin", defaultPlugin);
+     view.rootContext()->setContextProperty("mountPoint", mountPoint);
+     view.rootContext()->setContextProperty("isSnap", isSnap);
+-    view.rootContext()->setContextProperty("i18nDirectory", mountPoint + I18N_DIRECTORY);
++    view.rootContext()->setContextProperty("i18nDirectory", mountPoint + dataPrefix + "/" + NIX_I18N_DIRECTORY_RELATIVE);
+     view.rootContext()->setContextProperty("pluginOptions", pluginOptions);
+     view.rootContext()->setContextProperty("view", &view);
+     view.setSource(QUrl("qrc:/qml/MainWindow.qml"));
+diff --git a/src/plugin.cpp b/src/plugin.cpp
+index 133821af..6a1a152c 100644
+--- a/src/plugin.cpp
++++ b/src/plugin.cpp
+@@ -36,9 +36,16 @@
+ #include <LomiriSystemSettings/ItemBase>
+ #include <LomiriSystemSettings/PluginInterface>
+ 
++#include <libintl.h>
++
+ using namespace LomiriSystemSettings;
+ 
+-static const QLatin1String pluginModuleDir{PLUGIN_MODULE_DIR};
++const QLatin1String getWrapperPrefix()
++{
++    const QLatin1String pluginWrapperPrefix {qEnvironmentVariableIsSet("NIX_LSS_PREFIX") ? qgetenv("NIX_LSS_PREFIX") : NIX_FALLBACK_PREFIX};
++    return pluginWrapperPrefix;
++}
++static const QLatin1String pluginModuleDirRelative{NIX_PLUGIN_MODULE_DIR_RELATIVE};
+ static const QLatin1String pluginQmlDir{QML_DIR};
+ 
+ namespace LomiriSystemSettings {
+@@ -89,6 +96,11 @@ PluginPrivate::PluginPrivate(Plugin *q, const QFileInfo &manifest):
+ 
+     m_data = json.toVariant().toMap();
+     m_dataPath = manifest.absolutePath();
++
++    QString textDomain = m_data.value(keyTranslations).toString();
++    QString textDomainDir = QString("%1/%2")
++        .arg(getWrapperPrefix()).arg(NIX_I18N_DIRECTORY_RELATIVE);
++    bindtextdomain(qPrintable(textDomain), qPrintable(textDomainDir));
+ }
+ 
+ bool PluginPrivate::ensureLoaded() const
+@@ -110,8 +122,11 @@ bool PluginPrivate::ensureLoaded() const
+         ctx->contextProperty("mountPoint").value<QByteArray>() :
+         "";
+ 
++    QString wrapperModuleDir = QString("%1/%2")
++        .arg(getWrapperPrefix()).arg(pluginModuleDirRelative);
++
+     QString name = QString("%1%2/lib%3.so")
+-        .arg(mountPoint).arg(pluginModuleDir).arg(plugin);
++        .arg(mountPoint).arg(wrapperModuleDir).arg(plugin);
+ 
+     m_loader.setFileName(name);
+     if (Q_UNLIKELY(!m_loader.load())) {
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index c10b2e2d..a998b641 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -9,13 +9,23 @@ include_directories(
+ set(XVFB_CMD xvfb-run -a -s "-screen 0 640x480x24")
+ 
+ add_definitions(-DI18N_DOMAIN="lomiri-system-settings")
+-add_definitions(-DPLUGIN_PRIVATE_MODULE_DIR="${PLUGIN_PRIVATE_MODULE_DIR}")
+-add_definitions(-DPLUGIN_MODULE_DIR="${CMAKE_CURRENT_BINARY_DIR}")
++
++add_definitions(-DNIX_FALLBACK_PREFIX="${CMAKE_CURRENT_BINARY_DIR}")
++
++add_definitions(-DI18N_DIRECTORY=do_not_use_me)
++add_definitions(-DNIX_I18N_DIRECTORY_RELATIVE="")
++add_definitions(-DPLUGIN_PRIVATE_MODULE_DIR=do_not_use_me)
++add_definitions(-DNIX_PLUGIN_PRIVATE_MODULE_DIR_RELATIVE="")
++add_definitions(-DPLUGIN_MODULE_DIR=do_not_use_me)
++add_definitions(-DNIX_PLUGIN_MODULE_DIR_RELATIVE="")
++add_definitions(-DPLUGIN_MANIFEST_DIR=do_not_use_me)
++add_definitions(-DNIX_PLUGIN_MANIFEST_DIR_RELATIVE="../../tests/data")
++add_definitions(-DPLUGIN_QML_DIR=do_not_use_me)
++add_definitions(-DNIX_PLUGIN_QML_DIR_RELATIVE="")
++
+ add_definitions(-DMANIFEST_DIR="data")
+-add_definitions(-DPLUGIN_MANIFEST_DIR="${CMAKE_CURRENT_SOURCE_DIR}/data")
+ add_definitions(-DQML_TEST_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
+ add_definitions(-DQML_DIR="${CMAKE_CURRENT_BINARY_DIR}")
+-add_definitions(-DPLUGIN_QML_DIR="${CMAKE_CURRENT_BINARY_DIR}")
+ add_definitions(-DSYSTEM_IMAGE_DBUS_TEMPLATE="${CMAKE_SOURCE_DIR}/tests/autopilot/lomiri_system_settings/tests/systemimage.py")
+ 
+ add_library(test-plugin SHARED test-plugin.cpp test-plugin.h)
+-- 
+2.42.0
+

--- a/pkgs/desktops/lomiri/applications/lomiri-system-settings/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-system-settings/default.nix
@@ -1,0 +1,253 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, fetchpatch
+, gitUpdater
+, testers
+, accountsservice
+, ayatana-indicator-datetime
+, cmake
+, cmake-extras
+, content-hub
+, dbus
+, deviceinfo
+, geonames
+, gettext
+, glib
+, gnome-desktop
+, gsettings-qt
+, gtk3
+, icu
+, intltool
+, json-glib
+, libqofono
+, libqtdbustest
+, libqtdbusmock
+, lomiri-indicator-network
+, lomiri-schemas
+, lomiri-settings-components
+, lomiri-ui-toolkit
+, maliit-keyboard
+, pkg-config
+, python3
+, qmenumodel
+, qtbase
+, qtdeclarative
+, qtmultimedia
+, ubports-click
+, upower
+, validatePkgConfig
+, wrapGAppsHook
+, wrapQtAppsHook
+, xvfb-run
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-system-settings-unwrapped";
+  version = "1.0.2";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lomiri-system-settings";
+    rev = finalAttrs.version;
+    hash = "sha256-gi6ZujIs0AEDLsqcTNlRNSS8SyqEU6q0+xaDf55XwuM=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  patches = [
+    # Remove when https://gitlab.com/ubports/development/core/lomiri-system-settings/-/merge_requests/433 merged & in release
+    (fetchpatch {
+      name = "0001-lomiri-system-settings-plugins-language-Fix-linking-against-accountsservice.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-system-settings/-/commit/75763ae2f9669f5f7f29aec3566606e6f6cb7478.patch";
+      hash = "sha256-2CE0yizkaz93kK82DhaaFjKmGnMoaikrwFj4k7RN534=";
+    })
+
+    # Remove when https://gitlab.com/ubports/development/core/lomiri-system-settings/-/merge_requests/434 merged & in release
+    (fetchpatch {
+      name = "0002-lomiri-system-settings-GNUInstallDirs-and-fix-absolute-path-handling.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-system-settings/-/commit/93ee84423f3677a608ef73addcd3ddcbe7dc1d32.patch";
+      hash = "sha256-lSKAhtE3oSSv7USvDbbcfBZWAtWMmuKneWawKQABIiM=";
+    })
+
+    # Remove when version > 1.0.2
+    (fetchpatch {
+      name = "0003-lomiri-system-settings-Use-GSettings-for-DT2W-value.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-system-settings/-/commit/29e2533efcac23e41b083b11c540c9221b71de7e.patch";
+      hash = "sha256-d52d/b1ZdafaqhOljCg5E3I12XWtFAfG4rmn8CYngB4=";
+    })
+  ] ++ lib.optionals (lib.strings.versionOlder python3.pkgs.python-dbusmock.version "0.30.1") [
+    # Makes tests work with newer dbusmock, but breaks with much-newer dbusmock
+    # See for details:
+    # - https://gitlab.com/ubports/development/core/lomiri-system-settings/-/merge_requests/354
+    # - https://gitlab.com/ubports/development/core/lomiri-system-settings/-/merge_requests/426
+    # Remove/adjust based on merges & next LSS release, and packaged version of dbusmock
+    (fetchpatch {
+      name = "0101-lomiri-system-settings-Pass-missing-parameters-to-dbusmock.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-system-settings/-/commit/b9aacd88e3789dbb7578f32b31ad5b239db227a2.patch";
+      hash = "sha256-jf+jMc+6QxONavlX5C9UZyX23jb6fZnYV8mWFyQGGbU=";
+    })
+    (fetchpatch {
+      name = "0102-lomiri-system-settings-Fix-BT-plugin-testIsPaired.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-system-settings/-/commit/e39b9728e18635413f07f9c9f6ddc73208260b2a.patch";
+      hash = "sha256-YUtdlQ2XcanXzsxD40SbML7fSxG75yMKz/XnaQN9YP8=";
+    })
+    (fetchpatch {
+      name = "0103-lomiri-system-settings-Fix-BT-plugin-testGet-IconName-Type.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-system-settings/-/commit/9ad5d9324945f06f764d3a963dbfc7bccefe574b.patch";
+      # Merge conflict, relevant change handled further down
+      excludes = [ "CMakeLists.txt" ];
+      hash = "sha256-QCgkVos9Q9/8jd25rqzdEKdnBw0Re47X7B9nLH8QOQU=";
+    })
+  ] ++ [
+
+    ./2000-Support-wrapping-for-Nixpkgs.patch
+
+    # Make it work with regular accountsservice
+    # https://gitlab.com/ubports/development/core/lomiri-system-settings/-/issues/341
+    (fetchpatch {
+      name = "2001-lomiri-system-settings-disable-current-language-switching.patch";
+      url = "https://sources.debian.org/data/main/l/lomiri-system-settings/1.0.1-2/debian/patches/2001_disable-current-language-switching.patch";
+      hash = "sha256-ZOFYwxS8s6+qMFw8xDCBv3nLBOBm86m9d/VhbpOjamY=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}" \
+
+    # Port from lomiri-keyboard to maliit-keyboard
+    substituteInPlace plugins/language/CMakeLists.txt \
+      --replace-fail 'LOMIRI_KEYBOARD_PLUGIN_PATH=\"''${CMAKE_INSTALL_FULL_LIBDIR}/lomiri-keyboard/plugins\"' 'LOMIRI_KEYBOARD_PLUGIN_PATH=\"${lib.getLib maliit-keyboard}/lib/maliit/keyboard2/languages\"'
+    substituteInPlace plugins/language/{PageComponent,SpellChecking,ThemeValues}.qml plugins/language/onscreenkeyboard-plugin.cpp plugins/sound/PageComponent.qml \
+      --replace-fail 'com.lomiri.keyboard.maliit' 'org.maliit.keyboard.maliit'
+
+    # Decide which entries should be visible based on the current system
+    substituteInPlace plugins/*/*.settings \
+      --replace-warn '/etc' '/run/current-system/sw/etc'
+
+    # Don't use absolute paths in desktop file
+    substituteInPlace lomiri-system-settings.desktop.in.in \
+      --replace-fail 'Icon=@SETTINGS_SHARE_DIR@/system-settings.svg' 'Icon=lomiri-system-settings' \
+      --replace-fail 'X-Lomiri-Splash-Image=@SETTINGS_SHARE_DIR@/system-settings-app-splash.svg' 'X-Lomiri-Splash-Image=lomiri-app-launch/splash/lomiri-system-settings.svg' \
+      --replace-fail 'X-Screenshot=@SETTINGS_SHARE_DIR@/screenshot.png' 'X-Screenshot=lomiri-app-launch/screenshot/lomiri-system-settings.png'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    gettext
+    glib # glib-compile-schemas
+    intltool
+    pkg-config
+    validatePkgConfig
+  ];
+
+  buildInputs = [
+    accountsservice
+    cmake-extras
+    deviceinfo
+    geonames
+    gnome-desktop
+    gsettings-qt
+    gtk3
+    icu
+    json-glib
+    qtbase
+    ubports-click
+    upower
+  ];
+
+  # QML components and schemas the wrapper needs
+  propagatedBuildInputs = [
+    ayatana-indicator-datetime
+    content-hub
+    libqofono
+    lomiri-indicator-network
+    lomiri-schemas
+    lomiri-settings-components
+    lomiri-ui-toolkit
+    maliit-keyboard
+    qmenumodel
+    qtdeclarative
+    qtmultimedia
+  ];
+
+  nativeCheckInputs = [
+    dbus
+    (python3.withPackages (ps: with ps; [
+      python-dbusmock
+    ]))
+    xvfb-run
+  ];
+
+  checkInputs = [
+    libqtdbustest
+    libqtdbusmock
+  ];
+
+  # Not wrapping in this derivation
+  dontWrapQtApps = true;
+
+  cmakeFlags = [
+    (lib.cmakeBool "ENABLE_LIBDEVICEINFO" true)
+    (lib.cmakeBool "ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" (lib.concatStringsSep ";" [
+      # Exclude tests
+      "-E" (lib.strings.escapeShellArg "(${lib.concatStringsSep "|" [
+        # Hits OpenGL context issue inside lomiri-ui-toolkit, see derivation of that on details
+        "^testmouse"
+        "^tst_notifications"
+      ]})")
+    ]))
+  ];
+
+  # CMake option had to be excluded from earlier patchset
+  env.NIX_CFLAGS_COMPILE = lib.optionalString (lib.strings.versionOlder python3.pkgs.python-dbusmock.version "0.30.1") "-DMODERN_PYTHON_DBUSMOCK";
+
+  # The linking for this normally ignores missing symbols, which is inconvenient for figuring out why subpages may be
+  # failing to load their library modules. Force it to report them at linktime instead of runtime.
+  env.NIX_LDFLAGS = "--unresolved-symbols=report-all";
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  # Parallelism breaks D-Bus tests
+  enableParallelChecking = false;
+
+  preCheck = ''
+    export QT_PLUGIN_PATH=${lib.getBin qtbase}/${qtbase.qtPluginPrefix}
+    export QML2_IMPORT_PATH=${lib.makeSearchPathOutput "bin" qtbase.qtQmlPrefix ([ qtdeclarative lomiri-ui-toolkit lomiri-settings-components ] ++ lomiri-ui-toolkit.propagatedBuildInputs)}
+  '';
+
+  postInstall = ''
+    glib-compile-schemas $out/share/glib-2.0/schemas
+
+    mkdir -p $out/share/{icons/hicolor/scalable/apps,lomiri-app-launch/{splash,screenshot}}
+
+    ln -s $out/share/lomiri-system-settings/system-settings.svg $out/share/icons/hicolor/scalable/apps/lomiri-system-settings.svg
+    ln -s $out/share/lomiri-system-settings/system-settings-app-splash.svg $out/share/lomiri-app-launch/splash/lomiri-system-settings.svg
+    ln -s $out/share/lomiri-system-settings/screenshot.png $out/share/lomiri-app-launch/screenshot/lomiri-system-settings.png
+  '';
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "System Settings application for Lomiri";
+    homepage = "https://gitlab.com/ubports/development/core/lomiri-system-settings";
+    changelog = "https://gitlab.com/ubports/development/core/lomiri-system-settings/-/blob/${finalAttrs.version}/ChangeLog";
+    license = licenses.gpl3Only;
+    mainProgram = "lomiri-system-settings";
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+    pkgConfigModules = [
+      "LomiriSystemSettings"
+    ];
+  };
+})

--- a/pkgs/desktops/lomiri/applications/lomiri-system-settings/plugins/lomiri-system-settings-security-privacy.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-system-settings/plugins/lomiri-system-settings-security-privacy.nix
@@ -1,0 +1,89 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, biometryd
+, cmake
+, libqtdbusmock
+, libqtdbustest
+, lomiri-system-settings-unwrapped
+, pkg-config
+, polkit
+, python3
+, qtbase
+, qtdeclarative
+, trust-store
+, xvfb-run
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-system-settings-security-privacy";
+  version = "1.0.2";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lomiri-system-settings-security-privacy";
+    rev = finalAttrs.version;
+    hash = "sha256-d7OgxV362gJ3t5N+DEFgwyK+m6Ij6juRPuxfmbCg68Y=";
+  };
+
+  postPatch = ''
+    # CMake pkg_get_variable cannot replace prefix variable yet
+    for pcvar in plugin_manifest_dir plugin_private_module_dir plugin_qml_dir; do
+      pcvarname=$(echo $pcvar | tr '[:lower:]' '[:upper:]')
+      substituteInPlace CMakeLists.txt \
+        --replace-fail "pkg_get_variable($pcvarname LomiriSystemSettings $pcvar)" "set($pcvarname $(pkg-config LomiriSystemSettings --define-variable=prefix=$out --define-variable=libdir=$out/lib --variable=$pcvar))"
+    done
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    lomiri-system-settings-unwrapped
+    polkit
+    qtbase
+    qtdeclarative
+    trust-store
+  ];
+
+  # QML components and schemas the wrapper needs
+  propagatedBuildInputs = [
+    biometryd
+  ];
+
+  nativeCheckInputs = [
+    xvfb-run
+  ];
+
+  checkInputs = [
+    libqtdbusmock
+    libqtdbustest
+  ];
+
+  # Plugin library & modules for LSS
+  dontWrapQtApps = true;
+
+  cmakeFlags = [
+    (lib.cmakeBool "ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  preCheck = ''
+    export QT_PLUGIN_PATH=${lib.getBin qtbase}/${qtbase.qtPluginPrefix}
+  '';
+
+  meta = with lib; {
+    description = "Security and privacy settings plugin for Lomiri system settings";
+    homepage = "https://gitlab.com/ubports/development/core/lomiri-system-settings-security-privacy";
+    changelog = "https://gitlab.com/ubports/development/core/lomiri-system-settings-security-privacy/-/blob/${finalAttrs.version}/ChangeLog";
+    license = licenses.gpl3Only;
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/desktops/lomiri/applications/lomiri-system-settings/wrapper.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-system-settings/wrapper.nix
@@ -1,0 +1,67 @@
+{ stdenvNoCC
+, lib
+, glib
+, lndir
+, lomiri-system-settings-unwrapped
+, lomiri-system-settings-security-privacy
+, wrapGAppsHook
+, wrapQtAppsHook
+, plugins ? [ lomiri-system-settings-security-privacy ]
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "lomiri-system-settings";
+  inherit (lomiri-system-settings-unwrapped) version;
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    lndir
+    wrapGAppsHook
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    glib # schema hook
+    lomiri-system-settings-unwrapped
+  ] ++ plugins;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    ln -s ${lib.getExe lomiri-system-settings-unwrapped} $out/bin/${finalAttrs.meta.mainProgram}
+
+    for inheritedPath in share/lomiri-app-launch share/lomiri-url-dispatcher share/applications share/icons; do
+      mkdir -p $out/$inheritedPath
+      lndir ${lomiri-system-settings-unwrapped}/$inheritedPath $out/$inheritedPath
+    done
+
+    for mergedPath in lib/lomiri-system-settings share/lomiri-system-settings share/locale; do
+      mkdir -p $out/$mergedPath
+      for lssPart in ${lomiri-system-settings-unwrapped} ${lib.strings.concatStringsSep " " plugins}; do
+        lndir $lssPart/$mergedPath $out/$mergedPath
+      done
+    done
+
+    runHook postInstall
+  '';
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    qtWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+      --set NIX_LSS_PREFIX "$out"
+    )
+  '';
+
+  meta = lomiri-system-settings-unwrapped.meta // {
+    description = "System Settings application for Lomiri (wrapped)";
+    priority = (lomiri-system-settings-unwrapped.meta.priority or 0) - 1;
+  };
+})

--- a/pkgs/desktops/lomiri/applications/lomiri-system-settings/wrapper.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-system-settings/wrapper.nix
@@ -1,5 +1,6 @@
 { stdenvNoCC
 , lib
+, nixosTests
 , glib
 , lndir
 , lomiri-system-settings-unwrapped
@@ -59,6 +60,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       --set NIX_LSS_PREFIX "$out"
     )
   '';
+
+  passthru.tests.standalone = nixosTests.lomiri-system-settings;
 
   meta = lomiri-system-settings-unwrapped.meta // {
     description = "System Settings application for Lomiri (wrapped)";

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -10,6 +10,7 @@ let
     #### Core Apps
     lomiri-system-settings-unwrapped = callPackage ./applications/lomiri-system-settings { };
     lomiri-system-settings-security-privacy = callPackage ./applications/lomiri-system-settings/plugins/lomiri-system-settings-security-privacy.nix { };
+    lomiri-system-settings = callPackage ./applications/lomiri-system-settings/wrapper.nix { };
     lomiri-terminal-app = callPackage ./applications/lomiri-terminal-app { };
     morph-browser = callPackage ./applications/morph-browser { };
 

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -8,6 +8,7 @@ let
     inherit (self) callPackage;
   in {
     #### Core Apps
+    lomiri-system-settings-unwrapped = callPackage ./applications/lomiri-system-settings { };
     lomiri-terminal-app = callPackage ./applications/lomiri-terminal-app { };
     morph-browser = callPackage ./applications/morph-browser { };
 

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -9,6 +9,7 @@ let
   in {
     #### Core Apps
     lomiri-system-settings-unwrapped = callPackage ./applications/lomiri-system-settings { };
+    lomiri-system-settings-security-privacy = callPackage ./applications/lomiri-system-settings/plugins/lomiri-system-settings-security-privacy.nix { };
     lomiri-terminal-app = callPackage ./applications/lomiri-terminal-app { };
     morph-browser = callPackage ./applications/morph-browser { };
 


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[Lomiri System Settings](https://gitlab.com/ubports/development/core/lomiri-system-settings) is the main settings app for Lomiri. It's also one of the more integral parts of the `lomiri` shell & experience:
- It's a dependency for building it
- Some of the Ayatana indicators Lomiri displays have buttons that dispatch URL requests into the settings page
- Lomiri's first-time-wizard uses some of its QML modules in its setup pages
  - I don't think we'll keep the wizard enabled in our packaging, since it can't really configure much with the way NixOS works, but it's good to keep in mind that its QML modules get used in other places
- It's also one of the more convenient ways of graphically checking if URL dispatches (session indicator has a button that dispatches into it) and content-hub exchanges (wallpaper page lets you ask other applications for images) work as they should.

![Bildschirmfoto von 2024-01-02 23 08 22](https://github.com/NixOS/nixpkgs/assets/23431373/363003d4-124c-4b3e-979c-24cf355aa2ad)

If my overview of dependencies isn't *super* off, then this should be one of the last big dependencies (if not *the* last big dependency) needed for building the `lomiri` shell.

---

I've submitted everything that I think is good to have for everyone upstream, but some things remain on our end:

1. Replacing the dependency on `lomiri-keyboard` with `maliit-keyboard`. I have so far been unable to get either of them working, but `maliit-keyboard` saves us a dependency. [Debian is also patching this to `maliit-keyboard`](https://salsa.debian.org/ubports-team/lomiri-system-settings/-/blob/8b0a1d5e16668bc5db48075ead1eef8fc77c2899/debian/patches/2000_use-maliit-keyboard-for-language-plugin.patch), and [`lomiri-keyboard` might get replaced by `maliit-keyboard`](https://gitlab.com/ubports/development/core/lomiri-keyboard/-/issues/191), so this seems fine to me.
2. There is an assumption that all plugins store their data under the same shared prefix - this affects plugin finding, loading, and localisation. I'm solving this via an envvar that points at the prefix to use, and a wrapper that symlinks files together & sets the envvar.

To ensure that everything works, I have packaged one of the external plugins (security-privacy) and added a VM test that:

- carefully checks that all pages for internal & wrapped external plugins don't crash & display the expected content, to check if the general wrapping is correct
- verifies that localisation is properly covered by the patch

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
