### PR TITLE
apptainer: unbreak --nv (userns+nvliblist.conf variant)

### DIFF
--- a/nixos/modules/programs/singularity.nix
+++ b/nixos/modules/programs/singularity.nix
@@ -61,7 +61,12 @@ in
     };
     enableSuid = mkOption {
       type = types.bool;
-      default = true;
+      # SingularityCE requires SETUID for most things. Apptainer prefers user
+      # namespaces, e.g. `apptainer exec --nv` would fail if built
+      # `--with-suid`:
+      # > `FATAL: nvidia-container-cli not allowed in setuid mode`
+      default = cfg.package.projectName != "apptainer";
+      defaultText = literalExpression ''config.services.singularity.package.projectName != "apptainer"'';
       example = false;
       description = mdDoc ''
         Whether to enable the SUID support of Singularity/Apptainer.

--- a/pkgs/applications/virtualization/singularity/apptainer/0001-ldCache-patch-for-driverLink.patch
+++ b/pkgs/applications/virtualization/singularity/apptainer/0001-ldCache-patch-for-driverLink.patch
@@ -1,0 +1,84 @@
+From 783ec26c0d83013baf04579a6a415d7f8776ac93 Mon Sep 17 00:00:00 2001
+From: Someone Serge <sergei.kozlukov@aalto.fi>
+Date: Sun, 7 Jan 2024 11:48:24 +0000
+Subject: [PATCH] ldCache(): patch for @driverLink@
+
+---
+ internal/pkg/util/paths/resolve.go | 41 +++++++++++++++++++++++++++---
+ 1 file changed, 38 insertions(+), 3 deletions(-)
+
+diff --git a/internal/pkg/util/paths/resolve.go b/internal/pkg/util/paths/resolve.go
+index db45d9db1..9d0110b6b 100644
+--- a/internal/pkg/util/paths/resolve.go
++++ b/internal/pkg/util/paths/resolve.go
+@@ -14,6 +14,7 @@ import (
+ 	"fmt"
+ 	"os"
+ 	"os/exec"
++	"path"
+ 	"path/filepath"
+ 	"regexp"
+ 	"strings"
+@@ -154,14 +155,49 @@ func Resolve(fileList []string) ([]string, []string, error) {
+ // lists three variants of libEGL.so.1 that are in different locations, we only
+ // report the first, highest priority, variant.
+ func ldCache() (map[string]string, error) {
++    driverDirs := strings.Split("@driverLink@/lib", ":")
++    if machine, err := elfMachine(); err == nil && machine == elf.EM_386 {
++        driverDirs = strings.Split("@driverLink@-32/lib", ":")
++    }
++
++    soPattern, err := regexp.Compile(`[^\s]+\.so(\.\d+(\.\d+(\.\d+)?)?)?$`)
++    if err != nil {
++		return nil, fmt.Errorf("could not compile ldconfig regexp: %v", err)
++    }
++
++	ldCache := make(map[string]string)
++    for _, dirPath := range driverDirs {
++        dir, err := os.Open(dirPath)
++        if err != nil {
++            /* Maybe we're not running under NixOS */
++            continue
++        }
++        files, err := dir.ReadDir(-1)
++        if err != nil {
++            continue
++        }
++        for _, f := range files {
++            if !soPattern.MatchString(f.Name()) {
++                continue
++            }
++            libName := f.Name()
++            libPath := path.Join(dirPath, f.Name())
++			if _, ok := ldCache[libName]; !ok {
++				ldCache[libName] = libPath
++			}
++        }
++    }
++
+ 	// walk through the ldconfig output and add entries which contain the filenames
+ 	// returned by nvidia-container-cli OR the nvliblist.conf file contents
+ 	ldconfig, err := bin.FindBin("ldconfig")
+-	if err != nil {
++	if err != nil && len(ldCache) == 0 {
++        // Note that missing ldconfig is only an "error" as long
++        // as there's no driverLink
+ 		return nil, err
+ 	}
+ 	out, err := exec.Command(ldconfig, "-p").Output()
+-	if err != nil {
++	if err != nil && len(ldCache) == 0 {
+ 		return nil, fmt.Errorf("could not execute ldconfig: %v", err)
+ 	}
+ 
+@@ -173,7 +209,6 @@ func ldCache() (map[string]string, error) {
+ 	}
+ 
+ 	// store library name with associated path
+-	ldCache := make(map[string]string)
+ 	for _, match := range r.FindAllSubmatch(out, -1) {
+ 		if match != nil {
+ 			// libName is the "libnvidia-ml.so.1" (from the above example)
+-- 
+2.42.0
+

--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -33,6 +33,7 @@ in
 , which
   # Build inputs
 , bash
+, callPackage
 , conmon
 , coreutils
 , cryptsetup
@@ -270,6 +271,39 @@ in
         contents = [ hello cowsay ];
         singularity = finalAttrs.finalPackage;
       };
+    };
+    gpuChecks = lib.optionalAttrs (projectName == "apptainer") {
+      # Should be in tests, but Ofborg would skip image-hello-cowsay because
+      # saxpy is unfree.
+      image-saxpy = callPackage
+        ({ singularity-tools, cudaPackages }:
+          singularity-tools.buildImage {
+            name = "saxpy";
+            contents = [ cudaPackages.saxpy ];
+            memSize = 2048;
+            diskSize = 2048;
+            singularity = finalAttrs.finalPackage;
+          })
+        { };
+      saxpy =
+        callPackage
+          ({ runCommand, writeShellScriptBin }:
+            let
+              unwrapped = writeShellScriptBin "apptainer-cuda-saxpy"
+                ''
+                  ${lib.getExe finalAttrs.finalPackage} exec --nv $@ ${finalAttrs.passthru.gpuChecks.image-saxpy} saxpy
+                '';
+            in
+            runCommand "run-apptainer-cuda-saxpy"
+              {
+                requiredSystemFeatures = [ "cuda" ];
+                nativeBuildInputs = [ unwrapped ];
+                passthru = { inherit unwrapped; };
+              }
+              ''
+                apptainer-cuda-saxpy
+              '')
+          { };
     };
   };
 })

--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -175,11 +175,18 @@ in
     if [[ ! -e .git || ! -e VERSION ]]; then
       echo "${version}" > VERSION
     fi
+
     # Patch shebangs for script run during build
     patchShebangs --build "$configureScript" makeit e2e scripts mlocal/scripts
+
     # Patching the hard-coded defaultPath by prefixing the packages in defaultPathInputs
     substituteInPlace cmd/internal/cli/actions.go \
       --replace "defaultPath = \"${defaultPathOriginal}\"" "defaultPath = \"''${defaultPathInputs// /\/bin:}''${defaultPathInputs:+/bin:}${defaultPathOriginal}\""
+
+    substituteInPlace internal/pkg/util/gpu/nvidia.go \
+      --replace \
+        'return fmt.Errorf("/usr/bin not writable in the container")' \
+        ""
   '';
 
   postConfigure = ''

--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -27,6 +27,7 @@ in
 , buildGoModule
 , runCommandLocal
   # Native build inputs
+, addDriverRunpath
 , makeWrapper
 , pkg-config
 , util-linux
@@ -55,6 +56,9 @@ in
 , hello
   # Overridable configurations
 , enableNvidiaContainerCli ? true
+  # --nvccli currently requires extra privileges:
+  # https://github.com/apptainer/apptainer/issues/1893#issuecomment-1881240800
+, forceNvcCli ? false
   # Compile with seccomp support
   # SingularityCE 3.10.0 and above requires explicit --without-seccomp when libseccomp is not available.
 , enableSeccomp ? true
@@ -66,6 +70,7 @@ in
   # Whether to compile with SUID support
 , enableSuid ? false
 , starterSuidPath ? null
+, substituteAll
   # newuidmapPath and newgidmapPath are to support --fakeroot
   # where those SUID-ed executables are unavailable from the FHS system PATH.
   # Path to SUID-ed newuidmap executable
@@ -94,6 +99,10 @@ let
 in
 (buildGoModule {
   inherit pname version src;
+
+  patches = lib.optionals (projectName == "apptainer") [
+    (substituteAll { src = ./apptainer/0001-ldCache-patch-for-driverLink.patch; inherit (addDriverRunpath) driverLink; })
+  ];
 
   # Override vendorHash with the output got from
   # nix-prefetch -E "{ sha256 }: ((import ./. { }).apptainer.override { vendorHash = sha256; }).goModules"
@@ -220,7 +229,7 @@ in
     wrapProgram "$out/bin/${projectName}" \
       --prefix PATH : "''${defaultPathInputs// /\/bin:}''${defaultPathInputs:+/bin:}"
     # Make changes in the config file
-    ${lib.optionalString enableNvidiaContainerCli ''
+    ${lib.optionalString forceNvcCli ''
       substituteInPlace "$out/etc/${projectName}/${projectName}.conf" \
         --replace "use nvidia-container-cli = no" "use nvidia-container-cli = yes"
     ''}
@@ -291,7 +300,7 @@ in
             let
               unwrapped = writeShellScriptBin "apptainer-cuda-saxpy"
                 ''
-                  ${lib.getExe finalAttrs.finalPackage} exec --nv $@ ${finalAttrs.passthru.gpuChecks.image-saxpy} saxpy
+                  ${lib.getExe finalAttrs.finalPackage} exec --nv $@ ${finalAttrs.passthru.tests.image-saxpy} saxpy
                 '';
             in
             runCommand "run-apptainer-cuda-saxpy"

--- a/pkgs/development/cuda-modules/saxpy/default.nix
+++ b/pkgs/development/cuda-modules/saxpy/default.nix
@@ -36,7 +36,9 @@ backendStdenv.mkDerivation {
   buildInputs =
     lib.optionals (lib.versionOlder cudaVersion "11.4") [cudatoolkit]
     ++ lib.optionals (lib.versionAtLeast cudaVersion "11.4") [
-      libcublas
+      libcublas.dev
+      libcublas.lib
+      libcublas.static
       cuda_cudart
     ]
     ++ lib.optionals (lib.versionAtLeast cudaVersion "12.0") [cuda_cccl];


### PR DESCRIPTION
## Description of changes

Supersedes (the apptainer part of) https://github.com/NixOS/nixpkgs/pull/279235 whose scope grew out of control


CC @misumisumi @ShamrockLee I'm going to merge as soon as Ofborg is green, unless there are any objections

Closes https://github.com/NixOS/nixpkgs/issues/230851

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
