### PR TITLE
kluctl: 2.22.1 -> 2.25.0

### DIFF
--- a/pkgs/applications/networking/cluster/kluctl/default.nix
+++ b/pkgs/applications/networking/cluster/kluctl/default.nix
@@ -1,24 +1,28 @@
-{ lib, buildGoModule, fetchFromGitHub, testers, kluctl }:
+{ lib, buildGoModule, fetchFromGitHub, testers, makeWrapper, python310, kluctl }:
 
 buildGoModule rec {
   pname = "kluctl";
-  version = "2.22.1";
+  version = "2.25.0";
 
   src = fetchFromGitHub {
     owner = "kluctl";
     repo = "kluctl";
     rev = "v${version}";
-    hash = "sha256-s7ADEWy3wx2hGeJzfXPVSBv+bAOoOQPsF75Sq02T/AI=";
+    hash = "sha256-WtTBkc9mop+bfMcVLI8k4Bqmift5JG9riF+QbDeiR9c=";
   };
 
   subPackages = [ "cmd" ];
 
-  vendorHash = "sha256-EEOVd15f1SK8InSIG+TuVwWibkf+ePJ5AGZpiMD+RaQ=";
+  vendorHash = "sha256-TckT39wQn4dclcYSfxootv1Lw5+iYxY6/wwdUc1+Z6s=";
 
   ldflags = [ "-s" "-w" "-X main.version=v${version}" ];
 
   # Depends on docker
   doCheck = false;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
 
   passthru.tests.version = testers.testVersion {
     package = kluctl;
@@ -27,6 +31,9 @@ buildGoModule rec {
 
   postInstall = ''
     mv $out/bin/{cmd,kluctl}
+    wrapProgram $out/bin/kluctl \
+        --set KLUCTL_USE_SYSTEM_PYTHON 1 \
+        --prefix PATH : '${lib.makeBinPath [ python310 ]}'
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Changelogs: 
  - https://github.com/kluctl/kluctl/releases/tag/v2.23.0
  - https://github.com/kluctl/kluctl/releases/tag/v2.23.1
  - https://github.com/kluctl/kluctl/releases/tag/v2.23.2
  - https://github.com/kluctl/kluctl/releases/tag/v2.23.3
  - https://github.com/kluctl/kluctl/releases/tag/v2.23.4
  - https://github.com/kluctl/kluctl/releases/tag/v2.23.5
  - https://github.com/kluctl/kluctl/releases/tag/v2.24.0
  - https://github.com/kluctl/kluctl/releases/tag/v2.24.1
  - https://github.com/kluctl/kluctl/releases/tag/v2.25.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
