### PR TITLE
ci-edit: init at 51-unstable-2023-04-11

### DIFF
--- a/pkgs/by-name/ci/ci-edit/package.nix
+++ b/pkgs/by-name/ci/ci-edit/package.nix
@@ -1,0 +1,40 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+
+python3.pkgs.buildPythonApplication {
+  pname = "ci-edit";
+  version = "51-unstable-2023-04-11";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "ci_edit";
+    # Last build iteration is v51 from 2021, but there are some recent
+    # additions of syntax highlighting and dictionary files.
+    rev = "2976f01dc6421b5639505292b335212d413d044f";
+    hash = "sha256-DwVNNotRcYbvJX6iXffSQyZMFTxQexIhfG8reFmozN8=";
+  };
+
+  nativeBuildInputs = with python3.pkgs; [
+    setuptools
+  ];
+
+  postInstall = ''
+    ln -s $out/bin/ci.py $out/bin/ci_edit
+    ln -s $out/bin/ci.py $out/bin/we
+    install -Dm644 $src/app/*.words $out/${python3.sitePackages}/app/
+  '';
+
+  pythonImportsCheck = [ "app" ];
+
+  meta = with lib; {
+    description = "A terminal text editor with mouse support and ctrl+Q to quit";
+    homepage = "https://github.com/google/ci_edit";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ katexochen ];
+    mainProgram = "ci_edit";
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

> Many other command line text editors require learning a different set of mouse and keyboard commands. 
> Many of us use a graphical editor (GUI) that supports a common set of commands like ctrl+q to quit (that is, hold the control key and press Q). Here are a few common commands:
> 
> ctrl+q to quit the program
> ctrl+s to save the file
> ctrl+z undo
> ctrl+x cut
> ctrl+c copy
> ctrl+v paste
> There are more, but you probably get the idea. These common controls are not common in command line editors.

https://github.com/google/ci_edit

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
