### PR TITLE
Allow redeploying to interactive tests

### DIFF
--- a/nixos/doc/manual/development/running-nixos-tests-interactively.section.md
+++ b/nixos/doc/manual/development/running-nixos-tests-interactively.section.md
@@ -24,6 +24,23 @@ back into the test driver command line upon its completion. This allows
 you to inspect the state of the VMs after the test (e.g. to debug the
 test script).
 
+## Separating outputs {#sec-nixos-test-separating-outputs}
+
+Logs from the running virtual machines get output in-line and can be disruptive
+while using the python REPL. You can separate these streams by redirecting
+stderr:
+
+```ShellSession
+$ ./result/bin/nixos-test-driver 2>machine_output`
+[...]
+````
+
+and to see the output live in another terminal:
+
+```ShellSession
+$ less -F machine_output
+```
+
 ## Shell access in interactive mode {#sec-nixos-test-shell-access}
 
 The function `<yourmachine>.shell_interact()` grants access to a shell running
@@ -89,6 +106,35 @@ $ ./result/bin/nixos-test-driver --keep-vm-state
 
 The machine state is stored in the `$TMPDIR/vm-state-machinename`
 directory.
+
+## Rebuilding the test / redeploying the VMs {#sec-nixos-test-rebuild}
+
+When you change the VM configurations, you can update the running interactive
+driver and redeploy to those machines without restarting. The `rebuild()`
+command at the python REPL will update the running driver based on the
+executable produced by the command provided.
+
+```py
+>>> rebuild("nix-build . -A nixosTests.login.driverInteractive")
+```
+
+By default the new `nixos-test-driver` executable is assumed to be located at
+the same place the running driver was launched from. This works because the
+`reuslt/` symlink is updated to point at the new derivation. If needed, the path
+can be overridden with the `exe` parameter to `rebuild()`.
+
+You can also specify the rebuild command at the command line when the driver is
+first launched. Then `rebuild()` can be called without arguments.
+
+```ShellSession
+$ build_cmd="nix-build . -A nixosTests.login.driverInteractive"
+$ $build_cmd
+$ ./result/bin/nixos-test-driver --rebuild-cmd $build_cmd 2>machine_output
+>>> start_all()
+[test edited in another window]
+>>> rebuild()
+[new configurations deployed to VMs]
+```
 
 ## Interactive-only test configuration {#sec-nixos-test-interactive-configuration}
 

--- a/nixos/doc/manual/development/running-nixos-tests-interactively.section.md
+++ b/nixos/doc/manual/development/running-nixos-tests-interactively.section.md
@@ -98,30 +98,25 @@ command at the python REPL will update the running driver based on the
 executable produced by the command provided.
 
 ```py
->>> rebuild("nix-build . -A nixosTests.login.driverInteractive", exe="./result/bin/nixos-test-driver")
+>>> rebuild("nix-build . -A nixosTests.login.driverInteractive")
 ```
 
-You can also specify the arguments at the command line when the driver is first
-launched. Then `rebuild()` can be called without arguments.
+By default the new `nixos-test-driver` executable is assumed to be located at
+the same place the running driver was launched from. This works when the
+`result/` symlink is updated to point at the new derivation output. If needed, the path
+can be overridden with the `exe` parameter to `rebuild()`.
+
+You can also specify the rebuild command at the command line when the driver is
+first launched. Then `rebuild()` can be called without arguments.
 
 ```ShellSession
 $ build_cmd="nix-build . -A nixosTests.login.driverInteractive"
-$ exe="./result/bin/nixos-test-driver"
 $ eval $build_cmd
-$ eval $exe --rebuild-cmd "$build_cmd" --rebuild-exe "$exe"
+$ ./result/bin/nixos-test-driver --rebuild-cmd "$build_cmd"
 >>> start_all()
 [test edited in another window]
 >>> rebuild()
 [new configurations deployed to VMs]
-```
-
-Or using the special `rebuildCmd` and `rebuildExe` environment variables:
-
-```ShellSession
-$ export rebuildCmd="nix-build . -A nixosTests.login.driverInteractive"
-$ export rebuildExe="./result/bin/nixos-test-driver"
-$ eval $rebuildCmd && eval $rebuildExe
->>> rebuild()
 ```
 
 ## Interactive-only test configuration {#sec-nixos-test-interactive-configuration}

