### PR TITLE
vcard: enable auto-update

### DIFF
--- a/pkgs/development/python-modules/vcard/default.nix
+++ b/pkgs/development/python-modules/vcard/default.nix
@@ -8,9 +8,13 @@
   pythonAtLeast,
   pythonOlder,
 }:
-buildPythonPackage rec {
-  pname = "vcard";
+let
   version = "0.15.4";
+in
+buildPythonPackage {
+  inherit version;
+
+  pname = "vcard";
   format = "setuptools";
 
   disabled = pythonOlder "3.8" || pythonAtLeast "3.12";

--- a/pkgs/development/python-modules/vcard/default.nix
+++ b/pkgs/development/python-modules/vcard/default.nix
@@ -2,6 +2,7 @@
   buildPythonPackage,
   fetchFromGitLab,
   lib,
+  nix-update-script,
   pytestCheckHook,
   python-dateutil,
   pythonAtLeast,
@@ -26,6 +27,8 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "vcard" ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://gitlab.com/engmark/vcard";


### PR DESCRIPTION
## Description of changes

Should be self-explanatory. Tested with `nix-shell maintainers/scripts/update.nix --argstr package vcard`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable: `nix-update python3Packages.vcard` updated the package
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
