### PR TITLE
maildir-rank-addr: init at 1.3.0

### DIFF
--- a/pkgs/by-name/ma/maildir-rank-addr/package.nix
+++ b/pkgs/by-name/ma/maildir-rank-addr/package.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "maildir-rank-addr";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "ferdinandyb";
+    repo = "maildir-rank-addr";
+    rev = "v${version}";
+    hash = "sha256-LABqd9FojbQUG3c0XBH5ZKsJNPTMEt3Yzn6gpYEWddc=";
+  };
+
+  vendorHash = "sha256-Mqx938j8LwM+bDnrK3V46FFy86JbVoh9Zxr/CA/egk8=";
+
+  meta = with lib; {
+    description = "Creates a ranked list of email addresses from maildir folders";
+    homepage = "https://github.com/ferdinandyb/maildir-rank-addr/";
+    maintainers = with maintainers; [ ryangibb ];
+    mainProgram = "maildir-rank-addr";
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

https://github.com/ferdinandyb/maildir-rank-addr/

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
