### PR TITLE
plymouth: 23.360.11 -> 24.004.60

### DIFF
--- a/pkgs/os-specific/linux/plymouth/default.nix
+++ b/pkgs/os-specific/linux/plymouth/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchFromGitLab
 , writeText
+, substituteAll
 , meson
 , pkg-config
 , ninja
@@ -16,11 +17,12 @@
 , pango
 , systemd
 , xorg
+, fontconfig
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "plymouth";
-  version = "23.360.11";
+  version = "24.004.60";
 
   outputs = [ "out" "dev" ];
 
@@ -29,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "plymouth";
     repo = "plymouth";
     rev = finalAttrs.version;
-    hash = "sha256-Uun4KtrbkFCiGq3WpZlZ8NKKCOnM+jcgYa8qoqAYdaw=";
+    hash = "sha256-9JmZCm8bjteJTQrMSJeL4x2CAI6RpKowFUDSCcMS4MM=";
   };
 
   patches = [
@@ -37,6 +39,11 @@ stdenv.mkDerivation (finalAttrs: {
     ./dont-create-broken-symlink.patch
     # add support for loading plugins from /run to assist NixOS module
     ./add-runtime-plugin-path.patch
+    # fix FHS hardcoded paths
+    (substituteAll {
+      src = ./fix-paths.patch;
+      fcmatch = "${fontconfig}/bin/fc-match";
+    })
   ];
 
   strictDeps = true;

--- a/pkgs/os-specific/linux/plymouth/fix-paths.patch
+++ b/pkgs/os-specific/linux/plymouth/fix-paths.patch
@@ -1,0 +1,21 @@
+diff --git a/src/plugins/controls/label-freetype/plugin.c b/src/plugins/controls/label-freetype/plugin.c
+index 917b04c0..83f2bec2 100644
+--- a/src/plugins/controls/label-freetype/plugin.c
++++ b/src/plugins/controls/label-freetype/plugin.c
+@@ -127,7 +127,7 @@ find_default_font_path (void)
+         FILE *fp;
+         static char fc_match_out[PATH_MAX];
+
+-        fp = popen ("/usr/bin/fc-match -f %{file}", "r");
++        fp = popen ("@fcmatch@ -f %{file}", "r");
+         if (!fp)
+                 return FONT_FALLBACK;
+
+@@ -144,7 +144,7 @@ find_default_monospace_font_path (void)
+         FILE *fp;
+         static char fc_match_out[PATH_MAX];
+
+-        fp = popen ("/usr/bin/fc-match -f %{file} monospace", "r");
++        fp = popen ("@fcmatch@ -f %{file} monospace", "r");
+         if (!fp)
+                 return MONOSPACE_FONT_FALLBACK;


### PR DESCRIPTION
## Description of changes

Closes: https://github.com/NixOS/nixpkgs/issues/280910
Changelog: https://gitlab.freedesktop.org/plymouth/plymouth/-/releases/24.004.60
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
