### PR TITLE
newcomputermodern: init at 5.1

### DIFF
--- a/pkgs/by-name/ne/newcomputermodern/package.nix
+++ b/pkgs/by-name/ne/newcomputermodern/package.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenvNoCC
+, fetchgit
+, fontforge
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "newcomputermodern";
+  version = "5.1";
+
+  src = fetchgit {
+    url = "https://git.gnu.org.ua/newcm.git";
+    rev = finalAttrs.version;
+    hash = "sha256-a6paSdF754jCp4DePbx2in9316H9EjyrAKOQpyc3hEo=";
+  };
+
+  nativeBuildInputs = [ fontforge ];
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+    for i in sfd/*.sfd; do
+      fontforge -lang=ff -c \
+        'Open($1);
+        Generate($1:r + ".otf");
+        ' $i;
+    done
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -m444 -Dt $out/share/fonts/opentype/public sfd/*.otf
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Computer Modern fonts including matching non-latin alphabets";
+    homepage = "https://ctan.org/pkg/newcomputermodern";
+    # "The GUST Font License (GFL), which is a free license, legally
+    # equivalent to the LaTeX Project Public License (LPPL), version 1.3c or
+    # later." - GUST website
+    license = lib.licenses.lppl13c;
+    maintainers = [ lib.maintainers.drupol ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Lately, I've been discussing with Antonis, the author of New Computer Modern fonts.
From now on and since version 5.02, a git repository is available. There's no need to rely on CTAN URLs anymore to download the fonts, it's now built from the sources! \o/

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
