### PR TITLE
abcl: make deterministic and clean up

### DIFF
--- a/pkgs/development/compilers/abcl/default.nix
+++ b/pkgs/development/compilers/abcl/default.nix
@@ -1,39 +1,37 @@
-{ stdenv
-, lib
+{ lib
+, stdenv
+, writeShellScriptBin
 , fetchurl
 , ant
-, jre
 , jdk
+, jre
 , makeWrapper
+, canonicalize-jars-hook
 }:
 
-stdenv.mkDerivation rec {
+let
+  fakeHostname = writeShellScriptBin "hostname" ''
+    echo nix-builder.localdomain
+  '';
+in
+stdenv.mkDerivation (finalAttrs: {
   pname = "abcl";
   version = "1.9.2";
 
   src = fetchurl {
-    url = "https://common-lisp.net/project/armedbear/releases/${version}/${pname}-src-${version}.tar.gz";
-    sha256 = "sha256-Ti9Lj4Xi2V2V5b282foXrWExoX4vzxK8Gf+5e0i8HTg=";
+    url = "https://common-lisp.net/project/armedbear/releases/${finalAttrs.version}/abcl-src-${finalAttrs.version}.tar.gz";
+    hash = "sha256-Ti9Lj4Xi2V2V5b282foXrWExoX4vzxK8Gf+5e0i8HTg=";
   };
-
-  configurePhase = ''
-    runHook preConfigure
-
-    mkdir nix-tools
-    export PATH="$PWD/nix-tools:$PATH"
-    echo "echo nix-builder.localdomain" > nix-tools/hostname
-    chmod a+x nix-tools/*
-
-    hostname
-
-    runHook postConfigure
-  '';
-
-  buildInputs = [ jre ];
 
   # note for the future:
   # if you use makeBinaryWrapper, you will trade bash for glibc, the closure will be slightly larger
-  nativeBuildInputs = [ makeWrapper ant jdk ];
+  nativeBuildInputs = [
+    ant
+    jdk
+    fakeHostname
+    makeWrapper
+    canonicalize-jars-hook
+  ];
 
   buildPhase = ''
     runHook preBuild
@@ -46,13 +44,12 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p "$out"/{bin,share/doc/abcl,lib/abcl}
+    mkdir -p "$out"/{share/doc/abcl,lib/abcl}
     cp -r README COPYING CHANGES examples/  "$out/share/doc/abcl/"
     cp -r dist/*.jar contrib/ "$out/lib/abcl/"
 
     makeWrapper ${jre}/bin/java $out/bin/abcl \
-      --prefix CLASSPATH : $out/lib/abcl/abcl.jar \
-      --prefix CLASSPATH : $out/lib/abcl/abcl-contrib.jar \
+      --add-flags "-classpath $out/lib/abcl/\*" \
       ${lib.optionalString (lib.versionAtLeast jre.version "17")
         # Fix for https://github.com/armedbear/abcl/issues/484
         "--add-flags --add-opens=java.base/java.util.jar=ALL-UNNAMED \\"
@@ -66,9 +63,10 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "A JVM-based Common Lisp implementation";
-    license = lib.licenses.gpl3 ;
+    homepage = "https://common-lisp.net/project/armedbear/";
+    license = lib.licenses.gpl2Classpath;
+    mainProgram = "abcl";
     maintainers = lib.teams.lisp.members;
     platforms = lib.platforms.darwin ++ lib.platforms.linux;
-    homepage = "https://common-lisp.net/project/armedbear/";
   };
-}
+})


### PR DESCRIPTION
## Description of changes

- use `finalAttrs` instead of `rec`
- use `hash` instead of `sha256`
- remove `buildInputs`
- use `writeShellScriptBin` instead of a custom script inside `nix-tools` for faking `hostname`
- use `canonicalize-jars-hook` (related issue: https://github.com/NixOS/nixpkgs/issues/278518)
- set `meta.license` to `gpl2Classpath` (link: https://abcl.org/svn/tags/1.9.2/COPYING)
- set `meta.mainProgram`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
