### PR TITLE
betterdiscord-installer: 1.0.0-beta → 1.3.0

### DIFF
--- a/pkgs/tools/misc/betterdiscord-installer/default.nix
+++ b/pkgs/tools/misc/betterdiscord-installer/default.nix
@@ -1,23 +1,24 @@
 { appimageTools, lib, fetchurl }:
 let
   pname = "betterdiscord-installer";
-  version = "1.0.0-beta";
+  version = "1.3.0";
   name = "${pname}-${version}";
 
   src = fetchurl {
     url = "https://github.com/BetterDiscord/Installer/releases/download/v${version}/Betterdiscord-Linux.AppImage";
-    sha256 = "103acb11qmvjmf6g9lgsfm5jyahfwfdqw0x9w6lmv1hzwbs26dsr";
+    sha256 = "sha256-In5J6TWoJsFODDwMXd1lMg3341IZJD2OJebVtgISxP0=";
   };
 
   appimageContents = appimageTools.extract { inherit name src; };
-in appimageTools.wrapType2 {
+in
+appimageTools.wrapType2 {
   inherit name src;
 
   extraInstallCommands = ''
     mv $out/bin/${name} $out/bin/${pname}
 
-    install -m 444 -D ${appimageContents}/betterdiscord.desktop -t $out/share/applications
-    substituteInPlace $out/share/applications/betterdiscord.desktop \
+    install -m 444 -D ${appimageContents}/betterdiscord-installer.desktop -t $out/share/applications
+    substituteInPlace $out/share/applications/betterdiscord-installer.desktop \
       --replace 'Exec=AppRun' 'Exec=${pname}'
     cp -r ${appimageContents}/usr/share/icons $out/share
   '';
@@ -26,7 +27,7 @@ in appimageTools.wrapType2 {
     description = "Installer for BetterDiscord";
     homepage = "https://betterdiscord.app";
     license = licenses.mit;
-    maintainers = [ maintainers.ivar ];
+    maintainers = with maintainers; [ ivar aikooo7 ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "betterdiscord-installer";
   };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Short changelog: https://github.com/BetterDiscord/Installer/releases

Full changelog:
    v.1.0 until v.1.1.1: https://github.com/BetterDiscord/Installer/compare/v1.1.0...v1.1.1
    v.1.1 until v.1.2: https://github.com/BetterDiscord/Installer/compare/v1.1.1...v1.1.2
    v.1.2 until v.2.0: https://github.com/BetterDiscord/Installer/compare/v1.1.2...v1.2.0
    v.2.0 until v.2.1: https://github.com/BetterDiscord/Installer/compare/v1.2.0...v1.2.1
    v.2.1 until v.3.0: https://github.com/BetterDiscord/Installer/compare/v1.2.1...v1.3.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Closes #280744

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
