### PR TITLE
auto-multiple-choice: use absolute paths instead of "portable" strategy

### DIFF
--- a/pkgs/applications/misc/auto-multiple-choice/default.nix
+++ b/pkgs/applications/misc/auto-multiple-choice/default.nix
@@ -37,31 +37,28 @@ stdenv.mkDerivation (finalAttrs: rec {
 
   makeFlags = [
     "PERLPATH=${perl}/bin/perl"
-    # We *need* to pass DESTDIR, as the Makefile ignores PREFIX.
-    "DESTDIR=$(out)"
-    # Relative paths.
-    "BINDIR=/bin"
-    "PERLDIR=/share/perl5"
-    "MODSDIR=/lib" # At runtime, AMC will test for that dir before
-    # defaulting to the "portable" strategy we use, so this test
-    # *must* fail.  *But* this variable cannot be set to anything but
-    # "/lib" , because that name is hardcoded in the main executable
-    # and this variable controls both both the path AMC will check at
-    # runtime, AND the path where the actual modules will be stored at
-    # build-time.  This has been reported upstream as
-    # https://project.auto-multiple-choice.net/issues/872
-    "TEXDIR=/tex/latex/" # what texlive.combine expects
-    "TEXDOCDIR=/share/doc/texmf/" # TODO where to put this?
-    "MAN1DIR=/share/man/man1"
-    "DESKTOPDIR=/share/applications"
-    "METAINFODIR=/share/metainfo"
-    "ICONSDIR=/share/auto-multiple-choice/icons"
-    "APPICONDIR=/share/icons/hicolor"
-    "LOCALEDIR=/share/locale"
-    "MODELSDIR=/share/auto-multiple-choice/models"
-    "DOCDIR=/share/doc/auto-multiple-choice"
-    "SHARED_MIMEINFO_DIR=/share/mime/packages"
-    "LANG_GTKSOURCEVIEW_DIR=/share/gtksourceview-4/language-specs"
+    # We *need* to set DESTDIR as empty and use absolute paths below,
+    # because the Makefile ignores PREFIX and MODSDIR is required to
+    # be an absolute path to not trigger "portable distribution" check
+    # in auto-multiple-choice.in.
+    "DESTDIR="
+    # Set variables from Makefile.conf to absolute paths
+    "BINDIR=${placeholder "out"}/bin"
+    "PERLDIR=${placeholder "out"}/share/perl5"
+    "MODSDIR=${placeholder "out"}/lib"
+    "TEXDIR=${placeholder "out"}/tex/latex/" # what texlive.combine expects
+    "TEXDOCDIR=${placeholder "out"}/share/doc/texmf/" # TODO where to put this?
+    "MAN1DIR=${placeholder "out"}/share/man/man1"
+    "DESKTOPDIR=${placeholder "out"}/share/applications"
+    "METAINFODIR=${placeholder "out"}/share/metainfo"
+    "ICONSDIR=${placeholder "out"}/share/auto-multiple-choice/icons"
+    "CSSDIR=${placeholder "out"}/share/auto-multiple-choice/gtk"
+    "APPICONDIR=${placeholder "out"}/share/icons/hicolor"
+    "LOCALEDIR=${placeholder "out"}/share/locale"
+    "MODELSDIR=${placeholder "out"}/share/auto-multiple-choice/models"
+    "DOCDIR=${placeholder "out"}/share/doc/auto-multiple-choice"
+    "SHARED_MIMEINFO_DIR=${placeholder "out"}/share/mime/packages"
+    "LANG_GTKSOURCEVIEW_DIR=${placeholder "out"}/share/gtksourceview-4/language-specs"
     # Pretend to be redhat so `install` doesn't try to chown/chgrp.
     "SYSTEM_TYPE=rpm"
     "GCC=${stdenv.cc.targetPrefix}cc"

--- a/pkgs/applications/misc/auto-multiple-choice/default.nix
+++ b/pkgs/applications/misc/auto-multiple-choice/default.nix
@@ -90,6 +90,7 @@ stdenv.mkDerivation (finalAttrs: rec {
       XMLWriter
     ]}:"$out/share/perl5 \
     --prefix XDG_DATA_DIRS : "$out/share:$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH" \
+    --prefix PATH : "$out/bin" \
     --set TEXINPUTS ":.:$out/tex/latex"
   '';
 


### PR DESCRIPTION
Currently, auto-multiple-choice from nixpkgs doesn't work on systems with /lib directory. Running auto-multiple-choice there fails with:

    Unknown action gui at /nix/store/n3cyw5ngp0v52rny9gr6z35vslh5d4vx-auto-multiple-choice-1.6.0/bin/.auto-multiple-choice-wrapped line 94.

This happens on non-NixOS systems as well as on NixOS with e.g. nix-ld [1] enabled.

The reason is documented in the Nix expression and the problem is reported upstream at https://project.auto-multiple-choice.net/issues/872. However, the problem can be worked around without requiring upstream changes, as shown in this commit. We stop using the "portable distribution", which tries to detect the base directory at run time, and instead hardcode all paths as absolute at build time.

[1] https://github.com/Mic92/nix-ld

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
