### PR TITLE
kodiPackages.pvr-vdr-vnsi: init at 20.4.1

### DIFF
--- a/pkgs/applications/video/kodi/addons/pvr-vdr-vnsi/default.nix
+++ b/pkgs/applications/video/kodi/addons/pvr-vdr-vnsi/default.nix
@@ -1,0 +1,23 @@
+{ lib, rel, buildKodiBinaryAddon, fetchFromGitHub, libGL }:
+buildKodiBinaryAddon rec {
+  pname = "pvr-vdr-vnsi";
+  namespace = "pvr.vdr.vnsi";
+  version = "20.4.1";
+
+  src = fetchFromGitHub {
+    owner = "kodi-pvr";
+    repo = "pvr.vdr.vnsi";
+    rev = "${version}-${rel}";
+    sha256 = "sha256-QooWK+LwlN5RAISjAQ2YiyDAjQQMzod8fFXpI0ll+hc=";
+  };
+
+  extraBuildInputs = [ libGL ];
+
+  meta = with lib; {
+    homepage = "https://github.com/kodi-pvr/pvr.vdr.vnsi";
+    description = "Kodi's VDR VNSI PVR client addon";
+    platforms = platforms.all;
+    license = licenses.gpl2Only;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -106,6 +106,8 @@ let self = rec {
 
   pvr-iptvsimple = callPackage ../applications/video/kodi/addons/pvr-iptvsimple { };
 
+  pvr-vdr-vnsi = callPackage ../applications/video/kodi/addons/pvr-vdr-vnsi { };
+
   osmc-skin = callPackage ../applications/video/kodi/addons/osmc-skin { };
 
   vfs-libarchive = callPackage ../applications/video/kodi/addons/vfs-libarchive { };


### PR DESCRIPTION
## Description of changes

Add [pvr.vdr.vnsi](https://github.com/kodi-pvr/pvr.vdr.vnsi) as `kodiPackages` 

This is used as an alternative pvr backend to `tvheadend`

Had this working on kodi for about 4 month now without issues.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
