### PR TITLE
python311Packages.junos-eznc: 2.6.8 -> 2.7.0

### DIFF
--- a/pkgs/development/python-modules/junos-eznc/default.nix
+++ b/pkgs/development/python-modules/junos-eznc/default.nix
@@ -1,13 +1,12 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , jinja2
 , lxml
 , mock
 , ncclient
 , netaddr
-, nose
+, nose2
 , ntc-templates
 , paramiko
 , pyparsing
@@ -15,6 +14,8 @@
 , pythonOlder
 , pyyaml
 , scp
+, setuptools
+, pytestCheckHook
 , six
 , transitions
 , yamlordereddictloader
@@ -22,23 +23,21 @@
 
 buildPythonPackage rec {
   pname = "junos-eznc";
-  version = "2.6.8";
-  format = "setuptools";
+  version = "2.7.0";
+  pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "Juniper";
     repo = "py-junos-eznc";
     rev = "refs/tags/${version}";
-    hash = "sha256-5xZjuU2U3BodAMQiWZIJ27AZiAwoMm4yJ4qr3DjMd9o=";
+    hash = "sha256-06OV6UrF2i4SxL5dCvVxsEX2e8ef8UBFx/oMbvCZDaM=";
   };
 
-  postPatch = ''
-    # https://github.com/Juniper/py-junos-eznc/issues/1236
-    substituteInPlace lib/jnpr/junos/utils/scp.py \
-      --replace "inspect.getargspec" "inspect.getfullargspec"
-  '';
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   propagatedBuildInputs = [
     jinja2
@@ -58,21 +57,33 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     mock
-    nose
+    nose2
+    pytestCheckHook
   ];
 
-  checkPhase = ''
-    nosetests -v -a unit --exclude=test_sw_put_ftp
-  '';
+  pytestFlagsArray = [
+   "tests/unit"
+  ];
+
+  disabledTests = [
+    # jnpr.junos.exception.FactLoopError: A loop was detected while gathering the...
+    "TestPersonality"
+    "TestGetSoftwareInformation"
+    "TestIfdStyle"
+    # KeyError: 'mac'
+    "test_textfsm_table_mutli_key"
+    # AssertionError: None != 'juniper.net'
+    "test_domain_fact_from_config"
+  ];
 
   pythonImportsCheck = [
     "jnpr.junos"
   ];
 
   meta = with lib; {
-    changelog = "https://github.com/Juniper/py-junos-eznc/releases/tag/${version}";
     description = "Junos 'EZ' automation for non-programmers";
     homepage = "https://github.com/Juniper/py-junos-eznc";
+    changelog = "https://github.com/Juniper/py-junos-eznc/releases/tag/${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ xnaveira ];
   };


### PR DESCRIPTION
Diff: https://github.com/Juniper/py-junos-eznc/compare/refs/tags/2.6.8...2.7.0

Changelog: https://github.com/Juniper/py-junos-eznc/releases/tag/2.7.0

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
