### PR TITLE
doc: update conventions with repl examples and function (in|out)puts

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -157,6 +157,9 @@ watermelon
 
 In an effort to keep the Nixpkgs manual in a consistent style, please follow the conventions below, unless they prevent you from properly documenting something.
 In that case, please open an issue about the particular documentation convention and tag it with a "needs: documentation" label.
+When needed, each convention explain why it exists, so you can make a decision whether to follow it or not based on your particular case.
+Note that these conventions are about the **structure** of the manual (and its source files), not about the content that goes in it.
+You, as the writer of documentation, are still in charge of its content.
 
 - Put each sentence in its own line.
   This makes reviews and suggestions much easier, since GitHub's review system is based on lines.
@@ -188,6 +191,57 @@ In that case, please open an issue about the particular documentation convention
   }
   ```
 
+- When showing inputs/outputs of any [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop), such as a shell or the Nix REPL, use a format as you'd see in the REPL, while trying to visually separate inputs from outputs.
+  This means that for a shell, you should use a format like the following:
+  ```shell
+  $ nix-build -A hello '<nixpkgs>' \
+    --option require-sigs false \
+    --option trusted-substituters file:///tmp/hello-cache \
+    --option substituters file:///tmp/hello-cache
+  /nix/store/zhl06z4lrfrkw5rp0hnjjfrgsclzvxpm-hello-2.12.1
+  ```
+  Note how the input is preceded by `$` on the first line and indented on subsequent lines, and how the output is provided as you'd see on the shell.
+
+  For the Nix REPL, you should use a format like the following:
+  ```shell
+  nix-repl> builtins.attrNames { a = 1; b = 2; }
+  [ "a" "b" ]
+  ```
+  Note how the input is preceded by `nix-repl>` and the output is provided as you'd see on the Nix REPL.
+
+- When documenting functions or anything that has inputs/outputs and example usage, use nested headings to clearly separate inputs, outputs, and examples.
+  Keep examples as the last nested heading, and link to the examples wherever applicable in the documentation.
+
+  The purpose of this convention is to provide a familiar structure for navigating the manual, so any reader can expect to find content related to inputs in an "inputs" heading, examples in an "examples" heading, and so on.
+  An example:
+  ```
+  ## buildImage
+
+  Some explanation about the function here.
+  Describe a particular scenario, and point to [](#ex-dockerTools-buildImage), which is an example demonstrating it.
+
+  ### Inputs
+
+  Documentation for the inputs of `buildImage`.
+  Perhaps even point to [](#ex-dockerTools-buildImage) again when talking about something specifically linked to it.
+
+  ### Passthru outputs
+
+  Documentation for any passthru outputs of `buildImage`.
+
+  ### Examples
+
+  Note that this is the last nested heading in the `buildImage` section.
+
+  :::{.example #ex-dockerTools-buildImage}
+
+  # Using `buildImage`
+
+  Example of how to use `buildImage` goes here.
+
+  :::
+  ```
+
 - Use [definition lists](#definition-lists) to document function arguments, and the attributes of such arguments as well as their [types](https://nixos.org/manual/nix/stable/language/values).
   For example:
 
@@ -195,6 +249,9 @@ In that case, please open an issue about the particular documentation convention
   # pkgs.coolFunction
 
   Description of what `coolFunction` does.
+
+  ## Inputs
+
   `coolFunction` expects a single argument which should be an attribute set, with the following possible attributes:
 
   `name` (String)


### PR DESCRIPTION
## Description of changes

Closes #276829.

This PR adds two more items to the nixpkgs documentation conventions as discussed in the documentation meetings and PR reviews.

This is related to #278769, where I'm going through the nixpkgs manual to make it more consistent (and also update its content). I'm documenting the conventions I'm applying as I do this work in an effort to:
1. Let other people know the conventions I'm using, should they want to help with this work.
2. Let other people start using the same conventions for future work.
3. Have conventions clearly documented, because they weren't (or didn't even exist) before this work started.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
