### PR TITLE
pyfa - Add Pyfa appimage package

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3877,6 +3877,12 @@
       fingerprint = "1C3C 6547 538D 7152 310C 0EEA 84DD 0C01 30A5 4DF7";
     }];
   };
+  CryoMyst= {
+    name = "CryoMyst";
+    email = "CryoMyst@hotmail.com";
+    github = "CryoMyst";
+    githubId = 38846413;
+  };
   cryptix = {
     email = "cryptix@riseup.net";
     github = "cryptix";

--- a/pkgs/games/pyfa/default.nix
+++ b/pkgs/games/pyfa/default.nix
@@ -1,0 +1,45 @@
+{ lib, appimageTools, fetchurl }:
+let
+  pname = "pyfa";
+  version = "2.57.3";
+
+  src = fetchurl {
+    url = "https://github.com/pyfa-org/Pyfa/releases/download/v${version}/pyfa-v${version}-linux.AppImage";
+    sha256 = "sha256-IS+yYYn+aRh8QxCMmlQjV1ysR1rSmPgRSa+2+gKtw5c=";
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraInstallCommands =
+    let
+      appimageContents = appimageTools.extractType2 { inherit pname version src; };
+    in
+    ''
+      # Remove version from entrypoint
+      mv $out/bin/pyfa-"${version}" $out/bin/pyfa
+
+      # Install .desktop files
+      install -Dm444 ${appimageContents}/pyfa.desktop -t $out/share/applications
+      install -Dm444 ${appimageContents}/pyfa.png -t $out/share/pixmaps
+      substituteInPlace $out/share/applications/pyfa.desktop \
+        --replace 'Exec=usr/bin/python3.11' 'Exec=pyfa'
+    '';
+
+  extraPkgs = pkgs: with pkgs; [
+    libnotify
+    pcre2
+  ];
+
+  meta = with lib; {
+    description = "Python fitting assistant, cross-platform fitting tool for EVE Online ";
+    homepage = "https://github.com/pyfa-org/Pyfa";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [
+      CryoMyst
+    ];
+    platforms = [
+      "x86_64-linux"
+    ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34666,6 +34666,8 @@ with pkgs;
 
   purpur = callPackage ../games/purpur { };
 
+  pyfa = callPackage ../games/pyfa { };
+
   pikopixel = callPackage ../applications/graphics/pikopixel { };
 
   pithos = callPackage ../applications/audio/pithos {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Pyfa is a fitting assistant program for Eve Online.
https://github.com/pyfa-org/Pyfa/releases

I have built with an appimage due to [this issue]( https://github.com/pyfa-org/Pyfa/issues/2502) linked in [the package request](https://github.com/NixOS/nixpkgs/issues/239454).
Where pyfa is tied to a lower sqlalchemy version than what's in nixpkgs by the maintainer.

(My first contribution, please be gentle)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
