### PR TITLE
cronutils: init at 1.10

### DIFF
--- a/pkgs/by-name/cr/cronutils/package.nix
+++ b/pkgs/by-name/cr/cronutils/package.nix
@@ -1,0 +1,54 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cronutils";
+  version = "1.10";
+
+  outputs = [ "out" "man" ];
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "cronutils";
+    rev = "version/${finalAttrs.version}";
+    hash = "sha256-XJksfX4jqE32l4HipvO26iv9W4c0Iss6DenlEatdL1k=";
+  };
+
+  patches = [
+    # Add missing libgen.h include. Backported from https://github.com/google/cronutils/pull/11.
+    (fetchpatch {
+      url = "https://github.com/google/cronutils/commit/5d742fc154fc1adcfebc646dca0c45b0f0060844.patch";
+      hash = "sha256-o1ylZ+fKL1fQYSKSOkujDsh4CUQya0wJ47uGNNC6mVQ=";
+    })
+    # Fix function declaration without a prototype. Backported from https://github.com/google/cronutils/pull/11.
+    (fetchpatch {
+      url = "https://github.com/google/cronutils/commit/c39df37c6c280e3f73ea57cfa598b8447e5a58fe.patch";
+      hash = "sha256-og/xEWn0M7+mkbLGY14nkYpV3ckr7eYrb0X22Zxmq8w=";
+    })
+    # Remove `LDLIBS+=-lrt` from Makefile. Backported from https://github.com/google/cronutils/pull/11.
+    (fetchpatch {
+      url = "https://github.com/google/cronutils/commit/de72c648d12d102b79d4e3bb57830f2d79f5702a.patch";
+      hash = "sha256-njftI3RbrjRtXpXKFHNE9HroIZr5tqVnEK77lu4+/sI=";
+    })
+  ];
+
+  makeFlags = [ "prefix=$(out)" ];
+
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin (toString [
+    "-D_DARWIN_C_SOURCE"
+    # runstat.c:81:81: error: format string is not a string literal
+    "-Wno-format-nonliteral"
+  ]);
+
+  meta = with lib; {
+    changelog = "https://github.com/google/cronutils/releases/tag/version%2F${finalAttrs.version}";
+    description = "Utilities to assist running periodic batch processing jobs";
+    homepage = "https://github.com/google/cronutils";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ katexochen ];
+    platforms = platforms.all;
+  };
+})


### PR DESCRIPTION
## Description of changes

> cronutils is a set of tools to assist the reliable running of periodic and batch jobs.
> 
> - runalarm: Limit the running time of a process.
> - runlock: Prevent concurrent runs of a process.
> - runstat: Export statistics about a process's execution.

https://github.com/google/cronutils

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
