### PR TITLE
python311Packages.pydash: 5.1.1 -> 7.0.6

### DIFF
--- a/pkgs/development/python-modules/pydash/default.nix
+++ b/pkgs/development/python-modules/pydash/default.nix
@@ -1,47 +1,63 @@
-{ stdenv
-, lib
+{ lib
+, stdenv
 , buildPythonPackage
 , fetchFromGitHub
 , invoke
 , mock
 , pytestCheckHook
 , pythonOlder
+, setuptools
 , sphinx-rtd-theme
+, typing-extensions
 }:
 
 buildPythonPackage rec {
   pname = "pydash";
-  version = "5.1.1";
-  format = "pyproject";
+  version = "7.0.6";
+  pyproject = true;
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "dgilland";
-    repo = pname;
-    rev = "v${version}";
-    hash = "sha256-VbuRzKwPMh5S4GZQYnh0sZOBi4LNFjMuol95tMC43b0=";
+    repo = "pydash";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-zwtUdP2fFFE5X0SDkBDetAQbKnZ1v24DGdzN3fQLa0A=";
   };
-
-  nativeCheckInputs = [
-    invoke
-    mock
-    sphinx-rtd-theme
-    pytestCheckHook
-  ];
 
   postPatch = ''
     sed -i "/--cov/d" setup.cfg
     sed -i "/--no-cov/d" setup.cfg
   '';
 
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    invoke
+    mock
+    pytestCheckHook
+    sphinx-rtd-theme
+  ];
+
   pythonImportsCheck = [
     "pydash"
+  ];
+
+  disabledTestPaths = [
+    # Disable mypy testing
+    "tests/pytest_mypy_testing/"
   ];
 
   meta = with lib; {
     description = "Python utility libraries for doing stuff in a functional way";
     homepage = "https://pydash.readthedocs.io";
+    changelog = "https://github.com/dgilland/pydash/blob/v${version}/CHANGELOG.rst";
     license = licenses.mit;
     maintainers = with maintainers; [ ma27 ];
   };

--- a/pkgs/development/python-modules/sphinx-markdown-parser/default.nix
+++ b/pkgs/development/python-modules/sphinx-markdown-parser/default.nix
@@ -1,24 +1,27 @@
-{ stdenv
-, lib
+{ lib
+, stdenv
 , buildPythonPackage
-, fetchFromGitHub
-, sphinx
-, markdown
 , commonmark
-, recommonmark
+, fetchFromGitHub
+, markdown
 , pydash
+, pytestCheckHook
+, pythonOlder
 , pyyaml
+, recommonmark
+, setuptools
+, sphinx
 , unify
 , yapf
-, python
 }:
 
 buildPythonPackage rec {
   pname = "sphinx-markdown-parser";
   version = "0.2.4";
-  format = "setuptools";
+  pyproject = true;
 
-  # PyPi release does not include requirements.txt
+  disabled = pythonOlder "3.8";
+
   src = fetchFromGitHub {
     owner = "clayrisser";
     repo = "sphinx-markdown-parser";
@@ -28,20 +31,44 @@ buildPythonPackage rec {
     sha256 = "0i0hhapmdmh83yx61lxi2h4bsmhnzddamz95844g2ghm132kw5mv";
   };
 
-  propagatedBuildInputs = [ sphinx markdown commonmark pydash pyyaml unify yapf recommonmark ];
+  nativeBuildInputs = [
+    setuptools
+  ];
 
-  # Avoids running broken tests in test_markdown.py
-  checkPhase = ''
-    ${python.interpreter} -m unittest -v tests/test_basic.py tests/test_sphinx.py
-  '';
+  propagatedBuildInputs = [
+    commonmark
+    markdown
+    pydash
+    pyyaml
+    recommonmark
+    unify
+    yapf
+  ];
 
-  pythonImportsCheck = [ "sphinx_markdown_parser" ];
+  buildInputs = [
+    sphinx
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "sphinx_markdown_parser"
+  ];
+
+  disabledTests = [
+    # AssertionError
+    "test_heading"
+    "test_headings"
+    "test_integration"
+  ];
 
   meta = with lib; {
-    broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
     description = "Write markdown inside of docutils & sphinx projects";
     homepage = "https://github.com/clayrisser/sphinx-markdown-parser";
     license = licenses.mit;
     maintainers = with maintainers; [ FlorianFranzen ];
+    broken = (stdenv.isLinux && stdenv.isAarch64) || stdenv.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/unify/default.nix
+++ b/pkgs/development/python-modules/unify/default.nix
@@ -1,26 +1,47 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, pythonOlder
+, setuptools
+, pytestCheckHook
 , untokenize
-, unittestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "unify";
   version = "0.5";
-  format = "setuptools";
+  pyproject = true;
 
-  # PyPi release is missing tests (see https://github.com/myint/unify/pull/18)
+  disabled = pythonOlder "3.9";
+
   src = fetchFromGitHub {
     owner = "myint";
     repo = "unify";
-    rev = "v${version}";
-    sha256 = "1l6xxygaigacsxf0g5f7w5gpqha1ava6mcns81kqqy6vw91pyrbi";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-cWV/Q+LbeIxnQNqyatRWQUF8X+HHlQdc10y9qJ7v3dA=";
   };
 
-  propagatedBuildInputs = [ untokenize ];
+  nativeBuildInputs = [
+    setuptools
+  ];
 
-  nativeCheckInputs = [ unittestCheckHook ];
+  propagatedBuildInputs = [
+    untokenize
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "unify"
+  ];
+
+  disabledTests = [
+    # https://github.com/myint/unify/issues/21
+    "test_format_code"
+    "test_format_code_with_backslash_in_comment"
+  ];
 
   meta = with lib; {
     description = "Modifies strings to all use the same quote where possible";


### PR DESCRIPTION
Diff: https://github.com/dgilland/pydash/compare/refs/tags/v5.1.1...v7.0.6

Changelog: https://github.com/dgilland/pydash/blob/v7.0.6/CHANGELOG.rst

## Description of changes
Fix builds (https://hydra.nixos.org/build/246566920, https://hydra.nixos.org/build/246450363)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
