### PR TITLE
pgadmin: 8.1 -> 8.2, python3Packages.webauthn 1.11.1 -> 2.0.0, python3Packages.flask-security-too: fix pydantic issue

### DIFF
--- a/nixos/modules/services/admin/pgadmin.nix
+++ b/nixos/modules/services/admin/pgadmin.nix
@@ -168,7 +168,7 @@ in
           echo "$PW"
           # Retype password:
           echo "$PW"
-        ) | ${cfg.package}/bin/pgadmin4-setup
+        ) | ${cfg.package}/bin/pgadmin4-cli setup-db
       '';
 
       restartTriggers = [

--- a/nixos/tests/pgadmin4.nix
+++ b/nixos/tests/pgadmin4.nix
@@ -56,8 +56,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
       # check for missing support files (css, js etc). Should catch not-generated files during build. See e.g. https://github.com/NixOS/nixpkgs/pull/229184
       machine.succeed("wget -nv --level=1 --spider --recursive localhost:5051/login")
       # test idempotenceny
-      machine.systemctl("stop pgadmin.service")
-      machine.systemctl("start pgadmin.service")
+      machine.systemctl("restart pgadmin.service")
       machine.wait_for_unit("pgadmin")
       machine.wait_until_succeeds("curl -sS localhost:5051")
       machine.wait_until_succeeds("curl -sS localhost:5051/login | grep \"<title>pgAdmin 4</title>\" > /dev/null")

--- a/nixos/tests/pgadmin4.nix
+++ b/nixos/tests/pgadmin4.nix
@@ -55,6 +55,12 @@ import ./make-test-python.nix ({ pkgs, lib, ... }:
       machine.wait_until_succeeds("curl -sS localhost:5051/login | grep \"<title>pgAdmin 4</title>\" > /dev/null")
       # check for missing support files (css, js etc). Should catch not-generated files during build. See e.g. https://github.com/NixOS/nixpkgs/pull/229184
       machine.succeed("wget -nv --level=1 --spider --recursive localhost:5051/login")
+      # test idempotenceny
+      machine.systemctl("stop pgadmin.service")
+      machine.systemctl("start pgadmin.service")
+      machine.wait_for_unit("pgadmin")
+      machine.wait_until_succeeds("curl -sS localhost:5051")
+      machine.wait_until_succeeds("curl -sS localhost:5051/login | grep \"<title>pgAdmin 4</title>\" > /dev/null")
 
     # pgadmin4 module saves the configuration to /etc/pgadmin/config_system.py
     # pgadmin4-desktopmode tries to read that as well. This normally fails with a PermissionError, as the config file

--- a/pkgs/development/python-modules/flask-security-too/default.nix
+++ b/pkgs/development/python-modules/flask-security-too/default.nix
@@ -3,7 +3,7 @@
 , fetchPypi
 , pythonOlder
 , setuptools
-, pydantic
+, fetchpatch
 
 # extras: babel
 , babel
@@ -58,6 +58,16 @@ buildPythonPackage rec {
     inherit version;
     hash = "sha256-we2TquU28qP/ir4eE67J0Nlft/8IL8w7Ny3ypSE5cNk=";
   };
+
+  patches = [
+    # https://github.com/Flask-Middleware/flask-security/pull/901
+    (fetchpatch {
+      name = "fixes-for-py_webauthn-2.0.patch";
+      url = "https://github.com/Flask-Middleware/flask-security/commit/5725f7021343567ec0b25c890e859f4e84c93ba6.patch";
+      hash = "sha256-4EgwT4zRj0mh4ZaoZFz7H5KeiZ9zs+BY4siYm8DwMfU=";
+      excludes = [ "CHANGES.rst" ];
+    })
+  ];
 
   nativeBuildInputs = [
     setuptools
@@ -128,7 +138,5 @@ buildPythonPackage rec {
     description = "Simple security for Flask apps (fork)";
     license = licenses.mit;
     maintainers = with maintainers; [ gador ];
-    # https://github.com/Flask-Middleware/flask-security/pull/851
-    broken = versionAtLeast pydantic.version "2";
   };
 }

--- a/pkgs/development/python-modules/webauthn/default.nix
+++ b/pkgs/development/python-modules/webauthn/default.nix
@@ -4,29 +4,27 @@
 , asn1crypto
 , cbor2
 , pythonOlder
-, pydantic
 , pyopenssl
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "webauthn";
-  version = "1.11.1";
+  version = "2.0.0";
   format = "setuptools";
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "duo-labs";
     repo = "py_webauthn";
     rev = "refs/tags/v${version}";
-    hash = "sha256-+pp21rtwavtjj6ahG091xsJpsYOH3zpqU3xH2/YFXqY=";
+    hash = "sha256-StqoSrzErV13/OUpSWbI+6N5tSFPEpvnmQcDiZMaXPI=";
   };
 
   propagatedBuildInputs = [
     asn1crypto
     cbor2
-    pydantic
     pyopenssl
   ];
 

--- a/pkgs/tools/admin/pgadmin/default.nix
+++ b/pkgs/tools/admin/pgadmin/default.nix
@@ -14,14 +14,14 @@
 
 let
   pname = "pgadmin";
-  version = "8.1";
-  yarnHash = "sha256-KAiY5TX2O8mxP7PjIJstYEzCBbqDgT+CpEhreuAGW/U=";
+  version = "8.2";
+  yarnHash = "sha256-uMSgpkYoLD32VYDAkjywC9bZjm7UKA0hhwVNc/toEbA=";
 
   src = fetchFromGitHub {
     owner = "pgadmin-org";
     repo = "pgadmin4";
     rev = "REL-${lib.versions.major version}_${lib.versions.minor version}";
-    hash = "sha256-zzS/fydNOXpIWdyLtWQhY+hVpneca+3wD88DmZEkS8s=";
+    hash = "sha256-RfpZXy265kwpMsWUBDVfbL/0eX0By79I4VNkG8zwVOs=";
   };
 
   # keep the scope, as it is used throughout the derivation and tests
@@ -181,6 +181,8 @@ pythonPackages.buildPythonApplication rec {
     google-auth-oauthlib
     google-api-python-client
     keyring
+    typer
+    rich
   ];
 
   passthru.tests = {

--- a/pkgs/tools/admin/pgadmin/expose-setup.py.patch
+++ b/pkgs/tools/admin/pgadmin/expose-setup.py.patch
@@ -1,64 +1,16 @@
- pkg/pip/setup_pip.py |  5 ++++-
- web/setup.py         | 14 ++++++++------
- 2 files changed, 12 insertions(+), 7 deletions(-)
-
 diff --git a/pkg/pip/setup_pip.py b/pkg/pip/setup_pip.py
-index 5592d1b04..131eaa1ed 100644
+index c65795b10..e56b6a6f3 100644
 --- a/pkg/pip/setup_pip.py
 +++ b/pkg/pip/setup_pip.py
-@@ -95,7 +95,10 @@ setup(
-     },
- 
+@@ -101,7 +101,7 @@ setup(
+
      entry_points={
--        'console_scripts': ['pgadmin4=pgadmin4.pgAdmin4:main'],
-+        'console_scripts': [
-+            'pgadmin4=pgadmin4.pgAdmin4:main',
-+            'pgadmin4-setup=pgadmin4.setup:main'
-+        ],
+         'console_scripts': ['pgadmin4=pgadmin4.pgAdmin4:main',
+-                            'pgadmin4-cli=pgadmin4.setup:main'],
++                            'pgadmin4-cli=pgadmin4.setup:app'],
      },
- 
+
  )
-diff --git a/web/setup.py b/web/setup.py
-index 2204ffb..d5fda9f 100644
---- a/web/setup.py
-+++ b/web/setup.py
-@@ -14,7 +14,6 @@ import argparse
- import os
- import sys
- import builtins
--import config
-
- # Grab the SERVER_MODE if it's been set by the runtime
- if 'SERVER_MODE' in globals():
-@@ -91,6 +90,9 @@ def load_servers(args):
- def setup_db(app):
-     """Setup the configuration database."""
-
-+    # here we need an additional import, since the call to setup_db changed
-+    # https://redmine.postgresql.org/projects/pgadmin4/repository/2/revisions/3a69d50458f57d19948b867aec55c55d635a36e5/diff/web/setup.py
-+    import config
-     create_app_data_directory(config)
-
-     print("pgAdmin 4 - Application Initialisation")
-@@ -139,8 +141,9 @@ def clear_servers():
-         clear_database_servers(load_user, True)
-
-
--if __name__ == '__main__':
-+def main():
-     # Configuration settings
-+    import config
-     parser = argparse.ArgumentParser(description='Setup the pgAdmin config DB')
-
-     exp_group = parser.add_argument_group('Dump server config')
-@@ -191,3 +194,6 @@ if __name__ == '__main__':
-     else:
-         app = create_app()
-         setup_db(app)
-+
-+if __name__ == '__main__':
-+    main()
-
 diff --git a/web/pgadmin/model/__init__.py b/web/pgadmin/model/__init__.py
 index 4c36dd1..a492365 100644
 --- a/web/pgadmin/model/__init__.py

--- a/pkgs/tools/admin/pgadmin/yarn.lock
+++ b/pkgs/tools/admin/pgadmin/yarn.lock
@@ -12716,3 +12716,8 @@ zustand@^4.4.1:
   resolved "https://github.com/pgadmin-org/react-data-grid.git#200d2f5e02de694e3e9ffbe177c279bc40240fb8"
   dependencies:
     "clsx" "^1.1.1"
+"react-data-grid@https://github.com/pgadmin-org/react-data-grid.git#200d2f5e02de694e3e9ffbe177c279bc40240fb8":
+  version "7.0.0-beta.14"
+  resolved "https://github.com/pgadmin-org/react-data-grid.git#200d2f5e02de694e3e9ffbe177c279bc40240fb8"
+  dependencies:
+    "clsx" "^1.1.1"


### PR DESCRIPTION
## Description of changes

This is a major update to pgadmin. (https://www.pgadmin.org/docs/pgadmin4/latest/release_notes_8_2.html)
Mainly, a new `cli` option has been added. 
Due to the change, we can drop most of our `expose-setup` patch.

## Required changes to other packages

- `webauthn` has been updated to version 2. This is a major release (See https://github.com/duo-labs/py_webauthn/blob/master/CHANGELOG.md). No new build failures have been detected, though.
- `flask-security-too`  can drop the `pydantic` broken flag, since `webauthn` has dropped pydantic. This did require an (already merged) patch from upstream

Updating `webauthn` is a more elegant solution IMHO than overwriting `pydantic` version in `pgadmin` and also fixes the until-now broken `flask-security-too`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Module tested successfully in a VM.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
