### PR TITLE
neovim-unwrapped: use finalAttrs

### DIFF
--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -68,6 +68,8 @@ in {
     pname = "neovim-unwrapped";
     version = "0.9.5";
 
+    __structuredAttrs = true;
+
     src = fetchFromGitHub {
       owner = "neovim";
       repo = "neovim";
@@ -84,7 +86,7 @@ in {
 
     dontFixCmake = true;
 
-    inherit lua;
+    inherit lua treesitter-parsers;
 
     buildInputs = [
       gperf
@@ -171,7 +173,7 @@ in {
           }}/parser \
           $out/lib/nvim/parser/${language}.so
       '')
-      treesitter-parsers);
+      finalAttrs.treesitter-parsers);
 
     shellHook=''
       export VIMRUNTIME=$PWD/runtime

--- a/pkgs/applications/editors/neovim/default.nix
+++ b/pkgs/applications/editors/neovim/default.nix
@@ -12,11 +12,10 @@
 
 # now defaults to false because some tests can be flaky (clipboard etc), see
 # also: https://github.com/neovim/neovim/issues/16233
-, doCheck ? false
 , nodejs ? null, fish ? null, python3 ? null
 }:
-
-let
+stdenv.mkDerivation (finalAttrs:
+  let
   nvim-lpeg-dylib = luapkgs: if stdenv.isDarwin
     then (luapkgs.lpeg.overrideAttrs (oa: {
       preConfigure = ''
@@ -42,7 +41,7 @@ let
     (nvim-lpeg-dylib ps)
     luabitop
     mpack
-  ] ++ lib.optionals doCheck [
+  ] ++ lib.optionals finalAttrs.doCheck [
     luv
     coxpcall
     busted
@@ -64,17 +63,15 @@ let
         in deterministicLuajit.withPackages(ps: [ ps.mpack (nvim-lpeg-dylib ps) ])
       else lua.luaOnBuild;
 
-  pyEnv = python3.withPackages(ps: with ps; [ pynvim msgpack ]);
 
-in
-  stdenv.mkDerivation rec {
+in {
     pname = "neovim-unwrapped";
     version = "0.9.5";
 
     src = fetchFromGitHub {
       owner = "neovim";
       repo = "neovim";
-      rev = "v${version}";
+      rev = "v${finalAttrs.version}";
       hash = "sha256-CcaBqA0yFCffNPmXOJTo8c9v1jrEBiqAl8CG5Dj5YxE=";
     };
 
@@ -105,15 +102,17 @@ in
       tree-sitter
       unibilium
     ] ++ lib.optionals stdenv.isDarwin [ libiconv CoreServices ]
-      ++ lib.optionals doCheck [ glibcLocales procps ]
+      ++ lib.optionals finalAttrs.doCheck [ glibcLocales procps ]
     ;
 
-    inherit doCheck;
+    doCheck = false;
 
     # to be exhaustive, one could run
     # make oldtests too
     checkPhase = ''
+      runHook preCheck
       make functionaltest
+      runHook postCheck
     '';
 
     nativeBuildInputs = [
@@ -123,7 +122,9 @@ in
     ];
 
     # extra programs test via `make functionaltest`
-    nativeCheckInputs = [
+    nativeCheckInputs = let
+      pyEnv = python3.withPackages(ps: with ps; [ pynvim msgpack ]);
+    in [
       fish
       nodejs
       pyEnv      # for src/clint.py
@@ -166,7 +167,7 @@ in
         ln -s \
           ${tree-sitter.buildGrammar {
             inherit language src;
-            version = "neovim-${version}";
+            version = "neovim-${finalAttrs.version}";
           }}/parser \
           $out/lib/nvim/parser/${language}.so
       '')
@@ -199,4 +200,4 @@ in
       maintainers = with maintainers; [ manveru rvolosatovs ];
       platforms   = platforms.unix;
     };
-  }
+  })


### PR DESCRIPTION
## Description of changes

basically making the neovim unwrapped more inspectable via REPL, I suspect I have the wrong treesitter grammars with my neovim nightly and these changes make it easier to investigate/override those attributes.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
