### PR TITLE
Revert "linux: drop XEN on 32-bit"

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -685,23 +685,23 @@ let
       VBOXGUEST = option no;
       DRM_VBOXVIDEO = option no;
 
-      XEN                         = mkIf stdenv.is64bit (option yes);
-      XEN_DOM0                    = mkIf stdenv.is64bit (option yes);
-      PCI_XEN                     = mkIf stdenv.is64bit (option yes);
-      HVC_XEN                     = mkIf stdenv.is64bit (option yes);
-      HVC_XEN_FRONTEND            = mkIf stdenv.is64bit (option yes);
-      XEN_SYS_HYPERVISOR          = mkIf stdenv.is64bit (option yes);
-      SWIOTLB_XEN                 = mkIf stdenv.is64bit (option yes);
-      XEN_BACKEND                 = mkIf stdenv.is64bit (option yes);
-      XEN_BALLOON                 = mkIf stdenv.is64bit (option yes);
-      XEN_BALLOON_MEMORY_HOTPLUG  = mkIf stdenv.is64bit (option yes);
-      XEN_EFI                     = mkIf stdenv.is64bit (option yes);
-      XEN_HAVE_PVMMU              = mkIf stdenv.is64bit (option yes);
-      XEN_MCE_LOG                 = mkIf stdenv.is64bit (option yes);
-      XEN_PVH                     = mkIf stdenv.is64bit (option yes);
-      XEN_PVHVM                   = mkIf stdenv.is64bit (option yes);
-      XEN_SAVE_RESTORE            = mkIf stdenv.is64bit (option yes);
-      XEN_SELFBALLOONING          = mkIf stdenv.is64bit (whenOlder "5.3" yes);
+      XEN                         = option yes;
+      XEN_DOM0                    = option yes;
+      PCI_XEN                     = option yes;
+      HVC_XEN                     = option yes;
+      HVC_XEN_FRONTEND            = option yes;
+      XEN_SYS_HYPERVISOR          = option yes;
+      SWIOTLB_XEN                 = option yes;
+      XEN_BACKEND                 = option yes;
+      XEN_BALLOON                 = option yes;
+      XEN_BALLOON_MEMORY_HOTPLUG  = option yes;
+      XEN_EFI                     = option yes;
+      XEN_HAVE_PVMMU              = option yes;
+      XEN_MCE_LOG                 = option yes;
+      XEN_PVH                     = option yes;
+      XEN_PVHVM                   = option yes;
+      XEN_SAVE_RESTORE            = option yes;
+      XEN_SELFBALLOONING          = whenOlder "5.3" yes;
 
       # Enable device detection on virtio-mmio hypervisors
       VIRTIO_MMIO_CMDLINE_DEVICES = yes;


### PR DESCRIPTION
## Description of changes

This reverts commit 096639c548e2b0256309c92c53542e052eaa3761.

The kernel bug that broke this has now been fixed, and we now set CONFIG_X86_GENERIC, which would have stopped us being affected by it anyway.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
