### PR TITLE
python311Packages.sqlalchemy_1_4: init at 1.4.51

### DIFF
--- a/pkgs/applications/version-management/sourcehut/default.nix
+++ b/pkgs/applications/version-management/sourcehut/default.nix
@@ -29,18 +29,7 @@ let
       scmsrht = self.callPackage ./scm.nix { };
 
       # sourcehut is not (yet) compatible with SQLAlchemy 2.x
-      sqlalchemy = super.sqlalchemy.overridePythonAttrs (oldAttrs: rec {
-        version = "1.4.46";
-        src = fetchPypi {
-          pname = "SQLAlchemy";
-          inherit version;
-          hash = "sha256-aRO4JH2KKS74MVFipRkx4rQM6RaB8bbxj2lwRSAMSjA=";
-        };
-        nativeCheckInputs = with super; [ pytestCheckHook mock ];
-        disabledTestPaths = []
-          # Disable incompatible tests on Darwin.
-          ++ lib.optionals stdenv.isDarwin [ "test/aaa_profiling" ];
-      });
+      sqlalchemy = super.sqlalchemy_1_4;
 
       flask-sqlalchemy = super.flask-sqlalchemy.overridePythonAttrs (oldAttrs: rec {
         version = "2.5.1";

--- a/pkgs/applications/video/pyca/default.nix
+++ b/pkgs/applications/video/pyca/default.nix
@@ -1,6 +1,5 @@
 { lib
 , python3
-, fetchPypi
 , buildNpmPackage
 , fetchFromGitHub
 , jq
@@ -11,18 +10,7 @@ let
   python = python3.override {
     packageOverrides = self: super: {
       # pyCA is incompatible with SQLAlchemy 2.0
-      sqlalchemy = super.sqlalchemy.overridePythonAttrs (old: rec {
-        version = "1.4.46";
-        src = fetchPypi {
-          pname = "SQLAlchemy";
-          inherit version;
-          hash = "sha256-aRO4JH2KKS74MVFipRkx4rQM6RaB8bbxj2lwRSAMSjA=";
-        };
-        disabledTestPaths = [
-           "test/aaa_profiling"
-           "test/ext/mypy"
-        ];
-      });
+      sqlalchemy = super.sqlalchemy_1_4;
     };
   };
 

--- a/pkgs/development/python-modules/alembic/default.nix
+++ b/pkgs/development/python-modules/alembic/default.nix
@@ -2,13 +2,21 @@
 , buildPythonPackage
 , fetchPypi
 , pythonOlder
-, mako
-, python-dateutil
-, sqlalchemy
+
+# build-system
+, setuptools
+
+# dependencies
 , importlib-metadata
 , importlib-resources
-, pytest-xdist
+, mako
+, sqlalchemy
+, typing-extensions
+
+# tests
 , pytestCheckHook
+, pytest-xdist
+, python-dateutil
 }:
 
 buildPythonPackage rec {
@@ -23,13 +31,16 @@ buildPythonPackage rec {
     hash = "sha256-jnZFwy5PIAZ15p8HRUFTNetZo2Y/X+tIer+gswxFiIs=";
   };
 
+  nativeBuildInputs = [
+    setuptools
+  ];
+
   propagatedBuildInputs = [
     mako
-    python-dateutil
     sqlalchemy
+    typing-extensions
   ] ++ lib.optionals (pythonOlder "3.9") [
     importlib-resources
-  ] ++ lib.optionals (pythonOlder "3.8") [
     importlib-metadata
   ];
 
@@ -40,6 +51,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-xdist
+    python-dateutil
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/spacy/models.nix
+++ b/pkgs/development/python-modules/spacy/models.nix
@@ -5,6 +5,7 @@
 , pymorphy3
 , pymorphy3-dicts-uk
 , sentencepiece
+, setuptools
 , spacy
 , spacy-pkuseg
 , spacy-transformers
@@ -23,6 +24,7 @@ let
     in
     buildPythonPackage {
       inherit pname version;
+      pyproject = true;
 
       src = fetchurl {
         url = "https://github.com/explosion/spacy-models/releases/download/${pname}-${version}/${pname}-${version}.tar.gz";
@@ -41,7 +43,9 @@ let
           --replace "protobuf<3.21.0" "protobuf"
       '';
 
-      nativeBuildInputs = lib.optionals requires-protobuf [
+      nativeBuildInputs = [
+        setuptools
+      ] ++ lib.optionals requires-protobuf [
         protobuf
       ];
 

--- a/pkgs/development/python-modules/sqlalchemy/1_4.nix
+++ b/pkgs/development/python-modules/sqlalchemy/1_4.nix
@@ -1,0 +1,140 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+
+# build-system
+, setuptools
+
+# dependencies
+, greenlet
+
+# optionals
+, aiomysql
+, aiosqlite
+, asyncmy
+, asyncpg
+, cx_oracle
+, mariadb
+, mypy
+, mysql-connector
+, mysqlclient
+, pg8000
+, psycopg2
+, psycopg2cffi
+# TODO: pymssql
+, pymysql
+, pyodbc
+# TODO: sqlcipher3
+, typing-extensions
+
+# tests
+, mock
+, pytest-xdist
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "sqlalchemy";
+  version = "1.4.51";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "sqlalchemy";
+    repo = "sqlalchemy";
+    rev = "rel_${lib.replaceStrings [ "." ] [ "_" ] version}";
+    hash = "sha256-KhLSKlQ4xfSh1nsAt+cRO+adh2aj/h/iqV6YmDbz39k=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    greenlet
+  ];
+
+  passthru.optional-dependencies = lib.fix (self: {
+    asyncio = [
+      greenlet
+    ];
+    mypy = [
+      mypy
+    ];
+    mssql = [
+      pyodbc
+    ];
+    mssql_pymysql = [
+      # TODO: pymssql
+    ];
+    mssql_pyodbc = [
+      pyodbc
+    ];
+    mysql = [
+      mysqlclient
+    ];
+    mysql_connector = [
+      mysql-connector
+    ];
+    mariadb_connector = [
+      mariadb
+    ];
+    oracle = [
+      cx_oracle
+    ];
+    postgresql = [
+      psycopg2
+    ];
+    postgresql_pg8000 = [
+      pg8000
+    ];
+    postgresql_asyncpg = [
+      asyncpg
+    ] ++ self.asyncio;
+    postgresql_psycopg2binary = [
+      psycopg2
+    ];
+    postgresql_psycopg2cffi = [
+      psycopg2cffi
+    ];
+    pymysql = [
+      pymysql
+    ];
+    aiomysql = [
+      aiomysql
+    ] ++ self.asyncio;
+    asyncmy = [
+      asyncmy
+    ] ++ self.asyncio;
+    aiosqlite = [
+      aiosqlite
+      typing-extensions
+    ] ++ self.asyncio;
+    sqlcipher = [
+      # TODO: sqlcipher3
+    ];
+  });
+
+  nativeCheckInputs = [
+    pytest-xdist
+    pytestCheckHook
+    mock
+  ];
+
+  disabledTestPaths = [
+    # typing correctness, not interesting
+    "test/ext/mypy"
+    # slow and high memory usage, not interesting
+    "test/aaa_profiling"
+  ];
+
+  pythonImportsCheck = [
+    "sqlalchemy"
+  ];
+
+  meta = with lib; {
+    changelog = "https://github.com/sqlalchemy/sqlalchemy/releases/tag/rel_${builtins.replaceStrings [ "." ] [ "_" ] version}";
+    description = "The Database Toolkit for Python";
+    homepage = "https://github.com/sqlalchemy/sqlalchemy";
+    license = licenses.mit;
+  };
+}

--- a/pkgs/development/python-modules/typeguard/default.nix
+++ b/pkgs/development/python-modules/typeguard/default.nix
@@ -6,6 +6,7 @@
 , setuptools-scm
 , pytestCheckHook
 , typing-extensions
+, importlib-metadata
 , sphinxHook
 , sphinx-autodoc-typehints
 , sphinx-rtd-theme
@@ -40,6 +41,8 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     typing-extensions
+  ] ++ lib.optionals (pythonOlder "3.10") [
+    importlib-metadata
   ];
 
   env.LC_ALL = "en_US.utf-8";

--- a/pkgs/development/tools/continuous-integration/buildbot/default.nix
+++ b/pkgs/development/tools/continuous-integration/buildbot/default.nix
@@ -6,18 +6,7 @@
 let
   python = python3.override {
     packageOverrides = self: super: {
-      sqlalchemy = super.sqlalchemy.overridePythonAttrs (oldAttrs: rec {
-        version = "1.4.50";
-        src = fetchPypi {
-          pname = "SQLAlchemy";
-          inherit version;
-          hash = "sha256-O5fd9Qn8IeELCUA7UhmwbFtViyf8JFMVAnT6TnBwfb8=";
-        };
-        disabledTestPaths = [
-           "test/aaa_profiling"
-           "test/ext/mypy"
-        ];
-      });
+      sqlalchemy = super.sqlalchemy_1_4;
       moto = super.moto.overridePythonAttrs (oldAttrs: rec {
         # a lot of tests -> very slow, we already build them when building python packages
         doCheck = false;

--- a/pkgs/servers/apache-airflow/default.nix
+++ b/pkgs/servers/apache-airflow/default.nix
@@ -52,19 +52,7 @@ let
       });
       # apache-airflow doesn't work with sqlalchemy 2.x
       # https://github.com/apache/airflow/issues/28723
-      sqlalchemy = pySuper.sqlalchemy.overridePythonAttrs (o: rec {
-        version = "1.4.48";
-        src = fetchFromGitHub {
-          owner = "sqlalchemy";
-          repo = "sqlalchemy";
-          rev = "refs/tags/rel_${lib.replaceStrings [ "." ] [ "_" ] version}";
-          hash = "sha256-qyD3uoxEnD2pdVvwpUlSqHB3drD4Zg/+ov4CzLFIlLs=";
-        };
-        disabledTestPaths = [
-           "test/aaa_profiling"
-           "test/ext/mypy"
-        ];
-      });
+      sqlalchemy = pySuper.sqlalchemy_1_4;
 
       apache-airflow = pySelf.callPackage ./python-package.nix { };
     };

--- a/pkgs/servers/calibre-web/default.nix
+++ b/pkgs/servers/calibre-web/default.nix
@@ -2,24 +2,12 @@
 , fetchFromGitHub
 , nixosTests
 , python3
-, fetchPypi
 }:
 
 let
   python = python3.override {
     packageOverrides = self: super: {
-      sqlalchemy = super.sqlalchemy.overridePythonAttrs (old: rec {
-        version = "1.4.46";
-        src = fetchPypi {
-          pname = "SQLAlchemy";
-          inherit version;
-          hash = "sha256-aRO4JH2KKS74MVFipRkx4rQM6RaB8bbxj2lwRSAMSjA=";
-        };
-        disabledTestPaths = [
-           "test/aaa_profiling"
-           "test/ext/mypy"
-        ];
-      });
+      sqlalchemy = super.sqlalchemy_1_4;
     };
   };
 in

--- a/pkgs/servers/geospatial/fit-trackee/default.nix
+++ b/pkgs/servers/geospatial/fit-trackee/default.nix
@@ -8,19 +8,8 @@
 let
   python = python3.override {
     packageOverrides = self: super: {
-      sqlalchemy = super.sqlalchemy.overridePythonAttrs (oldAttrs: rec {
-        version = "1.4.49";
-        src = fetchPypi {
-          pname = "SQLAlchemy";
-          inherit version;
-          hash = "sha256-Bv8ly64ww5bEt3N0ZPKn/Deme32kCZk7GCsCTOyArtk=";
-        };
-        # Remove "test/typing" that does not exist
-        disabledTestPaths = [
-          "test/aaa_profiling"
-          "test/ext/mypy"
-        ];
-      });
+      sqlalchemy = super.sqlalchemy_1_4;
+
       flask-sqlalchemy = super.flask-sqlalchemy.overridePythonAttrs (oldAttrs: rec {
         version = "3.0.5";
 

--- a/pkgs/servers/mail/mailman/package.nix
+++ b/pkgs/servers/mail/mailman/package.nix
@@ -31,6 +31,7 @@ buildPythonPackage rec {
     gunicorn
     lazr-config
     passlib
+    python-dateutil
     requests
     sqlalchemy
     zope-component

--- a/pkgs/tools/misc/ntfy/default.nix
+++ b/pkgs/tools/misc/ntfy/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , python39
-, fetchPypi
 , fetchFromGitHub
 , fetchpatch
 , withXmpp ? !stdenv.isDarwin
@@ -18,18 +17,9 @@ let
       ntfy-webpush = self.callPackage ./webpush.nix { };
 
       # databases, on which slack-sdk depends, is incompatible with SQLAlchemy 2.0
-      sqlalchemy = super.sqlalchemy.overridePythonAttrs rec {
-        version = "1.4.46";
-        src = fetchPypi {
-          pname = "SQLAlchemy";
-          inherit version;
-          hash = "sha256-aRO4JH2KKS74MVFipRkx4rQM6RaB8bbxj2lwRSAMSjA=";
-        };
-        disabledTestPaths = [
-           "test/aaa_profiling"
-           "test/ext/mypy"
-        ];
-      };
+      sqlalchemy = super.sqlalchemy_1_4;
+
+      django = super.django_3;
     };
   };
 in python.pkgs.buildPythonApplication rec {

--- a/pkgs/tools/text/csvkit/default.nix
+++ b/pkgs/tools/text/csvkit/default.nix
@@ -6,18 +6,7 @@
 let
   python = python3.override {
     packageOverrides = self: super: {
-      sqlalchemy = super.sqlalchemy.overridePythonAttrs (oldAttrs: rec {
-        version = "1.4.46";
-        src = fetchPypi {
-          pname = "SQLAlchemy";
-          inherit version;
-          hash = "sha256-aRO4JH2KKS74MVFipRkx4rQM6RaB8bbxj2lwRSAMSjA=";
-        };
-        disabledTestPaths = [
-           "test/aaa_profiling"
-           "test/ext/mypy"
-        ];
-      });
+      sqlalchemy = super.sqlalchemy_1_4;
     };
   };
 in

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13622,6 +13622,8 @@ self: super: with self; {
 
   sqlalchemy = callPackage ../development/python-modules/sqlalchemy { };
 
+  sqlalchemy_1_4 = callPackage ../development/python-modules/sqlalchemy/1_4.nix { };
+
   sqlalchemy-citext = callPackage ../development/python-modules/sqlalchemy-citext { };
 
   sqlalchemy-continuum = callPackage ../development/python-modules/sqlalchemy-continuum { };


### PR DESCRIPTION
## Description of changes

The removal of sqlalchemy 1.4.x should have been more graceful, since we forced many applications to create overrides, that went out of date quickly.

Reintroduce at 1.4.51 (released an hour ago) and replace outdated overrides.

This version should not be used in the python package set, only in overrides.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
