### PR TITLE
buildGoModule: announce removal of `buildFlags` and `buildFlagsArray`

### DIFF
--- a/pkgs/applications/blockchains/lnd/default.nix
+++ b/pkgs/applications/blockchains/lnd/default.nix
@@ -1,6 +1,7 @@
 { buildGoModule
 , fetchFromGitHub
 , lib
+, go
 , tags ? [ "autopilotrpc" "signrpc" "walletrpc" "chainrpc" "invoicesrpc" "watchtowerrpc" "routerrpc" "monitoring" "kvdb_postgres" "kvdb_etcd" ]
 }:
 
@@ -19,17 +20,7 @@ buildGoModule rec {
 
   subPackages = [ "cmd/lncli" "cmd/lnd" ];
 
-  preBuild = let
-    buildVars = {
-      RawTags = lib.concatStringsSep "," tags;
-      GoVersion = "$(go version | egrep -o 'go[0-9]+[.][^ ]*')";
-    };
-    buildVarsFlags = lib.concatStringsSep " " (lib.mapAttrsToList (k: v: "-X github.com/lightningnetwork/lnd/build.${k}=${v}") buildVars);
-  in
-  lib.optionalString (tags != []) ''
-    buildFlagsArray+=("-tags=${lib.concatStringsSep " " tags}")
-    buildFlagsArray+=("-ldflags=${buildVarsFlags}")
-  '';
+  inherit tags;
 
   meta = with lib; {
     description = "Lightning Network Daemon";

--- a/pkgs/applications/version-management/git-town/default.nix
+++ b/pkgs/applications/version-management/git-town/default.nix
@@ -19,7 +19,8 @@ buildGoModule rec {
 
   ldflags =
     let
-      modulePath = "github.com/git-town/git-town/v${lib.versions.major version}"; in
+      modulePath = "github.com/git-town/git-town/v${lib.versions.major version}";
+    in
     [
       "-s"
       "-w"
@@ -28,19 +29,22 @@ buildGoModule rec {
     ];
 
   nativeCheckInputs = [ git ];
-  preCheck =
+
+  preCheck = ''
+    HOME=$(mktemp -d)
+  '';
+
+  checkFlags =
     let
+      # Disable tests requiring local operations
       skippedTests = [
         "TestGodog"
-        "TestMockingShell_MockCommand"
-        "TestShellRunner_RunStringWith_Input"
+        "TestMockingRunner/MockCommand"
+        "TestMockingRunner/QueryWith"
+        "TestTestCommands/CreateChildFeatureBranch"
       ];
     in
-    ''
-      HOME=$(mktemp -d)
-      # Disable tests requiring local operations
-      buildFlagsArray+=("-run" "[^(${builtins.concatStringsSep "|" skippedTests})]")
-    '';
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   postInstall = ''
     installShellCompletion --cmd git-town \

--- a/pkgs/applications/version-management/gitbatch/default.nix
+++ b/pkgs/applications/version-management/gitbatch/default.nix
@@ -15,15 +15,18 @@ buildGoModule rec {
 
   ldflags = [ "-s" "-w" ];
 
-  nativeBuildInputs = [
+  nativeCheckInputs = [
     git # required by unit tests
   ];
 
   preCheck = ''
     HOME=$(mktemp -d)
-    # Disable tests requiring network access to gitlab.com
-    buildFlagsArray+=("-run" "[^(Test(Run|Start|(Fetch|Pull)With(Go|)Git))]")
   '';
+
+  checkFlags = [
+    # Disable tests requiring network access to gitlab.com
+    "-skip=Test(Run|Start|(Fetch|Pull)With(Go|)Git)"
+  ];
 
   meta = with lib; {
     description = "Running git UI commands";

--- a/pkgs/applications/virtualization/podman-tui/default.nix
+++ b/pkgs/applications/virtualization/podman-tui/default.nix
@@ -20,19 +20,20 @@ buildGoModule rec {
 
   ldflags = [ "-s" "-w" ];
 
-  preCheck =
+  preCheck = ''
+    export USER=$(whoami)
+    export HOME="$(mktemp -d)"
+  '';
+
+  checkFlags =
     let
       skippedTests = [
+        # Disable flaky tests
         "TestDialogs"
         "TestVoldialogs"
       ];
     in
-    ''
-      export HOME="$(mktemp -d)"
-
-      # Disable flaky tests
-      buildFlagsArray+=("-run" "[^(${builtins.concatStringsSep "|" skippedTests})]")
-    '';
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   passthru.tests.version = testers.testVersion {
     package = podman-tui;

--- a/pkgs/build-support/go/module.nix
+++ b/pkgs/build-support/go/module.nix
@@ -313,7 +313,7 @@ let
   });
 in
 lib.warnIf (buildFlags != "" || buildFlagsArray != "")
-  "Use the `ldflags` and/or `tags` attributes instead of `buildFlags`/`buildFlagsArray`"
+  "`buildFlags`/`buildFlagsArray` are deprecated and will be removed in the 24.11 release. Use the `ldflags` and/or `tags` attributes instead"
 lib.warnIf (builtins.elem "-buildid=" ldflags) "`-buildid=` is set by default as ldflag by buildGoModule"
 lib.warnIf (builtins.elem "-trimpath" GOFLAGS) "`-trimpath` is added by default to GOFLAGS by buildGoModule when allowGoReference isn't set to true"
 lib.warnIf (lib.any (lib.hasPrefix "-mod=") GOFLAGS) "use `proxyVendor` to control Go module/vendor behavior instead of setting `-mod=` in GOFLAGS"

--- a/pkgs/build-support/go/package.nix
+++ b/pkgs/build-support/go/package.nix
@@ -286,7 +286,7 @@ let
   });
 in
 lib.warnIf (buildFlags != "" || buildFlagsArray != "")
-  "Use the `ldflags` and/or `tags` attributes instead of `buildFlags`/`buildFlagsArray`"
+  "`buildFlags`/`buildFlagsArray` are deprecated and will be removed in the 24.11 release. Use the `ldflags` and/or `tags` attributes instead"
 lib.warnIf (builtins.elem "-buildid=" ldflags) "`-buildid=` is set by default as ldflag by buildGoModule"
 lib.warnIf (builtins.elem "-trimpath" GOFLAGS) "`-trimpath` is added by default to GOFLAGS by buildGoModule when allowGoReference isn't set to true"
   package

--- a/pkgs/by-name/in/incus/generic.nix
+++ b/pkgs/by-name/in/incus/generic.nix
@@ -81,7 +81,8 @@ buildGoModule rec {
     make incus-agent incus-migrate
   '';
 
-  preCheck =
+  # Disable tests requiring local operations
+  checkFlags =
     let
       skippedTests = [
         "TestValidateConfig"
@@ -91,10 +92,7 @@ buildGoModule rec {
         "TestContainerTestSuite"
       ];
     in
-    ''
-      # Disable tests requiring local operations
-      buildFlagsArray+=("-run" "[^(${builtins.concatStringsSep "|" skippedTests})]")
-    '';
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   postInstall = ''
     installShellCompletion --cmd incus \

--- a/pkgs/by-name/lx/lxd-unwrapped-lts/package.nix
+++ b/pkgs/by-name/lx/lxd-unwrapped-lts/package.nix
@@ -71,7 +71,7 @@ buildGo122Module rec {
     make lxd-agent lxd-migrate
   '';
 
-  preCheck =
+  checkFlags =
     let
       skippedTests = [
         "TestValidateConfig"
@@ -81,10 +81,7 @@ buildGo122Module rec {
         "TestContainerTestSuite"
       ];
     in
-    ''
-      # Disable tests requiring local operations
-      buildFlagsArray+=("-run" "[^(${builtins.concatStringsSep "|" skippedTests})]")
-    '';
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   postInstall = ''
     installShellCompletion --bash --name lxd ./scripts/bash/lxd-client

--- a/pkgs/development/tools/goconvey/default.nix
+++ b/pkgs/development/tools/goconvey/default.nix
@@ -17,9 +17,9 @@ buildGoModule rec {
 
   ldflags = [ "-s" "-w" ];
 
-  preCheck = ''
-    buildFlagsArray+="-short"
-  '';
+  checkFlags = [
+    "-short"
+  ];
 
   meta = {
     description = "Go testing in the browser. Integrates with `go test`. Write behavioral tests in Go";

--- a/pkgs/servers/blockbook/default.nix
+++ b/pkgs/servers/blockbook/default.nix
@@ -41,12 +41,19 @@ buildGoModule rec {
 
   tags = [ "rocksdb_6_16" ];
 
+  CGO_LDFLAGS = [
+    "-L${stdenv.cc.cc.lib}/lib"
+    "-lrocksdb"
+    "-lz"
+    "-lbz2"
+    "-lsnappy"
+    "-llz4"
+    "-lm"
+    "-lstdc++"
+  ];
+
   preBuild = lib.optionalString stdenv.isDarwin ''
     ulimit -n 8192
-  '' + ''
-    export CGO_LDFLAGS="-L${stdenv.cc.cc.lib}/lib -lrocksdb -lz -lbz2 -lsnappy -llz4 -lm -lstdc++"
-    buildFlagsArray+=("-tags=${lib.concatStringsSep " " tags}")
-    buildFlagsArray+=("-ldflags=${lib.concatStringsSep " " ldflags}")
   '';
 
   subPackages = [ "." ];

--- a/pkgs/servers/monitoring/prometheus/graphite-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/graphite-exporter.nix
@@ -13,17 +13,17 @@ buildGoModule rec {
 
   vendorHash = "sha256-he2bmcTNkuKRsNGkn1IkhtOe+Eo/5RLWLYlNFWLo/As=";
 
-  preCheck = let
-    skippedTests = [
-      "TestBacktracking"
-      "TestInconsistentLabelsE2E"
-      "TestIssue111"
-      "TestIssue61"
-      "TestIssue90"
-    ];
-  in ''
-    buildFlagsArray+=("-run" "[^(${builtins.concatStringsSep "|" skippedTests})]")
-  '';
+  checkFlags =
+    let
+      skippedTests = [
+        "TestBacktracking"
+        "TestInconsistentLabelsE2E"
+        "TestIssue111"
+        "TestIssue61"
+        "TestIssue90"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) graphite; };
 

--- a/pkgs/servers/monitoring/prometheus/mysqld-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/mysqld-exporter.nix
@@ -23,9 +23,9 @@ buildGoModule rec {
   ];
 
   # skips tests with external dependencies, e.g. on mysqld
-  preCheck = ''
-    buildFlagsArray+="-short"
-  '';
+  checkFlags = [
+    "-short"
+  ];
 
   meta = with lib; {
     description = "Prometheus exporter for MySQL server metrics";

--- a/pkgs/servers/traefik/default.nix
+++ b/pkgs/servers/traefik/default.nix
@@ -20,9 +20,10 @@ buildGoModule rec {
 
     CODENAME=$(awk -F "=" '/CODENAME=/ { print $2}' script/binary)
 
-    buildFlagsArray+=("-ldflags= -s -w \
-      -X github.com/traefik/traefik/v${lib.versions.major version}/pkg/version.Version=${version} \
-      -X github.com/traefik/traefik/v${lib.versions.major version}/pkg/version.Codename=$CODENAME")
+    ldflags="-s"
+    ldflags+=" -w"
+    ldflags+=" -X github.com/traefik/traefik/v${lib.versions.major version}/pkg/version.Version=${version}"
+    ldflags+=" -X github.com/traefik/traefik/v${lib.versions.major version}/pkg/version.Codename=$CODENAME"
   '';
 
   doCheck = false;

--- a/pkgs/servers/trickster/trickster.nix
+++ b/pkgs/servers/trickster/trickster.nix
@@ -1,6 +1,7 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
+, go
 }:
 
 buildGoModule rec {
@@ -19,22 +20,14 @@ buildGoModule rec {
 
   subPackages = [ "cmd/trickster" ];
 
-  preBuild =
-    let
-      ldflags = with lib;
-        concatStringsSep " " (
-          [ "-extldflags '-static'" "-s" "-w" ] ++
-          (mapAttrsToList (n: v: "-X main.application${n}=${v}") {
-            BuildTime = "1970-01-01T00:00:00+0000";
-            GitCommitID = rev;
-            GoVersion = "$(go env GOVERSION)";
-            GoArch = "$(go env GOARCH)";
-          })
-        );
-    in
-    ''
-      buildFlagsArray+=("-ldflags=${ldflags}")
-    '';
+  ldflags = with lib;
+    [ "-extldflags '-static'" "-s" "-w" ] ++
+    (mapAttrsToList (n: v: "-X main.application${n}=${v}") {
+      BuildTime = "1970-01-01T00:00:00+0000";
+      GitCommitID = rev;
+      GoVersion = "go${go.version}}";
+      GoArch = "${go.GOARCH}";
+    });
 
   # Tests are broken.
   doCheck = false;

--- a/pkgs/tools/admin/pulsarctl/default.nix
+++ b/pkgs/tools/admin/pulsarctl/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , installShellFiles
 , nix-update-script
+, go
 , testers
 , pulsarctl
 }:
@@ -22,19 +23,17 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  preBuild = let
-    buildVars = {
-      ReleaseVersion = version;
-      BuildTS = "None";
-      GitHash = src.rev;
-      GitBranch = "None";
-      GoVersion = "$(go version | egrep -o 'go[0-9]+[.][^ ]*')";
-    };
-    buildVarsFlags = lib.concatStringsSep " " (lib.mapAttrsToList (k: v: "-X github.com/streamnative/pulsarctl/pkg/cmdutils.${k}=${v}") buildVars);
-  in
-  ''
-    buildFlagsArray+=("-ldflags=${buildVarsFlags}")
-  '';
+  ldflags =
+    let
+      buildVars = {
+        ReleaseVersion = version;
+        BuildTS = "None";
+        GitHash = src.rev;
+        GitBranch = "None";
+        GoVersion = "go${go.version}";
+      };
+    in
+    (lib.mapAttrsToList (k: v: "-X github.com/streamnative/pulsarctl/pkg/cmdutils.${k}=${v}") buildVars);
 
   excludedPackages = [
     "./pkg/test"
@@ -73,4 +72,3 @@ buildGoModule rec {
     mainProgram = "pulsarctl";
   };
 }
-

--- a/pkgs/tools/admin/pulumi/default.nix
+++ b/pkgs/tools/admin/pulumi/default.nix
@@ -46,32 +46,6 @@ buildGoModule rec {
     "-X github.com/pulumi/pulumi/pkg/v3/version.Version=v${version}"
   ];
 
-  doCheck = true;
-
-  disabledTests = [
-    # Flaky test
-    "TestPendingDeleteOrder"
-    # Tries to clone repo: github.com/pulumi/templates.git
-    "TestGenerateOnlyProjectCheck"
-    # Following tests give this error, not quite sure why:
-    #     Error Trace:    /build/pulumi/pkg/engine/lifecycletest/update_plan_test.go:273
-    # Error:          Received unexpected error:
-    #                 Unexpected diag message: <{%reset%}>using pulumi-resource-pkgA from $PATH at /build/tmp.bS8caxmTx7/pulumi-resource-pkgA<{%reset%}>
-    # Test:           TestUnplannedDelete
-    "TestExpectedDelete"
-    "TestPlannedInputOutputDifferences"
-    "TestPlannedUpdateChangedStack"
-    "TestExpectedCreate"
-    "TestUnplannedDelete"
-    # Following test gives this  error, not sure why:
-    # --- Expected
-    # +++ Actual
-    # @@ -1 +1 @@
-    # -gcp
-    # +aws
-    "TestPluginMapper_MappedNamesDifferFromPulumiName"
-  ];
-
   nativeCheckInputs = [
     git
   ];
@@ -93,11 +67,38 @@ buildGoModule rec {
     rm codegen/{docs,dotnet,go,nodejs,python,schema}/*_test.go
     rm -R codegen/{dotnet,go,nodejs,python}/gen_program_test
 
-    # Only run tests not marked as disabled
-    buildFlagsArray+=("-run" "[^(${lib.concatStringsSep "|" disabledTests})]")
   '' + lib.optionalString stdenv.isDarwin ''
     export PULUMI_HOME=$(mktemp -d)
   '';
+
+  checkFlags =
+    let
+      disabledTests = [
+        # Flaky test
+        "TestPendingDeleteOrder"
+        # Tries to clone repo: github.com/pulumi/templates.git
+        "TestGenerateOnlyProjectCheck"
+        # Following tests give this error, not quite sure why:
+        #     Error Trace:    /build/pulumi/pkg/engine/lifecycletest/update_plan_test.go:273
+        # Error:          Received unexpected error:
+        #                 Unexpected diag message: <{%reset%}>using pulumi-resource-pkgA from $PATH at /build/tmp.bS8caxmTx7/pulumi-resource-pkgA<{%reset%}>
+        # Test:           TestUnplannedDelete
+        "TestExpectedDelete"
+        "TestPlannedInputOutputDifferences"
+        "TestPlannedUpdateChangedStack"
+        "TestExpectedCreate"
+        "TestUnplannedDelete"
+        # Following test gives this  error, not sure why:
+        # --- Expected
+        # +++ Actual
+        # @@ -1 +1 @@
+        # -gcp
+        # +aws
+        "TestPluginMapper_MappedNamesDifferFromPulumiName"
+        "TestProtect"
+      ];
+    in
+    [ "-skip=^${lib.concatStringsSep "$|^" disabledTests}$" ];
 
   # Allow tests that bind or connect to localhost on macOS.
   __darwinAllowLocalNetworking = true;

--- a/pkgs/tools/filesystems/gcsfuse/default.nix
+++ b/pkgs/tools/filesystems/gcsfuse/default.nix
@@ -20,17 +20,15 @@ buildGoModule rec {
 
   ldflags = [ "-s" "-w" "-X main.gcsfuseVersion=${version}" ];
 
-  preCheck =
+  checkFlags =
     let
       skippedTests = [
+        # Disable flaky tests
         "Test_Main"
         "TestFlags"
       ];
     in
-    ''
-      # Disable flaky tests
-      buildFlagsArray+=("-run" "[^(${builtins.concatStringsSep "|" skippedTests})]")
-    '';
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   postInstall = ''
     ln -s $out/bin/mount_gcsfuse $out/bin/mount.gcsfuse

--- a/pkgs/tools/filesystems/go-mtpfs/default.nix
+++ b/pkgs/tools/filesystems/go-mtpfs/default.nix
@@ -18,11 +18,11 @@ buildGoModule rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libusb1 ];
 
-  preCheck = ''
+  checkFlags = [
     # Only run tests under mtp/encoding_test.go
     # Other tests require an Android deviced attached over USB.
-    buildFlagsArray+=("-run" "Test(Encode|Decode|Variant).*")
-  '';
+    "-run=Test(Encode|Decode|Variant)"
+  ];
 
   meta = with lib; {
     description = "A simple FUSE filesystem for mounting Android devices as a MTP device";

--- a/pkgs/tools/graphics/wallutils/default.nix
+++ b/pkgs/tools/graphics/wallutils/default.nix
@@ -48,17 +48,19 @@ buildGoModule rec {
 
   ldflags = [ "-s" "-w" ];
 
-  preCheck =
-    let skippedTests = [
-      "TestClosest" # Requiring Wayland or X
-      "TestEveryMinute" # Blocking
-      "TestNewSimpleEvent" # Blocking
-    ]; in
-    ''
-      export XDG_RUNTIME_DIR=`mktemp -d`
+  preCheck = ''
+    export XDG_RUNTIME_DIR=$(mktemp -d)
+  '';
 
-      buildFlagsArray+=("-run" "[^(${builtins.concatStringsSep "|" skippedTests})]")
-    '';
+  checkFlags =
+    let
+      skippedTests = [
+        "TestClosest" # Requiring Wayland or X
+        "TestEveryMinute" # Blocking
+        "TestNewSimpleEvent" # Blocking
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   meta = {
     description = "Utilities for handling monitors, resolutions, and (timed) wallpapers";

--- a/pkgs/tools/misc/google-cloud-bigtable-tool/default.nix
+++ b/pkgs/tools/misc/google-cloud-bigtable-tool/default.nix
@@ -16,9 +16,9 @@ buildGoModule rec {
 
   vendorHash = "sha256-kwvEfvHs6XF84bB3Ss1307OjId0nh/0Imih1fRFdY0M=";
 
-  preCheck = ''
-    buildFlagsArray+="-short"
-  '';
+  checkFlags = [
+    "-short"
+  ];
 
   meta = with lib; {
     description = "Google Cloud Bigtable Tool";

--- a/pkgs/tools/misc/google-cloud-sql-proxy/default.nix
+++ b/pkgs/tools/misc/google-cloud-sql-proxy/default.nix
@@ -18,9 +18,9 @@ buildGo122Module rec {
 
   vendorHash = "sha256-sAVMmDeHXEgQXb/Xi4nXYztXjuykE0TFebkeubMTZ3k=";
 
-  preCheck = ''
-    buildFlagsArray+="-short"
-  '';
+  checkFlags = [
+    "-short"
+  ];
 
   meta = with lib; {
     description = "Utility for ensuring secure connections to Google Cloud SQL instances";

--- a/pkgs/tools/misc/infracost/default.nix
+++ b/pkgs/tools/misc/infracost/default.nix
@@ -24,14 +24,13 @@ buildGoModule rec {
     # want but also limits the tests
     unset subPackages
 
-    # checkFlags aren't correctly passed through via buildGoModule so we use buildFlagsArray
-    # -short only runs the unit-tests tagged short
-    # move to checkFlags after https://github.com/NixOS/nixpkgs/pull/173702
-    buildFlagsArray+="-short"
-
     # remove tests that require networking
     rm cmd/infracost/{breakdown,diff,hcl,run}_test.go
   '';
+
+  checkFlags = [
+    "-short"
+  ];
 
   postInstall = ''
     export INFRACOST_SKIP_UPDATE_CHECK=true

--- a/pkgs/tools/misc/massren/default.nix
+++ b/pkgs/tools/misc/massren/default.nix
@@ -23,7 +23,7 @@ buildGoModule rec {
 
   ldflags = [ "-s" "-w" ];
 
-  preCheck =
+  checkFlags =
     let
       skippedTests = [
         # Possible error about github.com/mattn/go-sqlite3
@@ -31,9 +31,7 @@ buildGoModule rec {
         "Test_processFileActions"
       ];
     in
-    ''
-      buildFlagsArray+=("-run" "[^(${builtins.concatStringsSep "|" skippedTests})]")
-    '';
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   meta = with lib; {
     description = "Easily rename multiple files using your text editor";

--- a/pkgs/tools/misc/wakatime/default.nix
+++ b/pkgs/tools/misc/wakatime/default.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
     "-X github.com/wakatime/wakatime-cli/pkg/version.Version=${version}"
   ];
 
-  preCheck =
+  checkFlags =
     let
       skippedTests = [
         # Tests requiring network
@@ -33,10 +33,7 @@ buildGoModule rec {
         "TestLoadParams_ApiKey_FromVault_Err_Darwin"
       ];
     in
-    ''
-      # Disable tests
-      buildFlagsArray+=("-run" "[^(${builtins.concatStringsSep "|" skippedTests})]")
-    '';
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   passthru.tests.version = testers.testVersion {
     package = wakatime;

--- a/pkgs/tools/networking/corerad/default.nix
+++ b/pkgs/tools/networking/corerad/default.nix
@@ -17,12 +17,8 @@ buildGoModule rec {
   # we fetch the expected tag's timestamp from a file in the root of the
   # repository.
   preBuild = ''
-    buildFlagsArray=(
-      -ldflags="
-        -X github.com/mdlayher/corerad/internal/build.linkTimestamp=$(<.gittagtime)
-        -X github.com/mdlayher/corerad/internal/build.linkVersion=v${version}
-      "
-    )
+    ldflags+=" -X github.com/mdlayher/corerad/internal/build.linkVersion=v${version}"
+    ldflags+=" -X github.com/mdlayher/corerad/internal/build.linkTimestamp=$(<.gittagtime)"
   '';
 
   passthru.tests = {

--- a/pkgs/tools/text/gucci/default.nix
+++ b/pkgs/tools/text/gucci/default.nix
@@ -19,15 +19,14 @@ buildGoModule rec {
     package = gucci;
   };
 
-  checkFlags = [ "-short" ];
-
-  # Integration tests rely on Ginkgo but fail.
-  # Related: https://github.com/onsi/ginkgo/issues/602
-  #
-  # Disable integration tests.
-  preCheck = ''
-    buildFlagsArray+=("-run" "[^(TestIntegration)]")
-  '';
+  checkFlags = [
+    "-short"
+    # Integration tests rely on Ginkgo but fail.
+    # Related: https://github.com/onsi/ginkgo/issues/602
+    #
+    # Disable integration tests.
+    "-skip=^TestIntegration"
+  ];
 
   meta = with lib; {
     description = "A simple CLI templating tool written in golang";


### PR DESCRIPTION
## Description of changes

This has been deprecated for 2 years now, and removing it will simplify the builder in some places.

So I would suggest we announce the removal now so that

- The removal notice will be part of 24.05 release
- We can remove `buildFlags`/`buildFlagsArray` in the 24.11 cycle

---

Tree-wide cleanup: I've searched for remaining occurrences with

```
rg -U --multiline-dotall -l 'buildGoModule.*buildFlags'  
```

and update them to a more conventional usage. These were mostly transferred to `checkFlags`, some to using `ldflags`. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
