### PR TITLE
manifest-tool: fix static build and update 2.0.6 -> 2.1.5

### DIFF
--- a/pkgs/development/tools/manifest-tool/default.nix
+++ b/pkgs/development/tools/manifest-tool/default.nix
@@ -9,15 +9,14 @@
 
 buildGoModule rec {
   pname = "manifest-tool";
-  version = "2.0.6";
-  gitCommit = "2ed9312726765567a84f2acc44a0c8a6e50f4b7a";
+  version = "2.1.5";
   modRoot = "v2";
 
   src = fetchFromGitHub {
     owner = "estesp";
     repo = "manifest-tool";
     rev = "v${version}";
-    sha256 = "sha256-oopk++IdNF6msxOszT0fKxQABgWKbaQZ2aNH9chqWU0=";
+    hash = "sha256-TCR8A35oETAZszrZFtNZulzCsh9UwGueTyHyYe+JQeI=";
     leaveDotGit = true;
     postFetch = ''
       git -C $out rev-parse HEAD > $out/.git-revision
@@ -30,7 +29,7 @@ buildGoModule rec {
   nativeBuildInputs = [ git ];
 
   preConfigure = ''
-    ldflags="-X main.gitCommit=$(cat .git-revision)"
+    ldflags="-X main.gitCommit=$(cat .git-revision) -X main.version=${version}"
   '';
 
   CGO_ENABLED = if stdenv.hostPlatform.isStatic then "0" else "1";

--- a/pkgs/development/tools/manifest-tool/default.nix
+++ b/pkgs/development/tools/manifest-tool/default.nix
@@ -32,12 +32,15 @@ buildGoModule rec {
     "-s"
     "-w"
     "-X main.version=${version}"
-    "-X main.gitCommit=${builtins.readFile "${src}/.git-revision"}"
   ] ++ lib.optionals stdenv.hostPlatform.isStatic [
     "-linkmode=external"
     "-extldflags"
     "-static"
   ];
+
+  preConfigure = ''
+    export ldflags+=" -X main.gitCommit=$(cat .git-revision)"
+  '';
 
   tags = lib.optionals stdenv.hostPlatform.isStatic [
     "cgo"


### PR DESCRIPTION
## Description of changes

- Updates manifest-tool from 2.0.6 -> 2.1.5
- Fixes static build

Supersedes https://github.com/NixOS/nixpkgs/pull/225468.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
