### PR TITLE
[staging-next] Pile of fixes, part 2

### DIFF
--- a/pkgs/applications/office/libreoffice/default.nix
+++ b/pkgs/applications/office/libreoffice/default.nix
@@ -13,6 +13,7 @@
 , IOCompress
 , zlib
 , libjpeg
+, liblangtag
 , expat
 , freetype
 , libwpd
@@ -225,6 +226,17 @@ in stdenv.mkDerivation (finalAttrs: {
       url = "https://cgit.freedesktop.org/libreoffice/core/patch/?id=ececb678b8362e3be8e02768ddd5e4197d87dc2a";
       hash = "sha256-TUfKlwNxUTOJ95VLqwVD+ez1xhu7bW6xZlgIaCyIiNg=";
     })
+
+    # Backport libxml 2.12 build fixes
+    # FIXME: remove in next release
+    (fetchpatch {
+      url = "https://cgit.freedesktop.org/libreoffice/core/patch/?id=c8f7408db73d2f2ccacb25a2b4fef8dfebdfc6cb";
+      hash = "sha256-uEgRx1eyS3Wx2ZDWEsUmpIbuKezVrIbO++qSL2QI8Lk=";
+    })
+    (fetchpatch {
+      url = "https://cgit.freedesktop.org/libreoffice/core/patch/?id=cbb17a548b5cc6a99b6ed7735479bb4f2bc40f26";
+      hash = "sha256-ofhif37uvQI+gidaUpyr6XlyBc3gTJUDBRb3ootrzz0=";
+    })
   ];
 
   # libreoffice tries to reference the BUILDCONFIG (e.g. PKG_CONFIG_PATH)
