### PR TITLE
libzip: backport patch for pkgconfig file

### DIFF
--- a/pkgs/development/libraries/libzip/default.nix
+++ b/pkgs/development/libraries/libzip/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv
 , cmake
+, fetchpatch2
 , fetchurl
 , perl
 , zlib
@@ -22,6 +23,15 @@ stdenv.mkDerivation rec {
     url = "https://libzip.org/download/${pname}-${version}.tar.gz";
     sha256 = "sha256-/Wp/dF3j1pz1YD7cnLM9KJDwGY5BUlXQmHoM8Q2CTG8=";
   };
+
+  patches = [
+    # https://github.com/nih-at/libzip/issues/404
+    (fetchpatch2 {
+      name = "Check-for-zstd_TARGET-before-using-it-in-a-regex.patch";
+      url = "https://github.com/nih-at/libzip/commit/c719428916b4d19e838f873b1a177b126a080d61.patch";
+      hash = "sha256-4ksbXEM8kNvs3wtbIaXLEQNSKaxl0es/sIg0EINaTHE=";
+    })
+  ];
 
   outputs = [ "out" "dev" "man" ];
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This backports the unreleased fix for https://github.com/nih-at/libzip/issues/404.
Without this patch the pkgconfig file contains garbage which makes it impossible to link against libzip (when using pkgconfig, of course).

Example error message:
```
/nix/store/w9dk8id4zmvmwqy42dyqc2k56nf14qvb-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: cannot find -lzstdZLIB::ZLIB: No such file or directory
```

Contents of `libzip.pc` before this patch (this was from a static build, that's why there is `static-x86_64-unknown-linux-musl` everywhere):
```
prefix=/nix/store/52wg6iaryw88vbwdsw6p5xh290klp02j-libzip-static-x86_64-unknown-linux-musl-1.10.1
exec_prefix=${prefix}
bindir=${prefix}/bin
libdir=${prefix}/lib
includedir=/nix/store/49fcxyxafnkc2c12k3lnvxifpr4vddmc-libzip-static-x86_64-unknown-linux-musl-1.10.1-dev/../49fcxyxafnkc2c12k3lnvxifpr4vddmc-libzip-static-x86_64-unknown-linux-musl-1.10.1-dev/include

zipcmp=${bindir}/zipcmp

Name: libzip
Description: library for handling zip archives
Version: 1.10.1
Libs:  -L${libdir} -lzip
Libs.private:  -lzstdZLIB::ZLIB
Cflags: -I${includedir}
```

Contents of `libzip.pc` after this patch:
```
prefix=/nix/store/snw41i59h4n4y50lpri6h60nsa2vzla3-libzip-1.10.1
exec_prefix=${prefix}
bindir=${prefix}/bin
libdir=${prefix}/lib
includedir=/nix/store/i1yh4v83y53i0yp1s91439i4qgwsylhq-libzip-1.10.1-dev/../i1yh4v83y53i0yp1s91439i4qgwsylhq-libzip-1.10.1-dev/include

zipcmp=${bindir}/zipcmp

Name: libzip
Description: library for handling zip archives
Version: 1.10.1
Libs:  -L${libdir} -lzip
Libs.private:  -lz
Cflags: -I${includedir}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
