### PR TITLE
j4-dmenu-desktop: 2.18 -> unstable-2023-09-12, clean up

### DIFF
--- a/pkgs/applications/misc/j4-dmenu-desktop/default.nix
+++ b/pkgs/applications/misc/j4-dmenu-desktop/default.nix
@@ -1,18 +1,19 @@
 { lib, stdenv, fetchFromGitHub, cmake, dmenu }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "j4-dmenu-desktop";
-  version = "2.18";
+  version = "unstable-2023-09-12";
 
   src = fetchFromGitHub {
     owner = "enkore";
-    repo = pname;
-    rev = "r${version}";
-    sha256 = "1gxpgifzy0hnpd0ymw3r32amzr32z3bgb90ldjzl438p6h1q0i26";
+    repo = "j4-dmenu-desktop";
+    rev = "7e3fd045482a8ea70619e422975b52feabc75175";
+    hash = "sha256-8PmfzQkHlEdMbrcQO0bPruP3jaKEcr/17x0/Z7Jedh0=";
   };
 
   postPatch = ''
-    sed -e 's,dmenu -i,${dmenu}/bin/dmenu -i,g' -i ./src/Main.hh
+    substituteInPlace src/main.cc \
+        --replace "dmenu -i" "${lib.getExe dmenu} -i"
   '';
 
   nativeBuildInputs = [ cmake ];
@@ -24,10 +25,12 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    description = "A wrapper for dmenu that recognize .desktop files";
+    changelog = "https://github.com/enkore/j4-dmenu-desktop/blob/${finalAttrs.src.rev}/CHANGELOG";
+    description = "A wrapper for dmenu that recognizes .desktop files";
     homepage = "https://github.com/enkore/j4-dmenu-desktop";
-    license = licenses.gpl3;
+    license = licenses.gpl3Only;
+    mainProgram = "j4-dmenu-desktop";
     maintainers = with maintainers; [ ericsagnes ];
     platforms = platforms.unix;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/281272
Closes https://github.com/NixOS/nixpkgs/pull/280925

This PR fixes the build for the package build by building from the currently latest commit.
It also has some cleanup:

Changes:
- use `finalAttrs` instead of `rec`
- use `hash` instead of `sha256`
- add `meta.changelog`
- add `meta.mainProgram`
- `meta.description`: "recognize" -> "recognizes"
- `meta.license`: `gpl3` -> `gpl3Only` (not sure if gpl3Plus is acceptable, so I went with gpl3Only)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
