### PR TITLE
nixos/nextcloud: add backup & restore scripts

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27029,6 +27029,11 @@
     githubId = 5356506;
     name = "Tricia Tan";
   };
+  triton = {
+    github = "Triton171";
+    githubId = 16193831;
+    name = "Daniel Ebert";
+  };
   trobert = {
     email = "thibaut.robert@gmail.com";
     github = "trobert";

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -71,6 +71,15 @@
   "module-services-tandoor-recipes-migrating-media-option-2": [
     "index.html#module-services-tandoor-recipes-migrating-media-option-2"
   ],
+  "module-services-nextcloudBackup": [
+    "index.html#module-services-nextcloudBackup"
+  ],
+  "module-services-nextcloudBackup-backup": [
+    "index.html#module-services-nextcloudBackup-backup"
+  ],
+  "module-services-nextcloudBackup-restore": [
+    "index.html#module-services-nextcloudBackup-restore"
+  ],
   "sec-override-nixos-test": [
     "index.html#sec-override-nixos-test"
   ],

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1682,6 +1682,7 @@
   ./services/web-apps/moodle.nix
   ./services/web-apps/movim.nix
   ./services/web-apps/netbox.nix
+  ./services/web-apps/nextcloud-backup/default.nix
   ./services/web-apps/nextcloud-notify_push.nix
   ./services/web-apps/nextcloud-whiteboard-server.nix
   ./services/web-apps/nextcloud.nix

--- a/nixos/modules/services/web-apps/nextcloud-backup/backup.sh
+++ b/nixos/modules/services/web-apps/nextcloud-backup/backup.sh
@@ -1,0 +1,75 @@
+# Nextcloud backup script, based on https://docs.nextcloud.com/server/latest/admin_manual/maintenance/backup.html.
+if [ "$(id -un)" != "nextcloud" ] ;then
+  echo "This script has to be run as the nextcloud user, aborting."
+  exit 1
+fi
+if [ ! -d "$BACKUP_DIR" ] ;then
+  echo "The backup directory '$BACKUP_DIR' does not exist, aborting."
+  exit 1
+fi
+
+echo "Enabling maintenance mode..."
+nextcloud-occ maintenance:mode --on
+echo "Copying config and manually installed apps..."
+mkdir -p "$BACKUP_DIR/nextcloud-backup"
+rsync -rlt --del --perms "$NEXTCLOUD_DATADIR/config/config.php" "$BACKUP_DIR/nextcloud-backup"
+rsync -rlt --del --perms "$NEXTCLOUD_HOME/store-apps" "$BACKUP_DIR/nextcloud-backup"
+echo "Copying data directory..."
+rsync -rlt --del --perms "$NEXTCLOUD_DATADIR/data" "$BACKUP_DIR/nextcloud-backup"
+
+echo "Dumping $NEXTCLOUD_DBTYPE database..."
+if [ ! "$NEXTCLOUD_DBPASS_FILE" = "" ] ;then
+  NEXTCLOUD_DBPASS=$(cat "$NEXTCLOUD_DBPASS_FILE")
+else
+  NEXTCLOUD_DBPASS=""
+fi
+if [ "$NEXTCLOUD_DBTYPE" = "sqlite" ] ;then
+  DB_BACKUP_NAME="database-sqlite.bak"
+  sqlite3 "$NEXTCLOUD_DATADIR/data/$NEXTCLOUD_DBNAME.db" .dump > "$BACKUP_DIR/nextcloud-backup/$DB_BACKUP_NAME"
+elif [ "$NEXTCLOUD_DBTYPE" = "pgsql" ] ;then
+  DB_BACKUP_NAME="database-pgsql.bak"
+  args=(
+    -h "$NEXTCLOUD_DBHOST"
+    -U "$NEXTCLOUD_DBUSER"
+    --no-password -F custom
+    -f "$BACKUP_DIR/nextcloud-backup/$DB_BACKUP_NAME"
+    "$NEXTCLOUD_DBNAME"
+  )
+  PGPASSWORD="$NEXTCLOUD_DBPASS" pg_dump "${args[@]}"
+elif [ "$NEXTCLOUD_DBTYPE" = "mysql" ] ;then
+  DB_BACKUP_NAME="database-mysql.bak"
+  args=(
+    -h "$NEXTCLOUD_DBHOST"
+    -u "$NEXTCLOUD_DBUSER"
+  )
+  if [ ! "$NEXTCLOUD_DBPASS" = "" ] ;then
+    args+=(-p "$NEXTCLOUD_DBPASS")
+  fi
+  args+=(
+    --add-drop-table
+    --single-transaction
+    "$NEXTCLOUD_DBNAME"
+  )
+  mysqldump "${args[@]}" > "$BACKUP_DIR/nextcloud-backup/$DB_BACKUP_NAME"
+fi
+
+echo "Disabling maintenance mode..."
+nextcloud-occ maintenance:mode --off
+jq --null-input \
+  "{time: \"$(date --rfc-3339=seconds)\", nextcloudVersion: \"$NEXTCLOUD_VERSION\", databaseType: \"$NEXTCLOUD_DBTYPE\"}" \
+  > "$BACKUP_DIR/nextcloud-backup/metadata.json"
+
+# Check that the backup seems complete
+for f in \
+  "$BACKUP_DIR/nextcloud-backup/config.php" \
+  "$BACKUP_DIR/nextcloud-backup/$DB_BACKUP_NAME" \
+  "$BACKUP_DIR/nextcloud-backup/store-apps" \
+  "$BACKUP_DIR/nextcloud-backup/data"
+do
+  if [ ! -e "$f" ] ;then
+    echo "Did not find file $f."
+    echo "It looks like the backup is incomplete, aborting."
+    exit 1
+  fi
+done
+echo "Successfully created backup in $BACKUP_DIR/nextcloud-backup."

--- a/nixos/modules/services/web-apps/nextcloud-backup/default.nix
+++ b/nixos/modules/services/web-apps/nextcloud-backup/default.nix
@@ -1,0 +1,107 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.nextcloudBackup;
+  nextcloudCfg = config.services.nextcloud;
+  runtimeInputs = [
+    pkgs.coreutils
+    pkgs.rsync
+    pkgs.jq
+    nextcloudCfg.occ
+  ]
+  ++ (
+    if nextcloudCfg.config.dbtype == "sqlite" then
+      [ pkgs.sqlite ]
+    else if nextcloudCfg.config.dbtype == "pgsql" then
+      [ config.services.postgresql.package ]
+    else if nextcloudCfg.config.dbtype == "mysql" then
+      [ config.services.mysql.package ]
+    else
+      throw "Unknown nextcloud database type ${nextcloudCfg.config.dbtype}"
+  );
+  runtimeEnv = {
+    "NEXTCLOUD_VERSION" = nextcloudCfg.package.version;
+    "NEXTCLOUD_DBTYPE" = nextcloudCfg.config.dbtype;
+    "NEXTCLOUD_DBHOST" =
+      if nextcloudCfg.config.dbtype == "mysql" && nextcloudCfg.database.createLocally then
+        "localhost"
+      else
+        nextcloudCfg.config.dbhost;
+    "NEXTCLOUD_DBNAME" = nextcloudCfg.config.dbname;
+    "NEXTCLOUD_DBUSER" = nextcloudCfg.config.dbuser;
+    "NEXTCLOUD_DBPASS_FILE" = lib.optionalString (
+      nextcloudCfg.config.dbpassFile != null
+    ) nextcloudCfg.config.dbpassFile;
+    "NEXTCLOUD_DATADIR" = nextcloudCfg.datadir;
+    "NEXTCLOUD_HOME" = nextcloudCfg.home;
+    "BACKUP_DIR" = lib.optionalString (cfg.backupDir != null) cfg.backupDir;
+  };
+  bashOptions = [
+    "errtrace"
+    "errexit"
+    "nounset"
+    "pipefail"
+  ];
+  backupScript = pkgs.writeShellApplication {
+    name = "nextcloud-backup";
+    inherit runtimeInputs runtimeEnv bashOptions;
+    text = builtins.readFile ./backup.sh;
+  };
+  restoreScript = pkgs.writeShellApplication {
+    name = "nextcloud-restore";
+    inherit runtimeInputs runtimeEnv bashOptions;
+    text = builtins.readFile ./restore.sh;
+  };
+in
+{
+  options.services.nextcloudBackup = {
+    enable = lib.mkEnableOption "nextcloud backup/restore scripts";
+    backupDir = lib.mkOption {
+      type = with lib.types; nullOr str;
+      default = null;
+      description = ''
+        The directory in which the Nextcloud backup will be stored.
+      '';
+      example = "/var/lib/backups";
+    };
+    restoreScript = lib.mkOption {
+      type = lib.types.package;
+      default = restoreScript;
+      defaultText = lib.literalMD "generated script";
+      description = ''
+        A script that restores the Nextcloud instance from a given backup (has to be run as root).
+        This option can be used to reference the script in the NixOS configuration and should usually not be changed.
+      '';
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.backupDir != null;
+        message = "In order to enable nextcloud backups, `services.nextcloudBackup.backupDir` must be set";
+      }
+    ];
+    systemd.services = {
+      nextcloud-backup = {
+        script = "${lib.getExe backupScript}";
+        serviceConfig = {
+          # Required to use nextcloud-occ
+          inherit (config.systemd.services.nextcloud-cron.serviceConfig)
+            User
+            LoadCredential
+            KillMode
+            ;
+        };
+      };
+    };
+    environment.systemPackages = [
+      cfg.restoreScript
+    ];
+  };
+  meta.doc = ./nextcloud-backup.md;
+  meta.maintainers = [ lib.maintainers.triton ];
+}

