### PR TITLE
jugglinglab: 1.6.3 -> 1.6.5, move to buildMavenPackage

### DIFF
--- a/pkgs/tools/misc/jugglinglab/default.nix
+++ b/pkgs/tools/misc/jugglinglab/default.nix
@@ -1,37 +1,73 @@
-{ lib, stdenv, fetchFromGitHub, jre, makeWrapper, ant, jdk }:
-stdenv.mkDerivation rec {
-  version = "1.6.3";
+{ lib
+, stdenv
+, maven
+, fetchFromGitHub
+, makeWrapper
+, wrapGAppsHook
+, jre
+}:
+
+let
+  platformName = {
+    "x86_64-linux" = "linux-x86-64";
+    "aarch64-linux" = "linux-aarch64";
+    "x86_64-darwin" = "darwin-x86-64";
+    "aarch64-darwin" = "darwin-aarch64";
+  }.${stdenv.system} or null;
+in
+maven.buildMavenPackage rec {
   pname = "jugglinglab";
+  version = "1.6.5";
+
   src = fetchFromGitHub {
     owner = "jkboyce";
     repo = "jugglinglab";
     rev = "v${version}";
-    sha256 = "sha256-Gq8V7gLl9IakQi7xaK8TCI/B2+6LlLjoLdcv9zlalIE=";
+    hash = "sha256-Y87uHFpVs4A/wErNO2ZF6Su0v4LEvaE9nIysrqFoY8w=";
   };
-  buildInputs = [ jre ];
-  nativeBuildInputs = [ ant jdk makeWrapper ];
-  buildPhase = "ant";
+
+  patches = [
+    # make sure mvnHash doesn't change when maven is updated
+    ./fix-default-maven-plugin-versions.patch
+  ];
+
+  mvnHash = "sha256-1Uzo9nRw+YR/sd7CC9MTPe/lttkRX6BtmcsHaagP1Do=";
+
+  # fix jar timestamps for reproducibility
+  mvnParameters = "-Dproject.build.outputTimestamp=1980-01-01T00:00:02Z";
+
+  nativeBuildInputs = [
+    makeWrapper
+    wrapGAppsHook
+  ];
+
+  dontWrapGApps = true;
 
   installPhase = ''
-    mkdir -p "$out/bin"
-    mkdir -p "$out/lib"
-    cp bin/*.jar $out/lib/
+    runHook preInstall
 
-    # copied from the upstream shell wrapper
-    classpath=$out/lib/JugglingLab.jar:$out/lib/commons-math3-3.6.1.jar:$out/lib/protobuf.jar:$out/lib/com.google.ortools.jar
+    install -Dm644 bin/JugglingLab.jar -t $out/share/jugglinglab
+    ${lib.optionalString (platformName != null) ''
+      install -Dm755 bin/ortools-lib/ortools-${platformName}/* -t $out/lib/ortools-lib
+    ''}
 
+    runHook postInstall
+  '';
+
+  # gappsWrapperArgs are set in preFixup
+  postFixup = ''
     makeWrapper ${jre}/bin/java $out/bin/jugglinglab \
-      --add-flags "-cp $classpath" \
-      --add-flags "-Xss2048k -Djava.library.path=ortools-lib" \
-      --add-flags jugglinglab.JugglingLab
+        "''${gappsWrapperArgs[@]}" \
+        --add-flags "-Xss2048k -Djava.library.path=$out/lib/ortools-lib" \
+        --add-flags "-jar $out/share/jugglinglab/JugglingLab.jar"
   '';
 
   meta = with lib; {
-      description = "A program to visualize different juggling pattens";
-      homepage = "https://jugglinglab.org/";
-      license = licenses.gpl2;
-      maintainers = with maintainers; [ wnklmnn ];
-      platforms = platforms.all;
-      mainProgram = "jugglinglab";
+    description = "A program to visualize different juggling pattens";
+    homepage = "https://jugglinglab.org/";
+    license = licenses.gpl2Only;
+    mainProgram = "jugglinglab";
+    maintainers = with maintainers; [ wnklmnn tomasajt ];
+    platforms = platforms.all;
   };
 }

--- a/pkgs/tools/misc/jugglinglab/fix-default-maven-plugin-versions.patch
+++ b/pkgs/tools/misc/jugglinglab/fix-default-maven-plugin-versions.patch
@@ -1,0 +1,70 @@
+diff --git a/pom.xml b/pom.xml
+index 93fd6be..5f929c3 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -42,6 +43,65 @@
+ 
+     <build>
+         <plugins>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-enforcer-plugin</artifactId>
++                <version>3.4.1</version>
++                <executions>
++                    <execution>
++                        <id>require-all-plugin-versions-to-be-set</id>
++                        <phase>validate</phase>
++                        <goals>
++                            <goal>enforce</goal>
++                        </goals>
++                        <configuration>
++                            <rules>
++                                <requirePluginVersions />
++                            </rules>
++                        </configuration>
++                    </execution>
++                </executions>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-compiler-plugin</artifactId>
++                <version>3.12.1</version>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-surefire-plugin</artifactId>
++                <version>3.2.3</version>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-jar-plugin</artifactId>
++                <version>3.3.0</version>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-clean-plugin</artifactId>
++                <version>3.3.2</version>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-install-plugin</artifactId>
++                <version>3.1.1</version>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-site-plugin</artifactId>
++                <version>4.0.0-M13</version>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-resources-plugin</artifactId>
++                <version>3.3.1</version>
++            </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-deploy-plugin</artifactId>
++                <version>3.1.1</version>
++            </plugin>
+ 
+             <!-- remove existing `bin/JugglingLab.jar` -->
+             <!-- otherwise on overwrite Maven creates `bin/original-JugglingLab.jar` -->


### PR DESCRIPTION
## Description of changes

This PR updates the `jugglinglab` package to version `1.6.5`

I added myself as a maintainer, as this is a pretty big overhaul of the derivation.

This version is now build with `maven`, so I used `maven.buildMavenPackage` for the job.

The package was originally not deterministic (related PR: https://github.com/NixOS/nixpkgs/issues/278518), but maven has a built in way of dealing with this. I needed to employ a few patches to make the package deterministic:
- Always set the output timestamp to the lowest accepted value
- Fix the default maven plugins' versions, as those change when maven updates, thus invalidating the provided hash.
  This utilizes the `maven-enforcer-plugin`, recommended in the nixpkgs docs, for detecting if a default plugin version is not explicitly set.

`ortools-lib` is downloaded as a dependency for the 4 main platforms during the build.
I made sure to only copy the files needed for the current platform.
If the platform is not in the list of 4 main platforms, `ortools-lib` will not be copied over, but this should not stop the program from working, as it's not a hard-dependency.



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
