### PR TITLE
nixos/qemu-vm: add opengl hardware acceleration option

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -1166,6 +1166,8 @@ in
       (mkIf pkgs.stdenv.hostPlatform.isx86 (mkMerge [
         [ "-usb" "-device usb-tablet,bus=usb-bus.0" ]
         (mkIf cfg.opengl [ "-vga none" "-device virtio-gpu-gl-pci" ])
+        # Use software rendering when opengl is required, but hardware acceleration is disabled
+        (mkIf (!cfg.opengl && config.hardware.opengl.enable) [ "-vga none" "-device virtio-gpu-pci" ])
       ]))
       (mkIf pkgs.stdenv.hostPlatform.isAarch (mkMerge [
         [ "-device usb-ehci,id=usb0" "-device usb-kbd" "-device usb-tablet" ]

--- a/nixos/tests/cage.nix
+++ b/nixos/tests/cage.nix
@@ -20,6 +20,10 @@ import ./make-test-python.nix ({ pkgs, ...} :
     };
   };
 
+  interactive.nodes.machine = {
+    virtualisation.opengl = true;
+  };
+
   enableOCR = true;
 
   testScript = { nodes, ... }: let

--- a/nixos/tests/cage.nix
+++ b/nixos/tests/cage.nix
@@ -18,9 +18,6 @@ import ./make-test-python.nix ({ pkgs, ...} :
       user = "alice";
       program = "${pkgs.xterm}/bin/xterm";
     };
-
-    # Need to switch to a different GPU driver than the default one (-vga std) so that Cage can launch:
-    virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
   };
 
   enableOCR = true;

--- a/nixos/tests/cagebreak.nix
+++ b/nixos/tests/cagebreak.nix
@@ -37,6 +37,10 @@ in
     environment.systemPackages = [ pkgs.cagebreak pkgs.wayland-utils ];
   };
 
+  interactive.nodes.machine = {
+    virtualisation.opengl = true;
+  };
+
   enableOCR = true;
 
   testScript = { nodes, ... }: let

--- a/nixos/tests/cagebreak.nix
+++ b/nixos/tests/cagebreak.nix
@@ -35,9 +35,6 @@ in
     programs.xwayland.enable = true;
     security.polkit.enable = true;
     environment.systemPackages = [ pkgs.cagebreak pkgs.wayland-utils ];
-
-    # Need to switch to a different GPU driver than the default one (-vga std) so that Cagebreak can launch:
-    virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
   };
 
   enableOCR = true;

--- a/nixos/tests/gnome-extensions.nix
+++ b/nixos/tests/gnome-extensions.nix
@@ -50,8 +50,11 @@ import ./make-test-python.nix (
           };
         };
       };
-
     };
+
+  interactive.nodes.machine = {
+    virtualisation.opengl = true;
+  };
 
   testScript = { nodes, ... }: let
     # Keep line widths somewhat manageable

--- a/nixos/tests/gnome-xorg.nix
+++ b/nixos/tests/gnome-xorg.nix
@@ -7,7 +7,6 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : {
   nodes.machine = { nodes, ... }: let
     user = nodes.machine.users.users.alice;
   in
-
     { imports = [ ./common/user-account.nix ];
 
       services.xserver.enable = true;
@@ -39,8 +38,11 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : {
           };
         };
       };
-
     };
+
+  interactive.nodes.machine = {
+    virtualisation.opengl = true;
+  };
 
   testScript = { nodes, ... }: let
     user = nodes.machine.users.users.alice;

--- a/nixos/tests/gnome.nix
+++ b/nixos/tests/gnome.nix
@@ -35,8 +35,11 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : {
           };
         };
       };
-
     };
+
+  interactive.nodes.machine = {
+    virtualisation.opengl = true;
+  };
 
   testScript = { nodes, ... }: let
     # Keep line widths somewhat manageable

--- a/nixos/tests/mate-wayland.nix
+++ b/nixos/tests/mate-wayland.nix
@@ -23,6 +23,10 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     hardware.pulseaudio.enable = true;
   };
 
+  interactive.nodes.machine = {
+    virtualisation.opengl = true;
+  };
+
   enableOCR = true;
 
   testScript = { nodes, ... }:

--- a/nixos/tests/mate-wayland.nix
+++ b/nixos/tests/mate-wayland.nix
@@ -21,9 +21,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     services.xserver.desktopManager.mate.enableWaylandSession = true;
 
     hardware.pulseaudio.enable = true;
-
-    # Need to switch to a different GPU driver than the default one (-vga std) so that wayfire can launch:
-    virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
   };
 
   enableOCR = true;

--- a/nixos/tests/mate.nix
+++ b/nixos/tests/mate.nix
@@ -27,6 +27,10 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     hardware.pulseaudio.enable = true;
   };
 
+  interactive.nodes.machine = {
+    virtualisation.opengl = true;
+  };
+
   enableOCR = true;
 
   testScript = { nodes, ... }:

--- a/nixos/tests/phosh.nix
+++ b/nixos/tests/phosh.nix
@@ -1,4 +1,4 @@
-import ./make-test-python.nix ({ pkgs, ...}: let
+import ./make-test-python.nix ({ pkgs, ... }: let
   pin = "1234";
 in {
   name = "phosh";
@@ -25,15 +25,12 @@ in {
         };
       };
 
-      systemd.services.phosh = {
-        environment = {
-          # Accelerated graphics fail on phoc 0.20 (wlroots 0.15)
-          "WLR_RENDERER" = "pixman";
-        };
-      };
-
       virtualisation.resolution = { x = 720; y = 1440; };
     };
+  };
+
+  interactive.nodes.phone = {
+    virtualisation.opengl = true;
   };
 
   enableOCR = true;

