### PR TITLE
pattypan: make deterministic and clean up

### DIFF
--- a/pkgs/applications/misc/pattypan/default.nix
+++ b/pkgs/applications/misc/pattypan/default.nix
@@ -1,60 +1,80 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, jdk
 , ant
+, jdk
 , makeWrapper
+, wrapGAppsHook
 , makeDesktopItem
 , copyDesktopItems
-, glib
-, wrapGAppsHook
+, canonicalize-jars-hook
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "pattypan";
   version = "22.03";
 
   src = fetchFromGitHub {
     owner = "yarl";
     repo = "pattypan";
-    rev = "v${version}";
-    sha256 = "0qmvlcqhqw5k500v2xdakk340ymgv5amhbfqxib5s4db1w32pi60";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-wMQrBg+rEV1W7NgtWFXZr3pAxpyqdbEBKLNwDDGju2I=";
   };
 
-  nativeBuildInputs = [ copyDesktopItems jdk ant makeWrapper wrapGAppsHook ];
-  buildInputs = [ glib jdk ];
+  nativeBuildInputs = [
+    ant
+    jdk
+    makeWrapper
+    wrapGAppsHook
+    copyDesktopItems
+    canonicalize-jars-hook
+  ];
+
+  dontWrapGApps = true;
+
+  env.JAVA_TOOL_OPTIONS = "-Dfile.encoding=UTF8"; # needed for jdk versions below jdk19
 
   buildPhase = ''
     runHook preBuild
-    export JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
     ant
     runHook postBuild
   '';
 
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/bin $out/share/java
-    cp pattypan.jar $out/share/java/pattypan.jar
-    makeWrapper ${jdk}/bin/java $out/bin/pattypan \
-      --add-flags "-cp $out/share/java/pattypan.jar pattypan.Launcher"
+    install -Dm644 pattypan.jar -t $out/share/pattypan
+    install -Dm644 src/pattypan/resources/logo.png $out/share/pixmaps/pattypan.png
     runHook postInstall
+  '';
+
+  # gappsWrapperArgs is set in preFixup
+  postFixup = ''
+    makeWrapper ${jdk}/bin/java $out/bin/pattypan \
+        ''${gappsWrapperArgs[@]} \
+        --add-flags "-jar $out/share/pattypan/pattypan.jar"
   '';
 
   desktopItems = [
     (makeDesktopItem {
+      name = "pattypan";
+      exec = "pattypan";
+      icon = "pattypan";
       desktopName = "Pattypan";
       genericName = "An uploader for Wikimedia Commons";
       categories = [ "Utility" ];
-      exec = "pattypan";
-      name = "pattypan";
     })
   ];
 
   meta = with lib; {
-    homepage = "https://commons.wikimedia.org/wiki/Commons:Pattypan";
     description = "An uploader for Wikimedia Commons";
+    homepage = "https://commons.wikimedia.org/wiki/Commons:Pattypan";
     license = licenses.mit;
-    platforms = [ "x86_64-linux" ];
+    mainProgram = "pattypan";
     maintainers = with maintainers; [ fee1-dead ];
+    platforms = platforms.all;
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode # source bundles dependencies as jars
+    ];
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Changes:
- use `finalAttrs` instead of `rec`
- use `hash` instead of `sha256`
- use `canonicalize-jars-hook` (related issue: https://github.com/NixOS/nixpkgs/issues/278518)
- remove `buildInputs`
- install icon for `.desktop` file
- use `dontWrapGApps = true;` (`gappsWrapperArgs` are provided manually)
- add `meta.mainProgram`, and `meta.sourceProvenance`
- update `meta.platforms`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
