### PR TITLE
dynamodb-local: init at 2023-12-14

### DIFF
--- a/pkgs/by-name/dy/dynamodb-local/package.nix
+++ b/pkgs/by-name/dy/dynamodb-local/package.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, jre
+, makeBinaryWrapper
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "dynamodb-local";
+  version = "2023-12-14";
+
+  src = fetchurl {
+    url = "https://d1ni2b6xgvw0s0.cloudfront.net/v2.x/dynamodb_local_${finalAttrs.version}.tar.gz";
+    hash = "sha256-F9xTcLNAVFVbH7l0FlMuVNoLBrJS/UcHKXTkJh1n40w=";
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/dynamodb-local
+    cp -r DynamoDBLocal* $out/share/dynamodb-local
+
+    makeBinaryWrapper ${jre}/bin/java $out/bin/dynamodb-local \
+      --add-flags "-jar $out/share/dynamodb-local/DynamoDBLocal.jar"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "DynamoDB Local is a small client-side database and server that mimics the DynamoDB service.";
+    homepage = "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html";
+    license = licenses.unfree;
+    mainProgram = "dynamodb-local";
+    maintainers = with maintainers; [ shyim ];
+    platforms = platforms.all;
+    sourceProvenance = with lib.sourceTypes; [
+      binaryBytecode
+      binaryNativeCode
+    ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Dynamodb local allows to simulate a Dynamodb completely locally and is ideal for local development.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).