### PR TITLE
mapserver: fix build with libxml2 2.12

### DIFF
--- a/pkgs/servers/geospatial/mapserver/default.nix
+++ b/pkgs/servers/geospatial/mapserver/default.nix
@@ -15,6 +15,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-fAf4kOe/6bQW0i46+EZbD/6iWI2Bjkn2no6XeR/+mg4=";
   };
 
+  patches = [
+    # drop this patch for version 8.0.2
+    ./fix-build-w-libxml2-12.patch
+  ];
+
   nativeBuildInputs = [
     cmake
     pkg-config

--- a/pkgs/servers/geospatial/mapserver/fix-build-w-libxml2-12.patch
+++ b/pkgs/servers/geospatial/mapserver/fix-build-w-libxml2-12.patch
@@ -1,0 +1,39 @@
+diff --git a/mapows.c b/mapows.c
+index f141a7b..5a94ecb 100644
+--- a/mapows.c
++++ b/mapows.c
+@@ -168,7 +168,7 @@ static int msOWSPreParseRequest(cgiRequestObj *request,
+ #endif
+     if (ows_request->document == NULL
+         || (root = xmlDocGetRootElement(ows_request->document)) == NULL) {
+-      xmlErrorPtr error = xmlGetLastError();
++      const xmlError *error = xmlGetLastError();
+       msSetError(MS_OWSERR, "XML parsing error: %s",
+                  "msOWSPreParseRequest()", error->message);
+       return MS_FAILURE;
+diff --git a/mapwcs.cpp b/mapwcs.cpp
+index 70e63b8..19afa79 100644
+--- a/mapwcs.cpp
++++ b/mapwcs.cpp
+@@ -362,7 +362,7 @@ static int msWCSParseRequest(cgiRequestObj *request, wcsParamsObj *params, mapOb
+     /* parse to DOM-Structure and get root element */
+     if((doc = xmlParseMemory(request->postrequest, strlen(request->postrequest)))
+         == NULL) {
+-      xmlErrorPtr error = xmlGetLastError();
++      const xmlError *error = xmlGetLastError();
+       msSetError(MS_WCSERR, "XML parsing error: %s",
+                  "msWCSParseRequest()", error->message);
+       return MS_FAILURE;
+diff --git a/mapwcs20.cpp b/mapwcs20.cpp
+index b35e803..2431bdc 100644
+--- a/mapwcs20.cpp
++++ b/mapwcs20.cpp
+@@ -1446,7 +1446,7 @@ int msWCSParseRequest20(mapObj *map,
+ 
+     /* parse to DOM-Structure and get root element */
+     if(doc == NULL) {
+-      xmlErrorPtr error = xmlGetLastError();
++      const xmlError *error = xmlGetLastError();
+       msSetError(MS_WCSERR, "XML parsing error: %s",
+                  "msWCSParseRequest20()", error->message);
+       return MS_FAILURE;


### PR DESCRIPTION
## Description of changes

Fix mapserver build with libxml2 2.12.

This PR is based on https://github.com/MapServer/MapServer/pull/6975 ,
which can't be applied without other patches.

Required for https://github.com/NixOS/nixpkgs/pull/275620 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
