### PR TITLE
barrier: fix 'uint8_t' is not a member of 'std'

### DIFF
--- a/pkgs/applications/misc/barrier/default.nix
+++ b/pkgs/applications/misc/barrier/default.nix
@@ -26,6 +26,11 @@ mkDerivation rec {
     })
   ];
 
+  CXXFLAGS = [
+    # error: 'uint8_t' is not a member of 'std'; did you mean 'wint_t'?
+    "-include cstdint"
+  ];
+
   buildInputs = [ curl xorg.libX11 xorg.libXext xorg.libXtst avahiWithLibdnssdCompat qtbase ];
   nativeBuildInputs = [ cmake wrapGAppsHook ];
 


### PR DESCRIPTION
Fixes a build failure on https://github.com/NixOS/nixpkgs/pull/275620