### PR TITLE
ranger: 1.9.3 -> 1.9.3-unstable-2023-08-23

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -353,6 +353,9 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 - New options were added to the dnsdist module to enable and configure a DNSCrypt endpoint (see `services.dnsdist.dnscrypt.enable`, etc.).
   The module can generate the DNSCrypt provider key pair, certificates and also performs their rotation automatically with no downtime.
 
+- The ranger file manager was updated from the latest release (which is a few
+  years old) to a more current revision from master.
+
 - With a bump to `sonarr` v4, existing config database files will be upgraded automatically, but note that some old apparently-working configs [might actually be corrupt and fail to upgrade cleanly](https://forums.sonarr.tv/t/sonarr-v4-released/33089).
 
 - The Yama LSM is now enabled by default in the kernel, which prevents ptracing

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -353,9 +353,6 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 - New options were added to the dnsdist module to enable and configure a DNSCrypt endpoint (see `services.dnsdist.dnscrypt.enable`, etc.).
   The module can generate the DNSCrypt provider key pair, certificates and also performs their rotation automatically with no downtime.
 
-- The ranger file manager was updated from the latest release (which is a few
-  years old) to a more current revision from master.
-
 - With a bump to `sonarr` v4, existing config database files will be upgraded automatically, but note that some old apparently-working configs [might actually be corrupt and fail to upgrade cleanly](https://forums.sonarr.tv/t/sonarr-v4-released/33089).
 
 - The Yama LSM is now enabled by default in the kernel, which prevents ptracing

--- a/pkgs/applications/file-managers/ranger/default.nix
+++ b/pkgs/applications/file-managers/ranger/default.nix
@@ -1,5 +1,6 @@
-{ lib, fetchFromGitHub, python3Packages, file, less, highlight, w3m, ranger, testers
+{ lib, fetchFromGitHub, python3Packages, file, less, highlight, w3m, ranger, imagemagick, testers
 , imagePreviewSupport ? true
+, sixelPreviewSupport ? true
 , neoVimSupport ? true
 , improvedEncodingDetection ? true
 , rightToLeftTextSupport ? false
@@ -7,22 +8,23 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "ranger";
-  version = "1.9.3";
+  version = "unstable-2023-08-23";
 
   src = fetchFromGitHub {
     owner = "ranger";
     repo = "ranger";
-    rev = "v${version}";
-    sha256= "1rygfryczanvqxn43lmlkgs04sbqznbvbb9hlbm3h5qgdcl0xlw8";
+    rev = "38bb8901004b75a407ffee4b9e176bc0a436cb15";
+    hash = "sha256-NpsrABk95xHNvhlRjKFh326IW83mYj1cmK3aE9JQSRo=";
   };
 
   LC_ALL = "en_US.UTF-8";
 
-  nativeCheckInputs = with python3Packages; [ pytestCheckHook ];
+  nativeCheckInputs = with python3Packages; [ pytestCheckHook astroid pylint ];
   propagatedBuildInputs = [
     less
     file
   ] ++ lib.optionals imagePreviewSupport [ python3Packages.pillow ]
+    ++ lib.optionals sixelPreviewSupport [ imagemagick ]
     ++ lib.optionals neoVimSupport [ python3Packages.pynvim ]
     ++ lib.optionals improvedEncodingDetection [ python3Packages.chardet ]
     ++ lib.optionals rightToLeftTextSupport [ python3Packages.python-bidi ];

--- a/pkgs/applications/file-managers/ranger/default.nix
+++ b/pkgs/applications/file-managers/ranger/default.nix
@@ -8,7 +8,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "ranger";
-  version = "unstable-2023-08-23";
+  version = "1.9.3-unstable-2023-08-23";
 
   src = fetchFromGitHub {
     owner = "ranger";

--- a/pkgs/applications/file-managers/ranger/default.nix
+++ b/pkgs/applications/file-managers/ranger/default.nix
@@ -51,10 +51,6 @@ python3Packages.buildPythonApplication rec {
       --replace "set preview_images false" "set preview_images true"
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = ranger;
-  };
-
   meta =  with lib; {
     description = "File manager with minimalistic curses interface";
     homepage = "https://ranger.github.io/";


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

ranger hasn't seen a new release for years, but development has been continuing, and some interesting new features (such as sixel image previews) are only available in master.

I don't expect this patch to be merged, but it's still useful, so I'm submitting it as a draft.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
