### PR TITLE
qt6Packages.qwlroots: init at 0.1.0

### DIFF
--- a/pkgs/development/libraries/qwlroots/default.nix
+++ b/pkgs/development/libraries/qwlroots/default.nix
@@ -1,0 +1,69 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, pkg-config
+, wrapQtAppsHook
+, wayland-scanner
+, qtbase
+, wayland
+, wayland-protocols
+, wlr-protocols
+, pixman
+, mesa
+, vulkan-loader
+, libinput
+, xorg
+, seatd
+, wlroots
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qwlroots";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "vioken";
+    repo = "qwlroots";
+    rev = finalAttrs.version;
+    hash = "sha256-ev4oCKR43XaYNTavj9XI3RAtB6RFprChpBFsrA2nVsM=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    wrapQtAppsHook
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    qtbase
+    wayland
+    wayland-protocols
+    wlr-protocols
+    pixman
+    mesa
+    vulkan-loader
+    libinput
+    xorg.libXdmcp
+    xorg.xcbutilerrors
+    seatd
+  ];
+
+  propagatedBuildInputs = [
+    wlroots
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "PREFER_QT_5" (lib.versionOlder qtbase.version "6"))
+  ];
+
+  meta = {
+    description = "Qt and QML bindings for wlroots";
+    homepage = "https://github.com/vioken/qwlroots";
+    license = with lib.licenses; [ gpl3Only lgpl3Only asl20 ];
+    platforms = wlroots.meta.platforms;
+    maintainers = with lib.maintainers; [ rewine ];
+  };
+})
+

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -48,6 +48,10 @@ makeScopeWithSplicing' {
 
   qscintilla = callPackage ../development/libraries/qscintilla { };
 
+  qwlroots = callPackage ../development/libraries/qwlroots {
+    wlroots = pkgs.wlroots_0_17;
+  };
+
   qxlsx = callPackage ../development/libraries/qxlsx { };
 
   qzxing = callPackage ../development/libraries/qzxing { };


### PR DESCRIPTION
## Description of changes

https://github.com/vioken/qwlroots

`qwlroots` is a binding of  `wlroots`, which provides a Qt style development interface.

`qwlroots ` support Qt5/Qt6 and wlroots 0.16/0.17,  qt6 and wlroots 0.17 are most commonly used


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
