### PR TITLE
pixi: init at 0.11.1

### DIFF
--- a/pkgs/by-name/pi/pixi/package.nix
+++ b/pkgs/by-name/pi/pixi/package.nix
@@ -1,0 +1,69 @@
+{ lib
+, stdenv
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, openssl
+, installShellFiles
+, darwin
+, testers
+, pixi
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "pixi";
+  version = "0.11.1";
+
+  src = fetchFromGitHub {
+    owner = "prefix-dev";
+    repo = "pixi";
+    rev = "v${version}";
+    hash = "sha256-NOa8OvZs+BoJQ9qIU1lpMmEOecZpmwwCNYpDk1LUSTI=";
+  };
+
+  cargoHash = "sha256-rDtr9ITYH5o/QPG1Iozh05iTA8c0i+3DnabXLzyqdrg=";
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+  ];
+
+  buildInputs = [
+    openssl
+  ]
+  ++ lib.optionals stdenv.isDarwin (
+    with darwin.apple_sdk_11_0.frameworks; [ CoreFoundation IOKit SystemConfiguration Security ]
+  );
+
+
+  checkFlags = [
+    # Skip tests requiring network
+    "--skip=add_channel"
+    "--skip=add_functionality"
+    "--skip=add_functionality_os"
+    "--skip=add_functionality_union"
+    "--skip=add_pypi_functionality"
+    "--skip=test_alias"
+    "--skip=test_cwd"
+    "--skip=test_incremental_lock_file"
+  ];
+
+  postInstall = ''
+    installShellCompletion --cmd pix \
+      --bash <($out/bin/pixi completion --shell bash) \
+      --fish <($out/bin/pixi completion --shell fish) \
+      --zsh <($out/bin/pixi completion --shell zsh)
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = pixi;
+  };
+
+  meta = with lib; {
+    description = "Package management made easy";
+    homepage = "https://pixi.sh/";
+    license = licenses.bsd3;
+    maintainers = with lib.maintainers; [ aaronjheng ];
+    mainProgram = "pixi";
+  };
+}


### PR DESCRIPTION
## Description of changes

Closes #249662
Closes #249998

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
