### PR TITLE
librdf_raptor2: unstable-2022-06-06 -> 2.0.16

### DIFF
--- a/pkgs/development/libraries/librdf/raptor2.nix
+++ b/pkgs/development/libraries/librdf/raptor2.nix
@@ -14,13 +14,14 @@
 
 stdenv.mkDerivation rec {
   pname = "raptor2";
-  version = "unstable-2022-06-06";
+  version = "2.0.16";
+  underscoredVersion = lib.strings.replaceStrings ["."] ["_"] version;
 
   src = fetchFromGitHub {
     owner = "dajobe";
     repo = "raptor";
-    rev = "3cca62a33da68143b687c9e486eefc7c7cbb4586";
-    sha256 = "sha256-h03IyFH1GHPqajfHBBTb19lCEu+VXzQLGC1wiEGVvgY=";
+    rev = "${pname}_${underscoredVersion}";
+    sha256 = "sha256-Eic63pV2p154YkSmkqWr86fGTr+XmVGy5l5/6q14LQM=";
   };
 
   cmakeFlags = [
@@ -29,13 +30,7 @@ stdenv.mkDerivation rec {
   ];
 
   patches = [
-    # https://github.com/dajobe/raptor/pull/52
-    (fetchpatch {
-      name = "fix-cmake-generated-pc-file";
-      url = "https://github.com/dajobe/raptor/commit/fa1ef9a27d8762f5588ac2e92554a188e73dee9f.diff";
-      sha256 = "sha256-zXIbrYGgC9oTpiD0WUikT4vRdc9b6bsyfnDkwUSlqao=";
-    })
-    # pull upstream fix for libxml2-2.11 API compatibility:
+    # pull upstream fix for libxml2-2.11 API compatibility, part of unreleased 2.0.17
     #   https://github.com/dajobe/raptor/pull/58
     (fetchpatch {
       name = "libxml2-2.11.patch";


### PR DESCRIPTION
## Description of changes

You can find the release notes [here](https://librdf.org/raptor/RELEASE.html#rel2_0_16) and a detailed diff [here](https://github.com/dajobe/raptor/compare/3cca62a33da68143b687c9e486eefc7c7cbb4586...raptor2_2_0_16).

While the CVE fixes were already included in the previous packaged version, it now also contains the following fixes:
- dajobe/raptor#52
- dajobe/raptor#53
- dajobe/raptor#55

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
