### PR TITLE
umr: unstable-2022-08-23 -> 1.0.8

### DIFF
--- a/pkgs/development/misc/umr/default.nix
+++ b/pkgs/development/misc/umr/default.nix
@@ -14,6 +14,8 @@
 , ncurses
 , SDL2
 , bash-completion
+
+, nix-update-script
 }:
 
 stdenv.mkDerivation rec {
@@ -49,6 +51,8 @@ stdenv.mkDerivation rec {
   postInstall = ''
     rm -r $out/lib
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "A userspace debugging and diagnostic tool for AMD GPUs";

--- a/pkgs/development/misc/umr/default.nix
+++ b/pkgs/development/misc/umr/default.nix
@@ -1,28 +1,48 @@
-{ lib, stdenv, fetchgit, bash-completion, cmake, pkg-config
-, json_c, libdrm, libpciaccess, llvmPackages, nanomsg, ncurses, SDL2
+{ lib
+, stdenv
+
+, fetchFromGitLab
+
+, cmake
+, pkg-config
+
+, libdrm
+, mesa # libgbm
+, libpciaccess
+, llvmPackages
+, nanomsg
+, ncurses
+, SDL2
+, bash-completion
 }:
 
 stdenv.mkDerivation rec {
   pname = "umr";
-  version = "unstable-2022-08-23";
+  version = "1.0.8";
 
-  src = fetchgit {
-    url = "https://gitlab.freedesktop.org/tomstdenis/umr";
-    rev = "87f814b1ffdbac8bfddd8529d344a7901cd7e112";
-    hash = "sha256-U1VP1AicSGWzBwzz99i7+3awATZocw5jaqtAxuRNaBE=";
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "tomstdenis";
+    repo = "umr";
+    rev = version;
+    hash = "sha256-ODkTYHDrKWNvjiEeIyfsCByf7hyr5Ps9ytbKb3253bU=";
   };
 
-  nativeBuildInputs = [ cmake pkg-config llvmPackages.llvm.dev ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
 
   buildInputs = [
-    bash-completion
-    json_c
     libdrm
+    mesa
     libpciaccess
     llvmPackages.llvm
     nanomsg
     ncurses
     SDL2
+
+    bash-completion # Tries to create bash-completions in /var/empty otherwise?
   ];
 
   # Remove static libraries (there are no dynamic libraries in there)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18203,9 +18203,7 @@ with pkgs;
 
   publii = callPackage ../development/web/publii {};
 
-  umr = callPackage ../development/misc/umr {
-    llvmPackages = llvmPackages_14;
-  };
+  umr = callPackage ../development/misc/umr { };
 
   refurb = callPackage ../development/tools/refurb { };
 


### PR DESCRIPTION
Fixes the build and uses a stable version

Also switched to the gitlab fetcher, did a bit of cleanup and fixed umrgui

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
