### PR TITLE
jasp-desktop: 0.18.2 -> 0.18.3

### DIFF
--- a/pkgs/by-name/ja/jasp-desktop/package.nix
+++ b/pkgs/by-name/ja/jasp-desktop/package.nix
@@ -17,13 +17,13 @@
 }:
 
 let
-  version = "0.18.2";
+  version = "0.18.3";
 
   src = fetchFromGitHub {
     owner = "jasp-stats";
     repo = "jasp-desktop";
     rev = "v${version}";
-    hash = "sha256-W0wYvk5T9srE1cOyGgahfGxEookdOgVcnzqH9SkFyo8=";
+    hash = "sha256-eKBxCIamNhUig+0vUEqXYbPjiaOsZk6QnOw8cnpjKFY=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/r-modules/cran-packages.nix
+++ b/pkgs/development/r-modules/cran-packages.nix
@@ -7209,7 +7209,7 @@ in with self; {
   bssn = derive2 { name="bssn"; version="1.0"; sha256="1brxbvcvqy8n9xpvp5kz47x5ps8hdqgnh6s49051qaylp95qm432"; depends=[ClusterR mvtnorm sn ssmn]; };
   bst = derive2 { name="bst"; version="0.3-24"; sha256="1x297sv9px7ipd7a6xprlff8rgkdr2z379xsm8rfqd8xal9nxnb4"; depends=[doParallel foreach gbm rpart]; };
   bstrl = derive2 { name="bstrl"; version="1.0.2"; sha256="10ncaicda2rwwrl2ykbrdhh51fziy3ahwp8z859cr2k4v19lviv0"; depends=[BRL doParallel extraDistr foreach]; };
-  bsts = derive2 { name="bsts"; version="0.9.9"; sha256="0zaic91yw214bq3285kw7wj8h1jf4g1z9lahgpmikvlqhgy5744g"; depends=[Boom BoomSpikeSlab xts zoo]; };
+  bsts = derive2 { name="bsts"; version="0.9.10"; sha256="1cbiha8pgb2xmpwqbgb16d1dpjj9x41wx3dzly1xxy2fs04bq0m3"; depends=[Boom BoomSpikeSlab xts zoo]; };
   bsub = derive2 { name="bsub"; version="1.1.0"; sha256="112hlvg15jlzg3drfzkslaly42vnvsycn9vif0w3iaw5fzsaa954"; depends=[clisymbols crayon digest GetoptLong GlobalOptions]; };
   bsvars = derive2 { name="bsvars"; version="2.1.0"; sha256="1gnjl27ik6p8zsis8fdqhwdzp2jp0kyqnidil4jgy02fiwdww6c5"; depends=[GIGrvg R6 Rcpp RcppArmadillo RcppProgress RcppTN stochvol]; };
   btb = derive2 { name="btb"; version="0.2.0"; sha256="1gm03md6ky134nzmnnp054mi2w8kl4bgcgg4k65zf2cyniz4arxq"; depends=[BH dplyr magrittr mapsf Rcpp RcppArmadillo RcppParallel sf]; };


### PR DESCRIPTION
## Description of changes

~~This PR fixes the build of the `rPackages.xml2` package.~~

This PR updates `jasp-desktop`.

As always, it's gonna take a long time to build these, as `jasp-desktop` hasn't once been successfully built on hydra, because `rPackages.xml2` was failing.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
