### PR TITLE
apptainer: unbreak --nv

### DIFF
--- a/nixos/modules/programs/singularity.nix
+++ b/nixos/modules/programs/singularity.nix
@@ -61,7 +61,12 @@ in
     };
     enableSuid = mkOption {
       type = types.bool;
-      default = true;
+      # SingularityCE requires SETUID for most things. Apptainer prefers user
+      # namespaces, e.g. `apptainer exec --nv` would fail if built
+      # `--with-suid`:
+      # > `FATAL: nvidia-container-cli not allowed in setuid mode`
+      default = cfg.package.projectName != "apptainer";
+      defaultText = literalExpression ''config.services.singularity.package.projectName != "apptainer"'';
       example = false;
       description = mdDoc ''
         Whether to enable the SUID support of Singularity/Apptainer.

--- a/pkgs/applications/virtualization/libnvidia-container/0001-libnvc-ldconfig-and-PATH-fixes.patch
+++ b/pkgs/applications/virtualization/libnvidia-container/0001-libnvc-ldconfig-and-PATH-fixes.patch
@@ -1,3 +1,15 @@
+From b6ad711cc3b4b1145fc4a884b6b325c843c39488 Mon Sep 17 00:00:00 2001
+From: Averell Dalton <averell+nixpkgs@rxd4.com>
+Date: Wed, 27 Feb 2019 09:44:05 +0100
+Subject: [PATCH] libnvc: ldconfig and PATH fixes
+
+---
+ src/ldcache.c     | 43 +++++++++++++++----------------------------
+ src/ldcache.h     |  2 +-
+ src/nvc_info.c    | 10 +++-------
+ src/nvc_ldcache.c |  2 +-
+ 4 files changed, 20 insertions(+), 37 deletions(-)
+
 diff --git a/src/ldcache.c b/src/ldcache.c
 index 38bab05..e1abc89 100644
 --- a/src/ldcache.c
@@ -71,10 +83,10 @@ index 33d78dd..2b087db 100644
  
  #endif /* HEADER_LDCACHE_H */
 diff --git a/src/nvc_info.c b/src/nvc_info.c
-index 30e3cfd..6d12a50 100644
+index 2d203ae..8f0f4dd 100644
 --- a/src/nvc_info.c
 +++ b/src/nvc_info.c
-@@ -167,15 +167,13 @@ find_library_paths(struct error *err, struct nvc_driver_info *info, const char *
+@@ -218,15 +218,13 @@ find_library_paths(struct error *err, struct dxcore_context *dxcore, struct nvc_
          if (path_resolve_full(err, path, root, ldcache) < 0)
                  return (-1);
          ldcache_init(&ld, err, path);
@@ -91,7 +103,7 @@ index 30e3cfd..6d12a50 100644
                  goto fail;
  
          info->nlibs32 = size;
-@@ -183,13 +181,11 @@ find_library_paths(struct error *err, struct nvc_driver_info *info, const char *
+@@ -234,13 +232,11 @@ find_library_paths(struct error *err, struct dxcore_context *dxcore, struct nvc_
          if (info->libs32 == NULL)
                  goto fail;
          if (ldcache_resolve(&ld, LIB32_ARCH, root, libs,
@@ -106,7 +118,7 @@ index 30e3cfd..6d12a50 100644
          return (rv);
  }
  
-@@ -203,7 +199,7 @@ find_binary_paths(struct error *err, struct nvc_driver_info *info, const char *r
+@@ -254,7 +250,7 @@ find_binary_paths(struct error *err, struct dxcore_context* dxcore, struct nvc_d
          char path[PATH_MAX];
          int rv = -1;
  
@@ -116,15 +128,18 @@ index 30e3cfd..6d12a50 100644
                  return (-1);
          }
 diff --git a/src/nvc_ldcache.c b/src/nvc_ldcache.c
-index 6ff380f..cbe6a69 100644
+index db3b2f6..ae5def4 100644
 --- a/src/nvc_ldcache.c
 +++ b/src/nvc_ldcache.c
-@@ -340,7 +340,7 @@ nvc_ldcache_update(struct nvc_context *ctx, const struct nvc_container *cnt)
+@@ -367,7 +367,7 @@ nvc_ldcache_update(struct nvc_context *ctx, const struct nvc_container *cnt)
          if (validate_args(ctx, cnt != NULL) < 0)
                  return (-1);
  
--        argv = (char * []){cnt->cfg.ldconfig, cnt->cfg.libs_dir, cnt->cfg.libs32_dir, NULL};
+-        argv = (char * []){cnt->cfg.ldconfig, "-f", "/etc/ld.so.conf", "-C", "/etc/ld.so.cache", cnt->cfg.libs_dir, cnt->cfg.libs32_dir, NULL};
 +        argv = (char * []){cnt->cfg.ldconfig, "-f", "/tmp/ld.so.conf.nvidia-host", "-C", "/tmp/ld.so.cache.nvidia-host", cnt->cfg.libs_dir, cnt->cfg.libs32_dir, NULL};
          if (*argv[0] == '@') {
                  /*
                   * We treat this path specially to be relative to the host filesystem.
+-- 
+2.42.0
+

--- a/pkgs/applications/virtualization/libnvidia-container/0001-libnvc-ldconfig-and-PATH-fixes.patch
+++ b/pkgs/applications/virtualization/libnvidia-container/0001-libnvc-ldconfig-and-PATH-fixes.patch
@@ -1,124 +1,170 @@
-From b6ad711cc3b4b1145fc4a884b6b325c843c39488 Mon Sep 17 00:00:00 2001
+From a15ed348b14f65a4b25d666ad502b5f99a5e0b90 Mon Sep 17 00:00:00 2001
 From: Averell Dalton <averell+nixpkgs@rxd4.com>
 Date: Wed, 27 Feb 2019 09:44:05 +0100
-Subject: [PATCH] libnvc: ldconfig and PATH fixes
+Subject: [PATCH 1/4] libnvc: ldconfig and PATH fixes
 
+Signed-off-by: Someone Serge <sergei.kozlukov@aalto.fi>
 ---
- src/ldcache.c     | 43 +++++++++++++++----------------------------
- src/ldcache.h     |  2 +-
- src/nvc_info.c    | 10 +++-------
+ src/common.h      |  2 +-
+ src/ldcache.c     | 73 +++++++++++++++++++++++++++++++++++++++++++----
+ src/nvc_info.c    |  7 +++--
  src/nvc_ldcache.c |  2 +-
- 4 files changed, 20 insertions(+), 37 deletions(-)
+ 4 files changed, 73 insertions(+), 11 deletions(-)
 
+diff --git a/src/common.h b/src/common.h
+index c91d349..58e7926 100644
+--- a/src/common.h
++++ b/src/common.h
+@@ -20,7 +20,7 @@
+ #define PROC_OVERFLOW_UID         "/proc/sys/kernel/overflowuid"
+ #define PROC_OVERFLOW_GID         "/proc/sys/kernel/overflowgid"
+ 
+-#define LDCACHE_PATH              "/etc/ld.so.cache"
++#define LDCACHE_PATH              "/tmp/ld.so.conf.nvidia-host"
+ #define LDCONFIG_PATH             "/sbin/ldconfig"
+ #define LDCONFIG_ALT_PATH         "/sbin/ldconfig.real"
+ 
 diff --git a/src/ldcache.c b/src/ldcache.c
-index 38bab05..e1abc89 100644
+index 38bab05..4ccdff4 100644
 --- a/src/ldcache.c
 +++ b/src/ldcache.c
-@@ -108,40 +108,27 @@ ldcache_close(struct ldcache *ctx)
+@@ -9,7 +9,10 @@
+ #include <string.h>
+ #include <stdlib.h>
+ #include <unistd.h>
++#include <fts.h>
++#include <gelf.h>
  
++#include "elftool.h"
+ #include "ldcache.h"
+ #include "utils.h"
+ #include "xfuncs.h"
+@@ -65,6 +68,15 @@ ldcache_open(struct ldcache *ctx)
+         struct header_libc6 *h6;
+         size_t padding;
+ 
++        bool cacheExists = access(ctx->path, F_OK) == 0;
++
++        if (!cacheExists) {
++                ctx->ptr = NULL;
++                ctx->size = 0;
++                ctx->addr = NULL;
++                return (0);
++        }
++
+         ctx->addr = ctx->ptr = file_map(ctx->err, ctx->path, &ctx->size);
+         if (ctx->addr == NULL)
+                 return (-1);
+@@ -97,6 +109,9 @@ ldcache_open(struct ldcache *ctx)
  int
- ldcache_resolve(struct ldcache *ctx, uint32_t arch, const char *root, const char * const libs[],
--    char *paths[], size_t size, ldcache_select_fn select, void *select_ctx)
-+    char *paths[], size_t size, const char* version)
+ ldcache_close(struct ldcache *ctx)
+ {
++        if (ctx->ptr == NULL)
++                return (0);
++
+         if (file_unmap(ctx->err, ctx->path, ctx->addr, ctx->size) < 0)
+                 return (-1);
+ 
+@@ -111,16 +126,58 @@ ldcache_resolve(struct ldcache *ctx, uint32_t arch, const char *root, const char
+     char *paths[], size_t size, ldcache_select_fn select, void *select_ctx)
  {
          char path[PATH_MAX];
 -        struct header_libc6 *h;
--        int override;
-+        char dir[PATH_MAX];
-+        char lib[PATH_MAX];
++        struct header_libc6 *h = NULL;
++        int nLdEntries = 0;
+         int override;
  
 -        h = (struct header_libc6 *)ctx->ptr;
++        if (ctx != NULL && ctx->ptr != NULL) {
++                h = (struct header_libc6 *)ctx->ptr;
++                nLdEntries = h->nlibs;
++        }
          memset(paths, 0, size * sizeof(*paths));
  
 -        for (uint32_t i = 0; i < h->nlibs; ++i) {
 -                int32_t flags = h->libs[i].flags;
 -                char *key = (char *)ctx->ptr + h->libs[i].key;
 -                char *value = (char *)ctx->ptr + h->libs[i].value;
--
--                if (!(flags & LD_ELF) || (flags & LD_ARCH_MASK) != arch)
-+        for (size_t j = 0; j < size; ++j) {
-+                snprintf(dir, 100, "/run/opengl-driver%s/lib",
-+                    arch == LD_I386_LIB32 ? "-32" : "");
-+                if (!strncmp(libs[j], "libvdpau_nvidia.so", 100))
-+                  strcat(dir, "/vdpau");
-+                snprintf(lib, 100, "%s/%s.%s", dir, libs[j], version);
-+                if (path_resolve_full(ctx->err, path, "/", lib) < 0)
-+                        return (-1);
-+                if (!file_exists(ctx->err, path))
++        FTS *ftsp;
++        FTSENT *p = NULL;
++        char *ftsArgv[] = {"argv0", "@driverLink@/lib", NULL};
++        if (arch == LD_I386_LIB32) {
++                ftsArgv[1] = "@driverLink@-32/lib";
++        }
++        ftsp = fts_open(ftsArgv, FTS_LOGICAL | FTS_NOCHDIR, NULL);
++        bool driverLinkExists = ftsp != NULL && fts_children(ftsp, 0) != NULL;
++        bool moreChildren = driverLinkExists;
++
++        for (int iLd = 0; (driverLinkExists && moreChildren) || iLd < nLdEntries;) {
++                int32_t flags = 0;
++                char *key, *value;
++                if (driverLinkExists && moreChildren && (moreChildren = (p = fts_read(ftsp)) != NULL)) {
++                    key = p->fts_name;
++                    value = p->fts_path;
++
++                    struct elftool et;
++                    elftool_init(&et, ctx->err);
++                    if (elftool_open(&et, value) < 0) {
++                        error_reset(et.err);
++                        continue;
++                    }
++                    GElf_Ehdr ehdr;
++                    if (gelf_getehdr(et.elf , &ehdr) == NULL) {
++                        error_setx(ctx->err, "gelf_getehdr failed");
++                    }
++                    if (ehdr.e_machine == EM_386) {
++                        flags |= LD_I386_LIB32;
++                        flags |= LD_ELF;
++                    } else if (ehdr.e_machine == EM_X86_64) {
++                        /* FIXME */
++                        flags |= LD_X8664_LIB64;
++                        flags |= LD_ELF;
++                    }
++                    elftool_close(&et);
++                } else if (iLd < nLdEntries) {
++                    flags = h->libs[iLd].flags;
++                    key = (char *)ctx->ptr + h->libs[iLd].key;
++                    value = (char *)ctx->ptr + h->libs[iLd].value;
++                    iLd += 1;
++                }
+ 
+                 if (!(flags & LD_ELF) || (flags & LD_ARCH_MASK) != arch)
                          continue;
--
--                for (size_t j = 0; j < size; ++j) {
--                        if (!str_has_prefix(key, libs[j]))
--                                continue;
--                        if (path_resolve(ctx->err, path, root, value) < 0)
--                                return (-1);
--                        if (paths[j] != NULL && str_equal(paths[j], path))
--                                continue;
--                        if ((override = select(ctx->err, select_ctx, root, paths[j], path)) < 0)
--                                return (-1);
--                        if (override) {
--                                free(paths[j]);
--                                paths[j] = xstrdup(ctx->err, path);
--                                if (paths[j] == NULL)
--                                        return (-1);
--                        }
--                        break;
--                }
-+                paths[j] = xstrdup(ctx->err, path);
-+                if (paths[j] == NULL)
-+                        return (-1);
+@@ -143,5 +200,9 @@ ldcache_resolve(struct ldcache *ctx, uint32_t arch, const char *root, const char
+                         break;
+                 }
          }
++
++        if (ftsp != NULL) {
++                fts_close(ftsp);
++        }
          return (0);
  }
-diff --git a/src/ldcache.h b/src/ldcache.h
-index 33d78dd..2b087db 100644
---- a/src/ldcache.h
-+++ b/src/ldcache.h
-@@ -50,6 +50,6 @@ void ldcache_init(struct ldcache *, struct error *, const char *);
- int  ldcache_open(struct ldcache *);
- int  ldcache_close(struct ldcache *);
- int  ldcache_resolve(struct ldcache *, uint32_t, const char *, const char * const [],
--    char *[], size_t, ldcache_select_fn, void *);
-+    char *[], size_t, const char*);
- 
- #endif /* HEADER_LDCACHE_H */
 diff --git a/src/nvc_info.c b/src/nvc_info.c
-index 2d203ae..8f0f4dd 100644
+index 2d203ae..7f21589 100644
 --- a/src/nvc_info.c
 +++ b/src/nvc_info.c
-@@ -218,15 +218,13 @@ find_library_paths(struct error *err, struct dxcore_context *dxcore, struct nvc_
+@@ -218,8 +218,9 @@ find_library_paths(struct error *err, struct dxcore_context *dxcore, struct nvc_
          if (path_resolve_full(err, path, root, ldcache) < 0)
                  return (-1);
          ldcache_init(&ld, err, path);
 -        if (ldcache_open(&ld) < 0)
--                return (-1);
++        if (ldcache_open(&ld) < 0) {
+                 return (-1);
++        }
  
          info->nlibs = size;
          info->libs = array_new(err, size);
-         if (info->libs == NULL)
-                 goto fail;
-         if (ldcache_resolve(&ld, LIB_ARCH, root, libs,
--            info->libs, info->nlibs, select_libraries_fn, info) < 0)
-+            info->libs, info->nlibs, info->nvrm_version) < 0)
-                 goto fail;
- 
-         info->nlibs32 = size;
-@@ -234,13 +232,11 @@ find_library_paths(struct error *err, struct dxcore_context *dxcore, struct nvc_
-         if (info->libs32 == NULL)
-                 goto fail;
-         if (ldcache_resolve(&ld, LIB32_ARCH, root, libs,
--            info->libs32, info->nlibs32, select_libraries_fn, info) < 0)
-+            info->libs32, info->nlibs32, info->nvrm_version) < 0)
-                 goto fail;
+@@ -239,7 +240,7 @@ find_library_paths(struct error *err, struct dxcore_context *dxcore, struct nvc_
          rv = 0;
  
   fail:
 -        if (ldcache_close(&ld) < 0)
--                return (-1);
++        if (ld.ptr != NULL && ldcache_close(&ld) < 0)
+                 return (-1);
          return (rv);
  }
- 
-@@ -254,7 +250,7 @@ find_binary_paths(struct error *err, struct dxcore_context* dxcore, struct nvc_d
+@@ -254,7 +255,7 @@ find_binary_paths(struct error *err, struct dxcore_context* dxcore, struct nvc_d
          char path[PATH_MAX];
          int rv = -1;
  

--- a/pkgs/applications/virtualization/libnvidia-container/0001-libnvc-ldconfig-and-PATH-fixes.patch
+++ b/pkgs/applications/virtualization/libnvidia-container/0001-libnvc-ldconfig-and-PATH-fixes.patch
@@ -1,4 +1,4 @@
-From a15ed348b14f65a4b25d666ad502b5f99a5e0b90 Mon Sep 17 00:00:00 2001
+From df52a846881fdd233da1353c9feae06bf3bca963 Mon Sep 17 00:00:00 2001
 From: Averell Dalton <averell+nixpkgs@rxd4.com>
 Date: Wed, 27 Feb 2019 09:44:05 +0100
 Subject: [PATCH 1/4] libnvc: ldconfig and PATH fixes
@@ -8,8 +8,8 @@ Signed-off-by: Someone Serge <sergei.kozlukov@aalto.fi>
  src/common.h      |  2 +-
  src/ldcache.c     | 73 +++++++++++++++++++++++++++++++++++++++++++----
  src/nvc_info.c    |  7 +++--
- src/nvc_ldcache.c |  2 +-
- 4 files changed, 73 insertions(+), 11 deletions(-)
+ src/nvc_ldcache.c | 20 +++++++------
+ 4 files changed, 84 insertions(+), 18 deletions(-)
 
 diff --git a/src/common.h b/src/common.h
 index c91d349..58e7926 100644
@@ -174,10 +174,17 @@ index 2d203ae..7f21589 100644
                  return (-1);
          }
 diff --git a/src/nvc_ldcache.c b/src/nvc_ldcache.c
-index db3b2f6..ae5def4 100644
+index db3b2f6..f15a6c9 100644
 --- a/src/nvc_ldcache.c
 +++ b/src/nvc_ldcache.c
-@@ -367,7 +367,7 @@ nvc_ldcache_update(struct nvc_context *ctx, const struct nvc_container *cnt)
+@@ -361,32 +361,34 @@ nvc_ldcache_update(struct nvc_context *ctx, const struct nvc_container *cnt)
+         bool drop_groups = true;
+         bool host_ldconfig = false;
+         int fd = -1;
++        bool ldconfigExists = false;
+ 
+         if (validate_context(ctx) < 0)
+                 return (-1);
          if (validate_args(ctx, cnt != NULL) < 0)
                  return (-1);
  
@@ -186,6 +193,48 @@ index db3b2f6..ae5def4 100644
          if (*argv[0] == '@') {
                  /*
                   * We treat this path specially to be relative to the host filesystem.
+                  * Force proc to be remounted since we're creating a PID namespace and fexecve depends on it.
+                  */
+                 ++argv[0];
+-                if ((fd = xopen(&ctx->err, argv[0], O_RDONLY|O_CLOEXEC)) < 0)
+-                        return (-1);
++                if ((fd = xopen(&ctx->err, argv[0], O_RDONLY|O_CLOEXEC)) < 0) {
++                    ldconfigExists = true;
++                }
+                 host_ldconfig = true;
+                 log_infof("executing %s from host at %s", argv[0], cnt->cfg.rootfs);
+         } else {
+                 log_infof("executing %s at %s", argv[0], cnt->cfg.rootfs);
+         }
+ 
+-        if ((child = create_process(&ctx->err, CLONE_NEWPID|CLONE_NEWIPC)) < 0) {
++        if (ldconfigExists && (child = create_process(&ctx->err, CLONE_NEWPID|CLONE_NEWIPC)) < 0) {
+                 xclose(fd);
+                 return (-1);
+         }
+-        if (child == 0) {
++        if (ldconfigExists && child == 0) {
+                 prctl(PR_SET_NAME, (unsigned long)"nvc:[ldconfig]", 0, 0, 0);
+ 
+                 if (ns_enter(&ctx->err, cnt->mnt_ns, CLONE_NEWNS) < 0)
+@@ -412,12 +414,14 @@ nvc_ldcache_update(struct nvc_context *ctx, const struct nvc_container *cnt)
+                 (ctx->err.code == ENOENT) ? _exit(EXIT_SUCCESS) : _exit(EXIT_FAILURE);
+         }
+ 
+-        xclose(fd);
+-        if (waitpid(child, &status, 0) < 0) {
++        if (ldconfigExists) {
++                xclose(fd);
++        }
++        if (ldconfigExists && waitpid(child, &status, 0) < 0) {
+                 error_set(&ctx->err, "process reaping failed");
+                 return (-1);
+         }
+-        if (WIFSIGNALED(status)) {
++        if (ldconfigExists && WIFSIGNALED(status)) {
+                 error_setx(&ctx->err, "process %s terminated with signal %d", argv[0], WTERMSIG(status));
+                 return (-1);
+         }
 -- 
 2.42.0
 

--- a/pkgs/applications/virtualization/libnvidia-container/0002-prctl-localize-the-capability-change-failed-messages.patch
+++ b/pkgs/applications/virtualization/libnvidia-container/0002-prctl-localize-the-capability-change-failed-messages.patch
@@ -1,0 +1,331 @@
+From 46ae709a60b6b6a4e1254b14afb02dc3cbd1894b Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Sat, 6 Jan 2024 02:50:17 +0000
+Subject: [PATCH 2/4] prctl: localize the "capability change failed" messages
+
+perm_drop_privileges: set detailed errors
+---
+ src/cli/configure.c |  7 +++++-
+ src/error_generic.c | 12 +++++++---
+ src/nvc_info.c      | 42 ++++++++++++++++++++++++++--------
+ src/nvc_ldcache.c   |  3 ++-
+ src/utils.c         | 56 ++++++++++++++++++++++++++++++++-------------
+ 5 files changed, 89 insertions(+), 31 deletions(-)
+
+diff --git a/src/cli/configure.c b/src/cli/configure.c
+index 415f6b3..f682ca5 100644
+--- a/src/cli/configure.c
++++ b/src/cli/configure.c
+@@ -242,6 +242,7 @@ configure_command(const struct context *ctx)
+             perm_set_capabilities(&err, CAP_INHERITABLE, NULL, 0) < 0 ||
+             perm_set_bounds(&err, bcaps, nitems(bcaps)) < 0) {
+                 warnx("permission error: %s", err.msg);
++                error_setx(&err, "perm_set_capabilities CAP_PERMITTED or CAP_INHERITABLE: permission error");
+                 return (rv);
+         }
+ 
+@@ -249,11 +250,13 @@ configure_command(const struct context *ctx)
+         int c = ctx->load_kmods ? NVC_INIT_KMODS : NVC_INIT;
+         if (perm_set_capabilities(&err, CAP_EFFECTIVE, ecaps[c], ecaps_size(c)) < 0) {
+                 warnx("permission error: %s", err.msg);
++                error_setx(&err, "%s:%d: perm_set_capabilities CAP_EFFECTIVE: permission error", __FILE__, __LINE__);
+                 goto fail;
+         }
+         if ((nvc = libnvc.context_new()) == NULL ||
+             (nvc_cfg = libnvc.config_new()) == NULL ||
+             (cnt_cfg = libnvc.container_config_new(ctx->pid, ctx->rootfs)) == NULL) {
++                error_setx(&err, "perm_set_capabilities CAP_EFFECTIVE: permission error");
+                 warn("memory allocation failed");
+                 goto fail;
+         }
+@@ -264,10 +267,12 @@ configure_command(const struct context *ctx)
+         nvc_cfg->ldcache = ctx->ldcache;
+         if (libnvc.init(nvc, nvc_cfg, ctx->init_flags) < 0) {
+                 warnx("initialization error: %s", libnvc.error(nvc));
++                error_setx(&err, "%s:%d: libnvc.init failed", __FILE__, __LINE__);
+                 goto fail;
+         }
+         if (perm_set_capabilities(&err, CAP_EFFECTIVE, ecaps[NVC_CONTAINER], ecaps_size(NVC_CONTAINER)) < 0) {
+                 warnx("permission error: %s", err.msg);
++                error_setx(&err, "%s:%d: perm_set_capabilities CAP_EFFECTIVE: permission error", __FILE__, __LINE__);
+                 goto fail;
+         }
+         cnt_cfg->ldconfig = ctx->ldconfig;
+@@ -283,7 +288,7 @@ configure_command(const struct context *ctx)
+         }
+         if ((drv = libnvc.driver_info_new(nvc, NULL)) == NULL ||
+             (dev = libnvc.device_info_new(nvc, NULL)) == NULL) {
+-                warnx("detection error: %s", libnvc.error(nvc));
++                warnx("detection error: %s; drv is %s, dev is %s", libnvc.error(nvc), drv == NULL ? "NULL" : "not NULL", dev == NULL ? "NULL" : "not NULL");
+                 goto fail;
+         }
+ 
+diff --git a/src/error_generic.c b/src/error_generic.c
+index 3c01499..428ffce 100644
+--- a/src/error_generic.c
++++ b/src/error_generic.c
+@@ -29,6 +29,8 @@ error_vset(struct error *err, int errcode, const char *errmsg, const char *fmt,
+         if (err == NULL)
+                 return (0);
+ 
++        char *oldMsg = err->msg == NULL ? NULL : xstrdup(err, err->msg);
++
+         error_reset(err);
+         err->code = errcode;
+ 
+@@ -37,19 +39,23 @@ error_vset(struct error *err, int errcode, const char *errmsg, const char *fmt,
+                 goto fail;
+         }
+         if (errmsg == NULL) {
+-                err->msg = msg;
+-                return (0);
++            errmsg = "[no errmsg]";
+         }
+-        if (asprintf(&err->msg, "%s: %s", msg, errmsg) < 0) {
++        if (oldMsg == NULL && asprintf(&err->msg, "%s: %s", msg, errmsg) < 0) {
+                 err->msg = NULL;
+                 goto fail;
+         }
++        if (oldMsg != NULL && asprintf(&err->msg, "%s: %s. Previous message: %s", msg, errmsg, oldMsg) < 0) {
++        }
+         err->msg[strcspn(err->msg, "\n")] = '\0';
+         str_lower(strrchr(err->msg, ':'));
+         rv = 0;
+ 
+  fail:
+         free(msg);
++        if (oldMsg != NULL) {
++            free(oldMsg);
++        }
+         return (rv);
+ }
+ 
+diff --git a/src/nvc_info.c b/src/nvc_info.c
+index 7f21589..2965fba 100644
+--- a/src/nvc_info.c
++++ b/src/nvc_info.c
+@@ -215,10 +215,13 @@ find_library_paths(struct error *err, struct dxcore_context *dxcore, struct nvc_
+ 
+         ldcache_select_fn select_libraries_fn = dxcore->initialized ? select_wsl_libraries : select_libraries;
+ 
+-        if (path_resolve_full(err, path, root, ldcache) < 0)
++        if (path_resolve_full(err, path, root, ldcache) < 0) {
++                error_setx(err, "path_resolve_full failed");
+                 return (-1);
++        }
+         ldcache_init(&ld, err, path);
+         if (ldcache_open(&ld) < 0) {
++                error_setx(err, "ldcache_open failed");
+                 return (-1);
+         }
+ 
+@@ -359,6 +362,7 @@ static int
+ lookup_paths(struct error *err, struct dxcore_context *dxcore, struct nvc_driver_info *info, const char *root, int32_t flags, const char *ldcache)
+ {
+         if (lookup_libraries(err, dxcore, info, root, flags, ldcache) < 0) {
++                error_setx(err, "lookup_libraries failed;");
+                 log_err("error looking up libraries");
+                 return (-1);
+         }
+@@ -395,8 +399,10 @@ lookup_libraries(struct error *err, struct dxcore_context *dxcore, struct nvc_dr
+         if (dxcore->initialized)
+                 ptr = array_append(ptr, dxcore_libs, nitems(dxcore_libs));
+ 
+-        if (find_library_paths(err, dxcore, info, root, ldcache, libs, (size_t)(ptr - libs)) < 0)
++        if (find_library_paths(err, dxcore, info, root, ldcache, libs, (size_t)(ptr - libs)) < 0) {
++                error_setx(err, "find_library_paths failed;");
+                 return (-1);
++        }
+ 
+         for (size_t i = 0; info->libs != NULL && i < info->nlibs; ++i) {
+                 if (info->libs[i] == NULL)
+@@ -789,27 +795,43 @@ nvc_driver_info_new(struct nvc_context *ctx, const char *opts)
+         struct nvc_driver_info *info;
+         int32_t flags;
+ 
+-        if (validate_context(ctx) < 0)
++        if (validate_context(ctx) < 0) {
++                error_setx(&ctx->err, "%s:%d: validate_context failed;", __FILE__, __LINE__);
+                 return (NULL);
++        }
+         if (opts == NULL)
+                 opts = default_driver_opts;
+-        if ((flags = options_parse(&ctx->err, opts, driver_opts, nitems(driver_opts))) < 0)
++        if ((flags = options_parse(&ctx->err, opts, driver_opts, nitems(driver_opts))) < 0) {
++                error_setx(&ctx->err, "%s:%d: options_parse failed", __FILE__, __LINE__);
+                 return (NULL);
++        }
+ 
+         log_infof("requesting driver information with '%s'", opts);
+-        if ((info = xcalloc(&ctx->err, 1, sizeof(*info))) == NULL)
++        if ((info = xcalloc(&ctx->err, 1, sizeof(*info))) == NULL) {
++                error_setx(&ctx->err, "%s:%d: xcalloc failed", __FILE__, __LINE__);
+                 return (NULL);
++        }
+ 
+-        if (driver_get_rm_version(&ctx->err, &info->nvrm_version) < 0)
++        if (driver_get_rm_version(&ctx->err, &info->nvrm_version) < 0) {
++                error_setx(&ctx->err, "%s:%d: driver_get_rm_version failed", __FILE__, __LINE__);
+                 goto fail;
+-        if (driver_get_cuda_version(&ctx->err, &info->cuda_version) < 0)
++        }
++        if (driver_get_cuda_version(&ctx->err, &info->cuda_version) < 0) {
++                error_setx(&ctx->err, "%s:%d: driver_get_cuda_version failed", __FILE__, __LINE__);
+                 goto fail;
+-        if (lookup_paths(&ctx->err, &ctx->dxcore, info, ctx->cfg.root, flags, ctx->cfg.ldcache) < 0)
++        }
++        if (lookup_paths(&ctx->err, &ctx->dxcore, info, ctx->cfg.root, flags, ctx->cfg.ldcache) < 0) {
++                error_setx(&ctx->err, "%s:%d: lookup_paths failed", __FILE__, __LINE__);
+                 goto fail;
+-        if (lookup_devices(&ctx->err, &ctx->dxcore, info, ctx->cfg.root, flags) < 0)
++        }
++        if (lookup_devices(&ctx->err, &ctx->dxcore, info, ctx->cfg.root, flags) < 0) {
++                error_setx(&ctx->err, "%s:%d: lookup_devices failed", __FILE__, __LINE__);
+                 goto fail;
+-        if (lookup_ipcs(&ctx->err, info, ctx->cfg.root, flags) < 0)
++        }
++        if (lookup_ipcs(&ctx->err, info, ctx->cfg.root, flags) < 0) {
++                error_setx(&ctx->err, "%s:%d: lookup_ipcs failed", __FILE__, __LINE__);
+                 goto fail;
++        }
+         return (info);
+ 
+  fail:
+diff --git a/src/nvc_ldcache.c b/src/nvc_ldcache.c
+index ae5def4..514d05b 100644
+--- a/src/nvc_ldcache.c
++++ b/src/nvc_ldcache.c
+@@ -221,7 +221,7 @@ adjust_privileges(struct error *err, uid_t uid, gid_t gid, bool drop_groups)
+                 if (errno == EPERM)
+                         log_warn("could not preserve capabilities, containers may require additional tuning");
+                 else {
+-                        error_set(err, "privilege change failed");
++                        error_set(err, "adjust_privileges: privilege change failed");
+                         return (-1);
+                 }
+         }
+@@ -384,6 +384,7 @@ nvc_ldcache_update(struct nvc_context *ctx, const struct nvc_container *cnt)
+ 
+         if ((child = create_process(&ctx->err, CLONE_NEWPID|CLONE_NEWIPC)) < 0) {
+                 xclose(fd);
++                error_setx(&ctx->err, "%s:%d create_process failed", __FILE__, __LINE__);
+                 return (-1);
+         }
+         if (child == 0) {
+diff --git a/src/utils.c b/src/utils.c
+index 8ff6f26..eee7b7d 100644
+--- a/src/utils.c
++++ b/src/utils.c
+@@ -406,8 +406,10 @@ file_map(struct error *err, const char *path, size_t *length)
+         struct stat s;
+         void *p = NULL;
+ 
+-        if ((fd = xopen(err, path, O_RDONLY)) < 0)
++        if ((fd = xopen(err, path, O_RDONLY)) < 0) {
++                error_setx(err, "file_map: xopen(..., \"%s\", ...) failed", path);
+                 return (NULL);
++        }
+         if (fstat(fd, &s) < 0)
+                 goto fail;
+ 
+@@ -637,6 +639,10 @@ file_exists_at(struct error *err, const char *dir, const char *path)
+         int fd;
+         int rv;
+ 
++        if (access(path, F_OK) != 0) {
++            error_setx(err, "file_map: %s doesn't exist", path);
++        }
++
+         if ((fd = xopen(err, dir, O_PATH|O_DIRECTORY)) < 0)
+                 return (-1);
+         if ((rv = faccessat(fd, (*path == '/') ? path + 1 : path, F_OK, 0)) < 0 && errno != ENOENT) {
+@@ -913,36 +919,47 @@ perm_drop_privileges(struct error *err, uid_t uid, gid_t gid, bool drop_groups)
+         if (drop_groups) {
+                 switch (getgroups(0, NULL)) {
+                 case -1:
+-                        goto fail;
++                        error_set(err, "perm_drop_privileges: getgroups(0, NULL) == -1");
++                        return (-1);
+                 case 0:
+                         break;
+                 case 1:
+-                        if (getgroups(1, &egroup) < 0)
+-                                goto fail;
++                        if (getgroups(1, &egroup) < 0) {
++                                error_set(err, "perm_drop_privileges: getgroups(1, &egroup) < 0");
++                                return (-1);
++                        }
+                         if (egroup == gid)
+                                 break;
+                         /* Fallthrough */
+                 default:
+-                        if (setgroups(1, &gid) < 0)
+-                                goto fail;
++                        if (setgroups(1, &gid) < 0) {
++                                error_set(err, "perm_drop_privileges: setgroups(1, &gid) < 0");
++                                return (-1);
++                        }
+                         break;
+                 }
+         }
+         if (egid != gid && setregid(gid, gid) < 0)
+-                goto fail;
+-        if (euid != uid && setreuid(uid, uid) < 0)
+-                goto fail;
++                error_setx(err, "perm_drop_privileges: setregid(gid, gid) < 0; gid=%d", gid);
++                return (-1);
++        if (euid != uid && setreuid(uid, uid) < 0) {
++                error_set(err, "perm_drop_privileges: setreuid(uid, uid) < 0");
++                return (-1);
++        }
+         if ((egid != gid && getegid() != gid) ||
+             (euid != uid && geteuid() != uid)) {
+                 errno = EPERM;
+-                goto fail;
++                error_set(err, "perm_drop_privileges: egid != gid || euid != uid");
++                return (-1);
++        }
++        if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0) {
++                error_set(err, "perm_drop_privileges: prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0");
++                return (-1);
+         }
+-        if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0)
+-                goto fail;
+         return (0);
+ 
+  fail:
+-        error_set(err, "privilege change failed");
++        error_set(err, "perm_drop_privileges: privilege change failed");
+         return (-1);
+ }
+ 
+@@ -963,7 +980,7 @@ perm_set_bounds(struct error *err, const cap_value_t caps[], size_t size)
+                                 goto next;
+                 }
+                 if (prctl(PR_CAPBSET_READ, c) > 0 && prctl(PR_CAPBSET_DROP, c) < 0) {
+-                        error_set(err, "capability change failed");
++                        error_set(err, "perm_set_bounds: capability change failed");
+                         return (-1);
+                 }
+          next:;
+@@ -1015,8 +1032,15 @@ perm_set_capabilities(struct error *err, cap_flag_t type, const cap_value_t caps
+         rv = 0;
+ 
+  fail:
+-        if (rv < 0)
+-                error_set(err, "capability change failed");
++        if (rv < 0) {
++            error_set(err,
++                      "%s:%d: perm_set_capabilities(%s, ...): capability change failed",
++                      __FILE__, __LINE__,
++                      type == CAP_EFFECTIVE   ? "CAP_EFFECTIVE"
++                      : type == CAP_AMBIENT   ? "CAP_AMBIENT"
++                      : type == CAP_PERMITTED ? "CAP_PERMITTED"
++                                              : "CAP_UNKNOWN");
++        }
+         cap_free(state);
+         cap_free(tmp);
+         return (rv);
+-- 
+2.42.0
+

--- a/pkgs/applications/virtualization/libnvidia-container/0002-prctl-localize-the-capability-change-failed-messages.patch
+++ b/pkgs/applications/virtualization/libnvidia-container/0002-prctl-localize-the-capability-change-failed-messages.patch
@@ -1,19 +1,19 @@
-From 46ae709a60b6b6a4e1254b14afb02dc3cbd1894b Mon Sep 17 00:00:00 2001
+From 4af3ccb478d7b6655da033903ed83c5896a53c1c Mon Sep 17 00:00:00 2001
 From: Someone Serge <sergei.kozlukov@aalto.fi>
 Date: Sat, 6 Jan 2024 02:50:17 +0000
 Subject: [PATCH 2/4] prctl: localize the "capability change failed" messages
 
 perm_drop_privileges: set detailed errors
 ---
- src/cli/configure.c |  7 +++++-
+ src/cli/configure.c |  9 ++++++--
  src/error_generic.c | 12 +++++++---
  src/nvc_info.c      | 42 ++++++++++++++++++++++++++--------
  src/nvc_ldcache.c   |  3 ++-
  src/utils.c         | 56 ++++++++++++++++++++++++++++++++-------------
- 5 files changed, 89 insertions(+), 31 deletions(-)
+ 5 files changed, 90 insertions(+), 32 deletions(-)
 
 diff --git a/src/cli/configure.c b/src/cli/configure.c
-index 415f6b3..f682ca5 100644
+index 415f6b3..6f4ecb6 100644
 --- a/src/cli/configure.c
 +++ b/src/cli/configure.c
 @@ -242,6 +242,7 @@ configure_command(const struct context *ctx)
@@ -57,6 +57,15 @@ index 415f6b3..f682ca5 100644
              (dev = libnvc.device_info_new(nvc, NULL)) == NULL) {
 -                warnx("detection error: %s", libnvc.error(nvc));
 +                warnx("detection error: %s; drv is %s, dev is %s", libnvc.error(nvc), drv == NULL ? "NULL" : "not NULL", dev == NULL ? "NULL" : "not NULL");
+                 goto fail;
+         }
+ 
+@@ -413,7 +418,7 @@ configure_command(const struct context *ctx)
+                 goto fail;
+         }
+         if (libnvc.ldcache_update(nvc, cnt) < 0) {
+-                warnx("ldcache error: %s", libnvc.error(nvc));
++                warnx("%s:%d: ldcache error: %s", __FILE__, __LINE__, libnvc.error(nvc));
                  goto fail;
          }
  
@@ -192,7 +201,7 @@ index 7f21589..2965fba 100644
  
   fail:
 diff --git a/src/nvc_ldcache.c b/src/nvc_ldcache.c
-index ae5def4..514d05b 100644
+index f15a6c9..28e1d8b 100644
 --- a/src/nvc_ldcache.c
 +++ b/src/nvc_ldcache.c
 @@ -221,7 +221,7 @@ adjust_privileges(struct error *err, uid_t uid, gid_t gid, bool drop_groups)
@@ -204,14 +213,14 @@ index ae5def4..514d05b 100644
                          return (-1);
                  }
          }
-@@ -384,6 +384,7 @@ nvc_ldcache_update(struct nvc_context *ctx, const struct nvc_container *cnt)
+@@ -386,6 +386,7 @@ nvc_ldcache_update(struct nvc_context *ctx, const struct nvc_container *cnt)
  
-         if ((child = create_process(&ctx->err, CLONE_NEWPID|CLONE_NEWIPC)) < 0) {
+         if (ldconfigExists && (child = create_process(&ctx->err, CLONE_NEWPID|CLONE_NEWIPC)) < 0) {
                  xclose(fd);
 +                error_setx(&ctx->err, "%s:%d create_process failed", __FILE__, __LINE__);
                  return (-1);
          }
-         if (child == 0) {
+         if (ldconfigExists && child == 0) {
 diff --git a/src/utils.c b/src/utils.c
 index 8ff6f26..eee7b7d 100644
 --- a/src/utils.c

--- a/pkgs/applications/virtualization/libnvidia-container/0003-perm_drop_privileges-ignore-EPERM-on-setgroups.patch
+++ b/pkgs/applications/virtualization/libnvidia-container/0003-perm_drop_privileges-ignore-EPERM-on-setgroups.patch
@@ -1,0 +1,77 @@
+From c5793b0d72c8e34f2cc6f5ddb276740e128b7903 Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Sat, 6 Jan 2024 03:49:56 +0000
+Subject: [PATCH 3/4] perm_drop_privileges: ignore EPERM on setgroups
+
+...and EINVAL on setregid/setreuid
+---
+ src/utils.c | 39 +++++++++++++++++++++++++++++----------
+ 1 file changed, 29 insertions(+), 10 deletions(-)
+
+diff --git a/src/utils.c b/src/utils.c
+index eee7b7d..4f051a4 100644
+--- a/src/utils.c
++++ b/src/utils.c
+@@ -916,6 +916,9 @@ perm_drop_privileges(struct error *err, uid_t uid, gid_t gid, bool drop_groups)
+         euid = geteuid();
+         egid = getegid();
+ 
++        bool ignoreUid = false;
++        bool ignoreGid = false;
++
+         if (drop_groups) {
+                 switch (getgroups(0, NULL)) {
+                 case -1:
+@@ -933,23 +936,39 @@ perm_drop_privileges(struct error *err, uid_t uid, gid_t gid, bool drop_groups)
+                         /* Fallthrough */
+                 default:
+                         if (setgroups(1, &gid) < 0) {
+-                                error_set(err, "perm_drop_privileges: setgroups(1, &gid) < 0");
+-                                return (-1);
++                                /* We may not have a the capability to setgroups */
++                                if (errno == EPERM) {
++                                    errno = 0;
++                                } else {
++                                    error_set(err, "perm_drop_privileges: setgroups(1, &gid) < 0");
++                                    return (-1);
++                                }
+                         }
+                         break;
+                 }
+         }
+-        if (egid != gid && setregid(gid, gid) < 0)
+-                error_setx(err, "perm_drop_privileges: setregid(gid, gid) < 0; gid=%d", gid);
+-                return (-1);
++        if (egid != gid && setregid(gid, gid) < 0) {
++                /* EINVAL probably means we're trying to set a non-existent group */
++                if (errno != EINVAL) {
++                    error_setx(err, "perm_drop_privileges: setregid(gid, gid) < 0; gid=%d", gid);
++                    return (-1);
++                }
++                errno = 0;
++                ignoreGid = true;
++        }
+         if (euid != uid && setreuid(uid, uid) < 0) {
+-                error_set(err, "perm_drop_privileges: setreuid(uid, uid) < 0");
+-                return (-1);
++                /* EINVAL probably means we're trying to set a non-existent user */
++                if (errno != EINVAL) {
++                    error_set(err, "perm_drop_privileges: setreuid(uid, uid) < 0");
++                    return (-1);
++                }
++                errno = 0;
++                ignoreUid = true;
+         }
+-        if ((egid != gid && getegid() != gid) ||
+-            (euid != uid && geteuid() != uid)) {
++        if ((egid != gid && getegid() != gid && !ignoreGid) ||
++            (euid != uid && geteuid() != uid && !ignoreUid)) {
++                error_setx(err, "perm_drop_privileges: egid != gid || euid != uid; (uid, gid)=(%d, %d); (euid, egid)=(%d, %d) (geteuid(), getegid())=(%d, %d)", uid, gid, euid, egid, geteuid(), getegid());
+                 errno = EPERM;
+-                error_set(err, "perm_drop_privileges: egid != gid || euid != uid");
+                 return (-1);
+         }
+         if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0) {
+-- 
+2.42.0
+

--- a/pkgs/applications/virtualization/libnvidia-container/0003-perm_drop_privileges-ignore-EPERM-on-setgroups.patch
+++ b/pkgs/applications/virtualization/libnvidia-container/0003-perm_drop_privileges-ignore-EPERM-on-setgroups.patch
@@ -1,4 +1,4 @@
-From c5793b0d72c8e34f2cc6f5ddb276740e128b7903 Mon Sep 17 00:00:00 2001
+From b8896cebe11e0385c2ec5cf062047b6637bea4f6 Mon Sep 17 00:00:00 2001
 From: Someone Serge <sergei.kozlukov@aalto.fi>
 Date: Sat, 6 Jan 2024 03:49:56 +0000
 Subject: [PATCH 3/4] perm_drop_privileges: ignore EPERM on setgroups

--- a/pkgs/applications/virtualization/libnvidia-container/default.nix
+++ b/pkgs/applications/virtualization/libnvidia-container/default.nix
@@ -116,6 +116,7 @@ stdenv.mkDerivation rec {
     description = "NVIDIA container runtime library";
     license = licenses.asl20;
     platforms = platforms.linux;
+    mainProgram = "nvidia-container-cli";
     maintainers = with maintainers; [ cpcloud ];
   };
 }

--- a/pkgs/applications/virtualization/nvidia-container-toolkit/default.nix
+++ b/pkgs/applications/virtualization/nvidia-container-toolkit/default.nix
@@ -47,6 +47,14 @@ buildGoModule rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
+  preConfigure = ''
+    # Ensure the runc symlink isn't broken:
+    if ! readlink --quiet --canonicalize-existing "${isolatedContainerRuntimePath}/runc" ; then
+      echo "${isolatedContainerRuntimePath}/runc: broken symlink" >&2
+      exit 1
+    fi
+  '';
+
   checkFlags =
     let
       skippedTests = [

--- a/pkgs/applications/virtualization/nvidia-container-toolkit/packages.nix
+++ b/pkgs/applications/virtualization/nvidia-container-toolkit/packages.nix
@@ -12,6 +12,11 @@ lib.makeScope newScope (
 
     nvidia-container-toolkit = self.callPackage ./. {
       containerRuntimePath = "${docker}/libexec/docker/docker";
+    };
+
+    # Keeping around for compatibility.
+    # Setting the default `config.toml` is no longer necessary.
+    nvidia-container-toolkit-docker = self.nvidia-container-toolkit.override {
       configTemplate = ../nvidia-docker/config.toml;
     };
     nvidia-container-toolkit-podman = self.nvidia-container-toolkit.override {

--- a/pkgs/applications/virtualization/nvidia-container-toolkit/packages.nix
+++ b/pkgs/applications/virtualization/nvidia-container-toolkit/packages.nix
@@ -29,7 +29,7 @@ lib.makeScope newScope (
       paths = [
         libnvidia-container
         self.nvidia-docker-unwrapped
-        self.nvidia-container-toolkit
+        self.nvidia-container-toolkit-docker
       ];
     };
     nvidia-docker-unwrapped = self.callPackage ../nvidia-docker { };

--- a/pkgs/applications/virtualization/nvidia-container-toolkit/packages.nix
+++ b/pkgs/applications/virtualization/nvidia-container-toolkit/packages.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  newScope,
+  docker,
+  libnvidia-container,
+  runc,
+  symlinkJoin,
+}:
+
+lib.makeScope newScope (
+  self: {
+
+    nvidia-container-toolkit = self.callPackage ./. {
+      containerRuntimePath = "${docker}/libexec/docker/docker";
+      configTemplate = ../nvidia-docker/config.toml;
+    };
+    nvidia-container-toolkit-podman = self.nvidia-container-toolkit.override {
+      containerRuntimePath = lib.getExe runc;
+      configTemplate = ../nvidia-podman/config.toml;
+    };
+
+    nvidia-docker = symlinkJoin {
+      name = "nvidia-docker";
+      paths = [
+        libnvidia-container
+        self.nvidia-docker-unwrapped
+        self.nvidia-container-toolkit
+      ];
+    };
+    nvidia-docker-unwrapped = self.callPackage ../nvidia-docker { };
+
+    nvidia-podman = symlinkJoin {
+      name = "nvidia-podman";
+      paths = [
+        libnvidia-container
+        self.nvidia-container-toolkit-podman
+      ];
+    };
+  }
+)

--- a/pkgs/applications/virtualization/singularity/apptainer/0001-ldCache-patch-for-driverLink.patch
+++ b/pkgs/applications/virtualization/singularity/apptainer/0001-ldCache-patch-for-driverLink.patch
@@ -1,0 +1,84 @@
+From 783ec26c0d83013baf04579a6a415d7f8776ac93 Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Sun, 7 Jan 2024 11:48:24 +0000
+Subject: [PATCH] ldCache(): patch for @driverLink@
+
+---
+ internal/pkg/util/paths/resolve.go | 41 +++++++++++++++++++++++++++---
+ 1 file changed, 38 insertions(+), 3 deletions(-)
+
+diff --git a/internal/pkg/util/paths/resolve.go b/internal/pkg/util/paths/resolve.go
+index db45d9db1..9d0110b6b 100644
+--- a/internal/pkg/util/paths/resolve.go
++++ b/internal/pkg/util/paths/resolve.go
+@@ -14,6 +14,7 @@ import (
+ 	"fmt"
+ 	"os"
+ 	"os/exec"
++	"path"
+ 	"path/filepath"
+ 	"regexp"
+ 	"strings"
+@@ -154,14 +155,49 @@ func Resolve(fileList []string) ([]string, []string, error) {
+ // lists three variants of libEGL.so.1 that are in different locations, we only
+ // report the first, highest priority, variant.
+ func ldCache() (map[string]string, error) {
++    driverDirs := strings.Split("@driverLink@/lib", ":")
++    if machine, err := elfMachine(); err == nil && machine == elf.EM_386 {
++        driverDirs = strings.Split("@driverLink@-32/lib", ":")
++    }
++
++    soPattern, err := regexp.Compile(`[^\s]+\.so(\.\d+(\.\d+(\.\d+)?)?)?$`)
++    if err != nil {
++		return nil, fmt.Errorf("could not compile ldconfig regexp: %v", err)
++    }
++
++	ldCache := make(map[string]string)
++    for _, dirPath := range driverDirs {
++        dir, err := os.Open(dirPath)
++        if err != nil {
++            /* Maybe we're not running under NixOS */
++            continue
++        }
++        files, err := dir.ReadDir(-1)
++        if err != nil {
++            continue
++        }
++        for _, f := range files {
++            if !soPattern.MatchString(f.Name()) {
++                continue
++            }
++            libName := f.Name()
++            libPath := path.Join(dirPath, f.Name())
++			if _, ok := ldCache[libName]; !ok {
++				ldCache[libName] = libPath
++			}
++        }
++    }
++
+ 	// walk through the ldconfig output and add entries which contain the filenames
+ 	// returned by nvidia-container-cli OR the nvliblist.conf file contents
+ 	ldconfig, err := bin.FindBin("ldconfig")
+-	if err != nil {
++	if err != nil && len(ldCache) == 0 {
++        // Note that missing ldconfig is only an "error" as long
++        // as there's no driverLink
+ 		return nil, err
+ 	}
+ 	out, err := exec.Command(ldconfig, "-p").Output()
+-	if err != nil {
++	if err != nil && len(ldCache) == 0 {
+ 		return nil, fmt.Errorf("could not execute ldconfig: %v", err)
+ 	}
+ 
+@@ -173,7 +209,6 @@ func ldCache() (map[string]string, error) {
+ 	}
+ 
+ 	// store library name with associated path
+-	ldCache := make(map[string]string)
+ 	for _, match := range r.FindAllSubmatch(out, -1) {
+ 		if match != nil {
+ 			// libName is the "libnvidia-ml.so.1" (from the above example)
+-- 
+2.42.0
+

--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -43,8 +43,7 @@ in
 , gpgme
 , libseccomp
 , libuuid
-  # This is for nvidia-container-cli
-, nvidia-docker
+, libnvidia-container
 , openssl
 , squashfsTools
 , squashfuse
@@ -137,7 +136,7 @@ in
     openssl
     squashfsTools # Required at build time by SingularityCE
   ]
-  ++ lib.optional enableNvidiaContainerCli nvidia-docker
+  ++ lib.optionals enableNvidiaContainerCli [ libnvidia-container ]
   ++ lib.optional enableSeccomp libseccomp
   ;
 
@@ -168,7 +167,7 @@ in
     squashfsTools # mksquashfs unsquashfs # Make / unpack squashfs image
     squashfuse # squashfuse_ll squashfuse # Mount (without unpacking) a squashfs image without privileges
   ]
-  ++ lib.optional enableNvidiaContainerCli nvidia-docker
+  ++ lib.optionals enableNvidiaContainerCli [ libnvidia-container ]
   ;
 
   postPatch = ''
@@ -218,7 +217,7 @@ in
     ''}
     ${lib.optionalString (enableNvidiaContainerCli && projectName == "singularity") ''
       substituteInPlace "$out/etc/${projectName}/${projectName}.conf" \
-        --replace "# nvidia-container-cli path =" "nvidia-container-cli path = ${nvidia-docker}/bin/nvidia-container-cli"
+        --replace "# nvidia-container-cli path =" "nvidia-container-cli path = ${libnvidia-container}/bin/nvidia-container-cli"
     ''}
     ${lib.optionalString (removeCompat && (projectName != "singularity")) ''
       unlink "$out/bin/singularity"

--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -174,11 +174,18 @@ in
     if [[ ! -e .git || ! -e VERSION ]]; then
       echo "${version}" > VERSION
     fi
+
     # Patch shebangs for script run during build
     patchShebangs --build "$configureScript" makeit e2e scripts mlocal/scripts
+
     # Patching the hard-coded defaultPath by prefixing the packages in defaultPathInputs
     substituteInPlace cmd/internal/cli/actions.go \
       --replace "defaultPath = \"${defaultPathOriginal}\"" "defaultPath = \"''${defaultPathInputs// /\/bin:}''${defaultPathInputs:+/bin:}${defaultPathOriginal}\""
+
+    substituteInPlace internal/pkg/util/gpu/nvidia.go \
+      --replace \
+        'return fmt.Errorf("/usr/bin not writable in the container")' \
+        ""
   '';
 
   postConfigure = ''

--- a/pkgs/development/cuda-modules/saxpy/default.nix
+++ b/pkgs/development/cuda-modules/saxpy/default.nix
@@ -36,7 +36,9 @@ backendStdenv.mkDerivation {
   buildInputs =
     lib.optionals (lib.versionOlder cudaVersion "11.4") [cudatoolkit]
     ++ lib.optionals (lib.versionAtLeast cudaVersion "11.4") [
-      libcublas
+      libcublas.dev
+      libcublas.lib
+      libcublas.static
       cuda_cudart
     ]
     ++ lib.optionals (lib.versionAtLeast cudaVersion "12.0") [cuda_cccl];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24203,7 +24203,6 @@ with pkgs;
       { };
   inherit (nvidiaCtkPackages)
     nvidia-container-toolkit
-    nvidia-container-toolkit-podman
     nvidia-docker
     nvidia-podman
     ;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24198,31 +24198,15 @@ with pkgs;
   nv-codec-headers-11 = callPackage ../development/libraries/nv-codec-headers/11_x.nix { };
   nv-codec-headers-12 = callPackage ../development/libraries/nv-codec-headers/12_x.nix { };
 
-  mkNvidiaContainerPkg = { name, containerRuntimePath, configTemplate, additionalPaths ? [] }:
-    let
-      nvidia-container-toolkit = callPackage ../applications/virtualization/nvidia-container-toolkit {
-        inherit containerRuntimePath configTemplate;
-      };
-    in symlinkJoin {
-      inherit name;
-      paths = [
-        libnvidia-container
-        nvidia-container-toolkit
-      ] ++ additionalPaths;
-    };
-
-  nvidia-docker = mkNvidiaContainerPkg {
-    name = "nvidia-docker";
-    containerRuntimePath = "${docker}/libexec/docker/docker";
-    configTemplate = ../applications/virtualization/nvidia-docker/config.toml;
-    additionalPaths = [ (callPackage ../applications/virtualization/nvidia-docker { }) ];
-  };
-
-  nvidia-podman = mkNvidiaContainerPkg {
-    name = "nvidia-podman";
-    containerRuntimePath = "${runc}/bin/runc";
-    configTemplate = ../applications/virtualization/nvidia-podman/config.toml;
-  };
+  nvidiaCtkPackages =
+    callPackage ../applications/virtualization/nvidia-container-toolkit/packages.nix
+      { };
+  inherit (nvidiaCtkPackages)
+    nvidia-container-toolkit
+    nvidia-container-toolkit-podman
+    nvidia-docker
+    nvidia-podman
+    ;
 
   nvidia-vaapi-driver = lib.hiPrio (callPackage ../development/libraries/nvidia-vaapi-driver { });
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24213,7 +24213,7 @@ with pkgs;
 
   nvidia-docker = mkNvidiaContainerPkg {
     name = "nvidia-docker";
-    containerRuntimePath = "${docker}/libexec/docker/runc";
+    containerRuntimePath = "${docker}/libexec/docker/docker";
     configTemplate = ../applications/virtualization/nvidia-docker/config.toml;
     additionalPaths = [ (callPackage ../applications/virtualization/nvidia-docker { }) ];
   };


### PR DESCRIPTION
## Description of changes

This is work in progress.

Shortcut to the first error:

```
❯ APPTAINER_MESSAGELEVEL=100000 NVIDIA_VISIBLE_DEVICES=all nix run --arg config '{ allowUnfree = true; }' -I nixpkgs=flake:github:SomeoneSerge/nixpkgs/feat/nixos-apptainer-nosuid -f '<nixpkgs>' apptainer.gpuChecks.saxpy.unwrapped
...
VERBOSE [U=1001,P=1319708] addCwdMount()                 /home/ss/Sources/nixpkgs/.worktree/apptainer found within container
DEBUG   [U=1001,P=1319708] create()                      nvidia-container-cli
DEBUG   [U=1001,P=1319732] findOnPath()                  Found "nvidia-container-cli" at "/nix/store/j9raldl3nsv797ydmc7v8kxgf8vbkks3-libnvidia-container-1.14.3/bin/nvidia-container-cli"
DEBUG   [U=1001,P=1319732] findOnPath()                  Found "ldconfig" at "/run/current-system/sw/bin/ldconfig"
DEBUG   [U=1001,P=1319732] NVCLIConfigure()              nvidia-container-cli binary: "/nix/store/j9raldl3nsv797ydmc7v8kxgf8vbkks3-libnvidia-container-1.14.3/bin/nvidia-container-cli" args: ["--debug" "--user" "configure" "--no-cgroups" "--device=all" "--compute" "--utility" "--ldconfig=@/run/current-system/sw/bin/ldconfig" "/nix/store/v1mwsgk404dryqfbffyafybyab1snzfp-apptainer-1.2.5/var/lib/apptainer/mnt/session/final"]
DEBUG   [U=1001,P=1319732] NVCLIConfigure()              Running nvidia-container-cli in user namespace
DEBUG   [U=1001,P=1319708] create()                      Chroot into /nix/store/v1mwsgk404dryqfbffyafybyab1snzfp-apptainer-1.2.5/var/lib/apptainer/mnt/session/final
DEBUG   [U=1001,P=1319732] Chroot()                      Hold reference to host / directory
DEBUG   [U=1001,P=1319732] Chroot()                      Called pivot_root on /nix/store/v1mwsgk404dryqfbffyafybyab1snzfp-apptainer-1.2.5/var/lib/apptainer/mnt/session/final
DEBUG   [U=1001,P=1319732] Chroot()                      Change current directory to host / directory
...
CUDA error at cudaRuntimeGetVersion(&rtVersion): CUDA driver version is insufficient for CUDA runtime version
```

Progress so far

- Updated and fixed the build-time errors in libnvidia-container, nvidia-docker, nvidia-container-cli.
- Patched out several undocumented abortions from apptainer and libnvidia-docker. I had to extend libnvidia-docker's error messages
- Verified `nvidia-container --list` and `nvidia-container info`

Still suffering from:

- `apptainer --nv --nvccli` still doesn't mount any of the libraries from `/run/opengl-driver/lib`, even though nvidia-container-cli is being called, and its `ldcache_resolve` does hit them
- the `nvliblist` method is broken because we still haven't patched out the ldconfig abuse
- Running `nvidia-container-cli --debug --user configure ...` from the shell (outside singularity) still fails, e.g.:
  ```
  ❯ "/nix/store/scsh1pr4n520c4mklmwai3bclb3hipj0-libnvidia-container-1.14.3/bin/nvidia-container-cli" "--debug" "--user" "configure" "--no-cgroups" "--device=all" "--compute" "--utility" "--ldconfig=@/nix/store/bh4lz3c2n3qfbm2hhwjhnqcaxcjs2sm8-glibc-2.38-27-bin/bin/ldconfig" "/var/lib/apptainer/mnt/session/final"
  nvidia-container-cli: permission error: /build/source/src/utils.c:1055: perm_set_capabilities(CAP_PERIMTTED, ...): capability change failed: operation not permitted
  ```

  It's still unclear to me if nvidia-container-cli was ever meant to be used by unprivileged users
- libnvc's logs (`warnx`, etc) aren't visible; I don't even think apptainer eats them, I think they're never actually printed. The `NVC_DEBUG_FILE` is also ignored. Essentially, `error_setx` is the only way I found so far to get any logs out of nvidia-container-cli

## Motivation

Apptainer and singularity's GPU support is (mostly) broken again. Note that singularity+setuid used to work (with the fake ldconfig). Recap:

- [ ] Both default to abusing glibc internals (ld.so.cache and/or `ldconfig -P`) hoping to scan for the sonames listed in `etc/nvliblist.conf`. This isn't new, but we should add a patch making them support at least nixos (ideally we need a generic posix solution accepted upstream); tracking upstream as well: https://github.com/apptainer/apptainer/issues/1894
- [ ] Singularity only works with setuid
- [ ] Apptainer refuses to use `--nvccli` unless the setuid bit is _unset_
- [ ] Apptainer's `--nv` aborts unless the image is writable, but doesn't explain why it needs the write access
- [ ] The `--nvccli` uses nvidia-container-toolkit which abuses ld.so.cache, obscurely fails trying to manage capabilities, but also silently fails to copy or mount the host libraries into the container (even if `ldcache_resolve` succeeds locating them)
- [ ] Nixpkgs' libnvidia-container and nvidia-container-toolkit are outdated
- [ ] Several packages in Nixpkgs still use the upstream-deprecated nvidia-docker
- [ ] This is also related to the podman/kubernetes/containerd issues brought up on discourse


Naturally, we need to contact both apptainer, singularityce, and libnvidia-container about these issues. Ideally, they would reach out with the glibc maintainers and ask what would have been the reasonable approach to locating the host libraries.

⚠️ I apologize for the language, but I'm pretty tired and I wasn't planning to be spending time on this

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

CC @ShamrockLee 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
