### PR TITLE
vdrPlugins.xineliboutput: 2.2.0 -> 2.3.0

### DIFF
--- a/pkgs/applications/video/vdr/xineliboutput/default.nix
+++ b/pkgs/applications/video/vdr/xineliboutput/default.nix
@@ -1,18 +1,34 @@
-{ stdenv, fetchurl, lib, vdr
-, libav, libcap, libvdpau
-, xine-lib, libjpeg, libextractor, libglvnd, libGLU
-, libX11, libXext, libXrender, libXrandr
+{ stdenv
+, fetchurl
+, lib
+, vdr
+, libcap
+, libvdpau
+, xine-lib
+, libjpeg
+, libextractor
+, libglvnd
+, libGLU
+, libX11
+, libXext
+, libXrender
+, libXrandr
+, ffmpeg
+, avahi
+, wayland
 , makeWrapper
-}: let
+, dbus-glib
+}:
+let
   makeXinePluginPath = l: lib.concatStringsSep ":" (map (p: "${p}/lib/xine/plugins") l);
 
-  self =  stdenv.mkDerivation rec {
+  self = stdenv.mkDerivation rec {
     pname = "vdr-xineliboutput";
-    version = "2.2.0";
+    version = "2.3.0";
 
     src = fetchurl {
       url = "mirror://sourceforge/project/xineliboutput/xineliboutput/${pname}-${version}/${pname}-${version}.tgz";
-      sha256 = "0a24hs5nr7ncf51c5agyfn1xrvb4p70y3i0s6dlyyd9bwbfjldns";
+      sha256 = "sha256-GnTaGaIbBufZP2npa9mAbrO1ccMf1RzhbvjrWhKBTjg=";
     };
 
     postPatch = ''
@@ -41,7 +57,8 @@
     nativeBuildInputs = [ makeWrapper ];
 
     buildInputs = [
-      libav
+      dbus-glib
+      ffmpeg
       libcap
       libextractor
       libjpeg
@@ -54,6 +71,8 @@
       libX11
       vdr
       xine-lib
+      avahi
+      wayland
     ];
 
     passthru.requiredXinePlugins = [ xine-lib self ];
@@ -66,4 +85,5 @@
       inherit (vdr.meta) platforms;
     };
   };
-in self
+in
+self


### PR DESCRIPTION
## Description of changes

- Update to latest version
- applied nixpkgs-fmt
- enabled features like wayland
- replaced insecure package libav with ffmpeg

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
