### PR TITLE
dnsjit: init at 1.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -938,6 +938,12 @@
       fingerprint = "DF68 C500 4024 23CC F9C5  E6CA 3D17 C832 4696 FE70";
     }];
   };
+  alsvartr = {
+    email = "nazarov.pn@gmail.com";
+    github = "alsvartr";
+    githubId = 205880;
+    name = "Pavel Nazarov";
+  };
   alternateved = {
     email = "alternateved@pm.me";
     github = "alternateved";

--- a/pkgs/by-name/dn/dnsjit/package.nix
+++ b/pkgs/by-name/dn/dnsjit/package.nix
@@ -1,0 +1,39 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, makeWrapper
+, autoreconfHook
+, autoconf
+, automake
+, libpcap
+, luajit
+, lmdb
+, libck
+, gnutls
+, lz4
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dnsjit";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "DNS-OARC";
+    repo = "dnsjit";
+    rev = "03719c6538a019a9b3c857f0ff9d031208160027";
+    sha256 = "sha256-NaJqrPWeTeCSnPGJUXn7vIGRRWwztxfbEI6Wb+q4/hc=";
+  };
+
+  nativeBuildInputs = [ pkg-config autoreconfHook libpcap luajit lmdb libck gnutls lz4 ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Engine for capturing, parsing and replaying DNS";
+    homepage = "https://www.dns-oarc.net/tools/dnsjit";
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ alsvartr ];
+  };
+}


### PR DESCRIPTION
## Description of changes

dnsjit is a combination of parts taken from [dsc](https://www.dns-oarc.net/tools/dsc), [dnscap](https://www.dns-oarc.net/tools/dnscap), [drool](https://www.dns-oarc.net/tools/drool), and put together around Lua to create a script-based engine for easy capturing, parsing and statistics gathering of DNS messages while also providing facilities for replaying DNS traffic.

https://www.dns-oarc.net/tools/dnsjit

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