--- a/nixos/doc/manual/development/running-nixos-tests-interactively.section.md
+++ b/nixos/doc/manual/development/running-nixos-tests-interactively.section.md
@@ -98,25 +98,30 @@ command at the python REPL will update the running driver based on the
 executable produced by the command provided.
 
 ```py
->>> rebuild("nix-build . -A nixosTests.login.driverInteractive")
+>>> rebuild("nix-build . -A nixosTests.login.driverInteractive", exe="./result/bin/nixos-test-driver")
 ```
 
-By default the new `nixos-test-driver` executable is assumed to be located at
-the same place the running driver was launched from. This works when the
-`result/` symlink is updated to point at the new derivation output. If needed, the path
-can be overridden with the `exe` parameter to `rebuild()`.
-
-You can also specify the rebuild command at the command line when the driver is
-first launched. Then `rebuild()` can be called without arguments.
+You can also specify the arguments at the command line when the driver is first
+launched. Then `rebuild()` can be called without arguments.
 
 ```ShellSession
 $ build_cmd="nix-build . -A nixosTests.login.driverInteractive"
+$ exe="./result/bin/nixos-test-driver"
 $ eval $build_cmd
-$ ./result/bin/nixos-test-driver --rebuild-cmd "$build_cmd"
+$ eval $exe --rebuild-cmd "$build_cmd" --rebuild-exe "$exe"
 >>> start_all()
 [test edited in another window]
 >>> rebuild()
 [new configurations deployed to VMs]
+```
+
+Or using the special `rebuildCmd` and `rebuildExe` environment variables:
+
+```ShellSession
+$ export rebuildCmd="nix-build . -A nixosTests.login.driverInteractive"
+$ export rebuildExe="./result/bin/nixos-test-driver"
+$ eval $rebuildCmd && eval $rebuildExe
+>>> rebuild()
 ```
 
 ## Interactive-only test configuration {#sec-nixos-test-interactive-configuration}

--- a/nixos/doc/manual/development/running-nixos-tests-interactively.section.md
+++ b/nixos/doc/manual/development/running-nixos-tests-interactively.section.md
@@ -128,7 +128,7 @@ first launched. Then `rebuild()` can be called without arguments.
 
 ```ShellSession
 $ build_cmd="nix-build . -A nixosTests.login.driverInteractive"
-$ $build_cmd
+$ eval $build_cmd
 $ ./result/bin/nixos-test-driver --rebuild-cmd $build_cmd 2>machine_output
 >>> start_all()
 [test edited in another window]

--- a/nixos/doc/manual/development/running-nixos-tests-interactively.section.md
+++ b/nixos/doc/manual/development/running-nixos-tests-interactively.section.md
@@ -119,8 +119,8 @@ executable produced by the command provided.
 ```
 
 By default the new `nixos-test-driver` executable is assumed to be located at
-the same place the running driver was launched from. This works because the
-`reuslt/` symlink is updated to point at the new derivation. If needed, the path
+the same place the running driver was launched from. This works when the
+`result/` symlink is updated to point at the new derivation output. If needed, the path
 can be overridden with the `exe` parameter to `rebuild()`.
 
 You can also specify the rebuild command at the command line when the driver is

--- a/nixos/doc/manual/development/running-nixos-tests-interactively.section.md
+++ b/nixos/doc/manual/development/running-nixos-tests-interactively.section.md
@@ -129,7 +129,7 @@ first launched. Then `rebuild()` can be called without arguments.
 ```ShellSession
 $ build_cmd="nix-build . -A nixosTests.login.driverInteractive"
 $ eval $build_cmd
-$ ./result/bin/nixos-test-driver --rebuild-cmd $build_cmd 2>machine_output
+$ ./result/bin/nixos-test-driver --rebuild-cmd "$build_cmd" 2>machine_output
 >>> start_all()
 [test edited in another window]
 >>> rebuild()

--- a/nixos/doc/manual/development/running-nixos-tests-interactively.section.md
+++ b/nixos/doc/manual/development/running-nixos-tests-interactively.section.md
@@ -24,23 +24,6 @@ back into the test driver command line upon its completion. This allows
 you to inspect the state of the VMs after the test (e.g. to debug the
 test script).
 
-## Separating outputs {#sec-nixos-test-separating-outputs}
-
-Logs from the running virtual machines get output in-line and can be disruptive
-while using the python REPL. You can separate these streams by redirecting
-stderr:
-
-```ShellSession
-$ ./result/bin/nixos-test-driver 2>machine_output`
-[...]
-````
-
-and to see the output live in another terminal:
-
-```ShellSession
-$ less -F machine_output
-```
-
 ## Shell access in interactive mode {#sec-nixos-test-shell-access}
 
 The function `<yourmachine>.shell_interact()` grants access to a shell running
@@ -129,7 +112,7 @@ first launched. Then `rebuild()` can be called without arguments.
 ```ShellSession
 $ build_cmd="nix-build . -A nixosTests.login.driverInteractive"
 $ eval $build_cmd
