### PR TITLE
[Backport release-23.11] swift: force-unwrap file handles in swift-tools-support-core

### DIFF
--- a/pkgs/development/compilers/swift/sourcekit-lsp/default.nix
+++ b/pkgs/development/compilers/swift/sourcekit-lsp/default.nix
@@ -40,6 +40,9 @@ stdenv.mkDerivation {
     swiftpmMakeMutable indexstore-db
     patch -p1 -d .build/checkouts/indexstore-db -i ${./patches/indexstore-db-macos-target.patch}
 
+    swiftpmMakeMutable swift-tools-support-core
+    patch -p1 -d .build/checkouts/swift-tools-support-core -i ${./patches/force-unwrap-file-handles.patch}
+
     # This toggles a section specific to Xcode XCTest, which doesn't work on
     # Darwin, where we also use swift-corelibs-xctest.
     substituteInPlace Sources/LSPTestSupport/PerfTestCase.swift \

--- a/pkgs/development/compilers/swift/sourcekit-lsp/patches/force-unwrap-file-handles.patch
+++ b/pkgs/development/compilers/swift/sourcekit-lsp/patches/force-unwrap-file-handles.patch
@@ -1,0 +1,33 @@
+From 8d9ab4b6ed24a97e8af0cc338a52aacdcf438b8c Mon Sep 17 00:00:00 2001
+From: Pavel Sobolev <paveloom@riseup.net>
+Date: Tue, 21 Nov 2023 20:53:33 +0300
+Subject: [PATCH] Force-unwrap file handles.
+
+---
+ Sources/TSCBasic/FileSystem.swift | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Sources/TSCBasic/FileSystem.swift b/Sources/TSCBasic/FileSystem.swift
+index 3a63bdf..a1f3d9d 100644
+--- a/Sources/TSCBasic/FileSystem.swift
++++ b/Sources/TSCBasic/FileSystem.swift
+@@ -425,7 +425,7 @@ private class LocalFileSystem: FileSystem {
+         if fp == nil {
+             throw FileSystemError(errno: errno, path)
+         }
+-        defer { fclose(fp) }
++        defer { fclose(fp!) }
+
+         // Read the data one block at a time.
+         let data = BufferedOutputByteStream()
+@@ -455,7 +455,7 @@ private class LocalFileSystem: FileSystem {
+         if fp == nil {
+             throw FileSystemError(errno: errno, path)
+         }
+-        defer { fclose(fp) }
++        defer { fclose(fp!) }
+
+         // Write the data in one chunk.
+         var contents = bytes.contents
+--
+2.42.0

--- a/pkgs/development/compilers/swift/swift-driver/default.nix
+++ b/pkgs/development/compilers/swift/swift-driver/default.nix
@@ -52,7 +52,10 @@ stdenv.mkDerivation {
     })
   ];
 
-  configurePhase = generated.configure;
+  configurePhase = generated.configure + ''
+    swiftpmMakeMutable swift-tools-support-core
+    patch -p1 -d .build/checkouts/swift-tools-support-core -i ${./patches/force-unwrap-file-handles.patch}
+  '';
 
   # TODO: Tests depend on indexstore-db being provided by an existing Swift
   # toolchain. (ie. looks for `../lib/libIndexStore.so` relative to swiftc.

--- a/pkgs/development/compilers/swift/swift-driver/patches/force-unwrap-file-handles.patch
+++ b/pkgs/development/compilers/swift/swift-driver/patches/force-unwrap-file-handles.patch
@@ -1,0 +1,33 @@
+From 8d9ab4b6ed24a97e8af0cc338a52aacdcf438b8c Mon Sep 17 00:00:00 2001
+From: Pavel Sobolev <paveloom@riseup.net>
+Date: Tue, 21 Nov 2023 20:53:33 +0300
+Subject: [PATCH] Force-unwrap file handles.
+
+---
+ Sources/TSCBasic/FileSystem.swift | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Sources/TSCBasic/FileSystem.swift b/Sources/TSCBasic/FileSystem.swift
+index 3a63bdf..a1f3d9d 100644
+--- a/Sources/TSCBasic/FileSystem.swift
++++ b/Sources/TSCBasic/FileSystem.swift
+@@ -425,7 +425,7 @@ private class LocalFileSystem: FileSystem {
+         if fp == nil {
+             throw FileSystemError(errno: errno, path)
+         }
+-        defer { fclose(fp) }
++        defer { fclose(fp!) }
+
+         // Read the data one block at a time.
+         let data = BufferedOutputByteStream()
+@@ -455,7 +455,7 @@ private class LocalFileSystem: FileSystem {
+         if fp == nil {
+             throw FileSystemError(errno: errno, path)
+         }
+-        defer { fclose(fp) }
++        defer { fclose(fp!) }
+
+         // Write the data in one chunk.
+         var contents = bytes.contents
+--
+2.42.0

--- a/pkgs/development/compilers/swift/swift-format/default.nix
+++ b/pkgs/development/compilers/swift/swift-format/default.nix
@@ -19,7 +19,10 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ swift swiftpm ];
   buildInputs = [ Foundation ];
 
-  configurePhase = generated.configure;
+  configurePhase = generated.configure + ''
+    swiftpmMakeMutable swift-tools-support-core
+    patch -p1 -d .build/checkouts/swift-tools-support-core -i ${./patches/force-unwrap-file-handles.patch}
+  '';
 
   # We only install the swift-format binary, so don't need the other products.
   swiftpmFlags = [ "--product swift-format" ];

--- a/pkgs/development/compilers/swift/swift-format/patches/force-unwrap-file-handles.patch
+++ b/pkgs/development/compilers/swift/swift-format/patches/force-unwrap-file-handles.patch
@@ -1,0 +1,33 @@
+From 8d9ab4b6ed24a97e8af0cc338a52aacdcf438b8c Mon Sep 17 00:00:00 2001
+From: Pavel Sobolev <paveloom@riseup.net>
+Date: Tue, 21 Nov 2023 20:53:33 +0300
+Subject: [PATCH] Force-unwrap file handles.
+
+---
+ Sources/TSCBasic/FileSystem.swift | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Sources/TSCBasic/FileSystem.swift b/Sources/TSCBasic/FileSystem.swift
+index 3a63bdf..a1f3d9d 100644
+--- a/Sources/TSCBasic/FileSystem.swift
++++ b/Sources/TSCBasic/FileSystem.swift
+@@ -425,7 +425,7 @@ private class LocalFileSystem: FileSystem {
+         if fp == nil {
+             throw FileSystemError(errno: errno, path)
+         }
+-        defer { fclose(fp) }
++        defer { fclose(fp!) }
+
+         // Read the data one block at a time.
+         let data = BufferedOutputByteStream()
+@@ -455,7 +455,7 @@ private class LocalFileSystem: FileSystem {
+         if fp == nil {
+             throw FileSystemError(errno: errno, path)
+         }
+-        defer { fclose(fp) }
++        defer { fclose(fp!) }
+
+         // Write the data in one chunk.
+         var contents = bytes.contents
+--
+2.42.0

--- a/pkgs/development/compilers/swift/swiftpm/default.nix
+++ b/pkgs/development/compilers/swift/swiftpm/default.nix
@@ -199,6 +199,10 @@ let
     name = "swift-tools-support-core";
     src = generated.sources.swift-tools-support-core;
 
+    patches = [
+      ./patches/force-unwrap-file-handles.patch
+    ];
+
     buildInputs = [
       swift-system
       sqlite
@@ -385,6 +389,7 @@ in stdenv.mkDerivation (commonAttrs // {
     swiftpmMakeMutable swift-tools-support-core
     substituteInPlace .build/checkouts/swift-tools-support-core/Sources/TSCTestSupport/XCTestCasePerf.swift \
       --replace 'canImport(Darwin)' 'false'
+    patch -p1 -d .build/checkouts/swift-tools-support-core -i ${./patches/force-unwrap-file-handles.patch}
 
     # Prevent a warning about SDK directories we don't have.
     swiftpmMakeMutable swift-driver

--- a/pkgs/development/compilers/swift/swiftpm/patches/force-unwrap-file-handles.patch
+++ b/pkgs/development/compilers/swift/swiftpm/patches/force-unwrap-file-handles.patch
@@ -1,0 +1,33 @@
+From 8d9ab4b6ed24a97e8af0cc338a52aacdcf438b8c Mon Sep 17 00:00:00 2001
+From: Pavel Sobolev <paveloom@riseup.net>
+Date: Tue, 21 Nov 2023 20:53:33 +0300
+Subject: [PATCH] Force-unwrap file handles.
+
+---
+ Sources/TSCBasic/FileSystem.swift | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Sources/TSCBasic/FileSystem.swift b/Sources/TSCBasic/FileSystem.swift
+index 3a63bdf..a1f3d9d 100644
+--- a/Sources/TSCBasic/FileSystem.swift
++++ b/Sources/TSCBasic/FileSystem.swift
+@@ -425,7 +425,7 @@ private class LocalFileSystem: FileSystem {
+         if fp == nil {
+             throw FileSystemError(errno: errno, path)
+         }
+-        defer { fclose(fp) }
++        defer { fclose(fp!) }
+
+         // Read the data one block at a time.
+         let data = BufferedOutputByteStream()
+@@ -455,7 +455,7 @@ private class LocalFileSystem: FileSystem {
+         if fp == nil {
+             throw FileSystemError(errno: errno, path)
+         }
+-        defer { fclose(fp) }
++        defer { fclose(fp!) }
+
+         // Write the data in one chunk.
+         var contents = bytes.contents
+--
+2.42.0


### PR DESCRIPTION
## Description of changes

This backports https://github.com/NixOS/nixpkgs/pull/269015 to `release-23.11`, as without these patches, the Swift programming language is broken on 23.11

Affected derivations are:
* `swiftpm`
* `sourcekit-lsp`
* `swift-format`
* `swift-driver`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
