### PR TITLE
crust: init at 0.6

### DIFF
--- a/pkgs/misc/crust/default.nix
+++ b/pkgs/misc/crust/default.nix
@@ -1,0 +1,93 @@
+{ lib
+, fetchurl
+, fetchFromGitHub
+, stdenv
+, pkgsCross
+, flex
+, bison
+, swig
+, buildPackages
+}:
+let
+  buildCrustFirmware = lib.makeOverridable (
+    { filesToInstall ? [ "build/scp/scp.bin" ]
+    , installDir ? "$out"
+    , defconfig
+    , extraConfig ? ""
+    , extraPatches ? [ ]
+    , extraMakeFlags ? [ ]
+    , extraMeta ? { }
+    , ...
+    } @ args:
+
+    stdenv.mkDerivation (rec {
+      pname = "crust-scp-${defconfig}";
+      version = "0.6";
+
+      src = fetchFromGitHub {
+        owner = "crust-firmware";
+        repo = "crust";
+        rev = "refs/tags/v${version}";
+        hash = "sha256-zalBVP9rI81XshcurxmvoCwkdlX3gMw5xuTVLOIymK4=";
+      };
+
+      depsBuildBuild = [ buildPackages.stdenv.cc ];
+
+      nativeBuildInputs = [ flex bison swig pkgsCross.or1k.stdenv.cc ];
+
+      patches = [
+      ] ++ extraPatches;
+
+      passAsFile = [ "extraConfig" ];
+
+      configurePhase = ''
+        runHook preConfigure
+        make ${defconfig}
+        cat $extraConfigPath >> .config
+        runHook postConfigure
+      '';
+
+      makeFlags = [
+        "HOST_COMPILE="
+        "CROSS_COMPILE=or1k-elf-"
+      ] ++ extraMakeFlags;
+
+      installPhase = ''
+        runHook preInstall
+        mkdir -p ${installDir}
+        cp ${lib.concatStringsSep " " filesToInstall} ${installDir}
+        runHook postInstall
+      '';
+
+      hardeningDisable = [ "all" ];
+      dontStrip = true;
+
+      enableParallelBuilding = true;
+
+      meta = with lib; {
+        homepage = "https://github.com/crust-firmware/crust";
+        description = "SCP (power management) firmware for sunxi SoCs";
+        license = [ licenses.bsd3 licenses.gpl2Only ];
+        platforms = platforms.linux;
+        maintainers = with maintainers; [ zaldnoay ];
+      } // extraMeta;
+    } // builtins.removeAttrs args [ "extraMeta" ])
+  );
+in
+{
+  inherit buildCrustFirmware;
+
+  crustFirmwareOrangePi3LTS = buildCrustFirmware {
+    extraPatches = [
+      (fetchurl {
+        url = "https://raw.githubusercontent.com/armbian/build/fd06307ebae7cc170f072f71687adbb65d707953/patch/crust/add-defconfig-for-orangepi-3-lts.patch";
+        sha256 = "11dzphqzf8547fp35dj9n5zj55cqqbn7dzba6ybkrgkm0r66imx2";
+      })
+    ];
+    defconfig = "orangepi_3_lts_defconfig";
+  };
+
+  crustFirmwareOlimexA64Teres1 = buildCrustFirmware {
+    defconfig = "teres_i_defconfig";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -580,6 +580,12 @@ with pkgs;
 
   crow-translate = libsForQt5.callPackage ../applications/misc/crow-translate { };
 
+  inherit (callPackage ../misc/crust { })
+    buildCrustFirmware
+    crustFirmwareOrangePi3LTS
+    crustFirmwareOlimexA64Teres1
+  ;
+
   dae = callPackage ../tools/networking/dae { };
 
   darling = callPackage ../applications/emulators/darling { };


### PR DESCRIPTION
## Description of changes

Add open source Allwinner SCP firmware. This firmware will be used during the U-boot build. Currently, the allwinner chip's U-boot build has SCP disabled.  
Related PR https://github.com/NixOS/nixpkgs/pull/265411.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
