### PR TITLE
unrar-free: init at 0.1.3

### DIFF
--- a/pkgs/by-name/un/unrar-free/package.nix
+++ b/pkgs/by-name/un/unrar-free/package.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, autoreconfHook
+, libarchive
+, pkg-config
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "unrar-free";
+  version = "0.1.3";
+
+  src = fetchFromGitLab {
+    owner = "bgermann";
+    repo = "unrar-free";
+    rev = finalAttrs.version;
+    hash = "sha256-pNcbbHFcEzXKGKUg9nLM3NuUCgZFmFjFa4dXmUuuLYo";
+  };
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+
+  buildInputs = [ libarchive ];
+
+  meta = {
+    description = "Free utility to extract files from RAR archives";
+    longDescription = ''
+      unrar-free is a free software version of the non-free unrar utility.
+
+      This program is a simple command-line front-end to libarchive, and can list
+      and extract RAR archives but also other formats supported by libarchive.
+
+      It does not rival the non-free unrar in terms of features, but
+      special care has been taken to ensure it meets most user's needs.
+    '';
+    homepage = "https://gitlab.com/bgermann/unrar-free";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "unrar";
+    maintainers = with lib.maintainers; [ thiagokokada ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/un/unrar-free/package.nix
+++ b/pkgs/by-name/un/unrar-free/package.nix
@@ -37,5 +37,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "unrar";
     maintainers = with lib.maintainers; [ thiagokokada ];
     platforms = lib.platforms.unix;
+    broken = stdenv.isDarwin;
   };
 })


### PR DESCRIPTION
## Description of changes

`unrar-free` is a an Free Software implementation of the `unrar` utility, supporting RAR 5.0 version.

Sadly it is not compatible with `unrar` itself, so it will not be that useful, but still can be nice to have here.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
