### PR TITLE
flet: fix out of the box experience

### DIFF
--- a/pkgs/by-name/fl/flet-client-flutter/package.nix
+++ b/pkgs/by-name/fl/flet-client-flutter/package.nix
@@ -1,0 +1,64 @@
+{ lib
+, fetchFromGitHub
+, pkg-config
+, flutter
+, gst_all_1
+, libunwind
+, makeWrapper
+, mimalloc
+, orc
+, nix-update-script
+, mpv-unwrapped
+, libplacebo
+}:
+
+flutter.buildFlutterApplication rec {
+  pname = "flet-client-flutter";
+  version = "0.21.1";
+
+  src = fetchFromGitHub {
+    owner = "flet-dev";
+    repo = "flet";
+    rev = "v${version}";
+    hash = "sha256-7zAcjek4iZRsNRVA85KBtU7PGbnLDZjnEO8Q5xwBiwM=";
+  };
+
+  sourceRoot = "${src.name}/client";
+
+  cmakeFlags = [
+    "-DMIMALLOC_LIB=${mimalloc}/lib/mimalloc.o"
+  ];
+
+  pubspecLock = lib.importJSON ./pubspec.lock.json;
+
+  nativeBuildInputs = [
+    makeWrapper
+    mimalloc
+    pkg-config
+  ];
+
+  buildInputs = [
+    mpv-unwrapped
+    gst_all_1.gst-libav
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-vaapi
+    gst_all_1.gstreamer
+    libunwind
+    orc
+    mimalloc
+  ]
+    ++ mpv-unwrapped.buildInputs
+    ++ libplacebo.buildInputs
+  ;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A framework that enables you to easily build realtime web, mobile, and desktop apps in Python. The frontend part";
+    homepage = "https://flet.dev/";
+    changelog = "https://github.com/flet-dev/flet/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ heyimnova lucasew ];
+    mainProgram = "flet";
+  };
+}

