### PR TITLE
gamescope: 3.12.5 -> 3.13.19, refactor

### DIFF
--- a/pkgs/applications/window-managers/gamescope/default.nix
+++ b/pkgs/applications/window-managers/gamescope/default.nix
@@ -8,7 +8,6 @@
 , vulkan-loader
 , vulkan-headers
 , wayland
-, wayland-scanner
 , wayland-protocols
 , libxkbcommon
 , glm
@@ -16,11 +15,8 @@
 , libcap
 , SDL2
 , pipewire
-, udev
 , pixman
 , libinput
-, seatd
-, xwayland
 , glslang
 , hwdata
 , openvr
@@ -30,31 +26,50 @@
 , libdisplay-info
 , lib
 , makeBinaryWrapper
+, enableExecutable ? true
+, enableWsi ? true
 }:
 let
-  pname = "gamescope";
-  version = "3.12.5";
-
-  vkroots = fetchFromGitHub {
+  joshShaders = fetchFromGitHub {
     owner = "Joshua-Ashton";
-    repo = "vkroots";
-    rev = "26757103dde8133bab432d172b8841df6bb48155";
-    hash = "sha256-eet+FMRO2aBQJcCPOKNKGuQv5oDIrgdVPRO00c5gkL0=";
+    repo = "GamescopeShaders";
+    rev = "v0.1";
+    hash = "sha256-gR1AeAHV/Kn4ntiEDUSPxASLMFusV6hgSGrTbMCBUZA=";
   };
 in
-stdenv.mkDerivation {
-  inherit pname version;
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gamescope";
+  version = "3.13.19";
 
   src = fetchFromGitHub {
     owner = "ValveSoftware";
     repo = "gamescope";
-    rev = "refs/tags/${version}";
-    hash = "sha256-u4pnKd5ZEC3CS3E2i8E8Wposd8Tu4ZUoQXFmr0runwE=";
+    rev = "refs/tags/${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-WKQgVbuHvTbZnvTU5imV35AKZ4AF0EDsdESBZwVH7+M=";
   };
 
   patches = [
+    # Unvendor dependencies
     ./use-pkgconfig.patch
+
+    # Make it look for shaders in the right place
+    ./shaders-path.patch
   ];
+
+  # We can't substitute the patch itself because substituteAll is itself a derivation,
+  # so `placeholder "out"` ends up pointing to the wrong place
+  postPatch = ''
+    substituteInPlace src/reshade_effect_manager.cpp --replace "@out@" "$out"
+  '';
+
+  mesonFlags = [
+    (lib.mesonBool "enable_gamescope" enableExecutable)
+    (lib.mesonBool "enable_gamescope_wsi_layer" enableWsi)
+  ];
+
+  # don't install vendored vkroots etc
+  mesonInstallFlags = ["--skip-subprojects"];
 
   strictDeps = true;
 
@@ -66,70 +81,62 @@ stdenv.mkDerivation {
     meson
     pkg-config
     ninja
-    wayland-scanner
-    glslang
+  ] ++ lib.optionals enableExecutable [
     makeBinaryWrapper
+    glslang
   ];
 
   buildInputs = [
-    xorg.libXdamage
-    xorg.libXcomposite
-    xorg.libXrender
-    xorg.libXext
-    xorg.libXxf86vm
-    xorg.libXtst
-    xorg.libXres
-    xorg.libXi
-    xorg.libXmu
-    libdrm
-    libliftoff
-    vulkan-loader
-    vulkan-headers
-    SDL2
+    pipewire
+    hwdata
+    xorg.libX11
     wayland
     wayland-protocols
+    vulkan-loader
+    openvr
+    glm
+  ] ++ lib.optionals enableWsi [
+    vulkan-headers
+  ] ++ lib.optionals enableExecutable [
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXi
+    xorg.libXmu
+    xorg.libXrender
+    xorg.libXres
+    xorg.libXtst
+    xorg.libXxf86vm
+    libdrm
+    libliftoff
+    SDL2
     wlroots
-    xwayland
-    seatd
     libinput
     libxkbcommon
-    glm
     gbenchmark
-    udev
     pixman
-    pipewire
     libcap
     stb
-    hwdata
-    openvr
-    vkroots
     libdisplay-info
   ];
 
-  outputs = [ "out" "lib" ];
-
-  postUnpack = ''
-    rm -rf source/subprojects/vkroots
-    ln -s ${vkroots} source/subprojects/vkroots
-  '';
-
-  # --debug-layers flag expects these in the path
-  postInstall = ''
+  postInstall = lib.optionalString enableExecutable ''
+    # --debug-layers flag expects these in the path
     wrapProgram "$out/bin/gamescope" \
       --prefix PATH : ${with xorg; lib.makeBinPath [xprop xwininfo]}
 
-    # Install Vulkan layer in lib output
-    install -d $lib/share/vulkan
-    mv $out/share/vulkan/implicit_layer.d $lib/share/vulkan
-    rm -r $out/share/vulkan
+    # Install ReShade shaders
+    mkdir -p $out/share/gamescope/reshade
+    cp -r ${joshShaders}/* $out/share/gamescope/reshade/
   '';
 
   meta = with lib; {
     description = "SteamOS session compositing window manager";
     homepage = "https://github.com/ValveSoftware/gamescope";
     license = licenses.bsd2;
-    maintainers = with maintainers; [ nrdxp pedrohlc Scrumplex zhaofengli ];
+    maintainers = with maintainers; [ nrdxp pedrohlc Scrumplex zhaofengli k900 ];
     platforms = platforms.linux;
     mainProgram = "gamescope";
   };
-}
+})

--- a/pkgs/applications/window-managers/gamescope/shaders-path.patch
+++ b/pkgs/applications/window-managers/gamescope/shaders-path.patch
@@ -1,0 +1,13 @@
+diff --git a/src/reshade_effect_manager.cpp b/src/reshade_effect_manager.cpp
+index 3597ca1..de45250 100644
+--- a/src/reshade_effect_manager.cpp
++++ b/src/reshade_effect_manager.cpp
+@@ -34,7 +34,7 @@ static std::string GetLocalUsrDir()
+
+ static std::string GetUsrDir()
+ {
+-    return "/usr";
++    return "@out@";
+ }
+
+ static LogScope reshade_log("gamescope_reshade");

--- a/pkgs/applications/window-managers/gamescope/use-pkgconfig.patch
+++ b/pkgs/applications/window-managers/gamescope/use-pkgconfig.patch
@@ -1,11 +1,9 @@
-diff --git a/meson.build b/meson.build
-index 1311784..77043ac 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -6,7 +6,6 @@ project(
    default_options: [
-     'cpp_std=c++14',
+     'cpp_std=c++20',
      'warning_level=2',
--    'force_fallback_for=wlroots,libliftoff',
+-    'force_fallback_for=wlroots,libliftoff,vkroots',
    ],
  )

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1812,7 +1812,13 @@ with pkgs;
   };
 
   gamescope = callPackage ../applications/window-managers/gamescope {
-    wlroots = wlroots_0_16;
+    enableExecutable = true;
+    enableWsi = false;
+  };
+
+  gamescope-wsi = callPackage ../applications/window-managers/gamescope {
+    enableExecutable = false;
+    enableWsi = true;
   };
 
   gay = callPackage ../tools/misc/gay {  };


### PR DESCRIPTION
## Description of changes

This mostly brings in changes from Jovian, but also splits the dependencies between the WSI layer and the Gamescope executable, which simplifies i686 layer builds a whole lot.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
