### PR TITLE
ad-miner: 0.6.0 -> 1.0.0, python311Packages.neo4j: refactor 

### DIFF
--- a/pkgs/by-name/ad/ad-miner/package.nix
+++ b/pkgs/by-name/ad/ad-miner/package.nix
@@ -5,18 +5,22 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "ad-miner";
-  version = "0.6.0";
+  version = "1.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Mazars-Tech";
     repo = "AD_Miner";
     rev = "refs/tags/v${version}";
-    hash = "sha256-Iwg00vAnCs9FbEAmB54vNDLmxyZeCtZMl/VEFoYeEcM=";
+    hash = "sha256-HM7PR1i7/L3MuUaTBPcDblflCH40NmEYSCTJUB06Fjg=";
   };
+
+  # ALl requirements are pinned
+  pythonRelaxDeps = true;
 
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
+    pythonRelaxDepsHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [

--- a/pkgs/development/python-modules/neo4j/default.nix
+++ b/pkgs/development/python-modules/neo4j/default.nix
@@ -1,15 +1,19 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, numpy
+, pandas
+, pyarrow
 , pythonOlder
 , pytz
+, setuptools
 , tomlkit
 }:
 
 buildPythonPackage rec {
   pname = "neo4j";
   version = "5.16.0";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -20,10 +24,35 @@ buildPythonPackage rec {
     hash = "sha256-ly/R2ufd5gEkUyfajpeMQblTiKipC9HFtxkWkh16zLo=";
   };
 
+  postPatch = ''
+    # The dynamic versioning adds a postfix (.dev0) to the version
+    substituteInPlace pyproject.toml \
+      --replace '"tomlkit ~= 0.11.6"' '"tomlkit >= 0.11.6"' \
+      --replace 'dynamic = ["version", "readme"]' 'dynamic = ["readme"]' \
+      --replace '#readme = "README.rst"' 'version = "${version}"'
+  '';
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
   propagatedBuildInputs = [
     pytz
     tomlkit
   ];
+
+  passthru.optional-dependencies = {
+    numpy = [
+      numpy
+    ];
+    pandas = [
+      numpy
+      pandas
+    ];
+    pyarrow = [
+      pyarrow
+    ];
+  };
 
   # Missing dependencies
   doCheck = false;


### PR DESCRIPTION
Diff: https://github.com/Mazars-Tech/AD_Miner/compare/refs/tags/v0.6.0...v1.0.0

Changelog: https://github.com/Mazars-Tech/AD_Miner/blob/1.0.0/CHANGELOG.md

## Description of changes
Fix build (https://hydra.nixos.org/build/246264717)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
