### PR TITLE
google-guest-configs: 20211116.00 -> 20231214.00

### DIFF
--- a/pkgs/tools/virtualization/google-guest-configs/default.nix
+++ b/pkgs/tools/virtualization/google-guest-configs/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "google-guest-configs";
-  version = "20211116.00";
+  version = "20231214.00";
 
   src = fetchFromGitHub {
     owner = "GoogleCloudPlatform";
     repo = "guest-configs";
     rev = version;
-    sha256 = "sha256-0SRu6p/DsHNNI20mkXJitt/Ee5S2ooiy5hNmD+ndecM=";
+    hash = "sha256-V0eoAPpzx2Dso0zw5Rx5VPK/H4pNEkGnvlDF7yc3qRg=";
   };
 
   binDeps = lib.makeBinPath [ coreutils util-linux gnugrep gnused ethtool ipcalc iproute2 ];
@@ -23,9 +23,7 @@ stdenv.mkDerivation rec {
     substitute ${./fix-paths.patch} fix-paths.patch \
       --subst-var out \
       --subst-var-by nvme "${nvme-cli}/bin/nvme" \
-      --subst-var-by sh "${stdenv.shell}" \
-      --subst-var-by umount "${util-linux}/bin/umount" \
-      --subst-var-by logger "${util-linux}/bin/logger"
+      --subst-var-by sh "${stdenv.shell}"
     patch -p1 < ./fix-paths.patch
   '';
 

--- a/pkgs/tools/virtualization/google-guest-configs/fix-paths.patch
+++ b/pkgs/tools/virtualization/google-guest-configs/fix-paths.patch
@@ -1,44 +1,52 @@
-diff -ru3 source.old/src/lib/udev/google_nvme_id source.new/src/lib/udev/google_nvme_id
---- source.old/src/lib/udev/google_nvme_id	1970-01-01 03:00:01.000000000 +0300
-+++ source.new/src/lib/udev/google_nvme_id	2022-02-05 13:30:00.986242869 +0300
+diff --git a/src/lib/dracut/modules.d/30gcp-udev-rules/module-setup.sh b/src/lib/dracut/modules.d/30gcp-udev-rules/module-setup.sh
+index 88f75cf..cb2b372 100755
+--- a/src/lib/dracut/modules.d/30gcp-udev-rules/module-setup.sh
++++ b/src/lib/dracut/modules.d/30gcp-udev-rules/module-setup.sh
+@@ -5,8 +5,8 @@
+ # called by dracut
+ install() {
+   inst_multiple nvme grep sed
+-  inst_simple /usr/lib/udev/google_nvme_id
+-  inst_simple /usr/lib/udev/rules.d/65-gce-disk-naming.rules
++  inst_simple @out@/lib/udev/google_nvme_id
++  inst_simple @out@/lib/udev/rules.d/65-gce-disk-naming.rules
+ }
+ 
+ installkernel() {
+diff --git a/src/lib/udev/google_nvme_id b/src/lib/udev/google_nvme_id
+index ef02963..85b9959 100755
+--- a/src/lib/udev/google_nvme_id
++++ b/src/lib/udev/google_nvme_id
 @@ -17,7 +17,7 @@
- # the metadata server
+ # persistent disk) using the disk names reported by the metadata server.
  
  # Locations of the script's dependencies
 -readonly nvme_cli_bin=/usr/sbin/nvme
 +readonly nvme_cli_bin=@nvme@
  
  # Bash regex to parse device paths and controller identification
- readonly NAMESPACE_NUMBER_REGEX="/dev/nvme[[:digit:]]+n([[:digit:]]+).*"
-diff -ru3 source.old/src/lib/udev/rules.d/64-gce-disk-removal.rules source.new/src/lib/udev/rules.d/64-gce-disk-removal.rules
---- source.old/src/lib/udev/rules.d/64-gce-disk-removal.rules	1970-01-01 03:00:01.000000000 +0300
-+++ source.new/src/lib/udev/rules.d/64-gce-disk-removal.rules	2022-02-05 13:27:42.635300567 +0300
-@@ -14,4 +14,4 @@
- #
- # When a disk is removed, unmount any remaining attached volumes.
- 
--ACTION=="remove", SUBSYSTEM=="block", KERNEL=="sd*|vd*|nvme*", RUN+="/bin/sh -c '/bin/umount -fl /dev/$name && /usr/bin/logger -p daemon.warn -s WARNING: hot-removed /dev/$name that was still mounted, data may have been corrupted'"
-+ACTION=="remove", SUBSYSTEM=="block", KERNEL=="sd*|vd*|nvme*", RUN+="@sh@ -c '@umount@ -fl /dev/$name && @logger@ -p daemon.warn -s WARNING: hot-removed /dev/$name that was still mounted, data may have been corrupted'"
-diff -ru3 source.old/src/lib/udev/rules.d/65-gce-disk-naming.rules source.new/src/lib/udev/rules.d/65-gce-disk-naming.rules
---- source.old/src/lib/udev/rules.d/65-gce-disk-naming.rules	1970-01-01 03:00:01.000000000 +0300
-+++ source.new/src/lib/udev/rules.d/65-gce-disk-naming.rules	2022-02-05 13:27:05.053107964 +0300
-@@ -21,11 +21,11 @@
- KERNEL=="sd*|vd*", IMPORT{program}="scsi_id --export --whitelisted -d $tempnode"
+ readonly PD_CONTROLLER_REGEX="nvme_card-pd"
+diff --git a/src/lib/udev/rules.d/65-gce-disk-naming.rules b/src/lib/udev/rules.d/65-gce-disk-naming.rules
+index d5c4ea8..1d842ab 100644
+--- a/src/lib/udev/rules.d/65-gce-disk-naming.rules
++++ b/src/lib/udev/rules.d/65-gce-disk-naming.rules
+@@ -26,10 +26,10 @@ KERNEL=="sd*|vd*", ENV{ID_VENDOR}!="Google", GOTO="gce_disk_naming_end"
+ KERNEL=="nvme*", ATTRS{model}!="nvme_card*", GOTO="gce_disk_naming_end"
  
  # NVME Local SSD naming
 -KERNEL=="nvme*n*", ATTRS{model}=="nvme_card", PROGRAM="/bin/sh -c 'nsid=$$(echo %k|sed -re s/nvme[0-9]+n\([0-9]+\).\*/\\1/); echo $$((nsid-1))'", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-%c"
 +KERNEL=="nvme*n*", ATTRS{model}=="nvme_card", PROGRAM="@sh@ -c 'nsid=$$(echo %k|sed -re s/nvme[0-9]+n\([0-9]+\).\*/\\1/); echo $$((nsid-1))'", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-%c"
  KERNEL=="nvme*", ATTRS{model}=="nvme_card", ENV{ID_SERIAL}="Google_EphemeralDisk_$env{ID_SERIAL_SHORT}"
+ # Support for local SSD multi-controller
+-KERNEL=="nvme*n*", ATTRS{model}=="nvme_card[0-9]*", IMPORT{program}="google_nvme_id -d $tempnode"
++KERNEL=="nvme*n*", ATTRS{model}=="nvme_card[0-9]*", IMPORT{program}="@out@/lib/udev/google_nvme_id -d $tempnode"
  
- # NVME Persistent Disk Naming
--KERNEL=="nvme*n*", ATTRS{model}=="nvme_card-pd", IMPORT{program}="google_nvme_id -d $tempnode"
-+KERNEL=="nvme*n*", ATTRS{model}=="nvme_card-pd", IMPORT{program}="@out@/lib/udev/google_nvme_id -d $tempnode"
- 
- # Symlinks
- KERNEL=="sd*|vd*|nvme*", ENV{DEVTYPE}=="disk", SYMLINK+="disk/by-id/google-$env{ID_SERIAL_SHORT}"
-diff -ru3 source.old/src/sbin/google-dhclient-script source.new/src/sbin/google-dhclient-script
---- source.old/src/sbin/google-dhclient-script	1970-01-01 03:00:01.000000000 +0300
-+++ source.new/src/sbin/google-dhclient-script	2022-02-05 13:29:37.430058984 +0300
+ # NVME Persistent Disk IO Timeout
+ KERNEL=="nvme*n*", ENV{DEVTYPE}=="disk", ATTRS{model}=="nvme_card-pd", ATTR{queue/io_timeout}="4294967295"
+diff --git a/src/sbin/google-dhclient-script b/src/sbin/google-dhclient-script
+index 3b10cb9..446efb3 100755
+--- a/src/sbin/google-dhclient-script
++++ b/src/sbin/google-dhclient-script
 @@ -31,7 +31,6 @@
  # This script is found in EL 7 and used to fix local routing in EL 6.
  # ----------
@@ -47,7 +55,7 @@ diff -ru3 source.old/src/sbin/google-dhclient-script source.new/src/sbin/google-
  # scripts in dhclient.d/ use $SAVEDIR (#833054)
  SAVEDIR=/var/lib/dhclient
  
-@@ -58,9 +57,9 @@
+@@ -58,9 +57,9 @@ eventually_add_hostnames_domain_to_search() {
      if need_hostname; then
          status=1
          if [ -n "${new_ip_address}" ]; then


### PR DESCRIPTION
## Description of changes

updated `pkgs/tools/virtualization/google-guest-configs` from `20211116.00` -> `20231214.00`.

had to update the patches as well but the changes required seem to be totally mechanical.

i have not tested this on a GCE VM, though; is there any sort of automated testing for that or should i spin one up to verify?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
