### PR TITLE
gnuradioPackages.fosphor: init at unstable-2024-03-23

### DIFF
--- a/pkgs/development/gnuradio-modules/fosphor/default.nix
+++ b/pkgs/development/gnuradio-modules/fosphor/default.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  mkDerivation,
+  fetchgit,
+  gnuradio,
+  cmake,
+  pkg-config,
+  logLib,
+  mpir,
+  gmp,
+  boost,
+  libGL,
+  opencl-headers,
+  ocl-icd,
+  freetype,
+  fftwFloat,
+  qt5,
+  python,
+  enableGLFW ? true,
+  glfw3,
+  enablePNG ? true,
+  libpng,
+  gnuradioOlder,
+  gnuradioAtLeast,
+}:
+
+mkDerivation {
+  pname = "gr-fosphor";
+  version = "unstable-2024-03-23";
+
+  # It is a gitea instance, but its archive service doesn't work very well so
+  # we can't use it.
+  src = fetchgit {
+    url = "https://gitea.osmocom.org/sdr/gr-fosphor.git";
+    rev = "74d54fc0b3ec9aeb7033686526c5e766f36eaf24";
+    hash = "sha256-FBmH4DmKATl0FPFU7T30OrYYmxlSTTLm1SZpt0o1qkw=";
+  };
+  disabled = gnuradioOlder "3.9" || gnuradioAtLeast "3.11";
+
+  nativeBuildInputs =
+    [
+      cmake
+      pkg-config
+    ]
+    ++ lib.optionals (gnuradio.hasFeature "gr-qtgui") [
+      qt5.wrapQtAppsHook
+    ];
+
+  buildInputs =
+    [
+      logLib
+      mpir
+      gmp
+      boost
+      libGL
+      opencl-headers
+      ocl-icd
+      freetype
+      fftwFloat
+    ]
+    ++ lib.optionals (gnuradio.hasFeature "gr-qtgui") [
+      qt5.qtbase
+    ]
+    ++ lib.optionals (gnuradio.hasFeature "python-support") [
+      python.pkgs.pybind11
+      python.pkgs.numpy
+    ]
+    ++ lib.optionals enableGLFW [
+      glfw3
+    ]
+    ++ lib.optionals enablePNG [
+      libpng
+    ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "ENABLE_QT" (gnuradio.hasFeature "gr-qtgui"))
+    (lib.cmakeBool "ENABLE_PYTHON" (gnuradio.hasFeature "python-support"))
+    (lib.cmakeBool "ENABLE_GLFW" enableGLFW)
+    (lib.cmakeBool "ENABLE_PNG" enablePNG)
+  ];
+
+  meta = {
+    description = "GNU Radio block for RTSA-like spectrum visualization using OpenCL and OpenGL acceleration";
+    longDescription = ''
+      You'll need to install an OpenCL ICD for it to work.
+      See https://nixos.org/manual/nixos/stable/#sec-gpu-accel-opencl
+    '';
+    homepage = "https://projects.osmocom.org/projects/sdr/wiki/Fosphor";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ chuangzhu ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/gnuradio-packages.nix
+++ b/pkgs/top-level/gnuradio-packages.nix
@@ -39,6 +39,8 @@ in {
 
   ais = callPackage ../development/gnuradio-modules/ais/default.nix { };
 
+  fosphor = callPackage ../development/gnuradio-modules/fosphor/default.nix { };
+
   grnet = callPackage ../development/gnuradio-modules/grnet/default.nix { };
 
   gsm = callPackage ../development/gnuradio-modules/gsm/default.nix { };


### PR DESCRIPTION
## Description of changes

GNU Radio block for RTSA-like spectrum visualization using OpenCL and OpenGL acceleration.

https://projects.osmocom.org/projects/sdr/wiki/Fosphor

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
