### PR TITLE
Revert "nixos/gitlab: fix database config when no passwordfile is defined"

### DIFF
--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -1359,7 +1359,6 @@ in {
               ''
               else ''
                 jq <${pkgs.writeText "database.yml" (builtins.toJSON databaseConfig)} \
-                   '${if lib.versionAtLeast (lib.getVersion cfg.packages.gitlab) "15.9" then ".production.main as $main | del(.production.main) | .production |= {main: $main} + ." else ""}' \
                    >'${cfg.statePath}/config/database.yml'
               ''
             }


### PR DESCRIPTION
Reverts NixOS/nixpkgs#280009

This causes git clones over ssh to be broken