### PR TITLE
stm32cubemx: wrap with FHSEnv

### DIFF
--- a/pkgs/development/embedded/stm32/stm32cubemx/default.nix
+++ b/pkgs/development/embedded/stm32/stm32cubemx/default.nix
@@ -79,7 +79,7 @@ let
       sourceProvenance = with sourceTypes; [ binaryBytecode ];
       license = licenses.unfree;
       maintainers = with maintainers; [ angaz wucke13 ];
-      platforms = platforms.all;
+      platforms = [ "x86_64-linux" ];
     };
   };
   in

--- a/pkgs/development/embedded/stm32/stm32cubemx/default.nix
+++ b/pkgs/development/embedded/stm32/stm32cubemx/default.nix
@@ -1,84 +1,115 @@
 { fdupes
+, buildFHSEnv
 , fetchzip
 , icoutils
 , imagemagick
 , jdk17
 , lib
 , makeDesktopItem
-, stdenv
+, stdenvNoCC
 }:
 
 let
   iconame = "STM32CubeMX";
-in
-stdenv.mkDerivation rec {
-  pname = "stm32cubemx";
-  version = "6.10.0";
+  package = stdenvNoCC.mkDerivation rec {
+    pname = "stm32cubemx";
+    version = "6.10.0";
 
-  src = fetchzip {
-    url = "https://sw-center.st.com/packs/resource/library/stm32cube_mx_v${builtins.replaceStrings ["."] [""] version}-lin.zip";
-    sha256 = "sha256-B5Sf+zM7h9BiFqDYrLS0JdqZi3dGy6H9gAaJIN3izeM=";
-    stripRoot = false;
-  };
+    src = fetchzip {
+      url = "https://sw-center.st.com/packs/resource/library/stm32cube_mx_v${builtins.replaceStrings ["."] [""] version}-lin.zip";
+      sha256 = "sha256-B5Sf+zM7h9BiFqDYrLS0JdqZi3dGy6H9gAaJIN3izeM=";
+      stripRoot = false;
+    };
 
-  nativeBuildInputs = [ fdupes icoutils imagemagick ];
-  desktopItem = makeDesktopItem {
-    name = "STM32CubeMX";
-    exec = "stm32cubemx";
-    desktopName = "STM32CubeMX";
-    categories = [ "Development" ];
-    icon = "stm32cubemx";
-    comment = meta.description;
-    terminal = false;
-    startupNotify = false;
-    mimeTypes = [
-      "x-scheme-handler/sgnl"
-      "x-scheme-handler/signalcaptcha"
-    ];
-  };
+    nativeBuildInputs = [ fdupes icoutils imagemagick ];
+    desktopItem = makeDesktopItem {
+      name = "STM32CubeMX";
+      exec = "stm32cubemx";
+      desktopName = "STM32CubeMX";
+      categories = [ "Development" ];
+      icon = "stm32cubemx";
+      comment = meta.description;
+      terminal = false;
+      startupNotify = false;
+      mimeTypes = [
+        "x-scheme-handler/sgnl"
+        "x-scheme-handler/signalcaptcha"
+      ];
+    };
 
-  buildCommand = ''
-    mkdir -p $out/{bin,opt/STM32CubeMX,share/applications}
+    buildCommand = ''
+      mkdir -p $out/{bin,opt/STM32CubeMX,share/applications}
 
-    cp -r $src/MX/. $out/opt/STM32CubeMX/
-    chmod +rx $out/opt/STM32CubeMX/STM32CubeMX
+      cp -r $src/MX/. $out/opt/STM32CubeMX/
+      chmod +rx $out/opt/STM32CubeMX/STM32CubeMX
 
-    cat << EOF > $out/bin/${pname}
-    #!${stdenv.shell}
-    ${jdk17}/bin/java -jar $out/opt/STM32CubeMX/STM32CubeMX
-    EOF
-    chmod +x $out/bin/${pname}
+      cat << EOF > $out/bin/${pname}
+      #!${stdenvNoCC.shell}
+      ${jdk17}/bin/java -jar $out/opt/STM32CubeMX/STM32CubeMX
+      EOF
+      chmod +x $out/bin/${pname}
 
-    icotool --extract $out/opt/STM32CubeMX/help/${iconame}.ico
-    fdupes -dN . > /dev/null
-    ls
-    for size in 16 24 32 48 64 128 256; do
-      mkdir -pv $out/share/icons/hicolor/"$size"x"$size"/apps
-      if [ $size -eq 256 ]; then
-        mv ${iconame}_*_"$size"x"$size"x32.png \
-          $out/share/icons/hicolor/"$size"x"$size"/apps/${pname}.png
-      else
-        convert -resize "$size"x"$size" ${iconame}_*_256x256x32.png \
-          $out/share/icons/hicolor/"$size"x"$size"/apps/${pname}.png
-      fi
-    done;
+      icotool --extract $out/opt/STM32CubeMX/help/${iconame}.ico
+      fdupes -dN . > /dev/null
+      ls
+      for size in 16 24 32 48 64 128 256; do
+        mkdir -pv $out/share/icons/hicolor/"$size"x"$size"/apps
+        if [ $size -eq 256 ]; then
+          mv ${iconame}_*_"$size"x"$size"x32.png \
+            $out/share/icons/hicolor/"$size"x"$size"/apps/${pname}.png
+        else
+          convert -resize "$size"x"$size" ${iconame}_*_256x256x32.png \
+            $out/share/icons/hicolor/"$size"x"$size"/apps/${pname}.png
+        fi
+      done;
 
-    cp ${desktopItem}/share/applications/*.desktop $out/share/applications
-  '';
-
-  meta = with lib; {
-    description = "A graphical tool for configuring STM32 microcontrollers and microprocessors";
-    longDescription = ''
-      A graphical tool that allows a very easy configuration of STM32
-      microcontrollers and microprocessors, as well as the generation of the
-      corresponding initialization C code for the Arm® Cortex®-M core or a
-      partial Linux® Device Tree for Arm® Cortex®-A core), through a
-      step-by-step process.
+      cp ${desktopItem}/share/applications/*.desktop $out/share/applications
     '';
-    homepage = "https://www.st.com/en/development-tools/stm32cubemx.html";
-    sourceProvenance = with sourceTypes; [ binaryBytecode ];
-    license = licenses.unfree;
-    maintainers = with maintainers; [ angaz wucke13 ];
-    platforms = platforms.all;
+
+    meta = with lib; {
+      description = "A graphical tool for configuring STM32 microcontrollers and microprocessors";
+      longDescription = ''
+        A graphical tool that allows a very easy configuration of STM32
+        microcontrollers and microprocessors, as well as the generation of the
+        corresponding initialization C code for the Arm® Cortex®-M core or a
+        partial Linux® Device Tree for Arm® Cortex®-A core), through a
+        step-by-step process.
+      '';
+      homepage = "https://www.st.com/en/development-tools/stm32cubemx.html";
+      sourceProvenance = with sourceTypes; [ binaryBytecode ];
+      license = licenses.unfree;
+      maintainers = with maintainers; [ angaz wucke13 ];
+      platforms = platforms.all;
+    };
   };
+  in
+  buildFHSEnv {
+    inherit (package) pname meta;
+    runScript = "${package.outPath}/bin/stm32cubemx";
+    targetPkgs = pkgs:
+      with pkgs; [
+        alsa-lib
+        at-spi2-atk
+        cairo
+        cups
+        dbus
+        expat
+        glib
+        gtk3
+        libdrm
+        libGL
+        libudev0-shim
+        libxkbcommon
+        mesa
+        nspr
+        nss
+        pango
+        xorg.libX11
+        xorg.libxcb
+        xorg.libXcomposite
+        xorg.libXdamage
+        xorg.libXext
+        xorg.libXfixes
+        xorg.libXrandr
+      ];
 }


### PR DESCRIPTION
## Description of changes

As of recently STM32CubeMX is using JxBrowser for, now mandatory, user authentication.
Same browser is extracted from STM32CubeMX install binaries into ~/.stm32cubemx directory and depends on the system shared libraries.

This PR wrapps STM32CubeMX with FHSEnv in order call JxBrowser. 
Package remains mostly the same except a minor change where stdenv is replaced by stdenvNoCC.

STM32CubeMX login page takes a while to appear on Wayland (Sway) but works mostly fine.

Fixes: #272342 

cc @angaz @wucke13 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
