### PR TITLE
updatecli: init at 0.70.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3873,6 +3873,15 @@
     githubId = 6821729;
     github = "criyle";
   };
+  croissong = {
+    email = "jan.moeller0@pm.me";
+    name = "Jan Möller";
+    github = "Croissong";
+    githubId = 4162215;
+    keys = [{
+      fingerprint = "CE97 9DEE 904C 26AA 3716  78C2 96A4 38F9 EE72 572F";
+    }];
+  };
   crschnick = {
     email = "crschnick@xpipe.io";
     name = "Christopher Schnick";

--- a/pkgs/by-name/up/updatecli/package.nix
+++ b/pkgs/by-name/up/updatecli/package.nix
@@ -1,0 +1,60 @@
+{ lib
+, go
+, buildGoModule
+, fetchFromGitHub
+, nix-update-script
+, installShellFiles
+}:
+
+buildGoModule rec {
+  pname = "updatecli";
+  version = "0.70.0";
+
+  src = fetchFromGitHub {
+    owner = "updatecli";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-MQoi/HvJqGCYzQLNsJul/7N3MXkV1X5d48InUSIWT8o=";
+  };
+
+  vendorHash = "sha256-RjyVlj66CbkQlzXkdP6ZWf+cNVjOgoPdskQefv9bNoo=";
+
+  # tests require network access
+  doCheck = false;
+
+  CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/updatecli/updatecli/pkg/core/version.BuildTime=unknown"
+    ''-X "github.com/updatecli/updatecli/pkg/core/version.GoVersion=go version go${lib.getVersion go}"''
+    "-X github.com/updatecli/updatecli/pkg/core/version.Version=${version}"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installShellCompletion --cmd updatecli \
+      --bash <($out/bin/updatecli completion bash) \
+      --fish <($out/bin/updatecli completion fish) \
+      --zsh <($out/bin/updatecli completion zsh)
+
+    $out/bin/updatecli man > updatecli.1
+    installManPage updatecli.1
+  '';
+
+  meta = with lib; {
+    description = "A Declarative Dependency Management tool";
+    longDescription = ''
+      Updatecli is a command-line tool used to define and apply update strategies.
+    '';
+    homepage = "https://www.updatecli.io";
+    changelog = "https://github.com/updatecli/updatecli/releases/tag/v${version}";
+    license = licenses.asl20;
+    mainProgram = "updatecli";
+    maintainers = with maintainers; [ croissong ];
+  };
+}


### PR DESCRIPTION
## Description of changes

[Updatecli](https://updatecli.io/) is a command-line tool for declarative dependency management.
  
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).