### PR TITLE
gcc: prevent runtime references via __FILE__ but in a reversible manner

### DIFF
--- a/pkgs/development/compilers/gcc/patches/12/mangle-NIX_STORE-in-__FILE__.patch
+++ b/pkgs/development/compilers/gcc/patches/12/mangle-NIX_STORE-in-__FILE__.patch
@@ -12,9 +12,20 @@ inputs to be retained in runtime closure.
 Typical examples are `nix` -> `nlohmann_json` and `pipewire` ->
 `lttng-ust.dev`.
 
+For this reason we want to remove the occurrences of hashes in the
+expansion of `__FILE__`. `nuke-references` does it by replacing hashes
+by `eeeeee...` but those paths are also used for debug symbols. It is
+handy to be able to invert the transformation to go back to the original
+store path for debuginfod servers. The chosen solution is to make the
+hash uppercase:
+- it does not trigger runtime references (except for all digit hashes,
+  which are unlikely enough)
+- it visually looks like a bogus store path
+- it is easy to find the original store path if required
+
 Ideally we would like to use `-fmacro-prefix-map=` feature of `gcc` as:
 
-  -fmacro-prefix-map=/nix/store/$hash1-nlohmann-json-ver=/nix/store/eeee.eee-nlohmann-json-ver
+  -fmacro-prefix-map=/nix/store/$hash1-nlohmann-json-ver=/nix/store/$HASH1-nlohmann-json-ver
   -fmacro-prefix-map=/nix/...
 
 In practice it quickly exhausts argument length limit due to `gcc`
@@ -25,9 +36,9 @@ is present in the environment.
 
 Tested as:
 
-    $ printf "# 0 \"/nix/store/01234567890123456789012345678901-pppppp-vvvvvvv\" \nconst char * f(void) { return __FILE__; }" | NIX_STORE=/nix/store ./gcc/xgcc -Bgcc -x c - -S -o -
+    $ printf "# 0 \"/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-pppppp-vvvvvvv\" \nconst char * f(void) { return __FILE__; }" | NIX_STORE=/nix/store ./gcc/xgcc -Bgcc -x c - -S -o -
     ...
-    .string "/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-pppppp-vvvvvvv"
+    .string "/nix/store/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-pppppp-vvvvvvv"
     ...
 
 Mangled successfully.
@@ -43,7 +54,7 @@ Mangled successfully.
  /* Perform user-specified mapping of filename prefixes.  Return the
     GC-allocated new name corresponding to FILENAME or FILENAME if no
     remapping was performed.  */
-@@ -76,7 +79,30 @@ remap_filename (file_prefix_map *maps, const char *filename)
+@@ -76,7 +79,31 @@ remap_filename (file_prefix_map *maps, const char *filename)
      if (filename_ncmp (filename, map->old_prefix, map->old_len) == 0)
        break;
    if (!map)
