### PR TITLE
asusctl: 5.0.6 -> 5.0.7

### DIFF
--- a/pkgs/applications/system/asusctl/Cargo.lock
+++ b/pkgs/applications/system/asusctl/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "asusctl"
-version = "5.0.6"
+version = "5.0.7"
 dependencies = [
  "asusd",
  "cargo-husky",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "asusd"
-version = "5.0.6"
+version = "5.0.7"
 dependencies = [
  "async-trait",
  "cargo-husky",
@@ -226,7 +226,7 @@ dependencies = [
  "config-traits",
  "dmi_id",
  "env_logger",
- "futures-lite 2.1.0",
+ "futures-lite 1.13.0",
  "log",
  "logind-zbus",
  "rog_anime",
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "asusd-user"
-version = "5.0.6"
+version = "5.0.7"
 dependencies = [
  "cargo-husky",
  "config-traits",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "config-traits"
-version = "5.0.6"
+version = "5.0.7"
 dependencies = [
  "cargo-husky",
  "log",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "cpuctl"
-version = "5.0.6"
+version = "5.0.7"
 
 [[package]]
 name = "cpufeatures"
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "dmi_id"
-version = "5.0.6"
+version = "5.0.7"
 dependencies = [
  "log",
  "udev",
@@ -2836,7 +2836,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rog-control-center"
-version = "5.0.6"
+version = "5.0.7"
 dependencies = [
  "asusd",
  "cargo-husky",
@@ -2869,7 +2869,7 @@ dependencies = [
 
 [[package]]
 name = "rog_anime"
-version = "5.0.6"
+version = "5.0.7"
 dependencies = [
  "cargo-husky",
  "dmi_id",
@@ -2886,7 +2886,7 @@ dependencies = [
 
 [[package]]
 name = "rog_aura"
-version = "5.0.6"
+version = "5.0.7"
 dependencies = [
  "cargo-husky",
  "dmi_id",
@@ -2900,7 +2900,7 @@ dependencies = [
 
 [[package]]
 name = "rog_dbus"
-version = "5.0.6"
+version = "5.0.7"
 dependencies = [
  "asusd",
  "cargo-husky",
@@ -2913,7 +2913,7 @@ dependencies = [
 
 [[package]]
 name = "rog_platform"
-version = "5.0.6"
+version = "5.0.7"
 dependencies = [
  "cargo-husky",
  "concat-idents",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "rog_profiles"
-version = "5.0.6"
+version = "5.0.7"
 dependencies = [
  "cargo-husky",
  "log",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "rog_simulators"
-version = "5.0.6"
+version = "5.0.7"
 dependencies = [
  "glam",
  "log",

--- a/pkgs/applications/system/asusctl/default.nix
+++ b/pkgs/applications/system/asusctl/default.nix
@@ -13,13 +13,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "asusctl";
-  version = "5.0.6";
+  version = "5.0.7";
 
   src = fetchFromGitLab {
     owner = "asus-linux";
     repo = "asusctl";
     rev = version;
-    hash = "sha256-xeskbfpznXki+MnPt+Tli7+DYprRnpZaNb/O5mdnZy0=";
+    hash = "sha256-thTzNB6GmzHG0BaaacmmQogRrLK1udkTYifEivwDtjM=";
   };
 
   cargoHash = "";


### PR DESCRIPTION
## Description of changes

**Changed**

- Fix to suspend process in anime thread to let custom anims run on wake.
- Fix to reload the fan curves correctly on boot.
- Add new config option `platform_policy_linked_epp` to set if energy_performance_preference should be paired with platform_profile/throttle_thermal_policy
- Small fixes to rog-control-center

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
