### PR TITLE
python311Packages.cov-core: rename from covCore

### DIFF
--- a/pkgs/development/python-modules/dyn/default.nix
+++ b/pkgs/development/python-modules/dyn/default.nix
@@ -1,5 +1,5 @@
 { lib, buildPythonPackage, fetchPypi, pytest, pytest-cov, mock
-, pytest-xdist, covCore, glibcLocales }:
+, pytest-xdist, cov-core, glibcLocales }:
 
 buildPythonPackage rec {
   pname = "dyn";
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     pytest-cov
     mock
     pytest-xdist
-    covCore
+    cov-core
   ];
   # Disable checks because they are not stateless and require internet access.
   doCheck = false;

--- a/pkgs/development/python-modules/nose-cov/default.nix
+++ b/pkgs/development/python-modules/nose-cov/default.nix
@@ -1,4 +1,4 @@
-{ buildPythonPackage, fetchPypi, lib, nose, covCore }:
+{ buildPythonPackage, fetchPypi, lib, nose, cov-core }:
 
 buildPythonPackage rec {
   pname = "nose-cov";
@@ -10,7 +10,7 @@ buildPythonPackage rec {
     sha256 = "04j4fw01bv648gimqqj4z88606lcczbm1k326agcc74gb4sh7v4b";
   };
 
-  propagatedBuildInputs = [ nose covCore ];
+  propagatedBuildInputs = [ nose cov-core ];
 
   meta = with lib; {
     homepage = "https://pypi.org/project/nose-cov/";

--- a/pkgs/development/python-modules/pylti/default.nix
+++ b/pkgs/development/python-modules/pylti/default.nix
@@ -12,7 +12,7 @@
 , pytest
 , pytestcache
 , pytest-cov
-, covCore
+, cov-core
 , pytest-flakes
 , sphinx
 , mock
@@ -34,7 +34,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ httplib2 oauth oauth2 semantic-version ];
   nativeCheckInputs = [
-    flask httpretty oauthlib pyflakes pytest pytestcache pytest-cov covCore
+    flask httpretty oauthlib pyflakes pytest pytestcache pytest-cov cov-core
     pytest-flakes sphinx mock chalice
   ];
 

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -86,6 +86,7 @@ mapAliases ({
   CommonMark = commonmark; # added 2023-02-1
   ConfigArgParse = configargparse; # added 2021-03-18
   coronavirus = throw "coronavirus was removed, because the source is not providing the data anymore."; # added 2023-05-04
+  covCore = cov-core; # added 2024-01-03
   cozy = throw "cozy was removed because it was not actually https://pypi.org/project/Cozy/."; # added 2022-01-14
   cryptography_vectors = "cryptography_vectors is no longer exposed in python*Packages because it is used for testing cryptography only."; # Added 2022-03-23
   cx_Freeze = cx-freeze; # added 2023-08-02

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2370,7 +2370,7 @@ self: super: with self; {
 
   cot = callPackage ../development/python-modules/cot { };
 
-  covCore = callPackage ../development/python-modules/cov-core { };
+  cov-core = callPackage ../development/python-modules/cov-core { };
 
   coverage = callPackage ../development/python-modules/coverage { };
 


### PR DESCRIPTION
## Description of changes

part of #245383

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
