### PR TITLE
yazi: 0.1.5 -> 0.2.1

### DIFF
--- a/pkgs/applications/file-managers/yazi/default.nix
+++ b/pkgs/applications/file-managers/yazi/default.nix
@@ -31,16 +31,18 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "yazi";
-  version = "0.1.5";
+  version = "0.2.1";
 
   src = fetchFromGitHub {
     owner = "sxyazi";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-FhKrq4N32uJRHGc0qRl+CIVNRW597jACcTFEgj8hiSE=";
+    hash = "sha256-XdN2oP5c2lK+bR3i+Hwd4oOlccMQisbzgevHsZ8YbSQ=";
   };
 
-  cargoHash = "sha256-YUymZhDp1Pjm+W6m8Vmh2AgMCdaNt6TQQpiJwSg/gPw=";
+  cargoHash = "sha256-0JNKlzmMS5wcTW0faTnhFgNK2VHXixNnMx6ZS3eKbPA=";
+
+  env.YAZI_GEN_COMPLETIONS = true;
 
   nativeBuildInputs = [ makeWrapper installShellFiles ];
   buildInputs = lib.optionals stdenv.isDarwin [ Foundation ];
@@ -62,9 +64,9 @@ rustPlatform.buildRustPackage rec {
       wrapProgram $out/bin/yazi \
          --prefix PATH : "${makeBinPath runtimePaths}"
       installShellCompletion --cmd yazi \
-        --bash ./config/completions/yazi.bash \
-        --fish ./config/completions/yazi.fish \
-        --zsh  ./config/completions/_yazi
+        --bash ./yazi-config/completions/yazi.bash \
+        --fish ./yazi-config/completions/yazi.fish \
+        --zsh  ./yazi-config/completions/_yazi
     '';
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
## Description of changes

[v0.2.1 Changelog](https://github.com/sxyazi/yazi/releases/tag/v0.2.1)
[v0.2.0 Changelog](https://github.com/sxyazi/yazi/releases/tag/v0.2.0)

Yazi's config has [breaking changes](https://github.com/sxyazi/yazi/issues/461)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
