### PR TITLE
tests.buildFHSEnv.libtinfo: init

### DIFF
--- a/pkgs/test/buildFHSEnv/default.nix
+++ b/pkgs/test/buildFHSEnv/default.nix
@@ -58,6 +58,16 @@ let
   '';
 
 in {
+  # This test proves an issue with buildFHSEnv - don't expect it to succeed,
+  # this is discussed in https://github.com/NixOS/nixpkgs/pull/279844 .
+  libtinfo = makeSharedObjectTest (getSharedObjectFromDebian "libedit.so.2.0.70" (fetchurl {
+    url = "mirror://debian/pool/main/libe/libedit/libedit2_3.1-20221030-2_amd64.deb";
+    hash = "sha256-HPFKvycW0yedsS0GV6VzfPcAdKHnHTvfcyBmJePInOY=";
+  })) (p: [
+    p.ncurses
+    p.libbsd
+  ]);
+
   liblzma = makeSharedObjectTest (getSharedObjectFromDebian "libxml2.so.2.9.14" (fetchurl {
     url = "mirror://debian/pool/main/libx/libxml2/libxml2_2.9.14+dfsg-1.3~deb12u1_amd64.deb";
     hash = "sha256-NbdstwOPwclAIEpPBfM/+3nQJzU85Gk5fZrc+Pmz4ac=";

--- a/pkgs/test/buildFHSEnv/default.nix
+++ b/pkgs/test/buildFHSEnv/default.nix
@@ -63,8 +63,13 @@ in {
   libtinfo = makeSharedObjectTest (getSharedObjectFromDebian "libedit.so.2.0.70" (fetchurl {
     url = "mirror://debian/pool/main/libe/libedit/libedit2_3.1-20221030-2_amd64.deb";
     hash = "sha256-HPFKvycW0yedsS0GV6VzfPcAdKHnHTvfcyBmJePInOY=";
-  })) (p: [
-    p.ncurses
+  })) (p: let
+    ncurses' = p.ncurses.overrideAttrs (old: {
+      configureFlags = old.configureFlags ++ [ "--with-termlib" ];
+      postFixup = "";
+    });
+  in [
+    (ncurses'.override { unicodeSupport = false; })
     p.libbsd
   ]);
 

--- a/pkgs/test/buildFHSEnv/default.nix
+++ b/pkgs/test/buildFHSEnv/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, buildFHSEnv
+, runCommand
+, stdenv
+, fetchurl
+, dpkg
+, glibc
+, callPackage
+}:
+
+let
+  getSharedObjectFromDebian = sharedObjectName: src: stdenv.mkDerivation  {
+    name = "${sharedObjectName}-fetcher";
+    inherit src;
+    nativeBuildInputs = [
+      dpkg
+    ];
+    dontBuild = true;
+    dontConfigure = true;
+    dontFixup = true;
+    installPhase = ''
+      echo shared objects found are:
+      ls -l usr/lib/*/
+      cp usr/lib/*/${sharedObjectName} $out
+    '';
+  };
+
+  makeSharedObjectTest = sharedObject: targetPkgs: let
+    lddFHSEnv = buildFHSEnv {
+      name = "ldd-with-ncurses-FHS-env";
+      inherit targetPkgs;
+      runScript = "ldd";
+    };
+    ldd-in-FHS = "${lddFHSEnv}/bin/${lddFHSEnv.name}";
+    ldd = "${lib.getBin glibc}/bin/ldd";
+    find_libFHSEnv = buildFHSEnv {
+      name = "ls-with-ncurses-FHS-env";
+      targetPkgs = p: [
+        p.ncurses5
+      ];
+      runScript = "find /lib/ -executable";
+    };
+    find_lib-in-FHS = "${find_libFHSEnv}/bin/${find_libFHSEnv.name}";
+  in runCommand "FHS-lib-test" {} ''
+    echo original ldd output is:
+    ${ldd} ${sharedObject}
+    lddOutput="$(${ldd-in-FHS} ${sharedObject})"
+    echo ldd output inside FHS is:
+    echo "$lddOutput"
+    if echo $lddOutput | grep -q "not found"; then
+      echo "shared object could not find all dependencies in the FHS!"
+      echo The libraries below where found in the FHS:
+      ${find_lib-in-FHS}
+      exit 1
+    else
+      echo $lddOutput > $out
+    fi
+  '';
+
+in {
+  liblzma = makeSharedObjectTest (getSharedObjectFromDebian "libxml2.so.2.9.14" (fetchurl {
+    url = "mirror://debian/pool/main/libx/libxml2/libxml2_2.9.14+dfsg-1.3~deb12u1_amd64.deb";
+    hash = "sha256-NbdstwOPwclAIEpPBfM/+3nQJzU85Gk5fZrc+Pmz4ac=";
+  })) (p: [
+    p.xz
+    p.zlib
+    p.icu72
+  ]);
+}

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -168,5 +168,7 @@ with pkgs;
 
   pkgs-lib = recurseIntoAttrs (import ../pkgs-lib/tests { inherit pkgs; });
 
+  buildFHSEnv = recurseIntoAttrs (callPackages ./buildFHSEnv { });
+
   nixpkgs-check-by-name = callPackage ./nixpkgs-check-by-name { };
 }


### PR DESCRIPTION
## Description of changes

This PR adds two tests to `pkgs/test/` that test whether `buildFHSEnv` actually does what it promises to do - make binaries from the outside world find shared objects in the FHS environment.

I wrote these tests in order to prove that there is something wrong with it - one fails, the other succeeds. I'm not sure exactly what is the problem so I'd like investigate this together with others. Hence I'm ccing @Atemu as it seems you maintain `buildFHSEnv`.

To run the tests:

```
nix-build -A tests.buildFHSEnv.liblzma # not failing
nix-build -A tests.buildFHSEnv.libtinfo # Very similar concept, failing
```

I encountered this issue with the `libtinfo` while trying to use the badly designed, very NixOS-unfriendly tool called [Petalinux](https://www.xilinx.com/products/design-tools/embedded-software/petalinux-sdk.html). The two shared objects committed here were extracted from Petalinux' installer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
