### PR TITLE
parallel-disk-usage (pdu): init at 0.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14367,6 +14367,11 @@
     github = "pennae";
     githubId = 82953136;
   };
+  peret = {
+    name = "Peter Retzlaff";
+    github = "peret";
+    githubId = 617977;
+  };
   periklis = {
     email = "theopompos@gmail.com";
     github = "periklis";

--- a/pkgs/by-name/pa/parallel-disk-usage/package.nix
+++ b/pkgs/by-name/pa/parallel-disk-usage/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   rustPlatform,
+  stdenv,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "parallel-disk-usage";
@@ -22,7 +23,8 @@ rustPlatform.buildRustPackage rec {
     license = licenses.asl20;
     maintainers = [maintainers.peret];
     mainProgram = "pdu";
-    platforms = platforms.all;
-    badPlatforms = ["aarch64-linux"];
+    # broken due to unit test failure
+    # https://github.com/KSXGitHub/parallel-disk-usage/issues/251
+    broken = stdenv.isLinux && stdenv.isAarch64;
   };
 }

--- a/pkgs/by-name/pa/parallel-disk-usage/package.nix
+++ b/pkgs/by-name/pa/parallel-disk-usage/package.nix
@@ -22,5 +22,7 @@ rustPlatform.buildRustPackage rec {
     license = licenses.asl20;
     maintainers = [maintainers.peret];
     mainProgram = "pdu";
+    platforms = platforms.all;
+    badPlatforms = ["aarch64-linux"];
   };
 }

--- a/pkgs/by-name/pa/parallel-disk-usage/package.nix
+++ b/pkgs/by-name/pa/parallel-disk-usage/package.nix
@@ -21,5 +21,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/KSXGitHub/parallel-disk-usage";
     license = licenses.asl20;
     maintainers = [maintainers.peret];
+    mainProgram = "pdu";
   };
 }

--- a/pkgs/by-name/pa/parallel-disk-usage/package.nix
+++ b/pkgs/by-name/pa/parallel-disk-usage/package.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "parallel-disk-usage";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "KSXGitHub";
+    repo = pname;
+    rev = version;
+    hash = "sha256-kOMbVKwnGh47zZkWAWkctfTIE5F8oeSnAgJEU/OdsQc=";
+  };
+
+  cargoHash = "sha256-Jk9sNvApq4t/FoEzfjlDT2Td5sr38Jbdo6RoaOVQJK8=";
+
+  meta = with lib; {
+    description = "Highly parallelized, blazing fast directory tree analyzer";
+    homepage = "https://github.com/KSXGitHub/parallel-disk-usage";
+    license = licenses.asl20;
+    maintainers = [maintainers.peret];
+  };
+}


### PR DESCRIPTION
## Description of changes
Add parallel-disk-usage (pdu) package. `pdu` is a CLI disk usage analyzer.
Project repository: https://github.com/KSXGitHub/parallel-disk-usage

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
