### PR TITLE
flatpak-builder: 1.2.3 -> 1.4.2

### DIFF
--- a/pkgs/development/libraries/appstream/default.nix
+++ b/pkgs/development/libraries/appstream/default.nix
@@ -6,6 +6,7 @@
 , mesonEmulatorHook
 , ninja
 , pkg-config
+, cmake
 , gettext
 , xmlto
 , docbook-xsl-nons
@@ -23,6 +24,10 @@
 , gperf
 , vala
 , curl
+, cairo
+, gdk-pixbuf
+, pango
+, librsvg
 , systemd
 , nixosTests
 , testers
@@ -63,6 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     pkg-config
+    cmake
     gettext
     libxslt
     xmlto
@@ -85,6 +91,10 @@ stdenv.mkDerivation (finalAttrs: {
     libxmlb
     libyaml
     curl
+    cairo
+    gdk-pixbuf
+    pango
+    librsvg
   ] ++ lib.optionals withSystemd [
     systemd
   ];
@@ -94,6 +104,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-Ddocs=false"
     "-Dvapi=true"
     "-Dinstalled_test_prefix=${placeholder "installedTests"}"
+    "-Dcompose=true"
   ] ++ lib.optionals (!withSystemd) [
     "-Dsystemd=false"
   ];

--- a/pkgs/development/tools/flatpak-builder/default.nix
+++ b/pkgs/development/tools/flatpak-builder/default.nix
@@ -3,18 +3,18 @@
 , substituteAll
 , nixosTests
 
-, autoreconfHook
-, docbook_xml_dtd_412
-, docbook_xml_dtd_42
-, docbook_xml_dtd_43
+, docbook_xml_dtd_45
 , docbook_xsl
 , gettext
 , libxml2
 , libxslt
 , pkg-config
 , xmlto
+, meson
+, ninja
 
 , acl
+, appstream
 , breezy
 , binutils
 , bzip2
@@ -36,23 +36,24 @@
 , libyaml
 , ostree
 , patch
-, python2
 , rpm
 , unzip
+, attr
 }:
 
 let
   installed_testdir = "${placeholder "installedTests"}/libexec/installed-tests/flatpak-builder";