-$ ./result/bin/nixos-test-driver --rebuild-cmd "$build_cmd" 2>machine_output
+$ ./result/bin/nixos-test-driver --rebuild-cmd "$build_cmd"
 >>> start_all()
 [test edited in another window]
 >>> rebuild()

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -759,6 +759,8 @@
 
 - `nixos-firewall-tool` now supports nftables in addition to iptables and is installed by default when NixOS firewall is enabled.
 
+- NixOS tests can now be rebuilt/redeployed with the `rebuild()` command when running interactively.
+
 - Support for *runner registration tokens* has been [deprecated](https://gitlab.com/gitlab-org/gitlab/-/issues/380872)
   in `gitlab-runner` 15.6 and is expected to be removed in `gitlab-runner` 18.0. Configuration of existing runners
   should be changed to using *runner authentication tokens* by configuring

--- a/nixos/lib/test-driver/test_driver/__init__.py
+++ b/nixos/lib/test-driver/test_driver/__init__.py
@@ -103,14 +103,30 @@ def main() -> None:
         type=Path,
     )
     arg_parser.add_argument(
-        "testscript",
+        "--testscript",
         action=EnvDefault,
         envvar="testScript",
         help="the test script to run",
         type=Path,
     )
+    arg_parser.add_argument(
+        # TODO: pick a name for this
+        "--internal-print-update-driver-info-and-exit",
+        action="store_true",
+        # For internal use. Don't print help text.
+        help=argparse.SUPPRESS,
+    )
 
     args = arg_parser.parse_args()
+
+    # print the info needed to update another Driver
+    # TODO: properly escape these arguments
+    if args.internal_print_update_driver_info_and_exit:
+        print(*args.start_scripts)
+        print(*args.vlans)
+        print(args.testscript)
+        print(args.output_directory)
+        exit(0)
 
     output_directory = args.output_directory.resolve()
     logger = CompositeLogger([TerminalLogger()])

--- a/nixos/lib/test-driver/test_driver/__init__.py
+++ b/nixos/lib/test-driver/test_driver/__init__.py
@@ -110,7 +110,13 @@ def main() -> None:
         type=Path,
     )
     arg_parser.add_argument(
-        # TODO: pick a name for this
+        "--rebuild-cmd",
+        action=EnvDefault,
+        envvar="rebuildCmd",
+        help="When running the driver interactively, this command builds a new version of the driver when rebuild() is called",
+        type=str,
+    )
+    arg_parser.add_argument(
         "--internal-print-update-driver-info-and-exit",
         action="store_true",
         # For internal use. Don't print help text.
@@ -140,6 +146,9 @@ def main() -> None:
     if not args.keep_vm_state:
         logger.info("Machine state will be reset. To keep it, pass --keep-vm-state")
 
+    if args.rebuild_cmd and args.interactive:
+        logger.warning("--rebuild-cmd is not useful outside of interactive mode")
+
     with Driver(
         args.start_scripts,
         args.vlans,
@@ -148,6 +157,7 @@ def main() -> None:
         logger,
         args.keep_vm_state,
         args.global_timeout,
+        args.rebuild_cmd,
     ) as driver:
         if args.interactive:
             history_dir = os.getcwd()

--- a/nixos/lib/test-driver/test_driver/__init__.py
+++ b/nixos/lib/test-driver/test_driver/__init__.py
@@ -112,6 +112,13 @@ def main() -> None:
         type=str,
     )
     arg_parser.add_argument(
+        "--rebuild-exe",
+        action=EnvDefault,
+        envvar="rebuildExe",
+        help="When running the driver interactively, rebuild() will execute this to find out new driver information. It should be behind a symlink.",
+        type=str,
+    )
+    arg_parser.add_argument(
         "--internal-print-update-driver-info-and-exit",
         action="store_true",
         # For internal use. Don't print help text.
@@ -150,6 +157,8 @@ def main() -> None:
 
     if args.rebuild_cmd and not args.interactive:
         logger.warning("--rebuild-cmd is not useful outside of interactive mode")
+    if args.rebuild_exe and not args.interactive:
+        logger.warning("--rebuild-exe is not useful outside of interactive mode")
 
     with Driver(
         args.start_scripts,
@@ -160,6 +169,7 @@ def main() -> None:
         args.keep_vm_state,
         args.global_timeout,
         args.rebuild_cmd,
+        args.rebuild_exe,
     ) as driver:
         if args.interactive:
             history_dir = os.getcwd()

--- a/nixos/lib/test-driver/test_driver/driver.py
+++ b/nixos/lib/test-driver/test_driver/driver.py
@@ -140,8 +140,7 @@ class Driver:
 
         with self.logger.nested("updating machines"):
             start_cmds = [
-                NixStartScript(start_script)
-                for start_script in start_scripts.split(" ")
+                NixStartScript(start_script) for start_script in start_scripts.split()
             ]
             names = [start_cmd.machine_name for start_cmd in start_cmds]
 
@@ -201,7 +200,6 @@ class Driver:
                         f"{start_cmd.machine_name} has multiple instances. This shouldn't be possible, but either way it's now ambiguous which to update."
                     )
 
