### PR TITLE
indico: init at 3.3.1

### DIFF
--- a/pkgs/by-name/in/indico.nix
+++ b/pkgs/by-name/in/indico.nix
@@ -1,0 +1,174 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "indico";
+  version = "3.3.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "indico";
+    repo = "indico";
+    rev = "v${version}";
+    hash = "sha256-u2PUZjcyQSMn3ImKtTcwYoD68oAlrKXo8EksOHhsNiM=";
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+    python3.pkgs.wheel
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    alembic
+    amqp
+    asttokens
+    async-timeout
+    attrs
+    authlib
+    babel
+    bcrypt
+    billiard
+    bleach
+    blinker
+    brotli
+    cachelib
+    cachetools
+    captcha
+    celery
+    certifi
+    cffi
+    chardet
+    charset-normalizer
+    click
+    click-didyoumean
+    click-plugins
+    click-repl
+    colorclass
+    cryptography
+    cssselect2
+    decorator
+    deprecated
+    distro
+    dnspython
+    email-validator
+    executing
+    feedgen
+    flask
+    flask-babel
+    flask-caching
+    flask-cors
+    flask-limiter
+    flask-marshmallow
+    flask-migrate
+    flask-multipass
+    flask-pluginengine
+    flask-sqlalchemy
+    flask-webpackext
+    flask-wtf
+    fonttools
+    google-auth
+    greenlet
+    hiredis
+    html2text
+    html5lib
+    icalendar
+    idna
+    importlib-metadata
+    importlib-resources
+    indico-fonts
+    ipython
+    itsdangerous
+    jedi
+    jinja2
+    jsonschema
+    jsonschema-specifications
+    kombu
+    limits
+    lxml
+    mako
+    markdown
+    markdown-it-py
+    markupsafe
+    marshmallow
+    marshmallow-dataclass
+    marshmallow-enum
+    marshmallow-oneofschema
+    marshmallow-sqlalchemy
+    matplotlib-inline
+    mdurl
+    mypy-extensions
+    ordered-set
+    packaging
+    parso
+    pexpect
+    pillow
+    prompt-toolkit
+    psycopg2
+    ptyprocess
+    pure-eval
+    pyasn1
+    pyasn1-modules
+    pycountry
+    pycparser
+    pydyf
+    pygments
+    pynpm
+    pypdf
+    pyphen
+    pypng
+    python-dateutil
+    pytz
+    pywebpack
+    pyyaml
+    qrcode
+    redis
+    referencing
+    reportlab
+    requests
+    rich
+    rpds-py
+    rsa
+    sentry-sdk
+    simplejson
+    six
+    speaklater
+    sqlalchemy
+    stack-data
+    terminaltables
+    tinycss2
+    traitlets
+    translitcodec
+    typing-extensions
+    typing-inspect
+    tzdata
+    ua-parser
+    urllib3
+    vine
+    wcwidth
+    weasyprint
+    webargs
+    webencodings
+    werkzeug
+    wrapt
+    wtforms
+    wtforms-dateutil
+    wtforms-sqlalchemy
+    xlsxwriter
+    zipp
+    zopfli
+  ];
+
+  pythonImportsCheck = [ "indico" ];
+
+  meta = {
+    description = "Indico - A feature-rich event management system, made @ CERN, the place where the Web was born";
+    homepage = "https://github.com/indico/indico";
+    changelog = "https://github.com/indico/indico/blob/${src.rev}/CHANGES.rst";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ thubrecht ];
+    mainProgram = "indico";
+  };
+}

