### PR TITLE
nixos-rebuild: add lib to repl to make debugging even easier

### DIFF
--- a/nixos/lib/eval-config.nix
+++ b/nixos/lib/eval-config.nix
@@ -110,6 +110,7 @@ let
   withExtraAttrs = configuration: configuration // {
     inherit extraArgs;
     inherit (configuration._module.args) pkgs;
+    inherit lib;
     extendModules = args: withExtraAttrs (configuration.extendModules args);
   };
 in

--- a/pkgs/os-specific/linux/nixos-rebuild/default.nix
+++ b/pkgs/os-specific/linux/nixos-rebuild/default.nix
@@ -1,4 +1,5 @@
-{ substituteAll
+{ callPackage
+, substituteAll
 , runtimeShell
 , coreutils
 , gnused
@@ -36,6 +37,7 @@ substituteAll {
   # run some a simple installer tests to make sure nixos-rebuild still works for them
   passthru.tests = {
     install-bootloader = nixosTests.nixos-rebuild-install-bootloader;
+    repl = callPackage ./test/repl.nix {};
     simple-installer = nixosTests.installer.simple;
     specialisations = nixosTests.nixos-rebuild-specialisations;
   };

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -567,7 +567,7 @@ if [ "$action" = repl ]; then
                 configuration._module.specialArgs //
                 {
                   inherit (configuration) config options;
-                  inherit (configuration.pkgs) lib;
+                  lib = configuration.lib or configuration.pkgs.lib;
                   inherit flake;
                 };
           in builtins.seq scope builtins.trace motd scope

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -546,6 +546,7 @@ if [ "$action" = repl ]; then
                     - ${blue}config${reset}   All option values
                     - ${blue}options${reset}  Option data and metadata
                     - ${blue}pkgs${reset}     Nixpkgs package set
+                    - ${blue}lib${reset}      Nixpkgs library functions
                     - other module arguments
 
                     - ${blue}flake${reset}    Flake outputs, inputs and source info of $flake
@@ -566,6 +567,7 @@ if [ "$action" = repl ]; then
                 configuration._module.specialArgs //
                 {
                   inherit (configuration) config options;
+                  inherit (configuration.pkgs) lib;
                   inherit flake;
                 };
           in builtins.seq scope builtins.trace motd scope

--- a/pkgs/os-specific/linux/nixos-rebuild/test/repl.nix
+++ b/pkgs/os-specific/linux/nixos-rebuild/test/repl.nix
@@ -24,6 +24,12 @@ let
       }
     }
   '';
+
+  # In case we want/need to evaluate packages or the assertions or whatever,
+  # we want to have a linux system.
+  # TODO: make the non-flake test use thise.
+  linuxSystem = lib.replaceStrings ["darwin"] ["linux"] stdenv.hostPlatform.system;
+
 in
 runCommand "test-nixos-rebuild-repl" {
   nativeBuildInputs = [
@@ -88,7 +94,7 @@ runCommand "test-nixos-rebuild-repl" {
   EOF
 
   # Make the config pure
-  echo '{ nixpkgs.hostPlatform = "${stdenv.hostPlatform.system}"; }' > ~/hardware-configuration.nix
+  echo '{ nixpkgs.hostPlatform = "${linuxSystem}"; }' > ~/hardware-configuration.nix
 
   cat >~/flake.nix <<EOF
   {

--- a/pkgs/os-specific/linux/nixos-rebuild/test/repl.nix
+++ b/pkgs/os-specific/linux/nixos-rebuild/test/repl.nix
@@ -1,0 +1,140 @@
+{ lib,
+  expect,
+  nix,
+  nixos-rebuild,
+  path,
+  runCommand,
+  stdenv,
+  writeText,
+}:
+let
+  # Arguably not true, but it holds up for now.
+  escapeExpect = lib.strings.escapeNixString;
+
+  expectSetup = ''
+    set timeout 180
+    proc expect_simple { pattern } {
+      puts "Expecting: $pattern"
+      expect {
+        timeout {
+          puts "\nTimeout waiting for: $pattern\n"
+          exit 1
+        }
+        $pattern
+      }
+    }
+  '';
+in
+runCommand "test-nixos-rebuild-repl" {
+  nativeBuildInputs = [
+    expect
+    nix
+    nixos-rebuild
+  ];
+  nixpkgs =
+    if builtins.pathExists (path + "/.git")
+    then lib.cleanSource path
+    else path;
+} ''
+  export HOME=$(mktemp -d)
+  export TEST_ROOT=$PWD/test-tmp
+
+  # Prepare for running Nix in sandbox
+  export NIX_BUILD_HOOK=
+  export NIX_CONF_DIR=$TEST_ROOT/etc
+  export NIX_LOCALSTATE_DIR=$TEST_ROOT/var
+  export NIX_LOG_DIR=$TEST_ROOT/var/log/nix
+  export NIX_STATE_DIR=$TEST_ROOT/var/nix
+  export NIX_STORE_DIR=$TEST_ROOT/store
+  export PAGER=cat
+  mkdir -p $TEST_ROOT $NIX_CONF_DIR
+
+  echo General setup
+  ##################
+
+  export NIX_PATH=nixpkgs=$nixpkgs:nixos-config=$HOME/configuration.nix
+  cat >> ~/configuration.nix <<EOF
+  {
+    boot.loader.grub.enable = false;
+    fileSystems."/".device = "x";
+    imports = [ ./hardware-configuration.nix ];
+  }
+  EOF
+
+  echo '{ }' > ~/hardware-configuration.nix
+
+
+  echo Test traditional NixOS configuration
+  #########################################
+
+  expect ${writeText "test-nixos-rebuild-repl-expect" ''
+    ${expectSetup}
+    spawn nixos-rebuild repl --fast
+
+    expect "nix-repl> "
+
+    send "config.networking.hostName\n"
+    expect "\"nixos\""
+  ''}
+
+
+  echo Test flake based NixOS configuration
+  #########################################
+
+  # Switch to flake flavored environment
+  unset NIX_PATH
+  cat > $NIX_CONF_DIR/nix.conf <<EOF
+  experimental-features = nix-command flakes
+  EOF
+
+  # Make the config pure
+  echo '{ nixpkgs.hostPlatform = "${stdenv.hostPlatform.system}"; }' > ~/hardware-configuration.nix
+
+  cat >~/flake.nix <<EOF
+  {
+    inputs.nixpkgs.url = "path:$nixpkgs";
+    outputs = { nixpkgs, ... }: {
+      nixosConfigurations.testconf = nixpkgs.lib.nixosSystem {
+        modules = [
+          ./configuration.nix
+          # Let's change it up a bit
+          { networking.hostName = "itsme"; }
+        ];
+      };
+    };
+  }
+  EOF
+
+  # cat -n ~/flake.nix
+
+  expect ${writeText "test-nixos-rebuild-repl-expect" ''
+    ${expectSetup}
+    spawn sh -c "nixos-rebuild repl --fast --flake path:\$HOME#testconf"
+
+    expect_simple "nix-repl>"
+
+    send "config.networking.hostName\n"
+    expect_simple "itsme"
+
+    expect_simple "nix-repl>"
+    send "lib.version\n"
+    expect_simple ${escapeExpect (
+      # The version string is a bit different in the flake lib, so we expect a prefix and ignore the rest
+      # Furthermore, including the revision (suffix) would cause unnecessary rebuilds.
+      # Note that a length of 4 only matches e.g. "24.
+      lib.strings.substring 0 4 (lib.strings.escapeNixString lib.version))}
+
+    # Make sure it's the right lib - should be the flake lib, not Nixpkgs lib.
+    expect_simple "nix-repl>"
+    send "lib?nixosSystem\n"
+    expect_simple "true"
+    expect_simple "nix-repl>"
+    send "lib?nixos\n"
+    expect_simple "true"
+  ''}
+  echo
+
+  #########
+  echo Done
+  touch $out
+''


### PR DESCRIPTION
## Description of changes

When debugging things you often need lib. I think that is probably the last commonly used arg.
Tested on my system.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
