### PR TITLE
lomiri.lomiri-api: Apply patch for GCC13 support

### DIFF
--- a/pkgs/desktops/lomiri/development/lomiri-api/default.nix
+++ b/pkgs/desktops/lomiri/development/lomiri-api/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitLab
+, fetchpatch
 , gitUpdater
 , makeFontsConf
 , testers
@@ -30,6 +31,14 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   outputs = [ "out" "dev" "doc" ];
+
+  patches = [
+    (fetchpatch {
+      name = "0001-lomiri-api-Add-missing-headers-for-GCC13.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-api/-/commit/029b42a9b4d5467951595dff8bc536eb5a9e3ef7.patch";
+      hash = "sha256-eWrDQGrwf22X49rtUAVbrd+QN+OwyGacVLCWYFsS02o=";
+    })
+  ];
 
   postPatch = ''
     patchShebangs $(find test -name '*.py')


### PR DESCRIPTION
## Description of changes

https://github.com/NixOS/nixpkgs/pull/262118#issuecomment-1889770611

```
In file included from /build/source/include/lomiri/util/GlibMemory.h:28,
                 from /build/source/test/gtest/lomiri/util/GlibMemory/GlibMemory_test.cpp:19:
/build/source/include/lomiri/util/ResourcePtr.h: In member function 'R lomiri::util::ResourcePtr<R, D>::release()':
/build/source/include/lomiri/util/ResourcePtr.h:390:20: error: 'logic_error' is not a member of 'std'
  390 |         throw std::logic_error("release() called on ResourcePtr without resource");
      |                    ^~~~~~~~~~~
/build/source/include/lomiri/util/ResourcePtr.h:23:1: note: 'std::logic_error' is defined in header '<stdexcept>'; did you forget to '#include <stdexcept>'?
   22 | #include <mutex>
  +++ |+#include <stdexcept>
   23 | #include <type_traits>
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
