### PR TITLE
python3Packages.colour-science: init at 0.4.6

### DIFF
--- a/pkgs/development/python-modules/colour-science/default.nix
+++ b/pkgs/development/python-modules/colour-science/default.nix
@@ -1,0 +1,108 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  pythonOlder,
+  opencolorio,
+  hatchling,
+  imageio,
+  numpy,
+  scipy,
+  typing-extensions,
+  pytestCheckHook,
+  pytest-xdist,
+  trimesh,
+  pydot,
+  matplotlib,
+  networkx,
+  pandas,
+  tqdm,
+  xxhash,
+}:
+buildPythonPackage rec {
+  pname = "colour-science";
+  version = "0.4.6";
+  pyproject = true;
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "colour-science";
+    repo = "colour";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-kjJc6D4jhvAJh6rIVvKO2bw++K3XlfjD4Djav6778lk=";
+  };
+
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    imageio
+    numpy
+    scipy
+    typing-extensions
+  ];
+
+  passthru.optional-dependencies = {
+    optional = [
+      matplotlib
+      networkx
+      opencolorio
+      pandas
+      pydot
+      tqdm
+      xxhash
+    ];
+    # docs = [
+    #   # biblib-simple # not available in nixpkgs
+    #   pydata-sphinx-theme
+    #   restructuredtext-lint
+    #   sphinx
+    #   sphinxcontrib-bibtex
+    # ];
+    meshing = [
+      trimesh
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-xdist
+  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
+
+  disabledTests = [
+    # slow tests, supposing math is correct and tested upstream
+    "test_fairchild1990"
+    "test_jakob2019"
+    "test_kang2002"
+    "test_macadam_limits"
+    "test_mallett2019"
+    "test_meng2015"
+    "test_munsell"
+    "test_ohno2013"
+    "test_osa_ucs"
+    "test_otsu2018"
+    "test_pointer_gamut"
+    "test_rayleigh"
+    "test_rgb"
+    "test_robertson1968"
+    # not working, problems reading/writing exr files
+    "test_write_image_Imageio"
+    "test_read_image_Imageio"
+    "test_read_image"
+    "test_write_image"
+    # not working, uses numpy>2 stuff
+    "test_machado2009"
+    "test_photometry"
+  ];
+
+  pythonImportsCheck = [ "colour" ];
+
+  meta = {
+    description = "Algorithms and datasets for colour science";
+    homepage = "https://github.com/colour-science/colour";
+    changelog = "https://github.com/colour-science/colour/releases/tag/v${version}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ laurent-f1z1 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2490,6 +2490,8 @@ self: super: with self; {
 
   colour = callPackage ../development/python-modules/colour { };
 
+  colour-science = callPackage ../development/python-modules/colour-science { };
+
   colout = callPackage ../development/python-modules/colout { };
 
   cometblue-lite = callPackage ../development/python-modules/cometblue-lite { };


### PR DESCRIPTION
## Description of changes

Hey!

This PR adds the `colour` package by colour-science (https://github.com/colour-science/colour). Since the package's name conflicts with an existing package named `colour` by vaab (https://github.com/vaab/colour already in nixpkgs), I named this new package `colour-science`.

I disabled some tests, some of them are very (very) slow, and 4 others are not passing (they fail to read/write an EXR file, I couldn't find a fix).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
