### PR TITLE
termcap: init at 1.3.1

### DIFF
--- a/pkgs/by-name/te/termcap/package.nix
+++ b/pkgs/by-name/te/termcap/package.nix
@@ -1,0 +1,67 @@
+{ lib
+, stdenv
+, fetchurl
+, fetchpatch
+, autoreconfHook
+, enableStatic ? stdenv.hostPlatform.isStatic
+, enableShared ? !stdenv.hostPlatform.isStatic
+}:
+
+stdenv.mkDerivation rec {
+  pname = "termcap";
+  version = "1.3.1";
+
+  src = fetchurl {
+    url = "mirror://gnu/termcap/termcap-${version}.tar.gz";
+    hash = "sha256-kaDiLlOHykRntbyxjt8cUbkwJi/UZtX9o5bdnSZxkQA=";
+  };
+
+  patches = [
+    (fetchpatch {
+      name = "0001-tparam-replace-write-with-fprintf.patch";
+      url = "https://github.com/msys2/MINGW-packages/raw/c6691ad1bd9d4c6823a18068ca0683c3e32ea005/mingw-w64-termcap/0001-tparam-replace-write-with-fprintf.patch";
+      hash = "sha256-R9XaLfa8fzQBt+M+uA1AFTvKYCeOWLUD/7GViazXwto=";
+    })
+  ];
+
+  outputs = [ "out" "dev" ];
+
+  enableParallelBuilding = true;
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ autoreconfHook ];
+
+  makeFlags = [
+    "AR=${stdenv.cc.targetPrefix}ar"
+  ];
+
+  env.NIX_CFLAGS_COMPILE = toString ([
+    "-DSTDC_HEADERS"
+  ] ++ lib.optionals stdenv.cc.isClang [
+    "-Wno-implicit-function-declaration"
+  ]);
+
+  # Library only statically links by default
+  postInstall = lib.optionalString (!enableStatic) ''
+    rm $out/lib/libtermcap.a
+  '' + lib.optionalString enableShared (let
+    libName = "lib${pname}${stdenv.hostPlatform.extensions.sharedLibrary}";
+    impLibName = "lib${pname}.dll.a";
+    winImpLib = lib.optionalString stdenv.hostPlatform.isWindows
+      "-Wl,--out-implib,${impLibName}";
+  in ''
+    ${stdenv.cc.targetPrefix}cc -shared -o ${libName} termcap.o tparam.o version.o ${winImpLib}
+    install -Dm644 ${libName} $out/lib
+  '' + lib.optionalString stdenv.hostPlatform.isWindows ''
+    install -Dm644 ${impLibName} $out/lib
+  '');
+
+  meta = {
+    description = "Terminal feature database";
+    homepage = "https://www.gnu.org/software/termutils/";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ wegank ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

An old library, but still needed for enabling MinGW support for readline (and gettext?)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
