### PR TITLE
treewide: update meta.description to fit the guidelines

### DIFF
--- a/pkgs/tools/admin/afterburn/default.nix
+++ b/pkgs/tools/admin/afterburn/default.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     homepage = "https://github.com/coreos/ignition";
-    description = "This is a small utility, typically used in conjunction with Ignition, which reads metadata from a given cloud-provider and applies it to the system.";
+    description = "A one-shot cloud provider agent";
     license = licenses.asl20;
     maintainers = [ maintainers.arianvp ];
     platforms = platforms.linux;

--- a/pkgs/tools/admin/aws-assume-role/default.nix
+++ b/pkgs/tools/admin/aws-assume-role/default.nix
@@ -23,7 +23,7 @@ buildGoPackage rec {
   '';
 
   meta = with lib; {
-    description = "Easily assume AWS roles in your terminal.";
+    description = "Easily assume AWS roles in your terminal";
     homepage = "https://github.com/remind101/assume-role";
     license = licenses.bsd2;
     mainProgram = "assume-role";

--- a/pkgs/tools/admin/aws-lambda-runtime-interface-emulator/default.nix
+++ b/pkgs/tools/admin/aws-lambda-runtime-interface-emulator/default.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "To locally test their Lambda function packaged as a container image.";
+    description = "Locally test Lambda functions packaged as container images";
     homepage = "https://github.com/aws/aws-lambda-runtime-interface-emulator";
     license = licenses.asl20;
     maintainers = with maintainers; [ teto ];

--- a/pkgs/tools/admin/copilot-cli/default.nix
+++ b/pkgs/tools/admin/copilot-cli/default.nix
@@ -38,7 +38,7 @@ buildGoModule rec {
   };
 
   meta = with lib; {
-    description = "Build, Release and Operate Containerized Applications on AWS.";
+    description = "Build, Release and Operate Containerized Applications on AWS";
     homepage = "https://github.com/aws/copilot-cli";
     changelog = "https://github.com/aws/copilot-cli/releases/tag/v${version}";
     license = licenses.asl20;

--- a/pkgs/tools/admin/drawterm/default.nix
+++ b/pkgs/tools/admin/drawterm/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation {
   };
 
   meta = with lib; {
-    description = "Connect to Plan 9 CPU servers from other operating systems.";
+    description = "Connect to Plan 9 CPU servers from other operating systems";
     homepage = "https://drawterm.9front.org/";
     license = licenses.mit;
     maintainers = with maintainers; [ luc65r moody ];

--- a/pkgs/tools/admin/ejson2env/default.nix
+++ b/pkgs/tools/admin/ejson2env/default.nix
@@ -22,7 +22,7 @@ buildGoModule rec {
   passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
-    description = "A tool to simplify storing secrets that should be accessible in the shell environment in your git repo.";
+    description = "Decrypt EJSON secrets and export them as environment variables";
     homepage = "https://github.com/Shopify/ejson2env";
     maintainers = with maintainers; [ viraptor ];
     license = licenses.mit;

--- a/pkgs/tools/admin/granted/default.nix
+++ b/pkgs/tools/admin/granted/default.nix
@@ -57,7 +57,7 @@ buildGoModule rec {
   '';
 
   meta = with lib; {
-    description = "The easiest way to access your cloud.";
+    description = "The easiest way to access your cloud";
     homepage = "https://github.com/common-fate/granted";
     changelog = "https://github.com/common-fate/granted/releases/tag/${version}";
     license = licenses.mit;

--- a/pkgs/tools/admin/lxd/ui.nix
+++ b/pkgs/tools/admin/lxd/ui.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    description = "Web user interface for LXD.";
+    description = "Web user interface for LXD";
     homepage = "https://github.com/canonical/lxd-ui";
     license = lib.licenses.gpl3;
     maintainers = lib.teams.lxc.members;

--- a/pkgs/tools/admin/oxidized/default.nix
+++ b/pkgs/tools/admin/oxidized/default.nix
@@ -11,7 +11,7 @@ bundlerApp {
   passthru.updateScript = bundlerUpdateScript "oxidized";
 
   meta = with lib; {
-    description = "A network device configuration backup tool. It's a RANCID replacement!";
+    description = "A network device configuration backup tool. It's a RANCID replacement";
     homepage    = "https://github.com/ytti/oxidized";
     license     = licenses.asl20;
     maintainers = with maintainers; [ nicknovitski ] ++ teams.wdz.members;

--- a/pkgs/tools/admin/pbm/default.nix
+++ b/pkgs/tools/admin/pbm/default.nix
@@ -7,7 +7,7 @@ buildDotnetGlobalTool {
   nugetSha256 = "sha256-xu3g8NFLZYnHzBuoIhIiAzaPJqY0xhLWLYi+ORRADH8=";
 
   meta = with lib; {
-    description = "CLI for managing Akka.NET applications and Akka.NET Clusters.";
+    description = "CLI for managing Akka.NET applications and Akka.NET Clusters";
     homepage = "https://cmd.petabridge.com/index.html";
     changelog = "https://cmd.petabridge.com/articles/RELEASE_NOTES.html";
     license = licenses.unfree;

--- a/pkgs/tools/admin/scalr-cli/default.nix
+++ b/pkgs/tools/admin/scalr-cli/default.nix
@@ -32,7 +32,7 @@ buildGoModule rec {
   doCheck = false; # Skip tests as they require creating actual Scalr resources.
 
   meta = with lib; {
-    description = "A command-line tool that communicates directly with the Scalr API.";
+    description = "A command-line tool that communicates directly with the Scalr API";
     homepage = "https://github.com/Scalr/scalr-cli";
     changelog = "https://github.com/Scalr/scalr-cli/releases/tag/v${version}";
     license = licenses.asl20;

--- a/pkgs/tools/archivers/dumpnar/default.nix
+++ b/pkgs/tools/archivers/dumpnar/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://github.com/stephank/dumpnar";
-    description = "Minimal tool to produce a Nix NAR archive.";
+    description = "Minimal tool to produce a Nix NAR archive";
     license = licenses.lgpl2Plus;
     platforms = platforms.all;
     maintainers = [ maintainers.stephank ];

--- a/pkgs/tools/cd-dvd/iat/default.nix
+++ b/pkgs/tools/cd-dvd/iat/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttr: {
   };
 
   meta = with lib; {
-    description = "The Iso9660 Analyzer Tool is a tool for detecting the structure of many types of CD/DVD images. It can convert from IMG to ISO format.";
+    description = "A tool for detecting the structure of many types of CD/DVD images";
     homepage = "https://www.berlios.de/software/iso9660-analyzer-tool/";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ hughobrien ];

--- a/pkgs/tools/filesystems/btrfs-snap/default.nix
+++ b/pkgs/tools/filesystems/btrfs-snap/default.nix
@@ -23,7 +23,7 @@ stdenvNoCC.mkDerivation rec {
     ]}
   '';
   meta = with lib; {
-    description = "btrfs-snap creates and maintains the history of snapshots of btrfs filesystems.";
+    description = "Create and maintain the history of snapshots of btrfs filesystems";
     homepage = "https://github.com/jf647/btrfs-snap";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ lionello ];

--- a/pkgs/tools/filesystems/dduper/default.nix
+++ b/pkgs/tools/filesystems/dduper/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "Fast block-level out-of-band BTRFS deduplication tool.";
+    description = "Fast block-level out-of-band BTRFS deduplication tool";
     homepage = "https://github.com/Lakshmipathi/dduper";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ thesola10 ];

--- a/pkgs/tools/filesystems/dupe-krill/default.nix
+++ b/pkgs/tools/filesystems/dupe-krill/default.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "sha256-JUcIDUVzSLzblb2EbmSfuCAB+S0fyW6wpGF0b/xR+b0=";
 
   meta = with lib; {
-    description = " A fast file deduplicator.";
+    description = "A fast file deduplicator";
     homepage = "https://github.com/kornelski/dupe-krill";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ urbas ];

--- a/pkgs/tools/filesystems/goofys/default.nix
+++ b/pkgs/tools/filesystems/goofys/default.nix
@@ -27,7 +27,7 @@ buildGoModule {
 
   meta = {
     homepage = "https://github.com/kahing/goofys";
-    description = "A high-performance, POSIX-ish Amazon S3 file system written in Go.";
+    description = "A high-performance, POSIX-ish Amazon S3 file system written in Go";
     license = [ lib.licenses.mit ];
     maintainers = [ lib.maintainers.adisbladis ];
     broken = stdenv.isDarwin; # needs to update gopsutil to at least v3.21.3 to include https://github.com/shirou/gopsutil/pull/1042

--- a/pkgs/tools/graphics/cgif/default.nix
+++ b/pkgs/tools/graphics/cgif/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://github.com/dloebl/cgif";
-    description = "CGIF, a GIF encoder written in C.";
+    description = "CGIF, a GIF encoder written in C";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.unix;

--- a/pkgs/tools/graphics/realesrgan-ncnn-vulkan/default.nix
+++ b/pkgs/tools/graphics/realesrgan-ncnn-vulkan/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "NCNN implementation of Real-ESRGAN. Real-ESRGAN aims at developing Practical Algorithms for General Image Restoration.";
+    description = "NCNN implementation of Real-ESRGAN. Real-ESRGAN aims at developing Practical Algorithms for General Image Restoration";
     homepage = "https://github.com/xinntao/Real-ESRGAN-ncnn-vulkan";
     license = licenses.mit;
     maintainers = with maintainers; [ tilcreator ];

--- a/pkgs/tools/graphics/wgpu-utils/default.nix
+++ b/pkgs/tools/graphics/wgpu-utils/default.nix
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   meta = with lib; {
-    description = "Safe and portable GPU abstraction in Rust, implementing WebGPU API.";
+    description = "Safe and portable GPU abstraction in Rust, implementing WebGPU API";
     homepage = "https://wgpu.rs/";
     license = with licenses; [ asl20 /* or */ mit ];
     maintainers = with maintainers; [ erictapen ];

--- a/pkgs/tools/inputmethods/interception-tools/dual-function-keys.nix
+++ b/pkgs/tools/inputmethods/interception-tools/dual-function-keys.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://gitlab.com/interception/linux/plugins/dual-function-keys";
-    description = "Tap for one key, hold for another.";
+    description = "Tap for one key, hold for another";
     license = licenses.mit;
     maintainers = with maintainers; [ svend ];
     platforms = platforms.linux;

--- a/pkgs/tools/inputmethods/keyd/default.nix
+++ b/pkgs/tools/inputmethods/keyd/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation {
   passthru.tests.keyd = nixosTests.keyd;
 
   meta = with lib; {
-    description = "A key remapping daemon for linux.";
+    description = "A key remapping daemon for Linux";
     license = licenses.mit;
     maintainers = with maintainers; [ peterhoeg ];
     platforms = platforms.linux;

--- a/pkgs/tools/inputmethods/remote-touchpad/default.nix
+++ b/pkgs/tools/inputmethods/remote-touchpad/default.nix
@@ -24,7 +24,7 @@ buildGoModule rec {
   vendorHash = "sha256-UX366UWROeorwYV4l1A3R03J10Gm7EajM+wEczIJEJM=";
 
   meta = with lib; {
-    description = "Control mouse and keyboard from the webbrowser of a smartphone.";
+    description = "Control mouse and keyboard from the web browser of a smartphone";
     homepage = "https://github.com/unrud/remote-touchpad";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ schnusch ];

--- a/pkgs/tools/llm/heygpt/default.nix
+++ b/pkgs/tools/llm/heygpt/default.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
   OPENSSL_DIR = "${lib.getDev openssl}";
 
   meta = with lib; {
-    description = "A simple command-line interface for ChatGPT API.";
+    description = "A simple command-line interface for ChatGPT API";
     homepage = "https://github.com/fuyufjh/heygpt";
     license = licenses.mit;
     mainProgram = "heygpt";

--- a/pkgs/tools/misc/SP800-90B_EntropyAssessment/default.nix
+++ b/pkgs/tools/misc/SP800-90B_EntropyAssessment/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "https://github.com/usnistgov/SP800-90B_EntropyAssessment";
-    description = "Implementation of min-entropy assessment methods included in Special Publication 800-90B.";
+    description = "Implementation of min-entropy assessment methods included in Special Publication 800-90B";
     platforms = lib.platforms.linux;
     license = lib.licenses.free; #this software uses the NIST software license
     maintainers = with lib.maintainers; [ orichter thillux ];

--- a/pkgs/tools/misc/aichat/default.nix
+++ b/pkgs/tools/misc/aichat/default.nix
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   meta = with lib; {
-    description = "Chat with gpt-3.5/chatgpt in terminal.";
+    description = "Use GPT-4(V), Gemini, LocalAI, Ollama and other LLMs in the terminal";
     homepage = "https://github.com/sigoden/aichat";
     license = licenses.mit;
     maintainers = with maintainers; [ mwdomino ];

--- a/pkgs/tools/misc/altserver-linux/default.nix
+++ b/pkgs/tools/misc/altserver-linux/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     homepage = "https://github.com/NyaMisty/AltServer-Linux";
-    description = "AltServer for AltStore, but on-device. Requires root privileges as well as running a custom anisette server currently.";
+    description = "AltServer for AltStore, but on-device. Requires root privileges as well as running a custom anisette server currently";
     license = licenses.agpl3;
     mainProgram = "alt-server";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];

--- a/pkgs/tools/misc/bcunit/default.nix
+++ b/pkgs/tools/misc/bcunit/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    description = "Belledonne Communications' fork of CUnit test framework. Part of the Linphone project.";
+    description = "Belledonne Communications' fork of CUnit test framework. Part of the Linphone project";
     homepage = "https://gitlab.linphone.org/BC/public/bcunit";
     license = licenses.lgpl2Plus;
     maintainers = with maintainers; [ raskin jluttine ];

--- a/pkgs/tools/misc/bkyml/default.nix
+++ b/pkgs/tools/misc/bkyml/default.nix
@@ -39,7 +39,7 @@ buildPythonApplication rec {
 
   meta = with lib; {
     homepage = "https://github.com/joscha/bkyml";
-    description = "A CLI tool to generate a pipeline.yaml file for Buildkite on the fly.";
+    description = "A CLI tool to generate a pipeline.yaml file for Buildkite on the fly";
     license = licenses.mit;
     maintainers = with maintainers; [ olebedev ];
   };

--- a/pkgs/tools/misc/clematis/default.nix
+++ b/pkgs/tools/misc/clematis/default.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
   vendorHash = "sha256-YKu+7LFUoQwCH//URIswiaqa0rmnWZJvuSn/68G3TUA=";
 
   meta = with lib; {
-    description = "Discord rich presence for MPRIS music players.";
+    description = "Discord rich presence for MPRIS music players";
     homepage = "https://github.com/TorchedSammy/Clematis";
     license = licenses.mit;
     platforms = platforms.linux;

--- a/pkgs/tools/misc/cyberchef/default.nix
+++ b/pkgs/tools/misc/cyberchef/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "The Cyber Swiss Army Knife for encryption, encoding, compression and data analysis.";
+    description = "The Cyber Swiss Army Knife for encryption, encoding, compression and data analysis";
     homepage = "https://gchq.github.io/CyberChef";
     changelog = "https://github.com/gchq/CyberChef/blob/v${version}/CHANGELOG.md";
     maintainers = with maintainers; [ sebastianblunt ];

--- a/pkgs/tools/misc/elfcat/default.nix
+++ b/pkgs/tools/misc/elfcat/default.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-Dc+SuLwbLFcNSr9RiNSc7dgisBOvOUEIDR8dFAkC/O0=";
 
   meta = with lib; {
-    description = "ELF visualizer, generates HTML files from ELF binaries.";
+    description = "ELF visualizer, generates HTML files from ELF binaries";
     homepage = "https://github.com/ruslashev/elfcat";
     license = licenses.zlib;
     maintainers = with maintainers; [ moni ];

--- a/pkgs/tools/misc/flashrom-stable/default.nix
+++ b/pkgs/tools/misc/flashrom-stable/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://www.flashrom.org";
-    description = "Utility for reading, writing, erasing and verifying flash ROM chips.";
+    description = "Utility for reading, writing, erasing and verifying flash ROM chips";
     license = with licenses; [ gpl2 gpl2Plus ];
     maintainers = with maintainers; [ felixsinger ];
     platforms = platforms.all;

--- a/pkgs/tools/misc/graylog/plugins.nix
+++ b/pkgs/tools/misc/graylog/plugins.nix
@@ -226,7 +226,7 @@ in {
     };
     meta = {
       homepage = "https://bitbucket.org/proximus/smseagle-graylog/";
-      description = "Alert/notification callback plugin for integrating the SMSEagle into Graylog.";
+      description = "Alert/notification callback plugin for integrating the SMSEagle into Graylog";
       license = lib.licenses.gpl3Only;
     };
   };
@@ -253,7 +253,7 @@ in {
     };
     meta = {
       homepage = "https://github.com/graylog-labs/graylog-plugin-spaceweather";
-      description = "Correlate proton density to the response time of your app and the ion temperature to your exception rate.";
+      description = "Correlate proton density to the response time of your app and the ion temperature to your exception rate";
     };
   };
   splunk = glPlugin rec {
@@ -266,7 +266,7 @@ in {
     };
     meta = {
       homepage = "https://github.com/graylog-labs/graylog-plugin-splunk";
-      description = "Graylog output plugin that forwards one or more streams of data to Splunk via TCP.";
+      description = "Graylog output plugin that forwards one or more streams of data to Splunk via TCP";
       license = lib.licenses.gpl3Only;
     };
   };

--- a/pkgs/tools/misc/isoimagewriter/default.nix
+++ b/pkgs/tools/misc/isoimagewriter/default.nix
@@ -21,7 +21,7 @@ mkDerivation rec {
   ];
 
   meta = {
-    description = "ISO Image Writer is a tool to write a .iso file to a USB disk.";
+    description = "A program to write hybrid ISO files onto USB disks";
     homepage = "https://invent.kde.org/utilities/isoimagewriter";
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl3Plus;

--- a/pkgs/tools/misc/maker-panel/default.nix
+++ b/pkgs/tools/misc/maker-panel/default.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   meta = with lib; {
-    description = "Make mechanical PCBs by combining shapes together.";
+    description = "Make mechanical PCBs by combining shapes together";
     homepage = "https://github.com/twitchyliquid64/maker-panel";
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ twitchyliquid64 ];

--- a/pkgs/tools/misc/mathpix-snipping-tool/default.nix
+++ b/pkgs/tools/misc/mathpix-snipping-tool/default.nix
@@ -22,7 +22,7 @@ in appimageTools.wrapType2 {
   '';
 
   meta = with lib; {
-    description = "OCR tool to convert pictures to LaTeX.";
+    description = "OCR tool to convert pictures to LaTeX";
     homepage = "https://mathpix.com/";
     license = licenses.unfree;
     maintainers = [ maintainers.hiro98 ];

--- a/pkgs/tools/misc/oscclip/default.nix
+++ b/pkgs/tools/misc/oscclip/default.nix
@@ -19,7 +19,7 @@ python3Packages.buildPythonApplication rec {
   nativeBuildInputs = with python3Packages; [ poetry-core ];
 
   meta = with lib; {
-    description = "A program that allows to copy/paste from a terminal using osc-52 control sequences.";
+    description = "A program that allows to copy/paste from a terminal using osc-52 control sequences";
     longDescription = ''
       oscclip provides two commands: osc-copy and osc-paste. These commands allow to interact with the clipboard through the terminal directly.
       This means that they work through ssh sessions for example (given that the terminal supports osc-52 sequences).

--- a/pkgs/tools/misc/paperlike-go/default.nix
+++ b/pkgs/tools/misc/paperlike-go/default.nix
@@ -19,7 +19,7 @@ buildGoModule {
   subPackages = [ "cmd/paperlike-cli" ];
 
   meta = {
-    description = "paperlike-go is a Linux Go library and CLI utility to control a Dasung Paperlike display via I2C DDC.";
+    description = "A Linux Go library and CLI utility to control a Dasung Paperlike display via I2C DDC";
     homepage = "https://github.com/leoluk/paperlike-go";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.adisbladis ];

--- a/pkgs/tools/misc/plantuml-server/default.nix
+++ b/pkgs/tools/misc/plantuml-server/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = with lib; {
-    description = "A web application to generate UML diagrams on-the-fly.";
+    description = "A web application to generate UML diagrams on-the-fly";
     homepage = "https://plantuml.com/";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.gpl3Plus;

--- a/pkgs/tools/misc/pouf/default.nix
+++ b/pkgs/tools/misc/pouf/default.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
   postInstall = "make PREFIX=$out copy-data";
 
   meta = with lib; {
-    description = "A cli program for produce fake datas.";
+    description = "A CLI program for produce fake datas";
     homepage = "https://github.com/mothsart/pouf";
     changelog = "https://github.com/mothsart/pouf/releases/tag/${version}";
     maintainers = with maintainers; [ mothsart ];

--- a/pkgs/tools/misc/seaborn-data/default.nix
+++ b/pkgs/tools/misc/seaborn-data/default.nix
@@ -4,7 +4,7 @@ let
     version = "unstable-2023-01-26";
     dontBuild = true;
     meta = with lib; {
-      description = "Data repository for seaborn examples.";
+      description = "Data repository for seaborn examples";
       homepage = "https://github.com/mwaskom/seaborn-data";
       platforms = platforms.all;
       maintainers = with maintainers; [ mbalatsko ];

--- a/pkgs/tools/misc/see/default.nix
+++ b/pkgs/tools/misc/see/default.nix
@@ -23,7 +23,7 @@ python3.pkgs.buildPythonApplication {
   ];
 
   meta = {
-    description = "Textualize See is a command line tool to open files in the terminal.";
+    description = "A CLI tool to open files in the terminal";
     homepage = "https://github.com/Textualize/textualize-see";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ anselmschueler ];

--- a/pkgs/tools/misc/sensible-utils/default.nix
+++ b/pkgs/tools/misc/sensible-utils/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "The package provides utilities used by programs to sensibly select and spawn an appropriate browser, editor, or pager.";
+    description = "A collection of utilities used by programs to sensibly select and spawn an appropriate browser, editor, or pager";
     longDescription = ''
        The specific utilities included are:
        - sensible-browser

--- a/pkgs/tools/misc/tagref/default.nix
+++ b/pkgs/tools/misc/tagref/default.nix
@@ -1,4 +1,5 @@
 { lib, fetchFromGitHub, rustPlatform }:
+
 rustPlatform.buildRustPackage rec {
   pname = "tagref";
   version = "1.8.4";
@@ -13,7 +14,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-Wis6C4Wlz7NScFeKXWODA8BKmRtL7adaYxPVR13wNsg=";
 
   meta = with lib; {
-    description = "Tagref helps you refer to other locations in your codebase.";
+    description = "Manage cross-references in your code";
     homepage = "https://github.com/stepchowfun/tagref";
     license = licenses.mit;
     maintainers = [ maintainers.yusdacra ];

--- a/pkgs/tools/misc/tdfgo/default.nix
+++ b/pkgs/tools/misc/tdfgo/default.nix
@@ -14,7 +14,7 @@ buildGoModule rec {
   vendorHash = "sha256-T6PSs5NfXSXvzlq67rIDbzURyA+25df3nMMfufo0fow=";
 
   meta = with lib; {
-    description = "TheDraw font parser and console text renderer.";
+    description = "TheDraw font parser and console text renderer";
     longDescription = "Supports more fonts than `tdfiglet`, and packs more features.";
     homepage = "https://github.com/digitallyserviced/tdfgo";
     license = licenses.cc0;

--- a/pkgs/tools/misc/trillian/default.nix
+++ b/pkgs/tools/misc/trillian/default.nix
@@ -25,7 +25,7 @@ buildGoModule rec {
 
   meta = with lib; {
     homepage = "https://github.com/google/trillian";
-    description = "A transparent, highly scalable and cryptographically verifiable data store.";
+    description = "A transparent, highly scalable and cryptographically verifiable data store";
     license = [ licenses.asl20 ];
     maintainers = [ maintainers.adisbladis ];
   };

--- a/pkgs/tools/misc/tvnamer/default.nix
+++ b/pkgs/tools/misc/tvnamer/default.nix
@@ -44,7 +44,7 @@ pypkgs.buildPythonApplication rec {
   doCheck = false;
 
   meta = with lib; {
-    description = "Automatic TV episode file renamer, uses data from thetvdb.com via tvdb_api.";
+    description = "Automatic TV episode file renamer, uses data from thetvdb.com via tvdb_api";
     homepage = "https://github.com/dbr/tvnamer";
     license = licenses.unlicense;
     maintainers = with maintainers; [ peterhoeg ];

--- a/pkgs/tools/misc/ugs/default.nix
+++ b/pkgs/tools/misc/ugs/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   desktopItems = [ desktopItem ];
 
   meta = with lib; {
-    description = "A cross-platform G-Code sender for GRBL, Smoothieware, TinyG and G2core.";
+    description = "A cross-platform G-Code sender for GRBL, Smoothieware, TinyG and G2core";
     homepage = "https://github.com/winder/Universal-G-Code-Sender";
     maintainers = with maintainers; [ matthewcroughan ];
     sourceProvenance = with sourceTypes; [ binaryBytecode ];

--- a/pkgs/tools/misc/wlc/default.nix
+++ b/pkgs/tools/misc/wlc/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "wlc is a Weblate commandline client using Weblate's REST API.";
+    description = "A Weblate commandline client using Weblate's REST API";
     homepage = "https://github.com/WeblateOrg/wlc";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ paperdigits ];

--- a/pkgs/tools/misc/zthrottle/default.nix
+++ b/pkgs/tools/misc/zthrottle/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "A program that throttles a pipeline, only letting a line through at most every $1 seconds.";
+    description = "A program that throttles a pipeline, only letting a line through at most every $1 seconds";
     homepage = "https://github.com/anko/zthrottle";
     license = licenses.unlicense;
     maintainers = [ maintainers.ckie ];

--- a/pkgs/tools/networking/grpc_cli/default.nix
+++ b/pkgs/tools/networking/grpc_cli/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
   meta = with lib; {
-    description = "The command line tool for interacting with grpc services.";
+    description = "The command line tool for interacting with grpc services";
     homepage = "https://github.com/grpc/grpc";
     license = licenses.asl20;
     maintainers = with maintainers; [ doriath ];

--- a/pkgs/tools/networking/hurl/default.nix
+++ b/pkgs/tools/networking/hurl/default.nix
@@ -42,7 +42,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   meta = with lib; {
-    description = "Command line tool that performs HTTP requests defined in a simple plain text format.";
+    description = "Command line tool that performs HTTP requests defined in a simple plain text format";
     homepage = "https://hurl.dev/";
     changelog = "https://github.com/Orange-OpenSource/hurl/blob/${version}/CHANGELOG.md";
     maintainers = with maintainers; [ eonpatapon figsoda ];

--- a/pkgs/tools/networking/lychee/default.nix
+++ b/pkgs/tools/networking/lychee/default.nix
@@ -46,7 +46,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   meta = with lib; {
-    description = "A fast, async, stream-based link checker written in Rust.";
+    description = "A fast, async, stream-based link checker written in Rust";
     homepage = "https://github.com/lycheeverse/lychee";
     downloadPage = "https://github.com/lycheeverse/lychee/releases/tag/v${version}";
     license = with licenses; [ asl20 mit ];

--- a/pkgs/tools/networking/ockam/default.nix
+++ b/pkgs/tools/networking/ockam/default.nix
@@ -53,9 +53,8 @@ rustPlatform.buildRustPackage {
   #   "--skip=util::tests::test_process_multi_addr"
   # ];
 
-
   meta = with lib; {
-    description = "Orchestrate end-to-end encryption, cryptographic identities, mutual authentication, and authorization policies between distributed applications – at massive scale. Use Ockam to build secure-by-design applications that can Trust Data-in-Motion.";
+    description = "Orchestrate end-to-end encryption, cryptographic identities, mutual authentication, and authorization policies between distributed applications – at massive scale";
     homepage = "https://github.com/build-trust/ockam";
     license = licenses.mpl20;
     maintainers = with maintainers; [ happysalada ];

--- a/pkgs/tools/networking/rosenpass/default.nix
+++ b/pkgs/tools/networking/rosenpass/default.nix
@@ -43,7 +43,7 @@ rustPlatform.buildRustPackage rec {
   passthru.tests.rosenpass = nixosTests.rosenpass;
 
   meta = with lib; {
-    description = "Build post-quantum-secure VPNs with WireGuard!";
+    description = "Build post-quantum-secure VPNs with WireGuard";
     homepage = "https://rosenpass.eu/";
     license = with licenses; [ mit /* or */ asl20 ];
     maintainers = with maintainers; [ wucke13 ];

--- a/pkgs/tools/networking/rosenpass/tools.nix
+++ b/pkgs/tools/networking/rosenpass/tools.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
   '';
 
   meta = rosenpass.meta // {
-    description = "This package contains the Rosenpass tool `rp`, which is a script that wraps the `rosenpass` binary.";
+    description = "The Rosenpass tool `rp`, which is a script that wraps the `rosenpass` binary";
     mainProgram = "rp";
   };
 }

--- a/pkgs/tools/networking/sleep-on-lan/default.nix
+++ b/pkgs/tools/networking/sleep-on-lan/default.nix
@@ -26,7 +26,7 @@ buildGoModule rec {
 
   meta = with lib; {
     homepage = "https://github.com/SR-G/sleep-on-lan";
-    description = "Multi-platform process allowing to sleep on LAN a linux or windows computer, through wake-on-lan (reversed) magic packets or through HTTP REST requests.";
+    description = "Multi-platform process allowing to sleep on LAN a Linux or Windows computer, through wake-on-lan (reversed) magic packets or through HTTP REST requests";
     license = licenses.asl20;
     platforms = platforms.linux;
     maintainers = with maintainers; [ devusb ];

--- a/pkgs/tools/networking/wget2/default.nix
+++ b/pkgs/tools/networking/wget2/default.nix
@@ -90,7 +90,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    description = "successor of GNU Wget, a file and recursive website downloader.";
+    description = "Successor of GNU Wget, a file and recursive website downloader";
     longDescription = ''
       Designed and written from scratch it wraps around libwget, that provides the basic
       functions needed by a web client.

--- a/pkgs/tools/package-management/ciel/default.nix
+++ b/pkgs/tools/package-management/ciel/default.nix
@@ -62,7 +62,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   meta = with lib; {
-    description = "A tool for controlling AOSC OS packaging environments using multi-layer filesystems and containers.";
+    description = "A tool for controlling AOSC OS packaging environments using multi-layer filesystems and containers";
     homepage = "https://github.com/AOSC-Dev/ciel-rs";
     license = licenses.mit;
     platforms = platforms.linux;

--- a/pkgs/tools/security/coze/default.nix
+++ b/pkgs/tools/security/coze/default.nix
@@ -18,7 +18,7 @@ buildGoModule rec {
   '';
 
   meta = with lib; {
-    description = "CLI client for Coze, a cryptographic JSON messaging specification.";
+    description = "CLI client for Coze, a cryptographic JSON messaging specification";
     homepage = "https://github.com/Cyphrme/coze_cli";
     license = with licenses; [ bsd3 ];
     maintainers = with maintainers; [ qbit ];

--- a/pkgs/tools/security/donkey/default.nix
+++ b/pkgs/tools/security/donkey/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   passthru.tests.version = testers.testVersion { package = donkey; };
 
   meta = with lib; {
-    description = "an alternative for S/KEY's 'key' command.";
+    description = "An alternative for S/KEY's 'key' command";
     longDescription = ''
 Donkey is an alternative for S/KEY's "key" command.  The new feature that
 the original key doesn't have is print an entry for skeykeys as

--- a/pkgs/tools/security/hash-identifier/default.nix
+++ b/pkgs/tools/security/hash-identifier/default.nix
@@ -18,7 +18,7 @@ python3Packages.buildPythonApplication rec {
   '';
 
   meta = with lib; {
-    description = "Software to identify the different types of hashes used to encrypt data and especially passwords.";
+    description = "Identify the different types of hashes used to encrypt data and especially passwords";
     homepage = "https://github.com/blackploit/hash-identifier";
     license = licenses.gpl3Plus;
     platforms = platforms.unix;

--- a/pkgs/tools/security/logkeys/default.nix
+++ b/pkgs/tools/security/logkeys/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
   preConfigure = "./autogen.sh";
 
   meta = with lib; {
-    description = "A GNU/Linux keylogger that works!";
+    description = "A GNU/Linux keylogger that works";
     license = licenses.gpl3;
     homepage = "https://github.com/kernc/logkeys";
     maintainers = with maintainers; [mikoim offline];

--- a/pkgs/tools/security/onlykey-agent/default.nix
+++ b/pkgs/tools/security/onlykey-agent/default.nix
@@ -66,7 +66,7 @@ python3Packages.buildPythonApplication rec {
   pythonImportsCheck = [ "onlykey_agent" ];
 
   meta = with lib; {
-    description = " The OnlyKey agent is essentially middleware that lets you use OnlyKey as a hardware SSH/GPG device.";
+    description = "Middleware that lets you use OnlyKey as a hardware SSH/GPG device";
     homepage = "https://github.com/trustcrypto/onlykey-agent";
     license = licenses.lgpl3Only;
     maintainers = with maintainers; [ kalbasit ];

--- a/pkgs/tools/security/pass/extensions/audit/default.nix
+++ b/pkgs/tools/security/pass/extensions/audit/default.nix
@@ -46,7 +46,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "Pass extension for auditing your password repository.";
+    description = "Pass extension for auditing your password repository";
     homepage = "https://github.com/roddhjav/pass-audit";
     license = licenses.gpl3Plus;
     platforms = platforms.unix;

--- a/pkgs/tools/security/pass/extensions/file.nix
+++ b/pkgs/tools/security/pass/extensions/file.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   installFlags = [ "PREFIX=$(out)" ];
 
   meta = with lib; {
-    description = "A pass extension that allows to add files to password-store.";
+    description = "A pass extension that allows to add files to password-store";
     homepage = "https://github.com/dvogt23/pass-file";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ taranarmo ];

--- a/pkgs/tools/security/quill/default.nix
+++ b/pkgs/tools/security/quill/default.nix
@@ -46,7 +46,7 @@ rustPlatform.buildRustPackage rec {
   meta = with lib; {
     homepage = "https://github.com/dfinity/quill";
     changelog = "https://github.com/dfinity/quill/releases/tag/v${version}";
-    description = "Minimalistic ledger and governance toolkit for cold wallets on the Internet Computer.";
+    description = "Minimalistic ledger and governance toolkit for cold wallets on the Internet Computer";
     license = licenses.asl20;
     maintainers = with maintainers; [ imalison ];
   };

--- a/pkgs/tools/security/solo2-cli/default.nix
+++ b/pkgs/tools/security/solo2-cli/default.nix
@@ -42,7 +42,7 @@ rustPlatform.buildRustPackage rec {
   buildFeatures = [ "cli" ];
 
   meta = with lib; {
-    description = "A CLI tool for managing SoloKeys' Solo2 USB security keys.";
+    description = "A CLI tool for managing SoloKeys' Solo2 USB security keys";
     homepage = "https://github.com/solokeys/solo2-cli";
     license = with licenses; [ asl20 mit ]; # either at your option
     maintainers = with maintainers; [ lukegb ];

--- a/pkgs/tools/security/sudo-rs/default.nix
+++ b/pkgs/tools/security/sudo-rs/default.nix
@@ -70,7 +70,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   meta = with lib; {
-    description = "A memory safe implementation of sudo and su.";
+    description = "A memory safe implementation of sudo and su";
     homepage = "https://github.com/memorysafety/sudo-rs";
     changelog = "${meta.homepage}/blob/v${version}/CHANGELOG.md";
     license = with licenses; [ asl20 mit ];

--- a/pkgs/tools/security/truecrack/default.nix
+++ b/pkgs/tools/security/truecrack/default.nix
@@ -40,7 +40,7 @@ gccStdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with lib; {
-    description = "TrueCrack is a brute-force password cracker for TrueCrypt volumes. It works on Linux and it is optimized for Nvidia Cuda technology.";
+    description = "A brute-force password cracker for TrueCrypt volumes, optimized for Nvidia Cuda technology";
     homepage = "https://gitlab.com/kalilinux/packages/truecrack";
     broken = cudaSupport;
     license = licenses.gpl3Plus;

--- a/pkgs/tools/security/yubikey-touch-detector/default.nix
+++ b/pkgs/tools/security/yubikey-touch-detector/default.nix
@@ -44,7 +44,7 @@ buildGoModule rec {
   '';
 
   meta = with lib; {
-    description = "A tool to detect when your YubiKey is waiting for a touch (to send notification or display a visual indicator on the screen).";
+    description = "A tool to detect when your YubiKey is waiting for a touch";
     homepage = "https://github.com/maximbaz/yubikey-touch-detector";
     maintainers = with maintainers; [ sumnerevans ];
     license = with licenses; [ bsd2 isc ];

--- a/pkgs/tools/security/zsteg/default.nix
+++ b/pkgs/tools/security/zsteg/default.nix
@@ -8,7 +8,7 @@ bundlerApp {
   exes = [ "zsteg" ];
 
   meta = with lib; {
-    description = "Detect stegano-hidden data in PNG & BMP.";
+    description = "Detect stegano-hidden data in PNG & BMP";
     homepage = "http://zed.0xff.me/";
     license = licenses.mit;
     maintainers = with maintainers; [ applePrincess h7x4 ];

--- a/pkgs/tools/system/dell-command-configure/default.nix
+++ b/pkgs/tools/system/dell-command-configure/default.nix
@@ -98,7 +98,7 @@ in stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "Configure BIOS settings on Dell laptops.";
+    description = "Configure BIOS settings on Dell laptops";
     homepage =
       "https://www.dell.com/support/article/us/en/19/sln311302/dell-command-configure";
     license = licenses.unfree;

--- a/pkgs/tools/system/fancy-motd/default.nix
+++ b/pkgs/tools/system/fancy-motd/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "Fancy, colorful MOTD written in bash. Server status at a glance.";
+    description = "Fancy, colorful MOTD written in bash. Server status at a glance";
     homepage = "https://github.com/bcyran/fancy-motd";
     license = licenses.mit;
     maintainers = with maintainers; [ rhoriguchi ];

--- a/pkgs/tools/system/journalwatch/default.nix
+++ b/pkgs/tools/system/journalwatch/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage rec {
 
 
   meta = with lib; {
-    description = "journalwatch is a tool to find error messages in the systemd journal.";
+    description = "A tool to find error messages in the systemd journal";
     homepage = "https://github.com/The-Compiler/journalwatch";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ florianjacob ];

--- a/pkgs/tools/system/jsvc/default.nix
+++ b/pkgs/tools/system/jsvc/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage    = "https://commons.apache.org/proper/commons-daemon";
-    description = "JSVC is part of the Apache Commons Daemon software, a set of utilities and Java support classes for running Java applications as server processes.";
+    description = "A part of the Apache Commons Daemon software, a set of utilities and Java support classes for running Java applications as server processes";
     maintainers = with lib.maintainers; [ rsynnest ];
     license     = lib.licenses.asl20;
     platforms = with lib.platforms; unix;

--- a/pkgs/tools/system/osquery/default.nix
+++ b/pkgs/tools/system/osquery/default.nix
@@ -84,7 +84,7 @@ buildStdenv.mkDerivation rec {
   passthru.tests.osquery = nixosTests.osquery;
 
   meta = with lib; {
-    description = "SQL powered operating system instrumentation, monitoring, and analytics.";
+    description = "SQL powered operating system instrumentation, monitoring, and analytics";
     longDescription = ''
       The system controls table is not included as it does not presently compile with glibc >= 2.32.
       For more information, refer to https://github.com/osquery/osquery/issues/7823

--- a/pkgs/tools/text/boxes/default.nix
+++ b/pkgs/tools/text/boxes/default.nix
@@ -34,11 +34,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "Command line ASCII boxes unlimited!";
-    longDescription = ''
-      Boxes is a command line filter program that draws ASCII art boxes around
-      your input text.
-    '';
+    description = "A command line program which draws, removes, and repairs ASCII art boxes";
     homepage = "https://boxes.thomasjensen.com";
     license = licenses.gpl2;
     maintainers = with maintainers; [ waiting-for-dev ];

--- a/pkgs/tools/text/epub2txt2/default.nix
+++ b/pkgs/tools/text/epub2txt2/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ "CC:=$(CC)" "PREFIX:=$(out)" ];
 
   meta = {
-    description = "A simple command-line utility for Linux, for extracting text from EPUB documents.";
+    description = "A simple command-line utility for Linux, for extracting text from EPUB documents";
     homepage = "https://github.com/kevinboone/epub2txt2";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.unix;

--- a/pkgs/tools/text/mdbook-graphviz/default.nix
+++ b/pkgs/tools/text/mdbook-graphviz/default.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage rec {
   nativeCheckInputs = [ graphviz ];
 
   meta = with lib; {
-    description = "A preprocessor for mdbook, rendering Graphviz graphs to HTML at build time.";
+    description = "A preprocessor for mdbook, rendering Graphviz graphs to HTML at build time";
     homepage = "https://github.com/dylanowen/mdbook-graphviz";
     changelog = "https://github.com/dylanowen/mdbook-graphviz/releases/tag/v${version}";
     license = [ licenses.mpl20 ];

--- a/pkgs/tools/text/mdbook-katex/default.nix
+++ b/pkgs/tools/text/mdbook-katex/default.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = lib.optionals stdenv.isDarwin [ CoreServices ];
 
   meta = with lib; {
-    description = "A preprocessor for mdbook, rendering LaTeX equations to HTML at build time.";
+    description = "A preprocessor for mdbook, rendering LaTeX equations to HTML at build time";
     homepage = "https://github.com/lzanini/${pname}";
     license = [ licenses.mit ];
     maintainers = with maintainers; [ lovesegfault ];

--- a/pkgs/tools/text/mdbook-linkcheck/default.nix
+++ b/pkgs/tools/text/mdbook-linkcheck/default.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
   passthru.tests.version = testers.testVersion { package = mdbook-linkcheck; };
 
   meta = with lib; {
-    description = "A backend for `mdbook` which will check your links for you.";
+    description = "A backend for `mdbook` which will check your links for you";
     homepage = "https://github.com/Michael-F-Bryan/mdbook-linkcheck";
     license = licenses.mit;
     maintainers = with maintainers; [ zhaofengli ];

--- a/pkgs/tools/text/ruby-zoom/default.nix
+++ b/pkgs/tools/text/ruby-zoom/default.nix
@@ -9,7 +9,7 @@ bundlerEnv {
   passthru.updateScript = bundlerUpdateScript "ruby-zoom";
 
   meta = with lib; {
-    description = "Quickly open CLI search results in your favorite editor!";
+    description = "Quickly open CLI search results in your favorite editor";
     homepage    = "https://gitlab.com/mjwhitta/zoom";
     license     = with licenses; gpl3;
     maintainers = with maintainers; [ vmandela nicknovitski ];

--- a/pkgs/tools/text/to-html/default.nix
+++ b/pkgs/tools/text/to-html/default.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage rec {
   doCheck = false;
 
   meta = {
-    description = "Terminal wrapper for rendering a terminal on a website by converting ANSI escape sequences to HTML.";
+    description = "Terminal wrapper for rendering a terminal on a website by converting ANSI escape sequences to HTML";
     homepage = "https://github.com/Aloso/to-html";
     changelog = "https://github.com/Aloso/to-html/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;

--- a/pkgs/tools/typesetting/tex/advi/default.nix
+++ b/pkgs/tools/typesetting/tex/advi/default.nix
@@ -64,7 +64,7 @@ ocamlPackages.buildDunePackage rec {
 
   meta = with lib; {
     homepage = "http://advi.inria.fr/";
-    description = "Active-DVI is a Unix-platform DVI previewer and a programmable presenter for slides written in LaTeX.";
+    description = "A Unix-platform DVI previewer and a programmable presenter for slides written in LaTeX";
     license = licenses.lgpl21Only;
     maintainers = [ maintainers.xworld21 ];
   };

--- a/pkgs/tools/virtualization/dockstarter/default.nix
+++ b/pkgs/tools/virtualization/dockstarter/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "DockSTARTer helps you get started with running apps in Docker.";
+    description = "Make it quick and easy to get up and running with Docker";
     homepage = "https://dockstarter.com";
     license = licenses.mit;
     maintainers = with maintainers; [ urandom ];

--- a/pkgs/tools/virtualization/multipass/default.nix
+++ b/pkgs/tools/virtualization/multipass/default.nix
@@ -134,7 +134,7 @@ stdenv.mkDerivation
   };
 
   meta = with lib; {
-    description = "Ubuntu VMs on demand for any workstation.";
+    description = "Ubuntu VMs on demand for any workstation";
     homepage = "https://multipass.run";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ jnsgruk ];

--- a/pkgs/tools/wayland/proycon-wayout/default.nix
+++ b/pkgs/tools/wayland/proycon-wayout/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ wayland-protocols wayland cairo pango ];
 
   meta = with lib; {
-    description = "Takes text from standard input and outputs it to a desktop-widget on Wayland desktops.";
+    description = "Takes text from standard input and outputs it to a desktop-widget on Wayland desktops";
     homepage = "https://git.sr.ht/~proycon/wayout";
     license = licenses.gpl3;
     platforms = platforms.linux;


### PR DESCRIPTION
## Description of changes

Trying to fix descriptions in packages once and for all. Hopefully in the future these don't get merged in the first place :)

This PR ONLY touches `meta.description` (also removed `meta.longDescription` in one place) and nothing else in the derivations. I tried to do this as non-intrusively as possible. Good luck reviewers :P

### Note

I have only done this for packages within `pkgs/tools` for now. Wanted to gather comments; plus it was just exhausting to do it all at once.