### PR TITLE
writeShellApplication: Document and extend arguments

### DIFF
--- a/doc/build-helpers/trivial-build-helpers.chapter.md
+++ b/doc/build-helpers/trivial-build-helpers.chapter.md
@@ -502,9 +502,14 @@ concatScript "my-file" [ file1 file2 ]
 
 ## `writeShellApplication` {#trivial-builder-writeShellApplication}
 
-This can be used to easily produce a shell script that has some dependencies (`runtimeInputs`). It automatically sets the `PATH` of the script to contain all of the listed inputs, sets some sanity shellopts (`errexit`, `nounset`, `pipefail`), and checks the resulting script with [`shellcheck`](https://github.com/koalaman/shellcheck).
+`writeShellApplication` is similar to `writeShellScriptBin` and `writeScriptBin` but supports runtime dependencies with `runtimeInputs`.
+Writes an executable shell script to `/nix/store/<store path>/bin/<name>` and checks its syntax with [`shellcheck`](https://github.com/koalaman/shellcheck) and the `bash`'s `-n` option.
+Some basic Bash options are set by default (`errexit`, `nounset`, and `pipefail`), but can be overridden with `bashOptions`.
 
-For example, look at the following code:
+Extra arguments may be passed to `stdenv.mkDerivation` by setting `derivationArgs`; note that variables set in this manner will be set when the shell script is _built,_ not when it's run.
+Runtime environment variables can be set with the `runtimeEnv` argument.
+
+For example, the following shell application can refer to `curl` directly, rather than needing to write `${curl}/bin/curl`:
 
 ```nix
 writeShellApplication {
@@ -517,10 +522,6 @@ writeShellApplication {
   '';
 }
 ```
-
-Unlike with normal `writeShellScriptBin`, there is no need to manually write out `${curl}/bin/curl`, setting the PATH
-was handled by `writeShellApplication`. Moreover, the script is being checked with `shellcheck` for more strict
-validation.
 
 ## `symlinkJoin` {#trivial-builder-symlinkJoin}
 

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -269,6 +269,7 @@ rec {
     { name
     , text
     , runtimeInputs ? [ ]
+    , runtimeEnv ? null
     , meta ? { }
     , checkPhase ? null
     , excludeShellChecks ? [ ]
@@ -283,7 +284,15 @@ rec {
       text = ''
         #!${runtimeShell}
         ${lib.concatMapStringsSep "\n" (option: "set -o ${option}") bashOptions}
-      '' + lib.optionalString (runtimeInputs != [ ]) ''
+      '' + lib.optionalString (runtimeEnv != null)
+        (lib.concatStrings
+          (lib.mapAttrsToList
+            (name: value: ''
+              ${lib.toShellVar name value}
+              export ${name}
+            '')
+            runtimeEnv))
+      + lib.optionalString (runtimeInputs != [ ]) ''
 
         export PATH="${lib.makeBinPath runtimeInputs}:$PATH"
       '' + ''

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -272,6 +272,7 @@ rec {
     , meta ? { }
     , checkPhase ? null
     , excludeShellChecks ? [ ]
+    , bashOptions ? [ "errexit" "nounset" "pipefail" ]
     }:
     writeTextFile {
       inherit name meta;
@@ -281,9 +282,7 @@ rec {
       preferLocalBuild = false;
       text = ''
         #!${runtimeShell}
-        set -o errexit
-        set -o nounset
-        set -o pipefail
+        ${lib.concatMapStringsSep "\n" (option: "set -o ${option}") bashOptions}
       '' + lib.optionalString (runtimeInputs != [ ]) ''
 
         export PATH="${lib.makeBinPath runtimeInputs}:$PATH"

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -240,43 +240,75 @@ rec {
       meta.mainProgram = name;
     };
 
-  /*
-    Similar to writeShellScriptBin and writeScriptBin.
-    Writes an executable Shell script to /nix/store/<store path>/bin/<name> and
-    checks its syntax with shellcheck and the shell's -n option.
-    Individual checks can be foregone by putting them in the excludeShellChecks
-    list, e.g. [ "SC2016" ].
-    Automatically includes sane set of shellopts (errexit, nounset, pipefail)
-    and handles creation of PATH based on runtimeInputs
-
-    Note that the checkPhase uses stdenv.shell for the test run of the script,
-    while the generated shebang uses runtimeShell. If, for whatever reason,
-    those were to mismatch you might lose fidelity in the default checks.
-
-    Example:
-
-    Writes my-file to /nix/store/<store path>/bin/my-file and makes executable.
-
-
-    writeShellApplication {
-      name = "my-file";
-      runtimeInputs = [ curl w3m ];
-      text = ''
-        curl -s 'https://nixos.org' | w3m -dump -T text/html
-       '';
-    }
-
-  */
+  # See doc/build-helpers/trivial-build-helpers.chapter.md
+  # or https://nixos.org/manual/nixpkgs/unstable/#trivial-builder-text-writing
   writeShellApplication =
-    { name
-    , text
-    , runtimeInputs ? [ ]
-    , runtimeEnv ? null
-    , meta ? { }
-    , checkPhase ? null
-    , excludeShellChecks ? [ ]
-    , bashOptions ? [ "errexit" "nounset" "pipefail" ]
-    , derivationArgs ? { } # Extra arguments to pass to `stdenv.mkDerivation`
+    {
+      /*
+         The name of the script to write.
+
+         Type: String
+       */
+      name,
+      /*
+         The shell script's text, not including a shebang.
+
+         Type: String
+       */
+      text,
+      /*
+         Inputs to add to the shell script's `$PATH` at runtime.
+
+         Type: [String|Derivation]
+       */
+      runtimeInputs ? [ ],
+      /*
+         Extra environment variables to set at runtime.
+
+         Type: AttrSet
+       */
+      runtimeEnv ? null,
+      /*
+         `stdenv.mkDerivation`'s `meta` argument.
+
+         Type: AttrSet
+       */
+      meta ? { },
+      /*
+         The `checkPhase` to run. Defaults to `shellcheck` on supported
+         platforms and `bash -n`.
+
+         The script path will be given as `$target` in the `checkPhase`.
+
+         Type: String
+       */
+      checkPhase ? null,
+      /*
+         Checks to exclude when running `shellcheck`, e.g. `[ "SC2016" ]`.
+
+         See <https://www.shellcheck.net/wiki/> for a list of checks.
+
+         Type: [String]
+       */
+      excludeShellChecks ? [ ],
+      /*
+         Bash options to activate with `set -o` at the start of the script.
+
+         Defaults to `[ "errexit" "nounset" "pipefail" ]`.
+
+         Type: [String]
+       */
+      bashOptions ? [ "errexit" "nounset" "pipefail" ],
+      /* Extra arguments to pass to `stdenv.mkDerivation`.
+
+         :::{.caution}
+         Certain derivation attributes are used internally,
+         overriding those could cause problems.
+         :::
+
+         Type: AttrSet
+       */
+      derivationArgs ? { },
     }:
     writeTextFile {
       inherit name meta derivationArgs;

--- a/pkgs/build-support/trivial-builders/test/writeShellApplication.nix
+++ b/pkgs/build-support/trivial-builders/test/writeShellApplication.nix
@@ -1,29 +1,141 @@
-/*
-  Run with:
-
-      cd nixpkgs
-      nix-build -A tests.trivial-builders.writeShellApplication
-*/
-
-{ lib, writeShellApplication, runCommand }:
+# Run with:
+# nix-build -A tests.trivial-builders.writeShellApplication
+{ writeShellApplication
+, writeTextFile
+, runCommand
+, lib
+, linkFarm
+, diffutils
+, hello
+}:
 let
-  pkg = writeShellApplication {
-    name = "test-script";
+  checkShellApplication = args@{name, expected, ...}:
+    let
+      writeShellApplicationArgs = builtins.removeAttrs args ["expected"];
+      script = writeShellApplication writeShellApplicationArgs;
+      executable = lib.getExe script;
+      expected' = writeTextFile {
+        name = "${name}-expected";
+        text = expected;
+      };
+      actual = "${name}-actual";
+    in
+    runCommand name { } ''
+      echo "Running test executable ${name}"
+      ${executable} > ${actual}
+      echo "Got output from test executable:"
+      cat ${actual}
+      echo "Checking test output against expected output:"
+      ${diffutils}/bin/diff --color --unified ${expected'} ${actual}
+      touch $out
+    '';
+in
+linkFarm "writeShellApplication-tests" {
+  test-meta =
+    let
+      script = writeShellApplication {
+        name = "test-meta";
+        text = "";
+        meta.description = "A test for the `writeShellApplication` `meta` argument.";
+      };
+    in
+    assert script.meta.mainProgram == "test-meta";
+    assert script.meta.description == "A test for the `writeShellApplication` `meta` argument.";
+    script;
+
+  test-runtime-inputs =
+    checkShellApplication {
+      name = "test-runtime-inputs";
+      text = ''
+        hello
+      '';
+      runtimeInputs = [ hello ];
+      expected = "Hello, world!\n";
+    };
+
+  test-runtime-env =
+    checkShellApplication {
+      name = "test-runtime-env";
+      runtimeEnv = {
+        MY_COOL_ENV_VAR = "my-cool-env-value";
+        MY_OTHER_COOL_ENV_VAR = "my-other-cool-env-value";
+        # Check that we can serialize a bunch of different types:
+        BOOL = true;
+        INT = 1;
+        LIST = [1 2 3];
+        MAP = {
+          a = "a";
+          b = "b";
+        };
+      };
+      text = ''
+        echo "$MY_COOL_ENV_VAR"
+        echo "$MY_OTHER_COOL_ENV_VAR"
+      '';
+      expected = ''
+        my-cool-env-value
+        my-other-cool-env-value
+      '';
+    };
+
+  test-check-phase =
+    checkShellApplication {
+      name = "test-check-phase";
+      text = "";
+      checkPhase = ''
+        echo "echo -n hello" > $target
+      '';
+      expected = "hello";
+    };
+
+  test-argument-forwarding =
+    checkShellApplication {
+      name = "test-argument-forwarding";
+      text = "";
+      derivationArgs.MY_BUILD_TIME_VARIABLE = "puppy";
+      derivationArgs.postCheck = ''
+        if [[ "$MY_BUILD_TIME_VARIABLE" != puppy ]]; then
+          echo "\$MY_BUILD_TIME_VARIABLE is not set to 'puppy'!"
+          exit 1
+        fi
+      '';
+      meta.description = "A test checking that `writeShellApplication` forwards extra arguments to `stdenv.mkDerivation`.";
+      expected = "";
+    };
+
+  test-exclude-shell-checks = writeShellApplication {
+    name = "test-exclude-shell-checks";
     excludeShellChecks = [ "SC2016" ];
     text = ''
-      echo -e '#!/usr/bin/env bash\n' \
-       'echo "$SHELL"' > /tmp/something.sh  # this line would normally
-                                            # ...cause shellcheck error
+      # Triggers SC2016: Expressions don't expand in single quotes, use double
+      # quotes for that.
+      echo '$SHELL'
     '';
   };
-in
-  assert pkg.meta.mainProgram == "test-script";
-  runCommand "test-writeShellApplication" { } ''
 
-    echo Testing if writeShellApplication builds without shellcheck error...
+  test-bash-options-pipefail = checkShellApplication {
+    name = "test-bash-options-pipefail";
+    text = ''
+      touch my-test-file
+      echo puppy | grep doggy | sed 's/doggy/puppy/g'
+      #            ^^^^^^^^^^ This will fail.
+      true
+    '';
+    # Don't use `pipefail`:
+    bashOptions = ["errexit" "nounset"];
+    expected = "";
+  };
 
-    target=${lib.getExe pkg}
+  test-bash-options-nounset = checkShellApplication {
+    name = "test-bash-options-nounset";
+    text = ''
+      echo -n "$someUndefinedVariable"
+    '';
+    # Don't use `nounset`:
+    bashOptions = [];
+    # Don't warn about the undefined variable at build time:
+    excludeShellChecks = [ "SC2154" ];
+    expected = "";
+  };
 
-    touch $out
-  ''
-
+}


### PR DESCRIPTION
## Description of changes

Documented `pkgs.writeShellApplication` arguments, expanded the test suite, and added several new arguments:

1. The default Bash options can be customized with `bashOptions`.

   This is useful to e.g. exclude `nounset` if you want to check `[[ -n "$myVar" ]]` on a potentially-unset variable, or disable `pipefail` to use `grep` in a pipeline. Previously you could do `set +o pipefail`, but running that right after `set -o pipefail` always felt clumsy to me.
2. Added a `derivationArgs` argument which is used for extra `stdenv.mkDerivation` arguments.

   This allows customizing `postCheck` and other such parameters.
4. Runtime environment variables can now be set with `runtimeEnv`.

I also took care to make sure this doesn't change the hashes of derivations produced with any of the involved functions, so we don't have to worry about excessive rebuilds.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
