### PR TITLE
buildNpmPackage: use env vars

### DIFF
--- a/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
@@ -82,6 +82,7 @@ npmConfigHook() {
     fi
 
     echo "Setting npm_config_cache to $cachePath..."
+    # do not modify .npmrc
     export npm_config_cache="$cachePath"
     export npm_config_offline="true"
     export npm_config_progress="false"

--- a/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
@@ -81,9 +81,10 @@ npmConfigHook() {
         cachePath="$TMPDIR/cache"
     fi
 
-    npm config set cache "$cachePath"
-    npm config set offline true
-    npm config set progress false
+    echo "Setting npm_config_cache to $cachePath..."
+    export npm_config_cache="$cachePath"
+    export npm_config_offline="true"
+    export npm_config_progress="false"
 
     echo "Installing dependencies"
 


### PR DESCRIPTION
## Description of changes

Ayyyyyeee, you know it should be env vars not .npmrc that we use to set settings. That way we can use the hook in a nix shell without modifying the user's state. You know?

## Things done

I tested this via usage of the hook in a nix shell, worked.