### PR TITLE
nixos/nagios: use correct CGI cfg when web enabled

### DIFF
--- a/nixos/modules/services/monitoring/nagios.nix
+++ b/nixos/modules/services/monitoring/nagios.nix
@@ -57,7 +57,7 @@ let
   # Plain configuration for the Nagios web-interface with no
   # authentication.
   nagiosCGICfgFile = pkgs.writeText "nagios.cgi.conf" ''
-    main_config_file=${cfg.mainConfigFile}
+    main_config_file=${nagiosCfgFile}
     use_authentication=0
     url_html_path=${urlPath}
   '';
@@ -76,6 +76,7 @@ let
     <Directory "${pkgs.nagios}/share">
       Options None
       Require all granted
+      DirectoryIndex index.html index.php
     </Directory>
   '';
 
@@ -214,11 +215,14 @@ in
       };
     };
 
-    services.httpd.virtualHosts = lib.optionalAttrs cfg.enableWebInterface {
-      ${cfg.virtualHost.hostName} = lib.mkMerge [
-        cfg.virtualHost
-        { extraConfig = extraHttpdConfig; }
-      ];
+    services.httpd = lib.optionalAttrs cfg.enableWebInterface {
+      enablePHP = true;
+      virtualHosts = {
+        ${cfg.virtualHost.hostName} = lib.mkMerge [
+          cfg.virtualHost
+          { extraConfig = extraHttpdConfig; }
+        ];
+      };
     };
   };
 }


### PR DESCRIPTION
Fix issue where main_config_file is set to null in nagios.cgi.conf if `enableWebInterface = true` and mainConfigFile is auto-generated. Also, enable php since the web root of nagios uses index.php.

