### PR TITLE
opensuperclone: init at 2.4.1

### DIFF
--- a/pkgs/by-name/op/opensuperclone/package.nix
+++ b/pkgs/by-name/op/opensuperclone/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  unixtools,
+  wrapGAppsHook3,
+  gettext,
+  gtk3,
+  libconfig,
+  libusb1,
+  libusb-compat-0_1,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "opensuperclone";
+  version = "2.4.1";
+
+  src = fetchFromGitHub {
+    owner = "ISpillMyDrink";
+    repo = "OpenSuperClone";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-vkN+Y8aCyf7jPSxf0O0mfYWtaL9XnDqgjBIUWbGPFH4=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    unixtools.xxd
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    gettext
+    gtk3
+    libconfig
+    libusb1
+    libusb-compat-0_1
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "GIT_REVISION" "nixpkgs")
+  ];
+
+  meta = {
+    description = "Powerful data recovery utility for Linux with many advanced features";
+    homepage = "https://github.com/ISpillMyDrink/OpenSuperClone";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = [ "x86_64-linux" ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Package request: https://github.com/NixOS/nixpkgs/issues/271938

I didn't try to package the other one, because it didn't use `cmake`.

I do not have experience with this, so I couldn't really test it out.
I'll leave this PR here, so someone who needs this and knows about this program can test it out.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
