### PR TITLE
emacs.pkgs.wat-mode: convert to melpaBuild

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/wat-mode/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/wat-mode/default.nix
@@ -1,10 +1,10 @@
 # Manually packaged until it is upstreamed to melpa
 # See https://github.com/devonsparks/wat-mode/issues/1
-{ lib, trivialBuild, fetchFromGitHub, fetchpatch, emacs }:
+{ lib, melpaBuild, fetchFromGitHub, writeText }:
 
-trivialBuild rec {
+melpaBuild rec {
   pname = "wat-mode";
-  version = "unstable-2022-07-13";
+  version = "20220713.1";
 
   src = fetchFromGitHub {
     owner = "devonsparks";
@@ -13,11 +13,16 @@ trivialBuild rec {
     hash = "sha256-jV5V3TRY+D3cPSz3yFwVWn9yInhGOYIaUTPEhsOBxto=";
   };
 
-  meta = with lib; {
+  commit = "46b4df83e92c585295d659d049560dbf190fe501";
+
+  recipe = writeText "recipe" ''
+    (wat-mode :repo "devonsparks/wat-mode" :fetcher github)
+  '';
+
+  meta = {
     homepage = "https://github.com/devonsparks/wat-mode";
     description = "An Emacs major mode for WebAssembly's text format";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ nagy ];
-    inherit (emacs.meta) platforms;
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ nagy ];
   };
 }


### PR DESCRIPTION
###### Description of changes

Tracking issue #278925

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

### Priorities

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc