### PR TITLE
tart: 2.4.3 -> 2.6.0

### DIFF
--- a/pkgs/applications/virtualization/tart/default.nix
+++ b/pkgs/applications/virtualization/tart/default.nix
@@ -10,13 +10,13 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "tart";
-  version = "2.5.0";
+  version = "2.6.0";
 
   src = let
     binaryTarget = "arm64";
     throwError = throw "Unknown target ${binaryTarget} for tart package!";
     hash = {
-        "arm64" = "sha256-wQBvMRsywYiqi65RrtqCKEsOVCdnL3KfR8VTj+7/uA8=";
+        "arm64" = "sha256-QtVqgmjYpLAhFibW1DIVWNYiOjHB1X/YY6zRVB+1soA=";
     }.${binaryTarget} or throwError;
   in fetchurl {
       url = "https://github.com/cirruslabs/tart/releases/download/${finalAttrs.version}/tart-${binaryTarget}.tar.gz";

--- a/pkgs/applications/virtualization/tart/default.nix
+++ b/pkgs/applications/virtualization/tart/default.nix
@@ -12,15 +12,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "tart";
   version = "2.6.0";
 
-  src = let
-    binaryTarget = "arm64";
-    throwError = throw "Unknown target ${binaryTarget} for tart package!";
-    hash = {
-        "arm64" = "sha256-QtVqgmjYpLAhFibW1DIVWNYiOjHB1X/YY6zRVB+1soA=";
-    }.${binaryTarget} or throwError;
-  in fetchurl {
-      url = "https://github.com/cirruslabs/tart/releases/download/${finalAttrs.version}/tart-${binaryTarget}.tar.gz";
-      inherit hash;
+  src = fetchurl {
+      url = "https://github.com/cirruslabs/tart/releases/download/${finalAttrs.version}/tart-arm64.tar.gz";
+      hash = "sha256-QtVqgmjYpLAhFibW1DIVWNYiOjHB1X/YY6zRVB+1soA=";
   };
   sourceRoot = ".";
 

--- a/pkgs/applications/virtualization/tart/default.nix
+++ b/pkgs/applications/virtualization/tart/default.nix
@@ -10,11 +10,17 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "tart";
-  version = "2.4.3";
+  version = "2.5.0";
 
-  src = fetchurl {
-    url = "https://github.com/cirruslabs/tart/releases/download/${finalAttrs.version}/tart.tar.gz";
-    sha256 = "sha256-cXisvF+W/Uxe3Q0ZRhkvF13UWXxbsIQSzG172lzwruo=";
+  src = let
+    binaryTarget = "arm64";
+    throwError = throw "Unknown target ${binaryTarget} for tart package!";
+    hash = {
+        "arm64" = "sha256-wQBvMRsywYiqi65RrtqCKEsOVCdnL3KfR8VTj+7/uA8=";
+    }.${binaryTarget} or throwError;
+  in fetchurl {
+      url = "https://github.com/cirruslabs/tart/releases/download/${finalAttrs.version}/tart-${binaryTarget}.tar.gz";
+      inherit hash;
   };
   sourceRoot = ".";
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/cirruslabs/tart/releases/tag/2.4.4
https://github.com/cirruslabs/tart/releases/tag/2.5.0
https://github.com/cirruslabs/tart/releases/tag/2.6.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
