### PR TITLE
python311Packages.agate: 1.7.1 -> 1.9.1

### DIFF
--- a/pkgs/development/python-modules/agate/default.nix
+++ b/pkgs/development/python-modules/agate/default.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "agate";
-  version = "1.7.1";
+  version = "1.9.1";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "wireservice";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-7Ew9bgeheymCL8xXSW5li0LdFvGYb/7gPxmC4w6tHvM=";
+    hash = "sha256-I7jvZA/m06kUuUcfglySaroDbJ5wbgiF2lb84EFPmpw=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
This also fixes a test failure resulting in build failure https://hydra.nixos.org/build/246567659.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>12 packages marked as broken and skipped:</summary>
  <ul>
    <li>dbt</li>
    <li>dbt.dist</li>
    <li>python311Packages.dbt-bigquery</li>
    <li>python311Packages.dbt-bigquery.dist</li>
    <li>python311Packages.dbt-core</li>
    <li>python311Packages.dbt-core.dist</li>
    <li>python311Packages.dbt-postgres</li>
    <li>python311Packages.dbt-postgres.dist</li>
    <li>python311Packages.dbt-redshift</li>
    <li>python311Packages.dbt-redshift.dist</li>
    <li>python311Packages.dbt-snowflake</li>
    <li>python311Packages.dbt-snowflake.dist</li>
  </ul>
</details>
<details>
  <summary>10 packages built:</summary>
  <ul>
    <li>csvkit</li>
    <li>csvkit.dist</li>
    <li>python311Packages.agate</li>
    <li>python311Packages.agate-dbf</li>
    <li>python311Packages.agate-dbf.dist</li>
    <li>python311Packages.agate-excel</li>
    <li>python311Packages.agate-excel.dist</li>
    <li>python311Packages.agate-sql</li>
    <li>python311Packages.agate-sql.dist</li>
    <li>python311Packages.agate.dist</li>
  </ul>
</details>

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
