### PR TITLE
visidata: 2.11.1 -> 3.0

### DIFF
--- a/pkgs/applications/misc/visidata/default.nix
+++ b/pkgs/applications/misc/visidata/default.nix
@@ -45,13 +45,13 @@
 }:
 buildPythonApplication rec {
   pname = "visidata";
-  version = "2.11.1";
+  version = "3.0";
 
   src = fetchFromGitHub {
     owner = "saulpw";
     repo = "visidata";
     rev = "v${version}";
-    hash = "sha256-A8iYFdW30Em5pjGn3DRpaV0A7ixwfSzmIp8AgtPkBCI=";
+    hash = "sha256-LALWQu7BgMbAEyOXUE3p6bXhdx8h6jPEvjs/TEtf/wU==";
   };
 
   propagatedBuildInputs = [
@@ -70,6 +70,7 @@ buildPythonApplication rec {
     pyshp
     #mapbox-vector-tile
     pypng
+    #pyconll
     fonttools
     #sas7bdat
     #xport
@@ -114,10 +115,15 @@ buildPythonApplication rec {
 
   checkPhase = ''
     runHook preCheck
+
     # disable some tests which require access to the network
     rm -f tests/load-http.vd            # http
     rm -f tests/graph-cursor-nosave.vd  # http
     rm -f tests/messenger-nosave.vd     # dns
+
+    # tests to disable because we don't have a package to load such files
+    rm -f tests/load-conllu.vdj         # no 'pyconll'
+    rm -f tests/load-sav.vd             # no 'savReaderWriter'
 
     # tests use git to compare outputs to references
     git init -b "test-reference"


### PR DESCRIPTION
## Description of changes

The changelog can be found here: https://github.com/saulpw/visidata/blob/v3.0/CHANGELOG.md

Note: I had to disable the `conllu` and `sav` tests because the respective python packages `pyconll` and `savReaderWriter` are not packaged in nixpkgs and I am not deep enough into both python and the nix side to package them easily.

That means visidata will NOT be able to load those files :(

Fixes: https://github.com/NixOS/nixpkgs/issues/278482

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
