### PR TITLE
Fix #131353 Don't wrap byobu-launch

### DIFF
--- a/pkgs/by-name/by/byobu/package.nix
+++ b/pkgs/by-name/by/byobu/package.nix
@@ -65,6 +65,12 @@ stdenv.mkDerivation (finalAttrs: {
     cp --remove-destination $out/bin/byobu $out/bin/byobu-tmux
 
     for file in $out/bin/byobu*; do
+      # Don't wrap byobu-launch and byobu-launcher -- See: https://github.com/NixOS/nixpkgs/issues/131353
+      if [ "$(basename $file)" == "byobu-launch" ] || [ "$(basename $file)" == "byobu-launcher" ]
+      then
+        continue
+      fi
+
       # We don't use the usual "-wrapped" suffix because arg0 within the shebang
       # scripts points to the filename and byobu matches against this to know
       # which backend to start with
@@ -73,12 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
       makeWrapper "$out/bin/.$bname" "$out/bin/$bname" \
         --argv0 $bname \
         --prefix PATH ":" "$out/bin" \
-        --set BYOBU_PATH ${
-          lib.makeBinPath [
-            vim
-            bc
-          ]
-        } \
+        --set BYOBU_PREFIX "$out" \
         --set BYOBU_PYTHON "${pythonEnv}/bin/python"
     done
   '';


### PR DESCRIPTION
## Description of changes

Wrapping byobu-launch breaks interactive shell detection logic, which in turn breaks byobu-enable.
This commit avoids wrapping byobu-enable, and replaces unused BYOBU_PATH with needed BYOBU_PREFIX.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
