### PR TITLE
packj: init at 0.15-beta, python311Packages.pyisemail: init at 2.0.1

### DIFF
--- a/pkgs/by-name/pa/packj/package.nix
+++ b/pkgs/by-name/pa/packj/package.nix
@@ -1,0 +1,62 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "packj";
+  version = "0.15-beta";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ossillate-inc";
+    repo = "packj";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-OWcJE2Gtjgoj9bCGZcHDfAFLWRP4wdENeJAnILMdUXY=";
+  };
+
+  preBuild = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  nativeBuildInputs = with python3.pkgs; [
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    asttokens
+    colorama
+    django
+    dnspython
+    esprima
+    func-timeout
+    github3-py
+    gitpython
+    networkx
+    protobuf
+    pyisemail
+    python-dateutil
+    python-gitlab
+    python-magic
+    pytz
+    pyyaml
+    rarfile
+    requests
+    six
+    tldextract
+  ];
+
+  pythonImportsCheck = [
+    "packj"
+  ];
+
+  meta = with lib; {
+    description = "Tool to detect malicious/vulnerable open-source dependencies";
+    homepage = "https://github.com/ossillate-inc/packj";
+    changelog = "https://github.com/ossillate-inc/packj/releases/tag/v${version}";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ fab ];
+    mainProgram = "packj";
+  };
+}

--- a/pkgs/development/python-modules/pyisemail/default.nix
+++ b/pkgs/development/python-modules/pyisemail/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, buildPythonPackage
+, dnspython
+, fetchFromGitHub
+, hatchling
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pyisemail";
+  version = "2.0.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "michaelherold";
+    repo = "pyIsEmail";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-bJCaVUhvEAoQ8zMsbcb1Et728XHt+shEPhhBzPzY/vo=";
+  };
+
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    dnspython
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "pyisemail"
+  ];
+
+  meta = with lib; {
+    description = "Module for email validation";
+    homepage = "https://github.com/michaelherold/pyIsEmail";
+    changelog = "https://github.com/michaelherold/pyIsEmail/blob/${version}/CHANGELOG.rst";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9435,6 +9435,8 @@ self: super: with self; {
 
   pyinstaller-versionfile = callPackage ../development/python-modules/pyinstaller-versionfile { };
 
+  pyisemail = callPackage ../development/python-modules/pyisemail { };
+
   pyisy = callPackage ../development/python-modules/pyisy { };
 
   pyixapi = callPackage ../development/python-modules/pyixapi { };


### PR DESCRIPTION
## Description of changes
Tool to detect malicious/vulnerable open-source dependencies

https://github.com/ossillate-inc/packj

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
