### PR TITLE
smag: init at 0.7.0

### DIFF
--- a/pkgs/by-name/sm/smag/package.nix
+++ b/pkgs/by-name/sm/smag/package.nix
@@ -1,0 +1,28 @@
+{ lib, fetchFromGitHub, rustPlatform }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "smag";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "aantn";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-PdrK4kblXju23suMe3nYFT1KEbyQu4fwP/XTb2kV1fs=";
+  };
+
+  cargoHash = "sha256-SX6tOodmB0usM0laOt8mjIINPYbzHI4gyUhsR21Oqrw=";
+
+  meta = with lib; {
+    description = "Easily create graphs from cli commands and view them in the terminal";
+    longDescription = ''
+      Easily create graphs from cli commands and view them in the terminal.
+      Like the watch command but with a graph of the output.
+    '';
+    homepage = "https://github.com/aantn/smag";
+    license = licenses.mit;
+    changelog = "https://github.com/aantn/smag/releases/tag/v${version}";
+    mainProgram = "smag";
+    maintainers = with maintainers; [ zebreus ];
+  };
+}


### PR DESCRIPTION
## Description of changes

[smag](https://github.com/aantn/smag) is a cli utility to create graphs from cli commands and view them in the terminal. Like the watch command but with a graph of the output.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