@@ -436,6 +448,7 @@ in stdenv.mkDerivation (finalAttrs: {
     "--with-system-headers"
     "--with-system-openssl"
     "--with-system-libabw"
+    "--with-system-liblangtag"
     "--without-system-libcmis"
     "--with-system-libwps"
     "--with-system-openldap"
@@ -466,7 +479,6 @@ in stdenv.mkDerivation (finalAttrs: {
     "--without-system-lpsolve"
     "--without-system-libetonyek"
     "--without-system-libfreehand"
-    "--without-system-liblangtag"
     "--without-system-libmspub"
     "--without-system-libnumbertext"
     "--without-system-libpagemaker"
@@ -566,6 +578,7 @@ in stdenv.mkDerivation (finalAttrs: {
     libepoxy
     libexttextcat
     libjpeg
+    liblangtag
     libmspack
     libmwaw
     libmysqlclient

--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -2,10 +2,11 @@
 , lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , addOpenGLRunpath
 , cmake
 , fdk_aac
-, ffmpeg_4
+, ffmpeg
 , jansson
 , libjack2
 , libxkbcommon
@@ -70,6 +71,29 @@ stdenv.mkDerivation rec {
     # Lets obs-browser build against CEF 90.1.0+
     ./Enable-file-access-and-universal-access-for-file-URL.patch
     ./fix-nix-plugin-path.patch
+
+    # Backport ffmpeg 6.1 / GCC 13 build fixes
+    # FIXME: remove in next release
+    (fetchpatch {
+      url = "https://github.com/obsproject/obs-studio/commit/cd784644f5e82b9988043f229c19603289c6d32c.patch";
+      hash = "sha256-S4JE5kgr4x3uMHY2GRh0GBJpb7o/wYZb/v0CDITFNnQ=";
+    })
+    (fetchpatch {
+      url = "https://github.com/obsproject/obs-studio/commit/758b47d4ed9a25b8d64ad481d8d039990b9e57c9.patch";
+      hash = "sha256-jYpjwhx6e+dhN3kzbd6FcdjQ+WhIX0/BOu9PSkt+2yI=";
+    })
+    (fetchpatch {
+      url = "https://github.com/obsproject/obs-studio/commit/4b5be75c7e4b8cee908ed4a02fe0078285b4e8c9.patch";
+      hash = "sha256-tuOevhyxchwG42ilrplbiWoiDAKaY4HgzShlvp4VSQI=";
+    })
+    (fetchpatch {
+      url = "https://github.com/obsproject/obs-studio/commit/6e080a68067b27fe5463f0f4eee7df690451f3d7.patch";
+      hash = "sha256-nbn/q3uszoHaDvaW8Et1MS1sgQzMsJRmjGSMHzUxV70=";
+    })
+    (fetchpatch {
+      url = "https://github.com/obsproject/obs-studio/commit/df70743385965f979f922e05af9a249f20f94869.patch";
+      hash = "sha256-uIBsFuggz8SgQsQ0Ry2lvSPeMm63lgVe7oFx/3aT12k=";
+    })
   ];
 
   nativeBuildInputs = [
@@ -84,7 +108,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     curl
     fdk_aac
-    ffmpeg_4
+    ffmpeg
     jansson
     libcef
     libjack2

--- a/pkgs/development/python-modules/afdko/default.nix
+++ b/pkgs/development/python-modules/afdko/default.nix
@@ -1,8 +1,7 @@
 { lib
 , stdenv
 , buildPythonPackage
-, fetchPypi
-, fetchpatch
+, fetchFromGitHub
 , pythonOlder
 , fonttools
 , defcon
@@ -34,14 +33,16 @@
 
 buildPythonPackage rec {
   pname = "afdko";
-  version = "4.0.0";
+  version = "4.0.0+unstable-2023-11-07";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-66faoWBuCW0lQZP8/mBJLT+ErRGBl396HdG1RfPOYcM=";
+  src = fetchFromGitHub {
+    owner = "adobe-type-tools";
+    repo = pname;
+    rev = "6c832edbd81ecf689dbe66e840bf18ae61cf4bca";
+    hash = "sha256-XXkksHggUIs2O0/OSGsft8ofogcbtAa3w5JdldIAJAI=";
   };
 
   nativeBuildInputs = [
@@ -63,6 +64,11 @@ buildPythonPackage rec {
     # Use antlr4 runtime from nixpkgs and link it dynamically
     ./use-dynamic-system-antlr4-runtime.patch
   ];
+
+  # Happy new year
+  postPatch = ''
+    substituteInPlace tests/tx_data/expected_output/alt-missing-glif.pfb --replace 2023 2024
+  '';
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang (toString [
     "-Wno-error=incompatible-function-pointer-types"
@@ -98,6 +104,9 @@ buildPythonPackage rec {
 
   preCheck = ''
     export PATH=$PATH:$out/bin
+
+    # Remove build artifacts to prevent them from messing with the tests
+    rm -rf _skbuild
   '';
 
   disabledTests = lib.optionals (!runAllTests) [

--- a/pkgs/development/python-modules/jq/default.nix
+++ b/pkgs/development/python-modules/jq/default.nix
@@ -2,15 +2,15 @@
 , buildPythonPackage
 , cython
 , fetchFromGitHub
-, fetchpatch
 , jq
+, oniguruma
 , pytestCheckHook
 , pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "jq";
-  version = "1.5.0";
+  version = "1.6.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -19,18 +19,10 @@ buildPythonPackage rec {
     owner = "mwilliamson";
     repo = "jq.py";
     rev = "refs/tags/${version}";
-    hash = "sha256-mITk5y2AdUc9kZ/WrsnHxS1GRRmO4FDbPRgTtV2gIXI=";
+    hash = "sha256-c6tJI/mPlBGIYTk5ObIQ1CUTq73HouQ2quMZVWG8FFg=";
   };
 
-  patches = [
-    # Removes vendoring
-    ./jq-py-setup.patch
-    (fetchpatch {
-      url = "https://github.com/mwilliamson/jq.py/commit/805705dde4beb9db9a1743663d415198fb02eb1a.patch";
-      includes = [ "tests/*" ];
-      hash = "sha256-AgdpwmtOTeJ4nSbM6IknKaIVqqtWkpxTTtblXjlbWeA=";
-    })
-  ];
+  env.JQPY_USE_SYSTEM_LIBS = 1;
 
   nativeBuildInputs = [
     cython
@@ -38,6 +30,7 @@ buildPythonPackage rec {
 
   buildInputs = [
     jq
+    oniguruma
   ];
 
   preBuild = ''
@@ -46,6 +39,11 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
+  ];
+
+  disabledTests = [
+    # intentional behavior change in jq 1.7.1 not reflected upstream
+    "test_given_json_text_then_strings_containing_null_characters_are_preserved"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/streaming-form-data/default.nix
+++ b/pkgs/development/python-modules/streaming-form-data/default.nix
@@ -1,5 +1,5 @@
 { lib, fetchFromGitHub, buildPythonPackage, pythonOlder,
-cython, smart-open, pytestCheckHook, moto, requests-toolbelt }:
+cython, pytestCheckHook, requests-toolbelt }:
 
 buildPythonPackage rec {
   pname = "streaming-form-data";
@@ -14,11 +14,16 @@ buildPythonPackage rec {
     hash = "sha256-Ntiad5GZtfRd+2uDPgbDzLBzErGFroffK6ZAmMcsfXA=";
   };
 
+  # streaming-form-data has a small bit of code that uses smart_open, which has a massive closure.
+  # The only consumer of streaming-form-data is Moonraker, which doesn't use that code.
+  # So, just drop the dependency to not have to deal with it.
+  patches = [
+    ./drop-smart-open.patch
+  ];
+
   nativeBuildInputs = [ cython ];
 
-  propagatedBuildInputs = [ smart-open ];
-
-  nativeCheckInputs = [ pytestCheckHook moto requests-toolbelt ];
+  nativeCheckInputs = [ pytestCheckHook requests-toolbelt ];
 
   pytestFlagsArray = [ "tests" ];
 

--- a/pkgs/development/python-modules/streaming-form-data/drop-smart-open.patch
+++ b/pkgs/development/python-modules/streaming-form-data/drop-smart-open.patch
@@ -1,0 +1,40 @@
+diff --git a/streaming_form_data/targets.py b/streaming_form_data/targets.py
+index a399f3a..b816714 100644
+--- a/streaming_form_data/targets.py
++++ b/streaming_form_data/targets.py
+@@ -1,6 +1,5 @@
+ import hashlib
+ from pathlib import Path
+-import smart_open  # type: ignore
+ from typing import Callable, List, Optional
+ 
+ 
+@@ -164,6 +163,7 @@ class S3Target(BaseTarget):
+     S3Target enables chunked uploads to S3 buckets (using smart_open)"""
+ 
+     def __init__(self, file_path, mode, transport_params=None, **kwargs):
++        raise Exception("Nixpkgs: disabled")
+         super().__init__(**kwargs)
+ 
+         self._file_path = file_path
+diff --git a/tests/test_targets.py b/tests/test_targets.py
+index 0cc79ab..78ab40b 100644
+--- a/tests/test_targets.py
++++ b/tests/test_targets.py
+@@ -2,8 +2,6 @@ import os.path
+ import tempfile
+ 
+ import pytest
+-from moto import mock_s3
+-import boto3
+ 
+ from streaming_form_data.targets import (
+     BaseTarget,
+@@ -271,6 +269,7 @@ def mock_client():
+         yield client
+ 
+ 
++@pytest.mark.skip
+ def test_s3_upload(mock_client):
+     test_key = "test.txt"
+     path = f"s3://{BUCKET_NAME}/{test_key}"

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -506,6 +506,9 @@ in python.pkgs.buildPythonApplication rec {
   propagatedBuildInputs = with python.pkgs; [
     # Only packages required in pyproject.toml
     aiohttp
+    aiohttp-cors
+    aiohttp-fast-url-dispatcher
+    aiohttp-zlib-ng
     astral
     async-timeout
     atomicwrites-homeassistant

--- a/pkgs/tools/networking/urlwatch/default.nix
+++ b/pkgs/tools/networking/urlwatch/default.nix
@@ -23,9 +23,9 @@ python3Packages.buildPythonApplication rec {
     markdown2
     matrix-client
     minidb
+    playwright
     pushbullet-py
     pycodestyle
-    pyppeteer
     pyyaml
     requests
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34385,7 +34385,7 @@ with pkgs;
   obs-cli = callPackage ../applications/misc/obs-cli { };
 
   obs-studio = qt6Packages.callPackage ../applications/video/obs-studio {
-    ffmpeg_4 = ffmpeg-full;
+    ffmpeg = ffmpeg-full;
   };
 
   obs-studio-plugins = recurseIntoAttrs (callPackage ../applications/video/obs-studio/plugins {});


### PR DESCRIPTION
## Description of changes

Fixes the stuff I found while rebuilding my config:
- [x] urlwatch
- [x] moonraker
- [x] libreoffice
- [x] home-assistant
- [x] noto-fonts-emoji

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
