### PR TITLE
python3Packages.cffi: fix missing ffi_prep_closure_loc() on macos < 10.15

### DIFF
--- a/pkgs/development/python-modules/cffi/darwin-use-libffi-closures.diff
+++ b/pkgs/development/python-modules/cffi/darwin-use-libffi-closures.diff
@@ -2,15 +2,22 @@ diff --git a/src/c/_cffi_backend.c b/src/c/_cffi_backend.c
 index 537271f..9c3bf94 100644
 --- a/src/c/_cffi_backend.c
 +++ b/src/c/_cffi_backend.c
-@@ -103,7 +103,7 @@
+@@ -103,11 +103,11 @@
  # define CFFI_CHECK_FFI_PREP_CIF_VAR 0
  # define CFFI_CHECK_FFI_PREP_CIF_VAR_MAYBE 0
  
 -#elif defined(__APPLE__) && defined(FFI_AVAILABLE_APPLE)
 +#elif defined(__APPLE__)
  
- # define CFFI_CHECK_FFI_CLOSURE_ALLOC __builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)
+-# define CFFI_CHECK_FFI_CLOSURE_ALLOC __builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)
++# define CFFI_CHECK_FFI_CLOSURE_ALLOC 1
  # define CFFI_CHECK_FFI_CLOSURE_ALLOC_MAYBE 1
+-# define CFFI_CHECK_FFI_PREP_CLOSURE_LOC __builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)
++# define CFFI_CHECK_FFI_PREP_CLOSURE_LOC 1
+ # define CFFI_CHECK_FFI_PREP_CLOSURE_LOC_MAYBE 1
+-# define CFFI_CHECK_FFI_PREP_CIF_VAR __builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)
++# define CFFI_CHECK_FFI_PREP_CIF_VAR 1
+ # define CFFI_CHECK_FFI_PREP_CIF_VAR_MAYBE 1
 @@ -6422,7 +6422,7 @@ static PyObject *b_callback(PyObject *self, PyObject *args)
      else
  #endif


### PR DESCRIPTION
<details><summary>In the course of testing out the fix that ultimately landed in #278945, I ran into the following missing-function error in cffi's test suite:</summary>

