### PR TITLE
powersploit: init at 3.0.0-unstable-2020-08-22

### DIFF
--- a/pkgs/by-name/po/powersploit/package.nix
+++ b/pkgs/by-name/po/powersploit/package.nix
@@ -1,0 +1,33 @@
+{ lib
+, fetchFromGitHub
+, stdenvNoCC
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "powersploit";
+  version = "3.0.0-unstable-2020-08-22";
+
+  src = fetchFromGitHub {
+    owner = "PowerShellMafia";
+    repo = "PowerSploit";
+    rev = "d943001a7defb5e0d1657085a77a0e78609be58f";
+    hash = "sha256-xVMCB8siyYc8JI7vjlUdO93jI3Qh054F/4CCZyGe75c=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/powersploit
+    cp -a * $out/share/powersploit
+    find $out/share -type f -exec chmod -x {} \;
+    runHook postInstall
+  '';
+
+  meta = {
+    changelog = "https://github.com/PowerShellMafia/PowerSploit/releases/";
+    description = "A PowerShell Post-Exploitation Framework";
+    license = with lib.licenses; [ bsd3 ];
+    maintainers = with lib.maintainers; [ shard7 ];
+    platforms = lib.platforms.all;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+  };
+}


### PR DESCRIPTION
## Description of changes
PowerSploit - A collection of Microsoft PowerShell modules that can be used to aid penetration testers during all phases of an assessment.

See:
- https://repology.org/project/powersploit/information
- https://github.com/PowerShellMafia/PowerSploit

Note: Despite the project being not maintained anymore, this is a very useful post-exploitation framework used in a lot of cases when practicing offensive security. This package is only producing an ouput in the `share` folder, since it is a collection of powershell scripts.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
