### PR TITLE
bulloak: 0.5.4 -> 0.6.1

### DIFF
--- a/pkgs/by-name/bu/bulloak/package.nix
+++ b/pkgs/by-name/bu/bulloak/package.nix
@@ -1,23 +1,54 @@
 { lib
 , fetchFromGitHub
 , rustPlatform
+, fetchurl
+, stdenv
+, darwin
 }:
 
+let
+  # svm-rs-builds requires a list of solc versions to build, and would make network calls if not provided.
+  # The ethereum project does not provide static binaries for aarch64, so we use separate sources, the same as in
+  # svm-rs's source code.
+  solc-versions = {
+    x86_64-linux = fetchurl {
+      url = "https://raw.githubusercontent.com/ethereum/solc-bin/60de887187e5670c715931a82fdff6677b31f0cb/linux-amd64/list.json";
+      hash = "sha256-zm1cdqSP4Y9UQcq9OV8sXxnzr3+TWdc7mdg+Do8Y7WY=";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://raw.githubusercontent.com/ethereum/solc-bin/60de887187e5670c715931a82fdff6677b31f0cb/macosx-amd64/list.json";
+      hash = "sha256-uUdd5gCG7SHQgAW2DQXemTujb8bUJM27J02WjLkQgek=";
+    };
+    aarch64-linux = fetchurl {
+      url = "https://raw.githubusercontent.com/nikitastupin/solc/923ab4b852fadc00ffe87bb76fff21d0613bd280/linux/aarch64/list.json";
+      hash = "sha256-mJaEN63mR3XdK2FmEF+VhLR6JaCCtYkIRq00wYH6Xx8=";
+    };
+    aarch64-darwin = fetchurl {
+      url = "https://raw.githubusercontent.com/alloy-rs/solc-builds/260964c1fcae2502c0139070bdc5c83eb7036a68/macosx/aarch64/list.json";
+      hash = "sha256-xrtb3deMDAuDIjzN1pxm5NyW5NW5OyoOHTFsYyWJCYY=";
+    };
+  };
+in
 rustPlatform.buildRustPackage rec {
   pname = "bulloak";
-  version = "0.5.4";
+  version = "0.6.1";
 
   src = fetchFromGitHub {
     owner = "alexfertel";
     repo = "bulloak";
     rev = "v${version}";
-    hash = "sha256-lUTMQMBqCezuUsfvuYSCBFsokoY3bPoJDGWL90EjVqY=";
+    hash = "sha256-0pzn0gXlhdndCpsrVRNxl1ylIE/S9A0l8VjNn5wDVvw=";
   };
 
-  cargoHash = "sha256-LH96e/dBbv4J7g7wzh3/vL+PzZn779zUMBgio6w3rJw=";
+  cargoHash = "sha256-IlDbys5uluLm418UkGf+FIM1AfR2IBAZQ4Atqlybajw=";
+
+  buildInputs = lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.SystemConfiguration ];
 
   # tests run in CI on the source repo
   doCheck = false;
+
+  # provide the list of solc versions to the `svm-rs-builds` dependency
+  SVM_RELEASES_LIST_JSON = solc-versions.${stdenv.hostPlatform.system};
 
   meta = with lib; {
     description = "A Solidity test generator based on the Branching Tree Technique";


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/alexfertel/bulloak/blob/main/CHANGELOG.md

Newer versions added a dependency to `forge-fmt` which requires `svm-rs-builds` which in turn needs a JSON file with existing releases of the solidity compiler. This is normally fetched at build time by the rust compiler, but can be overriden with the `SVM_RELEASES_LIST_JSON` environment variable. As such, the correct file is now retrieved by the derivation and provided through this environment variable.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
