### PR TITLE
mise: 2023.12.35 -> 2024.1.11 rebrand from rtx

### DIFF
--- a/pkgs/tools/misc/mise/default.nix
+++ b/pkgs/tools/misc/mise/default.nix
@@ -11,28 +11,32 @@
 , direnv
 , Security
 , SystemConfiguration
-, rtx
+, mise
 , testers
 }:
 
 rustPlatform.buildRustPackage rec {
-  pname = "rtx";
-  version = "2023.12.35";
+  pname = "mise";
+  version = "2024.1.11";
 
   src = fetchFromGitHub {
     owner = "jdx";
-    repo = "rtx";
+    repo = "mise";
     rev = "v${version}";
-    hash = "sha256-vzMjC6qIPhZm80hzYQRpF3j+s85B0nwTcgSGRATQEIg=";
+    hash = "sha256-ELC+IpcWMHBDIGPAg8v1LJUUIXEmzJzCeJt2TkqXs7s=";
   };
 
-  cargoHash = "sha256-LvW5xGVggzuXlFPhbrc93Dht3S9zaQyx9Nm+Mx/Mjh0=";
+  cargoHash = "sha256-hZ8B3CVaTpIt3GudN/TWxI/xox724Prk8Uc8wA3Wd6Q=";
 
   nativeBuildInputs = [ installShellFiles pkg-config ];
   buildInputs = [ openssl ] ++ lib.optionals stdenv.isDarwin [ Security SystemConfiguration ];
 
   postPatch = ''
-    patchShebangs --build ./test/data/plugins/**/bin/* ./src/fake_asdf.rs ./src/cli/reshim.rs
+    patchShebangs --build \
+      ./test/data/plugins/**/bin/* \
+      ./src/fake_asdf.rs \
+      ./src/cli/reshim.rs \
+      ./test/cwd/.mise/tasks/filetask
 
     substituteInPlace ./src/env_diff.rs \
       --replace '"bash"' '"${bash}/bin/bash"'
@@ -51,25 +55,25 @@ rustPlatform.buildRustPackage rec {
   dontUseCargoParallelTests = true;
 
   postInstall = ''
-    installManPage ./man/man1/rtx.1
+    installManPage ./man/man1/mise.1
 
     installShellCompletion \
-      --bash ./completions/rtx.bash \
-      --fish ./completions/rtx.fish \
-      --zsh ./completions/_rtx
+      --bash ./completions/mise.bash \
+      --fish ./completions/mise.fish \
+      --zsh ./completions/_mise
   '';
 
   passthru = {
     updateScript = nix-update-script { };
-    tests.version = testers.testVersion { package = rtx; };
+    tests.version = testers.testVersion { package = mise; };
   };
 
   meta = {
-    homepage = "https://github.com/jdx/rtx";
-    description = "Polyglot runtime manager (asdf rust clone)";
-    changelog = "https://github.com/jdx/rtx/releases/tag/v${version}";
+    homepage = "https://mise.jdx.dev";
+    description = "The front-end to your dev env";
+    changelog = "https://github.com/jdx/mise/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ konradmalik ];
-    mainProgram = "rtx";
+    mainProgram = "mise";
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -896,6 +896,7 @@ mapAliases ({
   rr-unstable = rr; # Added 2022-09-17
   rtl8723bs-firmware = throw "rtl8723bs-firmware was added in mainline kernel version 4.12"; # Added 2023-07-03
   rtsp-simple-server = throw "rtsp-simple-server is rebranded as mediamtx, including default config path update"; # Added 2023-04-11
+  rtx = mise; # Added 2024-01-05
   runCommandNoCC = runCommand;
   runCommandNoCCLocal = runCommandLocal;
   rxvt_unicode = rxvt-unicode-unwrapped; # Added 2020-02-02

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18220,7 +18220,7 @@ with pkgs;
 
   asdf-vm = callPackage ../tools/misc/asdf-vm { };
 
-  rtx = callPackage ../tools/misc/rtx {
+  mise = callPackage ../tools/misc/mise {
     inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration;
   };
 


### PR DESCRIPTION
## Description of changes

`rtx` was rebranded upstream to `mise`. See: https://mise.jdx.dev/rtx.html.

This PR renames the package, creates an alias and updates it to 2024.1.11

Needed to add one new patchShebangs path for `test_task_run` (`./test/cwd/.mise/tasks/filetask`). Without it, this test failed in checkPhase.

Closes #278977 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
