### PR TITLE
starsector: add missing runtime dependency xrandr

### DIFF
--- a/pkgs/games/starsector/default.nix
+++ b/pkgs/games/starsector/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     ln -s $out/graphics/ui/s_icon64.png $out/share/icons/hicolor/64x64/apps/starsector.png
 
     wrapProgram $out/share/starsector/starsector.sh \
-      --prefix PATH : ${lib.makeBinPath [ openjdk ]} \
+      --prefix PATH : ${lib.makeBinPath [ openjdk xorg.xrandr ]} \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath buildInputs} \
       --run 'mkdir -p ''${XDG_DATA_HOME:-~/.local/share}/starsector' \
       --chdir "$out/share/starsector"

--- a/pkgs/games/starsector/default.nix
+++ b/pkgs/games/starsector/default.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
     homepage = "https://fractalsoftworks.com";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfree;
-    maintainers = with maintainers; [ bbigras ];
+    maintainers = with maintainers; [ bbigras rafaelrc ];
   };
 
   passthru.updateScript = writeScript "starsector-update-script" ''


### PR DESCRIPTION
The starsector game is made using LWJGL, which depends on `xrandr`. The library runs `xrandr -q` and parses its output to get screen resolutions. Thus, if the binary is missing, the game will crash on startup.

https://github.com/LWJGL/lwjgl/blob/master/src/java/org/lwjgl/opengl/XRandR.java#L72

## Description of changes

`xorg.xrandr` was added to the binary path, as LWJGL depends on it. I noticed the problem when trying to play the game after removing X from my system. It crashed on startup with the following message:
```
OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=128m; support was removed in 8.0
0    [main] INFO  com.fs.starfarer.StarfarerLauncher  - Starting Starsector 0.96a-RC10 launcher
1    [main] INFO  com.fs.starfarer.StarfarerLauncher  - Running in /nix/store/kwl1mff58w69n9r8jdynnk18cvqhnjb4-starsector-0.96a-RC10/share/starsector
1    [main] INFO  com.fs.starfarer.StarfarerLauncher  - OS: Linux 6.6.8-zen1
1    [main] INFO  com.fs.starfarer.StarfarerLauncher  - Java version: 1.8.0_362 (64-bit)
3    [main] INFO  com.fs.starfarer.settings.StarfarerSettings  - Loading settings
4    [main] INFO  com.fs.starfarer.loading.LoadingUtils  - Loading JSON from [ABSOLUTE_AND_CWD: null (data/config/settings.json)]
79   [main] ERROR com.fs.starfarer.StarfarerLauncher  - java.lang.ExceptionInInitializerError
java.lang.ExceptionInInitializerError
	at com.fs.graphics.DisplayManager.new(Unknown Source)
	at com.fs.starfarer.launcher.opengl.GLLauncher.detectResolutions(Unknown Source)
	at com.fs.starfarer.launcher.opengl.GLLauncher.<init>(Unknown Source)
	at com.fs.starfarer.launcher.opengl.GLLauncher.createUI(Unknown Source)
	at com.fs.starfarer.StarfarerLauncher.<init>(Unknown Source)
	at com.fs.starfarer.StarfarerLauncher.<init>(Unknown Source)
	at com.fs.starfarer.StarfarerLauncher.main(Unknown Source)
Caused by: java.lang.ArrayIndexOutOfBoundsException: 0
	at org.lwjgl.opengl.LinuxDisplay.getAvailableDisplayModes(LinuxDisplay.java:951)
	at org.lwjgl.opengl.LinuxDisplay.init(LinuxDisplay.java:738)
	at org.lwjgl.opengl.Display.<clinit>(Display.java:138)
	... 7 more

(java:59029): Gtk-WARNING **: 00:32:55.326: Unable to locate theme engine in module_path: "adwaita",
```

When searching about it, I found about the `xrandr` dependency. I then tried running the game in a nix shell with `xrandr` and it worked. Thus I added it to the binary PATH and it seems to have done the trick, the game now works fine.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
