### PR TITLE
ili2c: make deterministic and clean up

### DIFF
--- a/pkgs/tools/misc/ili2c/default.nix
+++ b/pkgs/tools/misc/ili2c/default.nix
@@ -1,30 +1,55 @@
-{ lib, stdenv, fetchFromGitHub, jdk8, ant, makeWrapper, jre8 }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, ant
+, jdk8
+, jre8
+, makeWrapper
+, canonicalize-jars-hook
+}:
 
-let jdk = jdk8; jre = jre8; in
-stdenv.mkDerivation rec {
+let
+  jdk = jdk8;
+  jre = jre8;
+in
+stdenv.mkDerivation (finalAttrs: {
   pname = "ili2c";
-  version = "5.1.1";
+  version = "5.1.1"; # There are newer versions, but they use gradle
 
-  nativeBuildInputs = [ ant jdk makeWrapper ];
+  nativeBuildInputs = [
+    ant
+    jdk
+    makeWrapper
+    canonicalize-jars-hook
+  ];
 
   src = fetchFromGitHub {
     owner = "claeis";
-    repo = pname;
-    rev = "${pname}-${version}";
-    sha256 = "sha256-FHhx+f253+UdbFjd2fOlUY1tpQ6pA2aVu9CBSwUVoKQ=";
+    repo = "ili2c";
+    rev = "ili2c-${finalAttrs.version}";
+    hash = "sha256-FHhx+f253+UdbFjd2fOlUY1tpQ6pA2aVu9CBSwUVoKQ=";
   };
 
-  buildPhase = "ant jar";
+  patches = [
+    # avoids modifying Version.properties file because that would insert the current timestamp into the file
+    ./dont-use-build-timestamp.patch
+  ];
 
-  installPhase =
-    ''
-      mkdir -p $out/share/${pname}
-      cp $build/build/source/build/jar/ili2c.jar $out/share/${pname}
+  buildPhase = ''
+    runHook preBuild
+    ant jar
+    runHook postBuild
+  '';
 
-      mkdir -p $out/bin
-      makeWrapper ${jre}/bin/java $out/bin/ili2c \
-        --add-flags "-jar $out/share/${pname}/ili2c.jar"
-    '';
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 build/jar/ili2c.jar -t $out/share/ili2c
+    makeWrapper ${jre}/bin/java $out/bin/ili2c \
+        --add-flags "-jar $out/share/ili2c/ili2c.jar"
+
+    runHook postInstall
+  '';
 
   meta = with lib; {
     description = "The INTERLIS Compiler";
@@ -34,11 +59,11 @@ stdenv.mkDerivation rec {
     homepage = "https://www.interlis.ch/downloads/ili2c";
     sourceProvenance = with sourceTypes; [
       fromSource
-      binaryBytecode  # source bundles dependencies as jars
+      binaryBytecode # source bundles dependencies as jars
     ];
     license = licenses.lgpl21Plus;
     maintainers = [ maintainers.das-g ];
     platforms = platforms.linux;
     mainProgram = "ili2c";
   };
-}
+})

--- a/pkgs/tools/misc/ili2c/dont-use-build-timestamp.patch
+++ b/pkgs/tools/misc/ili2c/dont-use-build-timestamp.patch
@@ -1,0 +1,29 @@
+diff --git a/build.xml b/build.xml
+index d0493d8..50d4286 100644
+--- a/build.xml
++++ b/build.xml
+@@ -221,11 +221,6 @@
+     </jar>
+   </target>
+   <target depends="init,compile-core,copyres" name="jar-core">
+-    <propertyfile file="${versionfile}">
+-	<!-- <entry  key="versionMicro" type="int" value="1" operation="+"/> -->
+-	<entry  key="versionDate" type="date" value="now" pattern="yyyyMMdd"/>
+-    </propertyfile>
+-
+     <jar jarfile="${build}/jar/${ant.project.name}-core.jar">
+ 	<!-- fileset dir="${build}/classes" excludes="ch/interlis/ili2c/tests/**/*.class" includes="ch/interlis/models/**/*.class,ch/interlis/ili2c/parser/**/*.class,ch/interlis/ili2c/generator/**/*.class,ch/interlis/ili2c/modelscan/**/*.class,ch/interlis/ili2c/metamodel/**/*.class,ch/interlis/ili2c/config/**/*.class,ch/interlis/ili2c/CompilerLogEvent.class,ch/interlis/ili2c/Ili2cException.class,ch/interlis/ili2c/Ili2cFailure.class,ch/interlis/ili2c/gui/UserSettings.class,ch/interlis/ilirepository/ReposManager.class,ch/interlis/ilirepository/impl/RepositoryAccessException.class,ch/interlis/ilirepository/Dataset.class"/--> 
+ 	<fileset dir="${build}/classes-core" excludes="ch/interlis/ili2c/tests/**/*.class" />
+diff --git a/src-core/ch/interlis/ili2c/metamodel/TransferDescription.java b/src-core/ch/interlis/ili2c/metamodel/TransferDescription.java
+index 9e165af..86d8f89 100644
+--- a/src-core/ch/interlis/ili2c/metamodel/TransferDescription.java
++++ b/src-core/ch/interlis/ili2c/metamodel/TransferDescription.java
+@@ -219,7 +219,7 @@ public static final String MIMETYPE_XTF = "application/interlis+xml;version=2.3"
+       ret.append(branch);
+       ret.append('-');
+       }
+-      ret.append(resVersion.getString("versionDate"));
++      ret.append("nixpkgs");
+       version = ret.toString();
+   }
+   return version;


### PR DESCRIPTION
## Description of changes

Changes:
- use `finalAttrs` instead of `rec`
- use `hash` instead of `sha256`
- use `canonicalize-jars-hook` (related issue: https://github.com/NixOS/nixpkgs/issues/278518)
- add patch which makes a `.properties` file deterministic
- remove too many appearances of `pname`
- use `install` instead of `mkdir` and `cp`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
