### PR TITLE
minifox: init at 0.13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11785,6 +11785,12 @@
     githubId = 158568;
     name = "Matthias C. M. Troffaes";
   };
+  mcoll = {
+    email = "marce@dziban.net";
+    github = "marcecoll";
+    githubId = 1399250;
+    name = "Marce Coll";
+  };
   McSinyx = {
     email = "cnx@loang.net";
     github = "McSinyx";

--- a/pkgs/by-name/mi/minifox/package.nix
+++ b/pkgs/by-name/mi/minifox/package.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, fetchurl
+, sqlite
+, libGL
+, libpng
+, libgcc
+, zlib
+, unzip
+, autoPatchelfHook
+, makeWrapper
+}:
+
+stdenv.mkDerivation rec {
+  pname = "minifox";
+  version = "0.11";
+
+  src = fetchurl {
+    url = "https://github.com/openfoxwq/openfoxwq.github.io/releases/download/v${version}/minifox-v${version}-linux.zip";
+    hash = "sha256-TG516VY3+5E8Sb0C9JpxGjlY71NTc2AerJkD944c9ls=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    unzip
+  ];
+
+  buildInputs = [
+    makeWrapper
+    libGL
+    sqlite
+    zlib
+    libpng
+    libgcc
+    stdenv.cc.cc.lib
+  ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+    install -m755 -D minifox $out/bin/minifox
+    install -m755 -D -d asset $out/bin/asset
+    for file in $(find asset -type f); do
+      install -m 644 -D $file $out/bin/$file
+    done
+
+    wrapProgram "$out/bin/minifox" --run 'export MINIFOXWQ_DATA_DIR="$HOME/.openfoxwq"' --run 'mkdir -p "$HOME/.openfoxwq"'
+  '';
+
+  meta = with lib; {
+    homepage = "https://openfoxwq.github.io/";
+    description = "MiniFox third party unofficial client for Fox Go server";
+    platforms = platforms.linux;
+    mainProgram = "minifox";
+    maintainers = [ maintainers.mcoll ];
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Minifox is a third-party implementation client for the FoxWQ Go server.

https://openfoxwq.github.io/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
