### PR TITLE
streamrip: init at 2.0.5

### DIFF
--- a/pkgs/by-name/st/streamrip/package.nix
+++ b/pkgs/by-name/st/streamrip/package.nix
@@ -1,0 +1,77 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+
+, ffmpeg
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "streamrip";
+  version = "2.0.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "nathom";
+    repo = "streamrip";
+    rev = "v${version}";
+    hash = "sha256-KwMt89lOPGt6nX7ywliG/iAJ1WnG0CRPwhAVlPR85q0=";
+  };
+
+  patches = [
+    ./patches/ensure-the-default-config-file-is-writable.patch
+  ];
+
+  nativeBuildInputs = with python3Packages; [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    aiodns
+    aiofiles
+    aiohttp
+    aiolimiter
+    appdirs
+    cleo
+    click-help-colors
+    deezer-py
+    m3u8
+    mutagen
+    pathvalidate
+    pillow
+    pycryptodomex
+    pytest-asyncio
+    pytest-mock
+    rich
+    simple-term-menu
+    tomlkit
+    tqdm
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+  ];
+
+  prePatch = ''
+    sed -i 's#aiofiles = ".*"#aiofiles = "*"#' pyproject.toml
+    sed -i 's#deezer-py = ".*"#deezer-py = "*"#' pyproject.toml
+    sed -i 's#m3u8 = ".*"#m3u8 = "*"#' pyproject.toml
+    sed -i 's#pathvalidate = ".*"#pathvalidate = "*"#' pyproject.toml
+    sed -i 's#Pillow = ".*"#Pillow = "*"#' pyproject.toml
+    sed -i 's#pytest-asyncio = ".*"#pytest-asyncio = "*"#' pyproject.toml
+    sed -i 's#tomlkit = ".*"#tomlkit = "*"#' pyproject.toml
+
+    sed -i 's#"ffmpeg"#"${lib.getBin ffmpeg}/bin/ffmpeg"#g' streamrip/client/downloadable.py
+  '';
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  meta = with lib; {
+    description = "A scriptable music downloader for Qobuz, Tidal, SoundCloud, and Deezer";
+    homepage = "https://github.com/nathom/streamrip";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ paveloom ];
+    mainProgram = "rip";
+  };
+}

--- a/pkgs/by-name/st/streamrip/patches/ensure-the-default-config-file-is-writable.patch
+++ b/pkgs/by-name/st/streamrip/patches/ensure-the-default-config-file-is-writable.patch
@@ -1,0 +1,26 @@
+From 18efb9b5c8e562b169425f6ba79977e52e8b91b9 Mon Sep 17 00:00:00 2001
+From: Pavel Sobolev <paveloomm@gmail.com>
+Date: Sat, 13 Jan 2024 12:49:45 +0000
+Subject: [PATCH] Ensure the default config file is writable.
+
+---
+ streamrip/config.py | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/streamrip/config.py b/streamrip/config.py
+index 7ee2f57..88a5fef 100644
+--- a/streamrip/config.py
++++ b/streamrip/config.py
+@@ -378,6 +378,9 @@ def set_user_defaults(path: str, /):
+     """Update the TOML file at the path with user-specific default values."""
+     shutil.copy(BLANK_CONFIG_PATH, path)
+
++    # Ensure the default config file is writable
++    os.chmod(path, 0o644)
++
+     with open(path) as f:
+         toml = parse(f.read())
+     toml["downloads"]["folder"] = DEFAULT_DOWNLOADS_FOLDER  # type: ignore
+--
+2.42.0
+


### PR DESCRIPTION
## Description of changes

https://github.com/nathom/streamrip

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
