### PR TITLE
`lib.callPackageWith`: Use abort again instead of throw and fix evaluation errors caused by it

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -203,7 +203,11 @@ rec {
 
     in if missingArgs == {}
        then makeOverridable f allArgs
-       else throw "lib.customisation.callPackageWith: ${error}";
+       # This needs to be an abort so it can't be caught with `builtins.tryEval`,
+       # which is used by nix-env and ofborg to filter out packages that don't evaluate.
+       # This way we're forced to fix such errors in Nixpkgs,
+       # which is especially relevant with allowAliases = false
+       else abort "lib.customisation.callPackageWith: ${error}";
 
 
   /* Like callPackage, but for a function that returns an attribute

--- a/pkgs/desktops/mate/mate-user-share/default.nix
+++ b/pkgs/desktops/mate/mate-user-share/default.nix
@@ -9,14 +9,16 @@
 , libnotify
 , libxml2
 , libcanberra-gtk3
-, mod_dnssd
-, apacheHttpd
+, apacheHttpdPackages
 , hicolor-icon-theme
 , mate
 , wrapGAppsHook
 , mateUpdateScript
 }:
 
+let
+  inherit (apacheHttpdPackages) apacheHttpd mod_dnssd;
+in
 stdenv.mkDerivation rec {
   pname = "mate-user-share";
   version = "1.26.0";

--- a/pkgs/development/cuda-modules/setup-hooks/extension.nix
+++ b/pkgs/development/cuda-modules/setup-hooks/extension.nix
@@ -53,7 +53,7 @@ final: _: {
   autoAddCudaCompatRunpathHook =
     final.callPackage
       (
-        {makeSetupHook, cuda_compat}:
+        {makeSetupHook, cuda_compat ? throw "autoAddCudaCompatRunpathHook: No cuda_compat for CUDA ${final.cudaMajorMinorVersion}" }:
         makeSetupHook
           {
             name = "auto-add-cuda-compat-runpath-hook";

--- a/pkgs/development/python-modules/dnf-plugins-core/default.nix
+++ b/pkgs/development/python-modules/dnf-plugins-core/default.nix
@@ -4,7 +4,7 @@
 
   # dependencies
 , cmake
-, dateutil
+, python-dateutil
 , dbus-python
 , dnf4
 , gettext
@@ -54,7 +54,7 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [
-    dateutil
+    python-dateutil
     dbus-python
     dnf4.py
     libcomps

--- a/pkgs/development/python-modules/snakemake-interface-common/default.nix
+++ b/pkgs/development/python-modules/snakemake-interface-common/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , poetry-core
 , argparse-dataclass
-, ConfigArgParse
+, configargparse
 }:
 
 buildPythonPackage rec {
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     argparse-dataclass
-    ConfigArgParse
+    configargparse
   ];
 
   pythonImportsCheck = [ "snakemake_interface_common" ];

--- a/pkgs/development/python-modules/sqlalchemy/1_4.nix
+++ b/pkgs/development/python-modules/sqlalchemy/1_4.nix
@@ -13,7 +13,7 @@
 , aiosqlite
 , asyncmy
 , asyncpg
-, cx_oracle
+, cx-oracle
 , mariadb
 , mypy
 , mysql-connector
@@ -79,7 +79,7 @@ buildPythonPackage rec {
       mariadb
     ];
     oracle = [
-      cx_oracle
+      cx-oracle
     ];
     postgresql = [
       psycopg2

--- a/pkgs/test/checkpointBuild/default.nix
+++ b/pkgs/test/checkpointBuild/default.nix
@@ -1,9 +1,9 @@
-{ hello, checkpointBuildTools, runCommandNoCC, texinfo, stdenv, rsync }:
+{ hello, checkpointBuildTools, runCommand, texinfo, stdenv, rsync }:
 let
   baseHelloArtifacts = checkpointBuildTools.prepareCheckpointBuild hello;
   patchedHello = hello.overrideAttrs (old: {
     buildInputs = [ texinfo ];
-    src = runCommandNoCC "patch-hello-src" { } ''
+    src = runCommand "patch-hello-src" { } ''
       mkdir -p $out
       cd $out
       tar xf ${hello.src} --strip-components=1
@@ -24,7 +24,7 @@ let
     patches = [ ./hello-additionalFile.patch ];
   }));
 
-  preparedHelloRemoveFileSrc = runCommandNoCC "patch-hello-src" { } ''
+  preparedHelloRemoveFileSrc = runCommand "patch-hello-src" { } ''
     mkdir -p $out
     cd $out
     tar xf ${hello.src} --strip-components=1
@@ -33,7 +33,7 @@ let
 
   patchedHelloRemoveFile = hello.overrideAttrs (old: {
     buildInputs = [ texinfo ];
-    src = runCommandNoCC "patch-hello-src" { } ''
+    src = runCommand "patch-hello-src" { } ''
       mkdir -p $out
       cd $out
       ${rsync}/bin/rsync -cutU --chown=$USER:$USER --chmod=+w -r ${preparedHelloRemoveFileSrc}/* .

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30292,7 +30292,7 @@ with pkgs;
   aaxtomp3 = callPackage ../applications/audio/aaxtomp3 { };
 
   abcde = callPackage ../applications/audio/abcde {
-    inherit (python3Packages) eyeD3;
+    inherit (python3Packages) eyed3;
   };
 
   abiword = callPackage ../applications/office/abiword { };


### PR DESCRIPTION
## Description of changes

In https://github.com/NixOS/nixpkgs/pull/269356 by @amjoseph-nixpkgs (but really the split-off https://github.com/NixOS/nixpkgs/pull/271123 by @Mic92), `lib.callPackageWith` was switched from an `abort` to a `throw`, which can be caught with `builtins.tryEval`. Because the ofborg evaluation gracefully handles evaluation failures that can be caught, this meant that all `lib.callPackageWith` errors weren't being guarded against by CI anymore, making CI succeed when it really shouldn't have.

This especially affected evaluation with `allowAliases = false`, which triggers the `callPackageWith` error when aliases are used.

Affected merged PRs are:
- https://github.com/NixOS/nixpkgs/pull/276112
- https://github.com/NixOS/nixpkgs/pull/272997
- https://github.com/NixOS/nixpkgs/pull/278560
- https://github.com/NixOS/nixpkgs/pull/167670
- https://github.com/NixOS/nixpkgs/pull/267247
- https://github.com/NixOS/nixpkgs/pull/275882

There may be more PRs in the pipeline that would fail on master.

@jtojnar already made a fix for one evaluation failure in https://github.com/NixOS/nixpkgs/pull/278744. This PR fixes the remaining errors and uses `abort` again to prevent against future breakages.

In particular `nix-build pkgs/test/release` continues succeeding with this PR.

Ping @lilyinstarlight

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
