### PR TITLE
readline: Cleanup for staging

### DIFF
--- a/pkgs/development/libraries/readline/8.2.nix
+++ b/pkgs/development/libraries/readline/8.2.nix
@@ -1,4 +1,10 @@
-{ fetchurl, stdenv, lib, ncurses
+{ lib, stdenv
+, fetchpatch, fetchurl
+, ncurses, termcap
+, curses-library ?
+    if stdenv.hostPlatform.isWindows
+    then termcap
+    else ncurses
 }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +19,7 @@ stdenv.mkDerivation rec {
   outputs = [ "out" "dev" "man" "doc" "info" ];
 
   strictDeps = true;
-  propagatedBuildInputs = [ ncurses ];
+  propagatedBuildInputs = [ curses-library ];
 
   patchFlags = [ "-p0" ];
 
@@ -27,11 +33,38 @@ stdenv.mkDerivation rec {
      in
        import ./readline-8.2-patches.nix patch);
 
-  patches =
-    [ ./link-against-ncurses.patch
-      ./no-arch_only-8.2.patch
-    ]
-    ++ upstreamPatches;
+  patches = lib.optionals (curses-library.pname == "ncurses") [
+    ./link-against-ncurses.patch
+  ] ++ [
+    ./no-arch_only-8.2.patch
+  ]
+  ++ upstreamPatches
+  ++ lib.optionals stdenv.hostPlatform.isWindows [
+    (fetchpatch {
+      name = "0001-sigwinch.patch";
+      url = "https://github.com/msys2/MINGW-packages/raw/90e7536e3b9c3af55c336d929cfcc32468b2f135/mingw-w64-readline/0001-sigwinch.patch";
+      stripLen = 1;
+      hash = "sha256-sFK6EJrSNl0KLWqFv5zBXaQRuiQoYIZVoZfa8BZqfKA=";
+    })
+    (fetchpatch {
+      name = "0002-event-hook.patch";
+      url = "https://github.com/msys2/MINGW-packages/raw/3476319d2751a676b911f3de9e1ec675081c03b8/mingw-w64-readline/0002-event-hook.patch";
+      stripLen = 1;
+      hash = "sha256-F8ytYuIjBtH83ZCJdf622qjwSw+wZEVyu53E/mPsoAo=";
+    })
+    (fetchpatch {
+      name = "0003-fd_set.patch";
+      url = "https://github.com/msys2/MINGW-packages/raw/35830ab27e5ed35c2a8d486961ab607109f5af50/mingw-w64-readline/0003-fd_set.patch";
+      stripLen = 1;
+      hash = "sha256-UiaXZRPjKecpSaflBMCphI2kqOlcz1JkymlCrtpMng4=";
+    })
+    (fetchpatch {
+      name = "0004-locale.patch";
+      url = "https://github.com/msys2/MINGW-packages/raw/f768c4b74708bb397a77e3374cc1e9e6ef647f20/mingw-w64-readline/0004-locale.patch";
+      stripLen = 1;
+      hash = "sha256-dk4343KP4EWXdRRCs8GRQlBgJFgu1rd79RfjwFD/nJc=";
+    })
+  ];
 
   meta = with lib; {
     description = "Library for interactive line editing";
@@ -57,7 +90,7 @@ stdenv.mkDerivation rec {
 
     maintainers = with maintainers; [ dtzWill ];
 
-    platforms = platforms.unix;
+    platforms = platforms.unix ++ platforms.windows;
     branch = "8.2";
   };
 }

--- a/pkgs/development/libraries/readline/8.2.nix
+++ b/pkgs/development/libraries/readline/8.2.nix
@@ -33,38 +33,37 @@ stdenv.mkDerivation rec {
      in
        import ./readline-8.2-patches.nix patch);
 
-  patches = lib.optionals (curses-library.pname == "ncurses") [
-    ./link-against-ncurses.patch
-  ] ++ [
+  patches = upstreamPatches ++ [
     ./no-arch_only-8.2.patch
-  ]
-  ++ upstreamPatches
-  ++ lib.optionals stdenv.hostPlatform.isWindows [
     (fetchpatch {
       name = "0001-sigwinch.patch";
-      url = "https://github.com/msys2/MINGW-packages/raw/90e7536e3b9c3af55c336d929cfcc32468b2f135/mingw-w64-readline/0001-sigwinch.patch";
+      url = "https://github.com/msys2/MINGW-packages/raw/b81ea935fc1d885134d4ff5463f639f10e34a29e/mingw-w64-readline/0001-sigwinch.patch";
       stripLen = 1;
       hash = "sha256-sFK6EJrSNl0KLWqFv5zBXaQRuiQoYIZVoZfa8BZqfKA=";
     })
     (fetchpatch {
       name = "0002-event-hook.patch";
-      url = "https://github.com/msys2/MINGW-packages/raw/3476319d2751a676b911f3de9e1ec675081c03b8/mingw-w64-readline/0002-event-hook.patch";
+      url = "https://github.com/msys2/MINGW-packages/raw/b81ea935fc1d885134d4ff5463f639f10e34a29e/mingw-w64-readline/0002-event-hook.patch";
       stripLen = 1;
-      hash = "sha256-F8ytYuIjBtH83ZCJdf622qjwSw+wZEVyu53E/mPsoAo=";
+      hash = "sha256-zJo/7Id0mizyBCYFeGGoZj3r+qPOcdYZvjVz5nc+02k=";
     })
     (fetchpatch {
       name = "0003-fd_set.patch";
-      url = "https://github.com/msys2/MINGW-packages/raw/35830ab27e5ed35c2a8d486961ab607109f5af50/mingw-w64-readline/0003-fd_set.patch";
+      url = "https://github.com/msys2/MINGW-packages/raw/b81ea935fc1d885134d4ff5463f639f10e34a29e/mingw-w64-readline/0003-fd_set.patch";
       stripLen = 1;
       hash = "sha256-UiaXZRPjKecpSaflBMCphI2kqOlcz1JkymlCrtpMng4=";
     })
     (fetchpatch {
       name = "0004-locale.patch";
-      url = "https://github.com/msys2/MINGW-packages/raw/f768c4b74708bb397a77e3374cc1e9e6ef647f20/mingw-w64-readline/0004-locale.patch";
+      url = "https://github.com/msys2/MINGW-packages/raw/b81ea935fc1d885134d4ff5463f639f10e34a29e/mingw-w64-readline/0004-locale.patch";
       stripLen = 1;
       hash = "sha256-dk4343KP4EWXdRRCs8GRQlBgJFgu1rd79RfjwFD/nJc=";
     })
+  ] ++ lib.optionals (curses-library.pname == "ncurses") [
+    ./link-against-ncurses.patch
   ];
+
+  enableParallelBuilding = true;
 
   meta = with lib; {
     description = "Library for interactive line editing";


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

We clean up #280099 by making the the mingw patches unconditional, using the slight modifications to one patch in https://github.com/msys2/MINGW-packages/pull/19701 to do so.

This is a separate commit so so #280099 can go to master right away.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
