### PR TITLE
scalpel: init at 2.1

### DIFF
--- a/pkgs/by-name/sc/scalpel/package.nix
+++ b/pkgs/by-name/sc/scalpel/package.nix
@@ -1,0 +1,56 @@
+{ lib
+, fetchFromGitHub
+, stdenv
+, autoconf
+, automake
+, libtool
+, tre
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "scalpel";
+  version = "2.1";
+
+  src = fetchFromGitHub {
+    owner = "sleuthkit";
+    repo = "scalpel";
+    rev = "35e1367ef2232c0f4883c92ec2839273c821dd39";
+    hash = "sha256-0lqU1CAcWXNw9WFa29BXla1mvABlzWV+hcozZyfR0oE=";
+  };
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
+    tre
+  ];
+
+  postPatch = ''
+    sed -i \
+      -e 's|#define\s*SCALPEL_DEFAULT_CONFIG_FILE\s.*"scalpel.conf"|#define SCALPEL_DEFAULT_CONFIG_FILE "${placeholder "out"}/share/scalpel/scalpel.conf"|' \
+      src/scalpel.h
+  '';
+
+  env.CXXFLAGS = "-std=c++14" + lib.optionalString  stdenv.cc.isClang " -Wno-error=reserved-user-defined-literal";
+
+  preConfigure = ''
+    ./bootstrap
+  '';
+
+  configureFlags = [
+    "--with-pic"
+  ];
+
+  postInstall = ''
+    install -Dm644 scalpel.conf -t $out/share/scalpel/
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/sleuthkit/scalpel";
+    description = "Recover files based on their headers, footers and internal data structures, based on Foremost";
+    mainProgram = "scalpel";
+    maintainers = with maintainers; [ shard7 ];
+    platforms = platforms.unix;
+    license = with licenses; [ asl20 ];
+  };
+})


### PR DESCRIPTION
## Description of changes
Scalpel - A file carving and indexing application. It recover files based on their headers, footers and internal data structures, the tool is based on Foremost.

See:
- https://repology.org/project/scalpel/information
- https://github.com/sleuthkit/scalpel

Added the backport label, since this is a new package.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
