### PR TITLE
mint: 0.15.3 -> 0.19.0

### DIFF
--- a/pkgs/development/compilers/mint/default.nix
+++ b/pkgs/development/compilers/mint/default.nix
@@ -1,14 +1,14 @@
 { lib, fetchFromGitHub, crystal, openssl }:
 
 crystal.buildCrystalPackage rec {
-  version = "0.15.3";
+  version = "0.19.0";
   pname = "mint";
 
   src = fetchFromGitHub {
     owner = "mint-lang";
     repo = "mint";
     rev = version;
-    hash = "sha256-VjQ736RWP9HK0QFKbgchnEPYH/Ny2w8SI/xnO3m94B8=";
+    hash = "sha256-s/ehv8Z71nWnxpajO7eR4MxoHppqkdleFluv+e5Vv6I=";
   };
 
   format = "shards";

--- a/pkgs/development/compilers/mint/shards.nix
+++ b/pkgs/development/compilers/mint/shards.nix
@@ -1,55 +1,51 @@
 {
   admiral = {
-    owner = "jwaldrip";
-    repo = "admiral.cr";
-    rev = "v1.11.4";
-    sha256 = "1rpybhhzz892s2dp2kzbkkn1c8c7574275ql6amhbvc6ds5j3i46";
+    url = "https://github.com/jwaldrip/admiral.cr.git";
+    rev = "v1.12.1";
+    sha256 = "0x8v9i8ixs7xcwz35kdlqvz0pfm1cqzm6gvwdjfrps0drisk7f6i";
   };
   ameba = {
-    owner = "crystal-ameba";
-    repo = "ameba";
-    rev = "v0.14.2";
-    sha256 = "1l1q1icpzg1zvhfj8948w36j7ikaj7w816677zi29vi6y2d1dmf2";
+    url = "https://github.com/crystal-ameba/ameba.git";
+    rev = "v1.5.0";
+    sha256 = "1idivsbpmi40aqvs82fsv37nrgikirprxrj3ls9chsb876fq9p2d";
+  };
+  ansi-escapes = {
+    url = "https://github.com/gtramontina/ansi-escapes.cr.git";
+    rev = "v1.0.0";
+    sha256 = "106cy7bq0j438cfs0zqcxhj84msjj9dybxlcjr8qhs1fpm02s00b";
+  };
+  backtracer = {
+    url = "https://github.com/sija/backtracer.cr.git";
+    rev = "v1.2.2";
+    sha256 = "1rknyylsi14m7i77x7c3138wdw27i4f6sd78m3srw851p47bwr20";
   };
   baked_file_system = {
-    owner = "schovi";
-    repo = "baked_file_system";
+    url = "https://github.com/schovi/baked_file_system.git";
     rev = "v0.10.0";
     sha256 = "10f25sby8ipps5c2jj4j2q30kscgv4g1s5nhdddmldhg9isj0jli";
   };
   dotenv = {
-    owner = "gdotdesign";
-    repo = "cr-dotenv";
+    url = "https://github.com/gdotdesign/cr-dotenv.git";
     rev = "v1.0.0";
     sha256 = "00pdawysns1w1iqwh6j3shilpwh41ljz1chsqkacn6dj2yn21n0r";
   };
   exception_page = {
-    owner = "crystal-loot";
-    repo = "exception_page";
-    rev = "v0.1.5";
-    sha256 = "0nlph4rmavwsndf94hisdikh3qhhkyyh97cc39mvbqzrqrc6lbx3";
+    url = "https://github.com/crystal-loot/exception_page.git";
+    rev = "v0.3.1";
+    sha256 = "00fpkhwaf94mz9d9qiinsa7hdbs3x2yqjwwzvbjwv86dv8s5008n";
   };
   kemal = {
-    owner = "kemalcr";
-    repo = "kemal";
-    rev = "v1.0.0";
-    sha256 = "0yy6mkqyxlgdi6svj206iprw3njrxw61y2s2wwz78yz7j6sly1wf";
-  };
-  kilt = {
-    owner = "jeromegn";
-    repo = "kilt";
-    rev = "v0.4.1";
-    sha256 = "1bhmmk4djnysf2fr0020dakn1730a33xzi10c8lg1a343x77rm64";
+    url = "https://github.com/kemalcr/kemal.git";
+    rev = "v1.4.0";
+    sha256 = "0pmcnbfzb0bqrnwbqikci4j0hbxsabmkz8a879vprf5gswnr7b63";
   };
   markd = {
-    owner = "icyleaf";
-    repo = "markd";
-    rev = "v0.4.0";
-    sha256 = "0zi39ik7zqnidysafwn6icpr0gdb6z40v63bx5hablarpf2r9637";
+    url = "https://github.com/icyleaf/markd.git";
+    rev = "v0.5.0";
+    sha256 = "1a677z57kwjq6lp4ws7br1ga8jgpgi8990glhd1r8756bdyd8mg0";
   };
   radix = {
-    owner = "luislavena";
-    repo = "radix";
+    url = "https://github.com/luislavena/radix.git";
     rev = "v0.4.1";
     sha256 = "1l08cydkdidq9yyil1wl240hvk41iycv04jrg6nx5mkvzw4z1bzg";
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16731,7 +16731,7 @@ with pkgs;
 
   minimacy = callPackage ../development/compilers/minimacy { };
 
-  mint = callPackage ../development/compilers/mint { crystal = crystal_1_2; };
+  mint = callPackage ../development/compilers/mint { crystal = crystal_1_9; };
 
   mitama-cpp-result = callPackage ../development/libraries/mitama-cpp-result { };
 


### PR DESCRIPTION
## Description of changes

There were a ton of updates in the meanwhile, this version now also requires a newer Crystal version, so it's now pinned to Crystal 1.9.x.

There were a couple of breaking changes especially in Mint 0.17.0.

https://github.com/mint-lang/mint/releases/tag/0.16.0
https://github.com/mint-lang/mint/releases/tag/0.16.1
https://github.com/mint-lang/mint/releases/tag/0.17.0
https://github.com/mint-lang/mint/releases/tag/0.18.0
https://github.com/mint-lang/mint/releases/tag/0.19.0

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
