### PR TITLE
trimmomatic: make deterministic and clean up

### DIFF
--- a/pkgs/applications/science/biology/trimmomatic/default.nix
+++ b/pkgs/applications/science/biology/trimmomatic/default.nix
@@ -1,30 +1,36 @@
 { lib
 , stdenv
-, ant
 , fetchFromGitHub
-, jdk11_headless
+, ant
+, jdk
 , jre
 , makeWrapper
+, canonicalize-jars-hook
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "trimmomatic";
   version = "0.39";
 
   src = fetchFromGitHub {
     owner = "usadellab";
     repo = "Trimmomatic";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-u+ubmacwPy/vsEi0YQCv0fTnVDesQvqeQDEwCbS8M6I=";
   };
 
-  # Set source and target version to 11
+  # Remove jdk version requirement
   postPatch = ''
     substituteInPlace ./build.xml \
-      --replace 'source="1.5" target="1.5"' 'release="11"'
+      --replace 'source="1.5" target="1.5"' ""
   '';
 
-  nativeBuildInputs = [ jdk11_headless ant makeWrapper ];
+  nativeBuildInputs = [
+    ant
+    jdk
+    makeWrapper
+    canonicalize-jars-hook
+  ];
 
   buildPhase = ''
     runHook preBuild
@@ -37,16 +43,17 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/bin $out/share
-    cp dist/jar/trimmomatic-${version}.jar $out/share/
-    cp -r adapters $out/share/
+    install -Dm644 dist/jar/trimmomatic-*.jar -t $out/share/trimmomatic
+    cp -r adapters $out/share/trimmomatic
+
     makeWrapper ${jre}/bin/java $out/bin/trimmomatic \
-      --add-flags "-cp $out/share/trimmomatic-${version}.jar org.usadellab.trimmomatic.Trimmomatic"
+        --add-flags "-jar $out/share/trimmomatic/trimmomatic-*.jar"
 
     runHook postInstall
   '';
 
   meta = {
+    changelog = "https://github.com/usadellab/Trimmomatic/blob/main/versionHistory.txt";
     description = "A flexible read trimming tool for Illumina NGS data";
     longDescription = ''
       Trimmomatic performs a variety of useful trimming tasks for illumina
@@ -59,8 +66,9 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Only;
     sourceProvenance = [
       lib.sourceTypes.fromSource
-      lib.sourceTypes.binaryBytecode  # source bundles dependencies as jars
+      lib.sourceTypes.binaryBytecode # source bundles dependencies as jars
     ];
+    mainProgram = "trimmomatic";
     maintainers = [ lib.maintainers.kupac ];
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39100,6 +39100,7 @@ with pkgs;
   trimal = callPackage ../applications/science/biology/trimal { };
 
   trimmomatic = callPackage ../applications/science/biology/trimmomatic {
+    jdk = pkgs.jdk11_headless;
     # Reduce closure size
     jre = pkgs.jre_minimal.override {
       modules = [ "java.base" "java.logging" ];


### PR DESCRIPTION
## Description of changes

Changes:

- use `finalAttrs` instead of `rec`
- make patch for jdk version check version-generic
- use `canonicalize-jars-hook` (related issue: https://github.com/NixOS/nixpkgs/issues/278518)
- move where `jdk11_headless` is specified to `all-packages.nix` (because the `jre` value was also specified there)
- use `install` instead of `mkdir` and `cp` where possible
- move file destination from `$out/share` to `$out/share/trimmomatic`
- use `-jar` instead of `-cp`
- set `meta.mainProgram` and `meta.changelog`

---

Maybe `jdk11_headless` could be changed to `jdk_headless` to always use the latest version. It seems to run properly, but I couldn't test it with actual data.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
