### PR TITLE
cudaPackages.cuda-library-samples: Only enable on Linux, fix channel

### DIFF
--- a/pkgs/test/cuda/cuda-library-samples/extension.nix
+++ b/pkgs/test/cuda/cuda-library-samples/extension.nix
@@ -2,7 +2,7 @@
 let
   # Samples are built around the CUDA Toolkit, which is not available for
   # aarch64. Check for both CUDA version and platform.
-  platformIsSupported = hostPlatform.isx86_64;
+  platformIsSupported = hostPlatform.isx86_64 && hostPlatform.isLinux;
 
   # Build our extension
   extension =


### PR DESCRIPTION
This very weirdly broke the channel evaluation: https://hydra.nixos.org/build/245871962

It appears that this attribute is only evaluated by Hydra, _not_ by ofborg. So this wouldn't have been detected by CI anyways in the PR that introduced the problem: https://github.com/NixOS/nixpkgs/pull/276800.

However, due to https://github.com/NixOS/nixpkgs/pull/271123#discussion_r1442134594, the channel only broke once that was fixed with https://github.com/NixOS/nixpkgs/pull/278777

Whether the fix is good, I don't know, but the failing-on-darwin attribute doesn't exist anymore with this commit, making the tarball build succeed again:

    nix-build pkgs/top-level/release.nix -A tarball

Ping @vcunat @NixOS/cuda-maintainers @amjoseph-nixpkgs @Mic92

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