--- a/pkgs/by-name/re/react-jsx-i18n/package.nix
+++ b/pkgs/by-name/re/react-jsx-i18n/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage rec {
+  pname = "react-jsx-i18n";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "indico";
+    repo = "react-jsx-i18n";
+    rev = "v${version}";
+    hash = "sha256-GQbjKG3Nr57cMVudCKA4Mo6aopsSrVQ9tyTvYciLv/s=";
+  };
+
+  npmDepsHash = "sha256-JK2Z18agCXEAMu6hBpYDHc+RmmwlIpHoOXexda+pauA=";
+
+  meta = with lib; {
+    description = "Gettext-enhanced React components";
+    homepage = "https://github.com/indico/react-jsx-i18n";
+    license = licenses.mit;
+    maintainers = with maintainers; [ thubrecht ];
+    mainProgram = "react-jsx-i18n";
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/flask-multipass/default.nix
+++ b/pkgs/development/python-modules/flask-multipass/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "flask-multipass";
+  version = "0.5.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "indico";
+    repo = "flask-multipass";
+    rev = "v${version}";
+    hash = "sha256-mGdynmVE7uZYt0FptDBOtnarOEHC0g/ANWI/Z1YbdaI=";
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+    python3.pkgs.wheel
+  ];
+
+  propagatedBuildInputs = [
+    python3.pkgs.flask
+  ];
+
+  pythonImportsCheck = [ "flask_multipass" ];
+
+  meta = with lib; {
+    description = "Multi-backend authentication system for Flask";
+    homepage = "https://github.com/indico/flask-multipass";
+    changelog = "https://github.com/indico/flask-multipass/blob/${src.rev}/CHANGES.rst";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ thubrecht ];
+    mainProgram = "flask-multipass";
+  };
+}

--- a/pkgs/development/python-modules/flask-pluginengine/default.nix
+++ b/pkgs/development/python-modules/flask-pluginengine/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "flask-pluginengine";
+  version = "0.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "indico";
+    repo = "flask-pluginengine";
+    rev = "v${version}";
+    hash = "sha256-O41z1GYA4pau6UP2rw4aU4SMr3sXsn4yd+yMvVNwT0k=";
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+    python3.pkgs.wheel
+    python3.pkgs.importlib-metadata
+  ];
+
+  propagatedBuildInputs = [
+    python3.pkgs.flask
+  ];
+
+  pythonImportsCheck = [ "flask_pluginengine" ];
+
+  meta = with lib; {
+    description = "Plugin system for Flask applications";
+    homepage = "https://github.com/indico/flask-pluginengine";
+    changelog = "https://github.com/indico/flask-pluginengine/blob/${src.rev}/CHANGES.rst";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ thubrecht ];
+    mainProgram = "flask-pluginengine";
+  };
+}

--- a/pkgs/development/python-modules/flask-webpackext/default.nix
+++ b/pkgs/development/python-modules/flask-webpackext/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, python3
+, fetchFromGitHub
+, pywebpack
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "flask-webpackext";
+  version = "1.0.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "inveniosoftware";
+    repo = "flask-webpackext";
+    rev = "v${version}";
+    hash = "sha256-mwLGhvFzid7SUWQpCNeQyWb4ZZxSI5yic9Nq8AO++YE=";
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+    python3.pkgs.wheel
+    python3.pkgs.pytest-runner
+  ];
+
+  propagatedBuildInputs = [
+    python3.pkgs.flask
+    pywebpack
+  ];
+
+  pythonImportsCheck = [ "flask_webpackext" ];
+
+  meta = with lib; {
+    description = "Webpack integration for Flask";
+    homepage = "https://github.com/inveniosoftware/flask-webpackext";
+    changelog = "https://github.com/inveniosoftware/flask-webpackext/blob/${src.rev}/CHANGES.rst";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ thubrecht ];
+    mainProgram = "flask-webpackext";
+  };
+}

--- a/pkgs/development/python-modules/indico-fonts/default.nix
+++ b/pkgs/development/python-modules/indico-fonts/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, python3
+, fetchPypi
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "indico-fonts";
+  version = "1.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-bwEh+VYRY2ZXjgR2s+KhZWwUexgMb3C8EXhok23KAD0=";
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+    python3.pkgs.wheel
+  ];
+
+  pythonImportsCheck = [ "indico_fonts" ];
+
+  meta = with lib; {
+    description = "Indico - Binary fonts";
+    homepage = "https://pypi.org/project/indico-fonts/";
+    license = with licenses; [ arphicpl ofl wadalab ];
+    maintainers = with maintainers; [ thubrecht ];
+    mainProgram = "indico-fonts";
+  };
+}

