### PR TITLE
tuxpaint: 0.9.28 -> 0.9.31, refactor

### DIFF
--- a/pkgs/by-name/sd/SDL2_Pango/package.nix
+++ b/pkgs/by-name/sd/SDL2_Pango/package.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, freetype
+, pango
+, SDL2
+, darwin
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sdl2-pango";
+  version = "2.1.5";
+
+  src = fetchFromGitHub {
+    owner = "markuskimius";
+    repo = "SDL2_Pango";
+    rev = "v${version}";
+    hash = "sha256-8SL5ylxi87TuKreC8m2kxlLr8rcmwYYvwkp4vQZ9dkc=";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    SDL2
+  ];
+
+  buildInputs = [
+    freetype
+    pango
+    SDL2
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.libobjc
+  ];
+
+  meta = with lib; {
+    description = "A library for graphically rendering internationalized and tagged text in SDL2 using TrueType fonts";
+    homepage = "https://github.com/markuskimius/SDL2_Pango";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ rardiol ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/games/tuxpaint/default.nix
+++ b/pkgs/games/tuxpaint/default.nix
@@ -1,37 +1,92 @@
-{ lib, stdenv, fetchurl, SDL, SDL_gfx, SDL_image, SDL_ttf, SDL_mixer, libpng
-, libimagequant, cairo, librsvg, gettext, libpaper, fribidi, pkg-config, gperf
+{ lib
+, stdenv
+, fetchurl
+, gettext
+, gperf
 , imagemagick
+, makeWrapper
+, pkg-config
+, SDL2
+, cairo
+, freetype
+, fribidi
+, libimagequant
+, libpaper
+, libpng
+, librsvg
+, pango
+, SDL2_gfx
+, SDL2_image
+, SDL2_mixer
+, SDL2_Pango
+, SDL2_ttf
+, netpbm
 }:
 
+let
+  stamps = fetchurl {
+    url = "mirror://sourceforge/project/tuxpaint/tuxpaint-stamps/2023-07-20/tuxpaint-stamps-2023.07.20.tar.gz";
+    hash = "sha256-D7QgYXRRdZpN3Ni/4lXoXCtsJORT+T2hHaLUFpgDeEI=";
+  };
+in
 stdenv.mkDerivation rec {
-  version = "0.9.28";
+  version = "0.9.31";
   pname = "tuxpaint";
 
   src = fetchurl {
-    url = "mirror://sourceforge/tuxpaint/${version}/${pname}-${version}-sdl1.tar.gz";
-    sha256 = "sha256-b4Ru9GqyGf2jMmM24szGXO2vbSxCwvPmA6tgEUWhhos=";
+    url = "mirror://sourceforge/tuxpaint/${version}/tuxpaint-${version}.tar.gz";
+    hash = "sha256-GoXAT6XJrms//Syo+oaoTAyLRitQWfofwsRFtc+oV+4=";
   };
 
-  nativeBuildInputs = [
-    SDL SDL_gfx SDL_image SDL_ttf SDL_mixer libpng cairo libimagequant librsvg
-    gettext libpaper fribidi pkg-config gperf imagemagick
+  patches = [
+    ./tuxpaint-completion.diff
   ];
-  hardeningDisable = [ "format" ];
-  makeFlags = [ "GPERF=${gperf}/bin/gperf"
-                "PREFIX=$$out"
-                "COMPLETIONDIR=$$out/share/bash-completion/completions"
-              ];
 
-  patches = [ ./tuxpaint-completion.diff ];
   postPatch = ''
-    grep -Zlr include.*SDL . | xargs -0 sed -i -e 's,"SDL,"SDL/SDL,'
+    grep -Zlr include.*SDL . | xargs -0 \
+      sed -i -E \
+        -e 's,"(SDL2?_?[a-zA-Z]*.h),"SDL2/\1,' \
+        -e 's,SDL2/SDL2_Pango.h,SDL2_Pango.h,'
   '';
 
-  # stamps
-  stamps = fetchurl {
-    url = "mirror://sourceforge/project/tuxpaint/tuxpaint-stamps/2022-06-04/tuxpaint-stamps-2022.06.04.tar.gz";
-    sha256 = "sha256-hCBlV2+uVUNY4A5R1xpJJhamSQsStZIigGdHfCh6C/g=";
-  };
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    gettext
+    gperf
+    imagemagick
+    makeWrapper
+    pkg-config
+    SDL2
+  ];
+
+  buildInputs = [
+    cairo
+    freetype
+    fribidi
+    libimagequant
+    libpaper
+    libpng
+    librsvg
+    pango
+    SDL2
+    SDL2_gfx
+    SDL2_image
+    SDL2_mixer
+    SDL2_Pango
+    SDL2_ttf
+  ];
+
+  hardeningDisable = [ "format" ];
+
+  makeFlags = [
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "COMPLETIONDIR=$(out)/share/bash-completion/completions"
+    "GPERF=${lib.getExe gperf}"
+    "PREFIX=$(out)"
+  ];
+
+  enableParallelBuilding = true;
 
   postInstall = ''
     # Install desktop file
@@ -40,13 +95,15 @@ stdenv.mkDerivation rec {
     sed -e "s+Exec=tuxpaint+Exec=$out/bin/tuxpaint+" < src/tuxpaint.desktop > $out/share/applications/tuxpaint.desktop
 
     # Install stamps
-    tar xzf $stamps
+    tar xzf ${stamps}
     cd tuxpaint-stamps-*
     make install-all PREFIX=$out
     rm -rf $out/share/tuxpaint/stamps/military
-  '';
 
-  enableParallelBuilding = true;
+    # Requirements for tuxpaint-import
+    wrapProgram $out/bin/tuxpaint-import \
+      --prefix PATH : ${lib.makeBinPath [ netpbm ]}
+  '';
 
   meta = {
     description = "Open Source Drawing Software for Children";


### PR DESCRIPTION
## Description of changes

Unblocks #276653.

Supersedes and closes #248007.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
