### PR TITLE
nixos/ntfy-sh: clean up DynamicUser workarounds

### DIFF
--- a/nixos/modules/services/misc/ntfy-sh.nix
+++ b/nixos/modules/services/misc/ntfy-sh.nix
@@ -84,12 +84,6 @@ in
         cache-file = mkDefault "/var/lib/ntfy-sh/cache-file.db";
       };
 
-      systemd.tmpfiles.rules = [
-        "f ${cfg.settings.auth-file} 0600 ${cfg.user} ${cfg.group} - -"
-        "d ${cfg.settings.attachment-cache-dir} 0700 ${cfg.user} ${cfg.group} - -"
-        "f ${cfg.settings.cache-file} 0600 ${cfg.user} ${cfg.group} - -"
-      ];
-
       systemd.services.ntfy-sh = {
         description = "Push notifications server";
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -559,6 +559,7 @@ in {
   nscd = handleTest ./nscd.nix {};
   nsd = handleTest ./nsd.nix {};
   ntfy-sh = handleTest ./ntfy-sh.nix {};
+  ntfy-sh-migration = handleTest ./ntfy-sh-migration.nix {};
   nzbget = handleTest ./nzbget.nix {};
   nzbhydra2 = handleTest ./nzbhydra2.nix {};
   oh-my-zsh = handleTest ./oh-my-zsh.nix {};

--- a/nixos/tests/ntfy-sh-migration.nix
+++ b/nixos/tests/ntfy-sh-migration.nix
@@ -1,0 +1,77 @@
+# the ntfy-sh module was switching to DynamicUser=true. this test assures that
+# the migration does not break existing setups.
+#
+# this test works doing a migration and asserting ntfy-sh runs properly. first,
+# ntfy-sh is configured to use a static user and group. then ntfy-sh is
+# started and tested. after that, ntfy-sh is shut down and a systemd drop
+# in configuration file is used to upate the service configuration to use
+# DynamicUser=true. then the ntfy-sh is started again and tested.
+
+import ./make-test-python.nix {
+  name = "ntfy-sh";
+
+  nodes.machine = {
+    lib,
+    pkgs,
+    ...
+  }: {
+    environment.etc."ntfy-sh-dynamic-user.conf".text = ''
+      [Service]
+      Group=new-ntfy-sh
+      User=new-ntfy-sh
+      DynamicUser=true
+    '';
+
+    services.ntfy-sh.enable = true;
+    services.ntfy-sh.settings.base-url = "http://localhost:2586";
+
+    systemd.services.ntfy-sh.serviceConfig = {
+      DynamicUser = lib.mkForce false;
+      ExecStartPre = [
+        "${pkgs.coreutils}/bin/id"
+        "${pkgs.coreutils}/bin/ls -lahd /var/lib/ntfy-sh/"
+        "${pkgs.coreutils}/bin/ls -lah /var/lib/ntfy-sh/"
+      ];
+      Group = lib.mkForce "old-ntfy-sh";
+      User = lib.mkForce "old-ntfy-sh";
+    };
+
+    users.users.old-ntfy-sh = {
+      isSystemUser = true;
+      group = "old-ntfy-sh";
+    };
+
+    users.groups.old-ntfy-sh = {};
+  };
+
+  testScript = ''
+    import json
+
+    msg = "Test notification"
+
+    def test_ntfysh():
+      machine.wait_for_unit("ntfy-sh.service")
+      machine.wait_for_open_port(2586)
+
+      machine.succeed(f"curl -d '{msg}' localhost:2586/test")
+
+      text = machine.succeed("curl -s localhost:2586/test/json?poll=1")
+      for line in text.splitlines():
+        notif = json.loads(line)
+        assert msg == notif["message"], "Wrong message"
+
+      machine.succeed("ntfy user list")
+
+    machine.wait_for_unit("multi-user.target")
+
+    test_ntfysh()
+
+    machine.succeed("systemctl stop ntfy-sh.service")
+    machine.succeed("mkdir -p /run/systemd/system/ntfy-sh.service.d")
+    machine.succeed("cp /etc/ntfy-sh-dynamic-user.conf /run/systemd/system/ntfy-sh.service.d/dynamic-user.conf")
+    machine.succeed("systemctl daemon-reload")
+    machine.succeed("systemctl start ntfy-sh.service")
+
+    test_ntfysh()
+  '';
+}


### PR DESCRIPTION
nixos/ntfy-sh: clean up DynamicUser workarounds

This commit removes the static assignments for the ntfy-sh user and group. Furthermore, it removes some tmpfiles.d rules which where initially put in place by https://github.com/NixOS/nixpkgs/pull/234811. These are however not required, as ntfy-sh will automatically create the required files and systemd automatically handles the migration process. 

A nixosTest is added to demonstrate that the migration is working reliably.

This also fixes an issue with where systemd would sometimes not start ntfy-sh. The tmpfiles rules in combination with impermanence caused `/var/lib/ntfy-sh` to be a directory when it should have been a symlink.

Similar changes have been proposed before. Before opening this PR, I have dug into why they ended up with more complex behavior than I deem necessary.
* https://github.com/NixOS/nixpkgs/pull/234498 in its initial form is similar to this PR in that is simply removes the static user and grou* assignment and enables `DynamicUser`. Later some ExecPreStart commands were added to create files and directories accessed by ntfy-sh. However, ntfy-sh automatically creates these files, which es explicitly confirmed in the [documentation for the auth-file](https://docs.ntfy.sh/config/#access-control) (which I was able to reproduce). I believe the reported error (of a missing database file) which caused these changes to be made was because the configured database file location was inaccessible to ntfy-sh. I was able to confirm that ntfy-sh prints the error message `unable to open database file: no such file or directory ` when the authentication database is inaccessible. This commit was merged and reverted because a user reported their setup was broken by this commit.
* https://github.com/NixOS/nixpkgs/pull/234811 was opened a couple days later	with a similar approach. the same user reported that the migration is still	failing, and this time included a journal log with the error message:
	```
	May 29 16:04:24 sd-02 systemd[1]: Starting Push notifications server...
	May 29 16:04:24 sd-02 (touch)[164053]: Found pre-existing public StateDirectory= directory /var/lib/ntfy-sh, migrating to /var/lib/private/ntfy-sh.
	May 29 16:04:24 sd-02 (touch)[164053]: Apparently, service previously had DynamicUser= turned off, and has now turned it on.
	May 29 16:04:24 sd-02 touch[164053]: /nix/store/l6jgwxkc3jhr029vfzfwzcy28iyckwsj-coreutils-9.1/bin/touch: cannot touch '/var/lib/ntfy/user.db': Permission denied
	May 29 16:04:24 sd-02 systemd[1]: ntfy-sh.service: Control process exited, code=exited, status=1/FAILURE
	May 29 16:04:24 sd-02 systemd[1]: ntfy-sh.service: Failed with result 'exit-code'.
	May 29 16:04:24 sd-02 systemd[1]: Failed to start Push notifications server.
	```
	By looking very closely at the paths, we can see that the error is not entirely caused by the effects of DynamicUser. In line 2 and 3 systemd successfully migrates `/var/lib/ntfy-sh` to `/var/private/ntfy-sh`. In line 4 the file `/var/lib/ntfy/users.db` fails to be created. However, this is not the same path, as the "-sh" is missing from "ntfy-sh". This means that the PR itself was working. However, at the time this difference in the path slipped by unnoticed and the error was assumed to be caused by enabling `DynamicUsers`. The proposed solution was so use systemd-tmpfiles which automatically creates parent directories and is not bound by user permissions.

I hope I have been thorough enough and this PR works as well as I belive it does.

cc @Tom-Hubrecht @JulienMalka @happysalada 

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

