### PR TITLE
Keyd application mapping

### DIFF
--- a/pkgs/tools/inputmethods/keyd/default.nix
+++ b/pkgs/tools/inputmethods/keyd/default.nix
@@ -29,11 +29,7 @@ let
       substituteInPlace scripts/${pname} \
         --replace /bin/sh ${runtimeShell}
       substituteInPlace scripts/${pname} \
-        --replace "CONFIG_PATH = os.getenv('HOME')+'/.config/keyd/app.conf'" "CONFIG_PATH = '/etc/keyd/application-mapper/app.conf'"
-      substituteInPlace scripts/${pname} \
-        --replace "LOCKFILE = os.getenv('HOME')+'/.config/keyd/app.lock'" "LOCKFILE = '/etc/keyd/application-mapper/app.lock'"
-      substituteInPlace scripts/${pname} \
-        --replace "LOGFILE = os.getenv('HOME')+'/.config/keyd/app.log'" "LOGFILE = '/etc/keyd/application-mapper/app.log'"
+        --replace "os.getenv('HOME')+'/.config/keyd" "'/etc/keyd/application-mapper"
       substituteInPlace scripts/${pname} \
         --replace "~/.config/keyd/app.conf" "/etc/keyd/application-mapper/app.conf"
     '';


### PR DESCRIPTION
## Description of changes
Properly handle the keyd-application-mapper python script and add settings for it.

## Things done

- wrap python script so that it can access `keyd` by name
- add users to group `keyd`, this is mandatory so that the script running in the userspace is allowed to bind
- rename socket to `keyd.socket`, the keyd.sock doesnt exist anymore i guess
- add systemd user service for `keyd-application-mapper`, make sure to keep its environment PATH
- migrate the `keyd-application-mapper` configs from .config to etc, so we dont need home-manager to run it
- add service that changes permissions of `/etc/keyd` so that the script can access them if user is in group `keyd`
- add module settings for the application mapping
- removed the systemd hardening because it somehow didnt let the process set the guid, someone should fix that and readd it

- Built on platform(s)
  - [ x ] x86_64-linux
  - works on my machine (wayland, hyprland)
 
 ### Needs testing
Other maintainers should thoroughly test this and probably make changes, but just throwing this out there because i had it locally for too long and i am irked that the one in nixpkgs doesnt support keyd-application-mapper. This is my first commit please tell me if i did something wrong. Cheers.
@peterhoeg , @JohnAZoidberg , @woojiq 
