### PR TITLE
javaCup: make deterministic and clean up

### DIFF
--- a/pkgs/development/libraries/java/cup/default.nix
+++ b/pkgs/development/libraries/java/cup/default.nix
@@ -1,38 +1,56 @@
-{ lib, stdenv, fetchurl, jdk, ant } :
+{ lib
+, stdenv
+, fetchurl
+, ant
+, jdk
+, makeWrapper
+, canonicalize-jars-hook
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "java-cup";
   version = "11b-20160615";
 
   src = fetchurl {
-    url = "http://www2.cs.tum.edu/projects/cup/releases/java-cup-src-${version}.tar.gz";
-    sha256 = "1ymz3plngxclh7x3xr31537rvvak7lwyd0qkmnl1mkj5drh77rz0";
+    url = "http://www2.cs.tum.edu/projects/cup/releases/java-cup-src-${finalAttrs.version}.tar.gz";
+    hash = "sha256-4OdzYG5FzhqorROD5jk9U+2dzyhh5D76gZT1Z+kdv/o=";
   };
 
   sourceRoot = ".";
 
-  nativeBuildInputs = [ jdk ant ];
-
   patches = [ ./javacup-0.11b_beta20160615-build-xml-git.patch ];
 
-  buildPhase = "ant";
+  nativeBuildInputs = [
+    ant
+    jdk
+    makeWrapper
+    canonicalize-jars-hook
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    ant
+    runHook postBuild
+  '';
 
   installPhase = ''
-    mkdir -p $out/{bin,share/{java,java-cup}}
-    cp dist/java-cup-11b.jar $out/share/java-cup/
-    cp dist/java-cup-11b-runtime.jar $out/share/java/
-    cat > $out/bin/javacup <<EOF
-    #! $shell
-    exec ${jdk.jre}/bin/java -jar $out/share/java-cup/java-cup-11b.jar "\$@"
-    EOF
-    chmod a+x $out/bin/javacup
+    runHook preInstall
+
+    install -Dm644 dist/java-cup-11b.jar -t $out/share/java-cup
+    install -Dm644 dist/java-cup-11b-runtime.jar -t $out/share/java
+
+    makeWrapper ${jdk.jre}/bin/java $out/bin/javacup \
+        --add-flags "-jar $out/share/java-cup/java-cup-11b.jar"
+
+    runHook postInstall
   '';
 
   meta = {
-    homepage = "http://www2.cs.tum.edu/projects/cup/";
     description = "LALR parser generator for Java";
+    homepage = "http://www2.cs.tum.edu/projects/cup/";
     license = lib.licenses.mit;
-    platforms = lib.platforms.all;
+    mainProgram = "javacup";
     maintainers = [ lib.maintainers.romildo ];
+    platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Changes:
- use `finalAttrs` instead of `rec`
- use `hash` instead of `sha256`
- use `canonicalize-jars-hook` (related issue: https://github.com/NixOS/nixpkgs/issues/278518)
- use `install` instead of `mkdir` and `cp`
- use `makeWrapper` instead of `cat` and `chmod`
- add `meta.mainProgram`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
