### PR TITLE
tika: init at 2.9.2

### DIFF
--- a/pkgs/by-name/ti/tika/package.nix
+++ b/pkgs/by-name/ti/tika/package.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  stdenv,
+  maven,
+  jdk8,
+  fetchFromGitHub,
+  makeWrapper,
+  mvnDepsHash ? null,
+}:
+
+let
+  maven' = maven.override { jdk = jdk8; };
+
+  mvnDepsHashes = {
+    "x86_64-linux" = "sha256-M8O1EJtlTm+mVy/qxapRcBWxD14eYL/LLUxP2uOBoM4=";
+    "aarch64-linux" = "sha256-+ewdV9g0MfgiBiRAimkIZp9lrOTKnKnBB1LqhIlOSaQ=";
+    "x86_64-darwin" = "sha256-nUAy2+O8REuq6pOWb8d+/c/YxPxj+XwtCtkaxfihDzc=";
+    "aarch64-darwin" = "sha256-D6adBXtBH1IokUwwA2Z6m+6rJP2xg6BK4rcPyDSgo6o=";
+  };
+
+  knownMvnDepsHash =
+    mvnDepsHashes.${stdenv.system}
+      or (lib.warn "This platform doesn't have a default mvnDepsHash value, you'll need to specify it manually" lib.fakeHash);
+in
+maven'.buildMavenPackage rec {
+  pname = "tika";
+  version = "2.9.2";
+
+  src = fetchFromGitHub {
+    owner = "apache";
+    repo = "tika";
+    rev = version;
+    hash = "sha256-4pSQcLDKgIcU+YypJ/ywdthi6tI1852fGVOCREzUFH0=";
+  };
+
+  buildOffline = true;
+
+  manualMvnArtifacts = [
+    "org.objenesis:objenesis:2.1"
+    "org.apache.apache.resources:apache-jar-resource-bundle:1.5"
+    "org.apache.maven.surefire:surefire-junit-platform:3.1.2"
+    "org.junit.platform:junit-platform-launcher:1.10.0"
+  ];
+
+  mvnHash = if mvnDepsHash != null then mvnDepsHash else knownMvnDepsHash;
+
+  mvnParameters = toString [
+    "-DskipTests=true" # skip tests (out of memory execptions)
+    "-Dossindex.skip" # skip dependency with vulnerability (recommended by upstream)
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    # Note: using * instead of version would match multiple files
+    install -Dm644 tika-app/target/tika-app-${version}.jar $out/share/tika/tika-app.jar
+    install -Dm644 tika-server/tika-server-standard/target/tika-server-standard-${version}.jar $out/share/tika/tika-server.jar
+
+    makeWrapper ${jdk8.jre}/bin/java $out/bin/tika-app \
+        --add-flags "-jar $out/share/tika/tika-app.jar"
+    makeWrapper ${jdk8.jre}/bin/java $out/bin/tika-server \
+        --prefix PATH : ${lib.makeBinPath [ jdk8.jre ]} \
+        --add-flags "-jar $out/share/tika/tika-server.jar"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    changelog = "https://github.com/apache/tika/blob/${src.rev}/CHANGES.txt";
+    description = "A toolkit for extracting metadata and text from over a thousand different file types";
+    longDescription = ''
+      The Apache Tika™ toolkit detects and extracts metadata and text
+      from over a thousand different file types (such as PPT, XLS, and PDF).
+      All of these file types can be parsed through a single interface,
+      making Tika useful for search engine indexing, content analysis,
+      translation, and much more.
+    '';
+    homepage = "https://tika.apache.org";
+    license = lib.licenses.asl20;
+    mainProgram = "tika-server";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode # maven dependencies
+    ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/278388

Supersedes https://github.com/NixOS/nixpkgs/pull/267418

This PR adds 1 package: `tika`

The installation was partially based off of the one in the [`AUR`](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=tika)

The package was, to my surprise, deterministic by default. (They set the build timestamp and specified every plugin version on the upstream)

This is the second package inside nixpkgs that uses the `buildOffline = true` functionality of `buildMavenPackage`, and I had a good experience with it (only 3 undetected deps, considering the size of the repo)

I have disabled the tests for now, because I was having some out of memory issues with some tests. Maybe I could disable only some of them.

Next update is still a beta, so I didn't immediately jump to that.

It looks like different platforms will need a different `mvnHash`. Using OfBorg I can only get the hashes for the 4 main platforms, other users will have to manually specify the hash

---

The `tika-server` executable will need a systemd service module, this PR doesn't address that yet.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
