### PR TITLE
lune: 0.7.11 -> 0.8.0

### DIFF
--- a/pkgs/development/interpreters/lune/default.nix
+++ b/pkgs/development/interpreters/lune/default.nix
@@ -32,6 +32,11 @@ rustPlatform.buildRustPackage rec {
     SystemConfiguration
   ];
 
+  # error: linker `aarch64-linux-gnu-gcc` not found
+  postPatch = ''
+    rm .cargo/config.toml
+  '';
+
   checkFlags = [
     # require internet access
     "--skip=tests::net_request_codes"

--- a/pkgs/development/interpreters/lune/default.nix
+++ b/pkgs/development/interpreters/lune/default.nix
@@ -6,6 +6,9 @@
 , darwin
 }:
 
+let
+  inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration;
+in
 rustPlatform.buildRustPackage rec {
   pname = "lune";
   version = "0.8.0";
@@ -25,7 +28,8 @@ rustPlatform.buildRustPackage rec {
   ];
 
   buildInputs = lib.optionals stdenv.isDarwin [
-    darwin.apple_sdk.frameworks.Security
+    Security
+    SystemConfiguration
   ];
 
   checkFlags = [

--- a/pkgs/development/interpreters/lune/default.nix
+++ b/pkgs/development/interpreters/lune/default.nix
@@ -33,7 +33,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   checkFlags = [
-    # these all require internet access
+    # require internet access
     "--skip=tests::net_request_codes"
     "--skip=tests::net_request_compression"
     "--skip=tests::net_request_methods"
@@ -44,7 +44,7 @@ rustPlatform.buildRustPackage rec {
     "--skip=tests::roblox_instance_custom_async"
     "--skip=tests::serde_json_decode"
 
-    # this tries to use the root directory as the CWD
+    # uses root as the CWD
     "--skip=tests::process_spawn_cwd"
   ];
 

--- a/pkgs/development/interpreters/lune/default.nix
+++ b/pkgs/development/interpreters/lune/default.nix
@@ -59,5 +59,7 @@ rustPlatform.buildRustPackage rec {
     changelog = "https://github.com/lune-org/lune/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mpl20;
     maintainers = with maintainers; [ lammermann ];
+    # note: Undefined symbols for architecture x86_64
+    broken = stdenv.isDarwin;
   };
 }

--- a/pkgs/development/interpreters/lune/default.nix
+++ b/pkgs/development/interpreters/lune/default.nix
@@ -8,17 +8,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "lune";
-  version = "0.7.11";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "filiptibell";
     repo = "lune";
     rev = "v${version}";
-    hash = "sha256-5agoAXeO16/CihsgvUHt+pgA+/ph6PualTY6xqDQbeU=";
+    hash = "sha256-ZVETw+GdkrR2V8RrHAWBR+avAuN0158DlJkYBquju8E=";
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-kPBPxlsicoFDyOsuJWhvQHDC2uwYQqpd7S+kQPRd8DY=";
+  cargoHash = "sha256-zOjDT8Sn/p3YaG+dWyYxSWUOo11p9/WG3EyNagZRtQQ=";
 
   nativeBuildInputs = [
     pkg-config
@@ -46,8 +46,8 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     description = "A standalone Luau script runtime";
-    homepage = "https://github.com/filiptibell/lune";
-    changelog = "https://github.com/filiptibell/lune/blob/${src.rev}/CHANGELOG.md";
+    homepage = "https://github.com/lune-org/lune";
+    changelog = "https://github.com/lune-org/lune/blob/${src.rev}/CHANGELOG.md";
     license = licenses.mpl20;
     maintainers = with maintainers; [ lammermann ];
   };


### PR DESCRIPTION
## Description of changes

[Changelog](https://github.com/lune-org/lune/releases/tag/v0.8.0)

I updated the package links to match the new organization that owns the repository.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
