### PR TITLE
nitrokey-app2: 2.1.4 -> 2.1.5

### DIFF
--- a/pkgs/tools/security/nitrokey-app2/default.nix
+++ b/pkgs/tools/security/nitrokey-app2/default.nix
@@ -1,21 +1,26 @@
 { lib
-, python3
+, buildPythonApplication
 , fetchFromGitHub
-, wrapQtAppsHook
+, pythonOlder
+, pyside6
+, poetry-core
+, pynitrokey
+, pyudev
+, qt-material
 }:
 
-python3.pkgs.buildPythonApplication rec {
+buildPythonApplication rec {
   pname = "nitrokey-app2";
-  version = "2.1.4";
+  version = "2.1.5";
   pyproject = true;
 
-  disabled = python3.pythonOlder "3.9";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "Nitrokey";
     repo = "nitrokey-app2";
     rev = "v${version}";
-    hash = "sha256-loOCa6XlLx1YEfqR0SUUalVIEPCoYsNEHFo2MIKexeA=";
+    hash = "sha256-mR13zUgCdNS09EnpGLrnOnoIn3p6ZM/0fHKg0OUMWj4=";
   };
 
   # https://github.com/Nitrokey/nitrokey-app2/issues/152
@@ -23,35 +28,19 @@ python3.pkgs.buildPythonApplication rec {
   # pythonRelaxDepsHook does not work here, because it runs in postBuild and
   # only modifies the dependencies in the built distribution.
   postPatch = ''
-    substituteInPlace pyproject.toml --replace "pynitrokey ==" "pynitrokey >="
+    substituteInPlace pyproject.toml --replace 'pynitrokey = "' 'pynitrokey = ">='
   '';
 
-  # The pyproject.toml file seems to be incomplete and does not generate
-  # resources (i.e. run pyrcc5 and pyuic5) but the Makefile does.
-  preBuild = ''
-    make build-ui
-  '';
-
-  nativeBuildInputs = with python3.pkgs; [
-    flit-core
-    pyqt5
-    wrapQtAppsHook
+  nativeBuildInputs = [
+    poetry-core
   ];
 
-  dontWrapQtApps = true;
-
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = [
     pynitrokey
     pyudev
-    pyqt5
-    pyqt5-stubs
+    pyside6
     qt-material
   ];
-
-  preFixup = ''
-    wrapQtApp "$out/bin/nitrokeyapp" \
-      --set-default CRYPTOGRAPHY_OPENSSL_NO_LEGACY 1
-  '';
 
   pythonImportsCheck = [
     "nitrokeyapp"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -41613,7 +41613,7 @@ with pkgs;
 
   nitrokey-app = libsForQt5.callPackage ../tools/security/nitrokey-app { };
 
-  nitrokey-app2 = libsForQt5.callPackage ../tools/security/nitrokey-app2 { };
+  nitrokey-app2 = python3Packages.callPackage ../tools/security/nitrokey-app2 { };
 
   fpm2 = callPackage ../tools/security/fpm2 { };
 


### PR DESCRIPTION
## Description of changes

https://github.com/Nitrokey/nitrokey-app2/releases/tag/v2.1.5

Quite some changes, e.g. qt5 -> qt6.
https://github.com/Nitrokey/nitrokey-app2/compare/v2.1.4...v2.1.5

~Requires #280614 to be merged first.~ Done

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
ines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
