### PR TITLE
nixos/iso-image: improved grub and media config

### DIFF
--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -422,6 +422,18 @@ let
       echo "If you see this message, your EFI system doesn't support this feature."
       echo ""
     }
+
+    ${lib.concatStrings
+      (
+        map
+        ({name, class, body}: ''
+          menuentry '${name}' --class ${class} {
+            ${body}
+          }
+        '')
+        config.isoImage.grubExtraMenus
+      )}
+
     menuentry 'Shutdown' --class shutdown {
       halt
     }
@@ -443,6 +455,16 @@ let
       mkdir -p ./EFI/BOOT
       cp -rp "${efiDir}"/EFI/BOOT/{grub.cfg,*.EFI,*.efi} ./EFI/BOOT
 
+      ${lib.concatStrings
+        (
+          map
+          ({source, target}: ''
+            mkdir -p ./`dirname ./${target}`
+            cp -rp ${source} ./${target}
+          '')
+          config.isoImage.bootContents
+        )}
+
       # Rewrite dates for everything in the FS
       find . -exec touch --date=2000-01-01 {} +
 
@@ -459,11 +481,11 @@ let
       mkfs.vfat --invariant -i 12345678 -n EFIBOOT "$out"
 
       # Force a fixed order in mcopy for better determinism, and avoid file globbing
-      for d in $(find EFI -type d | sort); do
+      for d in $(find -type d | tail -n +2 | sort); do
         faketime "2000-01-01 00:00:00" mmd -i "$out" "::/$d"
       done
 
-      for f in $(find EFI -type f | sort); do
+      for f in $(find -type f | sort); do
         mcopy -pvm -i "$out" "$f" "::/$f"
       done
 
@@ -540,7 +562,20 @@ in
       '';
       description = ''
         This option lists files to be copied to fixed locations in the
-        generated ISO image.
+        main data partition of the generated ISO image.
+      '';
+    };
+
+    isoImage.bootContents = lib.mkOption {
+      default = [];
+      example = lib.literalExpression ''
+        [ { source = ./your-custom-efi-app.efi;
+            target = "EFI/boot/your-custom-efi-app.efi";
+        } ]
+      '';
+      description = ''
+        This option lists files to be copied to fixed locations in the
+        El-Torito boot catalog.
       '';
     };
 
@@ -624,6 +659,26 @@ in
       description = ''
         The grub2 theme used for UEFI boot.
       '';
+    };
+
+    isoImage.grubExtraMenus = lib.mkOption {
+      default = [];
+      type = lib.types.listOf (lib.types.submodule {
+        options.name = lib.mkOption {
+          description = "Label of the option on the GRUB menu.";
+          type = lib.types.str;
+        };
+
+        options.class = lib.mkOption {
+          description = "Class of the option in the GRUB menu (i.e. `settings`)";
+          type = lib.types.str;
+        };
+
+        options.body = lib.mkOption {
+          description = "GRUB script to be executed when the option is selected";
+          type = lib.types.str;
+        };
+      });
     };
 
     isoImage.syslinuxTheme = lib.mkOption {


### PR DESCRIPTION
## Description of changes

Added capability to add custom grub options and modify contents of the Boot Catalog of the iso images produced by the iso-image installer module. This, for example, allows users to create custom, pre-installation, pre-boot routines, such as hardware tests, BIOS updates, etc.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Extensively tested added functionality
- [23.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) (or backporting [23.05 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
