### PR TITLE
python3Packages.spsdk: 2.0.0 -> 2.0.1

### DIFF
--- a/pkgs/development/python-modules/spsdk/default.nix
+++ b/pkgs/development/python-modules/spsdk/default.nix
@@ -39,14 +39,14 @@
 
 buildPythonPackage rec {
   pname = "spsdk";
-  version = "2.0.0";
+  version = "2.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "nxp-mcuxpresso";
     repo = pname;
-    rev = "refs/tags/${version}";
-    hash = "sha256-1aW5ivdpnSscTaMIRn4tlsBG6StN95gHAyRIzmAO9Uo=";
+    rev = version;
+    hash = "sha256-C6cz5jhIHI4WkCYT0rURFa4kBAu6cMcKpQHiHACIiu8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/spsdk/default.nix
+++ b/pkgs/development/python-modules/spsdk/default.nix
@@ -26,6 +26,7 @@
 , pyocd
 , pypemicro
 , pyserial
+, requests
 , ruamel-yaml
 , setuptools
 , sly
@@ -63,6 +64,8 @@ buildPythonPackage rec {
     "pylink-square"
     "pyocd"
     "typing-extensions"
+    "click"
+    "ruamel.yaml"
   ];
 
   pythonRemoveDeps = [
@@ -93,6 +96,7 @@ buildPythonPackage rec {
     pyocd
     pypemicro
     pyserial
+    requests
     ruamel-yaml
     sly
     typing-extensions


### PR DESCRIPTION
## Description of changes

Relax deps to make spsdk buildable again and bump the version.
 * https://github.com/nxp-mcuxpresso/spsdk/releases/tag/2.0.1
 * https://github.com/nxp-mcuxpresso/spsdk/blob/2.0.1/docs/release_notes.rst

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>6 packages built:</summary>
  <ul>
    <li>nitrokey-app2</li>
    <li>nitrokey-app2.dist</li>
    <li>pynitrokey (python311Packages.pynitrokey)</li>
    <li>pynitrokey.dist (python311Packages.pynitrokey.dist)</li>
    <li>python311Packages.spsdk</li>
    <li>python311Packages.spsdk.dist</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
