### PR TITLE
pixman: 0.42.2 -> 0.43.0

### DIFF
--- a/pkgs/development/libraries/pixman/default.nix
+++ b/pkgs/development/libraries/pixman/default.nix
@@ -1,6 +1,8 @@
 { lib
 , stdenv
 , fetchurl
+, meson
+, ninja
 , pkg-config
 , libpng
 , glib /*just passthru*/
@@ -12,29 +14,37 @@
 , tigervnc
 , wlroots
 , xwayland
+
+, gitUpdater
 }:
 
 stdenv.mkDerivation rec {
   pname = "pixman";
-  version = "0.42.2";
+  version = "0.43.0";
 
   src = fetchurl {
     urls = [
       "mirror://xorg/individual/lib/${pname}-${version}.tar.gz"
       "https://cairographics.org/releases/${pname}-${version}.tar.gz"
     ];
-    hash = "sha256-6hSA762i/ZSLx1Nm98NJ4cltMpfQmj/mJibjjiNKYl4=";
+    hash = "sha256-plwoIJhY+xa+5Q2AnID5Co5BXA5P2DIQeKGCJ4WlVgo=";
   };
 
   separateDebugInfo = !stdenv.hostPlatform.isStatic;
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [ meson ninja pkg-config ];
 
   buildInputs = [ libpng ];
 
-  configureFlags = lib.optional stdenv.isAarch32 "--disable-arm-iwmmxt"
-    # Disable until https://gitlab.freedesktop.org/pixman/pixman/-/issues/46 is resolved
-    ++ lib.optional (stdenv.isAarch64 && !stdenv.cc.isGNU) "--disable-arm-a64-neon";
+  # Default "enabled" value attempts to enable CPU features on all
+  # architectures and requires used to disable them:
+  #   https://gitlab.freedesktop.org/pixman/pixman/-/issues/88
+  mesonAutoFeatures = "auto";
+  mesonFlags = [
+    "-Diwmmxt=disabled"
+  ]
+  # Disable until https://gitlab.freedesktop.org/pixman/pixman/-/issues/46 is resolved
+  ++ lib.optional (stdenv.isAarch64 && !stdenv.cc.isGNU) "-Da64-neon=disabled";
 
   preConfigure = ''
     # https://gitlab.freedesktop.org/pixman/pixman/-/issues/62
@@ -45,8 +55,14 @@ stdenv.mkDerivation rec {
 
   postInstall = glib.flattenInclude;
 
-  passthru.tests = {
-    inherit cairo qemu scribus tigervnc wlroots xwayland;
+  passthru = {
+    tests = {
+      inherit cairo qemu scribus tigervnc wlroots xwayland;
+    };
+    updateScript = gitUpdater {
+      url = "https://gitlab.freedesktop.org/pixman/pixman.git";
+      rev-prefix = "pixman-";
+    };
   };
 
   meta = with lib; {


### PR DESCRIPTION
While at it:
- added a trivial updater
- migrated to `meson` build system as `autotoocs`-based is dropped upstream

Changes: https://lists.freedesktop.org/archives/pixman/2024-January/005008.html

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
