### PR TITLE
{ungoogled-,}chromium: 120.0.6099.129 -> 120.0.6099.199, improve and move `recompressTarball`

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/README.md
+++ b/pkgs/applications/networking/browsers/chromium/README.md
@@ -39,16 +39,6 @@ update `upstream-info.nix`. After updates it is important to test at least
 `nixosTests.chromium` (or basic manual testing) and `google-chrome` (which
 reuses `upstream-info.nix`).
 
-Note: Due to the script downloading many large tarballs it might be
-necessary to adjust the available tmpfs size (it defaults to 10% of the
-systems memory)
-
-```nix
-services.logind.extraConfig = ''
-  RuntimeDirectorySize=4G
-'';
-```
-
 Note: The source tarball is often only available a few hours after the release
 was announced. The CI/CD status can be tracked here:
 - https://ci.chromium.org/p/infra/builders/cron/publish_tarball

--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -59,6 +59,7 @@ let
           inherit (upstream-info.deps.gn) url rev hash;
         };
       });
+      recompressTarball = callPackage ./recompress-tarball.nix { };
     });
 
     browser = callPackage ./browser.nix {

--- a/pkgs/applications/networking/browsers/chromium/recompress-tarball.nix
+++ b/pkgs/applications/networking/browsers/chromium/recompress-tarball.nix
@@ -1,0 +1,47 @@
+{ zstd
+, fetchurl
+}:
+
+{ version
+, hash ? ""
+, ...
+} @ args:
+
+fetchurl ({
+  name = "chromium-${version}.tar.zstd";
+  url = "https://commondatastorage.googleapis.com/chromium-browser-official/chromium-${version}.tar.xz";
+  inherit hash;
+
+  # chromium xz tarballs are multiple gigabytes big and are sometimes downloaded multiples
+  # times for different versions as part of our update script.
+  # We originally inherited fetchzip's default for downloadToTemp (true).
+  # Given the size of the /run/user tmpfs used defaults to logind's RuntimeDirectorySize=,
+  # which in turn defaults to 10% of the total amount of physical RAM, this often lead to
+  # "no space left" errors, eventually resulting in its own section in our chromium
+  # README.md (for users wanting to run the update script).
+  # Nowadays, we use fetchurl instead of fetchzip, which defaults to false instead of true.
+  # We just want to be explicit and provide a place to document the history and reasoning
+  # behind this.
+  downloadToTemp = false;
+
+  nativeBuildInputs = [ zstd ];
+
+  postFetch = ''
+    cat "$downloadedFile" \
+    | xz -d --threads=$NIX_BUILD_CORES \
+    | tar xf - \
+      --warning=no-timestamp \
+      --one-top-level=source \
+      --exclude=third_party/llvm \
+      --exclude=third_party/rust-src \
+      --strip-components=1
+
+    tar \
+      --use-compress-program "zstd -T$NIX_BUILD_CORES" \
+      --sort name \
+      --mtime "1970-01-01" \
+      --owner=root --group=root \
+      --numeric-owner --mode=go=rX,u+rw,a-s \
+      -cf $out source
+  '';
+} // removeAttrs args [ "version" ])

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -28,12 +28,12 @@
         version = "2023-10-23";
       };
       ungoogled-patches = {
-        hash = "sha256-kVhAa/+RnYEGy7McysqHsb3ysPIILnxGXe6BTLbioQk=";
-        rev = "120.0.6099.129-1";
+        hash = "sha256-B1MNo8BdjMOmTvIr4uu3kg/MO1t+YLQz2S23L4Cye3E=";
+        rev = "120.0.6099.199-1";
       };
     };
-    hash = "sha256-6RURdPU1k3GaQAgA1LMQ0NhSGBEpOEJBPvk2QjLdoHo=";
-    hash_deb_amd64 = "sha256-0FB1gTbsjqFRy0ocE0w5ACtD9kSJ5AMnxg+qBxqCulc=";
-    version = "120.0.6099.129";
+    hash = "sha256-lT1CCwYj0hT4tCJb689mZwNecUsEwcfn2Ot8r9LBT+M=";
+    hash_deb_amd64 = "sha256-4BWLn0+gYNWG4DsolbY6WlTvXWl7tZIZrnqXlrGUGjQ=";
+    version = "120.0.6099.199";
   };
 }

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -15,7 +15,7 @@
         version = "2023-10-23";
       };
     };
-    hash = "sha256-+T2TOLwIwFxVDae7MFDZrjREGF+3Zx2xt/Dlu7uZggc=";
+    hash = "sha256-6RURdPU1k3GaQAgA1LMQ0NhSGBEpOEJBPvk2QjLdoHo=";
     hash_deb_amd64 = "sha256-0FB1gTbsjqFRy0ocE0w5ACtD9kSJ5AMnxg+qBxqCulc=";
     version = "120.0.6099.129";
   };
@@ -32,7 +32,7 @@
         rev = "120.0.6099.129-1";
       };
     };
-    hash = "sha256-+T2TOLwIwFxVDae7MFDZrjREGF+3Zx2xt/Dlu7uZggc=";
+    hash = "sha256-6RURdPU1k3GaQAgA1LMQ0NhSGBEpOEJBPvk2QjLdoHo=";
     hash_deb_amd64 = "sha256-0FB1gTbsjqFRy0ocE0w5ACtD9kSJ5AMnxg+qBxqCulc=";
     version = "120.0.6099.129";
   };

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -15,9 +15,9 @@
         version = "2023-10-23";
       };
     };
-    hash = "sha256-6RURdPU1k3GaQAgA1LMQ0NhSGBEpOEJBPvk2QjLdoHo=";
-    hash_deb_amd64 = "sha256-0FB1gTbsjqFRy0ocE0w5ACtD9kSJ5AMnxg+qBxqCulc=";
-    version = "120.0.6099.129";
+    hash = "sha256-lT1CCwYj0hT4tCJb689mZwNecUsEwcfn2Ot8r9LBT+M=";
+    hash_deb_amd64 = "sha256-4BWLn0+gYNWG4DsolbY6WlTvXWl7tZIZrnqXlrGUGjQ=";
+    version = "120.0.6099.199";
   };
   ungoogled-chromium = {
     deps = {


### PR DESCRIPTION
## Description of changes

Please refer to the commit message for details about `recompressTarball`.

https://chromereleases.googleblog.com/2024/01/stable-channel-update-for-desktop.html

This update includes 6 security fixes.

CVEs:
CVE-2024-0222 CVE-2024-0223 CVE-2024-0224 CVE-2024-0225

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
