### PR TITLE
git-lfs: 3.4.1 -> cd04b35

### DIFF
--- a/pkgs/applications/version-management/git-lfs/default.nix
+++ b/pkgs/applications/version-management/git-lfs/default.nix
@@ -2,23 +2,26 @@
 
 buildGoModule rec {
   pname = "git-lfs";
-  version = "3.4.1";
+  # Inclues git compatibility fixes which are in master, but no official release
+  version = "unstable-2023-01-10";
+  # This is the commit hash on the upstream repo, used for vendoring
+  upstreamVersion = "cd04b35";
 
   src = fetchFromGitHub {
     owner = "git-lfs";
     repo = "git-lfs";
-    rev = "v${version}";
-    hash = "sha256-XqxkNCC2yzUTVOi/1iDsnxtLkw4jfQuBh9UsjtZ1zVc=";
+    rev = "cd04b3598344a57d22cd5e6ce2658a719de848e3";
+    hash = "sha256-JHfTge+vmjNKkbBeICaJ9srGSNdPIV8fPS9Xs8WSDMs=";
   };
 
-  vendorHash = "sha256-VmPeQYWOHFqFLHKcKH3WHz50yx7GMHVIDPzqiVwwjSg=";
+  vendorHash = "sha256-N8HB2qwBxjzfNucftHxmX2W9srCx62pjmkCWzwiCj/I=";
 
   nativeBuildInputs = [ asciidoctor installShellFiles ];
 
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/git-lfs/git-lfs/v${lib.versions.major version}/config.Vendor=${version}"
+    "-X github.com/git-lfs/git-lfs/v${lib.versions.major upstreamVersion}/config.Vendor=${upstreamVersion}"
   ];
 
   subPackages = [ "." ];


### PR DESCRIPTION
## Description of changes
Latest git-lfs includes a [patch](https://github.com/git-lfs/git-lfs/pull/5357) that fixes `builtins.fetchGit` for lfs-enabled repos.
I think that patch is especially useful for nix users. git-lfs, being a mature project, releases fairly slowly, so I'd like to point nixpkgs at tip of git-lfs `main` for the time being.

## Things done
Bumped git-lfs from `v3.4.1` to `cd04b35`
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
