### PR TITLE
proj-data: init at 1.16.0

### DIFF
--- a/pkgs/by-name/pr/proj-data/package.nix
+++ b/pkgs/by-name/pr/proj-data/package.nix
@@ -1,0 +1,73 @@
+{ lib
+, stdenv
+, callPackage
+, fetchFromGitHub
+
+  # proj-data grid directories to install (ex.: "nz_linz").
+  # By default, no grids are installed due to the large size (size of all proj-
+  # data grids is nearly 1GB and will grow over the time).
+, gridPackages ? [ ]
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "proj-data";
+  version = "1.16.0";
+
+  src = fetchFromGitHub {
+    owner = "OSGeo";
+    repo = "PROJ-data";
+    rev = finalAttrs.version;
+    hash = "sha256-/EgDeWy2+KdcI4DLsRfWi5OWcGwO3AieEJQ5Zh+wdYE=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    shopt -s extglob
+
+    mkdir -p $out
+    cp README.DATA $out/README-PROJ-DATA.md
+
+    for grid in ${builtins.toString gridPackages}; do
+      if [ ! -d $grid ]; then
+        echo "ERROR: Grid ($grid) does not exist." >&2
+        exit 1
+      fi
+
+      cp $grid/!(*.sh|*.py) $out/
+    done
+
+    shopt -u extglob
+    runHook postInstall
+  '';
+
+  passthru.tests =
+    let
+      # build custom package containing `nz_linz` grids
+      projDataWithGrid = finalAttrs.finalPackage.overrideAttrs (_: {
+        postInstall = "cp nz_linz/* $out/";
+      });
+    in
+    {
+      proj-data = callPackage ./tests.nix {
+        proj-data = projDataWithGrid;
+      };
+    };
+
+  meta = with lib; {
+    description = "Repository for proj datum grids (for use by PROJ 7 or later)";
+    homepage = "https://proj4.org";
+    # Licensing note:
+    # All grids in the package are released under permissive licenses. New grids
+    # are accepted into the package as long as they are released under a license that
+    # is compatible with the Open Source Definition and the source of the grid is
+    # clearly stated and verifiable. Suitable licenses include:
+    # Public domain
+    # X/MIT
+    # BSD 2/3/4 clause
+    # CC0
+    # CC-BY (v3.0 or later)
+    # CC-BY-SA (v3.0 or later)
+    license = licenses.mit;
+    maintainers = teams.geospatial.members;
+  };
+})

--- a/pkgs/by-name/pr/proj-data/tests.nix
+++ b/pkgs/by-name/pr/proj-data/tests.nix
@@ -1,0 +1,25 @@
+{ runCommand, proj, proj-data }:
+
+let
+  inherit (proj-data) pname;
+in
+runCommand "${pname}-tests" { meta.timeout = 60; }
+  ''
+    set -o pipefail
+
+    # add proj-data files to proj resources search path
+    export PROJ_DATA=${proj}/share/proj:${proj-data}
+
+    # conversion from NZGD1949 to NZGD2000 using proj strings
+    echo '173 -41 0' \
+      | ${proj}/bin/cs2cs --only-best -f %.8f \
+        +proj=longlat +ellps=intl +datum=nzgd49 +nadgrids=nz_linz_nzgd2kgrid0005.tif \
+        +to +proj=longlat +ellps=GRS80 +towgs84=0,0,0 \
+      | grep -E '[0-9\.\-]+*'
+
+    # conversion from NZGD1949 to NZGD2000 using EPSG codes
+    echo '-41 173 0' | ${proj}/bin/cs2cs --only-best -f %.8f EPSG:4272 EPSG:4167 \
+      | grep -E '[0-9\.\-]+*'
+
+    touch $out
+  ''

