### PR TITLE
icloudpd: init at 1.17.3

### DIFF
--- a/pkgs/by-name/ic/icloudpd/package.nix
+++ b/pkgs/by-name/ic/icloudpd/package.nix
@@ -1,0 +1,83 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+, nix-update-script
+, testers
+, icloudpd
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "icloudpd";
+  version = "1.17.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "icloud-photos-downloader";
+    repo = "icloud_photos_downloader";
+    rev = "v${version}";
+    hash = "sha256-GS6GqlZfj5kfjKLImkOTDAgQDGJQHl74uTqbZHVpbac=";
+  };
+
+  pythonRelaxDeps = true;
+
+  nativeBuildInputs = with python3Packages; [
+    pythonRelaxDepsHook
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    wheel
+    setuptools
+    requests
+    schema
+    click
+    python-dateutil
+    tqdm
+    piexif
+    urllib3
+    six
+    tzlocal
+    pytz
+    certifi
+    keyring
+    keyrings-alt
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    mock
+    freezegun
+    vcrpy
+    pytest-timeout
+  ];
+
+  disabledTests = [
+    # touches network
+    "test_autodelete_photos"
+    "test_download_autodelete_photos"
+    "test_retry_delete_after_download_session_error"
+    "test_retry_fail_delete_after_download_session_error"
+    "test_retry_delete_after_download_internal_error"
+    "test_autodelete_photos_dry_run"
+    "test_retry_fail_delete_after_download_internal_error"
+    "test_autodelete_invalid_creation_date"
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = testers.testVersion { package = icloudpd; };
+  };
+
+  preBuild = ''
+    substituteInPlace pyproject.toml \
+      --replace "setuptools==69.0.2" "setuptools" \
+      --replace "wheel==0.42.0" "wheel"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/icloud-photos-downloader/icloud_photos_downloader";
+    description = "iCloud Photos Downloader";
+    license = licenses.mit;
+    mainProgram = "icloudpd";
+    maintainers = with maintainers; [ anpin Enzime ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Replaces #171998 and #246307 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
