### PR TITLE
lib: add flake information to lib.trivial

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,8 +9,8 @@
         nixpkgs = self;
       };
 
-      libVersionInfoOverlay = import ./lib/flake-version-info.nix self;
-      lib = (import ./lib).extend libVersionInfoOverlay;
+      libFlakeInfoOverlay = import ./lib/flake-info.nix self;
+      lib = (import ./lib).extend libFlakeInfoOverlay;
 
       forAllSystems = lib.genAttrs lib.systems.flakeExposed;
     in
@@ -72,7 +72,7 @@
       # information rich.
       legacyPackages = forAllSystems (system:
         (import ./. { inherit system; }).extend (final: prev: {
-          lib = prev.lib.extend libVersionInfoOverlay;
+          lib = prev.lib.extend libFlakeInfoOverlay;
         })
       );
 

--- a/lib/flake-info.nix
+++ b/lib/flake-info.nix
@@ -17,6 +17,9 @@ finalLib: prevLib: # lib overlay
       ".${finalLib.substring 0 8 (self.lastModifiedDate or "19700101")}.${self.shortRev or "dirty"}";
     revisionWithDefault = default: self.rev or default;
 
+    # this overrides lib/trivial.nix, in which isFlake is unconditionally set
+    # to false.
+    isFlake = true;
     # This overrides the nixpkgsStorePathString logic in lib/trivial.nix for
     # the special case of flakes, where we are in pure eval mode and thus
     # would not be able to use builtins.storePath to establish a dependency on

--- a/lib/flake-info.nix
+++ b/lib/flake-info.nix
@@ -16,5 +16,16 @@ finalLib: prevLib: # lib overlay
     versionSuffix =
       ".${finalLib.substring 0 8 (self.lastModifiedDate or "19700101")}.${self.shortRev or "dirty"}";
     revisionWithDefault = default: self.rev or default;
+
+    # This overrides the nixpkgsStorePathString logic in lib/trivial.nix for
+    # the special case of flakes, where we are in pure eval mode and thus
+    # would not be able to use builtins.storePath to establish a dependency on
+    # this nixpkgs' sources (https://github.com/NixOS/nix/issues/5868).
+    #
+    # However, in this particular case, due to being used from a flake, we *do*
+    # have a string with context for our own sources in the store in the
+    # `outPath` of the `self` flake input, which we obtain by calling toString
+    # on it.
+    nixpkgsStorePathString = toString self;
   };
 }

--- a/lib/flake.nix
+++ b/lib/flake.nix
@@ -5,6 +5,6 @@
     let
       lib0 = import ./.;
     in {
-      lib = lib0.extend (import ./flake-version-info.nix self);
+      lib = lib0.extend (import ./flake-info.nix self);
     };
 }

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -174,6 +174,17 @@ runTests {
     expected = { x = false; };
   };
 
+  testNixpkgsStorePathString = {
+    # We expect that in all usages, this string will always have context.
+    #
+    # Although pretty much any version of C++Nix has a builtins.getContext,
+    # some alternate Nix implementations do not, and thus this test is
+    # meaningless for them (since they simply scan strings for store paths); it
+    # is thus bypassed in such cases.
+    expr = (builtins ? getContext) -> builtins.getContext trivial.nixpkgsStorePathString != { };
+    expected = true;
+  };
+
 # STRINGS
 
   testConcatMapStrings = {

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -274,6 +274,18 @@ in {
       # Here ../. is not in the store already, so we need to use string interpolation to copy the path to the store.
       "${../.}";
 
+  /* Whether this nixpkgs is being used directly as a flake.
+
+     Note that this is not set for `import nixpkgs` from another flake; it is
+     only set if using `nixpkgs.lib` or the `lib` flake.
+
+     Type: Bool
+   */
+  isFlake =
+    # Note: this is overlayed by lib/flake-info.nix if nixpkgs is used directly
+    # as a flake.
+    false;
+
   /* Determine whether the function is being called from inside a Nix
      shell.
 


### PR DESCRIPTION
## Description of changes

@infinisil

This is a splitting of the now-rewritten lib parts off of https://github.com/NixOS/nixpkgs/pull/254405, with the hopes it will be easier to merge.

This adds `lib.trivial.selfPath` (name subject to discussion) and `lib.isFlake`, implemented via the overlay we use for versions. The purpose of lib.trivial.selfPath is as a way of incurring a dependency on this nixpkgs that is not affected by https://github.com/NixOS/nix/issues/9428. Please see the commit messages for more context

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
