### PR TITLE
dynamodb-local: init at 2.2.1 (2024-01-04)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10493,6 +10493,12 @@
     githubId = 458783;
     name = "Martin Gammelsæter";
   };
+  martinjlowm = {
+    email = "martin@martinjlowm.dk";
+    github = "martinjlowm";
+    githubId = 110860;
+    name = "Martin Jesper Low Madsen";
+  };
   martinramm = {
     email = "martin-ramm@gmx.de";
     github = "MartinRamm";

--- a/pkgs/servers/nosql/dynamodb-local/default.nix
+++ b/pkgs/servers/nosql/dynamodb-local/default.nix
@@ -1,0 +1,58 @@
+{ fetchzip
+, jdk_headless
+, jre_minimal
+, lib
+, makeWrapper
+, stdenv
+}:
+
+let
+  name = "dynamodb-local";
+
+  release = "2024-01-04";
+  version = "v2.x";
+
+  jre = jre_minimal.override {
+    modules = [
+      "java.logging"
+      "java.xml"
+      "java.desktop"
+      "java.management"
+    ];
+    jdk = jdk_headless;
+  };
+in
+stdenv.mkDerivation {
+  inherit name;
+
+  version = ''${version}-${release}'';
+
+  src = fetchzip {
+    url = "https://d1ni2b6xgvw0s0.cloudfront.net/${version}/dynamodb_local_${release}.zip";
+    hash = "sha256-Tpqbm7NeBrhptPeaegZFj+5WnUGTxw0ul5/Cv+QL6+c=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/
+    install -D $src -d $out
+
+    makeWrapper ${jre}/bin/java $out/bin/dynamodb-local \
+      --add-flags "-Djava.library.path=$out/DynamoDBLocal_lib" \
+      --add-flags "-jar $out/DynamoDBLocal.jar" \
+      --add-flags "-inMemory"
+  '';
+
+  meta = with lib; {
+    description = ''A local development version of Amazon DynamoDB (${release})'';
+    homepage = "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html";
+    license = {
+      fullName = "Amazon DynamoDB Local License Agreement";
+      url = "https://aws.amazon.com/dynamodb/dynamodblocallicense/";
+      free = false;
+    };
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ martinjlowm ];
+  };
+}


### PR DESCRIPTION
Packaged releases are listed at https://s3-us-west-2.amazonaws.com/dynamodb-local/ stamped by date.

It's the S3 origin of the CloudFront distribution at d1ni2b6xgvw0s0.cloudfront.net.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
