### PR TITLE
symfony-cli: add nssTools as a runtime dependency

### DIFF
--- a/pkgs/development/tools/symfony-cli/default.nix
+++ b/pkgs/development/tools/symfony-cli/default.nix
@@ -4,6 +4,8 @@
 , nix-update-script
 , testers
 , symfony-cli
+, nssTools
+, makeBinaryWrapper
 }:
 
 buildGoModule rec {
@@ -25,8 +27,14 @@ buildGoModule rec {
     "-X main.channel=stable"
   ];
 
+  buildInputs = [ makeBinaryWrapper ];
+
   postInstall = ''
-    mv $out/bin/symfony-cli $out/bin/symfony
+    mkdir $out/libexec
+    mv $out/bin/symfony-cli $out/libexec/symfony
+
+    makeBinaryWrapper $out/libexec/symfony $out/bin/symfony \
+      --prefix PATH : ${lib.makeBinPath [ nssTools ]}
   '';
 
   # Tests requires network access


### PR DESCRIPTION
## Description of changes

`symfony-cli` provides useful commands to work with local fake domains. `symfony proxy:start` allows you to configure a proxy server to redirect any `http://<domain>.wip` and `https://<domain>.wip` to the right dev server port used by `symfony server:start`.

When you want to work with https, `symfony server:ca:install` can create and install a CA certificate. But without `certutil` installed, a note says "Firefox and/or Chrome/Chromium support is not available on your platform." and you need to manually add the certificate to Firefox or Chromium.

![Capture d’écran du 2024-01-05 00-53-12](https://github.com/NixOS/nixpkgs/assets/352634/d2069ceb-3e8d-459a-95c8-6a76e85ed01c)

This pull request adds `nssTools` and wraps `symfony-cli` to make `certutil` available. CA are then automatically added to
browsers and the note now says "The local CA is now installed in the Firefox and/or Chrome/Chromium trust store (requires browser restart)!"

![Capture d’écran du 2024-01-06 23-14-19](https://github.com/NixOS/nixpkgs/assets/352634/14e1a9eb-aafd-47b5-a1fa-e5d8ff40b01d)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).



---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
