### PR TITLE
rmg: init at 0.5.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17162,6 +17162,11 @@
     githubId = 3789764;
     name = "skykanin";
   };
+  slam-bert = {
+    github = "slam-bert";
+    githubId = 106779009;
+    name = "Slambert";
+  };
   slbtty = {
     email = "shenlebantongying@gmail.com";
     github = "shenlebantongying";

--- a/pkgs/by-name/rm/rmg/package.nix
+++ b/pkgs/by-name/rm/rmg/package.nix
@@ -1,0 +1,87 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, boost
+, cmake
+, discord-rpc
+, freetype
+, hidapi
+, libpng
+, libsamplerate
+, minizip
+, nasm
+, pkg-config
+, qt6Packages
+, SDL2
+, speexdsp
+, vulkan-headers
+, vulkan-loader
+, which
+, xdg-user-dirs
+, zlib
+}:
+
+let
+  inherit (qt6Packages) qtbase qtsvg wrapQtAppsHook;
+in
+stdenv.mkDerivation rec {
+  pname = "rmg";
+  version = "0.5.4";
+
+  src = fetchFromGitHub {
+    owner = "Rosalie241";
+    repo = "RMG";
+    rev = "v${version}";
+    hash = "sha256-SAQJKfYoouJ2DLVks6oXiyiOI2/kgmyaHqt/FRfqKjI=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    nasm
+    pkg-config
+    wrapQtAppsHook
+    which
+  ];
+
+  buildInputs = [
+    boost
+    discord-rpc
+    freetype
+    hidapi
+    libpng
+    libsamplerate
+    minizip
+    qtbase
+    qtsvg
+    SDL2
+    speexdsp
+    vulkan-headers
+    vulkan-loader
+    xdg-user-dirs
+    zlib
+  ];
+
+  cmakeFlags = [
+    "-DPORTABLE_INSTALL=OFF"
+    # mupen64plus-input-gca is written in Rust, so we can't build it with
+    # everything else.
+    "-DNO_RUST=ON"
+  ];
+
+  qtWrapperArgs = lib.optionals stdenv.isLinux [
+    "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ vulkan-loader ]}"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/Rosalie241/RMG";
+    description = "Rosalie's Mupen GUI";
+    longDescription = ''
+      Rosalie's Mupen GUI is a free and open-source mupen64plus front-end
+      written in C++. It offers a simple-to-use user interface.
+    '';
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    mainProgram = "RMG";
+    maintainers = with maintainers; [ slam-bert ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds [Rosalie's Mupen GUI](https://github.com/Rosalie241/RMG) to nixpkgs

NOTE: This project ships it's own mupen64plus-core instead of using the one that's already been packaged. It also comes
with plugins (such as GLideN64) that are compiled during the build phase.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

I've tested the program by changing plugins and playing through small chunks of some games.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
