### PR TITLE
Idris2: introduce `idris2Packages`, `idris2api`, and the `buildIdris` helper.

### DIFF
--- a/doc/languages-frameworks/idris2.section.md
+++ b/doc/languages-frameworks/idris2.section.md
@@ -1,0 +1,47 @@
+# Idris2 {#sec-idris2}
+
+In addition to exposing the Idris2 compiler itself, Nixpkgs exposes an `idris2Packages.buildIdris` helper to make it a bit more ergonomic to build Idris2 executables or libraries.
+
+The `buildIdris` function takes a package set that defines at a minimum the `src` and `projectName` of the package to be built and any `idrisLibraries` required to build it. The `src` is the same source you're familiar with but the `projectName` must be the name of the `ipkg` file for the project (omitting the `.ipkg` extension). The `idrisLibraries` is a list of other library derivations created with `buildIdris`. You can optionally specify other derivation properties as needed but sensible defaults for `configurePhase`, `buildPhase`, and `installPhase` are provided.
+
+Importantly, `buildIdris` does not create a single derivation but rather an attribute set with two properties: `executable` and `library`. The `executable` property is a derivation and the `library` property is a function that will return a derivation for the library with or without source code included. Source code need not be included unless you are aiming to use IDE or LSP features that are able to jump to definitions within an editor.
+
+A simple example of a fully packaged library would be the [`LSP-lib`](https://github.com/idris-community/LSP-lib) found in the `idris-community` GitHub organization.
+```nix
+{ fetchFromGitHub, idris2Packages }:
+let lspLibPkg = idris2Packages.buildIdris {
+  projectName = "lsp-lib";
+  src = fetchFromGitHub {
+   owner = "idris-community";
+   repo = "LSP-lib";
+   rev = "main";
+   hash = "sha256-EvSyMCVyiy9jDZMkXQmtwwMoLaem1GsKVFqSGNNHHmY=";
+  };
+  idrisLibraries = [ ];
+};
+in lspLibPkg.library
+```
+
+The above results in a derivation with the installed library results (with sourcecode).
+
+A slightly more involved example of a fully packaged executable would be the [`idris2-lsp`](https://github.com/idris-community/idris2-lsp) which is an Idris2 language server that uses the `LSP-lib` found above.
+```nix
+{ callPackage, fetchFromGitHub, idris2Packages }:
+
+# Assuming the previous example lives in `lsp-lib.nix`:
+let lspLib = callPackage ./lsp-lib.nix { };
+    lspPkg = idris2Packages.buildIdris {
+      projectName = "idris2-lsp";
+      src = fetchFromGitHub {
+         owner = "idris-community";
+         repo = "idris2-lsp";
+         rev = "main";
+         hash = "sha256-vQTzEltkx7uelDtXOHc6QRWZ4cSlhhm5ziOqWA+aujk=";
+      };
+      idrisLibraries = [(idris2Packages.idris2Api { }) (lspLib { })];
+    };
+in lspPkg.executable
+```
+
+The above uses the default value of `withSource = false` for both of the two required Idris libraries that the `idris2-lsp` executable depends on. `idris2Api` in the above derivation comes built in with `idris2Packages`. This library exposes many of the otherwise internal APIs of the Idris2 compiler.
+

--- a/doc/languages-frameworks/index.md
+++ b/doc/languages-frameworks/index.md
@@ -21,6 +21,7 @@ go.section.md
 haskell.section.md
 hy.section.md
 idris.section.md
+idris2.section.md
 ios.section.md
 java.section.md
 javascript.section.md

--- a/pkgs/development/compilers/idris2/build-idris.nix
+++ b/pkgs/development/compilers/idris2/build-idris.nix
@@ -1,0 +1,73 @@
+{ stdenv, lib, idris2
+}:
+# Usage: let
+#          pkg = idris2Packages.buildIdris {
+#            src = ...;
+#            projectName = "my-pkg";
+#            idrisLibraries = [ ];
+#          };
+#        in {
+#          lib = pkg.library { withSource = true; };
+#          bin = pkg.executable;
+#        }
+#
+{ src
+, projectName
+, idrisLibraries # Other libraries built with buildIdris
+, ... }@attrs:
+
+let
+  ipkgName = projectName + ".ipkg";
+  idrName = "idris2-${idris2.version}";
+  libSuffix = "lib/${idrName}";
+  libDirs =
+    lib.makeSearchPath libSuffix idrisLibraries;
+  drvAttrs = builtins.removeAttrs attrs [ "idrisLibraries" ];
+
+  sharedAttrs = {
+    name = projectName;
+    src = src;
+    nativeBuildInputs = [ idris2 ];
+
+    IDRIS2_PACKAGE_PATH = libDirs;
+
+    configurePhase = ''
+      runHook preConfigure
+      runHook postConfigure
+    '';
+
+    buildPhase = ''
+      runHook preBuild
+      idris2 --build ${ipkgName}
+      runHook postBuild
+    '';
+  };
+
+in {
+  executable = stdenv.mkDerivation (lib.attrsets.mergeAttrsList [
+    sharedAttrs
+    { installPhase = ''
+        runHook preInstall
+        mkdir -p $out/bin
+        mv build/exec/* $out/bin
+        runHook postInstall
+      '';
+    }
+    drvAttrs
+  ]);
+  library = { withSource ? false }:
+    let installCmd = if withSource then "--install-with-src" else "--install";
+    in stdenv.mkDerivation (lib.attrsets.mergeAttrsList [
+      sharedAttrs
+      {
+        installPhase = ''
+          runHook preInstall
+          mkdir -p $out/${libSuffix}
+          export IDRIS2_PREFIX=$out/lib
+          idris2 ${installCmd} ${ipkgName}
+          runHook postInstall
+        '';
+      }
+      drvAttrs
+    ]);
+}

--- a/pkgs/development/compilers/idris2/default.nix
+++ b/pkgs/development/compilers/idris2/default.nix
@@ -1,97 +1,20 @@
-# Almost 1:1 copy of idris2's nix/platform.nix. Some work done in their flake.nix
-# we do here instead.
-{ stdenv
-, lib
-, chez
-, chez-racket
-, clang
-, gmp
-, fetchFromGitHub
-, makeWrapper
-, gambit
-, nodejs
-, zsh
-, callPackage
+{ callPackage
+, idris2Packages
 }:
 
-# NOTICE: An `idris2WithPackages` is available at: https://github.com/claymager/idris2-pkgs
-
 let
-  # Taken from Idris2/idris2/flake.nix. Check if the idris2 project does it this
-  # way, still, every now and then.
-  platformChez = if stdenv.system == "x86_64-linux" then chez else chez-racket;
-# Uses scheme to bootstrap the build of idris2
-in stdenv.mkDerivation rec {
-  pname = "idris2";
-  version = "0.7.0";
+in {
+  idris2 = callPackage ./idris2.nix { };
 
-  src = fetchFromGitHub {
-    owner = "idris-lang";
-    repo = "Idris2";
-    rev = "v${version}";
-    sha256 = "sha256-VwveX3fZfrxEsytpbOc5Tm6rySpLFhTt5132J6rmrmM=";
-  };
+  buildIdris = callPackage ./build-idris.nix { };
 
-  strictDeps = true;
-  nativeBuildInputs = [ makeWrapper clang platformChez ]
-    ++ lib.optionals stdenv.isDarwin [ zsh ];
-  buildInputs = [ platformChez gmp ];
-
-  prePatch = ''
-    patchShebangs --build tests
-  '';
-
-  makeFlags = [ "PREFIX=$(out)" ]
-    ++ lib.optional stdenv.isDarwin "OS=";
-
-  # The name of the main executable of pkgs.chez is `scheme`
-  buildFlags = [ "bootstrap" "SCHEME=scheme" ];
-
-  checkTarget = "test";
-  nativeCheckInputs = [ gambit nodejs ]; # racket ];
-  checkFlags = [ "INTERACTIVE=" ];
-
-  # TODO: Move this into its own derivation, such that this can be changed
-  #       without having to recompile idris2 every time.
-  postInstall = let
-    name = "${pname}-${version}";
-    globalLibraries = [
-      "\\$HOME/.nix-profile/lib/${name}"
-      "/run/current-system/sw/lib/${name}"
-      "$out/${name}"
-    ];
-    globalLibrariesPath = builtins.concatStringsSep ":" globalLibraries;
-  in ''
-    # Remove existing idris2 wrapper that sets incorrect LD_LIBRARY_PATH
-    rm $out/bin/idris2
-    # The only thing we need from idris2_app is the actual binary
-    mv $out/bin/idris2_app/idris2.so $out/bin/idris2
-    rm $out/bin/idris2_app/*
-    rmdir $out/bin/idris2_app
-    # idris2 needs to find scheme at runtime to compile
-    # idris2 installs packages with --install into the path given by
-    #   IDRIS2_PREFIX. We set that to a default of ~/.idris2, to mirror the
-    #   behaviour of the standard Makefile install.
-    # TODO: Make support libraries their own derivation such that
-    #       overriding LD_LIBRARY_PATH is unnecessary
-    wrapProgram "$out/bin/idris2" \
-      --set-default CHEZ "${platformChez}/bin/scheme" \
-      --run 'export IDRIS2_PREFIX=''${IDRIS2_PREFIX-"$HOME/.idris2"}' \
-      --suffix IDRIS2_LIBS ':' "$out/${name}/lib" \
-      --suffix IDRIS2_DATA ':' "$out/${name}/support" \
-      --suffix IDRIS2_PACKAGE_PATH ':' "${globalLibrariesPath}" \
-      --suffix DYLD_LIBRARY_PATH ':' "$out/${name}/lib" \
-      --suffix LD_LIBRARY_PATH ':' "$out/${name}/lib"
-  '';
-
-  # Run package tests
-  passthru.tests = callPackage ./tests.nix { inherit pname; };
-
-  meta = {
-    description = "A purely functional programming language with first class types";
-    homepage = "https://github.com/idris-lang/Idris2";
-    license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ fabianhjr wchresta ];
-    inherit (chez.meta) platforms;
-  };
+  idris2Api = (idris2Packages.buildIdris {
+    inherit (idris2Packages.idris2) src;
+    projectName = "idris2api";
+    idrisLibraries = [ ];
+    preBuild = ''
+      export IDRIS2_PREFIX=$out/lib
+      make src/IdrisPaths.idr
+    '';
+  }).library;
 }

--- a/pkgs/development/compilers/idris2/idris2.nix
+++ b/pkgs/development/compilers/idris2/idris2.nix
@@ -1,0 +1,97 @@
+# Almost 1:1 copy of idris2's nix/package.nix. Some work done in their flake.nix
+# we do here instead.
+{ stdenv
+, lib
+, chez
+, chez-racket
+, clang
+, gmp
+, fetchFromGitHub
+, makeWrapper
+, gambit
+, nodejs
+, zsh
+, callPackage
+}:
+
+# NOTICE: An `idris2WithPackages` is available at: https://github.com/claymager/idris2-pkgs
+
+let
+  # Taken from Idris2/idris2/flake.nix. Check if the idris2 project does it this
+  # way, still, every now and then.
+  platformChez = if stdenv.system == "x86_64-linux" then chez else chez-racket;
+# Uses scheme to bootstrap the build of idris2
+in stdenv.mkDerivation rec {
+  pname = "idris2";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "idris-lang";
+    repo = "Idris2";
+    rev = "v${version}";
+    sha256 = "sha256-VwveX3fZfrxEsytpbOc5Tm6rySpLFhTt5132J6rmrmM=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [ makeWrapper clang platformChez ]
+    ++ lib.optionals stdenv.isDarwin [ zsh ];
+  buildInputs = [ platformChez gmp ];
+
+  prePatch = ''
+    patchShebangs --build tests
+  '';
+
+  makeFlags = [ "PREFIX=$(out)" ]
+    ++ lib.optional stdenv.isDarwin "OS=";
+
+  # The name of the main executable of pkgs.chez is `scheme`
+  buildFlags = [ "bootstrap" "SCHEME=scheme" ];
+
+  checkTarget = "test";
+  nativeCheckInputs = [ gambit nodejs ]; # racket ];
+  checkFlags = [ "INTERACTIVE=" ];
+
+  # TODO: Move this into its own derivation, such that this can be changed
+  #       without having to recompile idris2 every time.
+  postInstall = let
+    name = "${pname}-${version}";
+    globalLibraries = [
+      "\\$HOME/.nix-profile/lib/${name}"
+      "/run/current-system/sw/lib/${name}"
+      "$out/${name}"
+    ];
+    globalLibrariesPath = builtins.concatStringsSep ":" globalLibraries;
+  in ''
+    # Remove existing idris2 wrapper that sets incorrect LD_LIBRARY_PATH
+    rm $out/bin/idris2
+    # The only thing we need from idris2_app is the actual binary
+    mv $out/bin/idris2_app/idris2.so $out/bin/idris2
+    rm $out/bin/idris2_app/*
+    rmdir $out/bin/idris2_app
+    # idris2 needs to find scheme at runtime to compile
+    # idris2 installs packages with --install into the path given by
+    #   IDRIS2_PREFIX. We set that to a default of ~/.idris2, to mirror the
+    #   behaviour of the standard Makefile install.
+    # TODO: Make support libraries their own derivation such that
+    #       overriding LD_LIBRARY_PATH is unnecessary
+    wrapProgram "$out/bin/idris2" \
+      --set-default CHEZ "${platformChez}/bin/scheme" \
+      --run 'export IDRIS2_PREFIX=''${IDRIS2_PREFIX-"$HOME/.idris2"}' \
+      --suffix IDRIS2_LIBS ':' "$out/${name}/lib" \
+      --suffix IDRIS2_DATA ':' "$out/${name}/support" \
+      --suffix IDRIS2_PACKAGE_PATH ':' "${globalLibrariesPath}" \
+      --suffix DYLD_LIBRARY_PATH ':' "$out/${name}/lib" \
+      --suffix LD_LIBRARY_PATH ':' "$out/${name}/lib"
+  '';
+
+  # Run package tests
+  passthru.tests = callPackage ./tests.nix { inherit pname; };
+
+  meta = {
+    description = "A purely functional programming language with first class types";
+    homepage = "https://github.com/idris-lang/Idris2";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ fabianhjr wchresta ];
+    inherit (chez.meta) platforms;
+  };
+}

--- a/pkgs/development/compilers/idris2/idris2.nix
+++ b/pkgs/development/compilers/idris2/idris2.nix
@@ -91,7 +91,7 @@ in stdenv.mkDerivation rec {
     description = "A purely functional programming language with first class types";
     homepage = "https://github.com/idris-lang/Idris2";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ fabianhjr wchresta ];
+    maintainers = with lib.maintainers; [ fabianhjr wchresta mattpolzin ];
     inherit (chez.meta) platforms;
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16379,7 +16379,9 @@ with pkgs;
 
   idris = idrisPackages.with-packages [ idrisPackages.base ] ;
 
-  idris2 = callPackage ../development/compilers/idris2 { };
+  idris2Packages = recurseIntoAttrs (callPackage ../development/compilers/idris2 { });
+
+  inherit (idris2Packages) idris2;
 
   inherit (callPackage ../development/tools/database/indradb { })
     indradb-server


### PR DESCRIPTION
## Description of changes

The git diff isn't terribly helpful in identifying the fact that `default.nix` was renamed to `idris2.nix` with no substantive changes (I corrected a typo in one comment).

The new `default.nix` houses the `idris2Packages` namespace. `idris2` is still exposed at the top level, but it now also lives within `idris2Packages`.

I've also added the `buildIdris` helper which comes from the upstream Idris2 repository originally, though the same helper is being updated upstream at the same time as I am pushing improvements to it here in `nixpkgs` so the two versions will be a bit different until I've finished up everywhere (the end goal is rough parity).

This PR also adds `idris2Packages.idris2Api` which is an API offered by the compiler project; adding `idris2Api` to `nixpkgs` is a stepping stone on the way to adding the `idris2-lsp` language server to `nixpkgs` in a future PR.

Finally, I added a new documentation section for Idris 2 that mostly focuses on `buildIdris` for now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
