### PR TITLE
fead: 0.1.3 -> 1.0.0

### DIFF
--- a/pkgs/applications/misc/fead/default.nix
+++ b/pkgs/applications/misc/fead/default.nix
@@ -1,14 +1,12 @@
-{ lib, stdenv, fetchFromSourcehut, python3, help2man }:
+{ lib, stdenv, fetchzip, python3, help2man }:
 
 stdenv.mkDerivation rec {
   pname = "fead";
-  version = "0.1.3";
+  version = "1.0.0";
 
-  src = fetchFromSourcehut {
-    owner = "~cnx";
-    repo = pname;
-    rev = version;
-    sha256 = "sha256-cW0GxyvC9url2QAAWD0M2pR4gBiPA3eeAaw77TwMV/0=";
+  src = fetchzip {
+    url = "https://trong.loang.net/~cnx/fead/snapshot/fead-${version}.tar.gz";
+    hash = "sha256-cbU379Zz+mwRqEHiDUlGvWheLkkr0YidHeVs/1Leg38=";
   };
 
   nativeBuildInputs = [ help2man ];
@@ -29,9 +27,9 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Advert generator from web feeds";
-    homepage = "https://git.sr.ht/~cnx/fead";
+    homepage = "https://trong.loang.net/~cnx/fead";
     license = licenses.agpl3Plus;
-    changelog = "https://git.sr.ht/~cnx/fead/refs/${version}";
+    changelog = "https://trong.loang.net/~cnx/fead/tag?h=${version}";
     maintainers = with maintainers; [ McSinyx ];
   };
 }


### PR DESCRIPTION
## Description of changes

[Upstream change log](https://trong.loang.net/~cnx/fead/tag?h=1.0.0)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
