### PR TITLE
[staging] libmicrohttpd: 0.9.74 -> 0.9.77, several unpinnings

### DIFF
--- a/pkgs/applications/networking/taler/default.nix
+++ b/pkgs/applications/networking/taler/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchgit, curl, gnunet, jansson, libgcrypt, libmicrohttpd_0_9_74
+{ lib, stdenv, fetchgit, curl, gnunet, jansson, libgcrypt, libmicrohttpd
 , qrencode, libsodium, libtool, libunistring, pkg-config, postgresql
 , autoreconfHook, python39, recutils, wget, jq, gettext, texinfo
 }:
@@ -36,7 +36,7 @@ let
     ];
     buildInputs = [
       libgcrypt
-      libmicrohttpd_0_9_74
+      libmicrohttpd
       jansson
       libsodium
       postgresql

--- a/pkgs/development/libraries/libmicrohttpd/0.9.77.nix
+++ b/pkgs/development/libraries/libmicrohttpd/0.9.77.nix
@@ -1,0 +1,10 @@
+{ callPackage, fetchurl }:
+
+callPackage ./generic.nix ( rec {
+  version = "0.9.77";
+
+  src = fetchurl {
+    url = "mirror://gnu/libmicrohttpd/libmicrohttpd-${version}.tar.gz";
+    hash = "sha256-nnAjoVESAGDSgGpupME8qZM+zk6s/FyUZNIO3dt2sKA=";
+  };
+})

--- a/pkgs/servers/sql/proxysql/default.nix
+++ b/pkgs/servers/sql/proxysql/default.nix
@@ -17,7 +17,7 @@
 , libev
 , libgcrypt
 , libinjection
-, libmicrohttpd_0_9_69
+, libmicrohttpd
 , libuuid
 , lz4
 , nlohmann_json
@@ -111,7 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
           { f = "libdaemon"; p = libdaemon; }
           { f = "libev"; p = libev; }
           { f = "libinjection"; p = libinjection; }
-          { f = "libmicrohttpd"; p = libmicrohttpd_0_9_69; }
+          { f = "libmicrohttpd"; p = libmicrohttpd; }
           { f = "libssl"; p = openssl; }
           { f = "lz4"; p = lz4; }
           { f = "pcre"; p = pcre; }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23247,7 +23247,7 @@ with pkgs;
   libmicrohttpd_0_9_71 = callPackage ../development/libraries/libmicrohttpd/0.9.71.nix { };
   libmicrohttpd_0_9_72 = callPackage ../development/libraries/libmicrohttpd/0.9.72.nix { };
   libmicrohttpd_0_9_74 = callPackage ../development/libraries/libmicrohttpd/0.9.74.nix { };
-  libmicrohttpd = libmicrohttpd_0_9_71;
+  libmicrohttpd = libmicrohttpd_0_9_74;
 
   libmikmod = callPackage ../development/libraries/libmikmod {
     inherit (darwin.apple_sdk.frameworks) CoreAudio;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23245,7 +23245,8 @@ with pkgs;
   libmicrohttpd_0_9_71 = callPackage ../development/libraries/libmicrohttpd/0.9.71.nix { };
   libmicrohttpd_0_9_72 = callPackage ../development/libraries/libmicrohttpd/0.9.72.nix { };
   libmicrohttpd_0_9_74 = callPackage ../development/libraries/libmicrohttpd/0.9.74.nix { };
-  libmicrohttpd = libmicrohttpd_0_9_74;
+  libmicrohttpd_0_9_77 = callPackage ../development/libraries/libmicrohttpd/0.9.77.nix { };
+  libmicrohttpd = libmicrohttpd_0_9_77;
 
   libmikmod = callPackage ../development/libraries/libmikmod {
     inherit (darwin.apple_sdk.frameworks) CoreAudio;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23201,9 +23201,7 @@ with pkgs;
   libjpeg = libjpeg_turbo;
   libjpeg8 = libjpeg_turbo.override { enableJpeg8 = true; };
 
-  libjson-rpc-cpp = callPackage ../development/libraries/libjson-rpc-cpp {
-    libmicrohttpd = libmicrohttpd_0_9_72;
-  };
+  libjson-rpc-cpp = callPackage ../development/libraries/libjson-rpc-cpp { };
 
   libjwt = callPackage ../development/libraries/libjwt { };
 


### PR DESCRIPTION
## Description of changes

https://git.gnunet.org/libmicrohttpd.git/tree/ChangeLog?h=v0.9.77

I would keep the old versions for the moment and drop them when this mass rebuild went through fine and the old versions are known to not be needed any more (e.g. for pinning on the staging/staging-next cycles).

Closes #187811.

Since there are many pkgs transitively dependent on libmicrohttpd, I only built a hand-picked selection:

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>16 packages built:</summary>
  <ul>
    <li>coturn</li>
    <li>fileshare</li>
    <li>kismet</li>
    <li>kiwix</li>
    <li>kiwix-tools</li>
    <li>kodi</li>
    <li>libjson-rpc-cpp</li>
    <li>libpromhttp</li>
    <li>ola</li>
    <li>osmscout-server</li>
    <li>profanity</li>
    <li>proxysql</li>
    <li>taler-exchange</li>
    <li>taler-merchant</li>
    <li>xmrig</li>
    <li>xmrig-proxy</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
