### PR TITLE
meerk40t: 0.8.1000 -> 0.9.3010

### DIFF
--- a/pkgs/applications/misc/meerk40t/default.nix
+++ b/pkgs/applications/misc/meerk40t/default.nix
@@ -1,40 +1,60 @@
 { lib
 , fetchFromGitHub
 , meerk40t-camera
-, python3
+, python3Packages
 , gtk3
 , wrapGAppsHook
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "MeerK40t";
-  version = "0.8.1000";
-  format = "setuptools";
+  version = "0.9.3010";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "meerk40t";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-YCcnqaH4Npmct5IBHsnufswRz8bS7mUb1YFwTta/Dxc=";
+    hash = "sha256-RlIWqxmUiL1gFMxwcdWxDiebmEzVz6kTaSlAZHr8S+I=";
   };
 
   nativeBuildInputs = [
     wrapGAppsHook
-  ];
+  ] ++ (with python3Packages; [
+    setuptools
+  ]);
 
   # prevent double wrapping
   dontWrapGApps = true;
 
-  propagatedBuildInputs = with python3.pkgs; [
-    ezdxf
+  # https://github.com/meerk40t/meerk40t/blob/main/setup.py
+  propagatedBuildInputs = with python3Packages; [
     meerk40t-camera
-    opencv4
-    pillow
+    numpy
     pyserial
     pyusb
     setuptools
     wxpython
-  ];
+  ]
+  ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
+
+  passthru.optional-dependencies = with python3Packages; {
+    cam = [
+      opencv4
+    ];
+    camhead = [
+      opencv4
+    ];
+    dxf = [
+      ezdxf
+    ];
+    gui = [
+      wxpython
+      pillow
+      opencv4
+      ezdxf
+    ];
+  };
 
   preFixup = ''
     gappsWrapperArgs+=(
@@ -43,7 +63,7 @@ python3.pkgs.buildPythonApplication rec {
     makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with python3Packages; [
     unittestCheckHook
   ];
 


### PR DESCRIPTION
https://github.com/meerk40t/meerk40t/releases/tag/0.8.11001
https://github.com/meerk40t/meerk40t/releases/tag/0.8.12000
https://github.com/meerk40t/meerk40t/releases/tag/0.9.1000
https://github.com/meerk40t/meerk40t/releases/tag/0.9.2000
https://github.com/meerk40t/meerk40t/releases/tag/0.9.3001 https://github.com/meerk40t/meerk40t/releases/tag/0.9.3010

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
