### PR TITLE
rmfakecloud: 0.0.13.2 -> 0.0.17

### DIFF
--- a/pkgs/servers/rmfakecloud/default.nix
+++ b/pkgs/servers/rmfakecloud/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "rmfakecloud";
-  version = "0.0.13.2";
+  version = "0.0.17";
 
   src = fetchFromGitHub {
     owner = "ddvk";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-7lVNbqQv6MNIhHMFbH8VFVIjKiuTCbeVkAKeGprzrkw=";
+    sha256 = "sha256-Rb81CbtC1V8AugTNIGx07CvK20sZ5d4hfc4OxF259IQ=";
   };
 
-  vendorHash = "sha256-Pz/TtGjwGHaDSueBEHMtHjyAxYO5V+8jzXCowHcUW/4=";
+  vendorHash = "sha256-Rr2EVrQOdlOqSlTpXFMfnKNmdw6UiT7LZH0xBUwqkJc=";
 
   ui = callPackage ./webui.nix { inherit version src; };
 

--- a/pkgs/servers/rmfakecloud/webui.nix
+++ b/pkgs/servers/rmfakecloud/webui.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation rec {
 
   yarnOfflineCache = fetchYarnDeps {
     yarnLock = "${src}/ui/yarn.lock";
-    sha256 = "sha256-37P+acjaeG7TCyLoIHIHsB+DCUOsQOJ1H9T5SgajtLc=";
+    sha256 = "sha256-4boZCEly4HovK9BXlSoFd3wZoPaGnzbJg5AygSC/Lrg=";
   };
 
   nativeBuildInputs = [ prefetch-yarn-deps yarn nodejs ];

--- a/pkgs/servers/rmfakecloud/webui.nix
+++ b/pkgs/servers/rmfakecloud/webui.nix
@@ -1,4 +1,4 @@
-{ version, src, stdenv, lib, fetchFromGitHub, fetchYarnDeps, prefetch-yarn-deps, yarn, nodejs }:
+{ version, src, stdenv, lib, fetchYarnDeps, prefetch-yarn-deps, yarn, nodejs }:
 
 stdenv.mkDerivation rec {
   inherit version src;


### PR DESCRIPTION
## Description of changes

This updates the rmfakecloud package to the latest available version.

- rmfakecloud: remove unused input
- rmfakecloud: 0.0.13.2 -> 0.0.17


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