-        # XXX: something's going wrong here
         with self.logger.nested("updating vlans"):
             nrs = list(set([int(vlan) for vlan in vlans_str.split(" ")]))
             to_del = []

--- a/nixos/lib/test-driver/test_driver/driver.py
+++ b/nixos/lib/test-driver/test_driver/driver.py
@@ -197,7 +197,7 @@ class Driver:
                             machine.start_command = start_cmd
                 else:
                     self.logger.warning(
-                        f"{start_cmd.machine_name} has multiple instances. This shouldn't be possible, but either way it's now ambiguous which to update."
+                        f"Skipping the update of {start_cmd.machine_name}, because it has multiple instances. This shouldn't be possible, but either way it's now ambiguous which to update."
                     )
 
         with self.logger.nested("updating vlans"):

--- a/nixos/lib/test-driver/test_driver/driver.py
+++ b/nixos/lib/test-driver/test_driver/driver.py
@@ -123,7 +123,8 @@ class Driver:
         if cmd is None:
             cmd = self.rebuild_cmd
         if cmd is not None:
-            subprocess.run(cmd, shell=True, check=True)
+            with self.logger.nested(f"rebuilding test with `{cmd}`"):
+                subprocess.run(cmd, shell=True, check=True, stdout=sys.stderr.buffer)
 
         tmp_dir = get_tmp_dir()
 

--- a/nixos/lib/test-driver/test_driver/driver.py
+++ b/nixos/lib/test-driver/test_driver/driver.py
@@ -231,7 +231,7 @@ class Driver:
                                 machine.start_command = start_cmd
                 else:
                     self.logger.error(
-                        f"Skipping the update of {start_cmd.machine_name}, because there are mltiple machines with that name. This shouldn't be possible, and is an error in the testing framework."
+                        f"Skipping the update of {start_cmd.machine_name}, because there are multiple machines with that name. This shouldn't be possible, and is an error in the testing framework."
                     )
 
         with self.logger.nested("updating vlans"):

--- a/nixos/lib/test-driver/test_driver/driver.py
+++ b/nixos/lib/test-driver/test_driver/driver.py
@@ -186,7 +186,7 @@ class Driver:
                         with self.logger.nested(
                             f"{start_cmd.machine_name} updated. switching to new configuration"
                         ):
