### PR TITLE
fortran tight-binding ecosystem: enable static/dynamic builds depending on hostPlatform

### DIFF
--- a/pkgs/development/libraries/science/chemistry/dftd4/default.nix
+++ b/pkgs/development/libraries/science/chemistry/dftd4/default.nix
@@ -27,10 +27,17 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ blas lapack mctc-lib mstore multicharge ];
 
-  postInstall = ''
-    substituteInPlace $out/lib/pkgconfig/${pname}.pc \
-      --replace "''${prefix}/" ""
+  outputs = [ "out" "dev" ];
+
+  # Fix the Pkg-Config files for doubled store paths
+  postPatch = ''
+    substituteInPlace config/template.pc \
+      --replace "\''${prefix}/" ""
   '';
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
+  ];
 
   doCheck = true;
   preCheck = ''

--- a/pkgs/development/libraries/science/chemistry/mctc-lib/default.nix
+++ b/pkgs/development/libraries/science/chemistry/mctc-lib/default.nix
@@ -22,10 +22,17 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ json-fortran ];
 
-  postInstall = ''
-    substituteInPlace $out/lib/pkgconfig/${pname}.pc \
-      --replace "''${prefix}/" ""
+  outputs = [ "out" "dev" ];
+
+  # Fix the Pkg-Config files for doubled store paths
+  postPatch = ''
+    substituteInPlace config/template.pc \
+      --replace "\''${prefix}/" ""
   '';
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
+  ];
 
   doCheck = true;
 

--- a/pkgs/development/libraries/science/chemistry/mstore/default.nix
+++ b/pkgs/development/libraries/science/chemistry/mstore/default.nix
@@ -21,10 +21,17 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ mctc-lib ];
 
-  postInstall = ''
-    substituteInPlace $out/lib/pkgconfig/${pname}.pc \
-      --replace "''${prefix}/" ""
+  outputs = [ "out" "dev" ];
+
+  # Fix the Pkg-Config files for doubled store paths
+  postPatch = ''
+    substituteInPlace config/template.pc \
+      --replace "\''${prefix}/" ""
   '';
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
+  ];
 
   meta = with lib; {
     description = "Molecular structure store for testing";

--- a/pkgs/development/libraries/science/chemistry/multicharge/default.nix
+++ b/pkgs/development/libraries/science/chemistry/multicharge/default.nix
@@ -26,10 +26,17 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ blas lapack mctc-lib mstore ];
 
-  postInstall = ''
-    substituteInPlace $out/lib/pkgconfig/${pname}.pc \
-      --replace "''${prefix}/" ""
+  outputs = [ "out" "dev" ];
+
+  # Fix the Pkg-Config files for doubled store paths
+  postPatch = ''
+    substituteInPlace config/template.pc \
+      --replace "\''${prefix}/" ""
   '';
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
+  ];
 
   doCheck = true;
   preCheck = ''

--- a/pkgs/development/libraries/science/chemistry/simple-dftd3/default.nix
+++ b/pkgs/development/libraries/science/chemistry/simple-dftd3/default.nix
@@ -26,10 +26,16 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ mctc-lib mstore toml-f blas ];
 
-  postInstall = ''
-    substituteInPlace $out/lib/pkgconfig/s-dftd3.pc \
-      --replace "''${prefix}/" ""
+  outputs = [ "out" "dev" ];
+
+  # Fix the Pkg-Config files for doubled store paths
+  postPatch = ''
+    substituteInPlace config/template.pc \
+      --replace "\''${prefix}/" ""
   '';
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
+  ];
 
   doCheck = true;
   preCheck = ''

--- a/pkgs/development/libraries/science/chemistry/tblite/default.nix
+++ b/pkgs/development/libraries/science/chemistry/tblite/default.nix
@@ -35,6 +35,12 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  # Fix the Pkg-Config files for doubled store paths
+  postPatch = ''
+    substituteInPlace config/template.pc \
+      --replace "\''${prefix}/" ""
+  '';
+
   nativeBuildInputs = [ cmake gfortran ];
 
   buildInputs = [
@@ -48,14 +54,15 @@ stdenv.mkDerivation rec {
     simple-dftd3
   ];
 
+  outputs = [ "out" "dev" ];
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
+  ];
+
   doCheck = true;
   preCheck = ''
     export OMP_NUM_THREADS=2
-  '';
-
-  postInstall = ''
-    substituteInPlace $out/lib/pkgconfig/${pname}.pc \
-      --replace "''${prefix}" ""
   '';
 
   meta = with lib; {

--- a/pkgs/development/libraries/toml-f/default.nix
+++ b/pkgs/development/libraries/toml-f/default.nix
@@ -21,10 +21,17 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ test-drive ];
 
-  postInstall = ''
-    substituteInPlace $out/lib/pkgconfig/${pname}.pc \
-      --replace "''${prefix}/" ""
+  outputs = [ "out" "dev" ];
+
+  # Fix the Pkg-Config files for doubled store paths
+  postPatch = ''
+    substituteInPlace config/template.pc \
+      --replace "\''${prefix}/" ""
   '';
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
+  ];
 
   doCheck = true;
 


### PR DESCRIPTION
## Description of changes

For some reasons the packages of Fortran's ecosystem for tight-binding calculations and computational chemistry default to always static linking, irrespective of the host platform. This PR enables dynamic builds on `!stdenv.hostPlatform.isStatic` platforms.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
