### PR TITLE
errands: init at 45.1.9

### DIFF
--- a/pkgs/by-name/er/errands/package.nix
+++ b/pkgs/by-name/er/errands/package.nix
@@ -1,0 +1,67 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+, gobject-introspection
+, libadwaita
+, wrapGAppsHook
+, meson
+, ninja
+, desktop-file-utils
+, pkg-config
+, appstream
+, libsecret
+, gtk4
+, gtksourceview5
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "errands";
+  version = "45.1.9";
+
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "mrvladus";
+    repo = "Errands";
+    rev = "refs/tags/${version}";
+    hash = "sha256-q8vmT7XUx3XJjPfbEd/c3HrTENfopl1MqwT0x5OuG0c=";
+  };
+
+  nativeBuildInputs = [
+    gobject-introspection
+    wrapGAppsHook
+    desktop-file-utils
+    meson
+    ninja
+    pkg-config
+    appstream
+    gtk4
+  ];
+
+  buildInputs = [
+    libadwaita
+    libsecret
+    gtksourceview5
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    pygobject3
+    lxml
+    caldav
+    pycryptodomex
+  ];
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  meta = with lib; {
+    description = "Manage your tasks";
+    homepage = "https://github.com/mrvladus/Errands";
+    license = licenses.mit;
+    mainProgram = "errands";
+    maintainers = with maintainers; [ sund3RRR ];
+  };
+}


### PR DESCRIPTION
## Description of changes
Errands is an app that can help you manage your tasks
https://github.com/mrvladus/Errands

I know about https://github.com/NixOS/nixpkgs/issues/277705, so we can think about it here. **mrvladus** worries that the packaging of the application in `nix` will require additional support from him. imo, the application is made very competently, conforming to general standards and rules, so there were no problems with packaging in `nixpkgs`.

Even if we have to close this PR, we will have at least a working derivation of Errands.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
