### PR TITLE
Rephrase versioning requirements on OBS

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/obs-websocket.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-websocket.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "Legacy websocket 4.9.1 protocol support for OBS Studio 28 or above";
+    description = "Legacy websocket 4.9.1 protocol support for OBS Studio < 28";
     homepage = "https://github.com/obsproject/obs-websocket";
     maintainers = with maintainers; [ flexiondotorg ];
     license = licenses.gpl2Plus;


### PR DESCRIPTION
Based on description in: https://github.com/obsproject/obs-websocket

> obs-websocket is now included by default with OBS Studio 28.0.0 and above. As such, there should be no need to download obs-websocket if you have OBS Studio > 28.0.0.

## Description of changes

Docs change in `obs-websocket.nix`