### PR TITLE
fitsverify: init at 4.22

### DIFF
--- a/pkgs/by-name/fi/fitsverify/package.nix
+++ b/pkgs/by-name/fi/fitsverify/package.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenv
+, fetchurl
+, cfitsio
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fitsverify";
+  version = "4.22";
+
+  src = fetchurl {
+    url = "https://heasarc.gsfc.nasa.gov/docs/software/ftools/fitsverify/fitsverify-${finalAttrs.version}.tar.gz";
+    hash = "sha256-bEXoA6fg7by30TkYYVuuY2HSszPCkrhJxQnsm+vbGLQ=";
+  };
+
+  buildInputs = [
+    cfitsio
+  ];
+
+  # See build instructions in the README file in src.
+  buildPhase = ''
+    $CC -o fitsverify ftverify.c fvrf_data.c fvrf_file.c fvrf_head.c \
+       fvrf_key.c fvrf_misc.c -DSTANDALONE \
+       $NIX_CFLAGS_COMPILE \
+       -lcfitsio
+  '';
+
+  installPhase = ''
+    install -D fitsverify $out/bin/fitsverify
+  '';
+
+  meta = with lib; {
+    description = "FITS File Format-Verification Tool";
+    longDescription = ''
+      Fitsverify is a computer program that rigorously checks whether a FITS
+      (Flexible Image Transport System) data file conforms to all the
+      requirements defined in Version 3.0 of the FITS Standard document.
+    '';
+    homepage = "https://heasarc.gsfc.nasa.gov/docs/software/ftools/fitsverify/";
+    license = licenses.mit;
+    platforms = with platforms; linux;
+    maintainers = with maintainers; [ panicgh ];
+  };
+})


### PR DESCRIPTION
## Description of changes

FITS File Format-Verification Tool

See:
* https://heasarc.gsfc.nasa.gov/docs/software/ftools/fitsverify/
* https://repology.org/project/fitsverify/information

FITS is an image file format for astronomy. I manually tested the functionality of fitsverify with a local fits file.

I add the backport label, since it is a new package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (via `pkgsCross.aarch64-multiplatform`)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>fitsverify</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