-                            # TODO: assuming things are at well-known paths isn't great
+                            machine.succeed(f"ls {start_cmd._cmd}")
                             switch_cmd = (
                                 Path(start_cmd._cmd).parent.parent
                                 / "system"
@@ -217,11 +217,10 @@ class Driver:
                 if nr not in old_nrs:
                     self.vlans.append(VLan(nr, tmp_dir, self.logger))
 
-        # if the test script has already been run we can't post-hoc modify the actions, but we can at least update the script
         new_tests = Path(testscript).read_text()
         if new_tests != self.tests:
             self.tests = Path(testscript).read_text()
-            self.logger.info("test script updated")
+            self.logger.info("Test script updated. We cannot post-hoc modify anything caused by running test_script(), but if you run it now it will reflect the new version.")
 
         # we can't copy the existing outputs over to the new directory because there might be other files mixed in (and usually is)
         new_out_dir = Path(output_directory)

--- a/nixos/lib/test-driver/test_driver/driver.py
+++ b/nixos/lib/test-driver/test_driver/driver.py
@@ -175,9 +175,9 @@ class Driver:
             for idx, machine in enumerate(self.machines):
                 py_name = pythonize_name(machine.name)
                 if machine.name not in names:
-                    if machine.is_up():
+                    if machine.booted:
                         self.logger.warning(
-                            f"{machine.name} removed from the test, but it's running so we're not going to shut it down automatically. Call {py_name}.stop() and re-run rebuild() to remove."
+                            f"skipping removal of {machine.name} from the test, because it's running. Call {py_name}.shutdown() and re-run rebuild() to remove."
                         )
                     else:
                         to_del.append(idx)

--- a/nixos/lib/testing/driver.nix
+++ b/nixos/lib/testing/driver.nix
@@ -90,7 +90,7 @@ let
         ''}
 
         # set defaults through environment
-        # see: ./test-driver/test-driver.py argparse implementation
+        # see: nixos/lib/test-driver/test_driver/__init__.py argparse implementation
         wrapProgram $out/bin/nixos-test-driver \
           --set startScripts "''${vmStartScripts[*]}" \
           --set testScript "$out/test-script" \

--- a/nixos/lib/testing/driver.nix
+++ b/nixos/lib/testing/driver.nix
@@ -97,6 +97,13 @@ let
           --set globalTimeout "${toString config.globalTimeout}" \
           --set vlans '${toString vlans}' \
           ${lib.escapeShellArgs (lib.concatMap (arg: ["--add-flags" arg]) config.extraDriverArgs)}
