### PR TITLE
tectonic: add online passthru.tests.biber-compatibility

### DIFF
--- a/pkgs/tools/typesetting/tectonic/tests.nix
+++ b/pkgs/tools/typesetting/tectonic/tests.nix
@@ -1,0 +1,87 @@
+# This package provides `tectonic.passthru.tests`.
+# It requires internet access to fetch tectonic's resource bundle on demand.
+
+{ lib
+, fetchFromGitHub
+, runCommand
+, tectonic
+, curl
+, cacert
+, emptyFile
+}:
+
+let
+  /*
+    Currently, the test files are only fully available from the `dev` branch of
+    `biber`. When https://github.com/plk/biber/pull/467 is eventually released,
+    we can obtain the test files from `texlive.pkgs.biber.texsource`. For now,
+    i.e. biber<=2.19, we fetch the test files directly from GitHub.
+  */
+  biber-dev-source = fetchFromGitHub {
+    owner = "plk";
+    repo = "biber";
+    # curl https://api.github.com/repos/plk/biber/pulls/467 | jq .merge_commit_sha
+    rev = "d43e352586f5c9f98f0331978ca9d0b908986e09";
+    hash = "sha256-Z5BdMteBouiDQasF6GZXkS//YzrZkcX1eLvKIQIBkBs=";
+  };
+  testfiles = "${biber-dev-source}/testfiles";
+
+  noNetNotice = builtins.toFile "tectonic-offline-notice" ''
+    # To fetch tectonic's web bundle, the tests require internet access,
+    # which is not available in the current environment.
+  '';
+  # `cacert` is required for tls connections
+  nativeBuildInputs = [ curl cacert tectonic ];
+  checkInternet = ''
+    if curl --head "bing.com"; then
+      set -e # continue to the tests defined below, fail on error
+    else
+      cat "${noNetNotice}"
+      cp "${emptyFile}" "$out"
+      exit # bail out gracefully when there is no internet, do not panic
+    fi
+  '';
+
+  networkRequiringTestPkg = name: script: runCommand
+    /*
+      Introduce dependence on `tectonic` in the test package name. Note that
+      adding `tectonic` to `nativeBuildInputs` is not enough to trigger
+      rebuilds for a fixed-output derivation. One must update its name or
+      output hash to induce a rebuild. This behavior is exactly the same as a
+      standard nixpkgs "fetcher" such as `fetchurl`.
+    */
+    "test-${lib.removePrefix "${builtins.storeDir}/" tectonic.outPath}-${name}"
+    {
+      /*
+        Make a fixed-output derivation, return an `emptyFile` with fixed hash.
+        These derivations are allowed to access the internet from within a
+        sandbox, which allows us to test the automatic download of resource
+        files in tectonic, as a side effect. The `tectonic.outPath` is included
+        in `name` to induce rebuild of this fixed-output derivation whenever
+        the `tectonic` derivation is updated.
+      */
+      inherit (emptyFile)
+        outputHashAlgo
+        outputHashMode
+        outputHash
+        ;
+      allowSubstitutes = false;
+      inherit nativeBuildInputs;
+    }
+    ''
+      ${checkInternet}
+      ${script}
+      cp "${emptyFile}" "$out"
+    '';
+
+in
+lib.mapAttrs networkRequiringTestPkg {
+  biber-compatibility = ''
+    # import the test files
+    cp "${testfiles}"/* .
+
+    # tectonic caches in the $HOME directory, so set it to $PWD
+    export HOME=$PWD
+    tectonic -X compile ./test.tex
+  '';
+}

--- a/pkgs/tools/typesetting/tectonic/wrapper.nix
+++ b/pkgs/tools/typesetting/tectonic/wrapper.nix
@@ -3,6 +3,7 @@
 , tectonic-unwrapped
 , biber-for-tectonic
 , makeWrapper
+, callPackage
 }:
 
 symlinkJoin {
@@ -14,6 +15,7 @@ symlinkJoin {
   passthru = {
     unwrapped = tectonic-unwrapped;
     biber = biber-for-tectonic;
+    tests = callPackage ./tests.nix { };
   };
 
   # Replace the unwrapped tectonic with the one wrapping it with biber


### PR DESCRIPTION
## Description of changes

Implement the (LaTeX + biber) compile test for the tectonic package wrapped with biber.

- The test requires internet access to fetch Tectonic's web bundle on demand. This is achieved by (ab)using a [fixed-output derivation](https://nixos.org/manual/nix/unstable/language/advanced-attributes#adv-attr-outputHash), which is capable of internet access.
- The `tectonic.outPath` is included in the test package name. This ensures that it is always triggered for rebuild when the main derivation changes.

I do have a few concerns about doing this:
- How often will `tectonic.passthru.tests` be triggered by hydra? Every `staging-next` build would probably change tectonic's outPath, which will change the test's name according to this current design. I am not sure (1) whether this would trigger a test rebuild in hydra, and (2) if this happens, whether it would lead to too many test rebuilds. I don't want to accidentally DDoS the upstream server!
- The test is basically realized as a customized fetcher, just like `fetchurl`. Is that legal in nixpkgs?

This PR follows from discussions in https://github.com/NixOS/nixpkgs/pull/273740. Note, however, that this PR is independent of the previously discussed web-bundle-locking proposal (which I am also working on upstream, but independent of this PR).

**Update:**
- This PR is trivial to `nixpkgs-review` as it causes zero rebuild of the main packages.
- Ofborg happy on `x86_64-*` and `*-linux` [(log)](https://logs.ofborg.org/?key=nixos/nixpkgs.278410&attempt_id=cce08894-1fe7-4624-a1d5-63c190305f5c), still pending on [`aarch64-darwin`](https://github.com/NixOS/nixpkgs/pull/278410/checks?check_run_id=20114669738).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
