### PR TITLE
python312Packages.py65: 1.1.0 -> 1.2.0, clean up

### DIFF
--- a/pkgs/development/python-modules/py65/default.nix
+++ b/pkgs/development/python-modules/py65/default.nix
@@ -1,40 +1,42 @@
-{ lib
-, buildPythonPackage
-, pythonOlder
-, fetchFromGitHub
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  unittestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "py65";
-  version = "1.1.0";
-  format = "setuptools";
-
-  disabled = pythonOlder "3.6";
+  version = "1.2.0";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mnaberez";
     repo = "py65";
     rev = "refs/tags/${version}";
-    hash = "sha256-WLs3TAZovuphWZIvMvM3CZnqg1aZfMF4Yrqw46k+bLA=";
+    hash = "sha256-BMX+sMPx/YBFA4NFkaY0rl0EPicGHgb6xXVvLEIdllA=";
   };
 
-  postPatch = ''
-    substituteInPlace py65/tests/test_monitor.py \
-          --replace "test_argv_rom" "dont_test_argv_rom" \
-          --replace "test_argv_combination_rom_mpu" "dont_test_argv_combination_rom_mpu"
-  '';
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ unittestCheckHook ];
 
   meta = {
-    homepage = "https://py65.readthedocs.io/";
+    homepage = "https://github.com/mnaberez/py65";
     description = "Emulate 6502-based microcomputer systems in Python";
-    mainProgram = "py65mon";
     longDescription = ''
       Py65 includes a program called Py65Mon that functions as a machine
       language monitor. This kind of program is sometimes also called a
       debugger. Py65Mon provides a command line with many convenient commands
       for interacting with the simulated 6502-based system.
     '';
+    changelog = "https://github.com/mnaberez/py65/blob/${src.rev}/CHANGES.txt";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ AndersonTorres tomasajt ];
+    mainProgram = "py65mon";
+    maintainers = with lib.maintainers; [
+      AndersonTorres
+      tomasajt
+    ];
   };
 }


### PR DESCRIPTION
## Description of changes

Changes:
- bump package version (last version was from 2018)
- remove `pythonOlder` (I think this package even supports python2)
- use `pyproject = true;` to use the pypa builder (removes deprecation warnings)
  - add `setuptools` to `build-system`
  - add `unittestCheckHook` to `nativeBuildInputs`
- add `meta.changelog`
- remove broken `meta.homepage` link, use the GitHub repo link instead

---
I am never sure how to order `meta`'s attributes when there's a `meta.longDescription`.
Logically `description` and `longDescription` should be next to each other, but then I can't order the tags alphabetically, like I usually do...

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
