### PR TITLE
box2d: 2.3.1 -> 2.4.1

### DIFF
--- a/pkgs/development/libraries/box2d/default.nix
+++ b/pkgs/development/libraries/box2d/default.nix
@@ -1,30 +1,93 @@
-{ lib, stdenv, fetchFromGitHub, cmake, libGLU, libGL, freeglut, libX11, xorgproto
-, libXi, pkg-config }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, libGLU
+, libGL
+, freeglut
+, libX11
+, xorgproto
+, libXi
+, pkg-config
+, libXrandr
+, libXinerama
+, libXcursor
+, Carbon
+, Cocoa
+, IOKit
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "box2d";
-  version = "2.3.1";
+  version = "2.4.1";
 
   src = fetchFromGitHub {
     owner = "erincatto";
     repo = "box2d";
-    rev = "v${version}";
-    sha256 = "sha256-Z2J17YMzQNZqABIa5eyJDT7BWfXveymzs+DWsrklPIs=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-cL8L+WSTcswj+Bwy8kSOwuEqLyWEM6xa/j/94aBiSck=";
   };
 
-  nativeBuildInputs = [ cmake pkg-config ];
-  buildInputs = [ libGLU libGL freeglut libX11 xorgproto libXi ];
+  patches = [
+    # for outdated doctest.h
+    (fetchpatch {
+      url = "https://github.com/erincatto/box2d/commit/cd2c28dba83e4f359d08aeb7b70afd9e35e39eda.patch";
+      name = "update-doctest-version.patch";
+      hash = "sha256-IoXl6xUGi1YU7u1f/HWvrurb/ADCAxoR7WyiGjifYDE=";
+    })
 
-  cmakeFlags = [
-    "-DBOX2D_INSTALL=ON"
-    "-DBOX2D_BUILD_SHARED=ON"
-    "-DBOX2D_BUILD_EXAMPLES=OFF"
+    # for outdated doctest.h, see https://github.com/erincatto/box2d/issues/677
+    (fetchpatch {
+      url = "https://github.com/erincatto/box2d/commit/e76cf2d82792fbf915e42ae253f8a2ae252adbdf.patch";
+      name = "update-doctest.patch";
+      hash = "sha256-fBHM767bE02371FcJ+GXQyKcvbVYvcSh2jrC2WasBcE=";
+    })
+
+    # for outdated doctest.h, see https://github.com/erincatto/box2d/issues/732
+    (fetchpatch {
+      url = "https://github.com/erincatto/box2d/commit/87c98c6d39845e90439a192e8bc31befb56889d7.patch";
+      name = "miscellaneous-fixes.patch";
+      hash = "sha256-Smve1wK6t79WKi8ZcgDmkKrQ5A9u6/eZqlSlRe/4Aws=";
+      includes = [ "unit-test/doctest.h" ];
+    })
   ];
 
-  prePatch = ''
-    cd Box2D
-    substituteInPlace Box2D/Common/b2Settings.h \
-      --replace 'b2_maxPolygonVertices	8' 'b2_maxPolygonVertices	15'
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libGLU
+    libGL
+    freeglut
+    libX11
+    xorgproto
+    libXi
+    libXrandr
+    libXinerama
+    libXcursor
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    Carbon
+    Cocoa
+    IOKit
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DBOX2D_BUILD_TESTBED=OFF"
+    (lib.cmakeBool "BOX2D_BUILD_UNIT_TESTS" finalAttrs.finalPackage.doCheck)
+  ];
+
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+
+    bin/unit_test
+
+    runHook postCheck
   '';
 
   meta = with lib; {
@@ -34,4 +97,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     license = licenses.zlib;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20583,7 +20583,9 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreServices Security;
   };
 
-  box2d = callPackage ../development/libraries/box2d { };
+  box2d = callPackage ../development/libraries/box2d {
+    inherit (pkgs.darwin.apple_sdk.frameworks) Carbon Cocoa IOKit;
+  };
 
   boxfort = callPackage ../development/libraries/boxfort { };
 


### PR DESCRIPTION
## Description of changes

* https://github.com/erincatto/box2d/releases/tag/v2.4.0
* https://github.com/erincatto/box2d/releases/tag/v2.4.1

The current version in nixpkgs is very old, it was released in 2014. The new version was released in 2020.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>18 packages built:</summary>
  <ul>
    <li>box2d</li>
    <li>jpsxdec</li>
    <li>libreoffice (libreoffice-still)</li>
    <li>libreoffice-fresh</li>
    <li>libreoffice-fresh-unwrapped</li>
    <li>libreoffice-qt</li>
    <li>libreoffice-still-unwrapped</li>
    <li>paperwork</li>
    <li>paperwork.dist</li>
    <li>python310Packages.paperwork-backend</li>
    <li>python310Packages.paperwork-backend.dist</li>
    <li>python310Packages.paperwork-shell</li>
    <li>python310Packages.paperwork-shell.dist</li>
    <li>python311Packages.paperwork-backend</li>
    <li>python311Packages.paperwork-backend.dist</li>
    <li>python311Packages.paperwork-shell</li>
    <li>python311Packages.paperwork-shell.dist</li>
    <li>unoconv</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
