### PR TITLE
uemacs: init at 4.0-unstable-2018-07-19

### DIFF
--- a/pkgs/by-name/ue/uemacs/package.nix
+++ b/pkgs/by-name/ue/uemacs/package.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, fetchgit
+, ncurses
+}:
+
+stdenv.mkDerivation {
+  pname = "uemacs";
+  version = "4.0-unstable-2018-07-19";
+
+  src = fetchgit {
+    url = "https://git.kernel.org/pub/scm/editors/uemacs/uemacs.git";
+    rev = "1cdcf9df88144049750116e36fe20c8c39fa2517";
+    hash = "sha256-QSouqZiBmKBU6FqRRfWtTGRIl5sqJ8tVPYwdytt/43w=";
+  };
+
+  nativeBuildInputs = [
+    ncurses
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile --replace "lcurses" "lncurses"
+    substituteInPlace Makefile --replace "/usr/bin" "$out/bin"
+    substituteInPlace Makefile --replace "/usr/lib" "$out/share/uemacs"
+
+    substituteInPlace epath.h --replace "/usr/global/lib/" "$out/share/uemacs/"
+  '';
+
+  installPhase = ''
+    mkdir -p $out/{bin,share/uemacs}
+    make install
+  '';
+
+  meta = with lib; {
+    description = "Linus Torvalds's random version of microemacs with his personal modifications";
+    homepage = "https://git.kernel.org/pub/scm/editors/uemacs/uemacs.git/about/";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ networkexception ];
+    mainProgram = "em";
+    # MicroEMACS 3.9 can be copied and distributed freely for any
+    # non-commercial purposes. MicroEMACS 3.9 can only be incorporated
+    # into commercial software with the permission of the current author
+    # [Daniel M. Lawrence].
+    license = licenses.unfree;
+  };
+}


### PR DESCRIPTION
## Description of changes

Added the `uemacs` package for a more Torvalds complete distro /j

![image](https://github.com/NixOS/nixpkgs/assets/42888162/312b2a17-4914-4a41-a539-30bb896410a3)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
