### PR TITLE
bcachefs: FIXME after 23.11 release

### DIFF
--- a/nixos/modules/tasks/filesystems/bcachefs.nix
+++ b/nixos/modules/tasks/filesystems/bcachefs.nix
@@ -124,12 +124,9 @@ in
       # needed for systemd-remount-fs
       system.fsPackages = [ pkgs.bcachefs-tools ];
 
-      # FIXME: Replace this with `linuxPackages_testing` after NixOS 23.11 is released
       # FIXME: Replace this with `linuxPackages_latest` when 6.7 is released, remove this line when the LTS version is at least 6.7
       boot.kernelPackages = lib.mkDefault (
-        # FIXME: Remove warning after NixOS 23.11 is released
-        lib.warn "Please upgrade to Linux 6.7-rc1 or later: 'linuxPackages_testing_bcachefs' is deprecated. Use 'boot.kernelPackages = pkgs.linuxPackages_testing;' to silence this warning"
-        pkgs.linuxPackages_testing_bcachefs
+        pkgs.linuxPackages_testing
       );
 
       systemd.services = lib.mapAttrs' (mkUnits "") (lib.filterAttrs (n: fs: (fs.fsType == "bcachefs") && (!utils.fsNeededForBoot fs)) config.fileSystems);


### PR DESCRIPTION
## Description of changes

In the bcachefs module there was a FIXME for after the 23.11 release that was not yet applied.
As a result, the module will not build in 23.11.

## Things done

Execute the suggested changes in the module itself, no more, no less.