### PR TITLE
mlx42: 2.3.2 -> 2.3.3

### DIFF
--- a/pkgs/by-name/ml/mlx42/package.nix
+++ b/pkgs/by-name/ml/mlx42/package.nix
@@ -11,22 +11,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mlx42";
-  version = "2.3.2";
+  version = "2.3.3";
 
   src = fetchFromGitHub {
     owner = "codam-coding-college";
     repo = "MLX42";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-JCBV8NWibSugqXkbgP0v3gDfaaMNFYztWpBRfHJUG8E=";
+    hash = "sha256-igkTeOnqGYBISzmtDGlDx9cGJjoQ8fzXtVSR9hU4F5E=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "add-cmake-install.patch";
-      url = "https://github.com/codam-coding-college/MLX42/commit/a51ca8e0ec3fb793fa96d710696dcee8a4fe57d6.patch";
-      hash = "sha256-i+0yHZVvfTG19BGVrz7GuEuBw3B7lylCPEvx07il23M=";
-    })
-  ];
 
   postPatch = ''
     patchShebangs ./tools
@@ -46,10 +38,6 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     mkdir -p $out/lib/pkgconfig
     substituteAll ${./mlx42.pc} $out/lib/pkgconfig/mlx42.pc
-
-    # This file was removed after 2.3.2, so the used patch doesn't copy this file
-    # This line can be removed after the next release
-    cp $src/include/MLX42/MLX42_Input.h $out/include/MLX42
   '';
 
   meta = {


### PR DESCRIPTION
## Description of changes

This PR updates the version of `mlx42` to `2.3.3`

I could remove the patches, because this version now includes that code by default.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
