### PR TITLE
python3Packages.orjson: specify the interpreter version to maturin

### DIFF
--- a/pkgs/development/python-modules/orjson/default.nix
+++ b/pkgs/development/python-modules/orjson/default.nix
@@ -12,6 +12,7 @@
 , python-dateutil
 , pytz
 , xxhash
+, python
 }:
 
 buildPythonPackage rec {
@@ -33,6 +34,8 @@ buildPythonPackage rec {
     name = "${pname}-${version}";
     hash = "sha256-2eRV+oZQvsWWJ4AUTeuE0CHtTHC6jNZiX/y5uXuwvns=";
   };
+
+  maturinBuildFlags = [ "--interpreter ${python.executable}" ];
 
   nativeBuildInputs = [
     cffi


### PR DESCRIPTION
## Description of changes

Fixes: https://github.com/NixOS/nixpkgs/issues/279133
Related: https://github.com/NixOS/nixpkgs/issues/115601

x86_64-linux -> x86_64-linux python311
```
Executing maturinBuildHook
++ env CC_X86_64_UNKNOWN_LINUX_GNU=/nix/store/sfgnb6rr428bssyrs54d6d0vv2avi95c-gcc-wrapper-12.3.0/bin/cc CXX_X86_64_UNKNOWN_LINUX_GNU=/nix/store/sfgnb6rr428bssyrs54d6d0vv2avi95c-gcc-wrapper-12.3.0/bin/c++ CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/nix/store/sfgnb6rr428bssyrs54d6d0vv2avi95c-gcc-wrapper-12.3.0/bin/cc CC_X86_64_UNKNOWN_LINUX_GNU=/nix/store/sfgnb6rr428bssyrs54d6d0vv2avi95c-gcc-wrapper-12.3.0/bin/cc CXX_X86_64_UNKNOWN_LINUX_GNU=/nix/store/sfgnb6rr428bssyrs54d6d0vv2avi95c-gcc-wrapper-12.3.0/bin/c++ CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/nix/store/sfgnb6rr428bssyrs54d6d0vv2avi95c-gcc-wrapper-12.3.0/bin/cc CARGO_BUILD_TARGET=x86_64-unknown-linux-gnu HOST_CC=/nix/store/sfgnb6rr428bssyrs54d6d0vv2avi95c-gcc-wrapper-12.3.0/bin/cc HOST_CXX=/nix/store/sfgnb6rr428bssyrs54d6d0vv2avi95c-gcc-wrapper-12.3.0/bin/c++ maturin build --jobs=16 --frozen --target x86_64-unknown-linux-gnu --manylinux off --strip --release --interpreter python3.11
📦 Including license file "/build/source/LICENSE-APACHE"
📦 Including license file "/build/source/LICENSE-MIT"
🍹 Building a mixed python/rust project
🔗 Found pyo3-ffi bindings
🐍 Found CPython 3.11 at /nix/store/5k91mg4qjylxbfvrv748smfh51ppjq0g-python3-3.11.6/bin/python3.11
```

x86_64-linux -> x86_64-linux python310
```
Executing maturinBuildHook
++ env CC_X86_64_UNKNOWN_LINUX_GNU=/nix/store/sfgnb6rr428bssyrs54d6d0vv2avi95c-gcc-wrapper-12.3.0/bin/cc CXX_X86_64_UNKNOWN_LINUX_GNU=/nix/store/sfgnb6rr428bssyrs54d6d0vv2avi95c-gcc-wrapper-12.3.0/bin/c++ CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/nix/store/sfgnb6rr428bssyrs54d6d0vv2avi95c-gcc-wrapper-12.3.0/bin/cc CC_X86_64_UNKNOWN_LINUX_GNU=/nix/store/sfgnb6rr428bssyrs54d6d0vv2avi95c-gcc-wrapper-12.3.0/bin/cc CXX_X86_64_UNKNOWN_LINUX_GNU=/nix/store/sfgnb6rr428bssyrs54d6d0vv2avi95c-gcc-wrapper-12.3.0/bin/c++ CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/nix/store/sfgnb6rr428bssyrs54d6d0vv2avi95c-gcc-wrapper-12.3.0/bin/cc CARGO_BUILD_TARGET=x86_64-unknown-linux-gnu HOST_CC=/nix/store/sfgnb6rr428bssyrs54d6d0vv2avi95c-gcc-wrapper-12.3.0/bin/cc HOST_CXX=/nix/store/sfgnb6rr428bssyrs54d6d0vv2avi95c-gcc-wrapper-12.3.0/bin/c++ maturin build --jobs=16 --frozen --target x86_64-unknown-linux-gnu --manylinux off --strip --release --interpreter python3.10
📦 Including license file "/build/source/LICENSE-APACHE"
📦 Including license file "/build/source/LICENSE-MIT"
🍹 Building a mixed python/rust project
🔗 Found pyo3-ffi bindings
🐍 Found CPython 3.10 at /nix/store/l8d6q4y9cvp2d5qf2sxxj072668bfcjr-python3-3.10.13/bin/python3.10
```

x86_64-linux -> riscv64-linux python311
```
Executing maturinBuildHook
++ env CC_RISCV64GC_UNKNOWN_LINUX_GNU=/nix/store/xg2599knh81a19z9k3qq1fdp69c9lzkf-riscv64-linux-gcc-wrapper-13.2.0/bin/riscv64-linux-cc CXX_RISCV64GC_UNKNOWN_LINUX_GNU=/nix/store/xg2599knh81a19z9k3qq1fdp69c9lzkf-riscv64-linux-gcc-wrapper-13.2.0/bin/riscv64-linux-c++ CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=/nix/store/xg2599knh81a19z9k3qq1fdp69c9lzkf-riscv64-linux-gcc-wrapper-13.2.0/bin/riscv64-linux-cc CC_X86_64_UNKNOWN_LINUX_GNU=/nix/store/94xwlhrjl0z82l7x83hixbspy32slz70-gcc-wrapper-13.2.0/bin/cc CXX_X86_64_UNKNOWN_LINUX_GNU=/nix/store/94xwlhrjl0z82l7x83hixbspy32slz70-gcc-wrapper-13.2.0/bin/c++ CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/nix/store/94xwlhrjl0z82l7x83hixbspy32slz70-gcc-wrapper-13.2.0/bin/cc CC_X86_64_UNKNOWN_LINUX_GNU=/nix/store/94xwlhrjl0z82l7x83hixbspy32slz70-gcc-wrapper-13.2.0/bin/cc CXX_X86_64_UNKNOWN_LINUX_GNU=/nix/store/94xwlhrjl0z82l7x83hixbspy32slz70-gcc-wrapper-13.2.0/bin/c++ CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/nix/store/94xwlhrjl0z82l7x83hixbspy32slz70-gcc-wrapper-13.2.0/bin/cc CARGO_BUILD_TARGET=x86_64-unknown-linux-gnu HOST_CC=/nix/store/94xwlhrjl0z82l7x83hixbspy32slz70-gcc-wrapper-13.2.0/bin/cc HOST_CXX=/nix/store/94xwlhrjl0z82l7x83hixbspy32slz70-gcc-wrapper-13.2.0/bin/c++ maturin build --jobs=16 --frozen --target riscv64gc-unknown-linux-gnu --manylinux off --strip --release --interpreter python3.11
📦 Including license file "/build/source/LICENSE-APACHE"
📦 Including license file "/build/source/LICENSE-MIT"
🍹 Building a mixed python/rust project
🔗 Found pyo3-ffi bindings
🐍 Found CPython 3.11
```

x86_64-linux -> riscv64-linux python310
```
Executing maturinBuildHook
++ env CC_RISCV64GC_UNKNOWN_LINUX_GNU=/nix/store/xg2599knh81a19z9k3qq1fdp69c9lzkf-riscv64-linux-gcc-wrapper-13.2.0/bin/riscv64-linux-cc CXX_RISCV64GC_UNKNOWN_LINUX_GNU=/nix/store/xg2599knh81a19z9k3qq1fdp69c9lzkf-riscv64-linux-gcc-wrapper-13.2.0/bin/riscv64-linux-c++ CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=/nix/store/xg2599knh81a19z9k3qq1fdp69c9lzkf-riscv64-linux-gcc-wrapper-13.2.0/bin/riscv64-linux-cc CC_X86_64_UNKNOWN_LINUX_GNU=/nix/store/94xwlhrjl0z82l7x83hixbspy32slz70-gcc-wrapper-13.2.0/bin/cc CXX_X86_64_UNKNOWN_LINUX_GNU=/nix/store/94xwlhrjl0z82l7x83hixbspy32slz70-gcc-wrapper-13.2.0/bin/c++ CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/nix/store/94xwlhrjl0z82l7x83hixbspy32slz70-gcc-wrapper-13.2.0/bin/cc CC_X86_64_UNKNOWN_LINUX_GNU=/nix/store/94xwlhrjl0z82l7x83hixbspy32slz70-gcc-wrapper-13.2.0/bin/cc CXX_X86_64_UNKNOWN_LINUX_GNU=/nix/store/94xwlhrjl0z82l7x83hixbspy32slz70-gcc-wrapper-13.2.0/bin/c++ CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/nix/store/94xwlhrjl0z82l7x83hixbspy32slz70-gcc-wrapper-13.2.0/bin/cc CARGO_BUILD_TARGET=x86_64-unknown-linux-gnu HOST_CC=/nix/store/94xwlhrjl0z82l7x83hixbspy32slz70-gcc-wrapper-13.2.0/bin/cc HOST_CXX=/nix/store/94xwlhrjl0z82l7x83hixbspy32slz70-gcc-wrapper-13.2.0/bin/c++ maturin build --jobs=16 --frozen --target riscv64gc-unknown-linux-gnu --manylinux off --strip --release --interpreter python3.10
📦 Including license file "/build/source/LICENSE-APACHE"
📦 Including license file "/build/source/LICENSE-MIT"
🍹 Building a mixed python/rust project
🔗 Found pyo3-ffi bindings
🐍 Found CPython 3.10
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] riscv64-linux (cross)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
