### PR TITLE
mediawiki-dump-generator: init at unstable-2023-12-18

### DIFF
--- a/pkgs/by-name/me/mediawiki-dump-generator/package.nix
+++ b/pkgs/by-name/me/mediawiki-dump-generator/package.nix
@@ -1,0 +1,44 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+
+python3.pkgs.buildPythonApplication {
+  pname = "mediawiki-dump-generator";
+  version = "unstable-2023-12-18";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mediawiki-client-tools";
+    repo = "mediawiki-dump-generator";
+    rev = "e19ffbc13278c09400600dfc4a2c006ad74fa663";
+    hash = "sha256-fxpywv1W3XFnCIwOw9JByFahJWeWIOjMK79X5a3SjBo=";
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.poetry-core
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    file-read-backwards
+    internetarchive
+    lxml
+    mwclient
+    pre-commit-poetry-export
+    pymysql
+    pywikibot
+    requests
+    urllib3
+    wikitools3
+  ];
+
+  pythonImportsCheck = [ "wikiteam3" ];
+
+  meta = with lib; {
+    description = "Python 3 tools for downloading and preserving wikis";
+    homepage = "https://github.com/mediawiki-client-tools/mediawiki-dump-generator";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ TheBrainScrambler ];
+    mainProgram = "dumpgenerator";
+  };
+}

--- a/pkgs/development/python-modules/poster3/default.nix
+++ b/pkgs/development/python-modules/poster3/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, isPy3k
+, paste
+, webob
+, pyopenssl
+}:
+
+buildPythonPackage rec {
+  pname = "poster3";
+  version = "0.8.1";
+  format = "wheel"; # only redistributable available
+
+  disabled = !isPy3k;
+
+  src = fetchPypi {
+    inherit pname version format;
+    python = "py3";
+    sha256 = "1b27d7d63e3191e5d7238631fc828e4493590e94dcea034e386c079d853cce14";
+  };
+
+  checkInputs = [
+    paste
+    webob
+    pyopenssl
+  ];
+
+  meta = with lib; {
+    description = "Streaming HTTP uploads and multipart/form-data encoding";
+    homepage = "https://atlee.ca/software/poster/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ WhittlesJr ];
+  };
+}

--- a/pkgs/development/python-modules/poster3/default.nix
+++ b/pkgs/development/python-modules/poster3/default.nix
@@ -30,6 +30,6 @@ buildPythonPackage rec {
     description = "Streaming HTTP uploads and multipart/form-data encoding";
     homepage = "https://atlee.ca/software/poster/";
     license = licenses.mit;
-    maintainers = with maintainers; [ WhittlesJr ];
+    maintainers = with maintainers; [ TheBrainScrambler ];
   };
 }

--- a/pkgs/development/python-modules/pre-commit-poetry-export/default.nix
+++ b/pkgs/development/python-modules/pre-commit-poetry-export/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, python3
+, fetchPypi
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "pre-commit-poetry-export";
+  version = "0.1.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-gA1X31/5bG3P8cr2+PiLsIvQT1AXoSXpTOngXqJ+YLg=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace poetry.masonry.api poetry.core.masonry.api \
+      --replace "poetry>=0.12" "poetry-core>=0.12"
+  '';
+
+
+  nativeBuildInputs = [
+    python3.pkgs.poetry-core
+  ];
+
+  pythonImportsCheck = [ "pre_commit_poetry_export" ];
+
+  meta = with lib; {
+    description = "Pre-commit hook to keep requirements.txt updated";
+    homepage = "https://pypi.org/project/pre-commit-poetry-export/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ TheBrainScrambler ];
+  };
+}

