### PR TITLE
build-rust-crate: Allow missing `hostPlatform.extensions.sharedLibrary`

### DIFF
--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -51,7 +51,7 @@
     # configure & source common build functions
     LIB_RUSTC_OPTS="${libRustcOpts}"
     BIN_RUSTC_OPTS="${binRustcOpts}"
-    LIB_EXT="${stdenv.hostPlatform.extensions.sharedLibrary}"
+    LIB_EXT="${stdenv.hostPlatform.extensions.sharedLibrary or ""}"
     LIB_PATH="${libPath}"
     LIB_NAME="${libName}"
 


### PR DESCRIPTION
If you cross-build, sharedLibrary might not be set. E.g. for this nixpkgs instance:

```nix
pkgs = import <nixpkgs> {
    config = { };
    crossSystem = {
        config = "riscv32-unknown-none-elf";
        rustc = {
            config = "riscv32i-unknown-none-elf";
        };
    };
}
```

## Description of changes

Assume `""` if shared library extension is not given to make code not crash if we are cross-compiling.

This has been done for a while in this `crate2nix` test:

https://github.com/nix-community/crate2nix/blob/6ad412164795165f98a6238d7c460bcb0e39dc2f/sample_projects/empty_cross/default.nix#L33

## Things done

Generally, all platforms which set `extensions.sharedLibrary` should not even need to be rebuilt.

- Built on platform `crate2nix` as a test crate that used the function on
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
