### PR TITLE
fetch-npm-deps: handle all git+ urls the same during fixup

### DIFF
--- a/pkgs/build-support/node/fetch-npm-deps/src/main.rs
+++ b/pkgs/build-support/node/fetch-npm-deps/src/main.rs
@@ -66,7 +66,7 @@ fn fixup_lockfile(
             {
                 if let Some(Value::String(resolved)) = package.get("resolved") {
                     if let Some(Value::String(integrity)) = package.get("integrity") {
-                        if resolved.starts_with("git+ssh://") {
+                        if resolved.starts_with("git+") {
                             fixed = true;
 
                             package


### PR DESCRIPTION
## Description of changes

Extend the existing special treatment of `git+ssh://` urls in fetch-npm-deps to all `git+` urls.

Trying to build upstream Jitsi Meet, I get the following rather opaque message from `npmConfigHook`:

```
@nix { "action": "setPhase", "phase": "unpackPhase" }
Running phase: unpackPhase
unpacking source archive /nix/store/rf367jijk4gq9lgvl7h56h3vdv536lin-source
source root is source
@nix { "action": "setPhase", "phase": "patchPhase" }
Running phase: patchPhase
Executing npmConfigHook
Configuring npm
Validating consistency between /build/source/package-lock.json and /nix/store/j8821gfm1d92c36dvqr9kpn7aygp6135-npm-deps/package-lock.json
thread 'main' panicked at src/main.rs:79:34:
dependency should have a hash
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The [upstream package-lock.json](https://github.com/jitsi/jitsi-meet/blob/7712/package-lock.json) contains `git+https://` URLs which fetch-npm-deps seems to choke on. Jitsi Meet successfully builds after this patch.

<details>
<summary>Flake used to build Jitsi Meet</summary>

```nix
{
  inputs.nixpkgs.url = "github:NixOS/nixpkgs/317484b1ead87b9c1b8ac5261a8d2dd748a0492d";
  inputs.jitsi-meet = {
    url = "github:jitsi/jitsi-meet/7712";
    flake = false;
  };
  outputs = { nixpkgs, jitsi-meet, ... }:
    let
      pkgs = nixpkgs.legacyPackages.x86_64-linux;
      src = jitsi-meet;
    in {
      packages.x86_64-linux.default = with pkgs; stdenv.mkDerivation rec {
        pname = "jitsi-meet";
        version = "1.0.7712";

        inherit src;

        npmDeps = fetchNpmDeps {
          inherit src;
          hash = "sha256-u3lV+O1r9xQZa2x43FTVRD4NH+fuhhIb+ynkWfE7epc=";
        };

        nativeBuildInputs = [
          nodejs
          npmHooks.npmConfigHook
        ];

        NODE_PATH = "$npmDeps";
        makeCacheWritable = true;
        npmInstallFlagsArray = [ "--no-audit" ];

        buildFlags = [ "compile" "deploy" "source-package" ];

        installPhase = ''
          runHook preInstall
          mkdir $out
          tar xf jitsi-meet.tar.bz2 --directory=$out --strip-components=1
          runHook postInstall
        '';
      };
    };
}
```

</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
