### PR TITLE
deepin: move distribution.info back to deepin-desktop-base

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/deepin.nix
+++ b/nixos/modules/services/x11/desktop-managers/deepin.nix
@@ -96,18 +96,10 @@ in
         "/share/dde-daemon"
         "/share/dsg"
         "/share/deepin-themes"
+        "/share/deepin"
       ];
 
       environment.etc = {
-        "distribution.info".text = ''
-          [Distribution]
-          Name=NixOS
-          WebsiteName=www.nixos.org
-          Website=https://www.nixos.org
-          Logo=${pkgs.nixos-icons}/share/icons/hicolor/96x96/apps/nix-snowflake.png
-          LogoLight=${pkgs.nixos-icons}/share/icons/hicolor/32x32/apps/nix-snowflake.png
-          LogoTransparent=${pkgs.deepin.deepin-desktop-base}/share/pixmaps/distribution_logo_transparent.svg
-        '';
         "deepin-installer.conf".text = ''
           system_info_vendor_name="Copyright (c) 2003-2023 NixOS contributors"
         '';
@@ -156,6 +148,7 @@ in
             deepin-sound-theme
             deepin-gtk-theme
             deepin-wallpapers
+            deepin-desktop-base
 
             startdde
             dde-dock

--- a/pkgs/desktops/deepin/library/dtkcore/default.nix
+++ b/pkgs/desktops/deepin/library/dtkcore/default.nix
@@ -32,11 +32,6 @@ stdenv.mkDerivation rec {
     ./fix-pri-path.patch
   ];
 
-  postPatch = ''
-    substituteInPlace src/dsysinfo.cpp \
-      --replace "/usr/share/deepin/distribution.info" "/etc/distribution.info" \
-  '';
-
   nativeBuildInputs = [
     cmake
     pkg-config

--- a/pkgs/desktops/deepin/misc/deepin-desktop-base/default.nix
+++ b/pkgs/desktops/deepin/misc/deepin-desktop-base/default.nix
@@ -1,6 +1,7 @@
 { stdenvNoCC
 , lib
 , fetchFromGitHub
+, nixos-icons
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "deepin-desktop-base";
@@ -24,6 +25,15 @@ stdenvNoCC.mkDerivation rec {
     mv $out/usr/* $out/
     rm -r $out/usr
     install -D ${./distribution_logo_transparent.svg} $out/share/pixmaps/distribution_logo_transparent.svg
+    cat > $out/share/deepin/distribution.info <<EOF
+    [Distribution]
+    Name=NixOS
+    WebsiteName=www.nixos.org
+    Website=https://www.nixos.org
+    Logo=${nixos-icons}/share/icons/hicolor/96x96/apps/nix-snowflake.png
+    LogoLight=${nixos-icons}/share/icons/hicolor/32x32/apps/nix-snowflake.png
+    LogoTransparent=$out/share/pixmaps/distribution_logo_transparent.svg
+    EOF
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

dtkcore will search `distribution.info` form XDG_DATA_DIRS now (https://github.com/linuxdeepin/dtkcore/pull/355)

There is no need to move it to /etc，it is originally a part of deepin-desktop-base, and needs to modify for each distribution .

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
