### PR TITLE
mysql-workbench: fix build, small refactor

### DIFF
--- a/pkgs/applications/misc/mysql-workbench/default.nix
+++ b/pkgs/applications/misc/mysql-workbench/default.nix
@@ -1,4 +1,5 @@
-{ lib, stdenv
+{ lib
+, stdenv
 , fetchurl
 , substituteAll
 , cmake
@@ -44,13 +45,14 @@
 
 let
   inherit (python3.pkgs) paramiko pycairo pyodbc;
-in stdenv.mkDerivation rec {
+in
+stdenv.mkDerivation (finalAttrs: {
   pname = "mysql-workbench";
   version = "8.0.34";
 
   src = fetchurl {
-    url = "https://cdn.mysql.com//Downloads/MySQLGUITools/mysql-workbench-community-${version}-src.tar.gz";
-    sha256 = "sha256-ub/D6HRtXOvX+lai71t1UjMmMzBsz5ljCrJCuf9aq7U=";
+    url = "https://cdn.mysql.com/Downloads/MySQLGUITools/mysql-workbench-community-${finalAttrs.version}-src.tar.gz";
+    hash = "sha256-ub/D6HRtXOvX+lai71t1UjMmMzBsz5ljCrJCuf9aq7U=";
   };
 
   patches = [
@@ -75,6 +77,9 @@ in stdenv.mkDerivation rec {
       src = ./fix-swig-build.patch;
       cairoDev = "${cairo.dev}";
     })
+
+    # a newer libxml2 version has changed some interfaces
+    ./fix-xml2.patch
   ];
 
   # 1. have it look for 4.12.0 instead of 4.11.1
@@ -138,6 +143,10 @@ in stdenv.mkDerivation rec {
     patchShebangs tools/get_wb_version.sh
   '';
 
+  # GCC 13: error: 'int64_t' in namespace 'std' does not name a type
+  # when updating the version make sure this is still needed
+  env.CXXFLAGS = "-include cstdint";
+
   env.NIX_CFLAGS_COMPILE = toString ([
     # error: 'OGRErr OGRSpatialReference::importFromWkt(char**)' is deprecated
     "-Wno-error=deprecated-declarations"
@@ -183,7 +192,7 @@ in stdenv.mkDerivation rec {
     done
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Visual MySQL database modeling, administration and querying tool";
     longDescription = ''
       MySQL Workbench is a modeling tool that allows you to design
@@ -191,11 +200,10 @@ in stdenv.mkDerivation rec {
       and query development modules where you can manage MySQL server instances
       and execute SQL queries.
     '';
-
     homepage = "http://wb.mysql.com/";
-    license = licenses.gpl2;
-    maintainers = [ ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Only;
     mainProgram = "mysql-workbench";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/applications/misc/mysql-workbench/fix-xml2.patch
+++ b/pkgs/applications/misc/mysql-workbench/fix-xml2.patch
@@ -1,0 +1,25 @@
+diff --git a/library/grt/src/grt.h b/library/grt/src/grt.h
+index 47bfd63..59e664b 100644
+--- a/library/grt/src/grt.h
++++ b/library/grt/src/grt.h
+@@ -35,6 +35,7 @@
+ #include <stdexcept>
+ #include <boost/function.hpp>
+ #include <libxml/xmlmemory.h>
++#include <libxml/tree.h>
+ #include "base/threading.h"
+ #include <string>
+ #include <gmodule.h>
+diff --git a/library/grt/src/unserializer.cpp b/library/grt/src/unserializer.cpp
+index 6dda76d..a6f6a3c 100644
+--- a/library/grt/src/unserializer.cpp
++++ b/library/grt/src/unserializer.cpp
+@@ -401,7 +401,7 @@ ValueRef internal::Unserializer::unserialize_xmldata(const char *data, size_t si
+   xmlDocPtr doc = xmlReadMemory(data, (int)size, NULL, NULL, XML_PARSE_NOENT);
+ 
+   if (!doc) {
+-    xmlErrorPtr error = xmlGetLastError();
++    const xmlError* error = xmlGetLastError();
+ 
+     if (error)
+       throw std::runtime_error(base::strfmt("Could not parse XML data. Line %d, %s", error->line, error->message));


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/281112

This PR fixes the build for `mysql-workbench`
`libxml2` had updated some of its typedefs/headers which needed some patching.
Also, `gcc13` has removed the implicit `cstdint` include, so until they get it fixed, I added an extra flag, which just includes it.

I also added myself as a maintainer, as I will use this software for my work, and I'll gladly help make some fixes.

Some other small changes:
- use `finalAttrs` instead of `rec`
- use `hash` instead of `sha256`
- use `gpl2Only` instead of `gpl2`
- drop `with lib` from `meta`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
