### PR TITLE
treewide: use new tmpfiles API

### DIFF
--- a/nixos/modules/programs/regreet.nix
+++ b/nixos/modules/programs/regreet.nix
@@ -78,11 +78,15 @@ in
         else settingsFormat.generate "regreet.toml" cfg.settings;
     };
 
-    systemd.tmpfiles.rules = let
-      group = config.users.users.${config.services.greetd.settings.default_session.user}.group;
-    in [
-      "d /var/log/regreet 0755 greeter ${group} - -"
-      "d /var/cache/regreet 0755 greeter ${group} - -"
-    ];
+    systemd.tmpfiles.settings."10-regreet" = let
+      defaultConfig = {
+        user = "greeter";
+        group = config.users.users.${config.services.greetd.settings.default_session.user}.group;
+        mode = "0755";
+      };
+    in {
+      "/var/log/regreet".d = defaultConfig;
+      "/var/cache/regreet".d = defaultConfig;
+    };
   };
 }

--- a/nixos/modules/services/audio/mopidy.nix
+++ b/nixos/modules/services/audio/mopidy.nix
@@ -70,9 +70,10 @@ in {
 
   config = mkIf cfg.enable {
 
-    systemd.tmpfiles.rules = [
-      "d '${cfg.dataDir}' - mopidy mopidy - -"
-    ];
+    systemd.tmpfiles.settings."10-mopidy".${cfg.dataDir}.d = {
+      user = "mopidy";
+      group = "mopidy";
+    };
 
     systemd.services.mopidy = {
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/mail/mlmmj.nix
+++ b/nixos/modules/services/mail/mlmmj.nix
@@ -143,11 +143,13 @@ in
 
     environment.systemPackages = [ pkgs.mlmmj ];
 
-    systemd.tmpfiles.rules = [
-      ''d "${stateDir}" -''
-      ''d "${spoolDir}/${cfg.listDomain}" -''
-      ''Z "${spoolDir}" - "${cfg.user}" "${cfg.group}" -''
-    ];
+    systemd.tmpfiles.settings."10-mlmmj" = {
+      ${stateDir}.d = { };
+      "${spoolDir}/${cfg.listDomain}".d = { };
+      ${spoolDir}.Z = {
+        inherit (cfg) user group;
+      };
+    };
 
     systemd.services.mlmmj-maintd = {
       description = "mlmmj maintenance daemon";

--- a/nixos/modules/services/mail/postfixadmin.nix
+++ b/nixos/modules/services/mail/postfixadmin.nix
@@ -99,7 +99,11 @@ in
       ${cfg.extraConfig}
     '';
 
-    systemd.tmpfiles.rules = [ "d /var/cache/postfixadmin/templates_c 700 ${user} ${user}" ];
+    systemd.tmpfiles.settings."10-postfixadmin"."/var/cache/postfixadmin/templates_c".d = {
+      inherit user;
+      group = user;
+      mode = "700";
+    };
 
     services.nginx = {
       enable = true;

--- a/nixos/modules/services/mail/rss2email.nix
+++ b/nixos/modules/services/mail/rss2email.nix
@@ -95,9 +95,11 @@ in {
 
     services.rss2email.config.to = cfg.to;
 
-    systemd.tmpfiles.rules = [
-      "d /var/rss2email 0700 rss2email rss2email - -"
-    ];
+    systemd.tmpfiles.settings."10-rss2email"."/var/rss2email".d = {
+      user = "rss2email";
+      group = "rss2email";
+      mode = "0700";
+    };
 
     systemd.services.rss2email = let
       conf = pkgs.writeText "rss2email.cfg" (lib.generators.toINI {} ({

--- a/nixos/modules/services/mail/zeyple.nix
+++ b/nixos/modules/services/mail/zeyple.nix
@@ -93,7 +93,11 @@ in {
 
     environment.etc."zeyple.conf".source = ini.generate "zeyple.conf" cfg.settings;
 
-    systemd.tmpfiles.rules = [ "f '${cfg.settings.zeyple.log_file}' 0600 ${cfg.user} ${cfg.group} - -" ];
+    systemd.tmpfiles.settings."10-zeyple".${cfg.settings.zeyple.log_file}.f = {
+      inherit (cfg) user group;
+      mode = "0600";
+    };
+
     services.logrotate = mkIf cfg.rotateLogs {
       enable = true;
       settings.zeyple = {

--- a/nixos/modules/services/misc/etcd.nix
+++ b/nixos/modules/services/misc/etcd.nix
@@ -152,9 +152,10 @@ in {
   };
 
   config = mkIf cfg.enable {
-    systemd.tmpfiles.rules = [
-      "d '${cfg.dataDir}' 0700 etcd - - -"
-    ];
+    systemd.tmpfiles.settings."10-etcd".${cfg.dataDir}.d = {
+      user = "etcd";
+      mode = "0700";
+    };
 
     systemd.services.etcd = {
       description = "etcd key-value store";

--- a/nixos/modules/services/misc/lidarr.nix
+++ b/nixos/modules/services/misc/lidarr.nix
@@ -45,9 +45,10 @@ in
   };
 
   config = mkIf cfg.enable {
-    systemd.tmpfiles.rules = [
-      "d '${cfg.dataDir}' 0700 ${cfg.user} ${cfg.group} - -"
-    ];
+    systemd.tmpfiles.settings."10-lidarr".${cfg.dataDir}.d = {
+      inherit (cfg) user group;
+      mode = "0700";
+    };
 
     systemd.services.lidarr = {
       description = "Lidarr";

--- a/nixos/modules/services/misc/radarr.nix
+++ b/nixos/modules/services/misc/radarr.nix
@@ -40,9 +40,10 @@ in
   };
 
   config = mkIf cfg.enable {
-    systemd.tmpfiles.rules = [
-      "d '${cfg.dataDir}' 0700 ${cfg.user} ${cfg.group} - -"
-    ];
+    systemd.tmpfiles.settings."10-radarr".${cfg.dataDir}.d = {
+      inherit (cfg) user group;
+      mode = "0700";
+    };
 
     systemd.services.radarr = {
       description = "Radarr";

--- a/nixos/modules/services/misc/readarr.nix
+++ b/nixos/modules/services/misc/readarr.nix
@@ -45,9 +45,10 @@ in
   };
 
   config = mkIf cfg.enable {
-    systemd.tmpfiles.rules = [
-      "d '${cfg.dataDir}' 0700 ${cfg.user} ${cfg.group} - -"
-    ];
+    systemd.tmpfiles.settings."10-readarr".${cfg.dataDir}.d = {
+      inherit (cfg) user group;
+      mode = "0700";
+    };
 
     systemd.services.readarr = {
       description = "Readarr";

--- a/nixos/modules/services/monitoring/alerta.nix
+++ b/nixos/modules/services/monitoring/alerta.nix
@@ -79,9 +79,10 @@ in
   };
 
   config = mkIf cfg.enable {
-    systemd.tmpfiles.rules = [
-      "d '${cfg.logDir}' - alerta alerta - -"
-    ];
+    systemd.tmpfiles.settings."10-alerta".${cfg.logDir}.d = {
+      user = "alerta";
+      group = "alerta";
+    };
 
     systemd.services.alerta = {
       description = "Alerta Monitoring System";

--- a/nixos/modules/services/monitoring/kapacitor.nix
+++ b/nixos/modules/services/monitoring/kapacitor.nix
@@ -160,9 +160,9 @@ in
   config = mkIf cfg.enable {
     environment.systemPackages = [ pkgs.kapacitor ];
 
-    systemd.tmpfiles.rules = [
-      "d '${cfg.dataDir}' - ${cfg.user} ${cfg.group} - -"
-    ];
+    systemd.tmpfiles.settings."10-kapacitor".${cfg.dataDir}.d = {
+      inherit (cfg) user group;
+    };
 
     systemd.services.kapacitor = {
       description = "Kapacitor Real-Time Stream Processing Engine";

--- a/nixos/modules/services/monitoring/munin.nix
+++ b/nixos/modules/services/monitoring/munin.nix
@@ -374,7 +374,11 @@ in
     };
 
     # munin_stats plugin breaks as of 2.0.33 when this doesn't exist
-    systemd.tmpfiles.rules = [ "d /run/munin 0755 munin munin -" ];
+    systemd.tmpfiles.settings."10-munin"."/run/munin".d = {
+      mode = "0755";
+      user = "munin";
+      group = "munin";
+    };
 
   }) (mkIf cronCfg.enable {
 
@@ -399,11 +403,17 @@ in
       };
     };
 
-    systemd.tmpfiles.rules = [
-      "d /run/munin 0755 munin munin -"
-      "d /var/log/munin 0755 munin munin -"
-      "d /var/www/munin 0755 munin munin -"
-      "d /var/lib/munin 0755 munin munin -"
-    ];
+    systemd.tmpfiles.settings."20-munin" = let
+      defaultConfig = {
+        mode = "0755";
+        user = "munin";
+        group = "munin";
+      };
+    in {
+      "/run/munin".d = defaultConfig;
+      "/var/log/munin".d = defaultConfig;
+      "/var/www/munin".d = defaultConfig;
+      "/var/lib/munin".d = defaultConfig;
+    };
   })];
 }

--- a/nixos/modules/services/monitoring/osquery.nix
+++ b/nixos/modules/services/monitoring/osquery.nix
@@ -90,8 +90,10 @@ in
       };
       wantedBy = [ "multi-user.target" ];
     };
-    systemd.tmpfiles.rules = [
-      "d ${dirname (cfg.flags.pidfile)} 0755 root root -"
-    ];
+    systemd.tmpfiles.settings."10-osquery".${dirname (cfg.flags.pidfile)}.d = {
+      user = "root";
+      group = "root";
+      mode = "0755";
+    };
   };
 }

--- a/nixos/modules/services/monitoring/riemann-dash.nix
+++ b/nixos/modules/services/monitoring/riemann-dash.nix
@@ -59,9 +59,10 @@ in {
       group = "riemanndash";
     };
 
-    systemd.tmpfiles.rules = [
-      "d '${cfg.dataDir}' - riemanndash riemanndash - -"
-    ];
+    systemd.tmpfiles.settings."10-riemanndash".${cfg.dataDir}.d = {
+      user = "riemanndash";
+      group = "riemanndash";
+    };
 
     systemd.services.riemann-dash = {
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/network-filesystems/cachefilesd.nix
+++ b/nixos/modules/services/network-filesystems/cachefilesd.nix
@@ -56,8 +56,10 @@ in
       };
     };
 
-    systemd.tmpfiles.rules = [
-      "d ${cfg.cacheDir} 0700 root root - -"
-    ];
+    systemd.tmpfiles.settings."10-cachefilesd".${cfg.cacheDir}.d = {
+      user = "root";
+      group = "root";
+      mode = "0700";
+    };
   };
 }

--- a/nixos/modules/services/network-filesystems/kbfs.nix
+++ b/nixos/modules/services/network-filesystems/kbfs.nix
@@ -92,7 +92,12 @@ in {
     (mkIf cfg.enableRedirector {
       security.wrappers."keybase-redirector".source = "${pkgs.kbfs}/bin/redirector";
 
-      systemd.tmpfiles.rules = [ "d /keybase 0755 root root 0" ];
+      systemd.tmpfiles.settings."10-kbfs"."/keybase".d = {
+        user = "root";
+        group = "root";
+        mode = "0755";
+        age = "0";
+      };
 
       # Upstream: https://github.com/keybase/client/blob/master/packaging/linux/systemd/keybase-redirector.service
       systemd.user.services.keybase-redirector = {

--- a/nixos/modules/services/network-filesystems/kubo.nix
+++ b/nixos/modules/services/network-filesystems/kubo.nix
@@ -307,12 +307,13 @@ in
       ipfs.gid = config.ids.gids.ipfs;
     };
 
-    systemd.tmpfiles.rules = [
-      "d '${cfg.dataDir}' - ${cfg.user} ${cfg.group} - -"
-    ] ++ optionals cfg.autoMount [
-      "d '${cfg.settings.Mounts.IPFS}' - ${cfg.user} ${cfg.group} - -"
-      "d '${cfg.settings.Mounts.IPNS}' - ${cfg.user} ${cfg.group} - -"
-    ];
+    systemd.tmpfiles.settings."10-kubo" = let
+      defaultConfig = { inherit (cfg) user group; };
+    in {
+      ${cfg.dataDir}.d = defaultConfig;
+      ${cfg.settings.Mounts.IPFS}.d = mkIf (cfg.autoMount) defaultConfig;
+      ${cfg.settings.Mounts.IPNS}.d = mkIf (cfg.autoMount) defaultConfig;
+    };
 
     # The hardened systemd unit breaks the fuse-mount function according to documentation in the unit file itself
     systemd.packages = if cfg.autoMount

--- a/nixos/modules/services/networking/charybdis.nix
+++ b/nixos/modules/services/networking/charybdis.nix
@@ -81,9 +81,9 @@ in
         gid = config.ids.gids.ircd;
       };
 
-      systemd.tmpfiles.rules = [
-        "d ${cfg.statedir} - ${cfg.user} ${cfg.group} - -"
-      ];
+      systemd.tmpfiles.settings."10-charybdis".${cfg.statedir}.d = {
+        inherit (cfg) user group;
+      };
 
       environment.etc."charybdis/ircd.conf".source = configFile;
 

--- a/nixos/modules/services/networking/jibri/default.nix
+++ b/nixos/modules/services/networking/jibri/default.nix
@@ -395,11 +395,11 @@ in
       };
     };
 
-    systemd.tmpfiles.rules = [
-      "d /var/log/jitsi/jibri 755 jibri jibri"
-    ];
-
-
+    systemd.tmpfiles.settings."10-jibri"."/var/log/jitsi/jibri".d = {
+      user = "jibri";
+      group = "jibri";
+      mode = "755";
+    };
 
     # Configure Chromium to not show the "Chrome is being controlled by automatic test software" message.
     environment.etc."chromium/policies/managed/managed_policies.json".text = builtins.toJSON { CommandLineFlagSecurityWarningsEnabled = false; };

--- a/nixos/modules/services/torrent/deluge.nix
+++ b/nixos/modules/services/torrent/deluge.nix
@@ -191,17 +191,25 @@ in {
     # Provide a default set of `extraPackages`.
     services.deluge.extraPackages = with pkgs; [ unzip gnutar xz bzip2 ];
 
-    systemd.tmpfiles.rules = [
-      "d '${cfg.dataDir}' 0770 ${cfg.user} ${cfg.group}"
-      "d '${cfg.dataDir}/.config' 0770 ${cfg.user} ${cfg.group}"
-      "d '${cfg.dataDir}/.config/deluge' 0770 ${cfg.user} ${cfg.group}"
-    ]
-    ++ optional (cfg.config ? download_location)
-      "d '${cfg.config.download_location}' 0770 ${cfg.user} ${cfg.group}"
-    ++ optional (cfg.config ? torrentfiles_location)
-      "d '${cfg.config.torrentfiles_location}' 0770 ${cfg.user} ${cfg.group}"
-    ++ optional (cfg.config ? move_completed_path)
-      "d '${cfg.config.move_completed_path}' 0770 ${cfg.user} ${cfg.group}";
+    systemd.tmpfiles.settings."10-deluged" = let
+      defaultConfig = {
+        inherit (cfg) user group;
+        mode = "0770";
+      };
+    in {
+      "${cfg.dataDir}".d = defaultConfig;
+      "${cfg.dataDir}/.config".d = defaultConfig;
+      "${cfg.dataDir}/.config/deluge".d = defaultConfig;
+    }
+    // optionalAttrs (cfg.config ? download_location) {
+      ${cfg.config.download_location}.d = defaultConfig;
+    }
+    // optionalAttrs (cfg.config ? torrentfiles_location) {
+      ${cfg.config.torrentfiles_location}.d = defaultConfig;
+    }
+    // optionalAttrs (cfg.config ? move_completed_path) {
+      ${cfg.config.move_completed_path}.d = defaultConfig;
+    };
 
     systemd.services.deluged = {
       after = [ "network.target" ];

--- a/nixos/modules/services/video/epgstation/default.nix
+++ b/nixos/modules/services/video/epgstation/default.nix
@@ -309,17 +309,25 @@ in
         (lib.mkIf cfg.usePreconfiguredStreaming streamingConfig)
       ];
 
-    systemd.tmpfiles.rules = [
-      "d '/var/lib/epgstation/key' - ${username} ${groupname} - -"
-      "d '/var/lib/epgstation/streamfiles' - ${username} ${groupname} - -"
-      "d '/var/lib/epgstation/drop' - ${username} ${groupname} - -"
-      "d '/var/lib/epgstation/recorded' - ${username} ${groupname} - -"
-      "d '/var/lib/epgstation/thumbnail' - ${username} ${groupname} - -"
-      "d '/var/lib/epgstation/db/subscribers' - ${username} ${groupname} - -"
-      "d '/var/lib/epgstation/db/migrations/mysql' - ${username} ${groupname} - -"
-      "d '/var/lib/epgstation/db/migrations/postgres' - ${username} ${groupname} - -"
-      "d '/var/lib/epgstation/db/migrations/sqlite' - ${username} ${groupname} - -"
-    ];
+    systemd.tmpfiles.settings."10-epgstation" =
+      lib.listToAttrs
+        (map (dir: lib.nameValuePair dir {
+          d = {
+            user = username;
+            group = groupname;
+          };
+        })
+        [
+          "/var/lib/epgstation/key"
+          "/var/lib/epgstation/streamfiles"
+          "/var/lib/epgstation/drop"
+          "/var/lib/epgstation/recorded"
+          "/var/lib/epgstation/thumbnail"
+          "/var/lib/epgstation/db/subscribers"
+          "/var/lib/epgstation/db/migrations/mysql"
+          "/var/lib/epgstation/db/migrations/postgres"
+          "/var/lib/epgstation/db/migrations/sqlite"
+        ]);
 
     systemd.services.epgstation = {
       inherit description;

--- a/nixos/modules/services/video/mirakurun.nix
+++ b/nixos/modules/services/video/mirakurun.nix
@@ -165,9 +165,10 @@ in
         port = mkIf (cfg.port != null) cfg.port;
       };
 
-      systemd.tmpfiles.rules = [
-        "d '/etc/mirakurun' - ${username} ${groupname} - -"
-      ];
+      systemd.tmpfiles.settings."10-mirakurun"."/etc/mirakurun".d = {
+        user = username;
+        group = groupname;
+      };
 
       systemd.services.mirakurun = {
         description = mirakurun.meta.description;

--- a/nixos/modules/services/web-apps/bookstack.nix
+++ b/nixos/modules/services/web-apps/bookstack.nix
@@ -412,20 +412,25 @@ in {
       '';
     };
 
-    systemd.tmpfiles.rules = [
-      "d ${cfg.dataDir}                            0710 ${user} ${group} - -"
-      "d ${cfg.dataDir}/public                     0750 ${user} ${group} - -"
-      "d ${cfg.dataDir}/public/uploads             0750 ${user} ${group} - -"
-      "d ${cfg.dataDir}/storage                    0700 ${user} ${group} - -"
-      "d ${cfg.dataDir}/storage/app                0700 ${user} ${group} - -"
-      "d ${cfg.dataDir}/storage/fonts              0700 ${user} ${group} - -"
-      "d ${cfg.dataDir}/storage/framework          0700 ${user} ${group} - -"
-      "d ${cfg.dataDir}/storage/framework/cache    0700 ${user} ${group} - -"
-      "d ${cfg.dataDir}/storage/framework/sessions 0700 ${user} ${group} - -"
-      "d ${cfg.dataDir}/storage/framework/views    0700 ${user} ${group} - -"
-      "d ${cfg.dataDir}/storage/logs               0700 ${user} ${group} - -"
-      "d ${cfg.dataDir}/storage/uploads            0700 ${user} ${group} - -"
-    ];
+    systemd.tmpfiles.settings."10-bookstack" = let
+      defaultConfig = {
+        inherit user group;
+        mode = "0700";
+      };
+    in {
+      "${cfg.dataDir}".d = defaultConfig // { mode = "0710"; };
+      "${cfg.dataDir}/public".d = defaultConfig // { mode = "0750"; };
+      "${cfg.dataDir}/public/uploads".d = defaultConfig // { mode = "0750"; };
+      "${cfg.dataDir}/storage".d = defaultConfig;
+      "${cfg.dataDir}/storage/app".d = defaultConfig;
+      "${cfg.dataDir}/storage/fonts".d = defaultConfig;
+      "${cfg.dataDir}/storage/framework".d = defaultConfig;
+      "${cfg.dataDir}/storage/framework/cache".d = defaultConfig;
+      "${cfg.dataDir}/storage/framework/sessions".d = defaultConfig;
+      "${cfg.dataDir}/storage/framework/views".d = defaultConfig;
+      "${cfg.dataDir}/storage/logs".d = defaultConfig;
+      "${cfg.dataDir}/storage/uploads".d = defaultConfig;
+    };
 
     users = {
       users = mkIf (user == "bookstack") {

--- a/nixos/modules/services/web-apps/freshrss.nix
+++ b/nixos/modules/services/web-apps/freshrss.nix
@@ -228,9 +228,10 @@ in
       };
       users.groups."${cfg.user}" = { };
 
-      systemd.tmpfiles.rules = [
-        "d '${cfg.dataDir}' - ${cfg.user} ${config.users.users.${cfg.user}.group} - -"
-      ];
+      systemd.tmpfiles.settings."10-freshrss".${cfg.dataDir}.d = {
+        inherit (cfg) user;
+        group = config.users.users.${cfg.user}.group;
+      };
 
       systemd.services.freshrss-config =
         let

--- a/nixos/modules/services/web-apps/mattermost.nix
+++ b/nixos/modules/services/web-apps/mattermost.nix
@@ -277,9 +277,7 @@ in
 
       # The systemd service will fail to execute the preStart hook
       # if the WorkingDirectory does not exist
-      systemd.tmpfiles.rules = [
-        ''d "${cfg.statePath}" -''
-      ];
+      systemd.tmpfiles.settings."10-mattermost".${cfg.statePath}.d = { };
 
       systemd.services.mattermost = {
         description = "Mattermost chat service";

--- a/nixos/modules/services/web-apps/moodle.nix
+++ b/nixos/modules/services/web-apps/moodle.nix
@@ -255,9 +255,10 @@ in
       } ];
     };
 
-    systemd.tmpfiles.rules = [
-      "d '${stateDir}' 0750 ${user} ${group} - -"
-    ];
+    systemd.tmpfiles.settings."10-moodle".${stateDir}.d = {
+      inherit user group;
+      mode = "0750";
+    };
 
     systemd.services.moodle-init = {
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/web-apps/nifi.nix
+++ b/nixos/modules/services/web-apps/nifi.nix
@@ -163,10 +163,15 @@ in {
       Please do not disable HTTPS mode in production. In this mode, access to the nifi is opened without authentication.
     '';
 
-    systemd.tmpfiles.rules = [
-      "d '/var/lib/nifi/conf' 0750 ${cfg.user} ${cfg.group}"
-      "L+ '/var/lib/nifi/lib' - - - - ${cfg.package}/lib"
-    ];
+    systemd.tmpfiles.settings."10-nifi" = {
+      "/var/lib/nifi/conf".d = {
+        inherit (cfg) user group;
+        mode = "0750";
+      };
+      "/var/lib/nifi/lib"."L+" = {
+        argument = "${cfg.package}/lib";
+      };
+    };
 
 
     systemd.services.nifi = {

--- a/nixos/modules/services/web-apps/writefreely.nix
+++ b/nixos/modules/services/web-apps/writefreely.nix
@@ -334,8 +334,10 @@ in {
         optionalAttrs (cfg.group == "writefreely") { writefreely = { }; };
     };
 
-    systemd.tmpfiles.rules =
-      [ "d '${cfg.stateDir}' 0750 ${cfg.user} ${cfg.group} - -" ];
+    systemd.tmpfiles.settings."10-writefreely".${cfg.stateDir}.d = {
+      inherit (cfg) user group;
+      mode = "0750";
+    };
 
     systemd.services.writefreely = {
       after = [ "network.target" ]


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR revamps some of the `tmpfiles` configurations in a few modules to use the new API provided by #262731. While the change does not contribute anything new in terms of functionality, it is meant to kickstart the usage of the API among new PRs, where the PR author might look to other modules for reference. These are supposed to serve as such references.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
