### PR TITLE
bruno: fix darwin builds

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11603,6 +11603,12 @@
     githubId = 279868;
     name = "Matti Kariluoma";
   };
+  mattpolzin = {
+    email = "matt.polzin@gmail.com";
+    github = "mattpolzin";
+    githubId = 2075353;
+    name = "Matt Polzin";
+  };
   matt-snider = {
     email = "matt.snider@protonmail.com";
     github = "matt-snider";

--- a/pkgs/by-name/br/bruno/package.nix
+++ b/pkgs/by-name/br/bruno/package.nix
@@ -1,5 +1,6 @@
 { lib
 
+, stdenv
 , fetchFromGitHub
 , buildNpmPackage
 , nix-update-script
@@ -34,9 +35,10 @@ buildNpmPackage rec {
 
   nativeBuildInputs = [
     (writeShellScriptBin "phantomjs" "echo 2.1.1")
+    pkg-config
+  ] ++ lib.optionals (! stdenv.isDarwin) [
     makeWrapper
     copyDesktopItems
-    pkg-config
   ];
 
   buildInputs = [
@@ -74,11 +76,27 @@ buildNpmPackage rec {
 
     pushd packages/bruno-electron
 
+    ${if stdenv.isDarwin then ''
+    cp -r ${electron}/Applications/Electron.app ./
+    find ./Electron.app -name 'Info.plist' | xargs -d '\n' chmod +rw
+
+    substituteInPlace electron-builder-config.js \
+      --replace "identity: 'Anoop MD (W7LPPWA48L)'" 'identity: null' \
+      --replace "afterSign: 'notarize.js'," ""
+
+    npm exec electron-builder -- \
+      --dir \
+      --config electron-builder-config.js \
+      -c.electronDist=./ \
+      -c.electronVersion=${electron.version} \
+      -c.npmRebuild=false
+    '' else ''
     npm exec electron-builder -- \
       --dir \
       -c.electronDist=${electron}/libexec/electron \
       -c.electronVersion=${electron.version} \
       -c.npmRebuild=false
+    ''}
 
     popd
   '';
@@ -88,6 +106,12 @@ buildNpmPackage rec {
   installPhase = ''
     runHook preInstall
 
+
+    ${if stdenv.isDarwin then ''
+    mkdir -p $out/Applications
+
+    cp -R packages/bruno-electron/out/**/Bruno.app $out/Applications/
+    '' else ''
     mkdir -p $out/opt/bruno $out/bin
 
     cp -r packages/bruno-electron/dist/linux-unpacked/{locales,resources{,.pak}} $out/opt/bruno
@@ -102,6 +126,7 @@ buildNpmPackage rec {
       size=${"$"}{s}x$s
       install -Dm644 $src/packages/bruno-electron/resources/icons/png/$size.png $out/share/icons/hicolor/$size/apps/bruno.png
     done
+    ''}
 
     runHook postInstall
   '';

--- a/pkgs/by-name/br/bruno/package.nix
+++ b/pkgs/by-name/br/bruno/package.nix
@@ -138,7 +138,7 @@ buildNpmPackage rec {
     homepage = "https://www.usebruno.com";
     inherit (electron.meta) platforms;
     license = licenses.mit;
-    maintainers = with maintainers; [ water-sucks lucasew kashw2 ];
+    maintainers = with maintainers; [ water-sucks lucasew kashw2 mattpolzin ];
     mainProgram = "bruno";
   };
 }

--- a/pkgs/by-name/br/bruno/package.nix
+++ b/pkgs/by-name/br/bruno/package.nix
@@ -114,7 +114,7 @@ buildNpmPackage rec {
     '' else ''
     mkdir -p $out/opt/bruno $out/bin
 
-    cp -r packages/bruno-electron/dist/linux-unpacked/{locales,resources{,.pak}} $out/opt/bruno
+    cp -r packages/bruno-electron/dist/linux*-unpacked/{locales,resources{,.pak}} $out/opt/bruno
 
     makeWrapper ${lib.getExe electron} $out/bin/bruno \
       --add-flags $out/opt/bruno/resources/app.asar \


### PR DESCRIPTION
## Description of changes

Fix Darwin builds of the `bruno` package.

I'm a bit out of my depth here so not confident these changes are ideal, I just know that they do indeed work. Prior to these changes, builds on Darwin failed with very unhelpful errors from the `electron-builder` script, after these changes you get a working application bundle.

One thing I am very unclear on is the right way to track this added support for Darwin against the package. The package inherits `platforms` from `electron.meta` which feels very appropriate, but the `electron` derivation will be one of two different packages depending on the platform you evaluate it on; for Darwin, you get the binary electron package and for everything else you get the source code electron package. This means that the GitHub labeling will indicate this derivation does not cause any Darwin rebuilds but at the same time if I build `bruno` on my Darwin machine I don't need to do anything special (no overrides or overlays needed) for Nix to understand that my platform is supported. Pretty awkward.

Unrelatedly, it would not build for arm64 linux because the output path was `linux-arm64-unpacked` instead of `linux-unpacked` so I fixed that in a second commit.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
