### PR TITLE
nixos-23.11: unbreak hopenpgp-tools

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1215,6 +1215,10 @@ self: super: {
         }))
       ];
 
+  hopenpgp-tools = super.hopenpgp-tools.override {
+      optparse-applicative = self.optparse-applicative_0_18_1_0;
+  };
+
   # musl fixes
   # dontCheck: use of non-standard strptime "%s" which musl doesn't support; only used in test
   unix-time = if pkgs.stdenv.hostPlatform.isMusl then dontCheck super.unix-time else super.unix-time;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -2496,7 +2496,6 @@ broken-packages:
   - hopencc # failure in job https://hydra.nixos.org/build/233192954 at 2023-09-02
   - hopencl # failure in job https://hydra.nixos.org/build/233249443 at 2023-09-02
   - HOpenCV # failure in job https://hydra.nixos.org/build/233255422 at 2023-09-02
-  - hopenpgp-tools # failure in job https://hydra.nixos.org/build/233259304 at 2023-09-02
   - hopfield # failure in job https://hydra.nixos.org/build/233598214 at 2023-09-02
   - hoppy-generator # failure in job https://hydra.nixos.org/build/233240608 at 2023-09-02
   - hops # failure in job https://hydra.nixos.org/build/233207172 at 2023-09-02


### PR DESCRIPTION
Unbreak hopenpgp-tools to 23.11

Master PR: https://github.com/NixOS/nixpkgs/pull/275414