--- a/pkgs/development/libraries/proj/default.nix
+++ b/pkgs/development/libraries/proj/default.nix
@@ -1,11 +1,14 @@
 { lib
 , stdenv
+, callPackage
 , fetchFromGitHub
-, fetchpatch
+
+# install grid resource files from proj-data package
+, withProjData ? false
+
 , cmake
 , pkg-config
 , buildPackages
-, callPackage
 , sqlite
 , libtiff
 , curl
@@ -13,6 +16,7 @@
 , nlohmann_json
 , python3
 , cacert
+, proj-data
 }:
 
 stdenv.mkDerivation (finalAttrs: rec {
@@ -57,6 +61,10 @@ stdenv.mkDerivation (finalAttrs: rec {
       '';
 
   doCheck = true;
+
+  postInstall = lib.optionalString withProjData ''
+    cp --recursive ${proj-data}/* $out/share/proj/
+  '';
 
   passthru.tests = {
     python = python3.pkgs.pyproj;


### PR DESCRIPTION
## Description of changes

* add initial version of `proj-data` package containing datum grid resource files for `proj`
package
* add optional support for installing `proj-data` grid resource files in `proj` data directory

AFAIK, installation of `proj-data` resource files in `proj` directory is the only user-friendly way of enabling them for all programs using `proj`. Another alternative methods are:

* setting `PROJ_DATA` variable to `${proj}/share/proj:${proj-data}` (see `proj-data` package tests)
* adding them to user home directories

which can be very tricky for other applications using `proj` in containers or multi-user environments and can be error-prone.
For more information, see: https://proj.org/en/9.3/resource_files.html

Installation of `proj-data` files to `proj` is optional, because `proj-data` repository size is large (can reach 1GB of size soon) and it avoids downloading it when building `proj` package version where `proj-data` is not needed. 

### Example usage
* Example of building proj package containing `proj-data` grids provided by `nz_linz`:
```
$ nix-build -E 'with import ./. {}; proj.override { proj-data = proj-data.override { gridPackages = ["nz_linz"]; };  withProjData = true; }'

ls ./result/share/proj
CH                               nz_linz_nzgd2000-20130801.json           nz_linz_nzgd2000-ka20161114-grid02.tif   nz_linz_nzgd2000-ndm-grid01.tif
deformation_model.schema.json    nz_linz_nzgd2000-20140201.json           nz_linz_nzgd2000-ka20161114-grid03.tif   nz_linz_nzgd2000-ndm-grid02.tif
GL27                             nz_linz_nzgd2000-20150101.json           nz_linz_nzgd2000-ka20161114-grid04.tif   nz_linz_nzgd2000-si20030821-grid01.tif
ITRF2000                         nz_linz_nzgd2000-20160701.json           nz_linz_nzgd2000-ka20161114-grid05.tif   nz_linz_nzgd2kgrid0005.tif
ITRF2008                         nz_linz_nzgd2000-20171201.json           nz_linz_nzgd2000-ka20161114-grid06.tif   nz_linz_nzgeoid2009.tif
ITRF2014                         nz_linz_nzgd2000-20180701.json           nz_linz_nzgd2000-ka20161114-grid07.tif   nz_linz_nzgeoid2016.tif
nad27                            nz_linz_nzgd2000-c120100904-grid01.tif   nz_linz_nzgd2000-ka20161114-grid08.tif   nz_linz_ontpht1964-nzvd2016.tif
nad83                            nz_linz_nzgd2000-c220110222-grid01.tif   nz_linz_nzgd2000-ka20161114-grid09.tif   nz_linz_README.txt
nad.lst                          nz_linz_nzgd2000-c320110613-grid01.tif   nz_linz_nzgd2000-ka20161114-grid10.tif   nz_linz_stisht1977-nzvd2016.tif
nz_linz_auckht1946-nzvd2016.tif  nz_linz_nzgd2000-c420111223-grid01.tif   nz_linz_nzgd2000-ka20161114-grid11.tif   nz_linz_taraht1970-nzvd2016.tif
nz_linz_blufht1955-nzvd2016.tif  nz_linz_nzgd2000-ch20160214-grid01.tif   nz_linz_nzgd2000-ka20161114-grid12.tif   nz_linz_wellht1953-nzvd2016.tif
nz_linz_dublht1960-nzvd2016.tif  nz_linz_nzgd2000-cs20130721-grid01.tif   nz_linz_nzgd2000-lg20130816-grid01.tif   other.extra
nz_linz_duneht1958-nzvd2016.tif  nz_linz_nzgd2000-cs20130721-grid02.tif   nz_linz_nzgd2000-lg20130816-grid02.tif   proj.db
nz_linz_gisbht1926-nzvd2016.tif  nz_linz_nzgd2000-ds20090715-grid011.tif  nz_linz_nzgd2000-mq20041223-grid011.tif  proj.ini
nz_linz_lyttht1937-nzvd2016.tif  nz_linz_nzgd2000-ds20090715-grid012.tif  nz_linz_nzgd2000-mq20041223-grid012.tif  projjson.schema.json
nz_linz_motuht1953-nzvd2016.tif  nz_linz_nzgd2000-ds20090715-grid013.tif  nz_linz_nzgd2000-mq20041223-grid013.tif  README-PROJ-DATA.md
nz_linz_napiht1962-nzvd2016.tif  nz_linz_nzgd2000-ds20090715-grid014.tif  nz_linz_nzgd2000-mq20041223-grid014.tif  triangulation.schema.json
nz_linz_nelsht1955-nzvd2016.tif  nz_linz_nzgd2000-gs20071016-grid01.tif   nz_linz_nzgd2000-mq20041223-grid015.tif  world
nz_linz_nzgd2000-20000101.json   nz_linz_nzgd2000-ka20161114-grid01.tif   nz_linz_nzgd2000-mq20041223-grid016.tif
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
