### PR TITLE
rlottie: Switch to CMake

### DIFF
--- a/pkgs/development/libraries/rlottie/default.nix
+++ b/pkgs/development/libraries/rlottie/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , fetchpatch
-, meson
+, cmake
 , ninja
 , pkg-config
 }:
@@ -26,7 +26,11 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ meson ninja pkg-config ];
+  nativeBuildInputs = [ cmake ninja pkg-config ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "LIB_INSTALL_DIR" "${placeholder "out"}/lib")
+  ];
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString (stdenv.isDarwin && stdenv.isAarch64) "-U__ARM_NEON__";
 


### PR DESCRIPTION
## Description of changes

I've encountered a project which tries to use rlottie's CMake module, which appears to be missing:

```
CMake Error at CMakeLists.txt:22 (find_package):
  By not providing "Findrlottie.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "rlottie", but
  CMake did not find one.

  Could not find a package configuration file provided by "rlottie" with any
  of the following names:

    rlottieConfig.cmake
    rlottie-config.cmake

  Add the installation prefix of "rlottie" to CMAKE_PREFIX_PATH or set
  "rlottie_DIR" to a directory containing one of the above files.  If
  "rlottie" provides a separate development package or SDK, be sure it has
  been installed.
```

The meson script has [code for generating parts of the module](https://github.com/Samsung/rlottie/blob/bf3d272df3916a0c34575ac8286cb0fe672fd0d4/meson.build#L76-L94), but it seems to be missing code for generating [the targets file the config is expecting](https://github.com/Samsung/rlottie/blob/bf3d272df3916a0c34575ac8286cb0fe672fd0d4/cmake/rlottieConfig.cmake.in#L13).

```
CMake Error at /nix/store/jh2j6l7yfmz1yqbvkdkj4b0rhq789gr4-rlottie-0.2/lib/cmake/rlottie/rlottieConfig.cmake:13 (include):
  include could not find requested file:

    /nix/store/jh2j6l7yfmz1yqbvkdkj4b0rhq789gr4-rlottie-0.2/lib/cmake/rlottie/rlottieTargets.cmake
```
```
↪ ll /nix/store/jh2j6l7yfmz1yqbvkdkj4b0rhq789gr4-rlottie-0.2/lib/cmake/rlottie/
insgesamt 8,0K
dr-xr-xr-x 2 root root   67  1. Jan 1970  .
dr-xr-xr-x 3 root root   21  1. Jan 1970  ..
-r--r--r-- 1 root root  546  1. Jan 1970  rlottieConfig.cmake
-r--r--r-- 1 root root 1,4K  1. Jan 1970  rlottieConfigVersion.cmake
```

The CMake config module only seems to be generated properly when using CMake. I lack the meson skills to know how one would solve this within the meson code, so I'd like to propose this switch to CMake.

Result works fine in some not-yet-upstreamed packages ([rlottie-qml](https://gitlab.com/mymike00/rlottie-qml) builds but has no binaries -> [teleports](https://gitlab.com/ubports/development/apps/teleports) uses it and works fine), `nixpkgs-review rev HEAD` passes & `telegram-desktop` at least launches fine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
