### PR TITLE
linux/kernel/common-config: Reenable the rfkill-input module

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -296,6 +296,7 @@ let
       # At the time of writing (25-06-2023): this is only used in a "correct" way by ath drivers for initiating DFS radiation
       # for "certified devices"
       EXPERT                      = option yes; # this is needed for offering the certification option
+      RFKILL_INPUT                = option yes; # counteract an undesired effect of setting EXPERT
       CFG80211_CERTIFICATION_ONUS = option yes;
       # DFS: "Dynamic Frequency Selection" is a spectrum-sharing mechanism that allows
       # you to use certain interesting frequency when your local regulatory domain mandates it.


### PR DESCRIPTION
## Description of changes

The default value of the `RFKILL_INPUT` Kconfig option depends on the `EXPERT` option which was changed in 3b07356d2d55c5eacc7a11eb08c3a8de97884b2f. However, disabling the rfkill-input module was unintentional and [causes some airplane mode buttons on laptops to not function](https://github.com/NixOS/nixpkgs/issues/261880).

## Things done

- Built on platform(s)
  - [x] x86_64-linux 
  I built all kernel configurations in nixpkgs (except `linux_testing_bcachefs` which also fails without this patch) and verified that their build passes and `RFKILL_INPUT` is the only changed option.
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
