### PR TITLE
Update Hyprpicker- default.nix

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hyprpicker/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprpicker/default.nix
@@ -1,40 +1,35 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, pkg-config
-, cmake
-, ninja
-, cairo
-, fribidi
-, libGL
-, libdatrie
-, libjpeg
-, libselinux
-, libsepol
-, libthai
-, libxkbcommon
-, pango
-, pcre
-, util-linux
-, wayland
-, wayland-protocols
-, wayland-scanner
-, wlroots
-, libXdmcp
-, debug ? false
+{
+  lib,
+  stdenv,
+  pkg-config,
+  cmake,
+  ninja,
+  cairo,
+  fribidi,
+  libdatrie,
+  libGL,
+  libjpeg,
+  libselinux,
+  libsepol,
+  libthai,
+  libxkbcommon,
+  pango,
+  pcre,
+  utillinux,
+  wayland,
+  wayland-protocols,
+  wayland-scanner,
+  wlroots,
+  libXdmcp,
+  debug ? false,
+  version ? "git",
 }:
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation {
   pname = "hyprpicker" + lib.optionalString debug "-debug";
-  version = "0.2.0";
+  inherit version;
+  src = ../.;
 
-  src = fetchFromGitHub {
-    owner = "hyprwm";
-    repo = finalAttrs.pname;
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-bys8S7wuY9FJRLD5WriktWED5Hi7nCKSiNbs1Rvfk4s=";
-  };
-
-  cmakeBuildType = if debug then "Debug" else "Release";
+  cmakeFlags = lib.optional debug "-DCMAKE_BUILD_TYPE=Debug";
 
   nativeBuildInputs = [
     cmake
@@ -45,13 +40,12 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     cairo
     fribidi
-    libGL
     libdatrie
+    libGL
     libjpeg
     libselinux
     libsepol
     libthai
-    libxkbcommon
     pango
     pcre
     wayland
@@ -59,7 +53,8 @@ stdenv.mkDerivation (finalAttrs: {
     wayland-scanner
     wlroots
     libXdmcp
-    util-linux
+    libxkbcommon
+    utillinux
   ];
 
   configurePhase = ''
@@ -90,11 +85,9 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = with lib; {
-    description = "A wlroots-compatible Wayland color picker that does not suck";
     homepage = "https://github.com/hyprwm/hyprpicker";
+    description = "A wlroots-compatible Wayland color picker that does not suck";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ fufexan ];
-    platforms = wayland.meta.platforms;
-    mainProgram = "hyprpicker";
+    platforms = platforms.linux;
   };
-})
+}


### PR DESCRIPTION
fixed: Segmentation fault (core dumped)

## Description of changes
replaced default.nix with updated file from upstream: https://github.com/hyprwm/hyprpicker/blob/main/nix/default.nix
to fix "Segmentation fault (core dumped)" when running hyprpicker

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [-] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
