### PR TITLE
javacc: make deterministic and clean up

### DIFF
--- a/pkgs/development/tools/parsing/javacc/default.nix
+++ b/pkgs/development/tools/parsing/javacc/default.nix
@@ -1,39 +1,64 @@
-{ stdenv, lib, fetchFromGitHub, ant, jdk, jre, makeWrapper }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, ant
+, jdk
+, jre
+, makeWrapper
+, canonicalize-jars-hook
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "javacc";
   version = "7.0.13";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
-    rev = "${pname}-${version}";
-    sha256 = "sha256-nDJvKIbJc23Tvfn7Zqvt5tDDffNf4KQ0juGQQCZ+i1c=";
+    owner = "javacc";
+    repo = "javacc";
+    rev = "javacc-${finalAttrs.version}";
+    hash = "sha256-nDJvKIbJc23Tvfn7Zqvt5tDDffNf4KQ0juGQQCZ+i1c=";
   };
 
-  nativeBuildInputs = [ ant jdk makeWrapper ];
+  nativeBuildInputs = [
+    ant
+    jdk
+    makeWrapper
+    canonicalize-jars-hook
+  ];
 
   buildPhase = ''
+    runHook preBuild
     ant jar
+    runHook postBuild
   '';
 
   installPhase = ''
-    mkdir -p $out/target
-    mv scripts $out/bin
-    mv target/javacc.jar $out/target/
-    find -L "$out/bin" -type f -executable -print0 \
-      | while IFS= read -r -d ''' file; do
+    runHook preInstall
+
+    install -Dm644 target/javacc.jar -t $out/target
+    install -Dm755 scripts/{javacc,jjdoc,jjtree,jjrun} -t $out/bin
+
+    for file in $out/bin/*; do
       wrapProgram "$file" --suffix PATH : ${jre}/bin
     done
+
+    runHook postInstall
   '';
 
   doCheck = true;
-  checkPhase = "ant test";
+
+  checkPhase = ''
+    runHook preCheck
+    ant test
+    runHook postCheck
+  '';
 
   meta = with lib; {
-    homepage = "https://javacc.github.io/javacc";
+    changelog = "https://github.com/javacc/javacc/blob/${finalAttrs.src.rev}/docs/release-notes.md";
     description = "A parser generator for building parsers from grammars";
+    homepage = "https://javacc.github.io/javacc";
     license = licenses.bsd2;
+    mainProgram = "javacc";
     maintainers = teams.deshaw.members;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Changes:
- use `finalAttrs` instead of `rec`
- use `pname` less
- use `hash` instead of `sha256`
- use `canonicalize-jars-hook` (related issue: https://github.com/NixOS/nixpkgs/issues/278518)
- use `install` instead of `mkdir` and `mv`
- add `meta.changelog` and `meta.mainProgram`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
