### PR TITLE
modprobed-db: init at 2.46

### DIFF
--- a/pkgs/by-name/mo/modprobed-db/package.nix
+++ b/pkgs/by-name/mo/modprobed-db/package.nix
@@ -1,0 +1,50 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, libevdev
+, kmod
+, bash
+, installShellFiles
+}:
+let
+  pname = "modprobed-db";
+  version = "2.46";
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "graysky2";
+    repo = "modprobed-db";
+    rev = "v${version}";
+    hash = "sha256-GQME5CAZsGVHSPowKQMyUR7OjHeFZi/5YcWFUT9L/AQ=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [ pkg-config installShellFiles ];
+  buildInputs = [ kmod libevdev bash ];
+
+  installFlags = [
+    "PREFIX=$(out)"
+    "INITDIR_SYSTEMD=$(out)/lib/systemd/user"
+  ];
+
+  postPatch = ''
+    substituteInPlace ./common/modprobed-db.in \
+      --replace "/usr/share" "$out/share"
+  '';
+
+  postInstall = ''
+    installShellCompletion --zsh common/zsh-completion
+  '';
+
+  meta = {
+    homepage = "https://github.com/graysky2/modprobed-db";
+    description = "Useful utility for users wishing to build a minimal kernel via a make localmodconfig";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ NotAShelf ];
+    mainProgram = "modprobed-db";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
