### PR TITLE
tftui: init at 0.12.4

### DIFF
--- a/pkgs/applications/networking/cluster/tftui/default.nix
+++ b/pkgs/applications/networking/cluster/tftui/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonApplication
+, fetchPypi
+, makeWrapper
+, poetry-core
+, posthog
+, pyperclip
+, requests
+, rich
+, textual
+, enableUsageTracking ? false
+}:
+
+buildPythonApplication rec {
+  pname = "tftui";
+  version = "0.12.4";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-E4Y0qA7SooMlHh+oSFUl1hfblpirr/Jdb1C2fqU43t0=";
+  };
+
+  propagatedBuildInputs = [
+    posthog
+    pyperclip
+    requests
+    rich
+    textual
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    poetry-core
+  ];
+
+  pythonImportsCheck = [
+    "tftui"
+  ];
+
+  postInstall = lib.optionalString (!enableUsageTracking) ''
+    wrapProgram $out/bin/tftui \
+      --add-flags "--disable-usage-tracking"
+  '';
+
+  meta = with lib; {
+    description = "Textual UI to view and interact with Terraform state";
+    homepage = "https://github.com/idoavrah/terraform-tui";
+    changelog = "https://github.com/idoavrah/terraform-tui/releases";
+    license = licenses.asl20;
+    maintainers = with maintainers; teams.bitnomial.members;
+    mainProgram = "tftui";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -41093,6 +41093,8 @@ with pkgs;
 
   tfswitch = callPackage ../applications/networking/cluster/tfswitch { };
 
+  tftui = python3Packages.callPackage ../applications/networking/cluster/tftui { };
+
   tfupdate = callPackage ../applications/networking/cluster/tfupdate { };
 
   tgswitch = callPackage ../applications/networking/cluster/tgswitch { };


### PR DESCRIPTION
## Description of changes

[`tftui`](https://github.com/idoavrah/terraform-tui) is a TUI tool for viewing Terraform state files:

https://github.com/idoavrah/terraform-tui/blob/main/demo/tftui.gif

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