--- a/nixos/tests/phosh.nix
+++ b/nixos/tests/phosh.nix
@@ -33,7 +33,6 @@ in {
       };
 
       virtualisation.resolution = { x = 720; y = 1440; };
-      virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci,xres=720,yres=1440" ];
     };
   };
 

--- a/nixos/tests/plasma5.nix
+++ b/nixos/tests/plasma5.nix
@@ -7,7 +7,6 @@ import ./make-test-python.nix ({ pkgs, ...} :
   };
 
   nodes.machine = { ... }:
-
   {
     imports = [ ./common/user-account.nix ];
     services.xserver.enable = true;
@@ -20,6 +19,10 @@ import ./make-test-python.nix ({ pkgs, ...} :
       user = "alice";
     };
     hardware.pulseaudio.enable = true; # needed for the factl test, /dev/snd/* exists without them but udev doesn't care then
+  };
+
+  interactive.nodes.machine = {
+    virtualisation.opengl = true;
   };
 
   testScript = { nodes, ... }: let

--- a/nixos/tests/seatd.nix
+++ b/nixos/tests/seatd.nix
@@ -43,6 +43,10 @@ in
     services.seatd.enable = true;
   };
 
+  interactive.nodes.machine = {
+    virtualisation.opengl = true;
+  };
+
   testScript = ''
     machine.wait_for_file("/tmp/foot_started")
     machine.succeed("test $(seatd-client-pid) = $(pgrep dwl)")

--- a/nixos/tests/seatd.nix
+++ b/nixos/tests/seatd.nix
@@ -40,7 +40,6 @@ in
     '';
 
     hardware.opengl.enable = true;
-    virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
     services.seatd.enable = true;
   };
 

--- a/nixos/tests/sway.nix
+++ b/nixos/tests/sway.nix
@@ -70,9 +70,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
 
     # To test pinentry via gpg-agent:
     programs.gnupg.agent.enable = true;
-
-    # Need to switch to a different GPU driver than the default one (-vga std) so that Sway can launch:
-    virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
   };
 
   testScript = { nodes, ... }: ''

--- a/nixos/tests/sway.nix
+++ b/nixos/tests/sway.nix
@@ -19,15 +19,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
       # For glinfo and wayland-info:
       systemPackages = with pkgs; [ mesa-demos wayland-utils alacritty ];
       # Use a fixed SWAYSOCK path (for swaymsg):
-      variables = {
-        "SWAYSOCK" = "/tmp/sway-ipc.sock";
-        # TODO: Investigate if we can get hardware acceleration to work (via
-        # virtio-gpu and Virgil). We currently have to use the Pixman software
-        # renderer since the GLES2 renderer doesn't work inside the VM (even
-        # with WLR_RENDERER_ALLOW_SOFTWARE):
-        # "WLR_RENDERER_ALLOW_SOFTWARE" = "1";
-        "WLR_RENDERER" = "pixman";
-      };
+      variables."SWAYSOCK" = "/tmp/sway-ipc.sock";
       # For convenience:
       shellAliases = {
         test-x11 = "glinfo | tee /tmp/test-x11.out && touch /tmp/test-x11-exit-ok";
@@ -70,6 +62,10 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
 
     # To test pinentry via gpg-agent:
     programs.gnupg.agent.enable = true;
+  };
+
+  interactive.nodes.machine = {
+    virtualisation.opengl = true;
   };
 
   testScript = { nodes, ... }: ''

--- a/nixos/tests/tinywl.nix
+++ b/nixos/tests/tinywl.nix
@@ -29,9 +29,6 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
           touch /tmp/tinywl-exit-ok
         fi
       '';
-
-      # Switch to a different GPU driver (default: -vga std), otherwise TinyWL segfaults:
-      virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
     };
 
     testScript = { nodes, ... }: ''

--- a/nixos/tests/tinywl.nix
+++ b/nixos/tests/tinywl.nix
@@ -31,6 +31,10 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
       '';
     };
 
+    interactive.nodes.machine = {
+      virtualisation.opengl = true;
+    };
+
     testScript = { nodes, ... }: ''
       start_all()
       machine.wait_for_unit("multi-user.target")


### PR DESCRIPTION
## Description of changes

VMs built with `hardware.opengl.enable = true` will now use opengl hardware acceleration backed by [VirGL](https://www.qemu.org/docs/master/system/devices/virtio-gpu.html#virtio-gpu-virglrenderer).

This makes it possible to run most Wayland compositors in a VM, and enables hardware acceleration for X11 desktop environments.

Hardware acceleration can also be enabled when running a test VM interactively with:

```nix
{
  interactive.nodes.machine = {
    virtualisation.opengl = true;
  };
}
```

```shell
nix run .#nixosTests.gnome.driverInteractive
>>> start_all()
```

Compositors like [gamescope](https://github.com/ValveSoftware/gamescope) which rely on Vulkan still aren't supported out of the box. Although, it looks like we could eventually support this if we enable & use [rutabaga](https://www.qemu.org/docs/master/system/devices/virtio-gpu.html#virtio-gpu-rutabaga) when building qemu.

**NOTE:** I haven't tested this on aarch64-linux & darwin, but I assume it should work based on the similar usage instructions I found at https://github.com/knazarov/homebrew-qemu-virgl#usage---m1-macs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
