### PR TITLE
compressFirmwareXz: never compress lib/firmware/edid

### DIFF
--- a/pkgs/build-support/kernel/compress-firmware-xz.nix
+++ b/pkgs/build-support/kernel/compress-firmware-xz.nix
@@ -7,14 +7,20 @@ let
 in
 
 runCommand "${firmware.name}-xz" args ''
+  # note: `-path` represents a complete path, so just 'lib/firmware/edid' doesn't work
+  # note: `'(' -path 'lib/firmware/edid/*' ')'` could be wrapped in an array if we need more rules
+
   mkdir -p $out/lib
   (cd ${firmware} && find lib/firmware -type d -print0) |
-      (cd $out && xargs -0 mkdir -v --)
-  (cd ${firmware} && find lib/firmware -type f -print0) |
+      (cd $out && xargs -0 mkdir -pv --)
+  (cd ${firmware} && find lib/firmware -type f -not '(' -path 'lib/firmware/edid/*' ')' -print0) |
       (cd $out && xargs -0rtP "$NIX_BUILD_CORES" -n1 \
           sh -c 'xz -9c -T1 -C crc32 --lzma2=dict=2MiB "${firmware}/$1" > "$1.xz"' --)
-  (cd ${firmware} && find lib/firmware -type l) | while read link; do
+  (cd ${firmware} && find lib/firmware -type l -not '(' -path 'lib/firmware/edid/*' ')') | while read link; do
       target="$(readlink "${firmware}/$link")"
       ln -vs -- "''${target/^${firmware}/$out}.xz" "$out/$link.xz"
   done
+  (cd ${firmware} && find lib/firmware -type f '(' -path 'lib/firmware/edid/*' ')' -print0) |
+      (cd $out && xargs -0rtP "$NIX_BUILD_CORES" -n1 \
+          sh -c 'ln -vs -- "${firmware}/$1" "$out/$1"' --)
 ''

--- a/pkgs/tools/misc/edid-generator/default.nix
+++ b/pkgs/tools/misc/edid-generator/default.nix
@@ -21,9 +21,6 @@ stdenv.mkDerivation {
   pname = "edid-generator";
   version = "master-2023-11-20";
 
-  # so `hardware.firmware` doesn't compress it
-  compressFirmware = false;
-
   src = fetchFromGitHub {
     owner = "akatrevorjay";
     repo = "edid-generator";


### PR DESCRIPTION
this allows us not to pass `compressFirmware = false;` inside EDID derivations as this mechanic very tricky to discover.

related to #279789

## Description of changes

Always skips `edid` directory when doing compression, leaving it intact.

## Things done

I have tested it end-to-end through https://github.com/nazarewk-iac/nix-configs/commit/b9d935fca851e63a719e9bf6242c91bb10e1fe7d by using `nixos-rebuild switch` and inspecting image with `lsinitrd`:

```shell
$ lsinitrd $(cat /boot/loader/entries/*.conf | grep initrd | tail -n 1 | sed 's#initrd /efi#/boot/EFI#g') | grep 'firmware'
drwxr-xr-x   0 root     root            0 Jan  1  1970 ./nix/store/1419nq86gk6fkicq1y847d0ivgikap74-linux-6.6.10-modules-shrunk/lib/firmware/
drwxr-xr-x   0 root     root            0 Jan  1  1970 ./nix/store/1419nq86gk6fkicq1y847d0ivgikap74-linux-6.6.10-modules-shrunk/lib/firmware/edid/
-r--r--r--   0 root     root          128 Jan  1  1970 ./nix/store/1419nq86gk6fkicq1y847d0ivgikap74-linux-6.6.10-modules-shrunk/lib/firmware/edid/PG278Q_120.bin
-r--r--r--   0 root     root          128 Jan  1  1970 ./nix/store/1419nq86gk6fkicq1y847d0ivgikap74-linux-6.6.10-modules-shrunk/lib/firmware/edid/PG278Q_60.bin
-r--r--r--   0 root     root          128 Jan  1  1970 ./nix/store/1419nq86gk6fkicq1y847d0ivgikap74-linux-6.6.10-modules-shrunk/lib/firmware/edid/U2711_60.bin
drwxr-xr-x   0 root     root            0 Jan  1  1970 ./nix/store/1419nq86gk6fkicq1y847d0ivgikap74-linux-6.6.10-modules-shrunk/lib/firmware/rtl_nic/
-r--r--r--   0 root     root          864 Jan  1  1970 ./nix/store/1419nq86gk6fkicq1y847d0ivgikap74-linux-6.6.10-modules-shrunk/lib/firmware/rtl_nic/rtl8105e-1.fw.xz
...
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
