### PR TITLE
warp-terminal: 0.2023.12.05.08.02.stable_00 -> 0.2024.01.02.08.02.stable_02; Linux support; add channels

### DIFF
--- a/pkgs/by-name/wa/warp-terminal/package.nix
+++ b/pkgs/by-name/wa/warp-terminal/package.nix
@@ -1,16 +1,94 @@
 { lib
 , stdenvNoCC
 , fetchurl
+, makeWrapper
 , undmg
+, appimageTools
+, autoPatchelfHook
+, wayland
+, libGL
+, libz
+, e2fsprogs
+, gmp
+, p11-kit
+, libX11
+, libXcursor
+, libXi
+, libxkbcommon
+, vulkan-loader
+, channel ? "stable"
 }:
-stdenvNoCC.mkDerivation (finalAttrs: {
-  pname = "warp-terminal";
-  version = "0.2023.12.05.08.02.stable_00";
-
-  src = fetchurl {
-    url = "https://releases.warp.dev/stable/v${finalAttrs.version}/Warp.dmg";
-    hash = "sha256-9olAmczIPRXV15NYCOYmwuEmJ7lMeaQRTTfukaYXMR0=";
+let
+  versions = {
+    stable = "0.2024.01.02.08.02.stable_02";
+    beta = "0.2024.01.09.08.02.beta_00";
+    preview = "0.2024.01.09.17.38.preview_00";
+    dev = "0.2024.01.09.17.38.dev_00";
   };
+  platformSuffixes = {
+    darwin = ".dmg";
+    linux = "-x86_64.AppImage";
+  };
+  strTitleCase = str: with builtins; "${lib.strings.toUpper (substring 0 1 str)}${substring 1 (stringLength str) str}";
+  mkSrc = channel: platform: sha256: fetchurl {
+    inherit sha256;
+    url = "https://releases.warp.dev/${channel}/v${versions."${channel}"}/Warp${if channel == "stable" then "" else strTitleCase channel}${platformSuffixes."${platform}"}";
+  };
+  sources = {
+    linux = {
+      stable = mkSrc "stable" "linux" "sha256-olHiGdd09x5qnHpEp1RPbai2nnH1eFZfQs59+A3UC6Y=";
+      beta = mkSrc "beta" "linux" "sha256-IkX7yQAHCaiLzBYbkbZjuy+DyZ8937Ku5Wds92wc5RQ=";
+      # preview = mkSrc "preview" "linux" ""; # seems like there are no preview channel builds for Linux
+      dev = mkSrc "dev" "linux" "sha256-kXunWBTpswsFVo9u+bbpLC6TgqI28jnVk7EHDDXBbhI=";
+    };
+    darwin = {
+      stable = mkSrc "stable" "darwin" "sha256-ayJQI8Ui2wPS0RZLQMnnNDPcAw+3f4XrOztpg0JrXh0=";
+      beta = mkSrc "beta" "darwin" "sha256-g1ymediQizYZRVcqybaHv9uFqM+T1xPfkUuLdVMR6J0=";
+      preview = mkSrc "preview" "darwin" "sha256-sFxk2hzS+32Nnr6xtYfv2c0uzf2mYzVWaV6H4rhdOfQ=";
+      dev = mkSrc "dev" "darwin" "sha256-kPAf3MuJ14BIhMk3Goh/CutKmGpIf3o61eJ7OSVU+h8=";
+    };
+  };
+
+  pname = "warp-terminal";
+  version = versions."${channel}";
+  meta = with lib; {
+    description = "Rust-based terminal";
+    homepage = "https://www.warp.dev";
+    license = licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ emilytrau Enzime ];
+    platforms = platforms.darwin ++ (if channel != "preview" then [ "x86_64-linux" ] else []);
+  };
+in stdenvNoCC.mkDerivation (if stdenvNoCC.isLinux then {
+  inherit pname version;
+
+  src = appimageTools.extract {
+    inherit pname version;
+    src = sources.linux."${channel}";
+  };
+
+  nativeBuildInputs = [ makeWrapper autoPatchelfHook ];
+  buildInputs = [ libz e2fsprogs gmp p11-kit ];
+  runtimeDependencies = [ libX11 libXcursor libXi libxkbcommon vulkan-loader wayland libGL ];
+
+  installPhase = ''
+    install -m 444 -D usr/share/applications/dev.warp.Warp*.desktop -t $out/share/applications
+    substituteInPlace $out/share/applications/dev.warp.Warp*.desktop \
+      --replace 'Exec=${channel} %U' 'Exec=warp-term %U'
+    install -m 444 -D usr/share/icons/hicolor/512x512/apps/dev.warp.Warp*.png \
+      -t $out/share/icons/hicolor/512x512/apps
+
+    install -m 755 -D usr/bin/${channel} $out/bin/warp-term${if channel == "stable" then "" else "-${channel}"}
+    install -D usr/lib/* -t $out/lib
+
+    wrapProgram $out/bin/warp-term* --set WARP_ENABLE_WAYLAND 1
+  '';
+
+  inherit meta;
+} else (finalAttrs: {
+  inherit pname version;
+
+  src = sources.darwin."${channel}";
 
   sourceRoot = ".";
 
@@ -25,12 +103,5 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  meta = with lib; {
-    description = "Rust-based terminal";
-    homepage = "https://www.warp.dev";
-    license = licenses.unfree;
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    maintainers = with maintainers; [ emilytrau Enzime ];
-    platforms = platforms.darwin;
-  };
-})
+  inherit meta;
+}))

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36295,6 +36295,12 @@ with pkgs;
 
   warpd = callPackage ../applications/misc/warpd { };
 
+  warp-terminal-beta = callPackage ../by-name/wa/warp-terminal/package.nix { channel = "beta"; };
+
+  warp-terminal-preview = callPackage ../by-name/wa/warp-terminal/package.nix { channel = "preview"; };
+
+  warp-terminal-dev = callPackage ../by-name/wa/warp-terminal/package.nix { channel = "dev"; };
+
   watershot = callPackage ../applications/misc/watershot { };
 
   waypaper = callPackage ../applications/misc/waypaper { };


### PR DESCRIPTION
## Description of changes
Updates the version, added 3 new packages for different channels (beta, preview, dev), added Linux support
Latest change log of the stable (default) channel: https://docs.warp.dev/getting-started/changelog#id-2024.01.04-v0.2024.01.02.08.02

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
