### PR TITLE
pkgsMusl.systemd: fix build

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -208,6 +208,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./0017-core-don-t-taint-on-unmerged-usr.patch
     ./0018-tpm2_context_init-fix-driver-name-checking.patch
     ./0019-systemctl-edit-suggest-systemdctl-edit-runtime-on-sy.patch
+  ] ++ lib.optional (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isGnu) [
     ./0020-timesyncd-disable-NSCD-when-DNSSEC-validation-is-dis.patch
   ] ++ lib.optional stdenv.hostPlatform.isMusl (
     let


### PR DESCRIPTION
Because of mass notification, PR continues at: https://github.com/NixOS/nixpkgs/pull/281323
---

PR #239201 broke systemd for musl.

I lack context of patch and I can't reason on code changes. I don't know the correct fix.
So, I **NAIVELY** suggest the simplest workaround:
By disabling the patch, `pkgsMusl.systemd` gets to build again.

PR targets staging because of a build dependency on https://github.com/NixOS/nixpkgs/pull/278994 [not available
in master yet]. Tracking: https://nixpk.gs/pr-tracker.html?pr=278994

Fixes: https://github.com/NixOS/nixpkgs/issues/280738

@flokli @Kloenk @yu-re-ka @risicle @eclairevoyant @nesteroff @flokli @arianvp 