### PR TITLE
python3Packages.pyopengl: fix substituteInPlace

### DIFF
--- a/pkgs/development/python-modules/pyopengl/default.nix
+++ b/pkgs/development/python-modules/pyopengl/default.nix
@@ -23,22 +23,26 @@ buildPythonPackage rec {
     # Theses lines are patching the name of dynamic libraries
     # so pyopengl can find them at runtime.
     substituteInPlace OpenGL/platform/glx.py \
-      --replace "'GL'" "'${pkgs.libGL}/lib/libGL${ext}'" \
-      --replace "'GLU'" "'${pkgs.libGLU}/lib/libGLU${ext}'" \
-      --replace "'glut'" "'${pkgs.freeglut}/lib/libglut${ext}'" \
-      --replace "'GLESv1_CM'," "'${pkgs.libGL}/lib/libGLESv1_CM${ext}'," \
-      --replace "'GLESv2'," "'${pkgs.libGL}/lib/libGLESv2${ext}',"
+      --replace '"OpenGL",' '"${pkgs.libGL}/lib/libOpenGL${ext}",' \
+      --replace '"GL",' '"${pkgs.libGL}/lib/libGL${ext}",' \
+      --replace '"GLU",' '"${pkgs.libGLU}/lib/libGLU${ext}",' \
+      --replace '"GLX",' '"${pkgs.libglvnd}/lib/libGLX${ext}",' \
+      --replace '"glut",' '"${pkgs.freeglut}/lib/libglut${ext}",' \
+      --replace '"GLESv1_CM",' '"${pkgs.libGL}/lib/libGLESv1_CM${ext}",' \
+      --replace '"GLESv2",' '"${pkgs.libGL}/lib/libGLESv2${ext}",' \
+      --replace '"gle",' '"${pkgs.gle}/lib/libgle${ext}",' \
+      --replace "'EGL'" "'${pkgs.libGL}/lib/libEGL${ext}'"
     substituteInPlace OpenGL/platform/egl.py \
       --replace "('OpenGL','GL')" "('${pkgs.libGL}/lib/libOpenGL${ext}', '${pkgs.libGL}/lib/libGL${ext}')" \
       --replace "'GLU'," "'${pkgs.libGLU}/lib/libGLU${ext}'," \
       --replace "'glut'," "'${pkgs.freeglut}/lib/libglut${ext}'," \
       --replace "'GLESv1_CM'," "'${pkgs.libGL}/lib/libGLESv1_CM${ext}'," \
       --replace "'GLESv2'," "'${pkgs.libGL}/lib/libGLESv2${ext}'," \
+      --replace "'gle'," '"${pkgs.gle}/lib/libgle${ext}",' \
       --replace "'EGL'," "'${pkgs.libGL}/lib/libEGL${ext}',"
     substituteInPlace OpenGL/platform/darwin.py \
       --replace "'OpenGL'," "'${pkgs.libGL}/lib/libGL${ext}'," \
       --replace "'GLUT'," "'${pkgs.freeglut}/lib/libglut${ext}',"
-    # TODO: patch 'gle' in OpenGL/platform/egl.py
   '' + ''
     # https://github.com/NixOS/nixpkgs/issues/76822
     # pyopengl introduced a new "robust" way of loading libraries in 3.1.4.
@@ -48,7 +52,7 @@ buildPythonPackage rec {
     # The following patch put back the "name" (i.e. the path) in the
     # list of possible files.
     substituteInPlace OpenGL/platform/ctypesloader.py \
-      --replace "filenames_to_try = []" "filenames_to_try = [name]"
+      --replace "filenames_to_try = [base_name]" "filenames_to_try = [name]"
   '';
 
   # Need to fix test runner
@@ -61,7 +65,7 @@ buildPythonPackage rec {
   pythonImportsCheck = "OpenGL";
 
   meta = with lib; {
-    homepage = "https://pyopengl.sourceforge.net/";
+    homepage = "https://mcfletch.github.io/pyopengl/";
     description = "PyOpenGL, the Python OpenGL bindings";
     longDescription = ''
       PyOpenGL is the cross platform Python binding to OpenGL and


### PR DESCRIPTION
## Description of changes

Pyopengl is broken on `platform/glx`, which is what x86_64-linux seems to default to.
The substitutions were broken in 726628629f7ef3bf9b392e9f89b5a60b22f9836f during `python-updates`.
This would've been caught with #260776. _(please review it xoxo)_

I also took the liberty to fix some of the erroneous and missing patching I found. Now `pkgs.libglvnd` and `pkgs.gle` have become a part of the runtime closure.
For the interested, [here](https://gist.github.com/pbsds/116ba90c8362659188b2d42d7edb46ae) is a diff in `lib/python3.12/site-packages/OpenGL/platform` between v3.1.6 from before 726628629f7ef3bf9b392e9f89b5a60b22f9836f and v3.1.7 with these fixes applied.

Unbreaks https://hydra.nixos.org/build/246287273 and likely many others

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
