### PR TITLE
pkgsMusl.bun: mark broken for musl

### DIFF
--- a/pkgs/development/web/bun/default.nix
+++ b/pkgs/development/web/bun/default.nix
@@ -94,5 +94,8 @@ stdenvNoCC.mkDerivation rec {
     ];
     maintainers = with maintainers; [ DAlperin jk thilobillerbeck cdmistman coffeeispower ];
     platforms = builtins.attrNames passthru.sources;
+    # Broken for Musl at 2024-01-13, tracking issue:
+    # https://github.com/NixOS/nixpkgs/issues/280716
+    broken = stdenvNoCC.hostPlatform.isMusl;
   };
 }


### PR DESCRIPTION
pkgsMusl.bun: mark broken for musl

Tracking issue: https://github.com/NixOS/nixpkgs/issues/280716

ping bun maintainers: @DAlperin @jk @thilobillerbeck @cdmistman @coffeeispower