### PR TITLE
python311Packages.django-stubs: 4.2.6 -> 4.2.7, python311Packages.types-markdown: init at 3.5.0.20240106, python311Packages.django-stubs-ext: 4.2.5 -> 4.2.7

### DIFF
--- a/pkgs/development/python-modules/django-stubs-ext/default.nix
+++ b/pkgs/development/python-modules/django-stubs-ext/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "django-stubs-ext";
-  version = "4.2.5";
+  version = "4.2.7";
   format = "setuptools";
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-jE0ftfaEGbOyR0xlloGhiYA+J9al5av1qg2ldgG1hjM=";
+    hash = "sha256-UZNCrAhJzaFVl0bJpWPwP/mfY2sOvnwUt16BagDf3cM=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/django-stubs-ext/default.nix
+++ b/pkgs/development/python-modules/django-stubs-ext/default.nix
@@ -4,13 +4,14 @@
 , fetchPypi
 , pytestCheckHook
 , pythonOlder
+, setuptools
 , typing-extensions
 }:
 
 buildPythonPackage rec {
   pname = "django-stubs-ext";
   version = "4.2.7";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.8";
 
@@ -18,6 +19,10 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-UZNCrAhJzaFVl0bJpWPwP/mfY2sOvnwUt16BagDf3cM=";
   };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   propagatedBuildInputs = [
     django
@@ -35,6 +40,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Extensions and monkey-patching for django-stubs";
     homepage = "https://github.com/typeddjango/django-stubs";
+    changelog = "https://github.com/typeddjango/django-stubs/releases/tag/${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ elohmeier ];
   };

--- a/pkgs/development/python-modules/django-stubs/default.nix
+++ b/pkgs/development/python-modules/django-stubs/default.nix
@@ -6,6 +6,7 @@
 , mypy
 , pytestCheckHook
 , pythonOlder
+, setuptools
 , tomli
 , types-pytz
 , types-pyyaml
@@ -15,19 +16,22 @@
 buildPythonPackage rec {
   pname = "django-stubs";
   version = "4.2.6";
-  format = "setuptools";
+  pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-5gtD3mYqGZ20sVyAPAZmngrFA1YUrykcvTuRWR99zJQ=";
   };
 
+  nativeBuildInputs = [
+    setuptools
+  ];
+
   propagatedBuildInputs = [
     django
     django-stubs-ext
-    mypy
     types-pytz
     types-pyyaml
     typing-extensions
@@ -35,8 +39,18 @@ buildPythonPackage rec {
     tomli
   ];
 
+  passthru.optional-dependencies = {
+    compatible-mypy = [
+      mypy
+    ];
+  };
+
   nativeCheckInputs = [
     pytestCheckHook
+  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+
+  pythonImportsCheck = [
+    "django-stubs"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/django-stubs/default.nix
+++ b/pkgs/development/python-modules/django-stubs/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "django-stubs";
-  version = "4.2.6";
+  version = "4.2.7";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-5gtD3mYqGZ20sVyAPAZmngrFA1YUrykcvTuRWR99zJQ=";
+    hash = "sha256-jM0v9O5a3yK547expRbS4cIZHp2U5nLDXMK8PdYeD2s=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/djangorestframework-stubs/default.nix
+++ b/pkgs/development/python-modules/djangorestframework-stubs/default.nix
@@ -4,43 +4,67 @@
 , fetchFromGitHub
 , mypy
 , py
+, coreapi
 , pytest-mypy-plugins
 , pytestCheckHook
 , pythonOlder
 , requests
 , types-pyyaml
+, setuptools
+, types-markdown
 , types-requests
 , typing-extensions
 }:
 
 buildPythonPackage rec {
   pname = "djangorestframework-stubs";
-  version = "3.14.2";
-  format = "setuptools";
+  version = "3.14.5";
+  pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "typeddjango";
     repo = "djangorestframework-stubs";
-    rev = version;
-    hash = "sha256-T357ocJvDC+vt0I4VyAu0Q9YzY9cSK7shgp9fQ1qHyY=";
+    rev = "refs/tags/${version}";
+    hash = "sha256-AOhNlhTZ6Upevb/7Z1sUQoIkIlwYlIcf1CC+Ag7H4bg=";
   };
 
+  nativeBuildInputs = [
+    setuptools
+  ];
+
   propagatedBuildInputs = [
-    django-stubs
-    mypy
     requests
     types-pyyaml
     types-requests
     typing-extensions
   ];
 
+  passthru.optional-dependencies = {
+    compatible-mypy = [
+      django-stubs
+      mypy
+    ] ++ django-stubs.optional-dependencies.compatible-mypy;
+    coreapi = [
+      coreapi
+    ];
+    markdown = [
+      types-markdown
+    ];
+  };
+
   nativeCheckInputs = [
-    mypy
     py
     pytest-mypy-plugins
     pytestCheckHook
+  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+
+  # Upstream recommends mypy > 1.7 which we don't have yet, thus all testsare failing with 3.14.5 and below
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "rest_framework-stubs"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/types-markdown/default.nix
+++ b/pkgs/development/python-modules/types-markdown/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "types-markdown";
+  version = "3.5.0.20240106";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "types-Markdown";
+    inherit version;
+    hash = "sha256-vkfTXL5h1Fi9F67BJ/HaIzzW7Zb6mhMccQN4pOiFcDA=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  pythonImportsCheck = [
+    "markdown-stubs"
+  ];
+
+  meta = with lib; {
+    description = "Typing stubs for Markdown";
+    homepage = "https://pypi.org/project/types-Markdown/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15407,6 +15407,8 @@ self: super: with self; {
 
   types-ipaddress = callPackage ../development/python-modules/types-ipaddress { };
 
+  types-markdown = callPackage ../development/python-modules/types-markdown { };
+
   types-mock = callPackage ../development/python-modules/types-mock { };
 
   types-pillow = callPackage ../development/python-modules/types-pillow { };


### PR DESCRIPTION
Changelog: https://github.com/typeddjango/django-stubs/releases/tag/4.2.7

## Description of changes
Fix build (https://hydra.nixos.org/build/243933666)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
