### PR TITLE
waylandpp: pull `gcc-13` fix pending upstream inclusion

### DIFF
--- a/pkgs/development/libraries/waylandpp/default.nix
+++ b/pkgs/development/libraries/waylandpp/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , makeFontsConf
 , pkg-config
@@ -23,6 +24,18 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-Dw2RnLLyhykikHps1in+euHksO+ERbATbfmbUFOJklg=";
   };
+
+  patches = [
+    # Pull fixes for gcc-13 compatibility:
+    #   https://github.com/NilsBrause/waylandpp/pull/71
+    # Without the change `kodi` fails to find `uint32_t` in `waylandpp`
+    # headers.
+    (fetchpatch {
+      name = "gcc-13.patch";
+      url = "https://github.com/NilsBrause/waylandpp/commit/3c441910aa25f57df2a4db55f75f5d99cea86620.patch";
+      hash = "sha256-bxHMP09zCwUKD0M63C1FqQySAN9hr+7t/DyFDRwdtCo=";
+    })
+  ];
 
   cmakeFlags = [
     "-DCMAKE_INSTALL_DATADIR=${placeholder "dev"}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25548,9 +25548,9 @@ with pkgs;
 
   wayland-protocols = callPackage ../development/libraries/wayland/protocols.nix { };
 
-  waylandpp = pin-to-gcc12-if-gcc13 (callPackage ../development/libraries/waylandpp {
+  waylandpp = callPackage ../development/libraries/waylandpp {
     graphviz = graphviz-nox;
-  });
+  };
 
   wcslib = callPackage ../development/libraries/science/astronomy/wcslib { };
 


### PR DESCRIPTION
Without the change downstream projects like `kodi` fail to build on `gcc-13` as:

    [  6%] Building CXX object build/events/windows/CMakeFiles/events_windows.dir/GUIViewStateEventLog.cpp.o
    In file included from /build/source/xbmc/windowing/wayland/Connection.h:13,
                     from /build/source/xbmc/windowing/wayland/Connection.cpp:9:
    /nix/store/ygbnddg737vq1992xnn57k5j6xjwfkml-waylandpp-1.0.0-dev/include/wayland-client.hpp:167:73: error: 'std::uint32_t' has not been declared
      167 |                            const std::vector<detail::argument_t>& args, std::uint32_t version = 0);
          |                                                                         ^~~
    In file included from /nix/store/ygbnddg737vq1992xnn57k5j6xjwfkml-waylandpp-1.0.0-dev/include/wayland-client.hpp:768:
    /nix/store/ygbnddg737vq1992xnn57k5j6xjwfkml-waylandpp-1.0.0-dev/include/wayland-client-protocol.hpp:169:25: error: 'uint32_t' in namespace 'std' does not name a type; did you mean 'wint_t'?
      169 |   static constexpr std::uint32_t bind_since_version = 1;
          |                         ^~~~~~~~
          |                         wint_t

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
