### PR TITLE
adds block_args for autogenerated ids from trustworthy sources

### DIFF
--- a/doc/doc-support/lib-function-docs.nix
+++ b/doc/doc-support/lib-function-docs.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
     mkdir -p "$out"
 
     cat > "$out/index.md" << 'EOF'
-    ```{=include=} sections
+    ```{=include=} sections auto-id-prefix=auto-generated
     EOF
 
     ${lib.concatMapStrings ({ name, baseName ? name, description }: ''

--- a/pkgs/tools/nix/nixos-render-docs/src/tests/test_auto_id_prefix.py
+++ b/pkgs/tools/nix/nixos-render-docs/src/tests/test_auto_id_prefix.py
@@ -1,0 +1,92 @@
+from pathlib import Path
+
+from markdown_it.token import Token
+from nixos_render_docs.manual import HTMLConverter, HTMLParameters
+from nixos_render_docs.md import Converter
+
+auto_id_prefix="TEST_PREFIX"
+def set_prefix(token: Token, ident: str) -> None:
+    token.attrs["id"] = f"{auto_id_prefix}-{ident}"
+
+
+def test_auto_id_prefix_simple() -> None:
+    md = HTMLConverter("1.0.0", HTMLParameters("", [], [], 2, 2, 2, Path("")), {})
+
+    src = f"""
+# title
+
+## subtitle
+    """
+    tokens = Converter()._parse(src)
+    md._handle_headings(tokens, on_heading=set_prefix)
+
+    assert [
+        {**token.attrs, "tag": token.tag}
+        for token in tokens
+        if token.type == "heading_open"
+    ] == [
+        {"id": "TEST_PREFIX-1", "tag": "h1"},
+        {"id": "TEST_PREFIX-1.1", "tag": "h2"}
+    ]
+
+
+def test_auto_id_prefix_repeated() -> None:
+    md = HTMLConverter("1.0.0", HTMLParameters("", [], [], 2, 2, 2, Path("")), {})
+
+    src = f"""
+# title
+
+## subtitle
+
+# title2
+
+## subtitle2
+    """
+    tokens = Converter()._parse(src)
+    md._handle_headings(tokens, on_heading=set_prefix)
+
+    assert [
+        {**token.attrs, "tag": token.tag}
+        for token in tokens
+        if token.type == "heading_open"
+    ] == [
+        {"id": "TEST_PREFIX-1", "tag": "h1"},
+        {"id": "TEST_PREFIX-1.1", "tag": "h2"},
+        {"id": "TEST_PREFIX-2", "tag": "h1"},
+        {"id": "TEST_PREFIX-2.1", "tag": "h2"},
+    ]
+
+def test_auto_id_prefix_maximum_nested() -> None:
+    md = HTMLConverter("1.0.0", HTMLParameters("", [], [], 2, 2, 2, Path("")), {})
+
+    src = f"""
+# h1
+
+## h2
+
+### h3
+
+#### h4
+
+##### h5
+
+###### h6
+
+## h2.2
+    """
+    tokens = Converter()._parse(src)
+    md._handle_headings(tokens, on_heading=set_prefix)
+
+    assert [
+        {**token.attrs, "tag": token.tag}
+        for token in tokens
+        if token.type == "heading_open"
+    ] == [
+        {"id": "TEST_PREFIX-1", "tag": "h1"},
+        {"id": "TEST_PREFIX-1.1", "tag": "h2"},
+        {"id": "TEST_PREFIX-1.1.1", "tag": "h3"},
+        {"id": "TEST_PREFIX-1.1.1.1", "tag": "h4"},
+        {"id": "TEST_PREFIX-1.1.1.1.1", "tag": "h5"},
+        {"id": "TEST_PREFIX-1.1.1.1.1.1", "tag": "h6"},
+        {"id": "TEST_PREFIX-1.2", "tag": "h2"},
+    ]


### PR DESCRIPTION
## Description of changes

Add option to autogenerate heading ids. This is needed if we want to support regular commonmark documentation generated from nix source code. People are not expected to place heading ids in their code comments.
 
This PR resolves:

#280514

Which is needed for implementing [rfc145](https://github.com/NixOS/rfcs/blob/c65c8321782b40844167beb48818471f70900d9d/rfcs/0145-doc-strings.md) in nixpkgs.

- [x] Unit tests
- [x] Tested against the open PR of nixdoc (with new doc-comment support) as well as the current version.
- [x] Test against the migrated nixpkgs PR #262987


@pennae. Thank you a lot for your help with this PR.
 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
