### PR TITLE
mcap-cli: init at 0.0.38

### DIFF
--- a/pkgs/by-name/mc/mcap-cli/package.nix
+++ b/pkgs/by-name/mc/mcap-cli/package.nix
@@ -1,0 +1,44 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+let
+  version = "0.0.38";
+in
+buildGoModule {
+
+  pname = "mcap-cli";
+
+  inherit version;
+
+  src = fetchFromGitHub {
+    repo = "mcap";
+    owner = "foxglove";
+    rev = "releases/mcap-cli/v${version}";
+    hash = "sha256-mwKWf0kJ3uMx1cLUac+AqXgQ1Af3tLDOCTFKgq8FtHE=";
+  };
+
+  vendorHash = "sha256-Gl0zLBTWscKGtVOS6rPRL/r8KHYHpZwoUDbEyCL4Ijk=";
+
+  modRoot = "go/cli/mcap";
+
+  GOWORK="off";
+
+  # copy the local versions of the workspace modules
+  postConfigure = ''
+    chmod -R u+w vendor
+    rm -rf vendor/github.com/foxglove/mcap/go/{mcap,ros}
+    cp -r ../../{mcap,ros} vendor/github.com/foxglove/mcap/go
+  '';
+
+  checkFlags = [
+    # requires git-lfs and network
+    # https://github.com/foxglove/mcap/issues/895
+    "-skip=TestCat|TestInfo"
+  ];
+
+  meta = with lib; {
+    description = "MCAP CLI tool to inspect and fix MCAP files";
+    homepage = "https://github.com/foxglove/mcap";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ squalus therishidesai ];
+  };
+
+}


### PR DESCRIPTION
## Description of changes

Add the mcap-cli program.

https://github.com/foxglove/mcap

>  MCAP is a modular, performant, and serialization-agnostic container file format, useful for pub/sub and robotics applications. 

Tested a few basic features with a sample mcap file on x86_64-linux.

Prior work: #220057

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
