### PR TITLE
python311Packages.jinja2: 3.1.2 -> 3.1.3

### DIFF
--- a/pkgs/development/python-modules/jinja2/default.nix
+++ b/pkgs/development/python-modules/jinja2/default.nix
@@ -9,25 +9,37 @@
 , pytestCheckHook
 , sphinxHook
 , pallets-sphinx-themes
+, setuptools
 , sphinxcontrib-log-cabinet
 , sphinx-issues
 }:
 
 buildPythonPackage rec {
-  pname = "Jinja2";
+  pname = "jinja2";
   version = "3.1.3";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
-    inherit pname version;
+    pname = "Jinja2";
+    inherit version;
     hash = "sha256-rIvWVE1Lssl5K/OhWegLuo/afwfoG8Ou1WVDLVklupA=";
   };
 
+  nativeBuildInputs = [
+    setuptools
+  ];
+
   propagatedBuildInputs = [
-    babel
     markupsafe
   ];
+
+  passthru.optional-dependencies = {
+    i18n = [
+      babel
+    ];
+  };
 
   # Multiple tests run out of stack space on 32bit systems with python2.
   # See https://github.com/pallets/jinja/issues/1158
@@ -35,53 +47,45 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-  ];
+  ] ++ passthru.optional-dependencies.i18n;
 
-  pytestFlagsArray = [
-    # Avoid failure due to deprecation warning
-    # Fixed in https://github.com/python/cpython/pull/28153
-    # Remove after cpython 3.9.8
-    "-p no:warnings"
-  ];
+  passthru.doc = stdenv.mkDerivation {
+    # Forge look and feel of multi-output derivation as best as we can.
+    #
+    # Using 'outputs = [ "doc" ];' breaks a lot of assumptions.
+    name = "${pname}-${version}-doc";
+    inherit src pname version;
 
-  passthru = {
-    doc = stdenv.mkDerivation {
-      # Forge look and feel of multi-output derivation as best as we can.
-      #
-      # Using 'outputs = [ "doc" ];' breaks a lot of assumptions.
-      name = "${pname}-${version}-doc";
-      inherit src pname version;
+    patches = [
+      # Fix import of "sphinxcontrib-log-cabinet"
+      ./patches/import-order.patch
+    ];
 
-      patches = [
-        # Fix import of "sphinxcontrib-log-cabinet"
-        ./patches/import-order.patch
-      ];
+    postInstallSphinx = ''
+      mv $out/share/doc/* $out/share/doc/python$pythonVersion-$pname-$version
+    '';
 
-      postInstallSphinx = ''
-        mv $out/share/doc/* $out/share/doc/python$pythonVersion-$pname-$version
-      '';
+    nativeBuildInputs = [
+      sphinxHook
+      sphinxcontrib-log-cabinet
+      pallets-sphinx-themes
+      sphinx-issues
+    ];
 
-      nativeBuildInputs = [
-        sphinxHook
-        sphinxcontrib-log-cabinet
-        pallets-sphinx-themes
-        sphinx-issues
-      ];
-
-      inherit (python) pythonVersion;
-      inherit meta;
-    };
+    inherit (python) pythonVersion;
+    inherit meta;
   };
 
   meta = with lib; {
-    homepage = "https://jinja.palletsprojects.com/";
-    description = "Stand-alone template engine";
+    changelog = "https://github.com/pallets/jinja/blob/${version}/CHANGES.rst";
+    description = "Very fast and expressive template engine";
+    downloadPage = "https://github.com/pallets/jinja";
+    homepage = "https://jinja.palletsprojects.com";
     license = licenses.bsd3;
     longDescription = ''
       Jinja is a fast, expressive, extensible templating engine. Special
       placeholders in the template allow writing code similar to Python
       syntax. Then the template is passed data to render the final document.
-      an optional sandboxed environment.
     '';
     maintainers = with maintainers; [ pierron ];
   };

--- a/pkgs/development/python-modules/jinja2/default.nix
+++ b/pkgs/development/python-modules/jinja2/default.nix
@@ -15,13 +15,13 @@
 
 buildPythonPackage rec {
   pname = "Jinja2";
-  version = "3.1.2";
+  version = "3.1.3";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-MTUacCpAip51laj8YVD8P0O7a/fjGXcMvA2535Q36FI=";
+    hash = "sha256-rIvWVE1Lssl5K/OhWegLuo/afwfoG8Ou1WVDLVklupA=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
## Description of changes

https://github.com/pallets/jinja/releases/tag/3.1.3
https://github.com/pallets/jinja/security/advisories/GHSA-h5c8-rqwp-cp95

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s) for python311/312
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
