### PR TITLE
mountpoint-s3: init at 1.3.2

### DIFF
--- a/pkgs/by-name/mo/mountpoint-s3/package.nix
+++ b/pkgs/by-name/mo/mountpoint-s3/package.nix
@@ -1,0 +1,59 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, cmake
+, fuse3
+, pkg-config
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "mountpoint-s3";
+  version = "1.3.2";
+
+  src = fetchFromGitHub {
+    owner = "awslabs";
+    repo = "mountpoint-s3";
+    rev = "v${version}";
+    hash = "sha256-RMLlHopd+PZLvDtI5uqWlvtS2rahp0HnC/PZ3HVdzIo=";
+    fetchSubmodules = true;
+  };
+
+  cargoHash = "sha256-kvl89btgxa3tFbiiPlCyvXodruHRr7KC0lR2GG5UIKw=";
+
+  # thread 'main' panicked at cargo-auditable/src/collect_audit_data.rs:77:9:
+  # cargo metadata failure: error: none of the selected packages contains these features: libfuse3
+  auditable = false;
+
+  nativeBuildInputs = [ cmake pkg-config rustPlatform.bindgenHook ];
+  buildInputs = [ fuse3 ];
+
+  checkFlags = [
+    #thread 's3_crt_client::tests::test_expected_bucket_owner' panicked at mountpoint-s3-client/src/s3_crt_client.rs:1123:47:
+    #Create test client: ProviderFailure(Error(1173, "aws-c-io: AWS_IO_TLS_ERROR_DEFAULT_TRUST_STORE_NOT_FOUND, Default TLS trust store not found on this system. Trusted CA certificates must be installed, or \"override default trust store\" must be used while creating the TLS context."))
+    #
+    "--skip=s3_crt_client::tests::test_expected_bucket_owner"
+    "--skip=s3_crt_client::tests::test_user_agent_with_prefix"
+    "--skip=s3_crt_client::tests::test_user_agent_without_prefix"
+    "--skip=tests::smoke"
+    # fuse module not available on build machine ?
+    #
+    # fuse: device not found, try 'modprobe fuse' first
+    # thread 'unmount_no_send' panicked at vendor/fuser/tests/integration_tests.rs:16:79:
+    # called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
+    "--skip=unmount_no_send"
+    # sandbox issue ?
+    #
+    # thread 'mnt::test::mount_unmount' panicked at vendor/fuser/src/mnt/mod.rs:165:57:
+    # called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
+    "--skip=mnt::test::mount_unmount"
+    "--skip=test_get_identity_document"
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/awslabs/mountpoint-s3";
+    description = "A simple, high-throughput file client for mounting an Amazon S3 bucket as a local file system.";
+    license = licenses.amazonsl;
+    maintainers = with maintainers; [ lblasc ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

A simple, high-throughput file client for mounting an Amazon S3 bucket as a local file system.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
