### PR TITLE
jitsi-meet: Default NAT harvester, Excalidraw Caddy, Prosody lockdown

### DIFF
--- a/nixos/modules/services/web-apps/jitsi-meet.md
+++ b/nixos/modules/services/web-apps/jitsi-meet.md
@@ -19,6 +19,13 @@ A minimal configuration using Let's Encrypt for TLS certificates looks like this
 }
 ```
 
+Jitsi Meet depends on the Prosody XMPP server only for message passing from
+the web browser while the default Prosody configuration is intended for use
+with standalone XMPP clients and XMPP federation. If you only use Prosody as
+a backend for Jitsi Meet it is therefore recommended to also enable
+{option}`services.jitsi-meet.prosody.lockdown` option to disable unnecessary
+Prosody features such as federation or the file proxy.
+
 ## Configuration {#module-services-jitsi-configuration}
 
 Here is the minimal configuration with additional configurations:
@@ -27,6 +34,7 @@ Here is the minimal configuration with additional configurations:
   services.jitsi-meet = {
     enable = true;
     hostName = "jitsi.example.com";
+    prosody.lockdown = true;
     config = {
       enableWelcomePage = false;
       prejoinPageEnabled = true;

--- a/nixos/modules/services/web-apps/jitsi-meet.nix
+++ b/nixos/modules/services/web-apps/jitsi-meet.nix
@@ -232,7 +232,7 @@ in
           extraConfig = ''
             restrict_room_creation = true
             storage = "memory"
-            admins = { "focus@auth.${cfg.hostName}" }
+            admins = { "focus@auth.${cfg.hostName}", "jvb@auth.${cfg.hostName}" }
           '';
         }
         {

--- a/nixos/modules/services/web-apps/jitsi-meet.nix
+++ b/nixos/modules/services/web-apps/jitsi-meet.nix
@@ -444,7 +444,29 @@ in
         Type = "simple";
         ExecStart = "${pkgs.jitsi-excalidraw}/bin/jitsi-excalidraw-backend";
         Restart = "on-failure";
+
+        DynamicUser = true;
         Group = "jitsi-meet";
+        CapabilityBoundingSet = "";
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectClock = true;
+        ProtectHome = true;
+        ProtectProc = true;
+        ProtectKernelLogs = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        PrivateUsers = true;
+        ProtectHostname = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallFilter = [ "@system-service @pkey" "~@privileged" ];
       };
     };
 

--- a/nixos/modules/services/web-apps/jitsi-meet.nix
+++ b/nixos/modules/services/web-apps/jitsi-meet.nix
@@ -513,7 +513,11 @@ in
             cp ${overrideJs "${pkgs.jitsi-meet}/interface_config.js" "interfaceConfig" cfg.interfaceConfig ""} $out/interface_config.js
             cp ./libs/external_api.min.js $out/external_api.js
           '';
-        in ''
+        in (optionalString cfg.excalidraw.enable ''
+          handle /socket.io/ {
+            reverse_proxy 127.0.0.1:${toString cfg.excalidraw.port}
+          }
+        '') + ''
           handle /http-bind {
             header Host ${cfg.hostName}
             reverse_proxy 127.0.0.1:5280

--- a/nixos/modules/services/web-apps/jitsi-meet.nix
+++ b/nixos/modules/services/web-apps/jitsi-meet.nix
@@ -175,9 +175,24 @@ in
     prosody.enable = mkOption {
       type = bool;
       default = true;
+      example = false;
       description = ''
         Whether to configure Prosody to relay XMPP messages between Jitsi Meet components. Turn this
         off if you want to configure it manually.
+      '';
+    };
+    prosody.lockdown = mkOption {
+      type = bool;
+      default = false;
+      example = true;
+      description = ''
+        Whether to disable Prosody features not needed by Jitsi Meet.
+
+        The default Prosody configuration assumes that it will be used as a
+        general-purpose XMPP server rather than as a companion service for
+        Jitsi Meet. This option reconfigures Prosody to only listen on
+        localhost without support for TLS termination, XMPP federation or
+        the file transfer proxy.
       '';
     };
 
@@ -211,7 +226,10 @@ in
         smacks = mkDefault true;
         tls = mkDefault true;
         websocket = mkDefault true;
+        proxy65 = mkIf cfg.prosody.lockdown (mkDefault false);
       };
+      httpInterfaces = mkIf cfg.prosody.lockdown (mkDefault [ "127.0.0.1" ]);
+      httpsPorts = mkIf cfg.prosody.lockdown (mkDefault []);
       muc = [
         {
           domain = "conference.${cfg.hostName}";
@@ -300,7 +318,7 @@ in
             muc_component = "conference.${cfg.hostName}"
             breakout_rooms_component = "breakout.${cfg.hostName}"
         '')
-        (mkBefore ''
+        (mkBefore (''
           muc_mapper_domain_base = "${cfg.hostName}"
 
           cross_domain_websocket = true;
@@ -310,7 +328,10 @@ in
             "focus@auth.${cfg.hostName}",
             "jvb@auth.${cfg.hostName}"
           }
-        '')
+        '' + optionalString cfg.prosody.lockdown ''
+          c2s_interfaces = { "127.0.0.1" };
+          modules_disabled = { "s2s" };
+        ''))
       ];
       virtualHosts.${cfg.hostName} = {
         enabled = true;

--- a/pkgs/servers/web-apps/jitsi-meet/default.nix
+++ b/pkgs/servers/web-apps/jitsi-meet/default.nix
@@ -18,7 +18,8 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.tests = {
+  # Test requires running Jitsi Videobridge and Jicofo which are Linux-only
+  passthru.tests = lib.optionalAttrs stdenv.isLinux {
     single-host-smoke-test = nixosTests.jitsi-meet;
   };
 


### PR DESCRIPTION
## Description of changes

Several smaller changes to the Jitsi Meet modules (one commit each):

  * Added an internal MUC setting in the Jitsi Meet Docker package that hadn’t been included in the recent updates (originally from #264400)
  * Add default-enabled option to configure a NAT harvester addresses to make Jitsi Videobridge work in behind a NAT without manual address configuration
  * Update the Jitsi Meet Caddy configuration to also forward the Excalidraw WebSocket configuration there if the whiteboard is enabled
  * Don’t run the Jitsi Excalidraw backend service as root with maximum privileges
  * Add default-disabled option to disable unnecessary Prosody services when Prosody is only used for Jitsi Meet

Are the added options significant enough for the release notes?

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@cleeyv @ryantm