### PR TITLE
vimPlugins.codeium-nvim: use the correct version of codeium

### DIFF
--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -315,16 +315,77 @@
     src = "${nodePackages."@yaegassy/coc-nginx"}/lib/node_modules/@yaegassy/coc-nginx";
   };
 
-  codeium-nvim = super.codeium-nvim.overrideAttrs {
+  codeium-nvim = let
+    # Update according to https://github.com/Exafunction/codeium.nvim/blob/main/lua/codeium/versions.json
+    codeiumVersion = "1.6.7";
+    codeiumHashes = {
+      x86_64-linux = "sha256-z1cZ6xmP25iPezeLpz4xRh7czgx1JLwsYwGAEUA6//I=";
+      aarch64-linux = "sha256-8cSdCiIVbqv91lUMOLV1Xld8KuIzJA5HCIDbhyyc404=";
+      x86_64-darwin = "sha256-pjW7tNyO0cIFdIm69H6I3HDBpFwnJIRmIN7WRi1OfLw=";
+      aarch64-darwin = "sha256-DgE4EVNCM9+YdTVJeVYnrDGAXOJV1VrepiVeX3ziwfg=";
+    };
+
+    codeium' = codeium.overrideAttrs rec {
+      version = codeiumVersion;
+
+      src = let
+        inherit (stdenv.hostPlatform) system;
+        throwSystem = throw "Unsupported system: ${system}";
+
+        platform = {
+          x86_64-linux = "linux_x64";
+          aarch64-linux = "linux_arm";
+          x86_64-darwin = "macos_x64";
+          aarch64-darwin = "macos_arm";
+        }.${system} or throwSystem;
+
+        hash = codeiumHashes.${system} or throwSystem;
+      in fetchurl {
+        name = "codeium-${version}.gz";
+        url = "https://github.com/Exafunction/codeium/releases/download/language-server-v${version}/language_server_${platform}.gz";
+        inherit hash;
+      };
+    };
+
+  in super.codeium-nvim.overrideAttrs {
     dependencies = with self; [ nvim-cmp plenary-nvim ];
     buildPhase = ''
       cat << EOF > lua/codeium/installation_defaults.lua
       return {
         tools = {
-          language_server = "${codeium}/bin/codeium_language_server"
+          language_server = "${codeium'}/bin/codeium_language_server"
         };
       };
       EOF
+    '';
+
+    doCheck = true;
+    checkInputs = [ jq ];
+    checkPhase = ''
+      runHook preCheck
+
+      expected_codeium_version=$(jq -r '.version' lua/codeium/versions.json)
+      actual_codeium_version=$(${codeium'}/bin/codeium_language_server --version)
+
+      expected_codeium_stamp=$(jq -r '.stamp' lua/codeium/versions.json)
+      actual_codeium_stamp=$(${codeium'}/bin/codeium_language_server --stamp | grep STABLE_BUILD_SCM_REVISION | cut -d' ' -f2)
+
+      if [ "$actual_codeium_stamp" != "$expected_codeium_stamp" ]; then
+        echo "
+      The version of codeium patched in vimPlugins.codeium-nvim is incorrect.
+      Expected stamp: $expected_codeium_stamp
+      Actual stamp: $actual_codeium_stamp
+
+      Expected codeium version: $expected_codeium_version
+      Actual codeium version: $actual_codeium_version
+
+      Please, update 'codeiumVersion' in pkgs/applications/editors/vim/plugins/overrides.nix accordingly to:
+      https://github.com/Exafunction/codeium.nvim/blob/main/lua/codeium/versions.json
+        "
+        exit 1
+      fi
+
+      runHook postCheck
     '';
   };
 


### PR DESCRIPTION
## Description of changes

The `codeium-nvim` plugin [seem to require](https://github.com/Exafunction/codeium.nvim/blob/f871000e91faa9ed334da2bfa4eadbf54d0e1047/lua/codeium/update.lua) a [specific version](https://github.com/Exafunction/codeium.nvim/blob/f871000e91faa9ed334da2bfa4eadbf54d0e1047/lua/codeium/versions.json) of codeium in the nvim plugin. For normal (i.e. non-nix) users, this is not too bad, as the plugin itself is in charge of downloading the correct codeium binary.
However, in the nixpkgs version of codeium-nvim, we patch the binary path and set it to the codeium packaged in nixpkgs (which is currently more recent (1.6.16) than what is required by the plugin(1.6.7)).

In this PR, I patch the plugin to use the right version of `codeium`. However, this needs to be manually set when updating the plugins.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
