### PR TITLE
ocamlPackages.metrics: 0.4.0 → 0.4.1

### DIFF
--- a/pkgs/development/ocaml-modules/metrics/default.nix
+++ b/pkgs/development/ocaml-modules/metrics/default.nix
@@ -2,14 +2,13 @@
 
 buildDunePackage rec {
   pname = "metrics";
-  version = "0.4.0";
+  version = "0.4.1";
 
   minimalOCamlVersion = "4.04";
-  duneVersion = "3";
 
   src = fetchurl {
     url = "https://github.com/mirage/metrics/releases/download/v${version}/metrics-${version}.tbz";
-    sha256 = "sha256-kbh1WktQkDcXE8O1WRm+vtagVfSql8S5gr0bXn/jia8=";
+    sha256 = "sha256-d+DCD7XB0GED27DsC8YEW+48YcAK0EI8l4Uqx/PGFE0=";
   };
 
   propagatedBuildInputs = [ fmt ];

--- a/pkgs/development/ocaml-modules/metrics/unix.nix
+++ b/pkgs/development/ocaml-modules/metrics/unix.nix
@@ -6,13 +6,6 @@ buildDunePackage rec {
 
   inherit (metrics) version src;
 
-  duneVersion = "3";
-
-  # Fixes https://github.com/mirage/metrics/issues/57
-  postPatch = ''
-    substituteInPlace src/unix/dune --replace "mtime mtime.clock" "mtime"
-  '';
-
   propagatedBuildInputs = [ gnuplot lwt metrics mtime uuidm ];
 
   nativeCheckInputs = [ gnuplot ];


### PR DESCRIPTION
## Description of changes

Support for recent `mtime`.
https://github.com/mirage/metrics/blob/v0.4.1/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
