### PR TITLE
sbclPackages.cl-autowrap: compile cl-autowrap/libffi

### DIFF
--- a/pkgs/development/lisp-modules/patches/cl-autowrap-c2ffi-path.patch
+++ b/pkgs/development/lisp-modules/patches/cl-autowrap-c2ffi-path.patch
@@ -1,0 +1,13 @@
+diff --git a/autowrap/c2ffi.lisp b/autowrap/c2ffi.lisp
+index f24fb88..0aa9edd 100644
+--- a/autowrap/c2ffi.lisp
++++ b/autowrap/c2ffi.lisp
+@@ -60,7 +60,7 @@
+ 
+  ;; c2ffi
+ 
+-(defvar *c2ffi-program* "c2ffi")
++(defvar *c2ffi-program* "@c2ffi@")
+ 
+ (defvar *trace-c2ffi* nil)
+ 

--- a/pkgs/development/lisp-modules/ql.nix
+++ b/pkgs/development/lisp-modules/ql.nix
@@ -283,6 +283,13 @@ let
     vk = super.vk.overrideLispAttrs (o: {
       nativeLibs = [ pkgs.vulkan-loader ];
     });
+    cl-autowrap = super.cl-autowrap.overrideLispAttrs (o: {
+      asds = [ "cl-autowrap" "cl-plus-c" ];
+      systems = [ "cl-autowrap" "cl-autowrap/libffi" "cl-plus-c" ];
+      nativeLibs = [ pkgs.libffi ];
+      propagatedBuildInputs = [ pkgs.c2ffiHook ];
+    });
+    cl-plus-c = self.cl-autowrap;
   });
 
   qlpkgs =

--- a/pkgs/development/lisp-modules/ql.nix
+++ b/pkgs/development/lisp-modules/ql.nix
@@ -288,6 +288,12 @@ let
       systems = [ "cl-autowrap" "cl-autowrap/libffi" "cl-plus-c" ];
       nativeLibs = [ pkgs.libffi ];
       propagatedBuildInputs = [ pkgs.c2ffiHook ];
+      patches = [
+        (pkgs.substituteAll {
+          src = ./patches/cl-autowrap-c2ffi-path.patch;
+          c2ffi = "${pkgs.c2ffi}/bin/c2ffi";
+        })
+      ];
     });
     cl-plus-c = self.cl-autowrap;
   });

--- a/pkgs/development/tools/misc/c2ffi/c2ffi-wrapper.sh
+++ b/pkgs/development/tools/misc/c2ffi/c2ffi-wrapper.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec @c2ffi@ $@ -I . -i @libc@/include -i @clang@/resource-root/include $NIX_C2FFI_FLAGS

--- a/pkgs/development/tools/misc/c2ffi/default.nix
+++ b/pkgs/development/tools/misc/c2ffi/default.nix
@@ -3,6 +3,7 @@
 , cmake
 , llvmPackages_16
 , unstableGitUpdater
+, c2ffiHook
 }:
 
 let
@@ -33,11 +34,23 @@ llvmPackages.stdenv.mkDerivation {
     cmake
   ];
 
+  propagatedBuildInputs = [ c2ffiHook ];
+
   buildInputs = [
     llvmPackages.llvm
     llvmPackages.clang
     llvmPackages.libclang
   ];
+
+  postInstall = ''
+    mv $out/bin/c2ffi $out/bin/.c2ffi-wrapped
+    export c2ffi=$out/bin/.c2ffi-wrapped
+    export libc=${llvmPackages.stdenv.cc.libc.dev}
+    export clang=${llvmPackages.stdenv.cc}
+
+    substituteAll ${./c2ffi-wrapper.sh} $out/bin/c2ffi
+    chmod a+x $out/bin/c2ffi
+  '';
 
   # This isn't much, but...
   doInstallCheck = true;

--- a/pkgs/development/tools/misc/c2ffi/setup-hook.sh
+++ b/pkgs/development/tools/misc/c2ffi/setup-hook.sh
@@ -1,0 +1,13 @@
+addC2ffiDep() {
+    local role_post
+    getHostRoleEnvHook
+
+    if [ -d "$1/include" ]; then
+        export NIX_C2FFI_FLAGS+=" -i $1/include"
+    fi
+}
+
+getTargetRole
+getTargetRoleWrapper
+
+addEnvHooks "$targetOffset" addC2ffiDep

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19319,6 +19319,9 @@ with pkgs;
   swigWithJava = swig;
 
   c2ffi = callPackage ../development/tools/misc/c2ffi { };
+  c2ffiHook = makeSetupHook {
+    name = "c2ffi-hook";
+  } ../development/tools/misc/c2ffi/setup-hook.sh;
 
   c0 = callPackage ../development/compilers/c0 {
     stdenv = if stdenv.isDarwin then gccStdenv else stdenv;


### PR DESCRIPTION
## Description of changes

To do so, the system is added and libffi native dep is included.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