```
Executing pytestCheckPhase
============================= test session starts ==============================
platform darwin -- Python 3.11.7, pytest-7.4.3, pluggy-1.3.0
rootdir: /private/tmp/nix-build-python3.11-cffi-1.16.0.drv-0/cffi-1.16.0
collecting ... ^Mcollecting 229 items                                                           ^Mcollecting 641 items                                                           ^Mcollecting 872 items 

==================================== ERRORS ====================================
_____________ ERROR collecting testing/cffi1/test_parse_c_type.py ______________
/nix/store/xmn75r6ddzyqbky5zkaryl8djskgakd1-python3.11-pytest-7.4.3/lib/python3.11/site-packages/_pytest/runner.py:341: in from_call
    result: Optional[TResult] = func()
/nix/store/xmn75r6ddzyqbky5zkaryl8djskgakd1-python3.11-pytest-7.4.3/lib/python3.11/site-packages/_pytest/runner.py:372: in <lambda>
    call = CallInfo.from_call(lambda: list(collector.collect()), "collect")
/nix/store/xmn75r6ddzyqbky5zkaryl8djskgakd1-python3.11-pytest-7.4.3/lib/python3.11/site-packages/_pytest/python.py:531: in collect
    self._inject_setup_module_fixture()
/nix/store/xmn75r6ddzyqbky5zkaryl8djskgakd1-python3.11-pytest-7.4.3/lib/python3.11/site-packages/_pytest/python.py:545: in _inject_setup_module_fixture
    self.obj, ("setUpModule", "setup_module")
/nix/store/xmn75r6ddzyqbky5zkaryl8djskgakd1-python3.11-pytest-7.4.3/lib/python3.11/site-packages/_pytest/python.py:310: in obj
    self._obj = obj = self._getobj()
/nix/store/xmn75r6ddzyqbky5zkaryl8djskgakd1-python3.11-pytest-7.4.3/lib/python3.11/site-packages/_pytest/python.py:528: in _getobj
    return self._importtestmodule()
/nix/store/xmn75r6ddzyqbky5zkaryl8djskgakd1-python3.11-pytest-7.4.3/lib/python3.11/site-packages/_pytest/python.py:617: in _importtestmodule
    mod = import_path(self.path, mode=importmode, root=self.config.rootpath)
/nix/store/xmn75r6ddzyqbky5zkaryl8djskgakd1-python3.11-pytest-7.4.3/lib/python3.11/site-packages/_pytest/pathlib.py:567: in import_path
    importlib.import_module(module_name)
/nix/store/riwkg7zfhj0fzn918s8yiblnvyp0vcmd-python3-3.11.7/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1204: in _gcd_import
    ???
<frozen importlib._bootstrap>:1176: in _find_and_load
    ???
<frozen importlib._bootstrap>:1147: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:690: in _load_unlocked
    ???
/nix/store/xmn75r6ddzyqbky5zkaryl8djskgakd1-python3.11-pytest-7.4.3/lib/python3.11/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
    exec(co, module.__dict__)
testing/cffi1/test_parse_c_type.py:75: in <module>
    @ffi.callback("int(unsigned long long *)")
src/cffi/api.py:396: in callback_decorator_wrap
    return self._backend.callback(cdecl, python_callable,
E   SystemError: ffi_prep_closure_loc() is missing
------------------------------- Captured stderr --------------------------------
ld: warning: directory not found for option '-L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-zlib-1.3/lib'
ld: warning: directory not found for option '-L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-bzip2-1.0.8/lib'
ld: warning: directory not found for option '-L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-expat-2.5.0/lib'
ld: warning: directory not found for option '-L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-xz-5.4.5/lib'
ld: warning: directory not found for option '-L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libffi-3.4.4/lib'
ld: warning: directory not found for option '-L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gdbm-1.23/lib'
ld: warning: directory not found for option '-L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-sqlite-3.44.2/lib'
ld: warning: directory not found for option '-L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-readline-8.2p7/lib'
ld: warning: directory not found for option '-L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-ncurses-6.4/lib'
ld: warning: directory not found for option '-L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-openssl-3.0.12/lib'
ld: warning: directory not found for option '-L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-configd-453.19/lib'
ld: warning: directory not found for option '-L/nix/store/zd2q4dbddgw06nx4cv8qkzs4s24i4rh8-tzdata-2023d/lib'
ld: warning: directory not found for option '-L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-zlib-1.3/lib'
ld: warning: directory not found for option '-L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-bzip2-1.0.8/lib'
ld: warning: directory not found for option '-L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-expat-2.5.0/lib'
ld: warning: directory not found for option '-L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-xz-5.4.5/lib'
ld: warning: directory not found for option '-L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-libffi-3.4.4/lib'
ld: warning: directory not found for option '-L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-gdbm-1.23/lib'
ld: warning: directory not found for option '-L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-sqlite-3.44.2/lib'
ld: warning: directory not found for option '-L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-readline-8.2p7/lib'
ld: warning: directory not found for option '-L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-ncurses-6.4/lib'
ld: warning: directory not found for option '-L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-openssl-3.0.12/lib'
ld: warning: directory not found for option '-L/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-configd-453.19/lib'
ld: warning: directory not found for option '-L/nix/store/zd2q4dbddgw06nx4cv8qkzs4s24i4rh8-tzdata-2023d/lib'
=============================== warnings summary ===============================
src/cffi/_imp_emulation.py:4
  /private/tmp/nix-build-python3.11-cffi-1.16.0.drv-0/cffi-1.16.0/src/c/../cffi/_imp_emulation.py:4: DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in P
    from imp import *

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
ERROR testing/cffi1/test_parse_c_type.py - SystemError: ffi_prep_closure_loc() is missing
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
========================= 1 warning, 1 error in 7.96s ==========================
```

</details>

The missing function is in turn caused by these defines: https://github.com/python-cffi/cffi/blame/feaff378873d8a3f52bbb63f7d5e24f9ab18f1e9/src/c/_cffi_backend.c#L106-L113

If I understand correctly (I may not), cffi is assuming the system libffi here, which doesn't apply in our case. (cc @reckenrode)

(The underlying defines (which affect macOS before 10.15) have been in cffi for 4+ years now, so I'm not quite sure how we haven't picked up on it already.)

## Description of changes

I edited the patch for this behavior (pkgs/development/python-modules/cffi/darwin-use-libffi-closures.diff) to remove the version check.

I went ahead and did this for all 3 checks, even though I suspect we didn't technically need all of them to pass the test failure above.

## Things done

I was able to successfully build and use `nix` with this patch present.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
