### PR TITLE
dynamodb-local: 2023-12-14 -> 2.2.1

### DIFF
--- a/pkgs/by-name/dy/dynamodb-local/package.nix
+++ b/pkgs/by-name/dy/dynamodb-local/package.nix
@@ -3,14 +3,21 @@
 , fetchurl
 , jre
 , makeBinaryWrapper
+, curl
+, jq
+, yq
+, dynamodb-local
+, testers
+, common-updater-scripts
+, writeShellScript
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "dynamodb-local";
-  version = "2023-12-14";
+  version = "2.2.1";
 
   src = fetchurl {
-    url = "https://d1ni2b6xgvw0s0.cloudfront.net/v2.x/dynamodb_local_${finalAttrs.version}.tar.gz";
-    hash = "sha256-F9xTcLNAVFVbH7l0FlMuVNoLBrJS/UcHKXTkJh1n40w=";
+    url = "https://d1ni2b6xgvw0s0.cloudfront.net/v2.x/dynamodb_local_2024-01-04.tar.gz";
+    hash = "sha256-CbZ9Z9A70JoHu4G6It+7WycaEtzuwjVJ2YrOK+37zYA=";
   };
 
   sourceRoot = ".";
@@ -28,6 +35,29 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = dynamodb-local;
+    };
+    updateScript = writeShellScript "update-dynamodb-local" ''
+      set -o errexit
+      export PATH="${lib.makeBinPath [ curl jq yq common-updater-scripts ]}:$PATH"
+
+      NEW_VERSION=$(curl -s https://repo1.maven.org/maven2/com/amazonaws/DynamoDBLocal/maven-metadata.xml | xq -r '.metadata.versioning.latest')
+      NEW_VERSION_DATE=$(curl -s https://repo1.maven.org/maven2/com/amazonaws/DynamoDBLocal/maven-metadata.xml | xq -r '.metadata.versioning.lastUpdated | "\(.[:4])-\(.[4:6])-\(.[6:8])"')
+
+      if [[ "${finalAttrs.version}" = "$NEW_VERSION" ]]; then
+          echo "The new version same as the old version."
+          exit 0
+      fi
+
+      DOWNLOAD_URL="https://d1ni2b6xgvw0s0.cloudfront.net/v2.x/dynamodb_local_$NEW_VERSION_DATE.tar.gz"
+      NIX_HASH=$(nix hash to-sri sha256:$(nix-prefetch-url $DOWNLOAD_URL))
+
+      update-source-version "dynamodb-local" "$NEW_VERSION" "$NIX_HASH" "$DOWNLOAD_URL"
+    '';
+  };
 
   meta = with lib; {
     description = "DynamoDB Local is a small client-side database and server that mimics the DynamoDB service.";


### PR DESCRIPTION
## Description of changes

- Added a maintainer script to auto update the dynamodb-local package. 
- The version number was wrong, the downloads are versioned by their release date, but the version was different.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).