### PR TITLE
degate: init at 2.0.0

### DIFF
--- a/pkgs/applications/science/electronics/degate/default.nix
+++ b/pkgs/applications/science/electronics/degate/default.nix
@@ -1,0 +1,75 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, cmake
+, boost
+, qtbase
+, qtimageformats
+, qttools
+, wrapQtAppsHook
+}:
+
+let
+  boost_static = boost.override { enableStatic = true; };
+
+in stdenv.mkDerivation rec {
+  pname = "degate";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "DegateCommunity";
+    repo = "Degate";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-INoA3Z6ya03ZMn6E+nOCkXZLoxoo2WgPDw9v5miI09A=";
+  };
+
+  patches = [
+    # bump bundled catch2 to avoid incompatibility with modern glibc
+    (fetchpatch {
+      name = "catch2-2.13.9.patch";
+      url = "https://github.com/DegateCommunity/Degate/commit/06346dde4312cbb867854899eacf58679d6ac7e2.patch";
+      includes = [ "tests/catch2/catch.hpp" ];
+      hash = "sha256-SbSA813QI8RRVy1lvAOGMGAC2KUQKjwYR2imqX40pvU=";
+    })
+  ];
+
+  postPatch = ''
+    sed -i -E '/(_OUTPUT_DIRECTORY|DESTINATION)/s|\bout/||g' CMakeLists.txt
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    qttools
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    boost_static
+    qtbase
+  ];
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+
+    (
+      cd tests/out/bin
+
+      # provide qtimageformats plugin to allow tests to read tiff files
+      export QT_PLUGIN_PATH="${qtimageformats}/${qtbase.qtPluginPrefix}"
+
+      ./DegateTests
+    )
+
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "A modern and open-source cross-platform software for chips reverse engineering";
+    homepage = "https://degate.readthedocs.io/";
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ ris ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39698,6 +39698,8 @@ with pkgs;
     jdk = jdk17;
   };
 
+  degate = libsForQt5.callPackage ../applications/science/electronics/degate { };
+
   diylc = callPackage ../applications/science/electronics/diylc { };
 
   flatcam = python39.pkgs.callPackage ../applications/science/electronics/flatcam { };


### PR DESCRIPTION
## Description of changes

http://degate.readthedocs.io/
https://media.ccc.de/v/37c3-12033-unlocking_hardware_security_red_team_blue_team_and_trojan_tales

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
