### PR TITLE
bazel-watcher: set GOPROXY for fetching deps

### DIFF
--- a/pkgs/development/tools/bazel-watcher/default.nix
+++ b/pkgs/development/tools/bazel-watcher/default.nix
@@ -50,6 +50,10 @@ buildBazelPackage rec {
   fetchAttrs = {
     inherit patches;
 
+    preHook = ''
+      export GOPROXY=https://proxy.golang.org,direct
+    '';
+
     preBuild = ''
       patchShebangs .
 


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/253706

Currently, `bazel-watcher.deps` only builds because it has a known outputHash that is already cached.

## Reproduce error

If you build with a blanked `outputHash`, e.g. by editing the source or executing this command:

```
nix build -L --impure --expr 'let pkgs = import ./.{}; in pkgs.bazel-watcher.deps.overrideAttrs (x: y: { outputHash="";})'
```

(tested on  x86_64-linux and aarch64-darwin)

You get the following error (and more):

```
...
bazel-watcher> ERROR: An error occurred during the fetch of repository 'com_github_jaschaephraim_lrserver':
bazel-watcher>    Traceback (most recent call last):
bazel-watcher>  File "/build/output/external/bazel_gazelle/internal/go_repository.bzl", line 247, column 17, in _go_repository_impl
bazel-watcher>          fail("failed to fetch %s: %s" % (ctx.name, result.stderr))
bazel-watcher> Error in fail: failed to fetch com_github_jaschaephraim_lrserver: fetch_repo: github.com/jaschaephraim/lrserver@v0.0.0-20171129202958-50d19f603f71: GOPROXY list is not the empty string, but contains no entries
...
```

## Breaking change

The error was introduced when the go version used for building bazel-watcher was unpinned from `1.18.x` and thus implicitly set to the latest version: `1.21.x` in https://github.com/NixOS/nixpkgs/commit/dc6ea0a4f702aad1eb29a84231ec6026db3c1f9b.

It works as defined until `1.20.x` but in `1.21.x` some changes were introduced that affected `GOPROXY`:  Maybe related to https://github.com/golang/go/issues/61928

## Description of changes

Setting `GOPROXY` explicitly in `deps` derivation of `bazel-watcher`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
