### PR TITLE
lomiri.lomiri-wallpapers: init at 20.04.0

### DIFF
--- a/pkgs/desktops/lomiri/data/lomiri-wallpapers/default.nix
+++ b/pkgs/desktops/lomiri/data/lomiri-wallpapers/default.nix
@@ -1,0 +1,47 @@
+{ stdenvNoCC
+, lib
+, fetchFromGitLab
+, gitUpdater
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "lomiri-wallpapers";
+  version = "20.04.0";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lomiri-wallpapers";
+    rev = finalAttrs.version;
+    hash = "sha256-n8+vY+MPVqW6s5kSo4aEtGZv1AsjB3nNEywbmcNWfhI=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share
+
+    # release-specific wallpapers
+    cp -r ${lib.versions.majorMinor finalAttrs.version} $out/share/wallpapers
+    rm $out/share/wallpapers/.placeholder
+
+    # eternal hardwired fallback/default
+    install -Dm644 {.,$out/share/wallpapers}/warty-final-ubuntu.png
+    ln -s warty-final-ubuntu.png $out/share/wallpapers/lomiri-default-background.png
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = with lib; {
+    description = "Wallpapers for the Lomiri Operating Environment, gathered from people of the Ubuntu Touch / UBports community";
+    homepage = "https://gitlab.com/ubports/development/core/lomiri-wallpapers";
+    # On update, recheck debian/copyright for which licenses apply to the installed images
+    license = with licenses; [ cc-by-sa-30 ];
+    maintainers = teams.lomiri.members;
+    platforms = platforms.all;
+  };
+})

--- a/pkgs/desktops/lomiri/data/lomiri-wallpapers/default.nix
+++ b/pkgs/desktops/lomiri/data/lomiri-wallpapers/default.nix
@@ -39,6 +39,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   meta = with lib; {
     description = "Wallpapers for the Lomiri Operating Environment, gathered from people of the Ubuntu Touch / UBports community";
     homepage = "https://gitlab.com/ubports/development/core/lomiri-wallpapers";
+    changelog = "https://gitlab.com/ubports/development/core/lomiri-wallpapers/-/blob/${finalAttrs.version}/ChangeLog";
     # On update, recheck debian/copyright for which licenses apply to the installed images
     license = with licenses; [ cc-by-sa-30 ];
     maintainers = teams.lomiri.members;

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -13,6 +13,7 @@ let
     #### Data
     lomiri-schemas = callPackage ./data/lomiri-schemas { };
     lomiri-sounds = callPackage ./data/lomiri-sounds { };
+    lomiri-wallpapers = callPackage ./data/lomiri-wallpapers { };
     suru-icon-theme = callPackage ./data/suru-icon-theme { };
 
     #### Development tools / libraries


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[Wallpapers for Lomiri](https://gitlab.com/ubports/development/core/lomiri-wallpapers), by the Ubuntu Touch & UBports community. Simple & straight-forward.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
