### PR TITLE
nixos/anki-sync-server: do not use unqualified 'cat' in execStart script

### DIFF
--- a/nixos/modules/services/misc/anki-sync-server.nix
+++ b/nixos/modules/services/misc/anki-sync-server.nix
@@ -16,7 +16,7 @@ with lib; let
     cfg.users;
   usersWithIndexesFile = filter (x: x.user.passwordFile != null) usersWithIndexes;
   usersWithIndexesNoFile = filter (x: x.user.passwordFile == null && x.user.password != null) usersWithIndexes;
-  anki-sync-server-run = pkgs.writeShellScriptBin "anki-sync-server-run" ''
+  anki-sync-server-run = pkgs.writeShellScript "anki-sync-server-run" ''
     # When services.anki-sync-server.users.passwordFile is set,
     # each password file is passed as a systemd credential, which is mounted in
     # a file system exposed to the service. Here we read the passwords from
@@ -25,7 +25,10 @@ with lib; let
     ${
       concatMapStringsSep
       "\n"
-      (x: ''export SYNC_USER${toString x.i}=${escapeShellArg x.user.username}:"''$(cat "''${CREDENTIALS_DIRECTORY}/"${escapeShellArg x.user.username})"'')
+      (x: ''
+        read -r pass < "''${CREDENTIALS_DIRECTORY}/"${escapeShellArg x.user.username}
+        export SYNC_USER${toString x.i}=${escapeShellArg x.user.username}:"$pass"
+      '')
       usersWithIndexesFile
     }
     # For users where services.anki-sync-server.users.password isn't set,
@@ -36,7 +39,7 @@ with lib; let
       (x: ''export SYNC_USER${toString x.i}=${escapeShellArg x.user.username}:${escapeShellArg x.user.password}'')
       usersWithIndexesNoFile
     }
-    exec ${cfg.package}/bin/anki-sync-server
+    exec ${lib.getExe cfg.package}
   '';
 in {
   options.services.anki-sync-server = {
@@ -123,7 +126,7 @@ in {
         Type = "simple";
         DynamicUser = true;
         StateDirectory = name;
-        ExecStart = "${anki-sync-server-run}/bin/anki-sync-server-run";
+        ExecStart = anki-sync-server-run;
         Restart = "always";
         LoadCredential =
           map


### PR DESCRIPTION
## Description of changes

Using cat relies on coreutils (or equivalent) being in $PATH, which is not always true.
We could write ${pkgs.coreutils}/bin/cat but in this case we can get by with the 'read' builtin

While here, cleanup a bit to avoid the x/bin/x patterns we can easily avoid:
 - use lib.getExe for anki-sync-server
 - use writeShellScript instead of writeShellScriptBin

FWIW test passed locally and here's the generated config associated:
```
#!/nix/store/q8qq40xg2grfh9ry1d9x4g7lq4ra7n81-bash-5.2-p21/bin/bash
# When services.anki-sync-server.users.passwordFile is set,
# each password file is passed as a systemd credential, which is mounted in
# a file system exposed to the service. Here we read the passwords from
# the credential files to pass them as environment variables to the Anki
# sync server.
read -r pass < "${CREDENTIALS_DIRECTORY}/"'passfileuser'
export SYNC_USER2='passfileuser':"$pass"

# For users where services.anki-sync-server.users.password isn't set,
# export passwords in environment variables in plaintext.
export SYNC_USER1='user':'password'
exec /nix/store/x6bw21bq81wi0vcs4qgp7nq1hz83nh7r-anki-sync-server-23.12.1/bin/anki-sync-server
```
(I was bitten by this because of my systemd.confinement setup -- truth to be told I wanted to get rid of bash as well so I ended up skipping all of this and directly using an EnvironmentFilie so I don't really care either way, but might as well fix the dependency on path)

cc @telotortium 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
