### PR TITLE
i3 documentation fix

### DIFF
--- a/nixos/modules/services/x11/window-managers/i3.nix
+++ b/nixos/modules/services/x11/window-managers/i3.nix
@@ -16,6 +16,9 @@ in
       description = lib.mdDoc ''
         Path to the i3 configuration file.
         If left at the default value, $HOME/.i3/config will be used.
+
+        To pass in derivation paths from nix,
+        use pkgs.writeTextFile rather than builtins.toFile to provide this path.
       '';
     };
 


### PR DESCRIPTION
Confuses noobs like myself as to why they cannot pass in a derivation path

## Description of changes

I changed the documentation for 1 option to be more noob friendly.