### PR TITLE
[treewide] unpin go

### DIFF
--- a/pkgs/applications/audio/go-musicfox/default.nix
+++ b/pkgs/applications/audio/go-musicfox/default.nix
@@ -1,5 +1,5 @@
 { lib
-, buildGo121Module
+, buildGoModule
 , fetchFromGitHub
 , pkg-config
 , alsa-lib
@@ -7,7 +7,7 @@
 , nix-update-script
 }:
 
-buildGo121Module rec {
+buildGoModule rec {
   pname = "go-musicfox";
   version = "4.3.0";
 

--- a/pkgs/applications/networking/cluster/k0sctl/default.nix
+++ b/pkgs/applications/networking/cluster/k0sctl/default.nix
@@ -1,10 +1,10 @@
 { lib
-, buildGo121Module
+, buildGoModule
 , fetchFromGitHub
 , installShellFiles
 }:
 
-buildGo121Module rec {
+buildGoModule rec {
   pname = "k0sctl";
   version = "0.17.3";
 

--- a/pkgs/applications/networking/cluster/kubectl-klock/default.nix
+++ b/pkgs/applications/networking/cluster/kubectl-klock/default.nix
@@ -1,6 +1,6 @@
-{ lib, buildGo121Module, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
-buildGo121Module rec {
+buildGoModule rec {
   pname = "kubectl-klock";
   version = "0.5.0";
 

--- a/pkgs/applications/networking/cluster/timoni/default.nix
+++ b/pkgs/applications/networking/cluster/timoni/default.nix
@@ -1,10 +1,10 @@
 { lib
-, buildGo121Module
+, buildGoModule
 , fetchFromGitHub
 , installShellFiles
 }:
 
-buildGo121Module rec {
+buildGoModule rec {
   pname = "timoni";
   version = "0.17.0";
 

--- a/pkgs/applications/networking/ktailctl/default.nix
+++ b/pkgs/applications/networking/ktailctl/default.nix
@@ -1,11 +1,11 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, buildGo121Module
+, buildGoModule
 , cmake
 , extra-cmake-modules
 , git
-, go_1_21
+, go
 , wrapQtAppsHook
 , qtbase
 , qtquickcontrols2
@@ -28,13 +28,14 @@ let
     hash = "sha256-nY6DEHkDVWIlvc64smXb9KshrhNgNLKiilYydbMKCqc=";
   };
 
-  goDeps = (buildGo121Module {
+  goDeps = (buildGoModule {
     pname = "tailwrap";
     inherit src version;
     modRoot = "tailwrap";
     vendorHash = "sha256-Y9xhoTf3vCtiNi5qOPg020EQmASo58BZI3rAoUEC8qE=";
   }).goModules;
-in stdenv.mkDerivation {
+in
+stdenv.mkDerivation {
   pname = "ktailctl";
   inherit version src;
 
@@ -56,7 +57,7 @@ in stdenv.mkDerivation {
     cmake
     extra-cmake-modules
     git
-    go_1_21
+    go
     wrapQtAppsHook
   ];
 

--- a/pkgs/by-name/st/static-server/package.nix
+++ b/pkgs/by-name/st/static-server/package.nix
@@ -1,5 +1,5 @@
 { lib
-, buildGo121Module
+, buildGoModule
 , fetchFromGitHub
 , curl
 , stdenv
@@ -8,7 +8,7 @@
 , substituteAll
 }:
 
-buildGo121Module rec {
+buildGoModule rec {
   pname = "static-server";
   version = "1.2.1";
 

--- a/pkgs/by-name/up/uplosi/package.nix
+++ b/pkgs/by-name/up/uplosi/package.nix
@@ -1,8 +1,8 @@
 { lib
 , fetchFromGitHub
-, buildGo121Module
+, buildGoModule
 }:
-buildGo121Module rec {
+buildGoModule rec {
   pname = "uplosi";
   version = "0.1.2";
 

--- a/pkgs/by-name/zi/zitadel/package.nix
+++ b/pkgs/by-name/zi/zitadel/package.nix
@@ -1,5 +1,5 @@
 { stdenv
-, buildGo121Module
+, buildGoModule
 , callPackage
 , fetchFromGitHub
 , lib
@@ -25,7 +25,7 @@ let
   goModulesHash = "sha256-IVf1YVnhyEYgZqM31Cv3aBFnPG7v5WW6fCEvlN+sTIE=";
 
   buildZitadelProtocGen = name:
-    buildGo121Module {
+    buildGoModule {
       pname = "protoc-gen-${name}";
       inherit version;
 
@@ -94,7 +94,7 @@ let
     hash = "sha256-xrEF1B4pMoCZs1WO9F6IoqHnSyt5BhPVTIABMWK/q2E=";
   };
 in
-buildGo121Module rec {
+buildGoModule rec {
   name = "zitadel";
   inherit version;
 

--- a/pkgs/development/interpreters/risor/default.nix
+++ b/pkgs/development/interpreters/risor/default.nix
@@ -1,11 +1,11 @@
 { lib
-, buildGo121Module
+, buildGoModule
 , fetchFromGitHub
 , testers
 , risor
 }:
 
-buildGo121Module rec {
+buildGoModule rec {
   pname = "risor";
   version = "1.1.2";
 

--- a/pkgs/development/tools/turso-cli/default.nix
+++ b/pkgs/development/tools/turso-cli/default.nix
@@ -1,12 +1,12 @@
 {
   lib,
   stdenv,
-  buildGo121Module,
+  buildGoModule,
   fetchFromGitHub,
   installShellFiles,
   nix-update-script,
 }:
-buildGo121Module rec {
+buildGoModule rec {
   pname = "turso-cli";
   version = "0.87.8";
 

--- a/pkgs/tools/networking/juicity/default.nix
+++ b/pkgs/tools/networking/juicity/default.nix
@@ -1,8 +1,8 @@
 { lib
 , fetchFromGitHub
-, buildGo121Module
+, buildGoModule
 }:
-buildGo121Module rec {
+buildGoModule rec {
   pname = "juicity";
   version = "0.3.0";
 

--- a/pkgs/tools/system/netdata/go.d.plugin.nix
+++ b/pkgs/tools/system/netdata/go.d.plugin.nix
@@ -1,6 +1,6 @@
-{ lib, fetchFromGitHub, buildGo121Module, nixosTests }:
+{ lib, fetchFromGitHub, buildGoModule, nixosTests }:
 
-buildGo121Module rec {
+buildGoModule rec {
   pname = "netdata-go-plugins";
   version = "0.57.2";
 


### PR DESCRIPTION
## Description of changes
go 1.21 is default
this should result in no rebuilds

also not sure how widely accepted is https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/README.md#changing-implicit-attribute-defaults

but I also think we should discourage overriding versions in individual files

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
