### PR TITLE
wlvncc: init at unstable-2023-01-05

### DIFF
--- a/pkgs/by-name/wl/wlvncc/package.nix
+++ b/pkgs/by-name/wl/wlvncc/package.nix
@@ -1,0 +1,68 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, aml
+, cyrus_sasl
+, ffmpeg
+, gnutls
+, libGL
+, libdrm
+, libgcrypt
+, libjpeg
+, libpng
+, libxkbcommon
+, lzo
+, mesa
+, meson
+, ninja
+, openssl
+, pkg-config
+, pixman
+, wayland
+, zlib
+}:
+stdenv.mkDerivation {
+  pname = "wlvncc";
+  version = "unstable-2023-01-05";
+
+  src = fetchFromGitHub {
+    owner = "any1";
+    repo = "wlvncc";
+    rev = "2b9a886edd38204ef36e9f9f65dd32aaa3784530";
+    hash = "sha256-0HbZEtDaLjr966RS+2GHc7N4nsivPIv57T/+AJliwUI=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    aml
+    cyrus_sasl
+    ffmpeg
+    gnutls
+    libGL
+    libdrm
+    libgcrypt
+    libjpeg
+    libpng
+    libxkbcommon
+    lzo
+    mesa
+    openssl
+    pixman
+    wayland
+    zlib
+  ];
+
+  meta = with lib; {
+    description = "A Wayland Native VNC Client";
+    homepage = "https://github.com/any1/wlvncc";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ teutat3s ];
+    platforms = platforms.linux;
+    mainProgram = "wlvncc";
+  };
+}


### PR DESCRIPTION
## Description of changes
A Wayland Native VNC Client.

Homepage: https://github.com/any1/wlvncc

Can be tested by running:
```
./result/bin/wlvncc 127.0.0.1 5900
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