+
+        # `--set rebuildExe $0` would substitute $0 when wrapProgram is called
+        # `--set rebuildExe '$0'` would set rebuildExe to the literal string '$0'
+        # wrapProgram doesn't have a mechanism for setting one variable to the
+        # value of another variable at runtime. So we use sed to add
+        # `export rebuildExe="$0"` to the second-to-last line of the file (before exec)
+        sed -i "$(wc -l < $out/bin/nixos-test-driver)"'i\export rebuildExe="$0"\' $out/bin/nixos-test-driver
       '';
 
 in

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -88,6 +88,7 @@ in {
   # Testing the test driver
   nixos-test-driver = {
     extra-python-packages = handleTest ./nixos-test-driver/extra-python-packages.nix {};
+    interactive-redeploy = pkgs.callPackage ./nixos-test-driver/interactive-redeploy.nix {};
     lib-extend = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./nixos-test-driver/lib-extend.nix {};
     node-name = runTest ./nixos-test-driver/node-name.nix;
     busybox = runTest ./nixos-test-driver/busybox.nix;

--- a/nixos/tests/nixos-test-driver/interactive-redeploy.nix
+++ b/nixos/tests/nixos-test-driver/interactive-redeploy.nix
@@ -1,0 +1,115 @@
+{
+  expect,
+  runCommand,
+  testers,
+  writeScript,
+}:
+let
+  test0 = testers.runNixOSTest {
+    name = "test-nixos-test-driver-interactive-redeploy-0";
+    nodes.machine = { config, pkgs, ... }: {
+      environment.etc."custom-test-marker".text = "test-0";
+    };
+    testScript = ''
+      start_all()
+      machine.wait_for_unit("multi-user.target")
+      machine.succeed("[[ $(cat /etc/custom-test-marker | tee /dev/stderr) == test-0 ]]")
+    '';
+  };
+  test1 = testers.runNixOSTest {
+    name = "test-nixos-test-driver-interactive-redeploy-1";
+    nodes.machine = { config, pkgs, ... }: {
+      environment.etc."custom-test-marker".text = "test-1";
+    };
+    testScript = ''
+      start_all()
+      machine.wait_for_unit("multi-user.target")
+      machine.succeed("[[ $(cat /etc/custom-test-marker | tee /dev/stderr) == test-1 ]]")
+    '';
+  };
+in
+runCommand "test-nixos-test-driver-interactive-redeploy" {
+  requiredSystemFeatures = ["nixos-test" "kvm"];
+  nativeBuildInputs = [ expect ];
+  passthru = {
+    inherit test0 test1;
+  };
+  expectScript = writeScript "test-nixos-test-driver-interactive-redeploy.expect" ''
+    proc log_header {message} {
+      send_user "\n================================================\n"
+      send_user "  $message\n"
+      send_user "================================================\n"
+    }
+
+    log_header "STARTING INTERACTIVE TEST DRIVER"
+
+    spawn ./result/bin/nixos-test-driver
+    log_user 1
+    set timeout 60
+
+    set test_script_sent 0
+
+    expect {
+      ">>>" {
+        log_header "STARTING TEST SCRIPT (test0)"
+        send "test_script()\r"
+      }
+      "Traceback" { puts "test-nixos-test-driver-interactive-redeploy unexpected errore"; exit 1 }
+      default { puts "unexpected output"; exit 1 }
+      timeout { puts "test-nixos-test-driver-interactive-redeploy timed out while waiting for prompt"; exit 1 }
+    }
+
+    expect {
+      "finished: run the VM test script" {
+      }
+      "Traceback" { puts "test-nixos-test-driver-interactive-redeploy unexpected errore"; exit 1 }
+      timeout { puts "test-nixos-test-driver-interactive-redeploy timed out while waiting for test_script()"; exit 1 }
+    }
+
+    log_header "REDEPLOYING"
+
+    # Docs example: nix-build . -A nixosTests.login.driverInteractive
+    send "rebuild(\"rm result; mv test1 result\")\r"
+
+    expect {
+      "finished: updating machines" { }
+      "Traceback" { puts "test-nixos-test-driver-interactive-redeploy unexpected errore"; exit 1 }
+      timeout { puts "test-nixos-test-driver-interactive-redeploy timed out while waiting for rebuild()"; exit 1 }
+    }
+
+    log_header "STARTING TEST SCRIPT (test1)"
+
+    send "test_script()\r"
+
+    expect {
+      "== test-1" { }
+      "Traceback" { puts "test-nixos-test-driver-interactive-redeploy unexpected errore"; exit 1 }
+      timeout { puts "test-nixos-test-driver-interactive-redeploy timed out while waiting for test output"; exit 1 }
+    }
+
+    expect {
+      "finished: run the VM test script" {
+      }
+      "Traceback" { puts "test-nixos-test-driver-interactive-redeploy unexpected errore"; exit 1 }
+      timeout { puts "test-nixos-test-driver-interactive-redeploy timed out while waiting for test_script()"; exit 1 }
+    }
+
+    log_header "EXITING"
+
+    send "exit\r"
+
+    expect {
+      eof { }
+      default { exp_continue }
+      timeout { puts "test-nixos-test-driver-interactive-redeploy timed out while waiting for exit"; exit 1 }
+    }
+
+    log_header "PASSED"
+  '';
+}
+''
+  ln -s ${test0.driverInteractive} result
+  ln -s ${test1.driverInteractive} test1
+  expect $expectScript
+  touch $out
+''

--- a/nixos/tests/nixos-test-driver/interactive-redeploy.nix
+++ b/nixos/tests/nixos-test-driver/interactive-redeploy.nix
@@ -12,9 +12,12 @@ let
       {
         environment.etc."custom-test-marker".text = "test-0";
         environment.systemPackages = with pkgs; [ getent ];
-        virtualisation.vlans = [ 1 2 ];
+        virtualisation.vlans = [
+          1
+          2
+        ];
       };
-    nodes.dud = {};
+    nodes.dud = { };
     testScript = ''
       start_all()
       machine.wait_for_unit("multi-user.target")
@@ -35,7 +38,10 @@ let
       {
         environment.etc."custom-test-marker".text = "test-1";
         environment.systemPackages = with pkgs; [ getent ];
-        virtualisation.vlans = [ 1 3 ];
+        virtualisation.vlans = [
+          1
+          3
+        ];
       };
     testScript = ''
       start_all()

--- a/nixos/tests/nixos-test-driver/interactive-redeploy.nix
+++ b/nixos/tests/nixos-test-driver/interactive-redeploy.nix
@@ -7,9 +7,11 @@
 let
   test0 = testers.runNixOSTest {
     name = "test-nixos-test-driver-interactive-redeploy-0";
-    nodes.machine = { config, pkgs, ... }: {
-      environment.etc."custom-test-marker".text = "test-0";
-    };
+    nodes.machine =
+      { config, pkgs, ... }:
+      {
+        environment.etc."custom-test-marker".text = "test-0";
+      };
     testScript = ''
       start_all()
       machine.wait_for_unit("multi-user.target")
@@ -18,9 +20,11 @@ let
   };
   test1 = testers.runNixOSTest {
     name = "test-nixos-test-driver-interactive-redeploy-1";
-    nodes.machine = { config, pkgs, ... }: {
-      environment.etc."custom-test-marker".text = "test-1";
-    };
+    nodes.machine =
+      { config, pkgs, ... }:
+      {
+        environment.etc."custom-test-marker".text = "test-1";
+      };
     testScript = ''
       start_all()
       machine.wait_for_unit("multi-user.target")
@@ -28,88 +32,92 @@ let
     '';
   };
 in
-runCommand "test-nixos-test-driver-interactive-redeploy" {
-  requiredSystemFeatures = ["nixos-test" "kvm"];
-  nativeBuildInputs = [ expect ];
-  passthru = {
-    inherit test0 test1;
-  };
-  expectScript = writeScript "test-nixos-test-driver-interactive-redeploy.expect" ''
-    proc log_header {message} {
-      send_user "\n================================================\n"
-      send_user "  $message\n"
-      send_user "================================================\n"
-    }
-
-    log_header "STARTING INTERACTIVE TEST DRIVER"
-
-    spawn ./result/bin/nixos-test-driver
-    log_user 1
-    set timeout 60
-
-    set test_script_sent 0
-
-    expect {
-      ">>>" {
-        log_header "STARTING TEST SCRIPT (test0)"
-        send "test_script()\r"
+runCommand "test-nixos-test-driver-interactive-redeploy"
+  {
+    requiredSystemFeatures = [
+      "nixos-test"
+      "kvm"
+    ];
+    nativeBuildInputs = [ expect ];
+    passthru = {
+      inherit test0 test1;
+    };
+    expectScript = writeScript "test-nixos-test-driver-interactive-redeploy.expect" ''
+      proc log_header {message} {
+        send_user "\n================================================\n"
+        send_user "  $message\n"
+        send_user "================================================\n"
       }
-      "Traceback" { puts "test-nixos-test-driver-interactive-redeploy unexpected errore"; exit 1 }
-      default { puts "unexpected output"; exit 1 }
-      timeout { puts "test-nixos-test-driver-interactive-redeploy timed out while waiting for prompt"; exit 1 }
-    }
 
-    expect {
-      "finished: run the VM test script" {
+      log_header "STARTING INTERACTIVE TEST DRIVER"
+
+      spawn ./result/bin/nixos-test-driver
+      log_user 1
+      set timeout 60
+
+      set test_script_sent 0
+
+      expect {
+        ">>>" {
+          log_header "STARTING TEST SCRIPT (test0)"
+          send "test_script()\r"
+        }
+        "Traceback" { puts "test-nixos-test-driver-interactive-redeploy unexpected error"; exit 1 }
+        default { puts "unexpected output"; exit 1 }
+        timeout { puts "test-nixos-test-driver-interactive-redeploy timed out while waiting for prompt"; exit 1 }
       }
-      "Traceback" { puts "test-nixos-test-driver-interactive-redeploy unexpected errore"; exit 1 }
-      timeout { puts "test-nixos-test-driver-interactive-redeploy timed out while waiting for test_script()"; exit 1 }
-    }
 
-    log_header "REDEPLOYING"
-
-    # Docs example: nix-build . -A nixosTests.login.driverInteractive
-    send "rebuild(\"rm result; mv test1 result\")\r"
-
-    expect {
-      "finished: updating machines" { }
-      "Traceback" { puts "test-nixos-test-driver-interactive-redeploy unexpected errore"; exit 1 }
-      timeout { puts "test-nixos-test-driver-interactive-redeploy timed out while waiting for rebuild()"; exit 1 }
-    }
-
-    log_header "STARTING TEST SCRIPT (test1)"
-
-    send "test_script()\r"
-
-    expect {
-      "== test-1" { }
-      "Traceback" { puts "test-nixos-test-driver-interactive-redeploy unexpected errore"; exit 1 }
-      timeout { puts "test-nixos-test-driver-interactive-redeploy timed out while waiting for test output"; exit 1 }
-    }
-
-    expect {
-      "finished: run the VM test script" {
+      expect {
+        "finished: run the VM test script" {
+        }
+        "Traceback" { puts "test-nixos-test-driver-interactive-redeploy unexpected error"; exit 1 }
+        timeout { puts "test-nixos-test-driver-interactive-redeploy timed out while waiting for test_script()"; exit 1 }
       }
-      "Traceback" { puts "test-nixos-test-driver-interactive-redeploy unexpected errore"; exit 1 }
-      timeout { puts "test-nixos-test-driver-interactive-redeploy timed out while waiting for test_script()"; exit 1 }
-    }
 
-    log_header "EXITING"
+      log_header "REDEPLOYING"
 
-    send "exit\r"
+      # Docs example: nix-build . -A nixosTests.login.driverInteractive
+      send "rebuild(\"rm result; mv test1 result\")\r"
 
-    expect {
-      eof { }
-      default { exp_continue }
-      timeout { puts "test-nixos-test-driver-interactive-redeploy timed out while waiting for exit"; exit 1 }
-    }
+      expect {
+        "finished: updating machines" { }
+        "Traceback" { puts "test-nixos-test-driver-interactive-redeploy unexpected error"; exit 1 }
+        timeout { puts "test-nixos-test-driver-interactive-redeploy timed out while waiting for rebuild()"; exit 1 }
+      }
 
-    log_header "PASSED"
-  '';
-}
-''
-  ln -s ${test0.driverInteractive} result
-  ln -s ${test1.driverInteractive} test1
-  expect $expectScript
-  touch $out
-''
+      log_header "STARTING TEST SCRIPT (test1)"
+
+      send "test_script()\r"
+
+      expect {
+        "== test-1" { }
+        "Traceback" { puts "test-nixos-test-driver-interactive-redeploy unexpected error"; exit 1 }
+        timeout { puts "test-nixos-test-driver-interactive-redeploy timed out while waiting for test output"; exit 1 }
+      }
+
+      expect {
+        "finished: run the VM test script" {
+        }
+        "Traceback" { puts "test-nixos-test-driver-interactive-redeploy unexpected error"; exit 1 }
+        timeout { puts "test-nixos-test-driver-interactive-redeploy timed out while waiting for test_script()"; exit 1 }
+      }
+
+      log_header "EXITING"
+
+      send "exit\r"
+
+      expect {
+        eof { }
+        default { exp_continue }
+        timeout { puts "test-nixos-test-driver-interactive-redeploy timed out while waiting for exit"; exit 1 }
+      }
+
+      log_header "PASSED"
+    '';
+  }
+  ''
+    ln -s ${test0.driverInteractive} result
+    ln -s ${test1.driverInteractive} test1
+    expect $expectScript
+    touch $out
+  ''


### PR DESCRIPTION
## Description of changes

- [x] adds a `rebuild()` command to the NixOS testing driver, that will rebuild the test and push any changes to running VMs
- [x] adds a `--rebuild-cmd` flag to the driver to specify what command rebuilds the test (can also be passed directly to `rebuild()`
- [x] adds a `--internal-print-update-driver-info-and-exit` flag to the driver that will just print the information needed to update another driver.
- [x] document the changes
- [x] do more extensive stress-testing
  - [x] adding machines
  - [x] removing machines
  - [x] multi-machine configs
    - [x] adding one machine and removing another
    - [x] removing a machine changes the other machines' configs accordingly
  - [x] changing vlans
  - [x] changing `testScript`

Bugs
- [x] The vlans are getting updated on every `rebuild()` for some reason

This PR has been reworked since it's original formulation. See below for the original text.

<details>
<summary>Original PR description</summary>

- [x] adds a command to the output of `driverInteractive`, as well as in its own output `redeploy`, which will deploy the current test machine configuration to an actively running `driverInteractive`
- [x] Adds an extra machine to `driverInteractive` which serves as a jump host so that the user can ssh into machines in the test (including to do the redeploy).
- [x] Adds an ssh config to the output of `driverInteractive`, as well as in its own output `sshConfig` to take advantage of that jump host. This can be used with `ssh -F ./result/ssh_config`
- [ ] document changes (haven't yet done. waiting for feedback)
- [ ] automatically start jump host. Currently this setup requires the manual step of running `redeploy_jumphost.start()` after starting the interactive driver (couldn't figure out how to do this. does anyone have ideas?)
</details>

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
