### PR TITLE
folly: split outputs to reduce closure sizes w/ cmake fixup

### DIFF
--- a/pkgs/development/libraries/folly/default.nix
+++ b/pkgs/development/libraries/folly/default.nix
@@ -4,7 +4,6 @@
 , boost
 , cmake
 , double-conversion
-, fetchpatch
 , fmt_8
 , gflags
 , glog
@@ -64,12 +63,21 @@ stdenv.mkDerivation rec {
     # temporary hack until folly builds work on aarch64,
     # see https://github.com/facebook/folly/issues/1880
     "-DCMAKE_LIBRARY_ARCHITECTURE=${if stdenv.isx86_64 then "x86_64" else "dummy"}"
+
+    # ensure correct dirs in $dev/lib/pkgconfig/libfolly.pc
+    # see https://github.com/NixOS/nixpkgs/issues/144170
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
   ];
 
+  # split outputs to reduce downstream closure sizes
+  outputs = [ "out" "dev" ];
+
+  # patch prefix issues again
+  # see https://github.com/NixOS/nixpkgs/issues/144170
   postFixup = ''
-    substituteInPlace "$out"/lib/pkgconfig/libfolly.pc \
-      --replace '=''${prefix}//' '=/' \
-      --replace '=''${exec_prefix}//' '=/'
+    substituteInPlace $dev/lib/cmake/${pname}/${pname}-targets-release.cmake  \
+      --replace '$'{_IMPORT_PREFIX}/lib/ $out/lib/
   '';
 
   # folly-config.cmake, will `find_package` these, thus there should be


### PR DESCRIPTION
## Description of changes

This shaves off a 100MiB+ `boost.dev` dependence from `folly.out`, which would benefit all downstream packages that dynamically link to folly.

Before:
```console
$ nix path-info -rsh nixpkgs#watchman | sort -hk2 -r | head -5
/nix/store/h1r04r2cay50i5k96b3miw27v8r9zwkr-boost-1.81.0-dev       	 145.1M
/nix/store/l77dphhwcw7j5k5kqxw1rqxbvhszgaw7-icu4c-73.2             	  37.7M
/nix/store/9y8pmvk8gdwwznmkzxa6pwyah52xy3nk-glibc-2.38-27          	  28.8M
/nix/store/9w9ndv9n74qid65gglh9h127mh4ndba8-boost-1.81.0           	  14.0M
/nix/store/bjmm3lshlbv99rx8mldnbb1yzhl2kya2-folly-2023.02.27.00    	  13.4M
```
After:
```console
$ nix path-info -rsh .#watchman | sort -hk2 -r | head -5
/nix/store/l77dphhwcw7j5k5kqxw1rqxbvhszgaw7-icu4c-73.2             	  37.7M
/nix/store/9y8pmvk8gdwwznmkzxa6pwyah52xy3nk-glibc-2.38-27          	  28.8M
/nix/store/9w9ndv9n74qid65gglh9h127mh4ndba8-boost-1.81.0           	  14.0M
/nix/store/dghjv6hfz0s0z4kffa5ahyw2mhp79215-gcc-12.3.0-lib         	   7.5M
/nix/store/xqidf03vlwb6paj02s23j8g77f1wag0k-watchman-2023.08.14.00 	   6.7M
```

Fixes #248660.

## Technical issues

Upstream's cmake configuration is not suitable for split packages, and some tweaks are needed for it to work; these are taken from:

- https://github.com/NixOS/nixpkgs/commit/04384d56cf6d88bf6fd5fd74b0a39b312b104d42
- https://github.com/NixOS/nixpkgs/commit/8d712ccc161b11323e92e87e7057e461462d50e0

See the tracking issue:
- https://github.com/NixOS/nixpkgs/issues/144170
- and also: https://github.com/jtojnar/cmake-snips


**Update:** turns out this will be a mass rebuild, re-targeted towards `staging`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
