### PR TITLE
powersupply: init at 0.9.0

### DIFF
--- a/pkgs/by-name/po/powersupply/package.nix
+++ b/pkgs/by-name/po/powersupply/package.nix
@@ -1,0 +1,62 @@
+{ lib
+, python3
+, fetchFromGitLab
+, desktop-file-utils
+, gobject-introspection
+, gtk3
+, libhandy
+, meson
+, ninja
+, pkg-config
+, wrapGAppsHook
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "powersupply";
+  version = "0.9.0";
+
+  format = "other";
+
+  src = fetchFromGitLab {
+    owner = "martijnbraam";
+    repo = "powersupply";
+    rev = version;
+    hash = "sha256-3NXoOqveMlMezYe4C78F3764KeAy5Sz3M714PO3h/eI=";
+  };
+
+  nativeBuildInputs = [
+    desktop-file-utils
+    gtk3
+    gobject-introspection
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    gtk3
+    libhandy
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    pygobject3
+  ];
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  strictDeps = true;
+
+  meta = with lib; {
+    description = "Graphical app to display power status of mobile Linux platforms";
+    homepage = "https://gitlab.com/MartijnBraam/powersupply";
+    license = licenses.mit;
+    mainProgram = "powersupply";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ Luflosi ];
+  };
+}


### PR DESCRIPTION
## Description of changes
Graphical app to display power status of mobile Linux platforms.
https://gitlab.com/MartijnBraam/powersupply

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
