### PR TITLE
rar: 6.21 -> 6.24

### DIFF
--- a/pkgs/tools/archivers/rar/default.nix
+++ b/pkgs/tools/archivers/rar/default.nix
@@ -8,7 +8,7 @@
 let
   version = "6.24";
   downloadVersion = lib.replaceStrings [ "." ] [ "" ] version;
-  # Use `./update.sh <version>` to generate the below
+  # Use `./update.sh` to generate the entries below
   srcUrl = {
     i686-linux = {
       url = "https://www.rarlab.com/rar/rarlinux-x32-${downloadVersion}.tar.gz";
@@ -60,6 +60,8 @@ stdenv.mkDerivation {
   postInstall = ''
     installManPage ${manSrc}
   '';
+
+  passthru.updateScript = ./update.sh;
 
   meta = with lib; {
     description = "Utility for RAR archives";

--- a/pkgs/tools/archivers/rar/default.nix
+++ b/pkgs/tools/archivers/rar/default.nix
@@ -9,7 +9,7 @@ let
   version = "6.24";
   downloadVersion = lib.replaceStrings [ "." ] [ "" ] version;
   # Use `./update.sh` to generate the entries below
-  srcUrl = {
+  srcs = {
     i686-linux = {
       url = "https://www.rarlab.com/rar/rarlinux-x32-${downloadVersion}.tar.gz";
       hash = "sha256-aacgJH0iJLRNEaZuVyzl/FxZgSnW3dIZFUfaqt0l88M=";
@@ -26,7 +26,7 @@ let
       url = "https://www.rarlab.com/rar/rarmacos-x64-${downloadVersion}.tar.gz";
       hash = "sha256-4vENPNfMpQstsm9+8+glHPK9fAlDmnHWbCHW+HUwSX4=";
     };
-  }.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
+  };
   manSrc = fetchurl {
     url = "https://aur.archlinux.org/cgit/aur.git/plain/rar.1?h=rar&id=8e39a12e88d8a3b168c496c44c18d443c876dd10";
     name = "rar.1";
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
   pname = "rar";
   inherit version;
 
-  src = fetchurl srcUrl;
+  src = fetchurl (srcs.${stdenv.hostPlatform.system});
 
   dontBuild = true;
 
@@ -69,7 +69,7 @@ stdenv.mkDerivation {
     license = licenses.unfree;
     mainProgram = "rar";
     maintainers = with maintainers; [ thiagokokada ];
-    platforms = with platforms; linux ++ darwin;
+    platforms = lib.attrNames srcs;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
   };
 }

--- a/pkgs/tools/archivers/rar/default.nix
+++ b/pkgs/tools/archivers/rar/default.nix
@@ -1,26 +1,30 @@
-{ lib, stdenv, fetchurl, autoPatchelfHook, installShellFiles }:
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, installShellFiles
+}:
 
 let
-  version = "6.21";
+  version = "6.24";
   downloadVersion = lib.replaceStrings [ "." ] [ "" ] version;
-  # Use `nix store prefetch-file <url>` to generate the hashes for the other systems
-  # TODO: create update script
+  # Use `./update.sh <version>` to generate the below
   srcUrl = {
     i686-linux = {
       url = "https://www.rarlab.com/rar/rarlinux-x32-${downloadVersion}.tar.gz";
-      hash = "sha256-mDeRmLTjF0ZLv4JoLrgI8YBFFulBSKfOPb6hrxDZIkU=";
+      hash = "sha256-aacgJH0iJLRNEaZuVyzl/FxZgSnW3dIZFUfaqt0l88M=";
     };
     x86_64-linux = {
       url = "https://www.rarlab.com/rar/rarlinux-x64-${downloadVersion}.tar.gz";
-      hash = "sha256-3fr5aVkh/r6OfBEcZULJSZp5ydakJOLRPlgzMdlwGTM=";
+      hash = "sha256-iOIqjoQSXJR2N7vyjHRuM4oKYyedgPn51zc2A4ddses=";
     };
     aarch64-darwin = {
       url = "https://www.rarlab.com/rar/rarmacos-arm-${downloadVersion}.tar.gz";
-      hash = "sha256-OR9HBlRteTzuyQ06tyXTSrFTBHFwmZ41kUfvgflogT4=";
+      hash = "sha256-2r4zWDT7Xw/CNvA7oNEsGfrXJDzFa5gNthIB/5TYR5U=";
     };
     x86_64-darwin = {
       url = "https://www.rarlab.com/rar/rarmacos-x64-${downloadVersion}.tar.gz";
-      hash = "sha256-UN3gmEuIpCXwmw3/l+KdarAYLy1DxGoPAOB2bfJTGbw=";
+      hash = "sha256-4vENPNfMpQstsm9+8+glHPK9fAlDmnHWbCHW+HUwSX4=";
     };
   }.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
   manSrc = fetchurl {
@@ -29,7 +33,7 @@ let
     hash = "sha256-93cSr9oAsi+xHUtMsUvICyHJe66vAImS2tLie7nt8Uw=";
   };
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "rar";
   inherit version;
 
@@ -60,9 +64,10 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Utility for RAR archives";
     homepage = "https://www.rarlab.com/";
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
+    mainProgram = "rar";
     maintainers = with maintainers; [ thiagokokada ];
     platforms = with platforms; linux ++ darwin;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
   };
 }

--- a/pkgs/tools/archivers/rar/update.sh
+++ b/pkgs/tools/archivers/rar/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl gnused jq
+#!nix-shell -i bash -p curl gawk gnused pup jq
 
 set -euo pipefail
 
@@ -8,8 +8,31 @@ readonly DIRNAME
 readonly NIXPKGS_ROOT="../../../.."
 readonly NIX_FLAGS=(--extra-experimental-features 'nix-command flakes')
 
-updateHash()
-{
+# awk is used for parsing the RARLAB website to get the newest version
+readonly AWK_FIELD_SEPARATOR='[-.]'
+# shellcheck disable=SC2016
+readonly AWK_COMMAND='
+# We will get the following output from pup:
+# /rar/rarlinux-x64-700b3.tar.gz
+# /rar/rarmacos-x64-700b3.tar.gz
+# /rar/rarlinux-x64-624.tar.gz
+# /rar/rarbsd-x64-624.tar.gz
+# /rar/rarmacos-x64-624.tar.gz
+
+# Ignore anything that is flagged as beta (e.g.: `/rar/rarlinux-x64-700b3.tar.gz`)
+!/[0-9]+b[0-9]*.tar.gz$/ {
+    # /rar/rarlinux-x64-624.tar.gz -> 624
+    val = $3
+    # Only get the value if it is bigger than the current one
+    if (val > max) max = val
+}
+END {
+    # 624 -> 6.24
+    printf "%.2f\n", max/100
+}
+'
+
+updateHash() {
     local -r version="${1//./}"
     local -r arch="$2"
     local -r os="$3"
@@ -22,25 +45,28 @@ updateHash()
     sed -i "s|$currentHash|$hash|g" "$DIRNAME/default.nix"
 }
 
-updateVersion()
-{
+updateVersion() {
     local -r version="$1"
     sed -i "s|version = \"[0-9.]*\";|version = \"$version\";|g" "$DIRNAME/default.nix"
 }
 
-# TODO: get latest version
-readonly latestVersion="${1:-}"
-
+latestVersion="${1:-}"
 if [[ -z "$latestVersion" ]]; then
-    echo "usage: $0 <version to update>"
-    exit 1
+    latestVersion=$(
+        curl --silent --location --fail https://www.rarlab.com/download.htm | \
+            pup 'a[href*=".tar.gz"] attr{href}' | \
+            awk -F"$AWK_FIELD_SEPARATOR" "$AWK_COMMAND"
+    )
 fi
+readonly latestVersion
+echo "Latest version: $latestVersion"
 
 currentVersion=$(cd "$DIRNAME" && nix "${NIX_FLAGS[@]}" eval --raw "$NIXPKGS_ROOT#legacyPackages.x86_64-linux.rar.version")
 readonly currentVersion
+echo "Current version: $currentVersion"
 
 if [[ "$currentVersion" == "$latestVersion" ]]; then
-    echo "rar is up-to-date: ${currentVersion}"
+    echo "rar is up-to-date"
     exit 0
 fi
 

--- a/pkgs/tools/archivers/rar/update.sh
+++ b/pkgs/tools/archivers/rar/update.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnused jq
+
+set -euo pipefail
+
+DIRNAME=$(dirname "$0")
+readonly DIRNAME
+readonly NIXPKGS_ROOT="../../../.."
+readonly NIX_FLAGS=(--extra-experimental-features 'nix-command flakes')
+
+updateHash()
+{
+    local -r version="${1//./}"
+    local -r arch="$2"
+    local -r os="$3"
+    local -r nix_arch="$4"
+
+    url="https://www.rarlab.com/rar/rar$os-$arch-$version.tar.gz"
+    hash=$(nix store prefetch-file --json "$url" | jq -r .hash)
+    currentHash=$(cd "$DIRNAME" && nix "${NIX_FLAGS[@]}" eval --raw "$NIXPKGS_ROOT#legacyPackages.$nix_arch.rar.src.outputHash")
+
+    sed -i "s|$currentHash|$hash|g" "$DIRNAME/default.nix"
+}
+
+updateVersion()
+{
+    local -r version="$1"
+    sed -i "s|version = \"[0-9.]*\";|version = \"$version\";|g" "$DIRNAME/default.nix"
+}
+
+# TODO: get latest version
+readonly latestVersion="${1:-}"
+
+if [[ -z "$latestVersion" ]]; then
+    echo "usage: $0 <version to update>"
+    exit 1
+fi
+
+currentVersion=$(cd "$DIRNAME" && nix "${NIX_FLAGS[@]}" eval --raw "$NIXPKGS_ROOT#legacyPackages.x86_64-linux.rar.version")
+readonly currentVersion
+
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+    echo "rar is up-to-date: ${currentVersion}"
+    exit 0
+fi
+
+updateHash "$latestVersion" x32 linux i686-linux
+updateHash "$latestVersion" x64 linux x86_64-linux
+updateHash "$latestVersion" arm macos aarch64-darwin
+updateHash "$latestVersion" x64 macos x86_64-darwin
+
+updateVersion "$latestVersion"


### PR DESCRIPTION
## Description of changes

- Add update script
- Bump: 6.21 -> 6.24

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
