### PR TITLE
lib.extendDerivation: Add derivation attribute

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -251,7 +251,10 @@ rec {
             inherit (drv.${outputName}) type outputName;
             outputSpecified = true;
             # unsafeDiscardOutputDependency: see below
-            derivation = assert condition; drv.${outputName}.derivation or (builtins.unsafeDiscardOutputDependency drv.${outputName}.drvPath);
+            derivation = assert condition; drv.${outputName}.derivation or {
+              # NOTE: keep lean and align with https://github.com/NixOS/nix/issues/9774
+              path = builtins.unsafeDiscardOutputDependency drv.${outputName}.drvPath;
+            };
             drvPath = assert condition; drv.${outputName}.drvPath;
             outPath = assert condition; drv.${outputName}.outPath;
           } //
@@ -283,7 +286,10 @@ rec {
       # - `nix build foo.derivation` does not realise anything, because it only
       #   needs to instantiate a normal `.drv` closure, and that already constitutes
       #   a valid store path.
-      derivation = assert condition; drv.derivation or (builtins.unsafeDiscardOutputDependency drv.drvPath);
+      derivation = assert condition; drv.derivation or {
+        # NOTE: keep lean and align with https://github.com/NixOS/nix/issues/9774
+        path = builtins.unsafeDiscardOutputDependency drv.drvPath;
+      };
       drvPath = assert condition; drv.drvPath;
       outPath = assert condition; drv.outPath;
     };

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -55,6 +55,41 @@ runTests {
     expected = { a = false; b = false; c = true; };
   };
 
+  testExtendDerivationSimple = {
+    expr =
+      let actual = extendDerivation
+            # assertion condition: all good
+            true
+            # "passthru"
+            { tests = { nixos.foo = { }; }; }
+            # result of derivation or mkDerivation
+            (fix (d: {
+              type = "derivation";
+              drvPath = "/foo/bar.drv";
+              outPath = "/foo/bar";
+              out = d;
+              all = [ d ];
+              outputName = "out";
+            }));
+      in
+        {
+          inherit (actual) type drvPath outPath derivation;
+          # TODO test more attrs
+          out_derivation = actual.out.derivation;
+          all_derivation = (head actual.all).derivation;
+        };
+    expected = rec {
+      type = "derivation";
+      drvPath = "/foo/bar.drv";
+      outPath = "/foo/bar";
+      derivation = {
+        path = "/foo/bar.drv";
+      };
+      out_derivation = derivation;
+      all_derivation = derivation;
+    };
+  };
+
 # TRIVIAL
 
   testId = {


### PR DESCRIPTION

## Description of changes

Add a `derivation` attribute to all package, with appropriate string context; see code comment.

As discussed in the Nix team and in agreeance with Infinisil's advice to make this change in a non-breaking manner - with a new attribute that eventually makes drvPath obsolete.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