--- a/pkgs/development/python-modules/pywikibot/default.nix
+++ b/pkgs/development/python-modules/pywikibot/default.nix
@@ -1,0 +1,103 @@
+{ lib
+, python3
+, fetchPypi
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "pywikibot";
+  version = "8.6.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-OARU5rblOnT0kl0a+u2bSFMl+mL41HXrOTGluDoeABU=";
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+    python3.pkgs.wheel
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    mwparserfromhell
+    requests
+    setuptools
+  ];
+
+  passthru.optional-dependencies = with python3.pkgs; {
+    create_isbn_edition.py = [
+      isbnlib
+      unidecode
+    ];
+    eventstreams = [
+      sseclient
+    ];
+    flake8 = [
+      darglint
+      flake8
+      flake8-bugbear
+      flake8-coding
+      flake8-comprehensions
+      flake8-docstrings
+      flake8-mock-x2
+      flake8-no-u-prefixed-strings
+      flake8-print
+      flake8-quotes
+      flake8-string-format
+      flake8-tuple
+      pep8-naming
+      pydocstyle
+    ];
+    google = [
+      google
+    ];
+    graphviz = [
+      pydot
+    ];
+    hacking = [
+      hacking
+    ];
+    html = [
+      beautifulsoup4
+    ];
+    http = [
+      fake-useragent
+    ];
+    isbn = [
+      python-stdnum
+    ];
+    memento = [
+      memento-client
+    ];
+    mwoauth = [
+      mwoauth
+    ];
+    mysql = [
+      pymysql
+    ];
+    scripts = [
+      isbnlib
+      memento-client
+      unidecode
+    ];
+    tkinter = [
+      pillow
+    ];
+    weblinkchecker.py = [
+      memento-client
+    ];
+    wikitextparser = [
+      wikitextparser
+    ];
+  };
+
+  pythonImportsCheck = [ "pywikibot" ];
+
+  meta = with lib; {
+    description = "Python MediaWiki Bot Framework";
+    homepage = "https://pypi.org/project/pywikibot";
+    license = licenses.mit;
+    maintainers = with maintainers; [ TheBrainScrambler ];
+    mainProgram = "pwb";
+  };
+}

--- a/pkgs/development/python-modules/wikitools3/default.nix
+++ b/pkgs/development/python-modules/wikitools3/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, python3
+, fetchPypi
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "wikitools3";
+  version = "3.0.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-tJPmgG+xmFrRrylMVjZK66bqZ6NmVTvBG2W39SedABI=";
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.poetry-core
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    poster3
+  ];
+
+  pythonImportsCheck = [ "wikitools3" ];
+
+  meta = with lib; {
+    description = "Python package for interacting with a MediaWiki wiki. It is used by WikiTeam for archiving MediaWiki wikis";
+    homepage = "https://pypi.org/project/wikitools3";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ TheBrainScrambler ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12423,6 +12423,8 @@ with pkgs;
 
   pywal = with python3Packages; toPythonApplication pywal;
 
+  pywikibot = with python3Packages; toPythonApplication pywikibot;
+
   pystring = callPackage ../development/libraries/pystring { };
 
   raysession = python3Packages.callPackage ../applications/audio/raysession {};

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -283,7 +283,6 @@ mapAliases ({
   poetry = throw "poetry was promoted to a top-level attribute, use poetry-core to build Python packages"; # added 2023-01-09
   poetry2conda = throw "poetry2conda was promoted to a top-level attribute"; # Added 2022-10-02
   Polygon3 = polygon3; # Added 2023-08-08
-  poster3 = throw "poster3 is unmaintained and source is no longer available"; # added 2023-05-29
   postorius = throw "Please use pkgs.mailmanPackages.postorius"; # added 2022-04-29
   powerlineMemSegment = powerline-mem-segment; # added 2021-10-08
   privacyidea-ldap-proxy = throw "privacyidea-ldap-proxy has been removed from nixpkgs"; # added 2023-10-31

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16047,6 +16047,8 @@ self: super: with self; {
 
   wikitextparser = callPackage ../development/python-modules/wikitextparser { };
 
+  wikitools3 = callPackage ../development/python-modules/wikitools3 { };
+
   willow = callPackage ../development/python-modules/willow { };
 
   winacl = callPackage ../development/python-modules/winacl { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12104,6 +12104,8 @@ self: super: with self; {
 
   pywfa = callPackage ../development/python-modules/pywfa { };
 
+  pywikibot = callPackage ../development/python-modules/pywikibot { };
+
   pywilight = callPackage ../development/python-modules/pywilight { };
 
   pywinrm = callPackage ../development/python-modules/pywinrm { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9704,6 +9704,8 @@ self: super: with self; {
 
   posthog = callPackage ../development/python-modules/posthog { };
 
+  poster3 = callPackage ../development/python-modules/poster3 { };
+
   pot = callPackage ../development/python-modules/pot { };
 
   potentials = callPackage ../development/python-modules/potentials { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9746,6 +9746,8 @@ self: super: with self; {
 
   pre-commit-hooks = callPackage ../development/python-modules/pre-commit-hooks { };
 
+  pre-commit-poetry-export = callPackage ../development/python-modules/pre-commit-poetry-export { };
+
   preggy = callPackage ../development/python-modules/preggy { };
 
   premailer = callPackage ../development/python-modules/premailer { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Python 3 tools for downloading and preserving wikis

Works, I've been able to backup one wiki with those.

Note that I'm also adding dependencies of mediawiki-dump-generator that weren't in nixpkgs in this PR. Also note that I had to bring back from the dead the package `poster3` because mediawiki-dump-generator needs it. I added myself as a maintainer to that package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
