### PR TITLE
fetch-yarn-deps: retry on https failure

### DIFF
--- a/pkgs/build-support/node/fetch-yarn-deps/index.js
+++ b/pkgs/build-support/node/fetch-yarn-deps/index.js
@@ -42,7 +42,10 @@ const downloadFileHttps = (fileName, url, expectedHash, hashType = 'sha1') => {
 				} else if (h != expectedHash) return reject(new Error(`hash mismatch, expected ${expectedHash}, got ${h}`))
 				resolve()
 			})
-                        res.on('error', e => reject(e))
+		}).on("error", (e) => {
+			// error handler needs to be installed here, using res.on() in callback is registered too late for some errors
+			console.error(`Error fetching ${url}:`, e.code, ", retrying")
+			return get(url, redirects + 1)
 		})
 		get(url)
 	})


### PR DESCRIPTION
## Description of changes
I've been running into weird SSL issues[1] while using fetchYarnDeps, which result in the whole build failing.
I made a simple patch that re-uses the code for limiting the amount of redirects, to retry fetching from HTTP. I'm not sure if the `downloadGit` function would also benefit from a retry mechanism, but in general the nix-prefetch-* tools seem a bit more resilient already.


[1] These issues happen sporadically, but with builds that fetch lots of dependencies (mastodon) it's almost guaranteed to happen for one of them, failing the entire build.
It's unclear if this is a Cloudflare or NPM issue (registry.yarnpkg.com is just a CNAME to registry.npmjs.org), or something on my end, but I think this fetcher would benefit from some retry logic regardless.
```
downloading https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.7.tgz
node:events:495
      throw er; // Unhandled 'error' event
      ^

Error: C03714F5FF7F0000:error:0A0003FC:SSL routines:ssl3_read_bytes:sslv3 alert bad record mac:ssl/record/rec_layer_s3.c:1586:SSL alert number 20

Emitted 'error' event on ClientRequest instance at:
    at TLSSocket.socketErrorListener (node:_http_client:501:9)
    at TLSSocket.emit (node:events:517:28)
    at TLSSocket._emitTLSError (node:_tls_wrap:973:10)
    at TLSWrap.onerror (node:_tls_wrap:440:11) {
  library: 'SSL routines',
  reason: 'sslv3 alert bad record mac',
  code: 'ERR_SSL_SSLV3_ALERT_BAD_RECORD_MAC'
}
```

```
error in (662) Error: write EPROTO C0173C848E7F0000:error:0A0003FC:SSL routines:ssl3_read_bytes:sslv3 alert bad record mac:ssl/record/rec_layer_s3.c:1586:SSL alert number 20

    at WriteWrap.onWriteComplete [as oncomplete] (node:internal/stream_base_commons:94:16)
    at WriteWrap.callbackTrampoline (node:internal/async_hooks:130:17) {
  errno: -71,
  code: 'EPROTO',
  syscall: 'write'
}
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


The package does not list a maintainer, but most of the code seems to be written by @yu-re-ka 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc