### PR TITLE
unstableGitUpdater: Use stableVersion, update to new format, offer hardcoded 0 version

### DIFF
--- a/pkgs/common-updater/unstable-updater.nix
+++ b/pkgs/common-updater/unstable-updater.nix
@@ -90,19 +90,20 @@ let
                 ${git}/bin/git fetch --depth="$depth" --tags
                 depth=$(( $depth * 2 ))
             done
+
+            if [[ -z "$last_tag" ]]; then
+                # To be extra sure, check if full history helps with finding a tag
+                git fetch --tags
+                last_tag="$(${git}/bin/git describe --tags --abbrev=0 2> /dev/null || true)"
+            fi
         else
-          last_tag="$(${git}/bin/git describe --tags --abbrev=0 2> /dev/null || true)"
+            last_tag="$(${git}/bin/git describe --tags --abbrev=0 2> /dev/null || true)"
         fi
         if [[ -z "$last_tag" ]]; then
-            if [[ "$shallow_clone" == "1" ]]; then
-                echo "Cound not find a tag within last 10000 commits" > /dev/stderr
-            else
-                echo "Cound not find a tag" > /dev/stderr
-            fi
-            exit 1
+            last_tag="0"
         fi
         if [[ -n "$tag_prefix" ]]; then
-          last_tag="''${last_tag#$tag_prefix}"
+            last_tag="''${last_tag#$tag_prefix}"
         fi
         if [[ ! "$last_tag" =~ ^[[:digit:]] ]]; then
             echo "Last tag '$last_tag' (after removing prefix '$tag_prefix') does not start with a digit" > /dev/stderr

--- a/pkgs/common-updater/unstable-updater.nix
+++ b/pkgs/common-updater/unstable-updater.nix
@@ -84,9 +84,7 @@ let
       # Get info about HEAD from a shallow git clone
       tmpdir="$(mktemp -d)"
 
-      cloneArgs=(
-        --bare
-      )
+      cloneArgs=()
 
       if [[ "$shallow_clone" == "1" ]]; then
           cloneArgs+=(--depth=1)
@@ -120,7 +118,7 @@ let
                   last_tag="$(git describe --tags --abbrev=0 --match "''${tag_format}" 2> /dev/null || true)"
               fi
           else
-              last_tag="$(git describe --tags --abbrev=0 2> --match "''${tag_format}" /dev/null || true)"
+              last_tag="$(git describe --tags --abbrev=0 --match "''${tag_format}" 2> /dev/null || true)"
           fi
           if [[ -z "$last_tag" ]]; then
               last_tag="0"

--- a/pkgs/common-updater/unstable-updater.nix
+++ b/pkgs/common-updater/unstable-updater.nix
@@ -1,5 +1,5 @@
 { lib
-, writeShellScript
+, writeShellApplication
 , coreutils
 , git
 , nix
@@ -11,146 +11,156 @@
 { url ? null # The git url, if empty it will be set to src.gitRepoUrl
 , branch ? null
 , hardcodeZeroVersion ? false # Use a made-up version "0" instead of latest tag. Use when there is no previous release, or the project's tagging system is incompatible with what we expect from versions
-, tagFormat ? ".*" # A grep -Eo pattern that tags must match to be considered valid
-, tagPrefix ? "" # strip this prefix from a tag name
+, tagFormat ? "*" # A `git describe --tags --match '<format>'` pattern that tags must match to be considered
+, tagPrefix ? null # strip this prefix from a tag name
 , tagConverter ? null # A command to convert more complex tag formats. It receives the git tag via stdin and should convert it into x.y.z format to stdout
 , shallowClone ? true
 }:
 
+assert lib.asserts.assertMsg (tagPrefix == null || tagConverter == null) "Can only use either tagPrefix or tagConverter!";
+
 let
-  updateScript = writeShellScript "unstable-update-script.sh" ''
-    set -ex
+  updateScript = writeShellApplication {
+    name = "unstable-update-script";
+    runtimeInputs = [
+      common-updater-scripts
+      coreutils
+      git
+      nix
+    ];
+    text = ''
+      set -ex
 
-    url=""
-    branch=""
-    hardcode_zero_version=""
-    tag_format=""
-    tag_prefix=""
-    tag_converter=""
-    shallow_clone=""
+      url=""
+      branch=""
+      hardcode_zero_version=""
+      tag_format=""
+      tag_prefix=""
+      tag_converter=""
+      shallow_clone=""
+      : "''${systemArg:=}"
 
-    while (( $# > 0 )); do
-        flag="$1"
-        shift 1
-        case "$flag" in
-          --url=*)
-            url="''${flag#*=}"
-            ;;
-          --branch=*)
-            branch="''${flag#*=}"
-            ;;
-          --hardcode-zero-version)
-            hardcode_zero_version=1
-            ;;
-          --tag-format=*)
-            tag_format="''${flag#*=}"
-            ;;
-          --tag-prefix=*)
-            tag_prefix="''${flag#*=}"
-            ;;
-          --tag-converter=*)
-            tag_converter="''${flag#*=}"
-            ;;
-          --shallow-clone)
-            shallow_clone=1
-            ;;
-          *)
-            echo "$0: unknown option ‘''${flag}’"
-            exit 1
-            ;;
-        esac
-    done
+      while (( $# > 0 )); do
+          flag="$1"
+          shift 1
+          case "$flag" in
+            --url=*)
+              url="''${flag#*=}"
+              ;;
+            --branch=*)
+              branch="''${flag#*=}"
+              ;;
+            --hardcode-zero-version)
+              hardcode_zero_version=1
+              ;;
+            --tag-format=*)
+              tag_format="''${flag#*=}"
+              ;;
+            --tag-prefix=*)
+              tag_prefix="''${flag#*=}"
+              ;;
+            --tag-converter=*)
+              tag_converter="''${flag#*=}"
+              ;;
+            --shallow-clone)
+              shallow_clone=1
+              ;;
+            *)
+              echo "$0: unknown option ‘''${flag}’"
+              exit 1
+              ;;
+          esac
+      done
 
-    # By default we set url to src.gitRepoUrl
-    if [[ -z "$url" ]]; then
-        url="$(${nix}/bin/nix-instantiate $systemArg --eval -E \
-                   "with import ./. {}; $UPDATE_NIX_ATTR_PATH.src.gitRepoUrl" \
-            | tr -d '"')"
-    fi
+      # By default we set url to src.gitRepoUrl
+      if [[ -z "$url" ]]; then
+          # system argument cannot be passed as 1 argument
+          # shellcheck disable=SC2086
+          url="$(nix-instantiate $systemArg --eval -E \
+                     "with import ./. {}; $UPDATE_NIX_ATTR_PATH.src.gitRepoUrl" \
+              | tr -d '"')"
+      fi
 
-    # Get info about HEAD from a shallow git clone
-    tmpdir="$(${coreutils}/bin/mktemp -d)"
+      # Get info about HEAD from a shallow git clone
+      tmpdir="$(mktemp -d)"
 
-    cloneArgs=(
-      --bare
-    )
+      cloneArgs=(
+        --bare
+      )
 
-    if [[ "$shallow_clone" == "1" ]]; then
-        cloneArgs+=(--depth=1)
-    fi
+      if [[ "$shallow_clone" == "1" ]]; then
+          cloneArgs+=(--depth=1)
+      fi
 
-    if [[ -n "$branch" ]]; then
-        cloneArgs+=(--branch="$branch")
-    fi
+      if [[ -n "$branch" ]]; then
+          cloneArgs+=(--branch="$branch")
+      fi
 
-    ${git}/bin/git clone "''${cloneArgs[@]}" "$url" "$tmpdir"
+      git clone "''${cloneArgs[@]}" "$url" "$tmpdir"
 
-    pushd "$tmpdir"
-    commit_date="$(${git}/bin/git show -s --pretty='format:%cs')"
-    commit_sha="$(${git}/bin/git show -s --pretty='format:%H')"
-    last_tag=""
-    if [[ -z "$hardcode_zero_version" ]]; then
-        if [[ "$shallow_clone" == "1" ]]; then
-            depth=100
-            while (( $depth < 10000 )); do
-                last_tag="$(${git}/bin/git describe --tags --abbrev=0 2> /dev/null || true)"
-                if [[ -n "$last_tag" ]]; then
-                    tag_matched="$(echo ''${last_tag} | grep -Eo ''${tag_format} || true)"
-                    if [[ -z "$tag_matched" ]]; then
-                        ${lib.getExe git} tag -d ''${last_tag}
-                        continue
-                    fi
-                    break
-                fi
-                ${git}/bin/git fetch --depth="$depth" --tags
-                depth=$(( $depth * 2 ))
-            done
+      pushd "$tmpdir"
+      commit_date="$(git show -s --pretty='format:%cs')"
+      commit_sha="$(git show -s --pretty='format:%H')"
+      last_tag=""
+      if [[ -z "$hardcode_zero_version" ]]; then
+          if [[ "$shallow_clone" == "1" ]]; then
+              depth=100
+              while (( depth < 10000 )); do
+                  last_tag="$(git describe --tags --abbrev=0 --match "''${tag_format}" 2> /dev/null || true)"
+                  if [[ -n "$last_tag" ]]; then
+                      break
+                  fi
+                  git fetch --depth="$depth" --tags
+                  depth=$(( depth * 2 ))
+              done
 
-            if [[ -z "$last_tag" ]]; then
-                # To be extra sure, check if full history helps with finding a tag
-                git fetch --tags
-                last_tag="$(${git}/bin/git describe --tags --abbrev=0 2> /dev/null || true)"
-            fi
-        else
-            last_tag="$(${git}/bin/git describe --tags --abbrev=0 2> /dev/null || true)"
-        fi
-        if [[ -z "$last_tag" ]]; then
-            last_tag="0"
-        fi
-        if [[ -n "$tag_prefix" ]]; then
-            echo "Stripping prefix '$tag_prefix' from tag '$last_tag'"
-            last_tag="''${last_tag#$tag_prefix}"
-        fi
-        if [[ -n "$tag_converter" ]]; then
-            echo "Running '$last_tag' through: $tag_converter"
-            last_tag="$(echo ''${last_tag#$tag_prefix} | ''${tag_converter})"
-        fi
-        if [[ ! "$last_tag" =~ ^[[:digit:]] ]]; then
-            echo "Last tag '$last_tag' does not start with a digit" > /dev/stderr
-            exit 1
-        fi
-    else
-        last_tag="0"
-    fi
-    new_version="$last_tag-unstable-$commit_date"
-    popd
-    # ${coreutils}/bin/rm -rf "$tmpdir"
+              if [[ -z "$last_tag" ]]; then
+                  # To be extra sure, check if full history helps with finding a tag
+                  git fetch --tags
+                  last_tag="$(git describe --tags --abbrev=0 --match "''${tag_format}" 2> /dev/null || true)"
+              fi
+          else
+              last_tag="$(git describe --tags --abbrev=0 2> --match "''${tag_format}" /dev/null || true)"
+          fi
+          if [[ -z "$last_tag" ]]; then
+              last_tag="0"
+          fi
+          if [[ -n "$tag_prefix" ]]; then
+              echo "Stripping prefix '$tag_prefix' from tag '$last_tag'"
+              last_tag="''${last_tag#"''${tag_prefix}"}"
+          fi
+          if [[ -n "$tag_converter" ]]; then
+              echo "Running '$last_tag' through: $tag_converter"
+              last_tag="$(echo "''${last_tag}" | ''${tag_converter})"
+          fi
+      else
+          last_tag="0"
+      fi
+      if [[ ! "$last_tag" =~ ^[[:digit:]] ]]; then
+          echo "Last tag '$last_tag' does not start with a digit" > /dev/stderr
+          exit 1
+      fi
+      new_version="$last_tag-unstable-$commit_date"
+      popd
+      # rm -rf "$tmpdir"
 
-    # update the nix expression
-    ${common-updater-scripts}/bin/update-source-version \
-        "$UPDATE_NIX_ATTR_PATH" \
-        "$new_version" \
-        --rev="$commit_sha"
-  '';
+      # update the nix expression
+      update-source-version \
+          "$UPDATE_NIX_ATTR_PATH" \
+          "$new_version" \
+          --rev="$commit_sha"
+    '';
+  };
 
 in
 [
-  updateScript
+  (lib.getExe updateScript)
   "--url=${builtins.toString url}"
   "--tag-format=${tagFormat}"
-  "--tag-prefix=${tagPrefix}"
 ] ++ lib.optionals (branch != null) [
   "--branch=${branch}"
+] ++ lib.optionals (tagPrefix != null) [
+  "--tag-prefix=${tagPrefix}"
 ] ++ lib.optionals (tagConverter != null) [
   "--tag-converter=${tagConverter}"
 ] ++ lib.optionals hardcodeZeroVersion [

--- a/pkgs/common-updater/unstable-updater.nix
+++ b/pkgs/common-updater/unstable-updater.nix
@@ -95,6 +95,9 @@ let
       fi
 
       git clone "''${cloneArgs[@]}" "$url" "$tmpdir"
+      getLatestVersion() {
+          git describe --tags --abbrev=0 --match "''${tag_format}" 2> /dev/null || true
+      }
 
       pushd "$tmpdir"
       commit_date="$(git show -s --pretty='format:%cs')"
@@ -104,7 +107,7 @@ let
           if [[ "$shallow_clone" == "1" ]]; then
               depth=100
               while (( depth < 10000 )); do
-                  last_tag="$(git describe --tags --abbrev=0 --match "''${tag_format}" 2> /dev/null || true)"
+                  last_tag="$(getLatestVersion)"
                   if [[ -n "$last_tag" ]]; then
                       break
                   fi
@@ -115,10 +118,10 @@ let
               if [[ -z "$last_tag" ]]; then
                   # To be extra sure, check if full history helps with finding a tag
                   git fetch --tags
-                  last_tag="$(git describe --tags --abbrev=0 --match "''${tag_format}" 2> /dev/null || true)"
+                  last_tag="$(getLatestVersion)"
               fi
           else
-              last_tag="$(git describe --tags --abbrev=0 --match "''${tag_format}" 2> /dev/null || true)"
+              last_tag="$(getLatestVersion)"
           fi
           if [[ -z "$last_tag" ]]; then
               last_tag="0"


### PR DESCRIPTION
## Description of changes

With #280312, we now have more complete guidelines on what unstable versions should look like in our post-#234201 world. As a first step towards that, update `unstableGitUpdater` update script - and all users of it, to avoid update errors - to actually use it.

- Remove `stableVersion` option, the stable version schema will always be used now.
  The only usage of this option inside of Nixpkgs that I could find (`gnomeExtensions.dash-to-dock`, back when it was manually packaged) was removed ~ 2 years ago. GitHub-wide code search was only able to find stale Nixpkgs clones with that one usage, so it *seems* fine to just drop it?
- Add a `hardcodeZeroVersion` option, for projects without any releases & incompatible tagging systems. This skips the tag search in favour of a hardcoded version `0`.

Not 100% sure yet if the way this is implemented in the script is the best way of doing it, but it's a start. Open for complaints / alternative solutions :slightly_smiling_face:.

Closes #291729

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
closes https://github.com/NixOS/nixpkgs/pull/294213

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
