### PR TITLE
python.pkgs.nmslib: init at 2.1.2

### DIFF
--- a/pkgs/development/python-modules/nmslib/default.nix
+++ b/pkgs/development/python-modules/nmslib/default.nix
@@ -1,0 +1,49 @@
+{ lib
+, fetchPypi
+, buildPythonPackage
+, numpy
+, psutil
+, pybind11
+}:
+
+buildPythonPackage rec {
+  pname = "nmslib";
+  version = "2.1.2";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "fixed-install-nmslib";
+    hash = "sha256-RYTI79skdpHeHyOvopuL8TcT29kZK2jzf3sQpB3Rigs=";
+  };
+
+  postPatch = ''
+    substituteInPlace PKG-INFO setup.py \
+      --replace fixed-install-nmslib ${pname}
+    mv fixed_install_nmslib.egg-info ${pname}.egg-info
+    cd ${pname}.egg-info
+    substituteInPlace PKG-INFO \
+      --replace fixed-install-nmslib ${pname}
+    substituteInPlace SOURCES.txt \
+      --replace fixed_install_nmslib ${pname}
+    cd ..
+  '';
+
+  propagatedBuildInputs = [
+    numpy
+    psutil
+  ];
+
+  nativeCheckInputs = [
+    pybind11
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/nmslib/nmslib";
+    license = licenses.asl20;
+    description = ''
+      an efficient cross-platform similarity search library
+      and a toolkit for evaluation of similarity search methods
+    '';
+    maintainers = [ maintainers.gm6k ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8373,6 +8373,8 @@ self: super: with self; {
 
   nmapthon2 = callPackage ../development/python-modules/nmapthon2 { };
 
+  nmslib = callPackage ../development/python-modules/nmslib { };
+
   amaranth-boards = callPackage ../development/python-modules/amaranth-boards { };
 
   amaranth = callPackage ../development/python-modules/amaranth { };


### PR DESCRIPTION
## Description of changes

Adding a library for non-metric space searching: https://github.com/nmslib/nmslib

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
