### PR TITLE
gitlab: 16.7.0 -> 16.7.2

### DIFF
--- a/pkgs/applications/version-management/gitlab/data.json
+++ b/pkgs/applications/version-management/gitlab/data.json
@@ -1,15 +1,15 @@
 {
-  "version": "16.7.0",
-  "repo_hash": "sha256-l5TkjkVny2zQLUfbscG6adkmkC1KjxMAeFbSyUA1UbI=",
+  "version": "16.7.2",
+  "repo_hash": "sha256-YIwZkmTVmxXlZ07lCUco9VEbylMvE92LQdFOeZXWB2M=",
   "yarn_hash": "1qxz2p969qg7kzyvhwxws5zwdw986gdq9gxllzi58c5c56jz49zf",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v16.7.0-ee",
+  "rev": "v16.7.2-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "16.7.0",
-    "GITLAB_PAGES_VERSION": "16.7.0",
+    "GITALY_SERVER_VERSION": "16.7.2",
+    "GITLAB_PAGES_VERSION": "16.7.2",
     "GITLAB_SHELL_VERSION": "14.32.0",
     "GITLAB_ELASTICSEARCH_INDEXER_VERSION": "4.5.0",
-    "GITLAB_WORKHORSE_VERSION": "16.7.0"
+    "GITLAB_WORKHORSE_VERSION": "16.7.2"
   }
 }

--- a/pkgs/applications/version-management/gitlab/gitaly/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitaly/default.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  version = "16.7.0";
+  version = "16.7.2";
   package_version = "v${lib.versions.major version}";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/${package_version}";
 
@@ -18,7 +18,7 @@ let
       owner = "gitlab-org";
       repo = "gitaly";
       rev = "v${version}";
-      hash = "sha256-YLynUHE1lb0dfsZsalz91jSSk1Y5r7kqT2AcE27xf04=";
+      hash = "sha256-3R7x8eaUJqJ1mKlQ4kYThKyaSfSaow7lGx5EfNo+GNY=";
     };
 
     vendorHash = "sha256-btWHZMy1aBSsUVs30IqrdBCO79XQvTMXxkxYURF2Nqs=";

--- a/pkgs/applications/version-management/gitlab/gitlab-pages/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-pages/default.nix
@@ -2,14 +2,14 @@
 
 buildGoModule rec {
   pname = "gitlab-pages";
-  version = "16.7.0";
+  version = "16.7.2";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-pages";
     rev = "v${version}";
-    hash = "sha256-8jODsK5+o1fEaTuFv6bXfZp4oA87JUQbTdYQn66DKJA=";
+    hash = "sha256-rUSZDsQt6faNES3ibzo7fJqpzEmXRbbTXOkhOn7jggA=";
   };
 
   vendorHash = "sha256-NMky8v0YmN2pSeKJ7G0+DWAZvUx2JlwFbqPHvciYroM=";

--- a/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/applications/version-management/gitlab/gitlab-workhorse/default.nix
@@ -5,7 +5,7 @@ in
 buildGoModule rec {
   pname = "gitlab-workhorse";
 
-  version = "16.7.0";
+  version = "16.7.2";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitLab {


### PR DESCRIPTION
## Description of changes

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
