### PR TITLE
comet-gog: init at 0-unstable-2024-05-25

### DIFF
--- a/pkgs/by-name/co/comet-gog/package.nix
+++ b/pkgs/by-name/co/comet-gog/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  protobuf,
+  darwin,
+}:
+
+let
+  inherit (darwin.apple_sdk.frameworks) CoreFoundation SystemConfiguration;
+in
+rustPlatform.buildRustPackage {
+  pname = "comet-gog";
+  version = "0-unstable-2024-05-25";
+
+  src = fetchFromGitHub {
+    owner = "imLinguin";
+    repo = "comet";
+    rev = "378ec2abdc2498e7c0c12aa50b71f6d94c3e8e3c";
+    hash = "sha256-r7ZPpJLy2fZsyNijl0+uYWQN941TCbv+Guv3wzD83IQ=";
+    fetchSubmodules = true;
+  };
+
+  cargoHash = "sha256-dXNAGMVayzgT96ETrph9eCbQv28EK/OOxIRV8ewpVvs=";
+
+  # error: linker `aarch64-linux-gnu-gcc` not found
+  postPatch = ''
+    rm .cargo/config.toml
+  '';
+
+  env.PROTOC = lib.getExe' protobuf "protoc";
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    CoreFoundation
+    SystemConfiguration
+  ];
+
+  meta = {
+    description = "Open Source implementation of GOG Galaxy's Communication Service";
+    homepage = "https://github.com/imLinguin/comet";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "comet";
+    maintainers = with lib.maintainers; [ tomasajt ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/278554

This PR adds 1 package: `comet-gog`

There is no proper versioning as of creating this PR, so the latest commit was used here.

I haven't been able to check if it actually works in action.
@EthanHarp as the creator of the package request, could you possible check if it works?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
