### PR TITLE
[23.11] curl: apply 8.5.0 security fixes

### DIFF
--- a/pkgs/tools/networking/curl/0001-CVE-2023-42619.patch
+++ b/pkgs/tools/networking/curl/0001-CVE-2023-42619.patch
@@ -1,0 +1,132 @@
+From 94aa318e2bab65d607a1aa18e5b14b4d3922b9fc Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Thu, 23 Nov 2023 08:23:17 +0100
+Subject: [PATCH 1/2] fopen: create short(er) temporary file name
+
+Only using random letters in the name plus a ".tmp" extension. Not by
+appending characters to the final file name.
+
+Reported-by: Maksymilian Arciemowicz
+
+Closes #12388
+
+(cherry picked from commit 73b65e94f3531179de45c6f3c836a610e3d0a846)
+---
+ lib/fopen.c | 65 ++++++++++++++++++++++++++++++++++++++++++++++++-----
+ 1 file changed, 60 insertions(+), 5 deletions(-)
+
+diff --git a/lib/fopen.c b/lib/fopen.c
+index 75b8a7aa5..a73ac068e 100644
+--- a/lib/fopen.c
++++ b/lib/fopen.c
+@@ -39,6 +39,51 @@
+ #include "curl_memory.h"
+ #include "memdebug.h"
+ 
++/*
++  The dirslash() function breaks a null-terminated pathname string into
++  directory and filename components then returns the directory component up
++  to, *AND INCLUDING*, a final '/'.  If there is no directory in the path,
++  this instead returns a "" string.
++
++  This function returns a pointer to malloc'ed memory.
++
++  The input path to this function is expected to have a file name part.
++*/
++
++#ifdef _WIN32
++#define PATHSEP "\\"
++#define IS_SEP(x) (((x) == '/') || ((x) == '\\'))
++#elif defined(MSDOS) || defined(__EMX__) || defined(OS2)
++#define PATHSEP "\\"
++#define IS_SEP(x) ((x) == '\\')
++#else
++#define PATHSEP "/"
++#define IS_SEP(x) ((x) == '/')
++#endif
++
++static char *dirslash(const char *path)
++{
++  size_t n;
++  struct dynbuf out;
++  DEBUGASSERT(path);
++  Curl_dyn_init(&out, CURL_MAX_INPUT_LENGTH);
++  n = strlen(path);
++  if(n) {
++    /* find the rightmost path separator, if any */
++    while(n && !IS_SEP(path[n-1]))
++      --n;
++    /* skip over all the path separators, if any */
++    while(n && IS_SEP(path[n-1]))
++      --n;
++  }
++  if(Curl_dyn_addn(&out, path, n))
++    return NULL;
++  /* if there was a directory, append a single trailing slash */
++  if(n && Curl_dyn_addn(&out, PATHSEP, 1))
++    return NULL;
++  return Curl_dyn_ptr(&out);
++}
++
+ /*
+  * Curl_fopen() opens a file for writing with a temp name, to be renamed
+  * to the final name when completed. If there is an existing file using this
+@@ -50,25 +95,34 @@ CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
+                     FILE **fh, char **tempname)
+ {
+   CURLcode result = CURLE_WRITE_ERROR;
+-  unsigned char randsuffix[9];
++  unsigned char randbuf[41];
+   char *tempstore = NULL;
+   struct_stat sb;
+   int fd = -1;
++  char *dir;
+   *tempname = NULL;
+ 
++  dir = dirslash(filename);
++  if(!dir)
++    goto fail;
++
+   *fh = fopen(filename, FOPEN_WRITETEXT);
+   if(!*fh)
+     goto fail;
+-  if(fstat(fileno(*fh), &sb) == -1 || !S_ISREG(sb.st_mode))
++  if(fstat(fileno(*fh), &sb) == -1 || !S_ISREG(sb.st_mode)) {
++    free(dir);
+     return CURLE_OK;
++  }
+   fclose(*fh);
+   *fh = NULL;
+ 
+-  result = Curl_rand_alnum(data, randsuffix, sizeof(randsuffix));
++  result = Curl_rand_alnum(data, randbuf, sizeof(randbuf));
+   if(result)
+     goto fail;
+ 
+-  tempstore = aprintf("%s.%s.tmp", filename, randsuffix);
++  /* The temp file name should not end up too long for the target file
++     system */
++  tempstore = aprintf("%s%s.tmp", dir, randbuf);
+   if(!tempstore) {
+     result = CURLE_OUT_OF_MEMORY;
+     goto fail;
+@@ -95,6 +149,7 @@ CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
+   if(!*fh)
+     goto fail;
+ 
++  free(dir);
+   *tempname = tempstore;
+   return CURLE_OK;
+ 
+@@ -105,7 +160,7 @@ fail:
+   }
+ 
+   free(tempstore);
+-
++  free(dir);
+   return result;
+ }
+ 
+-- 
+2.42.0
+