--- a/nixos/modules/services/web-apps/nextcloud-backup/nextcloud-backup.md
+++ b/nixos/modules/services/web-apps/nextcloud-backup/nextcloud-backup.md
@@ -1,0 +1,52 @@
+# Nextcloud backup/restore {#module-services-nextcloudBackup}
+
+A module to backup up and restore a
+[nextcloud instance](#module-services-nextcloud).
+In order to use the module, add the following snippet
+to your NixOS configuration:
+```nix
+{
+  services.nextcloudBackup = {
+    enable = true;
+    # Replace this by the folder where you want to store the backups
+    backupDir = "/var/lib/backups";
+  };
+}
+```
+
+## Backing up the instance {#module-services-nextcloudBackup-backup}
+
+Running the systemd service `nextcloud-backup.service`
+creates a backup of the nextcloud instance in a folder
+`nextcloud-backup` under `services.nextcloudBackup.backupDir`.
+Note that for the duration of the backup, the nextcloud instance
+will be put in maintenance mode. Any subsequent runs will only
+copy files that changed since the last backup, so they will usually
+be much faster.
+
+Since the backup is created on the same machine and neither
+versioned nor compressed, it is recommended to combine this
+with another backup tool. For example, if a restic backup
+is set up via `services.restic.backups.nextcloud`, you can
+add the following snippet to your configuration to always run
+the nextcloud backup script before:
+```nix
+{
+  systemd.services.restic-backups-nextcloud = {
+    requires = [ "nextcloud-backup.service" ];
+    after = [ "nextcloud-backup.service" ];
+  };
+}
+```
+
+## Restoring a backup {#module-services-nextcloudBackup-restore}
+
+If you need to restore the nextcloud instance, first ensure
+that you have a working nextcloud installation with the correct
+version and database type (see the `metadata.json` file in the backup).
+Then, run `nextcloud-restore /path/to/backup/` if the backup is contained
+in `/path/to/backup/nextcloud-backup`. WARNING: This will delete
+all the data of the installed nextcloud instance and replace it
+by the data in the backup.
+
+

--- a/nixos/modules/services/web-apps/nextcloud-backup/restore.sh
+++ b/nixos/modules/services/web-apps/nextcloud-backup/restore.sh
@@ -1,0 +1,110 @@
+# Nextcloud restore script, based on https://docs.nextcloud.com/server/latest/admin_manual/maintenance/restore.html.
+if [ "$#" != "1" ] || [ "$1" = "-h" ] || [ "$1" = "--help" ] ;then
+  echo "Usage: nextcloud-restore BACKUP_DIR"
+  echo "Restore the backup contained in BACKUP_DIR/nextcloud-backup."
+  echo "Note that this requires a working nextcloud installation which will then be overwritten."
+  exit 1
+fi
+if [ "$(id -u)" != "0" ] ;then
+  echo "This script has to be run as root, aborting."
+  exit 1
+fi
+BACKUP_DIR="$1"
+
+# Read backup metadata
+METADATA_FILE="$BACKUP_DIR/nextcloud-backup/metadata.json"
+NEXTCLOUD_MAJOR_VERSION=$(echo "$NEXTCLOUD_VERSION" | jq --raw-input --raw-output '. / "." | .[0] | tonumber')
+BACKUP_NEXTCLOUD_MAJOR_VERSION=$(jq '.nextcloudVersion / "." | .[0] | tonumber' "$METADATA_FILE")
+BACKUP_NEXTCLOUD_DBTYPE=$(jq --raw-output '.databaseType' "$METADATA_FILE")
+# A few sanity checks to make sure that it's possible to restore the backup.
+if [ ! "$BACKUP_NEXTCLOUD_MAJOR_VERSION" = "$NEXTCLOUD_MAJOR_VERSION" ] ;then
+  echo "The backup is for Nextcloud $BACKUP_NEXTCLOUD_MAJOR_VERSION but Nextcloud $NEXTCLOUD_VERSION is installed."
+  echo "Please change to Nextcloud $BACKUP_NEXTCLOUD_MAJOR_VERSION before restoring (and then possibly upgrade), aborting."
+  exit 1
+fi
+if [ ! "$BACKUP_NEXTCLOUD_DBTYPE" = "$NEXTCLOUD_DBTYPE" ] ;then
+  echo "The backup is for the database $BACKUP_NEXTCLOUD_DBTYPE but the current installation uses $NEXTCLOUD_DBTYPE, aborting."
+  exit 1
+fi
+
+# Check that the backup seems complete
+if [ "$NEXTCLOUD_DBTYPE" = "sqlite" ] ;then
+  DB_BACKUP_NAME="database-sqlite.bak"
+elif [ "$NEXTCLOUD_DBTYPE" = "pgsql" ]; then
+  DB_BACKUP_NAME="database-pgsql.bak"
+elif [ "$NEXTCLOUD_DBTYPE" = "mysql" ]; then
+  DB_BACKUP_NAME="database-mysql.bak"
+fi
+for f in \
+  "$BACKUP_DIR/nextcloud-backup/config.php" \
+  "$BACKUP_DIR/nextcloud-backup/$DB_BACKUP_NAME" \
+  "$BACKUP_DIR/nextcloud-backup/store-apps" \
+  "$BACKUP_DIR/nextcloud-backup/data"
+do
+  if [ ! -e "$f" ] ;then
+    echo "Did not find file $f."
+    echo "It looks like the backup is incomplete, aborting."
+    exit 1
+  fi
+done
+
+if [ ! -e "$NEXTCLOUD_DATADIR/config/override.config.php" ] ;then
+  echo "Expected to find the file $NEXTCLOUD_DATADIR/config/override.config.php but it seems to be missing."
+  echo "It appears that nextcloud has not been set up correctly, aborting."
+  exit 1
+fi
+printf "WARNING: Restoring the backup will overwrite the current nextcloud instance. Continue? (y/n):"
+read -r answer
+if [ "$answer" = "${answer#[Yy]}" ] ;then
+    echo "Restore cancelled, aborting."
+    exit 1
+fi
+
+echo "Enabling maintenance mode..."
+nextcloud-occ maintenance:mode --on
+echo "Restoring config and manually installed apps..."
+rsync -rlt --del --perms --chmod=u+rwX --chown=nextcloud:nextcloud "$BACKUP_DIR/nextcloud-backup/config.php" "$NEXTCLOUD_DATADIR/config/"
+rsync -rlt --del --perms --chmod=u+rwX --chown=nextcloud:nextcloud "$BACKUP_DIR/nextcloud-backup/store-apps" "$NEXTCLOUD_HOME"
+echo "Restoring data directory..."
+rsync -rlt --del --perms --chmod=u+rwX --chown=nextcloud:nextcloud "$BACKUP_DIR/nextcloud-backup/data" "$NEXTCLOUD_DATADIR"
+echo "Restoring $NEXTCLOUD_DBTYPE database..."
+if [ "$NEXTCLOUD_DBPASS_FILE" != "" ] ;then
+  NEXTCLOUD_DBPASS=$(cat "$NEXTCLOUD_DBPASS_FILE")
+else
+  NEXTCLOUD_DBPASS=""
+fi
+if [ "$NEXTCLOUD_DBTYPE" = "sqlite" ] ;then
+  if [ -e "$NEXTCLOUD_DATADIR/data/$NEXTCLOUD_DBNAME.db" ] ;then
+    rm "$NEXTCLOUD_DATADIR/data/$NEXTCLOUD_DBNAME.db"
+  fi
+  sqlite3 "$NEXTCLOUD_DATADIR/data/$NEXTCLOUD_DBNAME.db" < "$BACKUP_DIR/nextcloud-backup/$DB_BACKUP_NAME"
+  chown nextcloud:nextcloud "$NEXTCLOUD_DATADIR/data/$NEXTCLOUD_DBNAME.db"
+  chmod u+rw "$NEXTCLOUD_DATADIR/data/$NEXTCLOUD_DBNAME.db"
+elif [ "$NEXTCLOUD_DBTYPE" = "pgsql" ] ;then
+  args=(
+    -h "$NEXTCLOUD_DBHOST"
+    -U "$NEXTCLOUD_DBUSER"
+    --no-password
+    --clean --if-exists
+    -d "$NEXTCLOUD_DBNAME"
+    "$BACKUP_DIR/nextcloud-backup/$DB_BACKUP_NAME"
+  )
+  PGPASSWORD="$NEXTCLOUD_DBPASS" sudo -E -u nextcloud pg_restore "${args[@]}"
+elif [ "$NEXTCLOUD_DBTYPE" = "mysql" ] ;then
+  args=(
+    -h "$NEXTCLOUD_DBHOST"
+    -u "$NEXTCLOUD_DBUSER"
+  )
+  if [ ! "$NEXTCLOUD_DBPASS" = "" ] ;then
+    args+=(-p "$NEXTCLOUD_DBPASS")
+  fi
+  args+=("$NEXTCLOUD_DBNAME")
+  # Shellcheck prints a warning that this reads the backup file as the root and not as the nextcloud user
+  # shellcheck disable=SC2024
+  sudo -u nextcloud mysql "${args[@]}" < "$BACKUP_DIR/nextcloud-backup/$DB_BACKUP_NAME"
+fi
+echo "Disabling maintenance mode..."
+nextcloud-occ maintenance:mode --off
+echo "Nextcloud backup successfully restored."
+echo "If the backup was not very recent, it might make sense to run \"nextcloud-occ maintenance:data-fingerprint\"."
+echo "See https://docs.nextcloud.com/server/latest/admin_manual/maintenance/restore.html#synchronising-with-clients-after-data-recovery for more information."


### PR DESCRIPTION
## Description of changes

Added backup & restore scripts to the `services.nextcloud` module. Since correctly backing up the entire state of an instance can be complicated and depends on the configuration of the instance (e.g. database config, data directory), I think it makes sense to include this in the module.

The scripts are mainly based on the [Nextcloud documentation](https://docs.nextcloud.com/server/latest/admin_manual/maintenance/backup.html). In order to make it easy to integrate it into different backup tools, the backup script doesn't do any compression, deduplication or versioning: Most people will probably want to use something like Restic or BorgBackup which does this anyways and otherwise one can simply call `tar` after `nextcloud-backup`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
