### PR TITLE
dlib: use cuda and blas properly

### DIFF
--- a/pkgs/development/python-modules/face-recognition/default.nix
+++ b/pkgs/development/python-modules/face-recognition/default.nix
@@ -2,15 +2,17 @@
 , fetchPypi
 , lib
 
-# propagates
+  # propagates
 , click
 , dlib
 , face-recognition-models
 , numpy
 , pillow
 
-# tests
+  # tests
 , pytestCheckHook
+, config
+, cudaSupport ? config.cudaSupport
 }:
 
 buildPythonPackage rec {
@@ -18,7 +20,7 @@ buildPythonPackage rec {
   version = "1.3.0";
   format = "setuptools";
 
-  src = fetchPypi  {
+  src = fetchPypi {
     pname = "face_recognition";
     inherit version;
     hash = "sha256-Xl790WhqpWavDTzBMTsTHksZdleo/9A2aebT+tknBew=";
@@ -35,6 +37,9 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ];
+
+  # Disables tests when running with cuda due to https://github.com/NixOS/nixpkgs/issues/225912
+  doCheck = !config.cudaSupport;
 
   meta = with lib; {
     license = licenses.mit;


### PR DESCRIPTION
 changed dlib to actually use cuda properly and switched back to blas and added lapack to make it easier to override, removed fftw because dlib hasn't supported it since 2015.

Fixes this [Issue](https://github.com/NixOS/nixpkgs/issues/279924) / closes #279924 

#### Not building with CUDA
When you set `cudaSupport = True`, although it sets the CMAKE flag correctly the resulting package isn't actually built correctly as cmake can't find cuda so it unsets the flag. This is due to the incorrect usage of `pkgs.stdenv.mkDerivation` instead of `pkgs.cudaPackages.backendStdenv.mkDerivation` when building the cuda related packages. The correct usage can be seen in the [OpenCV](https://github.com/NixOS/nixpkgs/blob/nixos-23.11/pkgs/development/libraries/opencv/4.x.nix#L496) package. It also tries to build with CUDA by default which is wrong.

#### dlib takes fftw as a build input
Dlib hasn't supported fftw since [2015](https://github.com/davisking/dlib/blob/b0f6be80587b94585949f6943a7ee263394c2d15/docs/docs/release_notes.xml#L1280-L1309) however there are leftover references to it in cmake which might lead people to think it does support fftw. fftw should be removed.

#### Taking in openblas rather than blas and adding lapack
As mentioned in this [pr](https://github.com/NixOS/nixpkgs/pull/83888) it makes more sense to have `blas` as an input into `dlib` rather that `openblas` so that people can override it with other BLAS implementations e.g `mkl` more easily if they want to. The package was also missing lapack which should be added.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
