### PR TITLE
signal-desktop: 6.42.1 -> 6.43.1; signal-desktop-beta: 6.43.0-beta.1 -> 6.44.0-beta.1

### DIFF
--- a/pkgs/applications/networking/instant-messengers/signal-desktop/generic.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/generic.nix
@@ -187,7 +187,7 @@ in stdenv.mkDerivation rec {
     homepage = "https://signal.org/";
     changelog = "https://github.com/signalapp/Signal-Desktop/releases/tag/v${version}";
     license = lib.licenses.agpl3Only;
-    maintainers = with lib.maintainers; [ mic92 equirosa urandom bkchr ];
+    maintainers = with lib.maintainers; [ eclairevoyant mic92 equirosa urandom bkchr ];
     mainProgram = pname;
     platforms = [ "x86_64-linux" "aarch64-linux" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/signal-desktop-beta.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/signal-desktop-beta.nix
@@ -2,7 +2,7 @@
 callPackage ./generic.nix {} rec {
   pname = "signal-desktop-beta";
   dir = "Signal Beta";
-  version = "6.43.0-beta.1";
+  version = "6.44.0-beta.1";
   url = "https://updates.signal.org/desktop/apt/pool/s/signal-desktop-beta/signal-desktop-beta_${version}_amd64.deb";
-  hash = "sha256-7UlfpOWAalJjZjAJLa2CL3HdR2LFlE1/5sdec5Sj/tg=";
+  hash = "sha256-SW/br1k7lO0hQngST0qV9Qol1hA9f1NZe86A5uyYhcI=";
 }

--- a/pkgs/applications/networking/instant-messengers/signal-desktop/signal-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/signal-desktop/signal-desktop.nix
@@ -2,7 +2,7 @@
 callPackage ./generic.nix {} rec {
   pname = "signal-desktop";
   dir = "Signal";
-  version = "6.42.1";
+  version = "6.43.1";
   url = "https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-  hash = "sha256-6X2+kvqijNq2KsWQ9o4+y2ACDfAd6eeNqVqpDOoqZgs=";
+  hash = "sha256-mDxZFs+rI2eHkkvkmflras1WqBa/HBVBDpdk9NKaC2E=";
 }


### PR DESCRIPTION
## Description of changes

- signal-desktop: 6.42.1 -> 6.43.1
- signal-desktop-beta: 6.43.0-beta.1 -> 6.44.0-beta.1
- add self to maintainers

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