--- a/pkgs/development/python-modules/pynpm/default.nix
+++ b/pkgs/development/python-modules/pynpm/default.nix
@@ -1,0 +1,29 @@
+{ lib, python3, fetchFromGitHub, }:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "pynpm";
+  version = "0.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "inveniosoftware";
+    repo = "pynpm";
+    rev = "v${version}";
+    hash = "sha256-GjfylyxPZrRGCLuNZejmTdQGz5JugKHYpVix8WF/8QI=";
+  };
+
+  nativeBuildInputs =
+    [ python3.pkgs.babel python3.pkgs.setuptools python3.pkgs.wheel ];
+
+  pythonImportsCheck = [ "pynpm" ];
+
+  meta = with lib; {
+    description = "Python interface to your NPM and package.json";
+    homepage = "https://github.com/inveniosoftware/pynpm";
+    changelog =
+      "https://github.com/inveniosoftware/pynpm/blob/${src.rev}/CHANGES.rst";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ thubrecht ];
+    mainProgram = "pynpm";
+  };
+}

--- a/pkgs/development/python-modules/pywebpack/default.nix
+++ b/pkgs/development/python-modules/pywebpack/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  fetchpatch,
+  pynpm,
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "pywebpack";
+  version = "unstable-2022-06-26";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "inveniosoftware";
+    repo = "pywebpack";
+    rev = "0ce57fb8445a1697acd74a1dd2902b9de279b48c";
+    hash = "sha256-Pl3WCjsk4bJ0cHlMPAwGvaBMh8m/QnMyXsO0wgV+wKg=";
+  };
+
+  patches =
+    [
+      # npm: change deps merging algorithm
+      (fetchpatch {
+        url = "https://github.com/inveniosoftware/pywebpack/pull/39.patch";
+        hash = "sha256-NN6PBeH4CouyB5X4Uj5hftcshKMserE8U6WdZSDY8rE=";
+      })
+    ];
+
+  nativeBuildInputs = [
+    python3.pkgs.babel
+    python3.pkgs.setuptools
+    python3.pkgs.wheel
+  ];
+
+  propagatedBuildInputs = [ pynpm ];
+
+  pythonImportsCheck = [ "pywebpack" ];
+
+  meta = with lib; {
+    description = "Webpack integration layer for Python";
+    homepage = "https://github.com/inveniosoftware/pywebpack";
+    changelog = "https://github.com/inveniosoftware/pywebpack/blob/${src.rev}/CHANGES.rst";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ thubrecht ];
+    mainProgram = "pywebpack";
+  };
+}

--- a/pkgs/development/python-modules/wtforms-dateutil/default.nix
+++ b/pkgs/development/python-modules/wtforms-dateutil/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "wtforms-dateutil";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "wtforms";
+    repo = "wtforms-dateutil";
+    rev = version;
+    hash = "sha256-k1DZqf2FgyupNvRIIrPLwxbTP5MteCnvASCkpCZRyAE=";
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+    python3.pkgs.wheel
+  ];
+
+  propagatedBuildInputs = [
+    python3.pkgs.python-dateutil
+    python3.pkgs.wtforms
+  ];
+
+  pythonImportsCheck = [ "wtforms_dateutil" ];
+
+  meta = with lib; {
+    description = "WTForms integration for dateutil";
+    homepage = "https://github.com/wtforms/wtforms-dateutil";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ thubrecht ];
+    mainProgram = "wtforms-dateutil";
+  };
+}