--- a/pkgs/tools/networking/curl/0002-CVE-2023-42618.patch
+++ b/pkgs/tools/networking/curl/0002-CVE-2023-42618.patch
@@ -1,0 +1,53 @@
+From 7a4d226be90cf590dbece4762806400dc7d1b024 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Thu, 23 Nov 2023 08:15:47 +0100
+Subject: [PATCH 2/2] cookie: lowercase the domain names before PSL checks
+
+Reported-by: Harry Sintonen
+
+Closes #12387
+
+(cherry picked from commit 2b0994c29a721c91c572cff7808c572a24d251eb)
+---
+ lib/cookie.c | 24 ++++++++++++++++--------
+ 1 file changed, 16 insertions(+), 8 deletions(-)
+
+diff --git a/lib/cookie.c b/lib/cookie.c
+index af01203a9..57b2ad9a5 100644
+--- a/lib/cookie.c
++++ b/lib/cookie.c
+@@ -1029,15 +1029,23 @@ Curl_cookie_add(struct Curl_easy *data,
+    * dereference it.
+    */
+   if(data && (domain && co->domain && !Curl_host_is_ipnum(co->domain))) {
+-    const psl_ctx_t *psl = Curl_psl_use(data);
+-    int acceptable;
+-
+-    if(psl) {
+-      acceptable = psl_is_cookie_domain_acceptable(psl, domain, co->domain);
+-      Curl_psl_release(data);
++    bool acceptable = FALSE;
++    char lcase[256];
++    char lcookie[256];
++    size_t dlen = strlen(domain);
++    size_t clen = strlen(co->domain);
++    if((dlen < sizeof(lcase)) && (clen < sizeof(lcookie))) {
++      const psl_ctx_t *psl = Curl_psl_use(data);
++      if(psl) {
++        /* the PSL check requires lowercase domain name and pattern */
++        Curl_strntolower(lcase, domain, dlen + 1);
++        Curl_strntolower(lcookie, co->domain, clen + 1);
++        acceptable = psl_is_cookie_domain_acceptable(psl, lcase, lcookie);
++        Curl_psl_release(data);
++      }
++      else
++        acceptable = !bad_domain(domain, strlen(domain));
+     }
+-    else
+-      acceptable = !bad_domain(domain, strlen(domain));
+ 
+     if(!acceptable) {
+       infof(data, "cookie '%s' dropped, domain '%s' must not "
+-- 
+2.42.0
+

--- a/pkgs/tools/networking/curl/default.nix
+++ b/pkgs/tools/networking/curl/default.nix
@@ -61,6 +61,10 @@ stdenv.mkDerivation (finalAttrs: {
     # fix ipv6 autodetect compile error in configure script
     # remove once https://github.com/curl/curl/pull/12607 released (8.6.0)
     ./configure-ipv6-autodetect.diff
+    # https://curl.se/docs/CVE-2023-46219.html
+    ./0001-CVE-2023-42619.patch
+    # https://curl.se/docs/CVE-2023-46218.html
+    ./0002-CVE-2023-42618.patch
   ];
 
   outputs = [ "bin" "dev" "out" "man" "devdoc" ];


### PR DESCRIPTION
https://curl.se/docs/CVE-2023-46218.html
https://curl.se/docs/CVE-2023-46219.html

Fixes: CVE-2023-46218, CVE-2023-46219

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
