### PR TITLE
med: init at 3.10.1

### DIFF
--- a/pkgs/by-name/me/med/package.nix
+++ b/pkgs/by-name/me/med/package.nix
@@ -1,0 +1,30 @@
+{ stdenv, lib, qt6, fetchFromGitHub, cmake, pkg-config, jsoncpp, readline }:
+
+stdenv.mkDerivation rec {
+  pname = "med";
+  version = "3.10.1";
+
+  src = fetchFromGitHub {
+    owner = "allencch";
+    repo = "med";
+    rev = version;
+    sha256 = "sha256-m2lVRSNaklB0Xfqgtyc0lNWXfTD8wTWsE06eGv4FOBE=";
+  };
+
+  nativeBuildInputs = [ qt6.wrapQtAppsHook cmake pkg-config ];
+  buildInputs = [ qt6.qtbase qt6.qttools qt6.qtwayland jsoncpp readline ];
+
+  postPatch = ''
+    find . -type f -exec sed -i "s|/opt/med|$out/share/med|g" {} +
+  '';
+
+  meta = with lib; {
+    description = "GUI game memory scanner and editor";
+    homepage = "https://github.com/allencch/med";
+    changelog = "https://github.com/allencch/med/releases/tag/${version}";
+    maintainers = with maintainers; [ zebreus ];
+    platforms = platforms.linux;
+    license = licenses.bsd3;
+    mainProgram = "med";
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[med](https://github.com/allencch/med) is a graphical memory scanner and editor similar to scanmem/gameconquerer. It offers more filter options than gameconquerer but is a bit slower and more unstable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
