### PR TITLE
libsidplayfp: 2.5.1 -> 2.6.0

### DIFF
--- a/pkgs/development/libraries/libsidplayfp/default.nix
+++ b/pkgs/development/libraries/libsidplayfp/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, fetchpatch
 , makeFontsConf
 , nix-update-script
 , testers
@@ -19,40 +18,20 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libsidplayfp";
-  version = "2.5.1";
+  version = "2.6.0";
 
   src = fetchFromGitHub {
     owner = "libsidplayfp";
     repo = "libsidplayfp";
     rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-1e1QDSJ8CjLU794saba2auCKko7p2ylrdI0JWhh8Kco=";
+    hash = "sha256-6Gbujz20EHQ7s9GaPpEPju+WqePjpduJqb5hcrswTm8=";
   };
 
   outputs = [
     "out"
   ] ++ lib.optionals docSupport [
     "doc"
-  ];
-
-  patches = [
-    # Pull autoconf-2.72 compatibility fix:
-    #   https://github.com/libsidplayfp/libsidplayfp/pull/103
-    # Remove when version > 2.5.1
-    (fetchpatch {
-      name = "0001-libsidplayfp-autoconf-2.72-compat.patch";
-      url = "https://github.com/libsidplayfp/libsidplayfp/commit/2b1b41beb5099d5697e3f8416d78f27634732a9e.patch";
-      hash = "sha256-5Hk202IuHUBow7HnnPr2/ieWFjKDuHLQjQ9mJUML9q8=";
-    })
-
-    # Fix --disable-tests logic
-    # https://github.com/libsidplayfp/libsidplayfp/pull/108
-    # Remove when version > 2.5.1
-    (fetchpatch {
-      name = "0002-libsidplayfp-Fix-autoconf-logic-for-tests-option.patch";
-      url = "https://github.com/libsidplayfp/libsidplayfp/commit/39dd2893b6186c4932d17b529bb62627b742b742.patch";
-      hash = "sha256-ErdfPvu8R81XxdHu2TaV87OpLFlRhJai51QcYUIkUZ4=";
-    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

https://github.com/libsidplayfp/libsidplayfp/releases/tag/v2.6.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  Tested `sidplayfp`.
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
