### PR TITLE
java-service-wrapper: enable aarch64-linux platform

### DIFF
--- a/pkgs/tools/system/java-service-wrapper/default.nix
+++ b/pkgs/tools/system/java-service-wrapper/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     homepage = "https://wrapper.tanukisoftware.com/";
     changelog = "https://wrapper.tanukisoftware.com/doc/english/release-notes.html#${version}";
     license = licenses.gpl2Only;
-    platforms = [ "x86_64-linux" "i686-linux" ];
+    platforms = [ "x86_64-linux" "i686-linux" "aarch64-linux" ];
     maintainers = [ maintainers.suhr ];
     mainProgram = "wrapper";
   };


### PR DESCRIPTION
java-service-wrapper: enable aarch64-linux platform