### PR TITLE
wl-clipboard-rs: init at 0.8.0-unstable-2023-11-27

### DIFF
--- a/pkgs/by-name/wl/wl-clipboard-rs/package.nix
+++ b/pkgs/by-name/wl/wl-clipboard-rs/package.nix
@@ -1,0 +1,60 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, wayland
+, withNativeLibs ? false
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "wl-clipboard-rs";
+  version = "0.8.0-unstable-2023-11-27";
+
+  src = fetchFromGitHub {
+    owner = "YaLTeR";
+    repo = "wl-clipboard-rs";
+    rev = "be851408e0f91edffdc2f1a76805035847f9f8a9";
+    hash = "sha256-OfLn7izG1KSUjdd2gO4aaSCDlcaWoFiFmgwwhR1hRsQ=";
+  };
+
+  cargoHash = "sha256-rYFCPyWTUhyrEcoRM8I+iX7IaY/6i1tBVjhs47m3XY8=";
+
+  cargoBuildFlags = [
+    "--package=wl-clipboard-rs"
+    "--package=wl-clipboard-rs-tools"
+  ] ++ lib.optionals withNativeLibs [
+    "--features=native_lib"
+  ];
+
+  nativeBuildInputs = lib.optionals withNativeLibs [
+    pkg-config
+  ];
+
+  buildInputs = lib.optionals withNativeLibs [
+    wayland
+  ];
+
+  preCheck = ''
+    export XDG_RUNTIME_DIR=$(mktemp -d)
+  '';
+
+  # Assertion errors
+  checkFlags = [
+    "--skip=tests::copy::copy_large"
+    "--skip=tests::copy::copy_multi_no_additional_text_mime_types_test"
+    "--skip=tests::copy::copy_multi_test"
+    "--skip=tests::copy::copy_randomized"
+    "--skip=tests::copy::copy_test"
+  ];
+
+  meta = {
+    description = "Command-line copy/paste utilities for Wayland, written in Rust";
+    homepage = "https://github.com/YaLTeR/wl-clipboard-rs";
+    # TODO: add `${version}` once we switch to tagged release
+    changelog = "https://github.com/YaLTeR/wl-clipboard-rs/blob/master/CHANGELOG.md";
+    platforms = lib.platforms.linux;
+    license = with lib.licenses; [ asl20 mit ];
+    mainProgram = "wl-clip";
+    maintainers = with lib.maintainers; [ thiagokokada ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Alternative implementation of `wl-clipboard` in Rust, includes replacements for:
- `wl-copy`
- `wl-paste`
- `wl-clip`

Including here mostly because I was having issues with `wl-clipboard` itself, so I hope a different implementation will behave better. Probably will only have different kinda of bugs though :sweat_smile:.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
