### PR TITLE
pkgsMusl.systemd: fix build

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -208,6 +208,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./0017-core-don-t-taint-on-unmerged-usr.patch
     ./0018-tpm2_context_init-fix-driver-name-checking.patch
     ./0019-systemctl-edit-suggest-systemdctl-edit-runtime-on-sy.patch
+  ] ++ lib.optional (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isGnu) [
     ./0020-timesyncd-disable-NSCD-when-DNSSEC-validation-is-dis.patch
   ] ++ lib.optional stdenv.hostPlatform.isMusl (
     let


### PR DESCRIPTION
PR #239201 broke systemd for musl.

Targets master despite a build dependency on #278994, which is unavailable in master [yet](https://nixpk.gs/pr-tracker.html?pr=278994).

Fixes: https://github.com/NixOS/nixpkgs/issues/280738

Co-authored-by: @nesteroff @yu-re-ka

Supersedes 281068 (mass notification issue).