### PR TITLE
opencv2: build with openexr 3

### DIFF
--- a/pkgs/development/libraries/opencv/default.nix
+++ b/pkgs/development/libraries/opencv/default.nix
@@ -4,7 +4,7 @@
 , enableJPEG ? true, libjpeg
 , enablePNG ? true, libpng
 , enableTIFF ? true, libtiff
-, enableEXR ? (!stdenv.isDarwin), openexr, ilmbase
+, enableEXR ? (!stdenv.isDarwin), openexr_3
 , enableFfmpeg ? false, ffmpeg
 , enableGStreamer ? false, gst_all_1
 , enableEigen ? true, eigen
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
     [ # Don't include a copy of the CMake status output in the
       # build. This causes a runtime dependency on GCC.
       ./no-build-info.patch
+      ./opencv2-openexr3.patch
     ];
 
   # This prevents cmake from using libraries in impure paths (which causes build failure on non NixOS)
@@ -47,7 +48,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional enableJPEG libjpeg
     ++ lib.optional enablePNG libpng
     ++ lib.optional enableTIFF libtiff
-    ++ lib.optionals enableEXR [ openexr ilmbase ]
+    ++ lib.optionals enableEXR [ openexr_3 ]
     ++ lib.optional enableFfmpeg ffmpeg
     ++ lib.optionals enableGStreamer (with gst_all_1; [ gstreamer gst-plugins-base ])
     ++ lib.optional enableEigen eigen
@@ -55,8 +56,6 @@ stdenv.mkDerivation rec {
     ;
 
   nativeBuildInputs = [ cmake pkg-config unzip ];
-
-  env.NIX_CFLAGS_COMPILE = lib.optionalString enableEXR "-I${ilmbase.dev}/include/OpenEXR";
 
   cmakeFlags = [
     (opencvFlag "TIFF" enableTIFF)

--- a/pkgs/development/libraries/opencv/opencv2-openexr3.patch
+++ b/pkgs/development/libraries/opencv/opencv2-openexr3.patch
@@ -1,0 +1,52 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 90e16c2a57f8..dd184d78a03c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -201,7 +201,7 @@ OCV_OPTION(BUILD_TIFF               "Build libtiff from source"          WIN32 O
+ OCV_OPTION(BUILD_JASPER             "Build libjasper from source"        WIN32 OR ANDROID OR APPLE )
+ OCV_OPTION(BUILD_JPEG               "Build libjpeg from source"          WIN32 OR ANDROID OR APPLE )
+ OCV_OPTION(BUILD_PNG                "Build libpng from source"           WIN32 OR ANDROID OR APPLE )
+-OCV_OPTION(BUILD_OPENEXR            "Build openexr from source"          WIN32 OR ANDROID OR APPLE )
++OCV_OPTION(BUILD_OPENEXR            "Build openexr from source"          OFF )
+ OCV_OPTION(BUILD_TBB                "Download and build TBB from source" ANDROID )
+ 
+ # OpenCV installation options
+diff --git a/cmake/OpenCVFindOpenEXR.cmake b/cmake/OpenCVFindOpenEXR.cmake
+index c0a46806e150..037ea7aa1b30 100644
+--- a/cmake/OpenCVFindOpenEXR.cmake
++++ b/cmake/OpenCVFindOpenEXR.cmake
+@@ -9,6 +9,22 @@
+ # OPENEXR_LIBRARIES = libraries that are needed to use OpenEXR.
+ #
+ 
++if(NOT OPENCV_SKIP_OPENEXR_FIND_PACKAGE)
++  find_package(OpenEXR 3 QUIET)
++  #ocv_cmake_dump_vars(EXR)
++  if(OpenEXR_FOUND)
++    if(TARGET OpenEXR::OpenEXR)  # OpenEXR 3+
++      set(OPENEXR_LIBRARIES OpenEXR::OpenEXR)
++      set(OPENEXR_INCLUDE_PATHS "")
++      set(OPENEXR_VERSION "${OpenEXR_VERSION}")
++      set(OPENEXR_FOUND 1)
++      return()
++    else()
++      message(STATUS "Unsupported find_package(OpenEXR) - missing OpenEXR::OpenEXR target (version ${OpenEXR_VERSION})")
++    endif()
++  endif()
++endif()
++
+ SET(OPENEXR_LIBRARIES "")
+ SET(OPENEXR_LIBSEARCH_SUFFIXES "")
+ file(TO_CMAKE_PATH "$ENV{ProgramFiles}" ProgramFiles_ENV_PATH)
+diff --git a/modules/highgui/src/grfmt_exr.hpp b/modules/highgui/src/grfmt_exr.hpp
+index b9467c6d26f6..5a725011fabe 100644
+--- a/modules/highgui/src/grfmt_exr.hpp
++++ b/modules/highgui/src/grfmt_exr.hpp
+@@ -53,6 +53,7 @@
+ #include <ImfInputFile.h>
+ #include <ImfChannelList.h>
+ #include <ImathBox.h>
++#include <ImfRgbaFile.h>
+ #include "grfmt_base.hpp"
+ 
+ namespace cv


### PR DESCRIPTION
OpenCV2 is no longer being developed, but apparently people are still using the nixpkgs package. Let's patch it ourselves.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
