### PR TITLE
msat: init at 0.9.1

### DIFF
--- a/pkgs/applications/science/logic/msat/default.nix
+++ b/pkgs/applications/science/logic/msat/default.nix
@@ -1,0 +1,13 @@
+{ lib, ocamlPackages }:
+
+with ocamlPackages; buildDunePackage {
+  pname = "msat-bin";
+
+  inherit (msat) version src;
+
+  buildInputs = [ camlzip containers msat ];
+
+  meta = msat.meta // {
+    description = "SAT solver binary based on the msat library";
+  };
+}

--- a/pkgs/development/ocaml-modules/msat/default.nix
+++ b/pkgs/development/ocaml-modules/msat/default.nix
@@ -1,0 +1,36 @@
+{ lib, fetchFromGitHub, buildDunePackage
+, iter
+, containers
+, mdx
+}:
+
+buildDunePackage rec {
+  pname = "msat";
+  version = "0.9.1";
+
+  src = fetchFromGitHub {
+    owner = "Gbury";
+    repo = "mSAT";
+    rev = "v${version}";
+    hash = "sha256-ER7ZUejW+Zy3l2HIoFDYbR8iaKMvLZWaeWrOAAYXjG4=";
+  };
+
+  propagatedBuildInputs = [
+    iter
+  ];
+
+  postPatch = ''
+    substituteInPlace dune --replace mdx ocaml-mdx
+  '';
+
+  doCheck = true;
+  checkInputs = [ containers ];
+  nativeCheckInputs = [ mdx.bin ];
+
+  meta = {
+    description = "A modular sat/smt solver with proof output.";
+    homepage = "https://gbury.github.io/mSAT/";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39555,6 +39555,8 @@ with pkgs;
 
   monosat = callPackage ../applications/science/logic/monosat { };
 
+  msat = callPackage ../applications/science/logic/msat { };
+
   nusmv = callPackage ../applications/science/logic/nusmv { };
 
   nuXmv = callPackage ../applications/science/logic/nuXmv { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1176,6 +1176,8 @@ let
 
     mrmime = callPackage ../development/ocaml-modules/mrmime { };
 
+    msat = callPackage ../development/ocaml-modules/msat { };
+
     mtime_1 =  callPackage ../development/ocaml-modules/mtime/1_x.nix { };
     mtime =  callPackage ../development/ocaml-modules/mtime { };
 


### PR DESCRIPTION
## Description of changes

A SAT solver and the OCaml library on which it is built.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
