### PR TITLE
aaaaxy: 1.4.119 -> 1.4.137

### DIFF
--- a/pkgs/by-name/aa/aaaaxy/package.nix
+++ b/pkgs/by-name/aa/aaaaxy/package.nix
@@ -2,7 +2,7 @@
 , fetchFromGitHub
 , buildGoModule
 , alsa-lib
-, libglvnd
+, libGL
 , libX11
 , libXcursor
 , libXext
@@ -14,26 +14,27 @@
 , pkg-config
 , zip
 , advancecomp
+, makeWrapper
 , nixosTests
 }:
 
 buildGoModule rec {
   pname = "aaaaxy";
-  version = "1.4.119";
+  version = "1.4.137";
 
   src = fetchFromGitHub {
     owner = "divVerent";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-M+HNYQl53vQZdKn/CyF5OZPyKGq/4A9DPoDV3fRdWMY=";
+    hash = "sha256-noKAf+Xd6yW45+0gtKBlRwCKNGCg7YBbWswOP7clv+M=";
     fetchSubmodules = true;
   };
 
-  vendorHash = "sha256-NoWfCn9P/i/8Xv0w2wqTFG3yoayGzc1TyF02zANP7Rg=";
+  vendorHash = "sha256-ig5ai28PR3VJUoVGexlfP2OMYmKI0qltTot4zIqfdO4=";
 
   buildInputs = [
     alsa-lib
-    libglvnd
+    libGL
     libX11 libXcursor libXext libXi libXinerama libXrandr
     libXxf86vm
   ];
@@ -43,6 +44,7 @@ buildGoModule rec {
     pkg-config
     zip
     advancecomp
+    makeWrapper
   ];
 
   outputs = [ "out" "testing_infra" ];
@@ -56,7 +58,27 @@ buildGoModule rec {
     patchShebangs scripts/
     substituteInPlace scripts/regression-test-demo.sh \
       --replace 'sh scripts/run-timedemo.sh' "$testing_infra/scripts/run-timedemo.sh"
+
+    substituteInPlace Makefile --replace \
+      'CPPFLAGS ?= -DNDEBUG' \
+      'CPPFLAGS ?= -DNDEBUG -D_GLFW_GLX_LIBRARY=\"${lib.getLib libGL}/lib/libGL.so\" -D_GLFW_EGL_LIBRARY=\"${lib.getLib libGL}/lib/libEGL.so\"'
   '';
+
+  overrideModAttrs = (_: {
+    # We can't patch in the path to libGL directly because
+    # this is a fixed output derivation and when the path to libGL
+    # changes, the hash would change.
+    # To work around this, use environment variables.
+    postBuild = ''
+      substituteInPlace 'vendor/github.com/hajimehoshi/ebiten/v2/internal/graphicsdriver/opengl/gl/procaddr_others.go' \
+        --replace \
+        '{"libGL.so", "libGL.so.2", "libGL.so.1", "libGL.so.0"}' \
+        '{os.Getenv("EBITENGINE_LIBGL")}' \
+        --replace \
+        '{"libGLESv2.so", "libGLESv2.so.2", "libGLESv2.so.1", "libGLESv2.so.0"}' \
+        '{os.Getenv("EBITENGINE_LIBGLESv2")}'
+    '';
+  });
 
   makeFlags = [
     "BUILDTYPE=release"
@@ -74,6 +96,10 @@ buildGoModule rec {
     install -Dm644 'aaaaxy.png' -t "$out/share/icons/hicolor/128x128/apps/"
     install -Dm644 'aaaaxy.desktop' -t "$out/share/applications/"
     install -Dm644 'io.github.divverent.aaaaxy.metainfo.xml' -t "$out/share/metainfo/"
+
+    wrapProgram $out/bin/aaaaxy \
+      --set EBITENGINE_LIBGL     '${lib.getLib libGL}/lib/libGL.so' \
+      --set EBITENGINE_LIBGLESv2 '${lib.getLib libGL}/lib/libGLESv2.so'
 
     install -Dm755 'scripts/run-timedemo.sh' -t "$testing_infra/scripts/"
     install -Dm755 'scripts/regression-test-demo.sh' -t "$testing_infra/scripts/"


### PR DESCRIPTION
## Description of changes
https://github.com/divVerent/aaaaxy/releases/tag/v1.4.137


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