--- a/pkgs/by-name/fl/flet-client-flutter/pubspec.lock.json
+++ b/pkgs/by-name/fl/flet-client-flutter/pubspec.lock.json
@@ -1,0 +1,1524 @@
+{
+  "packages": {
+    "archive": {
+      "dependency": "transitive",
+      "description": {
+        "name": "archive",
+        "sha256": "22600aa1e926be775fa5fe7e6894e7fb3df9efda8891c73f70fb3262399a432d",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.4.10"
+    },
+    "args": {
+      "dependency": "transitive",
+      "description": {
+        "name": "args",
+        "sha256": "eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.4.2"
+    },
+    "async": {
+      "dependency": "transitive",
+      "description": {
+        "name": "async",
+        "sha256": "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.11.0"
+    },
+    "audioplayers": {
+      "dependency": "transitive",
+      "description": {
+        "name": "audioplayers",
+        "sha256": "c05c6147124cd63e725e861335a8b4d57300b80e6e92cea7c145c739223bbaef",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "5.2.1"
+    },
+    "audioplayers_android": {
+      "dependency": "transitive",
+      "description": {
+        "name": "audioplayers_android",
+        "sha256": "b00e1a0e11365d88576320ec2d8c192bc21f1afb6c0e5995d1c57ae63156acb5",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.0.3"
+    },
+    "audioplayers_darwin": {
+      "dependency": "transitive",
+      "description": {
+        "name": "audioplayers_darwin",
+        "sha256": "3034e99a6df8d101da0f5082dcca0a2a99db62ab1d4ddb3277bed3f6f81afe08",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "5.0.2"
+    },
+    "audioplayers_linux": {
+      "dependency": "transitive",
+      "description": {
+        "name": "audioplayers_linux",
+        "sha256": "60787e73fefc4d2e0b9c02c69885402177e818e4e27ef087074cf27c02246c9e",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.0"
+    },
+    "audioplayers_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "audioplayers_platform_interface",
+        "sha256": "365c547f1bb9e77d94dd1687903a668d8f7ac3409e48e6e6a3668a1ac2982adb",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.1.0"
+    },
+    "audioplayers_web": {
+      "dependency": "transitive",
+      "description": {
+        "name": "audioplayers_web",
+        "sha256": "22cd0173e54d92bd9b2c80b1204eb1eb159ece87475ab58c9788a70ec43c2a62",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.1.0"
+    },
+    "audioplayers_windows": {
+      "dependency": "transitive",
+      "description": {
+        "name": "audioplayers_windows",
+        "sha256": "9536812c9103563644ada2ef45ae523806b0745f7a78e89d1b5fb1951de90e1a",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.0"
+    },
+    "boolean_selector": {
+      "dependency": "transitive",
+      "description": {
+        "name": "boolean_selector",
+        "sha256": "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.1"
+    },
+    "characters": {
+      "dependency": "transitive",
+      "description": {
+        "name": "characters",
+        "sha256": "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.3.0"
+    },
+    "checked_yaml": {
+      "dependency": "transitive",
+      "description": {
+        "name": "checked_yaml",
+        "sha256": "feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.3"
+    },
+    "cli_util": {
+      "dependency": "transitive",
+      "description": {
+        "name": "cli_util",
+        "sha256": "c05b7406fdabc7a49a3929d4af76bcaccbbffcbcdcf185b082e1ae07da323d19",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.4.1"
+    },
+    "clock": {
+      "dependency": "transitive",
+      "description": {
+        "name": "clock",
+        "sha256": "cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.1"
+    },
+    "collection": {
+      "dependency": "transitive",
+      "description": {
+        "name": "collection",
+        "sha256": "ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.18.0"
+    },
+    "convert": {
+      "dependency": "transitive",
+      "description": {
+        "name": "convert",
+        "sha256": "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.1"
+    },
+    "crypto": {
+      "dependency": "transitive",
+      "description": {
+        "name": "crypto",
+        "sha256": "ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.3"
+    },
+    "cupertino_icons": {
+      "dependency": "direct main",
+      "description": {
+        "name": "cupertino_icons",
+        "sha256": "d57953e10f9f8327ce64a508a355f0b1ec902193f66288e8cb5070e7c47eeb2d",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.6"
+    },
+    "dbus": {
+      "dependency": "transitive",
+      "description": {
+        "name": "dbus",
+        "sha256": "365c771ac3b0e58845f39ec6deebc76e3276aa9922b0cc60840712094d9047ac",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.7.10"
+    },
+    "equatable": {
+      "dependency": "transitive",
+      "description": {
+        "name": "equatable",
+        "sha256": "c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.5"
+    },
+    "fake_async": {
+      "dependency": "transitive",
+      "description": {
+        "name": "fake_async",
+        "sha256": "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.3.1"
+    },
+    "ffi": {
+      "dependency": "transitive",
+      "description": {
+        "name": "ffi",
+        "sha256": "493f37e7df1804778ff3a53bd691d8692ddf69702cf4c1c1096a2e41b4779e21",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.2"
+    },
+    "file": {
+      "dependency": "transitive",
+      "description": {
+        "name": "file",
+        "sha256": "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "7.0.0"
+    },
+    "file_picker": {
+      "dependency": "transitive",
+      "description": {
+        "name": "file_picker",
+        "sha256": "4e42aacde3b993c5947467ab640882c56947d9d27342a5b6f2895b23956954a6",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.1.1"
+    },
+    "fixnum": {
+      "dependency": "transitive",
+      "description": {
+        "name": "fixnum",
+        "sha256": "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.0"
+    },
+    "fl_chart": {
+      "dependency": "transitive",
+      "description": {
+        "name": "fl_chart",
+        "sha256": "5a74434cc83bf64346efb562f1a06eefaf1bcb530dc3d96a104f631a1eff8d79",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.65.0"
+    },
+    "flet": {
+      "dependency": "direct main",
+      "description": {
+        "path": "../packages/flet",
+        "relative": true
+      },
+      "source": "path",
+      "version": "0.21.1"
+    },
+    "flet_audio": {
+      "dependency": "direct main",
+      "description": {
+        "path": "../packages/flet_audio",
+        "relative": true
+      },
+      "source": "path",
+      "version": "0.21.1"
+    },
+    "flet_audio_recorder": {
+      "dependency": "direct main",
+      "description": {
+        "path": "../packages/flet_audio_recorder",
+        "relative": true
+      },
+      "source": "path",
+      "version": "0.21.1"
+    },
+    "flet_lottie": {
+      "dependency": "direct main",
+      "description": {
+        "path": "../packages/flet_lottie",
+        "relative": true
+      },
+      "source": "path",
+      "version": "0.21.1"
+    },
+    "flet_video": {
+      "dependency": "direct main",
+      "description": {
+        "path": "../packages/flet_video",
+        "relative": true
+      },
+      "source": "path",
+      "version": "0.21.1"
+    },
+    "flet_webview": {
+      "dependency": "direct main",
+      "description": {
+        "path": "../packages/flet_webview",
+        "relative": true
+      },
+      "source": "path",
+      "version": "0.21.1"
+    },
+    "flutter": {
+      "dependency": "direct main",
+      "description": "flutter",
+      "source": "sdk",
+      "version": "0.0.0"
+    },
+    "flutter_driver": {
+      "dependency": "transitive",
+      "description": "flutter",
+      "source": "sdk",
+      "version": "0.0.0"
+    },
+    "flutter_highlight": {
+      "dependency": "transitive",
+      "description": {
+        "name": "flutter_highlight",
+        "sha256": "7b96333867aa07e122e245c033b8ad622e4e3a42a1a2372cbb098a2541d8782c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.7.0"
+    },
+    "flutter_launcher_icons": {
+      "dependency": "direct dev",
+      "description": {
+        "name": "flutter_launcher_icons",
+        "sha256": "526faf84284b86a4cb36d20a5e45147747b7563d921373d4ee0559c54fcdbcea",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.13.1"
+    },
+    "flutter_lints": {
+      "dependency": "direct dev",
+      "description": {
+        "name": "flutter_lints",
+        "sha256": "b543301ad291598523947dc534aaddc5aaad597b709d2426d3a0e0d44c5cb493",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.4"
+    },
+    "flutter_markdown": {
+      "dependency": "transitive",
+      "description": {
+        "name": "flutter_markdown",
+        "sha256": "21b085a1c185e46701373866144ced56cfb7a0c33f63c916bb8fe2d0c1491278",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.6.19"
+    },
+    "flutter_plugin_android_lifecycle": {
+      "dependency": "transitive",
+      "description": {
+        "name": "flutter_plugin_android_lifecycle",
+        "sha256": "b068ffc46f82a55844acfa4fdbb61fad72fa2aef0905548419d97f0f95c456da",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.17"
+    },
+    "flutter_redux": {
+      "dependency": "transitive",
+      "description": {
+        "name": "flutter_redux",
+        "sha256": "3b20be9e08d0038e1452fbfa1fdb1ea0a7c3738c997734530b3c6d0bb5fcdbdc",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.10.0"
+    },
+    "flutter_svg": {
+      "dependency": "transitive",
+      "description": {
+        "name": "flutter_svg",
+        "sha256": "d39e7f95621fc84376bc0f7d504f05c3a41488c562f4a8ad410569127507402c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.9"
+    },
+    "flutter_test": {
+      "dependency": "direct dev",
+      "description": "flutter",
+      "source": "sdk",
+      "version": "0.0.0"
+    },
+    "flutter_web_plugins": {
+      "dependency": "transitive",
+      "description": "flutter",
+      "source": "sdk",
+      "version": "0.0.0"
+    },
+    "fuchsia_remote_debug_protocol": {
+      "dependency": "transitive",
+      "description": "flutter",
+      "source": "sdk",
+      "version": "0.0.0"
+    },
+    "highlight": {
+      "dependency": "transitive",
+      "description": {
+        "name": "highlight",
+        "sha256": "5353a83ffe3e3eca7df0abfb72dcf3fa66cc56b953728e7113ad4ad88497cf21",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.7.0"
+    },
+    "http": {
+      "dependency": "transitive",
+      "description": {
+        "name": "http",
+        "sha256": "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.2.1"
+    },
+    "http_parser": {
+      "dependency": "transitive",
+      "description": {
+        "name": "http_parser",
+        "sha256": "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.0.2"
+    },
+    "image": {
+      "dependency": "transitive",
+      "description": {
+        "name": "image",
+        "sha256": "4c68bfd5ae83e700b5204c1e74451e7bf3cf750e6843c6e158289cf56bda018e",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.1.7"
+    },
+    "integration_test": {
+      "dependency": "direct main",
+      "description": "flutter",
+      "source": "sdk",
+      "version": "0.0.0"
+    },
+    "js": {
+      "dependency": "transitive",
+      "description": {
+        "name": "js",
+        "sha256": "f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.6.7"
+    },
+    "json_annotation": {
+      "dependency": "transitive",
+      "description": {
+        "name": "json_annotation",
+        "sha256": "b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.8.1"
+    },
+    "leak_tracker": {
+      "dependency": "transitive",
+      "description": {
+        "name": "leak_tracker",
+        "sha256": "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "10.0.0"
+    },
+    "leak_tracker_flutter_testing": {
+      "dependency": "transitive",
+      "description": {
+        "name": "leak_tracker_flutter_testing",
+        "sha256": "b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.1"
+    },
+    "leak_tracker_testing": {
+      "dependency": "transitive",
+      "description": {
+        "name": "leak_tracker_testing",
+        "sha256": "a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.1"
+    },
+    "lints": {
+      "dependency": "transitive",
+      "description": {
+        "name": "lints",
+        "sha256": "a2c3d198cb5ea2e179926622d433331d8b58374ab8f29cdda6e863bd62fd369c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.1"
+    },
+    "logging": {
+      "dependency": "transitive",
+      "description": {
+        "name": "logging",
+        "sha256": "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.2.0"
+    },
+    "lottie": {
+      "dependency": "transitive",
+      "description": {
+        "name": "lottie",
+        "sha256": "1f0ce68112072d66ea271a9841994fa8d16442e23d8cf8996c9fa74174e58b4e",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.0"
+    },
+    "markdown": {
+      "dependency": "transitive",
+      "description": {
+        "name": "markdown",
+        "sha256": "1b134d9f8ff2da15cb298efe6cd8b7d2a78958c1b00384ebcbdf13fe340a6c90",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "7.2.1"
+    },
+    "matcher": {
+      "dependency": "transitive",
+      "description": {
+        "name": "matcher",
+        "sha256": "d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.12.16+1"
+    },
+    "material_color_utilities": {
+      "dependency": "transitive",
+      "description": {
+        "name": "material_color_utilities",
+        "sha256": "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.8.0"
+    },
+    "media_kit": {
+      "dependency": "transitive",
+      "description": {
+        "name": "media_kit",
+        "sha256": "3289062540e3b8b9746e5c50d95bd78a9289826b7227e253dff806d002b9e67a",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.10+1"
+    },
+    "media_kit_libs_android_video": {
+      "dependency": "transitive",
+      "description": {
+        "name": "media_kit_libs_android_video",
+        "sha256": "9dd8012572e4aff47516e55f2597998f0a378e3d588d0fad0ca1f11a53ae090c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.3.6"
+    },
+    "media_kit_libs_ios_video": {
+      "dependency": "transitive",
+      "description": {
+        "name": "media_kit_libs_ios_video",
+        "sha256": "b5382994eb37a4564c368386c154ad70ba0cc78dacdd3fb0cd9f30db6d837991",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.4"
+    },
+    "media_kit_libs_linux": {
+      "dependency": "transitive",
+      "description": {
+        "name": "media_kit_libs_linux",
+        "sha256": "e186891c31daa6bedab4d74dcdb4e8adfccc7d786bfed6ad81fe24a3b3010310",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.3"
+    },
+    "media_kit_libs_macos_video": {
+      "dependency": "transitive",
+      "description": {
+        "name": "media_kit_libs_macos_video",
+        "sha256": "f26aa1452b665df288e360393758f84b911f70ffb3878032e1aabba23aa1032d",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.4"
+    },
+    "media_kit_libs_video": {
+      "dependency": "transitive",
+      "description": {
+        "name": "media_kit_libs_video",
+        "sha256": "3688e0c31482074578652bf038ce6301a5d21e1eda6b54fc3117ffeb4bdba067",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.4"
+    },
+    "media_kit_libs_windows_video": {
+      "dependency": "transitive",
+      "description": {
+        "name": "media_kit_libs_windows_video",
+        "sha256": "7bace5f35d9afcc7f9b5cdadb7541d2191a66bb3fc71bfa11c1395b3360f6122",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.9"
+    },
+    "media_kit_native_event_loop": {
+      "dependency": "transitive",
+      "description": {
+        "name": "media_kit_native_event_loop",
+        "sha256": "a605cf185499d14d58935b8784955a92a4bf0ff4e19a23de3d17a9106303930e",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.8"
+    },
+    "media_kit_video": {
+      "dependency": "transitive",
+      "description": {
+        "name": "media_kit_video",
+        "sha256": "c048d11a19e379aebbe810647636e3fc6d18374637e2ae12def4ff8a4b99a882",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.2.4"
+    },
+    "meta": {
+      "dependency": "transitive",
+      "description": {
+        "name": "meta",
+        "sha256": "d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.11.0"
+    },
+    "package_info_plus": {
+      "dependency": "transitive",
+      "description": {
+        "name": "package_info_plus",
+        "sha256": "7e76fad405b3e4016cd39d08f455a4eb5199723cf594cd1b8916d47140d93017",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.2.0"
+    },
+    "package_info_plus_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "package_info_plus_platform_interface",
+        "sha256": "9bc8ba46813a4cc42c66ab781470711781940780fd8beddd0c3da62506d3a6c6",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.1"
+    },
+    "path": {
+      "dependency": "transitive",
+      "description": {
+        "name": "path",
+        "sha256": "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.9.0"
+    },
+    "path_parsing": {
+      "dependency": "transitive",
+      "description": {
+        "name": "path_parsing",
+        "sha256": "e3e67b1629e6f7e8100b367d3db6ba6af4b1f0bb80f64db18ef1fbabd2fa9ccf",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.1"
+    },
+    "path_provider": {
+      "dependency": "transitive",
+      "description": {
+        "name": "path_provider",
+        "sha256": "b27217933eeeba8ff24845c34003b003b2b22151de3c908d0e679e8fe1aa078b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.2"
+    },
+    "path_provider_android": {
+      "dependency": "transitive",
+      "description": {
+        "name": "path_provider_android",
+        "sha256": "477184d672607c0a3bf68fbbf601805f92ef79c82b64b4d6eb318cbca4c48668",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.2"
+    },
+    "path_provider_foundation": {
+      "dependency": "transitive",
+      "description": {
+        "name": "path_provider_foundation",
+        "sha256": "5a7999be66e000916500be4f15a3633ebceb8302719b47b9cc49ce924125350f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.3.2"
+    },
+    "path_provider_linux": {
+      "dependency": "transitive",
+      "description": {
+        "name": "path_provider_linux",
+        "sha256": "f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.1"
+    },
+    "path_provider_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "path_provider_platform_interface",
+        "sha256": "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.2"
+    },
+    "path_provider_windows": {
+      "dependency": "transitive",
+      "description": {
+        "name": "path_provider_windows",
+        "sha256": "8bc9f22eee8690981c22aa7fc602f5c85b497a6fb2ceb35ee5a5e5ed85ad8170",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.1"
+    },
+    "petitparser": {
+      "dependency": "transitive",
+      "description": {
+        "name": "petitparser",
+        "sha256": "c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.0.2"
+    },
+    "platform": {
+      "dependency": "transitive",
+      "description": {
+        "name": "platform",
+        "sha256": "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.4"
+    },
+    "plugin_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "plugin_platform_interface",
+        "sha256": "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.8"
+    },
+    "pointycastle": {
+      "dependency": "transitive",
+      "description": {
+        "name": "pointycastle",
+        "sha256": "43ac87de6e10afabc85c445745a7b799e04de84cebaa4fd7bf55a5e1e9604d29",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.7.4"
+    },
+    "process": {
+      "dependency": "transitive",
+      "description": {
+        "name": "process",
+        "sha256": "21e54fd2faf1b5bdd5102afd25012184a6793927648ea81eea80552ac9405b32",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "5.0.2"
+    },
+    "record": {
+      "dependency": "transitive",
+      "description": {
+        "name": "record",
+        "sha256": "5c8e12c692a4800b33f5f8b6c821ea083b12bfdbd031b36ba9322c40a4eeecc9",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "5.0.4"
+    },
+    "record_android": {
+      "dependency": "transitive",
+      "description": {
+        "name": "record_android",
+        "sha256": "805ecaa232a671aff2ee9ec4730ef6addb97c548d2db6b1fbd5197f1d4f47a5a",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.4"
+    },
+    "record_darwin": {
+      "dependency": "transitive",
+      "description": {
+        "name": "record_darwin",
+        "sha256": "ee8cb1bb1712d7ce38140ecabe70e5c286c02f05296d66043bee865ace7eb1b9",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.1"
+    },
+    "record_linux": {
+      "dependency": "transitive",
+      "description": {
+        "name": "record_linux",
+        "sha256": "7d0e70cd51635128fe9d37d89bafd6011d7cbba9af8dc323079ae60f23546aef",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.7.1"
+    },
+    "record_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "record_platform_interface",
+        "sha256": "3a4b56e94ecd2a0b2b43eb1fa6f94c5b8484334f5d38ef43959c4bf97fb374cf",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.2"
+    },
+    "record_web": {
+      "dependency": "transitive",
+      "description": {
+        "name": "record_web",
+        "sha256": "24847cdbcf999f7a5762170792f622ac844858766becd0f2370ec8ae22f7526e",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.5"
+    },
+    "record_windows": {
+      "dependency": "transitive",
+      "description": {
+        "name": "record_windows",
+        "sha256": "39998b3ea7d8d28b04159d82220e6e5e32a7c357c6fb2794f5736beea272f6c3",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.2"
+    },
+    "redux": {
+      "dependency": "transitive",
+      "description": {
+        "name": "redux",
+        "sha256": "1e86ed5b1a9a717922d0a0ca41f9bf49c1a587d50050e9426fc65b14e85ec4d7",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "5.0.0"
+    },
+    "safe_local_storage": {
+      "dependency": "transitive",
+      "description": {
+        "name": "safe_local_storage",
+        "sha256": "ede4eb6cb7d88a116b3d3bf1df70790b9e2038bc37cb19112e381217c74d9440",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.2"
+    },
+    "screen_brightness": {
+      "dependency": "transitive",
+      "description": {
+        "name": "screen_brightness",
+        "sha256": "ed8da4a4511e79422fc1aa88138e920e4008cd312b72cdaa15ccb426c0faaedd",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.2.2+1"
+    },
+    "screen_brightness_android": {
+      "dependency": "transitive",
+      "description": {
+        "name": "screen_brightness_android",
+        "sha256": "3df10961e3a9e968a5e076fe27e7f4741fa8a1d3950bdeb48cf121ed529d0caf",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.1.0+2"
+    },
+    "screen_brightness_ios": {
+      "dependency": "transitive",
+      "description": {
+        "name": "screen_brightness_ios",
+        "sha256": "99adc3ca5490b8294284aad5fcc87f061ad685050e03cf45d3d018fe398fd9a2",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.1.0"
+    },
+    "screen_brightness_macos": {
+      "dependency": "transitive",
+      "description": {
+        "name": "screen_brightness_macos",
+        "sha256": "64b34e7e3f4900d7687c8e8fb514246845a73ecec05ab53483ed025bd4a899fd",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.1.0+1"
+    },
+    "screen_brightness_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "screen_brightness_platform_interface",
+        "sha256": "b211d07f0c96637a15fb06f6168617e18030d5d74ad03795dd8547a52717c171",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.1.0"
+    },
+    "screen_brightness_windows": {
+      "dependency": "transitive",
+      "description": {
+        "name": "screen_brightness_windows",
+        "sha256": "9261bf33d0fc2707d8cf16339ce25768100a65e70af0fcabaf032fc12408ba86",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.1.3"
+    },
+    "screen_retriever": {
+      "dependency": "transitive",
+      "description": {
+        "name": "screen_retriever",
+        "sha256": "6ee02c8a1158e6dae7ca430da79436e3b1c9563c8cf02f524af997c201ac2b90",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.1.9"
+    },
+    "sensors_plus": {
+      "dependency": "transitive",
+      "description": {
+        "name": "sensors_plus",
+        "sha256": "8e7fa79b4940442bb595bfc0ee9da4af5a22a0fe6ebacc74998245ee9496a82d",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.0.2"
+    },
+    "sensors_plus_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "sensors_plus_platform_interface",
+        "sha256": "bc472d6cfd622acb4f020e726433ee31788b038056691ba433fec80e448a094f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.2.0"
+    },
+    "shared_preferences": {
+      "dependency": "transitive",
+      "description": {
+        "name": "shared_preferences",
+        "sha256": "81429e4481e1ccfb51ede496e916348668fd0921627779233bd24cc3ff6abd02",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.2"
+    },
+    "shared_preferences_android": {
+      "dependency": "transitive",
+      "description": {
+        "name": "shared_preferences_android",
+        "sha256": "8568a389334b6e83415b6aae55378e158fbc2314e074983362d20c562780fb06",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.1"
+    },
+    "shared_preferences_foundation": {
+      "dependency": "transitive",
+      "description": {
+        "name": "shared_preferences_foundation",
+        "sha256": "7708d83064f38060c7b39db12aefe449cb8cdc031d6062280087bc4cdb988f5c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.3.5"
+    },
+    "shared_preferences_linux": {
+      "dependency": "transitive",
+      "description": {
+        "name": "shared_preferences_linux",
+        "sha256": "9f2cbcf46d4270ea8be39fa156d86379077c8a5228d9dfdb1164ae0bb93f1faa",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.3.2"
+    },
+    "shared_preferences_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "shared_preferences_platform_interface",
+        "sha256": "22e2ecac9419b4246d7c22bfbbda589e3acf5c0351137d87dd2939d984d37c3b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.3.2"
+    },
+    "shared_preferences_web": {
+      "dependency": "transitive",
+      "description": {
+        "name": "shared_preferences_web",
+        "sha256": "d762709c2bbe80626ecc819143013cc820fa49ca5e363620ee20a8b15a3e3daf",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.1"
+    },
+    "shared_preferences_windows": {
+      "dependency": "transitive",
+      "description": {
+        "name": "shared_preferences_windows",
+        "sha256": "841ad54f3c8381c480d0c9b508b89a34036f512482c407e6df7a9c4aa2ef8f59",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.3.2"
+    },
+    "sky_engine": {
+      "dependency": "transitive",
+      "description": "flutter",
+      "source": "sdk",
+      "version": "0.0.99"
+    },
+    "source_span": {
+      "dependency": "transitive",
+      "description": {
+        "name": "source_span",
+        "sha256": "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.10.0"
+    },
+    "sprintf": {
+      "dependency": "transitive",
+      "description": {
+        "name": "sprintf",
+        "sha256": "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "7.0.0"
+    },
+    "stack_trace": {
+      "dependency": "transitive",
+      "description": {
+        "name": "stack_trace",
+        "sha256": "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.11.1"
+    },
+    "stream_channel": {
+      "dependency": "transitive",
+      "description": {
+        "name": "stream_channel",
+        "sha256": "ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.2"
+    },
+    "string_scanner": {
+      "dependency": "transitive",
+      "description": {
+        "name": "string_scanner",
+        "sha256": "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.2.0"
+    },
+    "sync_http": {
+      "dependency": "transitive",
+      "description": {
+        "name": "sync_http",
+        "sha256": "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.3.1"
+    },
+    "synchronized": {
+      "dependency": "transitive",
+      "description": {
+        "name": "synchronized",
+        "sha256": "539ef412b170d65ecdafd780f924e5be3f60032a1128df156adad6c5b373d558",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.0+1"
+    },
+    "term_glyph": {
+      "dependency": "transitive",
+      "description": {
+        "name": "term_glyph",
+        "sha256": "a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.2.1"
+    },
+    "test_api": {
+      "dependency": "transitive",
+      "description": {
+        "name": "test_api",
+        "sha256": "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.6.1"
+    },
+    "typed_data": {
+      "dependency": "transitive",
+      "description": {
+        "name": "typed_data",
+        "sha256": "facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.3.2"
+    },
+    "universal_platform": {
+      "dependency": "transitive",
+      "description": {
+        "name": "universal_platform",
+        "sha256": "d315be0f6641898b280ffa34e2ddb14f3d12b1a37882557869646e0cc363d0cc",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.0+1"
+    },
+    "uri_parser": {
+      "dependency": "transitive",
+      "description": {
+        "name": "uri_parser",
+        "sha256": "6543c9fd86d2862fac55d800a43e67c0dcd1a41677cb69c2f8edfe73bbcf1835",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.2"
+    },
+    "url_launcher": {
+      "dependency": "transitive",
+      "description": {
+        "name": "url_launcher",
+        "sha256": "c512655380d241a337521703af62d2c122bf7b77a46ff7dd750092aa9433499c",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.2.4"
+    },
+    "url_launcher_android": {
+      "dependency": "transitive",
+      "description": {
+        "name": "url_launcher_android",
+        "sha256": "d4ed0711849dd8e33eb2dd69c25db0d0d3fdc37e0a62e629fe32f57a22db2745",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.3.0"
+    },
+    "url_launcher_ios": {
+      "dependency": "transitive",
+      "description": {
+        "name": "url_launcher_ios",
+        "sha256": "75bb6fe3f60070407704282a2d295630cab232991eb52542b18347a8a941df03",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.2.4"
+    },
+    "url_launcher_linux": {
+      "dependency": "transitive",
+      "description": {
+        "name": "url_launcher_linux",
+        "sha256": "ab360eb661f8879369acac07b6bb3ff09d9471155357da8443fd5d3cf7363811",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.1"
+    },
+    "url_launcher_macos": {
+      "dependency": "transitive",
+      "description": {
+        "name": "url_launcher_macos",
+        "sha256": "b7244901ea3cf489c5335bdacda07264a6e960b1c1b1a9f91e4bc371d9e68234",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.0"
+    },
+    "url_launcher_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "url_launcher_platform_interface",
+        "sha256": "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.3.2"
+    },
+    "url_launcher_web": {
+      "dependency": "transitive",
+      "description": {
+        "name": "url_launcher_web",
+        "sha256": "7fd2f55fe86cea2897b963e864dc01a7eb0719ecc65fcef4c1cc3d686d718bb2",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.2.0"
+    },
+    "url_launcher_windows": {
+      "dependency": "transitive",
+      "description": {
+        "name": "url_launcher_windows",
+        "sha256": "ecf9725510600aa2bb6d7ddabe16357691b6d2805f66216a97d1b881e21beff7",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.1"
+    },
+    "url_strategy": {
+      "dependency": "direct main",
+      "description": {
+        "name": "url_strategy",
+        "sha256": "42b68b42a9864c4d710401add17ad06e28f1c1d5500c93b98c431f6b0ea4ab87",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.2.0"
+    },
+    "uuid": {
+      "dependency": "transitive",
+      "description": {
+        "name": "uuid",
+        "sha256": "cd210a09f7c18cbe5a02511718e0334de6559871052c90a90c0cca46a4aa81c8",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.3.3"
+    },
+    "vector_graphics": {
+      "dependency": "transitive",
+      "description": {
+        "name": "vector_graphics",
+        "sha256": "4ac59808bbfca6da38c99f415ff2d3a5d7ca0a6b4809c71d9cf30fba5daf9752",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.10+1"
+    },
+    "vector_graphics_codec": {
+      "dependency": "transitive",
+      "description": {
+        "name": "vector_graphics_codec",
+        "sha256": "f3247e7ab0ec77dc759263e68394990edc608fb2b480b80db8aa86ed09279e33",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.10+1"
+    },
+    "vector_graphics_compiler": {
+      "dependency": "transitive",
+      "description": {
+        "name": "vector_graphics_compiler",
+        "sha256": "18489bdd8850de3dd7ca8a34e0c446f719ec63e2bab2e7a8cc66a9028dd76c5a",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.10+1"
+    },
+    "vector_math": {
+      "dependency": "transitive",
+      "description": {
+        "name": "vector_math",
+        "sha256": "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.1.4"
+    },
+    "vm_service": {
+      "dependency": "transitive",
+      "description": {
+        "name": "vm_service",
+        "sha256": "b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "13.0.0"
+    },
+    "volume_controller": {
+      "dependency": "transitive",
+      "description": {
+        "name": "volume_controller",
+        "sha256": "189bdc7a554f476b412e4c8b2f474562b09d74bc458c23667356bce3ca1d48c9",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.0.7"
+    },
+    "wakelock_plus": {
+      "dependency": "transitive",
+      "description": {
+        "name": "wakelock_plus",
+        "sha256": "f268ca2116db22e57577fb99d52515a24bdc1d570f12ac18bb762361d43b043d",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.4"
+    },
+    "wakelock_plus_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "wakelock_plus_platform_interface",
+        "sha256": "40fabed5da06caff0796dc638e1f07ee395fb18801fbff3255a2372db2d80385",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.1.0"
+    },
+    "web": {
+      "dependency": "transitive",
+      "description": {
+        "name": "web",
+        "sha256": "1d9158c616048c38f712a6646e317a3426da10e884447626167240d45209cbad",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.5.0"
+    },
+    "web_socket_channel": {
+      "dependency": "transitive",
+      "description": {
+        "name": "web_socket_channel",
+        "sha256": "1d8e795e2a8b3730c41b8a98a2dff2e0fb57ae6f0764a1c46ec5915387d257b2",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.4.4"
+    },
+    "webdriver": {
+      "dependency": "transitive",
+      "description": {
+        "name": "webdriver",
+        "sha256": "003d7da9519e1e5f329422b36c4dcdf18d7d2978d1ba099ea4e45ba490ed845e",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.0.3"
+    },
+    "webview_flutter": {
+      "dependency": "transitive",
+      "description": {
+        "name": "webview_flutter",
+        "sha256": "25e1b6e839e8cbfbd708abc6f85ed09d1727e24e08e08c6b8590d7c65c9a8932",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "4.7.0"
+    },
+    "webview_flutter_android": {
+      "dependency": "transitive",
+      "description": {
+        "name": "webview_flutter_android",
+        "sha256": "3e5f4e9d818086b0d01a66fb1ff9cc72ab0cc58c71980e3d3661c5685ea0efb0",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.15.0"
+    },
+    "webview_flutter_platform_interface": {
+      "dependency": "transitive",
+      "description": {
+        "name": "webview_flutter_platform_interface",
+        "sha256": "d937581d6e558908d7ae3dc1989c4f87b786891ab47bb9df7de548a151779d8d",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "2.10.0"
+    },
+    "webview_flutter_wkwebview": {
+      "dependency": "transitive",
+      "description": {
+        "name": "webview_flutter_wkwebview",
+        "sha256": "9bf168bccdf179ce90450b5f37e36fe263f591c9338828d6bf09b6f8d0f57f86",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.12.0"
+    },
+    "win32": {
+      "dependency": "transitive",
+      "description": {
+        "name": "win32",
+        "sha256": "464f5674532865248444b4c3daca12bd9bf2d7c47f759ce2617986e7229494a8",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "5.2.0"
+    },
+    "window_manager": {
+      "dependency": "transitive",
+      "description": {
+        "name": "window_manager",
+        "sha256": "b3c895bdf936c77b83c5254bec2e6b3f066710c1f89c38b20b8acc382b525494",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.3.8"
+    },
+    "window_to_front": {
+      "dependency": "transitive",
+      "description": {
+        "name": "window_to_front",
+        "sha256": "7aef379752b7190c10479e12b5fd7c0b9d92adc96817d9e96c59937929512aee",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.0.3"
+    },
+    "xdg_directories": {
+      "dependency": "transitive",
+      "description": {
+        "name": "xdg_directories",
+        "sha256": "faea9dee56b520b55a566385b84f2e8de55e7496104adada9962e0bd11bcff1d",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "1.0.4"
+    },
+    "xml": {
+      "dependency": "transitive",
+      "description": {
+        "name": "xml",
+        "sha256": "b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "6.5.0"
+    },
+    "yaml": {
+      "dependency": "transitive",
+      "description": {
+        "name": "yaml",
+        "sha256": "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "3.1.2"
+    }
+  },
+  "sdks": {
+    "dart": ">=3.3.0 <4.0.0",
+    "flutter": ">=3.16.6"
+  }
+}

--- a/pkgs/development/compilers/dart/package-source-builders/default.nix
+++ b/pkgs/development/compilers/dart/package-source-builders/default.nix
@@ -4,6 +4,7 @@
   flutter_secure_storage_linux = callPackage ./flutter-secure-storage-linux { };
   handy_window = callPackage ./handy-window { };
   matrix = callPackage ./matrix { };
+  media_kit_libs_linux = callPackage ./media_kit_libs_linux { };
   olm = callPackage ./olm { };
   system_tray = callPackage ./system-tray { };
 }

--- a/pkgs/development/compilers/dart/package-source-builders/media_kit_libs_linux/default.nix
+++ b/pkgs/development/compilers/dart/package-source-builders/media_kit_libs_linux/default.nix
@@ -1,0 +1,33 @@
+{ stdenv
+}:
+
+# Implementation notes
+
+# The patch exploits the fact that the download part is enclosed with "# ---"
+# To use this module you will need to pass the CMake variable MIMALLOC_LIB
+# example: -DMIMALLOC_LIB=${pkgs.mimalloc}/lib/mimalloc.o
+
+# Direct link for the original CMakeLists.txt: https://raw.githubusercontent.com/media-kit/media-kit/main/libs/linux/media_kit_libs_linux/linux/CMakeLists.txt
+
+{version, src, ...}:
+
+stdenv.mkDerivation {
+  pname = "media_kit_libs_linux";
+  inherit version src;
+  inherit (src) passthru;
+
+  doBuild = false;
+
+  postPatch = ''
+    awk -i inplace 'BEGIN {opened = 0}; /# --*[^$]*/ { print (opened ? "]===]" : "#[===["); opened = !opened }; {print $0}' linux/CMakeLists.txt
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out"
+    cp -r ./* "$out"
+
+    runHook postInstall
+  '';
+}

--- a/pkgs/development/python-modules/flet-core/default.nix
+++ b/pkgs/development/python-modules/flet-core/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, flet-client-flutter
 
 # build-system
 , poetry-core
@@ -12,14 +12,10 @@
 
 buildPythonPackage rec {
   pname = "flet-core";
-  version = "0.21.1";
+  inherit (flet-client-flutter) version src;
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "flet_core";
-    inherit version;
-    hash = "sha256-PZY4aRj/zBuHHIPHkEbZ1oXGnJyeCOqP9Pp8jYbOZ4I=";
-  };
+  sourceRoot = "${src.name}/sdk/python/packages/flet-core";
 
   nativeBuildInputs = [
     poetry-core

--- a/pkgs/development/python-modules/flet-core/default.nix
+++ b/pkgs/development/python-modules/flet-core/default.nix
@@ -33,6 +33,6 @@ buildPythonPackage rec {
     description = "The library is the foundation of Flet framework and is not intended to be used directly";
     homepage = "https://flet.dev/";
     license = lib.licenses.asl20;
-    maintainers = [ lib.maintainers.heyimnova ];
+    maintainers = with lib.maintainers; [ heyimnova lucasew ];
   };
 }

--- a/pkgs/development/python-modules/flet-runtime/_setup_runtime.py
+++ b/pkgs/development/python-modules/flet-runtime/_setup_runtime.py
@@ -1,0 +1,3 @@
+import os
+if 'FLET_VIEW_PATH' not in os.environ:
+  os.environ["FLET_VIEW_PATH"] = "@flet-client-flutter@/bin"

--- a/pkgs/development/python-modules/flet-runtime/default.nix
+++ b/pkgs/development/python-modules/flet-runtime/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, flet-client-flutter
 , poetry-core
 , pythonRelaxDepsHook
 , flet-core
@@ -10,14 +10,18 @@
 
 buildPythonPackage rec {
   pname = "flet-runtime";
-  version = "0.21.1";
+  inherit (flet-client-flutter) version src;
+
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "flet_runtime";
-    inherit version;
-    hash = "sha256-48diTMTWbiZNF4jU6ABgWYsdhNNs3bte7brgdEJE3es=";
-  };
+  sourceRoot = "${src.name}/sdk/python/packages/flet-runtime";
+
+  postPatch = ''
+    substitute ${./_setup_runtime.py} src/flet_runtime/_setup_runtime.py \
+      --replace @flet-client-flutter@ ${flet-client-flutter}
+
+    echo -e "import flet_runtime._setup_runtime\n$(cat src/flet_runtime/__init__.py)" > src/flet_runtime/__init__.py
+  '';
 
   nativeBuildInputs = [
     poetry-core

--- a/pkgs/development/python-modules/flet-runtime/default.nix
+++ b/pkgs/development/python-modules/flet-runtime/default.nix
@@ -47,6 +47,6 @@ buildPythonPackage rec {
     description = "A base package for Flet desktop and Flet mobile";
     homepage = "https://flet.dev/";
     license = lib.licenses.asl20;
-    maintainers = [ lib.maintainers.wegank ];
+    maintainers = with lib.maintainers; [ lucasew wegank ];
   };
 }

--- a/pkgs/development/python-modules/flet/default.nix
+++ b/pkgs/development/python-modules/flet/default.nix
@@ -37,6 +37,8 @@ buildPythonPackage rec {
 
   pythonRelaxDeps = [
     "websockets"
+    "cookiecutter"
+    "watchdog"
   ];
 
   propagatedBuildInputs = [
@@ -52,6 +54,8 @@ buildPythonPackage rec {
     packaging
     qrcode
     cookiecutter
+    fastapi
+    uvicorn
   ];
 
   doCheck = false;

--- a/pkgs/development/python-modules/flet/default.nix
+++ b/pkgs/development/python-modules/flet/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, fetchPypi
+, flet-client-flutter
 , pythonRelaxDepsHook
 
 # build-system
@@ -24,13 +24,11 @@
 
 buildPythonPackage rec {
   pname = "flet";
-  version = "0.21.1";
+  inherit (flet-client-flutter) version src;
+
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-YAMZku8jbdQ8JvUr5aLATIGIiTDmG6CGvfUKo28q7ks=";
-  };
+  sourceRoot = "${src.name}/sdk/python/packages/flet";
 
   nativeBuildInputs = [
     poetry-core

--- a/pkgs/development/python-modules/flet/default.nix
+++ b/pkgs/development/python-modules/flet/default.nix
@@ -65,7 +65,7 @@ buildPythonPackage rec {
     homepage = "https://flet.dev/";
     changelog = "https://github.com/flet-dev/flet/releases/tag/v${version}";
     license = lib.licenses.asl20;
-    maintainers = [ lib.maintainers.heyimnova ];
+    maintainers = with lib.maintainers; [ heyimnova lucasew ];
     mainProgram = "flet";
   };
 }


### PR DESCRIPTION
## Description of changes
Right now flet just tries to download the runtime bundle and fails, the objective of this PR is to fix that.

Basically I created this because flet changed a lot since I last tried in #251877

The plan here is to use their monorepo instead of the pypi packages, use a update script on flet-flutter-client and it should propagate to the python libraries so the core and the utilites (from the same repo) would always be synced.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
