### PR TITLE
mdbook-i18n-helpers: 0.2.4 -> 0.3.0

### DIFF
--- a/pkgs/tools/text/mdbook-i18n-helpers/default.nix
+++ b/pkgs/tools/text/mdbook-i18n-helpers/default.nix
@@ -5,16 +5,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "mdbook-i18n-helpers";
-  version = "0.2.4";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "mdbook-i18n-helpers";
-    rev = "refs/tags/${version}";
-    hash = "sha256-TxSALv/uqRFdv4JZ8BCiAlirMcizGRkw0YxMCBVkgo4=";
+    # TODO fix once upstream uses semver for tags again
+    rev = "refs/tags/mdbook-i18n-helpers-${version}";
+    hash = "sha256-oS1U76BgTW+YnhyLPRTlIg03RR9s5oybFIdCm3MVkvc=";
   };
 
-  cargoHash = "sha256-BhaSK2A/z05a75dEx8c4RHKau1HRJabOcQ6/eLvcdio=";
+  cargoHash = "sha256-bDv6pJTFs6U5vnWy5vcLv28Mjf7zrepsfs+JCu00xkA=";
 
   meta = with lib; {
     description = "Helpers for a mdbook i18n workflow based on Gettext";


### PR DESCRIPTION
## Description of changes
https://github.com/google/mdbook-i18n-helpers/releases/tag/mdbook-i18n-helpers-0.3.0

Breaking change: This release changes how code blocks are treated
> This is a breaking change: if you translate strings and comments in your code blocks, then you should [run mdbook-i18n-normalize](https://github.com/google/mdbook-i18n-helpers/blob/mdbook-i18n-helpers-0.3.0/i18n-helpers/USAGE.md) to migrate them automatically!

Upstream seems to have messed up the git tag, that's why this release was not picked up by nixpkgs-update until now. Let's see if their next tag follows semver again.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
