### PR TITLE
ocamlPackages.trace: 0.3 → 0.5

### DIFF
--- a/pkgs/development/ocaml-modules/trace/default.nix
+++ b/pkgs/development/ocaml-modules/trace/default.nix
@@ -2,13 +2,13 @@
 
 buildDunePackage rec {
   pname = "trace";
-  version = "0.3";
+  version = "0.5";
 
   minimalOCamlVersion = "4.07";
 
   src = fetchurl {
-    url = "https://github.com/c-cube/ocaml-trace/releases/download/${version}/trace-${version}.tbz";
-    hash = "sha256-Krq6qYO7tKJktTRjFrdmONPHfjrd81Ighsb9nmG9ZQU=";
+    url = "https://github.com/c-cube/ocaml-trace/releases/download/v${version}/trace-${version}.tbz";
+    hash = "sha256-l0NvWPGBd1WR+b50WXEYfptuCUjda8MlZ/o5YngRNIg=";
   };
 
   meta = {

--- a/pkgs/development/ocaml-modules/trace/tef.nix
+++ b/pkgs/development/ocaml-modules/trace/tef.nix
@@ -4,6 +4,15 @@ buildDunePackage {
   pname = "trace-tef";
   inherit (trace) src version;
 
+  # This removes the dependency on the “atomic” package
+  # (not available in nixpkgs)
+  # Said package for OCaml ≥ 4.12 is empty
+  postPatch = ''
+    substituteInPlace src/tef/dune --replace 'atomic ' ""
+  '';
+
+  minimalOCamlVersion = "4.12";
+
   propagatedBuildInputs = [ mtime trace ];
 
   doCheck = true;


### PR DESCRIPTION
## Description of changes

https://github.com/c-cube/ocaml-trace/blob/v0.5/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
