### PR TITLE
jdepend: make deterministic and clean up

### DIFF
--- a/pkgs/development/tools/analysis/jdepend/default.nix
+++ b/pkgs/development/tools/analysis/jdepend/default.nix
@@ -1,35 +1,58 @@
-{ lib, stdenv, fetchFromGitHub, ant, jdk, runtimeShell }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, ant
+, jdk
+, makeWrapper
+, canonicalize-jars-hook
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "jdepend";
   version = "2.10";
 
   src = fetchFromGitHub {
     owner = "clarkware";
     repo = "jdepend";
-    rev = version;
-    sha256 = "1lxf3j9vflky7a2py3i59q7cwd1zvjv2b88l3za39vc90s04dz6k";
+    rev = finalAttrs.version;
+    hash = "sha256-0/xGgAaJ7TTUHxShJbbcPzTODk4lDn+FOn5St5McrtM=";
   };
 
-  nativeBuildInputs = [ ant jdk ];
-  buildPhase = "ant jar";
+  nativeBuildInputs = [
+    ant
+    jdk
+    makeWrapper
+    canonicalize-jars-hook
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    ant jar
+    runHook postBuild
+  '';
 
   installPhase = ''
-    mkdir -p $out/bin $out/share
-    install dist/${pname}-${version}.jar $out/share
+    runHook preInstall
 
-    cat > "$out/bin/jdepend" <<EOF
-    #!${runtimeShell}
-    exec ${jdk.jre}/bin/java -classpath "$out/share/*" "\$@"
-    EOF
-    chmod a+x $out/bin/jdepend
+    install -Dm644 dist/jdepend-*.jar -t $out/share/jdepend
+
+    makeWrapper ${jdk.jre}/bin/java $out/bin/jdepend \
+        --add-flags "-classpath $out/share/jdepend/jdepend-*.jar"
+
+    for type in "swingui" "textui" "xmlui"; do
+      makeWrapper $out/bin/jdepend $out/bin/jdepend-$type \
+          --add-flags "jdepend.$type.JDepend"
+    done
+
+    runHook postInstall
   '';
 
   meta = with lib; {
+    changelog = "https://github.com/clarkware/jdepend/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     description = "Traverses Java class file directories and generates design quality metrics for each Java package";
     homepage = "http://www.clarkware.com/software/JDepend.html";
     license = licenses.bsd3;
-    platforms = platforms.linux;
     maintainers = with maintainers; [ pSub ];
+    platforms = platforms.linux;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Changes:
- use `finalAttrs` instead of `rec`
- use `hash` instead of `sha256`
- use `canonicalize-jars-hook` (related issue: https://github.com/NixOS/nixpkgs/issues/278518)
- use `makeWrapper` instead of `cat`
- set `meta.changelog`
- add 3 more executables to `$out/bin`
  - `jdepend-swingui` `jdepend-textui` `jdepend-xmlui`
  - originally you had to manually input the class name for the entrypoint you wanted, now you can use these specialized commands to do it shorter
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
