### PR TITLE
cudaPackages: move .pc to hook-defined location

### DIFF
--- a/pkgs/development/cuda-modules/generic-builders/manifest.nix
+++ b/pkgs/development/cuda-modules/generic-builders/manifest.nix
@@ -26,6 +26,7 @@
   redistribRelease,
   # See ./modules/generic/manifests/feature/release.nix
   featureRelease,
+  cudaMajorMinorVersion,
 }:
 let
   inherit (lib)
@@ -96,7 +97,7 @@ backendStdenv.mkDerivation (
     outputToPatterns = {
       bin = [ "bin" ];
       dev = [
-        "share/pkg-config"
+        "share/pkgconfig"
         "**/*.pc"
         "**/*.cmake"
       ];
@@ -121,21 +122,33 @@ backendStdenv.mkDerivation (
       inherit (redistribRelease.${redistArch}) sha256;
     };
 
+    # Handle the pkg-config files:
+    # 1. No FHS
+    # 2. Location expected by the pkg-config wrapper
+    # 3. Generate unversioned names too
     postPatch = ''
-      if [[ -d pkg-config ]] ; then
-        mkdir -p share/pkg-config
-        mv pkg-config/* share/pkg-config/
-        rmdir pkg-config
-      fi
+      for path in pkg-config pkgconfig ; do
+        [[ -d "$path" ]] || continue
+        mkdir -p share/pkgconfig
+        mv "$path"/* share/pkgconfig/
+        rmdir "$path"
+      done
 
-      for pc in share/pkg-config/*.pc ; do
+      for pc in share/pkgconfig/*.pc ; do
         sed -i \
           -e "s|^cudaroot\s*=.*\$|cudaroot=''${!outputDev}|" \
           -e "s|^libdir\s*=.*/lib\$|libdir=''${!outputLib}/lib|" \
           -e "s|^includedir\s*=.*/include\$|includedir=''${!outputDev}/include|" \
           "$pc"
       done
+
+      # E.g. cuda-11.8.pc -> cuda.pc
+      for pc in share/pkgconfig/*-"$majorMinorVersion.pc" ; do
+        ln -s "$(basename "$pc")" "''${pc%-$majorMinorVersion.pc}".pc
+      done
     '';
+
+    env.majorMinorVersion = cudaMajorMinorVersion;
 
     # We do need some other phases, like configurePhase, so the multiple-output setup hook works.
     dontBuild = true;


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
