### PR TITLE
More gcc13 include fixes

### DIFF
--- a/pkgs/applications/graphics/hdrmerge/default.nix
+++ b/pkgs/applications/graphics/hdrmerge/default.nix
@@ -37,6 +37,11 @@ mkDerivation rec {
     "-DALGLIB_DIR:PATH=${alglib}"
   ];
 
+  CXXFLAGS = [
+    # GCC 13: error: 'uint32_t' does not name a type
+    "-include cstdint"
+  ];
+
   patches = [
     # https://github.com/jcelaya/hdrmerge/pull/222
     (fetchpatch {

--- a/pkgs/applications/graphics/meshlab/default.nix
+++ b/pkgs/applications/graphics/meshlab/default.nix
@@ -75,6 +75,11 @@ mkDerivation rec {
     "-DALLOW_BUNDLED_LEVMAR=ON"
   ];
 
+  CXXFLAGS = [
+    # GCC 13: error: 'int16_t' has not been declared in 'std'
+    "-include cstdint"
+  ];
+
   postFixup = ''
     patchelf --add-needed $out/lib/meshlab/libmeshlab-common.so $out/bin/.meshlab-wrapped
   '';

--- a/pkgs/development/libraries/termcolor/default.nix
+++ b/pkgs/development/libraries/termcolor/default.nix
@@ -18,6 +18,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   cmakeFlags = [ "-DTERMCOLOR_TESTS=ON" ];
+  CXXFLAGS = [
+    # GCC 13: error: 'uint8_t' has not been declared
+    "-include cstdint"
+  ];
 
   doCheck = true;
 

--- a/pkgs/development/tools/misc/gpuvis/default.nix
+++ b/pkgs/development/tools/misc/gpuvis/default.nix
@@ -31,6 +31,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ SDL2 gtk3 freetype ];
 
+  CXXFLAGS = [
+    # GCC 13: error: 'uint32_t' has not been declared
+    "-include cstdint"
+  ];
+
   meta = with lib; {
     description = "GPU Trace Visualizer";
     homepage = "https://github.com/mikesart/gpuvis";

--- a/pkgs/games/super-tux-kart/default.nix
+++ b/pkgs/games/super-tux-kart/default.nix
@@ -122,6 +122,13 @@ stdenv.mkDerivation rec {
     "-DOpenGL_GL_PREFERENCE=GLVND"
   ];
 
+  CXXFLAGS = [
+    # GCC 13: error: 'snprintf' was not declared in this scope
+    "-include cstdio"
+    # GCC 13: error: 'runtime_error' is not a member of 'std'
+    "-include stdexcept"
+  ];
+
   # Extract binary from built app bundle
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir $out/bin


### PR DESCRIPTION
## Description of changes

Spotted a few more easy leaf packages while skimming through the breakage versus nixos-unstable.

Meshlab builds & launches but seems a bit wonky, not sure if that's a regression and/or related to my plasma6 wayland session. It is "slightly" out of date anyway so paging @viric to have a look if possible.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
