### PR TITLE
nvidia-container-toolkit: 1.9.0 -> 1.15.0-rc.3

### DIFF
--- a/pkgs/applications/virtualization/nvidia-container-toolkit/0001-Add-dlopen-discoverer.patch
+++ b/pkgs/applications/virtualization/nvidia-container-toolkit/0001-Add-dlopen-discoverer.patch
@@ -1,0 +1,90 @@
+From e4449f06a8989ff22947309151855b388c311aed Mon Sep 17 00:00:00 2001
+From: Jared Baur <jaredbaur@fastmail.com>
+Date: Mon, 22 Jan 2024 20:42:48 -0800
+Subject: [PATCH] Add dlopen discoverer
+
+---
+ internal/lookup/dlopen.go  | 57 ++++++++++++++++++++++++++++++++++++++
+ internal/lookup/library.go |  3 ++
+ 2 files changed, 60 insertions(+)
+ create mode 100644 internal/lookup/dlopen.go
+
+diff --git a/internal/lookup/dlopen.go b/internal/lookup/dlopen.go
+new file mode 100644
+index 00000000..7cd84522
+--- /dev/null
++++ b/internal/lookup/dlopen.go
+@@ -0,0 +1,57 @@
++package lookup
++
++// #cgo LDFLAGS: -ldl
++// #define _GNU_SOURCE
++// #include <dlfcn.h>
++// #include <stdlib.h>
++import "C"
++
++import (
++	"fmt"
++	"path/filepath"
++	"unsafe"
++)
++
++// dlopenLocator can be used to locate libraries given a system's dynamic
++// linker.
++type dlopenLocator struct {
++	file
++}
++
++// NewDlopenLocator creats a locator that can be used for locating libraries
++// through the dlopen mechanism.
++func NewDlopenLocator(opts ...Option) Locator {
++	f := newFileLocator(opts...)
++	d := dlopenLocator{file: *f}
++	return &d
++}
++
++// Locate finds the specified pattern if the systems' dynamic linker can find
++// it via dlopen. Note that patterns with wildcard patterns will likely not be
++// found as it is uncommon for libraries to have wildcard patterns in their
++// file name.
++func (d dlopenLocator) Locate(pattern string) ([]string, error) {
++	libname := C.CString(pattern)
++	defer C.free(unsafe.Pointer(libname))
++
++	d.logger.Debugf("Calling dlopen for %s", pattern)
++
++	handle := C.dlopen(libname, C.RTLD_LAZY)
++	if handle == nil {
++		return nil, fmt.Errorf("dlopen %s failed", pattern)
++	}
++	defer C.dlclose(handle)
++
++	libParentPath := C.CString("")
++
++	d.logger.Debugf("Calling dlinfo on handle for %s", pattern)
++	ret := C.dlinfo(handle, C.RTLD_DI_ORIGIN, unsafe.Pointer(libParentPath))
++	if ret == -1 {
++		return nil, fmt.Errorf("dlinfo on handle for %s failed", pattern)
++	}
++
++	libAbsolutePath := filepath.Join(C.GoString(libParentPath), pattern)
++	d.logger.Debugf("Found library for %s at %s", pattern, libAbsolutePath)
++
++	return []string{libAbsolutePath}, nil
++}
+diff --git a/internal/lookup/library.go b/internal/lookup/library.go
+index 7f5cf7c8..916edde2 100644
+--- a/internal/lookup/library.go
++++ b/internal/lookup/library.go
+@@ -61,7 +61,10 @@ func NewLibraryLocator(opts ...Option) Locator {
+ 	// We construct a symlink locator for expected library locations.
+ 	symlinkLocator := NewSymlinkLocator(opts...)
+ 
++	dlopenLocator := NewDlopenLocator(opts...)
++
+ 	l := First(
++		dlopenLocator,
+ 		symlinkLocator,
+ 		newLdcacheLocator(opts...),
+ 	)
+--

--- a/pkgs/applications/virtualization/nvidia-container-toolkit/default.nix
+++ b/pkgs/applications/virtualization/nvidia-container-toolkit/default.nix
@@ -74,9 +74,15 @@ buildGoModule rec {
       --replace '/sbin/ldconfig' '${lib.getBin glibc}/sbin/ldconfig'
   '';
 
-  # Try to keep this close to the ldflags in the original Makefile. See:
+  # Based on upstream's Makefile:
   # https://gitlab.com/nvidia/container-toolkit/container-toolkit/-/blob/03cbf9c6cd26c75afef8a2dd68e0306aace80401/Makefile#L64
-  ldflags = [ "-extldflags=-Wl,-z,lazy" "-s" "-w" "-X" "${cliVersionPackage}.version=${version}" ];
+  ldflags = [
+    "-extldflags=-Wl,-z,lazy" # May be redunandant, cf. `man ld`: "Lazy binding is the default".
+    "--strip-all" # May be redundant. Upstream: "-s".
+    # Omitting the upstream flag: "-w" (suppresses errors and warnings).
+    "--discard-locals" # May be redundant. Upstream: "-X".
+    "${cliVersionPackage}.version=${version}"
+  ];
 
   nativeBuildInputs = [
     cudaPackages.autoAddOpenGLRunpathHook

--- a/pkgs/applications/virtualization/nvidia-container-toolkit/default.nix
+++ b/pkgs/applications/virtualization/nvidia-container-toolkit/default.nix
@@ -10,6 +10,7 @@
 , configTemplate
 , configTemplatePath ? null
 , libnvidia-container
+, cudaPackages
 }:
 
 assert configTemplate != null -> (lib.isAttrs configTemplate && configTemplatePath == null);
@@ -31,29 +32,56 @@ let
   '';
 
   configToml = if configTemplatePath != null then configTemplatePath else (formats.toml { }).generate "config.toml" configTemplate;
+
+  # From https://gitlab.com/nvidia/container-toolkit/container-toolkit/-/blob/03cbf9c6cd26c75afef8a2dd68e0306aace80401/Makefile#L54
+  cliVersionPackage = "github.com/NVIDIA/nvidia-container-toolkit/internal/info";
 in
 buildGoModule rec {
   pname = "container-toolkit/container-toolkit";
-  version = "1.9.0";
+  version = "1.15.0-rc.3";
 
   src = fetchFromGitLab {
     owner = "nvidia";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-b4mybNB5FqizFTraByHk5SCsNO66JaISj18nLgLN7IA=";
+    hash = "sha256-IH2OjaLbcKSGG44aggolAOuJkjk+GaXnnTbrXfZ0lVo=";
+
   };
 
   vendorHash = null;
 
+  patches = [
+    # This patch causes library lookups to first attempt loading via dlopen
+    # before falling back to the regular symlink location and ldcache location.
+    ./0001-Add-dlopen-discoverer.patch
+  ];
+
   postPatch = ''
-    # replace the default hookDefaultFilePath to the $out path
-    substituteInPlace cmd/nvidia-container-runtime/main.go \
-      --replace '/usr/bin/nvidia-container-runtime-hook' '${placeholder "out"}/bin/nvidia-container-runtime-hook'
+    # Replace the default hookDefaultFilePath to the $out path and override
+    # default ldconfig locations to the one in nixpkgs.
+
+    substituteInPlace internal/config/config.go \
+      --replace '/usr/bin/nvidia-container-runtime-hook' "$out/bin/nvidia-container-runtime-hook" \
+      --replace '/sbin/ldconfig' '${lib.getBin glibc}/sbin/ldconfig'
+
+    substituteInPlace internal/config/config_test.go \
+      --replace '/sbin/ldconfig' '${lib.getBin glibc}/sbin/ldconfig'
+
+    substituteInPlace tools/container/toolkit/toolkit.go \
+      --replace '/sbin/ldconfig' '${lib.getBin glibc}/sbin/ldconfig'
+
+    substituteInPlace cmd/nvidia-ctk/hook/update-ldcache/update-ldcache.go \
+      --replace '/sbin/ldconfig' '${lib.getBin glibc}/sbin/ldconfig'
   '';
 
-  ldflags = [ "-s" "-w" ];
+  # Try to keep this close to the ldflags in the original Makefile. See:
+  # https://gitlab.com/nvidia/container-toolkit/container-toolkit/-/blob/03cbf9c6cd26c75afef8a2dd68e0306aace80401/Makefile#L64
+  ldflags = [ "-extldflags=-Wl,-z,lazy" "-s" "-w" "-X" "${cliVersionPackage}.version=${version}" ];
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    cudaPackages.autoAddOpenGLRunpathHook
+    makeWrapper
+  ];
 
   preConfigure = ''
     # Ensure the runc symlink isn't broken:
@@ -95,7 +123,8 @@ buildGoModule rec {
     substituteInPlace $out/etc/nvidia-container-runtime/config.toml \
       --subst-var-by glibcbin ${lib.getBin glibc}
 
-    ln -s $out/bin/nvidia-container-{toolkit,runtime-hook}
+    # See: https://gitlab.com/nvidia/container-toolkit/container-toolkit/-/blob/03cbf9c6cd26c75afef8a2dd68e0306aace80401/packaging/debian/nvidia-container-toolkit.postinst#L12
+    ln -s $out/bin/nvidia-container-runtime-hook $out/bin/nvidia-container-toolkit
 
     wrapProgram $out/bin/nvidia-container-toolkit \
       --add-flags "-config ${placeholder "out"}/etc/nvidia-container-runtime/config.toml"


### PR DESCRIPTION
## Description of changes

This changes bumps the `nvidia-container-toolkit` from 1.9.0 to 1.15.0-rc.3. This likely won't be too much of a notable change yet, but it allows deprecating the ancient `nvidia-docker` packages in future commits. This change also adds the `nvidia-ctk` tool as it's part of the toolkit.

Fixes #278155
Fixes #272235 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
