### PR TITLE
nixos/mail/dovecot2: re-introduce extra settings and rename `sieveScripts`

### DIFF
--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -138,33 +138,7 @@ let
     # the control flow.
     ''
       plugin {
-        ${concatStringsSep "\n" (mapAttrsToList (to: from: "sieve_${to} = ${stateDir}/sieve/${to}") cfg.sieve.scripts)}
-        sieve_plugins = ${concatStringsSep " " cfg.sieve.plugins}
-        sieve_extensions = ${concatStringsSep " " (map (el: "+${el}") cfg.sieve.extensions)}
-        sieve_global_extensions = ${concatStringsSep " " (map (el: "+${el}") cfg.sieve.globalExtensions)}
-        ${concatStringsSep "\n" (mapAttrsToList (key: value: "${key} = ${value}") cfg.sieve.extraPluginSettings)}
-    ''
-    (optionalString (cfg.imapsieve.mailbox != []) ''
-      ${
-        concatStringsSep "\n" (flatten (imap1 (
-            idx: el:
-              singleton "imapsieve_mailbox${toString idx}_name = ${el.name}"
-              ++ optional (el.from != null) "imapsieve_mailbox${toString idx}_from = ${el.from}"
-              ++ optional (el.causes != null) "imapsieve_mailbox${toString idx}_causes = ${el.causes}"
-              ++ optional (el.before != null) "imapsieve_mailbox${toString idx}_before = file:${stateDir}/imapsieve/before/${baseNameOf el.before}"
-              ++ optional (el.after != null) "imapsieve_mailbox${toString idx}_after = file:${stateDir}/imapsieve/after/${baseNameOf el.after}"
-          )
-          cfg.imapsieve.mailbox))
-      }
-    '')
-    (optionalString (cfg.sieve.pipeBins != []) ''
-        sieve_pipe_bin_dir = ${pkgs.linkFarm "sieve-pipe-bins" (map (el: {
-          name = builtins.unsafeDiscardStringContext (baseNameOf el);
-          path = el;
-        })
-        cfg.sieve.pipeBins)}
-    '')
-    ''
+        ${concatStringsSep "\n" (mapAttrsToList (key: value: "  ${key} = ${value}") cfg.pluginSettings)}
       }
     ''
 
@@ -442,14 +416,14 @@ in
           };
 
           causes = mkOption {
-            default = null;
+            default = [ ];
             description = ''
               Only execute the administrator Sieve scripts for the mailbox configured with services.dovecot2.imapsieve.mailbox.<name>.name when one of the listed IMAPSIEVE causes apply.
 
               This has no effect on the user script, which is always executed no matter the cause.
             '';
-            example = "COPY";
-            type = types.nullOr (types.enum [ "APPEND" "COPY" "FLAG" ]);
+            example = [ "COPY" "APPEND" ];
+            type = types.listOf (types.enum [ "APPEND" "COPY" "FLAG" ]);
           };
 
           before = mkOption {


### PR DESCRIPTION
## Description of changes

https://github.com/NixOS/nixpkgs/pull/275031 introduced structured configuration for the dovecot2 sieve plugin, by doing so, it broke SNM configuration doing Sieve configurations.

I also made `imapsieve.mailbox.*.causes` a list instead of an element.

I introduced a warning mechanism to give help to users who may have used `extraConfig` and will have it explode on them.

This attempts to fix up the public API to make it possible for SNM to pick up the pieces.

Here's patch for SNM, GitLab is too broken for me to open a PR over there:
```patch
From a15c4eef88d126ea9d02efbfbfdfd0fcbf9a9976 Mon Sep 17 00:00:00 2001
From: Raito Bezarius <masterancpp@gmail.com>
Date: Sun, 14 Jan 2024 20:55:20 +0100
Subject: [PATCH] dovecot: support new `sieve` API in nixpkgs

Since https://github.com/NixOS/nixpkgs/pull/275031 things have became more structured
when it comes to the sieve plugin.

Relies on https://github.com/NixOS/nixpkgs/pull/281001 for full
features.
---
 mail-server/dovecot.nix | 50 +++++++++++++++++++++--------------------
 1 file changed, 26 insertions(+), 24 deletions(-)

diff --git a/mail-server/dovecot.nix b/mail-server/dovecot.nix
index 7d73ee2..3e5f9fb 100644
--- a/mail-server/dovecot.nix
+++ b/mail-server/dovecot.nix
@@ -175,8 +175,14 @@ in
       mailPlugins.globally.enable = lib.optionals cfg.fullTextSearch.enable [ "fts" "fts_xapian" ];
       protocols = lib.optional cfg.enableManageSieve "sieve";
 
-      sieveScripts = {
-        after = builtins.toFile "spam.sieve" ''
+      pluginSettings = {
+        sieve = "file:${cfg.sieveDirectory}/%u/scripts;active=${cfg.sieveDirectory}/%u/active.sieve";
+        sieve_default = "file:${cfg.sieveDirectory}/%u/default.sieve";
+        sieve_default_name = "default";
+      };
+
+      sieve = {
+        scripts.after = builtins.toFile "spam.sieve" ''
           require "fileinto";
 
           if header :is "X-Spam" "Yes" {
@@ -184,8 +190,26 @@ in
               stop;
           }
         '';
+
+        pipeBins = [
+          pipeBin
+        ];
       };
 
+      imapsieve.mailbox = [
+        {
+          name = junkMailboxName;
+          causes = [ "COPY" "APPEND" ];
+          before = "${stateDir}/imap_sieve/report-spam.sieve";
+        }
+        {
+          name = "*";
+          from = junkMailboxName;
+          causes = [ "COPY" ];
+          before = "${stateDir}/imap_sieve/report-ham.sieve";
+        }
+      ];
+
       mailboxes = cfg.mailboxes;
 
       extraConfig = ''
@@ -307,28 +331,6 @@ in
           inbox = yes
         }
 
-        plugin {
-          sieve_plugins = sieve_imapsieve sieve_extprograms
-          sieve = file:${cfg.sieveDirectory}/%u/scripts;active=${cfg.sieveDirectory}/%u/active.sieve
-          sieve_default = file:${cfg.sieveDirectory}/%u/default.sieve
-          sieve_default_name = default
-
-          # From elsewhere to Spam folder
-          imapsieve_mailbox1_name = ${junkMailboxName}
-          imapsieve_mailbox1_causes = COPY,APPEND
-          imapsieve_mailbox1_before = file:${stateDir}/imap_sieve/report-spam.sieve
-
-          # From Spam folder to elsewhere
-          imapsieve_mailbox2_name = *
-          imapsieve_mailbox2_from = ${junkMailboxName}
-          imapsieve_mailbox2_causes = COPY
-          imapsieve_mailbox2_before = file:${stateDir}/imap_sieve/report-ham.sieve
-
-          sieve_pipe_bin_dir = ${pipeBin}/pipe/bin
-
-          sieve_global_extensions = +vnd.dovecot.pipe +vnd.dovecot.environment
-        }
-
         ${lib.optionalString cfg.fullTextSearch.enable ''
         plugin {
           plugin = fts fts_xapian
-- 
2.43.0
```

I also needed to add `services.dovecot2.sieve.extensions = [ "fileinto" ];`, I'm not sure why.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
