### PR TITLE
nixos/invidious: fix typo on option name

### DIFF
--- a/nixos/modules/services/web-apps/invidious.nix
+++ b/nixos/modules/services/web-apps/invidious.nix
@@ -155,8 +155,9 @@ let
           to  work, the username used to connect to PostgreSQL must match the database name, that is
           services.invidious.settings.db.user must match services.invidious.settings.db.dbname.
           This is the default since NixOS 24.05. For older systems, it is normally safe to manually set
-          services.invidious.db.user to "invidious" as the new user will be created with permissions
-          for the existing database. `REASSIGN OWNED BY kemal TO invidious;` may also be needed.
+          services.invidious.settings.db.user to "invidious" as the new user will be created with
+          permissions for the existing database. `REASSIGN OWNED BY kemal TO invidious;` may also be
+          needed.
         '';
       }
     ];

--- a/nixos/modules/services/web-apps/invidious.nix
+++ b/nixos/modules/services/web-apps/invidious.nix
@@ -155,7 +155,7 @@ let
           to  work, the username used to connect to PostgreSQL must match the database name, that is
           services.invidious.settings.db.user must match services.invidious.settings.db.dbname.
           This is the default since NixOS 24.05. For older systems, it is normally safe to manually set
-          services.invidious.database.user to "invidious" as the new user will be created with permissions
+          services.invidious.db.user to "invidious" as the new user will be created with permissions
           for the existing database. `REASSIGN OWNED BY kemal TO invidious;` may also be needed.
         '';
       }


### PR DESCRIPTION
## Description of changes

This is just a change in the documentation; the comment is correct but the suggested change is incorrect (the option is named "db", not "database").

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
