### PR TITLE
evolution{,-data-server}: 3.50.2 -> 3.50.3

### DIFF
--- a/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
+++ b/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
@@ -44,11 +44,11 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution";
-  version = "3.50.2";
+  version = "3.50.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "D4M1214mmFRHi01tlHLu2s0Kiev3+0+DdWJDMMqqcSA=";
+    sha256 = "sha256-s1SjsFzRmWSjya2k7m4RsCzI25JtiB7ww30FmzAd/KQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome/core/evolution-data-server/default.nix
@@ -147,6 +147,10 @@ stdenv.mkDerivation rec {
       --replace "-Wl,--no-undefined" ""
     substituteInPlace src/services/evolution-alarm-notify/e-alarm-notify.c \
       --replace "G_OS_WIN32" "__APPLE__"
+  '' + lib.optionalString stdenv.cc.isClang ''
+    # https://gitlab.gnome.org/GNOME/evolution-data-server/-/issues/513
+    substituteInPlace src/addressbook/libebook-contacts/e-phone-number-private.cpp \
+      --replace "std::auto_ptr" "std::unique_ptr"
   '';
 
   postInstall = lib.optionalString stdenv.isDarwin ''

--- a/pkgs/desktops/gnome/core/evolution-data-server/default.nix
+++ b/pkgs/desktops/gnome/core/evolution-data-server/default.nix
@@ -33,7 +33,6 @@
 , enableOAuth2 ? stdenv.isLinux
 , webkitgtk_4_1
 , webkitgtk_6_0
-, libaccounts-glib
 , json-glib
 , glib
 , gtk3
@@ -51,13 +50,13 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution-data-server";
-  version = "3.50.2";
+  version = "3.50.3";
 
   outputs = [ "out" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution-data-server/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "XmYnA4jVDBTzsa4/oNISe5/tznUqzTk7VUUoGwH8SXA=";
+    sha256 = "sha256-Il1wtqQCaPIlwqxCjuXrUtWm/aJgKVXVCiSXBSb+JFI=";
   };
 
   patches = [
@@ -107,8 +106,6 @@ stdenv.mkDerivation rec {
     libphonenumber
     boost
     protobuf
-  ] ++ lib.optionals stdenv.isLinux [
-    libaccounts-glib
   ] ++ lib.optionals stdenv.isDarwin [
     libiconv
   ] ++ lib.optionals withGtk3 [

--- a/pkgs/desktops/gnome/core/evolution-data-server/hardcode-gsettings.patch
+++ b/pkgs/desktops/gnome/core/evolution-data-server/hardcode-gsettings.patch
@@ -361,7 +361,7 @@ index e61160c..b6553a4 100644
  		G_CALLBACK (mi_user_headers_settings_changed_cb), NULL);
  	G_UNLOCK (mi_user_headers);
 diff --git a/src/camel/providers/imapx/camel-imapx-server.c b/src/camel/providers/imapx/camel-imapx-server.c
-index ef34665..59f294b 100644
+index 8518c90..6a655a9 100644
 --- a/src/camel/providers/imapx/camel-imapx-server.c
 +++ b/src/camel/providers/imapx/camel-imapx-server.c
 @@ -5627,7 +5627,18 @@ camel_imapx_server_do_old_flags_update (CamelFolder *folder)

--- a/pkgs/development/libraries/libgweather/default.nix
+++ b/pkgs/development/libraries/libgweather/default.nix
@@ -65,6 +65,8 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     "-Dzoneinfo_dir=${tzdata}/share/zoneinfo"
     (lib.mesonBool "introspection" withIntrospection)
+  ] ++ lib.optionals stdenv.isDarwin [
+    "-Dc_args=-D_DARWIN_C_SOURCE"
   ];
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

Dropping `libaccounts-glib` so that no more unnecessary rebuilds are triggered by it. Upstream will have the last references removed to it when 3.52.x releases

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