--- a/pkgs/development/python-modules/wtforms-sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/wtforms-sqlalchemy/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "wtforms-sqlalchemy";
+  version = "0.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "wtforms";
+    repo = "wtforms-sqlalchemy";
+    rev = version;
+    hash = "sha256-x5fDfdf5BoclShrejNYI9Jt7LZiB9Sm5G3hmWvkWdoY=";
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+    python3.pkgs.wheel
+  ];
+
+  propagatedBuildInputs = [
+    python3.pkgs.sqlalchemy
+    python3.pkgs.wtforms
+  ];
+
+  pythonImportsCheck = [ "wtforms_sqlalchemy" ];
+
+  meta = with lib; {
+    description = "WTForms integration for SQLAlchemy";
+    homepage = "https://github.com/wtforms/wtforms-sqlalchemy";
+    changelog = "https://github.com/wtforms/wtforms-sqlalchemy/blob/${src.rev}/CHANGES.rst";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ thubrecht ];
+    mainProgram = "wtforms-sqlalchemy";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4267,6 +4267,8 @@ self: super: with self; {
 
   flask-mongoengine = callPackage ../development/python-modules/flask-mongoengine { };
 
+  flask-multipass = callPackage ../development/python-modules/flask-multipass { };
+
   flask-mysqldb = callPackage ../development/python-modules/flask-mysqldb { };
 
   flask-openid = callPackage ../development/python-modules/flask-openid { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16759,6 +16759,8 @@ self: super: with self; {
 
   wtforms-bootstrap5 = callPackage ../development/python-modules/wtforms-bootstrap5 { };
 
+  wtforms-dateutil = callPackage ../development/python-modules/wtforms-dateutil { };
+
   wunsen = callPackage ../development/python-modules/wunsen { };
 
   wtf-peewee = callPackage ../development/python-modules/wtf-peewee { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4277,6 +4277,8 @@ self: super: with self; {
 
   flask-paranoid = callPackage ../development/python-modules/flask-paranoid { };
 
+  flask-pluginengine = callPackage ../development/python-modules/flask-pluginengine { };
+
   flask-principal = callPackage ../development/python-modules/flask-principal { };
 
   flask-pymongo = callPackage ../development/python-modules/flask-pymongo { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4323,6 +4323,8 @@ self: super: with self; {
 
   flask-versioned = callPackage ../development/python-modules/flask-versioned { };
 
+  flask-webpackext = callPackage ../development/python-modules/flask-webpackext { };
+
   flask-wtf = callPackage ../development/python-modules/flask-wtf { };
 
   flatbuffers = callPackage ../development/python-modules/flatbuffers {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5687,6 +5687,8 @@ self: super: with self; {
 
   indexed-zstd = callPackage ../development/python-modules/indexed-zstd { inherit (pkgs) zstd; };
 
+  indico-fonts = callPackage ../development/python-modules/indico-fonts { };
+
   infinity = callPackage ../development/python-modules/infinity { };
 
   inflect = callPackage ../development/python-modules/inflect { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12571,6 +12571,8 @@ self: super: with self; {
 
   pyweatherflowudp = callPackage ../development/python-modules/pyweatherflowudp { };
 
+  pywebpack = callPackage ../development/python-modules/pywebpack { };
+
   pywebpush = callPackage ../development/python-modules/pywebpush { };
 
   pywebview = callPackage ../development/python-modules/pywebview { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16761,6 +16761,8 @@ self: super: with self; {
 
   wtforms-dateutil = callPackage ../development/python-modules/wtforms-dateutil { };
 
+  wtforms-sqlalchemy = callPackage ../development/python-modules/wtforms-sqlalchemy { };
+
   wunsen = callPackage ../development/python-modules/wunsen { };
 
   wtf-peewee = callPackage ../development/python-modules/wtf-peewee { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9817,6 +9817,8 @@ self: super: with self; {
 
   pynose = callPackage ../development/python-modules/pynose { };
 
+  pynpm = callPackage ../development/python-modules/pynpm { };
+
   pynuki = callPackage ../development/python-modules/pynuki { };
 
   pynut2 = callPackage ../development/python-modules/pynut2 { };


### PR DESCRIPTION
## Description of changes

Also adds required packages : 
- `react-jsx-i18n`
- `pythonPackages.flask-webpackext`
- `pythonPackages.indico-fonts`
- `pythonPackages.wtforms-sqlalchemy`
- `pythonPackages.wtforms-dateutil`
- `pythonPackages.pywebpack`
- `pythonPackages.flask-pluginengine`
- `pythonPackages.flask-multipass`
- `pythonPackages.pynpm`

For this package to run correctly, we need babel 2.13, which is currently in staging-next.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
