### PR TITLE
weechatScripts.signal: init at unstable-2024-01-06

### DIFF
--- a/pkgs/applications/networking/irc/weechat/scripts/signal/default.nix
+++ b/pkgs/applications/networking/irc/weechat/scripts/signal/default.nix
@@ -1,0 +1,26 @@
+{ fetchFromGitHub, lib, stdenv, weechat }:
+
+stdenv.mkDerivation {
+  pname = "signal";
+  version = "unstable-2024-01-06";
+
+  src = fetchFromGitHub {
+    owner = "thefinn93";
+    repo = "signal-weechat";
+    rev = "87ffb9fd5228f0b7c66615057e76502adba1e00f";
+    hash = "sha256-cnvLduG7ivl5JjLfgaTgI4+tlYf1IAOZraE1/Ql0M1A=";
+  };
+
+  installPhase = ''
+    install -D signal.py $out/share/signal.py
+  '';
+  passthru.scripts = [ "signal.py" ];
+
+  meta = with lib; {
+    inherit (weechat.meta) platforms;
+    description = "Use Signal in WeeChat";
+    homepage = "https://github.com/thefinn93/signal-weechat";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ getpsyched ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Add Signal bridge. Closes #279160.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
