### PR TITLE
normcap: 0.4.4 -> 0.5.2

### DIFF
--- a/pkgs/by-name/no/normcap/package.nix
+++ b/pkgs/by-name/no/normcap/package.nix
@@ -25,7 +25,7 @@ in
 
 ps.buildPythonApplication rec {
   pname = "normcap";
-  version = "0.4.4";
+  version = "0.5.2";
   format = "pyproject";
 
   disabled = ps.pythonOlder "3.9";
@@ -34,7 +34,7 @@ ps.buildPythonApplication rec {
     owner = "dynobo";
     repo = "normcap";
     rev = "refs/tags/v${version}";
-    hash = "sha256-dShtmoqS9TC3PHuwq24OEOhYfBHGhDCma8Du8QCkFuI=";
+    hash = "sha256-WkC9sdi6fKEHnf2j+p8KjO+MNbHWDYn5HnjeYBZLUj4==";
   };
 
   pythonRemoveDeps = [
@@ -43,11 +43,13 @@ ps.buildPythonApplication rec {
 
   nativeBuildInputs = [
     ps.pythonRelaxDepsHook
-    ps.poetry-core
+    ps.hatchling
   ];
 
   propagatedBuildInputs = [
     ps.pyside6
+    ps.babel
+    ps.toml
   ];
 
   preFixup = ''
@@ -61,6 +63,7 @@ ps.buildPythonApplication rec {
   nativeCheckInputs = wrapperDeps ++ [
     ps.pytestCheckHook
     ps.pytest-qt
+    ps.pytest-cov
     ps.toml
   ] ++ lib.optionals stdenv.isLinux [
     ps.pytest-xvfb


### PR DESCRIPTION
## Description of changes

A pretty big bump version-wise: https://github.com/dynobo/normcap/releases

<s>I had to add the `substituteInPlace` which is pretty ugly to avoid this error:</s> (EDIT: fixed by adding pytest-cov as @christoph-heiss suggested)

```
error: builder for '/nix/store/6jj1izjxnndzdrqags3kfdiap7qbhzy0-normcap-0.5.2.drv' failed with exit code 4;
       last 10 log lines:         
       > > Warning:          Could not resolve keysym XF86ClearvuSonar
       > > Warning:          Could not resolve keysym XF86SidevuSonar
       > > Warning:          Could not resolve keysym XF86NavInfo                                                                                                                                                   
       > Errors from xkbcomp are not fatal to the X server                                                                                                                                                          
       > ERROR: usage: __main__.py [options] [file_or_dir] [file_or_dir] [...]
       > __main__.py: error: unrecognized arguments: --cov --cov-report=xml --cov-report=html
       >   inifile: /build/source/pyproject.toml                                                                                                                                                                    
       >   rootdir: /build/source                                                                         
       > 
       > /nix/store/d4jf1cbbk494zwgbqz31pxgigpsbh6w2-stdenv-linux/setup: line 1553: pop_var_context: head of shell_variables not a function context
       For full logs, run 'nix log /nix/store/6jj1izjxnndzdrqags3kfdiap7qbhzy0-normcap-0.5.2.drv'.
```

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
