### PR TITLE
lib.types: Include the suboptions of both types for either

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -906,8 +906,14 @@ rec {
            then functor.type mt1 mt2
            else null;
       functor = (defaultFunctor name) // { wrapped = [ t1 t2 ]; };
+      getSubOptions = prefix: (t1.getSubOptions prefix) // (t2.getSubOptions prefix);
       nestedTypes.left = t1;
       nestedTypes.right = t2;
+    };
+
+    # Handle recursive leaf types, avoiding an infinite recursion
+    eitherRecursive = t1: t2: (either t1 t2) // {
+      getSubOptions = _: {};
     };
 
     # Any of the types in the given list
@@ -916,6 +922,13 @@ rec {
         head' = if ts == [] then throw "types.oneOf needs to get at least one type in its argument" else head ts;
         tail' = tail ts;
       in foldl' either head' tail';
+
+    # Handle recursive leaf types, avoiding an infinite recursion
+    oneOfRecursive = ts:
+      let
+        head' = if ts == [] then throw "types.oneOfRecursive needs to get at least one type in its argument" else head ts;
+        tail' = tail ts;
+      in foldl' eitherRecursive head' tail';
 
     # Either value of type `coercedType` or `finalType`, the former is
     # converted to `finalType` using `coerceFunc`.

--- a/nixos/modules/programs/dconf.nix
+++ b/nixos/modules/programs/dconf.nix
@@ -99,7 +99,7 @@ let
         type = attrs;
         default = { };
         description = lib.mdDoc "An attrset used to generate dconf keyfile.";
-        example = literalExpression ''
+        example = lib.literalExpression ''
           with lib.gvariant;
           {
             "com/raggesilver/BlackBox" = {
@@ -116,7 +116,7 @@ let
           A list of dconf keys to be lockdown. This doesn't take effect if `lockAll`
           is set.
         '';
-        example = literalExpression ''
+        example = lib.literalExpression ''
           [ "/org/gnome/desktop/background/picture-uri" ]
         '';
       };

--- a/nixos/modules/services/backup/btrbk.nix
+++ b/nixos/modules/services/backup/btrbk.nix
@@ -147,7 +147,7 @@ in
                 };
                 settings = mkOption {
                   type = types.submodule {
-                    freeformType = let t = types.attrsOf (types.either types.str (t // { description = "instances of this type recursively"; })); in t;
+                    freeformType = let t = types.attrsOf (types.eitherRecursive types.str (t // { description = "instances of this type recursively"; })); in t;
                     options = {
                       stream_compress = mkOption {
                         description = lib.mdDoc ''

--- a/nixos/modules/services/games/freeciv.nix
+++ b/nixos/modules/services/games/freeciv.nix
@@ -6,7 +6,7 @@ let
   rootDir = "/run/freeciv";
   argsFormat = {
     type = with lib.types; let
-      valueType = nullOr (oneOf [
+      valueType = nullOr (oneOfRecursive [
         bool int float str
         (listOf valueType)
       ]) // {

--- a/nixos/modules/services/mail/davmail.nix
+++ b/nixos/modules/services/mail/davmail.nix
@@ -7,7 +7,7 @@ let
   cfg = config.services.davmail;
 
   configType = with types;
-    oneOf [ (attrsOf configType) str int bool ] // {
+    oneOfRecursive [ (attrsOf configType) str int bool ] // {
       description = "davmail config type (str, int, bool or attribute set thereof)";
     };
 

--- a/nixos/modules/services/mail/rspamd.nix
+++ b/nixos/modules/services/mail/rspamd.nix
@@ -221,6 +221,8 @@ let
 in
 
 {
+  meta.buildDocsInSandbox = false;
+
   ###### interface
 
   options = {

--- a/nixos/modules/services/network-filesystems/moosefs.nix
+++ b/nixos/modules/services/network-filesystems/moosefs.nix
@@ -17,7 +17,7 @@ let
 
     in {
       type = with types; let
-        valueType = oneOf ([
+        valueType = oneOfRecursive ([
           (listOf valueType)
         ] ++ allowedTypes) // {
           description = "Flat key-value file";

--- a/nixos/modules/services/networking/ncdns.nix
+++ b/nixos/modules/services/networking/ncdns.nix
@@ -12,7 +12,7 @@ let
   valueType = with types; oneOf [ int str bool path ]
     // { description = "setting type (integer, string, bool or path)"; };
 
-  configType = with types; attrsOf (nullOr (either valueType configType))
+  configType = with types; attrsOf (nullOr (eitherRecursive valueType configType))
     // { description = ''
           ncdns.conf configuration type. The format consists of an
           attribute set of settings. Each setting can be either `null`,

--- a/nixos/modules/services/networking/searx.nix
+++ b/nixos/modules/services/networking/searx.nix
@@ -27,7 +27,7 @@ let
     done
   '';
 
-  settingType = with types; (oneOf
+  settingType = with types; (oneOfRecursive
     [ bool int float str
       (listOf settingType)
       (attrsOf settingType)

--- a/nixos/modules/services/networking/znc/default.nix
+++ b/nixos/modules/services/networking/znc/default.nix
@@ -64,7 +64,7 @@ let
   semanticTypes = with types; rec {
     zncAtom = nullOr (oneOf [ int bool str ]);
     zncAttr = attrsOf (nullOr zncConf);
-    zncAll = oneOf [ zncAtom (listOf zncAtom) zncAttr ];
+    zncAll = oneOfRecursive [ zncAtom (listOf zncAtom) zncAttr ];
     zncConf = attrsOf (zncAll // {
       # Since this is a recursive type and the description by default contains
       # the description of its subtypes, infinite recursion would occur without

--- a/nixos/modules/services/web-apps/akkoma.nix
+++ b/nixos/modules/services/web-apps/akkoma.nix
@@ -41,7 +41,7 @@ let
 
   elixirValue = let
     elixirValue' = with types;
-      nullOr (oneOf [ bool int float str (attrsOf elixirValue') (listOf elixirValue') ]) // {
+      nullOr (oneOfRecursive [ bool int float str (attrsOf elixirValue') (listOf elixirValue') ]) // {
         description = "Elixir value";
       };
   in elixirValue';

--- a/nixos/modules/services/web-apps/limesurvey.nix
+++ b/nixos/modules/services/web-apps/limesurvey.nix
@@ -14,7 +14,7 @@ let
 
   pkg = pkgs.limesurvey;
 
-  configType = with types; oneOf [ (attrsOf configType) str int bool ] // {
+  configType = with types; oneOfRecursive [ (attrsOf configType) str int bool ] // {
     description = "limesurvey config type (str, int, bool or attribute set thereof)";
   };
 

--- a/nixos/modules/services/web-servers/traefik.nix
+++ b/nixos/modules/services/web-servers/traefik.nix
@@ -6,7 +6,7 @@ let
   cfg = config.services.traefik;
   jsonValue = with types;
     let
-      valueType = nullOr (oneOf [
+      valueType = nullOr (oneOfRecursive [
         bool
         int
         float

--- a/nixos/modules/services/web-servers/trafficserver/default.nix
+++ b/nixos/modules/services/web-servers/trafficserver/default.nix
@@ -141,7 +141,7 @@ in
 
     records = mkOption {
       type = with types;
-        let valueType = (attrsOf (oneOf [ int float str valueType ])) // {
+        let valueType = (attrsOf (oneOfRecursive [ int float str valueType ])) // {
           description = "Traffic Server records value";
         };
         in

--- a/nixos/modules/services/web-servers/uwsgi.nix
+++ b/nixos/modules/services/web-servers/uwsgi.nix
@@ -91,7 +91,7 @@ in {
 
       instance = mkOption {
         type =  with types; let
-          valueType = nullOr (oneOf [
+          valueType = nullOr (oneOfRecursive [
             bool
             int
             float

--- a/nixos/modules/services/x11/picom.nix
+++ b/nixos/modules/services/x11/picom.nix
@@ -233,7 +233,7 @@ in {
       scalar = oneOf [ bool int float str ]
         // { description = "scalar types"; };
 
-      libConfig = oneOf [ scalar (listOf libConfig) (attrsOf libConfig) ]
+      libConfig = oneOfRecursive [ scalar (listOf libConfig) (attrsOf libConfig) ]
         // { description = "libconfig type"; };
 
       topLevel = attrsOf libConfig

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -44,7 +44,7 @@ rec {
   json = {}: {
 
     type = with lib.types; let
-      valueType = nullOr (oneOf [
+      valueType = nullOr (oneOfRecursive [
         bool
         int
         float
@@ -78,7 +78,7 @@ rec {
     '') {};
 
     type = with lib.types; let
-      valueType = nullOr (oneOf [
+      valueType = nullOr (oneOfRecursive [
         bool
         int
         float
@@ -218,7 +218,7 @@ rec {
 
   toml = {}: json {} // {
     type = with lib.types; let
-      valueType = oneOf [
+      valueType = oneOfRecursive [
         bool
         int
         float
@@ -333,7 +333,7 @@ rec {
     {
       type = with lib.types; let
         valueType = nullOr
-          (oneOf [
+          (oneOfRecursive [
             bool
             int
             float
@@ -442,7 +442,7 @@ rec {
   # Useful for many Django-based services
   pythonVars = {}: {
     type = with lib.types; let
-      valueType = nullOr(oneOf [
+      valueType = nullOr(oneOfRecursive [
         bool
         float
         int

--- a/pkgs/pkgs-lib/formats/libconfig/default.nix
+++ b/pkgs/pkgs-lib/formats/libconfig/default.nix
@@ -37,7 +37,7 @@ in
 
     type = with lib.types;
       let
-        valueType = (oneOf [
+        valueType = (oneOfRecursive [
           bool
           int
           float


### PR DESCRIPTION
## Description of changes

With this change types that are wrapped in `either` or `oneOf` will still display their suboptions in the documentation. This is import for types of the form `either a (submodule  ....))`.

Here are some options that were previously hidden, and are now visible:
```
services.tor.client.socksListenAddress.<xxx>
services.tor.relay.onionServices.<name>.map.*
services.tor.settings.ControlPort.*
services.tor.settings.DNSPort.*
services.tor.settings.ExtORPort.xxx
services.tor.settings.HTTPTunnelPort.*
services.tor.settings.NATDPort.*
....
```

Note that making `either` and `oneOf` handle suboptions means that they don't work with recursive types anymore. As such the types `eitherRecursive` and `oneOfRecursive` are added, that don't list suboptions, those types should not be used with submodules in order to correctly render their documentation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
