### PR TITLE
python312Packages.{strct,birch}: unbreak with upstreamed patch, properly set version

### DIFF
--- a/pkgs/development/python-modules/birch/default.nix
+++ b/pkgs/development/python-modules/birch/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , setuptools
 , strct
 , pytestCheckHook
@@ -19,11 +20,24 @@ buildPythonPackage rec {
     hash = "sha256-KdQZzQJvJ+logpcLQfaqqEEZJ/9VmNTQX/a4v0oBC98=";
   };
 
+  patches = [
+    # https://github.com/shaypal5/birch/pull/4
+    (fetchpatch {
+      name = "fix-versioneer-on-python312.patch";
+      url = "https://github.com/shaypal5/birch/commit/84d597b2251ebb76fb15fb70fc86c83baa19dc0b.patch";
+      hash = "sha256-xXADCSIhq1ARny2twzrhR1J8LkMFWFl6tmGxrM8RvkU=";
+    })
+  ];
+
   postPatch = ''
     substituteInPlace pytest.ini \
       --replace  \
         "--cov" \
         "#--cov"
+
+    # configure correct version, which fails due to missing .git
+    substituteInPlace versioneer.py birch/_version.py \
+      --replace '"0+unknown"' '"${version}"'
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/strct/default.nix
+++ b/pkgs/development/python-modules/strct/default.nix
@@ -1,5 +1,6 @@
 { lib
 , fetchFromGitHub
+, fetchpatch
 , buildPythonPackage
 , setuptools
 , pytestCheckHook
@@ -18,11 +19,24 @@ buildPythonPackage rec {
     hash = "sha256-ctafvdfSOdp7tlCUYg7d5XTXR1qBcWvOVtGtNUnhYIw=";
   };
 
+  patches = [
+    # https://github.com/shaypal5/strct/pull/4
+    (fetchpatch {
+      name = "fix-versioneer-on-python312.patch";
+      url = "https://github.com/shaypal5/strct/commit/a1e5b6ca9045b52efdfdbb3c82e12a01e251d41b.patch";
+      hash = "sha256-xXADCSIhq1ARny2twzrhR1J8LkMFWFl6tmGxrM8RvkU=";
+    })
+  ];
+
   postPatch = ''
     substituteInPlace pytest.ini \
       --replace  \
         "--cov" \
         "#--cov"
+
+    # configure correct version, which fails due to missing .git
+    substituteInPlace versioneer.py strct/_version.py \
+      --replace '"0+unknown"' '"${version}"'
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

Fix builds for python3.12, and properly set versions now that dependency versions are properly checked again.

This should fix:

* https://hydra.nixos.org/build/246262534
* https://hydra.nixos.org/build/246207056
* https://hydra.nixos.org/build/246280621
* https://hydra.nixos.org/build/246270456
* https://hydra.nixos.org/build/246279677

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
