### PR TITLE
jdt-language-server: 1.26.0 -> 1.31.0, use upstream wrapper

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -180,6 +180,14 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - [watchdogd](https://troglobit.com/projects/watchdogd/), a system and process supervisor using watchdog timers. Available as [services.watchdogd](#opt-services.watchdogd.enable).
 
+- The `jdt-language-server` package now uses upstream's provided python wrapper instead of our own custom wrapper. This results in the following breaking and notable changes:
+
+  - The main binary for the package is now named `jdtls` instead of `jdt-language-server`, equivalent to what most editors expect the binary to be named.
+
+  - JVM arguments should now be provided with the `--jvm-arg` flag instead of setting `JAVA_OPTS`.
+
+  - The `-data` path is no longer required to run the package, and will be set to point to a folder in `$TMP` if missing.
+
 ## Other Notable Changes {#sec-release-24.05-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/pkgs/development/tools/language-servers/jdt-language-server/default.nix
+++ b/pkgs/development/tools/language-servers/jdt-language-server/default.nix
@@ -1,102 +1,60 @@
 { lib
 , stdenv
 , fetchurl
-, makeWrapper
+, python3
 , jdk
 }:
 
-stdenv.mkDerivation rec {
+let
+  timestamp = "202401111522";
+in
+stdenv.mkDerivation (finalAttrs: {
   pname = "jdt-language-server";
-  version = "1.26.0";
-  timestamp = "202307271613";
+  version = "1.31.0";
 
   src = fetchurl {
-    url = "https://download.eclipse.org/jdtls/milestones/${version}/jdt-language-server-${version}-${timestamp}.tar.gz";
-    sha256 = "sha256-ul/l7jsqg5UofiSu8gzm4Xg0z46HcRfmyqysamiKbFM=";
+    url = "https://download.eclipse.org/jdtls/milestones/${finalAttrs.version}/jdt-language-server-${finalAttrs.version}-${timestamp}.tar.gz";
+    hash = "sha256-bCX2LQt00d2SqxmvuvvlBB6wbCuFPqtX9/Qv5v6wH3w=";
   };
 
   sourceRoot = ".";
 
   buildInputs = [
-    jdk
+    # Used for the included wrapper
+    python3
   ];
 
-  nativeBuildInputs = [
-    makeWrapper
-  ];
+  postPatch = ''
+    # We store the plugins, config, and features folder in different locations
+    # than in the original package. In addition, hard-code the path to the jdk
+    # in the wrapper, instead of searching for it in PATH at runtime.
+    substituteInPlace bin/jdtls.py \
+      --replace "jdtls_base_path = Path(__file__).parent.parent" "jdtls_base_path = Path(\"$out/share/java/jdtls/\")" \
+      --replace "java_executable = get_java_executable(known_args.validate_java_version)" "java_executable = '${lib.getExe jdk}'"
+  '';
 
   installPhase =
     let
-      # The application ships with config directories for linux and mac
+      # The application ships with different config directories for each platform.
+      # Note the application come with ARM variants as well, although the
+      # current included wrapper doesn't use them.
       configDir = if stdenv.isDarwin then "config_mac" else "config_linux";
     in
-      ''
-      # Copy jars
-      install -D -t $out/share/java/plugins/ plugins/*.jar
-
-      # Copy config directories for linux and mac
-      install -Dm 444 -t $out/share/config ${configDir}/*
-
-      # Get latest version of launcher jar
-      # e.g. org.eclipse.equinox.launcher_1.5.800.v20200727-1323.jar
-      launcher="$(ls $out/share/java/plugins/org.eclipse.equinox.launcher_* | sort -V | tail -n1)"
-
-      # The wrapper script will create a directory in the user's cache, copy in the config
-      # files since this dir can't be read-only, and by default use this as the runtime dir.
-      #
-      # The following options are required as per the upstream documentation:
-      #
-      #   -Declipse.application=org.eclipse.jdt.ls.core.id1
-      #   -Dosgi.bundles.defaultStartLevel=4
-      #   -Declipse.product=org.eclipse.jdt.ls.core.product
-      #   --add-modules=ALL-SYSTEM
-      #   --add-opens java.base/java.util=ALL-UNNAMED
-      #   --add-opens java.base/java.lang=ALL-UNNAMED
-      #
-      # The following options configure the server to run without writing logs to the nix store:
-      #
-      #   -Dosgi.sharedConfiguration.area.readOnly=true
-      #   -Dosgi.checkConfiguration=true
-      #   -Dosgi.configuration.cascaded=true
-      #   -Dosgi.sharedConfiguration.area=$out/share/config
-      #
-      # Other options which the caller may change:
-      #
-      #   -Dlog.level:
-      #     Log level.
-      #     This can be overidden by setting JAVA_OPTS.
-      #
-      # The caller must specify the following:
-      #
-      #   -data:
-      #     The application stores runtime data here. We set this to <cache-dir>/$PWD
-      #     so that projects don't collide with each other.
-      #     This can be overidden by specifying -configuration to the wrapper.
-      #
-      # Java options, such as -Xms and Xmx can be specified by setting JAVA_OPTS.
-      #
-      makeWrapper ${jdk}/bin/java $out/bin/jdt-language-server \
-        --add-flags "-Declipse.application=org.eclipse.jdt.ls.core.id1" \
-        --add-flags "-Dosgi.bundles.defaultStartLevel=4" \
-        --add-flags "-Declipse.product=org.eclipse.jdt.ls.core.product" \
-        --add-flags "-Dosgi.sharedConfiguration.area=$out/share/config" \
-        --add-flags "-Dosgi.sharedConfiguration.area.readOnly=true" \
-        --add-flags "-Dosgi.checkConfiguration=true" \
-        --add-flags "-Dosgi.configuration.cascaded=true" \
-        --add-flags "-Dlog.level=ALL" \
-        --add-flags "\$JAVA_OPTS" \
-        --add-flags "-jar $launcher" \
-        --add-flags "--add-modules=ALL-SYSTEM" \
-        --add-flags "--add-opens java.base/java.util=ALL-UNNAMED" \
-        --add-flags "--add-opens java.base/java.lang=ALL-UNNAMED"
+    ''
+      install -Dm444 -t $out/share/java/jdtls/plugins/ plugins/*
+      install -Dm444 -t $out/share/java/jdtls/features/ features/*
+      install -Dm444 -t $out/share/java/jdtls/${configDir} ${configDir}/*
+      install -Dm555 -t $out/bin bin/jdtls
+      install -Dm444 -t $out/bin bin/jdtls.py
     '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/eclipse/eclipse.jdt.ls";
     description = "Java language server";
-    sourceProvenance = with sourceTypes; [ binaryBytecode ];
-    license = licenses.epl20;
-    maintainers = with maintainers; [ matt-snider ];
-    platforms = platforms.all;
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    license = lib.licenses.epl20;
+    maintainers = with lib.maintainers; [ matt-snider ];
+    platforms = lib.platforms.all;
+    mainProgram = "jdtls";
   };
-}
+})


### PR DESCRIPTION
## Description of changes
Package update, but mainly a major change to use upstreams `jdtls` wrapper  instead of the one we previously included ourselves. This is because editors now rely on the behavior of the upstream `jdtls` wrapper to work, see https://discourse.nixos.org/t/cannot-get-jdt-language-server-working-with-helix/34482.

Breaking changes:
- The main executable has changed from `jdt-language-server` to `jdtls`
- ~~The application now searches for `java` in PATH instead of using `jdk` from the derivation.~~
- JVM arguments should now be provided with `--jvm-arg` instead of setting `JAVA_OPTS`

Other changes:
- the `-data` option is now optional, and pre-populated with a path pointing to $TMP.

Does this warrant a release note entry?
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
