### PR TITLE
xed-editor: Fix typelib path

### DIFF
--- a/pkgs/applications/editors/xed-editor/correct-gir-lib-path.patch
+++ b/pkgs/applications/editors/xed-editor/correct-gir-lib-path.patch
@@ -1,0 +1,13 @@
+diff --git a/xed/meson.build b/xed/meson.build
+index 7525bad..ae0814e 100644
+--- a/xed/meson.build
++++ b/xed/meson.build
+@@ -143,7 +143,7 @@ libxed = library(
+     dependencies: xed_deps,
+     include_directories: include_dirs,
+     install: true,
+-    install_dir: join_paths(libdir, 'xed')
++    install_dir: join_paths(prefix, libdir, 'xed')
+ )
+ 
+ install_headers(

--- a/pkgs/applications/editors/xed-editor/default.nix
+++ b/pkgs/applications/editors/xed-editor/default.nix
@@ -28,6 +28,12 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-MXRxzmRo/dRhp5Llib9ng1gzWW8uvzqTMjUVK8a3eJ8=";
   };
 
+  patches = [
+    # We patch gobject-introspection and meson to store absolute paths to libraries in typelibs
+    # but that requires the install_dir is an absolute path.
+    ./correct-gir-lib-path.patch
+  ];
+
   nativeBuildInputs = [
     meson
     pkg-config


### PR DESCRIPTION
We patch gobject-introspection and meson to store absolute paths to libraries in typelibs but that requires the install_dir is an absolute path.

ref: https://github.com/NixOS/nixpkgs/commit/1b2a061c87fd079f57a05c5390a42dcc777498f0

*(Fixes for plugins also requires 4422e611fe76cd1d692e3d9122b7249924ae713f)*

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