@@ -51,8 +62,7 @@ Mangled successfully.
 +    {
 +      if (maps == macro_prefix_maps)
 +	{
-+	  /* Remap all fo $NIX_STORE/.{32} paths to
-+	  * equivalent $NIX_STORE/e{32}.
++	  /* Remap the 32 characters after $NIX_STORE/ to uppercase
 +	  *
 +	  * That way we avoid argument parameters explosion
 +	  * and still avoid embedding headers into runtime closure:
@@ -66,7 +76,9 @@ Mangled successfully.
 +	    {
 +	       s = (char *) ggc_alloc_atomic (name_len + 1);
 +	       memcpy(s, name, name_len + 1);
-+	       memset(s + nix_store_len + 1, 'e', 32);
++	       for (int i = nix_store_len + 1; i < nix_store_len + 1 + 32; i++) {
++		 s[i] = TOUPPER(s[i]);
++	       }
 +	       return s;
 +	    }
 +	}
@@ -75,7 +87,7 @@ Mangled successfully.
    name = filename + map->old_len;
    name_len = strlen (name) + 1;
  
-@@ -90,7 +116,6 @@ remap_filename (file_prefix_map *maps, const char *filename)
+@@ -90,7 +117,6 @@ remap_filename (file_prefix_map *maps, const char *filename)
     ignore it in DW_AT_producer (dwarf2out.cc).  */
  
  /* Linked lists of file_prefix_map structures.  */

--- a/pkgs/development/compilers/gcc/patches/13/mangle-NIX_STORE-in-__FILE__.patch
+++ b/pkgs/development/compilers/gcc/patches/13/mangle-NIX_STORE-in-__FILE__.patch
@@ -12,9 +12,20 @@ inputs to be retained in runtime closure.
 Typical examples are `nix` -> `nlohmann_json` and `pipewire` ->
 `lttng-ust.dev`.
 
+For this reason we want to remove the occurrences of hashes in the
+expansion of `__FILE__`. `nuke-references` does it by replacing hashes
+by `eeeeee...` but those paths are also used for debug symbols. It is
+handy to be able to invert the transformation to go back to the original
+store path for debuginfod servers. The chosen solution is to make the
+hash uppercase:
+- it does not trigger runtime references (except for all digit hashes,
+  which are unlikely enough)
+- it visually looks like a bogus store path
+- it is easy to find the original store path if required
+
 Ideally we would like to use `-fmacro-prefix-map=` feature of `gcc` as:
 
-  -fmacro-prefix-map=/nix/store/$hash1-nlohmann-json-ver=/nix/store/eeee.eee-nlohmann-json-ver
+  -fmacro-prefix-map=/nix/store/$hash1-nlohmann-json-ver=/nix/store/$HASH1-nlohmann-json-ver
   -fmacro-prefix-map=/nix/...
 
 In practice it quickly exhausts argument length limit due to `gcc`
@@ -25,9 +36,9 @@ is present in the environment.
 
 Tested as:
 
-    $ printf "# 0 \"/nix/store/01234567890123456789012345678901-pppppp-vvvvvvv\" \nconst char * f(void) { return __FILE__; }" | NIX_STORE=/nix/store ./gcc/xgcc -Bgcc -x c - -S -o -
+    $ printf "# 0 \"/nix/store/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-pppppp-vvvvvvv\" \nconst char * f(void) { return __FILE__; }" | NIX_STORE=/nix/store ./gcc/xgcc -Bgcc -x c - -S -o -
     ...
-    .string "/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-pppppp-vvvvvvv"
+    .string "/nix/store/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-pppppp-vvvvvvv"
     ...
 
 Mangled successfully.
@@ -43,14 +54,13 @@ Mangled successfully.
  /* Perform user-specified mapping of filename prefixes.  Return the
     GC-allocated new name corresponding to FILENAME or FILENAME if no
     remapping was performed.  */
-@@ -102,6 +105,29 @@ remap_filename (file_prefix_map *maps, const char *filename)
+@@ -102,6 +105,30 @@ remap_filename (file_prefix_map *maps, const char *filename)
        break;
    if (!map)
      {
 +      if (maps == macro_prefix_maps)
 +	{
-+	  /* Remap all fo $NIX_STORE/.{32} paths to
-+	   * equivalent $NIX_STORE/e{32}.
++	  /* Remap all fo $NIX_STORE/.{32} paths to uppercase
 +	   *
 +	   * That way we avoid argument parameters explosion
 +	   * and still avoid embedding headers into runtime closure:
@@ -64,7 +74,9 @@ Mangled successfully.
 +	     {
 +		s = (char *) ggc_alloc_atomic (name_len + 1);
 +		memcpy(s, name, name_len + 1);
-+		memset(s + nix_store_len + 1, 'e', 32);
++		for (int i = nix_store_len + 1; i < nix_store_len + 1 + 32; i++) {
++		  s[i] = TOUPPER(s[i]);
++		}
 +		if (realname != filename)
 +		  free (const_cast <char *> (realname));
 +		return s;
@@ -73,7 +85,7 @@ Mangled successfully.
        if (realname != filename)
  	free (const_cast <char *> (realname));
        return filename;
-@@ -124,7 +150,6 @@ remap_filename (file_prefix_map *maps, const char *filename)
+@@ -124,7 +151,6 @@ remap_filename (file_prefix_map *maps, const char *filename)
     ignore it in DW_AT_producer (gen_command_line_string in opts.cc).  */
  
  /* Linked lists of file_prefix_map structures.  */
@@ -81,4 +93,3 @@ Mangled successfully.
  static file_prefix_map *debug_prefix_maps; /* -fdebug-prefix-map  */
  static file_prefix_map *profile_prefix_maps; /* -fprofile-prefix-map  */
  
-


### PR DESCRIPTION
the mangling done by mangle-NIX_STORE-in-__FILE__.patch also applies to source paths embedded in debug symbols. When putting a breakpoint in a template instanciation from another lib, the path that gdb looks for is therefore mangled (/nix/store/eeeeeee;...-the-lib-dev/include/foo.h) This severely degrades the debugging experience. To alleviate that, it's possible to make the mangling reversible: a debuginfod server can then reverse the mangling. I plan to implement that in nixseparatedebuginfod. The reversible mangling that was chosen in making the hash of the store path uppercase.

cc @trofi @Artturin #255192

will undraft after I rebuild gcc13

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