-  installed_test_metadir = "${placeholder "installedTests"}/share/installed-tests/flatpak-builder";
-in stdenv.mkDerivation rec {
+in stdenv.mkDerivation (finalAttrs: {
   pname = "flatpak-builder";
-  version = "1.2.3";
+  version = "1.4.2";
 
   outputs = [ "out" "doc" "man" "installedTests" ];
 
+  # fetchFromGitHub fetches an archive which does not contain the full source (https://github.com/flatpak/flatpak-builder/issues/558)
   src = fetchurl {
-    url = "https://github.com/flatpak/flatpak-builder/releases/download/${version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-4leCWkf3o+ceMPsPgPLZrG5IAfdG9VLfrw5WTj7jUcg=";
+    # TODO: remove the '-fixed-libglnx' in the next release
+    url = "https://github.com/flatpak/flatpak-builder/releases/download/${finalAttrs.version}/flatpak-builder-${finalAttrs.version}-fixed-libglnx.tar.xz";
+    hash = "sha256-wEG5dOA6LC082oig7+Hs9p+a30KhdY6sNB1VXnedBZY=";
   };
 
   patches = [
@@ -76,19 +77,17 @@ in stdenv.mkDerivation rec {
       euelfcompress = "${elfutils}/bin/eu-elfcompress";
     })
 
-    # The test scripts in Flatpak repo were updated so we are basing
-    # this on our patch for Flatpak 0.99.
     (substituteAll {
       src = ./fix-test-paths.patch;
       inherit glibcLocales;
-      # FIXME use python3 for tests that rely on python2
-      # inherit python2;
     })
+    ./fix-test-prefix.patch
   ];
 
   nativeBuildInputs = [
-    autoreconfHook
-    docbook_xml_dtd_43
+    meson
+    ninja
+    docbook_xml_dtd_45
     docbook_xsl
     gettext
     libxml2
@@ -99,6 +98,7 @@ in stdenv.mkDerivation rec {
 
   buildInputs = [
     acl
+    appstream
     bzip2
     curl
     debugedit
@@ -113,14 +113,9 @@ in stdenv.mkDerivation rec {
     ostree
   ];
 
-  configureFlags = [
-    "--enable-installed-tests"
-    "--with-system-debugedit"
-  ];
-
-  makeFlags = [
-    "installed_testdir=${installed_testdir}"
-    "installed_test_metadir=${installed_test_metadir}"
+  mesonFlags = [
+    "-Dinstalled_tests=true"
+    "-Dinstalled_test_prefix=${placeholder "installedTests"}"
   ];
 
   # Some scripts used by tests  need to use shebangs that are available in Flatpak runtimes.
@@ -130,7 +125,7 @@ in stdenv.mkDerivation rec {
 
   # Installed tests
   postFixup = ''
-    for file in ${installed_testdir}/{test-builder.sh,test-builder-python.sh}; do
+    for file in ${installed_testdir}/{test-builder.sh,test-builder-python.sh,test-builder-deprecated.sh}; do
       patchShebangs $file
     done
   '';
@@ -139,8 +134,10 @@ in stdenv.mkDerivation rec {
     installedTestsDependencies = [
       gnupg
       ostree
-      # FIXME python2
       gnumake
+      attr
+      libxml2
+      appstream
     ];
 
     tests = {
@@ -152,7 +149,7 @@ in stdenv.mkDerivation rec {
     description = "Tool to build flatpaks from source";
     homepage = "https://github.com/flatpak/flatpak-builder";
     license = licenses.lgpl21Plus;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ arthsmn ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/development/tools/flatpak-builder/fix-paths.patch
+++ b/pkgs/development/tools/flatpak-builder/fix-paths.patch
@@ -43,28 +43,28 @@ index ef517adb..6ab095f0 100644
  
    return res;
 diff --git a/src/builder-source-archive.c b/src/builder-source-archive.c
-index 3c694e57..0de62318 100644
+index ed66d5b..9ca9486 100644
 --- a/src/builder-source-archive.c
 +++ b/src/builder-source-archive.c
-@@ -443,7 +443,7 @@ tar (GFile   *dir,
+@@ -484,7 +484,7 @@ tar (GFile   *dir,
    va_list ap;
- 
+
    va_start (ap, error);
 -  res = flatpak_spawn (dir, NULL, 0, error, "tar", ap);
 +  res = flatpak_spawn (dir, NULL, 0, error, "@tar@", ap);
    va_end (ap);
- 
+
    return res;
-@@ -458,7 +458,7 @@ unzip (GFile   *dir,
-   va_list ap;
- 
-   va_start (ap, error);
--  res = flatpak_spawn (dir, NULL, 0, error, "unzip", ap);
-+  res = flatpak_spawn (dir, NULL, 0, error, "@unzip@", ap);
-   va_end (ap);
- 
-   return res;
-@@ -483,7 +483,7 @@ unrpm (GFile   *dir,
+@@ -496,7 +496,7 @@ unzip (GFile       *dir,
+        GError     **error)
+ {
+   gboolean res;
+-  const char *argv[] = { "unzip", "-q", zip_path, NULL };
++  const char *argv[] = { "@unzip@", "-q", zip_path, NULL };
+
+   res = flatpak_spawnv (dir, NULL, 0, error, argv, NULL);
+
+@@ -522,7 +522,7 @@ unrpm (GFile   *dir,
         GError **error)
  {
    gboolean res;
@@ -73,14 +73,14 @@ index 3c694e57..0de62318 100644
        "sh", /* shell's $0 */
        rpm_path, /* shell's $1 */
        NULL };
-@@ -631,7 +631,7 @@ git (GFile   *dir,
+@@ -677,7 +677,7 @@ git (GFile   *dir,
    va_list ap;
- 
+
    va_start (ap, error);
 -  res = flatpak_spawn (dir, NULL, 0, error, "git", ap);
 +  res = flatpak_spawn (dir, NULL, 0, error, "@git@", ap);
    va_end (ap);
- 
+
    return res;
 diff --git a/src/builder-source-bzr.c b/src/builder-source-bzr.c
 index ceeec94a..8abe6f53 100644

--- a/pkgs/development/tools/flatpak-builder/fix-test-prefix.patch
+++ b/pkgs/development/tools/flatpak-builder/fix-test-prefix.patch
@@ -1,0 +1,29 @@
+diff --git a/meson_options.txt b/meson_options.txt
+index d5a0bd22..7d69d3d2 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -22,6 +22,12 @@ option(
+   value: true,
+   description: 'Whether to build and run unit tests'
+ )
++option(
++  'installed_test_prefix',
++  type: 'string',
++  value: '',
++  description: 'Prefix for installed tests'
++)
+ option(
+   'fuse',
+   type: 'combo',
+diff --git a/tests/meson.build b/tests/meson.build
+index 6ec405d1..f43c165c 100644
+--- a/tests/meson.build
++++ b/tests/meson.build
+@@ -1,5 +1,5 @@
+-installed_testdir = get_option('prefix') / get_option('libexecdir') / 'installed-tests' / 'flatpak-builder'
+-installed_tests_metadir = get_option('prefix') / get_option('datadir') / 'installed-tests' / 'flatpak-builder'
++installed_testdir = get_option('installed_test_prefix') / get_option('libexecdir') / 'installed-tests' / 'flatpak-builder'
++installed_tests_metadir = get_option('installed_test_prefix') / get_option('datadir') / 'installed-tests' / 'flatpak-builder'
+
+ test_env = environment()
+ test_env.set('FLATPAK_TESTS_DEBUG', '1')


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/flatpak/flatpak-builder/releases/tag/1.4.2
Closes: https://github.com/NixOS/nixpkgs/issues/279784

I replaced the old build tool with meson, as recommended by upstream. Needed to adapt appstream to build with compose support, so flatpak-builder can use it. Also, updated the patch to fix paths and modified the test one, and also removed unused parts.

Btw should I set a withCompose in appstream and make it optional?
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
