### PR TITLE
jitsi-meet-electron: 2022.10.1 -> 2023.11.3, build from source

### DIFF
--- a/pkgs/applications/networking/instant-messengers/jitsi-meet-electron/default.nix
+++ b/pkgs/applications/networking/instant-messengers/jitsi-meet-electron/default.nix
@@ -1,60 +1,106 @@
-{ lib, stdenv
-, fetchurl
-, appimageTools
+{ lib
+, buildNpmPackage
+, fetchFromGitHub
+, copyDesktopItems
+, makeDesktopItem
 , makeWrapper
+, libpng
+, libX11
+, libXi
+, libXtst
+, zlib
 , electron
-, xorg
 , pipewire
 }:
 
-stdenv.mkDerivation rec {
+buildNpmPackage rec {
   pname = "jitsi-meet-electron";
-  version = "2022.10.1";
+  version = "2023.11.3";
 
-  src = fetchurl {
-    url = "https://github.com/jitsi/jitsi-meet-electron/releases/download/v${version}/jitsi-meet-x86_64.AppImage";
-    sha256 = "sha256-98zuAsGT30paxszSO1XcMY8tsrMBeBLDFjK/JWhLC8s=";
-    name = "${pname}-${version}.AppImage";
+  src = fetchFromGitHub {
+    owner = "jitsi";
+    repo = "jitsi-meet-electron";
+    rev = "v${version}";
+    hash = "sha256-gE5CP0l3SrAHGNS6Hr5/MefTtE86JTmc85CwOmylEpg=";
   };
 
-  appimageContents = appimageTools.extractType2 {
-    name = "${pname}-${version}";
-    inherit src;
-  };
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
 
-  dontUnpack = true;
-  dontConfigure = true;
-  dontBuild = true;
+  # robotjs node-gyp dependencies
+  buildInputs = [
+    libpng
+    libX11
+    libXi
+    libXtst
+    zlib
+  ];
 
-  nativeBuildInputs = [ makeWrapper ];
+  npmDepsHash = "sha256-JZVJcKzG4X7YIUvIRWZsDQnHx+dNqCj6kFm8mZaSH2k=";
+
+  makeCacheWritable = true;
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+
+  postPatch = ''
+    substituteInPlace main.js \
+        --replace "require('electron-is-dev')" "false"
+  '';
+
+  preBuild = ''
+    # remove some prebuilt binaries
+    find node_modules -type d -name prebuilds -exec rm -r {} +
+  '';
+
+  postBuild = ''
+    # generate .asar file
+    # asarUnpack makes sure to unwrap binaries so that nix can see the RPATH
+    npm exec electron-builder -- \
+        --dir \
+        -c.asarUnpack="**/*.node" \
+        -c.electronDist=${electron}/libexec/electron \
+        -c.electronVersion=${electron.version}
+  '';
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/bin $out/share/${pname} $out/share/applications
+    mkdir -p $out/share/jitsi-meet-electron
+    cp -r dist/*-unpacked/{locales,resources{,.pak}} $out/share/jitsi-meet-electron
 
-    cp -a ${appimageContents}/{locales,resources} $out/share/${pname}
-    cp -a ${appimageContents}/jitsi-meet.desktop $out/share/applications/${pname}.desktop
-    cp -a ${appimageContents}/usr/share/icons $out/share
+    makeWrapper ${lib.getExe electron} $out/bin/jitsi-meet-electron \
+        --add-flags $out/share/jitsi-meet-electron/resources/app.asar \
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ pipewire ]} \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+        --inherit-argv0
 
-    substituteInPlace $out/share/applications/${pname}.desktop \
-      --replace 'Exec=AppRun' 'Exec=${pname}'
+    install -Dm644 resources/icons/512x512.png $out/share/icons/hicolor/512x512/apps/jitsi-meet-electron.png
 
     runHook postInstall
   '';
 
-  postFixup = ''
-    makeWrapper ${electron}/bin/electron $out/bin/${pname} \
-      --add-flags $out/share/${pname}/resources/app.asar \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc xorg.libXtst pipewire ]}" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
-  '';
+  desktopItems = [
+    (makeDesktopItem {
+      name = "jitsi-meet-electron";
+      exec = "jitsi-meet-electron %U";
+      icon = "jitsi-meet-electron";
+      desktopName = "Jitsi Meet";
+      comment = meta.description;
+      categories = [ "VideoConference" "AudioVideo" "Audio" "Video" "Network" ];
+      mimeTypes = [ "x-scheme-handler/jitsi-meet" ];
+      terminal = false;
+    })
+  ];
 
   meta = with lib; {
+    changelog = "https://github.com/jitsi/jitsi-meet-electron/releases/tag/${src.rev}";
     description = "Jitsi Meet desktop application powered by Electron";
     homepage = "https://github.com/jitsi/jitsi-meet-electron";
     license = licenses.asl20;
-    maintainers = teams.jitsi.members;
-    platforms = [ "x86_64-linux" ];
+    mainProgram = "jitsi-meet-electron";
+    maintainers = teams.jitsi.members ++ [ maintainers.tomasajt ];
+    inherit (electron.meta) platforms;
   };
 }


### PR DESCRIPTION
## Description of changes

Other than updating the version, I did a major refactor of the derivation.
Now it builds from source.

I had to set `makeCacheWritable = true` for some reason, hopefully nothing breaks. 

I added a `postPatch` because it was thinking that it was in dev-mode, so the relative paths were from the PWD instead of the app root.

Upstream uses some npm packages, which had some prebuilt `.node` libraries, I made sure to remove those.
I also made sure to not pack into the .asar file all other `.node` libraries (only 1: robotjs) so that nix can find the dependencies from the RPATH.

I kept `pipewire` in `LD_LIBRARY_PATH` (though I don't use wayland, so I couldn't test it). Does `cc` still need to be added when building from source? (It worked OK for me without it)

I added some extra `meta` tags and added myself as a maintainer.

The desktop item and the icons are being set manually ATM, but maybe I could change the call to `electron-builder` so that it generates the unwrapped `deb` directory layout, which should contain the desktop file and icon.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
