### PR TITLE
python311Packages.jupyter related packages updates 2024-01-04

### DIFF
--- a/pkgs/development/python-modules/jupyter-core/default.nix
+++ b/pkgs/development/python-modules/jupyter-core/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "jupyter-core";
-  version = "5.5.1";
+  version = "5.7.0";
   disabled = pythonOlder "3.7";
 
   pyproject = true;
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "jupyter";
     repo = "jupyter_core";
     rev = "refs/tags/v${version}";
-    hash = "sha256-X8yBh63JYIuIatLtJU0pOD8Oz/QpJShU0R2VGAgPAa4=";
+    hash = "sha256-y3a2pSk+6QNSVg0skosbf6uHSXpvMubyflP6jQleI44=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/jupyter-server/default.nix
+++ b/pkgs/development/python-modules/jupyter-server/default.nix
@@ -34,14 +34,14 @@
 
 buildPythonPackage rec {
   pname = "jupyter-server";
-  version = "2.12.1";
-  format = "pyproject";
+  version = "2.12.2";
+  pyproject = true;
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     pname = "jupyter_server";
     inherit version;
-    hash = "sha256-3He33MX8BUesuisoRPAXmACGZyAe6ifGMZ/5JX1wCm0=";
+    hash = "sha256-Xq6GvhUiS1N1zewMNULOcv8g96JSl6KoFmolC7RVpRk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/jupyter-sphinx/default.nix
+++ b/pkgs/development/python-modules/jupyter-sphinx/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , hatchling
 , ipykernel
 , ipython
@@ -9,6 +9,7 @@
 , nbformat
 , pythonOlder
 , sphinx
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
@@ -18,10 +19,11 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.8";
 
-  src = fetchPypi {
-    inherit version;
-    pname = "jupyter_sphinx";
-    hash = "sha256-LiNpmjoc9dsxsQmB2lqjJgbucw9rc6hE0edtgAdWr1Y=";
+  src = fetchFromGitHub {
+    owner = "jupyter";
+    repo = "jupyter-sphinx";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-o/i3WravKZPf7uw2H4SVYfAyaZGf19ZJlkmeHCWcGtE=";
   };
 
   nativeBuildInputs = [
@@ -37,12 +39,26 @@ buildPythonPackage rec {
     sphinx
   ];
 
-  doCheck = false;
+  pythonImportsCheck = [
+    "jupyter_sphinx"
+  ];
+
+  env.JUPYTER_PLATFORM_DIRS = 1;
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  __darwinAllowLocalNetworking = true;
 
   meta = with lib; {
     description = "Jupyter Sphinx Extensions";
     homepage = "https://github.com/jupyter/jupyter-sphinx/";
+    changelog = "https://github.com/jupyter/jupyter-sphinx/releases/tag/${src.rev}";
     license = licenses.bsd3;
   };
-
 }

--- a/pkgs/development/python-modules/jupyter-sphinx/default.nix
+++ b/pkgs/development/python-modules/jupyter-sphinx/default.nix
@@ -1,29 +1,43 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, nbformat
-, sphinx
+, hatchling
+, ipykernel
+, ipython
 , ipywidgets
-, pythonOlder
 , nbconvert
+, nbformat
+, pythonOlder
+, sphinx
 }:
 
 buildPythonPackage rec {
   pname = "jupyter-sphinx";
-  version = "0.4.0";
-  format = "setuptools";
+  version = "0.5.3";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit version;
     pname = "jupyter_sphinx";
-    hash = "sha256-DBGjjxNDE48sUFHA00xMVF9EgBdMG9QcAlb+gm4LqlU=";
+    hash = "sha256-LiNpmjoc9dsxsQmB2lqjJgbucw9rc6hE0edtgAdWr1Y=";
   };
 
-  propagatedBuildInputs = [ nbconvert nbformat sphinx ipywidgets ];
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    ipykernel
+    ipython
+    ipywidgets
+    nbconvert
+    nbformat
+    sphinx
+  ];
 
   doCheck = false;
-
-  disabled = pythonOlder "3.5";
 
   meta = with lib; {
     description = "Jupyter Sphinx Extensions";

--- a/pkgs/development/python-modules/jupyterlab/default.nix
+++ b/pkgs/development/python-modules/jupyterlab/default.nix
@@ -19,14 +19,14 @@
 
 buildPythonPackage rec {
   pname = "jupyterlab";
-  version = "4.0.9";
+  version = "4.0.10";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-nrraQdUmUfYjwMnwad24oh1oSOTIh9jl3cBhMWbtXAs=";
+    hash = "sha256-Rhd+uO3nDcc76SKsmfjvlDvcLfvGoxs1PEvehIo13uE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/nbconvert/default.nix
+++ b/pkgs/development/python-modules/nbconvert/default.nix
@@ -32,14 +32,14 @@ let
   };
 in buildPythonPackage rec {
   pname = "nbconvert";
-  version = "7.13.1";
+  version = "7.14.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-Lcgmfb3+7c4tzTTJ4/G1GvGPQ8sQVUnRxaGBiewjuoU=";
+    hash = "sha256-krmkS2Plp/tPb6DvQSYeNcFpJQRszRwEpcgJm/EAR24=";
   };
 
   # Add $out/share/jupyter to the list of paths that are used to search for


### PR DESCRIPTION
## Description of changes

Update jupyter-related packages at once to avoid building hundreds of packages over and over again.

This PR is based on the commits generated by the following command.

```
nix search nixpkgs python311Packages 'ipython|jupyter' --json | jq -r 'keys | .[]' | cut -d . -f 3,4 | xargs -n 1 nix-update --commit
```


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
