### PR TITLE
nmt, nmd: turn into fixed-output derivations

### DIFF
--- a/pkgs/by-name/ni/nix-lib-nmd/package.nix
+++ b/pkgs/by-name/ni/nix-lib-nmd/package.nix
@@ -1,22 +1,19 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchFromSourcehut }:
 
 let version = "0.5.0";
 in stdenv.mkDerivation {
   pname = "nix-lib-nmd";
   inherit version;
 
-  # TODO: Restore when Sourcehut once its back from DDoS attack.
-  # src = fetchFromSourcehut {
-  #   owner = "~rycee";
-  #   repo = "nmd";
-  #   rev = "v${version}";
-  #   hash = "sha256-1glxIg/b+8qr+ZsSsBqZIqGpsYWzRuMyz74/sy765Uk=";
-  # };
-
-  src = fetchurl {
-    url = "https://rycee.net/tarballs/nmd-${version}.tar.gz";
-    hash = "sha256-+65+VYFgnbFGzCyyQytyxVStSZwEP989qi/6EDOdA8A=";
+  src = fetchFromSourcehut {
+    owner = "~rycee";
+    repo = "nmd";
+    rev = "v${version}";
+    hash = "sha256-x3zzcdvhJpodsmdjqB4t5mkVW22V3wqHLOun0KRBzUI=";
   };
+
+  outputHashMode = "recursive";
+  outputHash = "sha256-7BQmDJBo7rzv0rgfRiUAR3HvKkUHQ6x0umhBRhAAyzM=";
 
   installPhase = ''
     mkdir -v "$out"

--- a/pkgs/by-name/ni/nix-lib-nmt/package.nix
+++ b/pkgs/by-name/ni/nix-lib-nmt/package.nix
@@ -1,22 +1,19 @@
-{ lib, stdenv, fetchurl }:
+{ lib, stdenv, fetchFromSourcehut }:
 
-let version = "0.5.0";
+let version = "0.5.1";
 in stdenv.mkDerivation {
   pname = "nix-lib-nmt";
   inherit version;
 
-  # TODO: Restore when Sourcehut once its back from DDoS attack.
-  # src = fetchFromSourcehut {
-  #   owner = "~rycee";
-  #   repo = "nmt";
-  #   rev = "v${version}";
-  #   hash = "sha256-1glxIg/b+8qr+ZsSsBqZIqGpsYWzRuMyz74/sy765Uk=";
-  # };
-
-  src = fetchurl {
-    url = "https://rycee.net/tarballs/nmt-${version}.tar.gz";
-    hash = "sha256-AO1iLsfZSLbR65tRBsAqJ98CewfSl5yNf7C6XaZj0wM=";
+  src = fetchFromSourcehut {
+    owner = "~rycee";
+    repo = "nmt";
+    rev = "v${version}";
+    hash = "sha256-krVKx3/u1mDo8qe5qylYgmwAmlAPHa1BSPDzxq09FmI=";
   };
+
+  outputHashMode = "recursive";
+  outputHash = "sha256-N7kGGDDXsXtc1S3Nqw7lCIbnVHtGNNLM1oO+Xe64hSE=";
 
   installPhase = ''
     mkdir -pv "$out"


### PR DESCRIPTION
## Description of changes

This should avoid the need for IFD. Also switch source fetchs to Sourcehut since it is back online.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [ ] 
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
