### PR TITLE
seq66: fix build against `gcc-13`

### DIFF
--- a/pkgs/applications/audio/seq66/default.nix
+++ b/pkgs/applications/audio/seq66/default.nix
@@ -21,6 +21,10 @@ stdenv.mkDerivation rec {
     for d in libseq66/include libseq66/src libsessions/include libsessions/src seq_qt5/src seq_rtmidi/include seq_rtmidi/src Seqtool/src; do
       substituteInPlace "$d/Makefile.am" --replace '$(git_info)' '${version}'
     done
+
+    # gcc-13 headers compatibilty. TODO: try to remove with next version
+    # update
+    sed -e '1i #include <cstdint>' -i libseq66/src/os/daemonize.cpp
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/applications/audio/seq66/default.nix
+++ b/pkgs/applications/audio/seq66/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchFromGitHub, autoreconfHook, pkg-config, qttools, which
-, alsa-lib, libjack2, liblo, qtbase
+, alsa-lib, libjack2, liblo, qtbase, wrapQtAppsHook
 }:
 
 stdenv.mkDerivation rec {
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "1jvra1wzlycfpvffnqidk264zw6fyl4fsghkw5256ldk22aalmq9";
   };
 
-  nativeBuildInputs = [ autoreconfHook pkg-config qttools which ];
+  nativeBuildInputs = [ autoreconfHook pkg-config qttools which wrapQtAppsHook ];
 
   buildInputs = [ alsa-lib libjack2 liblo qtbase ];
 
@@ -29,13 +29,12 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  dontWrapQtApps = true;
-
   meta = with lib; {
     homepage = "https://github.com/ahlstromcj/seq66";
     description = "Loop based midi sequencer with Qt GUI derived from seq24 and sequencer64";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ orivej ];
+    mainProgram = "qseq66";
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
Without the chnage build fails on `master` as:

    In file included from os/daemonize.cpp:64:
    ../include/os/daemonize.hpp:58:8: error: 'uint32_t' does not name a type
       58 | extern uint32_t daemonize
          |        ^~~~~~~~
    ../include/os/daemonize.hpp:36:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
       35 | #include "seq66_platform_macros.h"      /* for detecting 32-bit builds      */
      +++ |+#include <cstdint>

As upstream changes are quite invasive for backport I am only injecting missing headers.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
