### PR TITLE
openrct2: 0.4.5 -> 0.4.7

### DIFF
--- a/pkgs/games/openrct2/default.nix
+++ b/pkgs/games/openrct2/default.nix
@@ -1,12 +1,14 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 
 , SDL2
 , cmake
 , curl
 , discord-rpc
 , duktape
+, expat
 , flac
 , fontconfig
 , freetype
@@ -28,48 +30,48 @@
 }:
 
 let
-  openrct2-version = "0.4.5";
+  openrct2-version = "0.4.7";
 
   # Those versions MUST match the pinned versions within the CMakeLists.txt
   # file. The REPLAYS repository from the CMakeLists.txt is not necessary.
-  objects-version = "1.3.11";
-  openmsx-version = "1.3.0";
+  objects-version = "1.3.13";
+  openmsx-version = "1.5";
   opensfx-version = "1.0.3";
-  title-sequences-version = "0.4.0";
+  title-sequences-version = "0.4.6";
 
   openrct2-src = fetchFromGitHub {
     owner = "OpenRCT2";
     repo = "OpenRCT2";
     rev = "v${openrct2-version}";
-    sha256 = "sha256-TMtaEqui3gUd+j3LwF7VsHiBtbYZMu6Rvo1aMkkU9LY=";
+    hash = "sha256-2nSzXbZH1o+BEaxhdQTCM/u4Qbun4tqBKjQ4z7owHeg=";
   };
 
   objects-src = fetchFromGitHub {
     owner = "OpenRCT2";
     repo = "objects";
     rev = "v${objects-version}";
-    sha256 = "sha256-fA2Kz4GALu6IP7ulbwpAFt3dz6NCPgyB0CWy5uOLBQY=";
+    hash = "sha256-7RvRe7skXH5x8RbkQgtKs1YMBwq8dHInVo/4FAJwUD0=";
   };
 
   openmsx-src = fetchFromGitHub {
     owner = "OpenRCT2";
     repo = "OpenMusic";
     rev = "v${openmsx-version}";
-    sha256 = "sha256-bp+uwTy2ZFMCK8Dq4YVACpQSwo8v1te+NQGwdqViIjU=";
+    hash = "sha256-p/wlvQFfu3R+jIuCcRbTMvxt0VKGGwJw0NDIsf6URWI=";
   };
 
   opensfx-src = fetchFromGitHub {
     owner = "OpenRCT2";
     repo = "OpenSoundEffects";
     rev = "v${opensfx-version}";
-    sha256 = "sha256-AMuCpq1Hszi2Vikto/cX9g81LwBDskaRMTLxNzU0/Gk=";
+    hash = "sha256-AMuCpq1Hszi2Vikto/cX9g81LwBDskaRMTLxNzU0/Gk=";
   };
 
   title-sequences-src = fetchFromGitHub {
     owner = "OpenRCT2";
     repo = "title-sequences";
     rev = "v${title-sequences-version}";
-    sha256 = "sha256-anqCZkhYoaxPu3MYCYSsFFngOmPp2wnx2MGb0hj6W5U=";
+    hash = "sha256-HWp2ecClNM/7O3oaydVipOnEsYNP/bZnZFS+SDidPi0=";
   };
 in
 stdenv.mkDerivation {
@@ -77,6 +79,19 @@ stdenv.mkDerivation {
   version = openrct2-version;
 
   src = openrct2-src;
+
+  patches = [
+    # https://github.com/OpenRCT2/OpenRCT2/pull/21043
+    #
+    # Basically <https://github.com/OpenRCT2/OpenRCT2/pull/19785> has broken
+    # OpenRCT2 - at least with older maps, as were used for testing - as stated
+    # in <https://github.com/NixOS/nixpkgs/issues/263025>.
+    (fetchpatch {
+      name = "remove-openrct2-music.patch";
+      url = "https://github.com/OpenRCT2/OpenRCT2/commit/9ea13848be0b974336c34e6eb119c49ba42a907c.patch";
+      hash = "sha256-2PPRqUZf4+ys89mdzp5nvdtdv00V9Vzj3v/95rmlf1c=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -88,6 +103,7 @@ stdenv.mkDerivation {
     curl
     discord-rpc
     duktape
+    expat
     flac
     fontconfig
     freetype


### PR DESCRIPTION
## Description of changes

- https://github.com/OpenRCT2/OpenRCT2/releases/tag/v0.4.6
- https://github.com/OpenRCT2/OpenRCT2/releases/tag/v0.4.7

Updating to 0.4.6 resulted some headaches, as suddenly lots of errors about missing music objects were thrown and old maps were not loadable. This was also mentioned in #263025.

Today I git bisect'ed OpenRCT2's source between 0.4.5 and 0.4.6, finding 5adbea9ac829b76507543e4c09b2000138ffbbcf as the culprit, which origins in OpenRCT2/OpenRCT2#19785. From there I got to OpenRCT2/OpenRCT2#21043 which addresses this very issue and fixes it by undoing the original change next to some later changes. This PR is now included as a patch and, et voilà, OpenRCT2 works again!

Closes #263025.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
