### PR TITLE
libphonenumber: fix reproducible builds patch

### DIFF
--- a/pkgs/development/libraries/libphonenumber/build-reproducibility.patch
+++ b/pkgs/development/libraries/libphonenumber/build-reproducibility.patch
@@ -1,8 +1,6 @@
-diff --git a/tools/cpp/src/cpp-build/generate_geocoding_data.cc b/tools/cpp/src/cpp-build/generate_geocoding_data.cc
-index 205947e831..1e628e2cd2 100644
---- a/tools/cpp/src/cpp-build/generate_geocoding_data.cc
-+++ b/tools/cpp/src/cpp-build/generate_geocoding_data.cc
-@@ -97,7 +97,8 @@ class DirEntry {
+--- a/tools/cpp/src/cpp-build/generate_geocoding_data.cc.orig	1970-01-01 01:00:01.000000000 +0100
++++ b/tools/cpp/src/cpp-build/generate_geocoding_data.cc	2024-01-16 19:03:45.409089423 +0100
+@@ -94,7 +94,8 @@
    DirEntryKinds kind_;
  };
  
@@ -12,13 +10,19 @@ index 205947e831..1e628e2cd2 100644
  // success.
  bool ListDirectory(const string& path, vector<DirEntry>* entries) {
    entries->clear();
-@@ -135,6 +136,9 @@ bool ListDirectory(const string& path, vector<DirEntry>* entries) {
+@@ -114,8 +115,14 @@
+     // http://pubs.opengroup.org/onlinepubs/9699919799/functions/readdir.html
+     errno = 0;
+     entry = readdir(dir);
++    if (errno != 0) {
++      return false;
++    }
+     if (entry == NULL) {
+-      return errno == 0;
++      std::sort(
++          entries->begin(), entries->end(),
++          [](const DirEntry& a, const DirEntry& b) { return a.name() < b.name(); });
++      return true;
      }
-     entries->push_back(DirEntry(entry->d_name, kind));
-   }
-+  std::sort(
-+      entries->begin(), entries->end(),
-+      [](const DirEntry& a, const DirEntry& b) { return a.name() < b.name(); });
- }
- 
- // Returns true if s ends with suffix.
+     if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
+        continue;

--- a/pkgs/development/libraries/libphonenumber/default.nix
+++ b/pkgs/development/libraries/libphonenumber/default.nix
@@ -12,7 +12,8 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    # Submitted upstream: https://github.com/google/libphonenumber/pull/2921
+    # An earlier version of this patch was submitted upstream but did not get
+    # any interest there - https://github.com/google/libphonenumber/pull/2921
     ./build-reproducibility.patch
   ];
 


### PR DESCRIPTION
## Description of changes

Now actually sorts the directory listings

Fixes https://github.com/NixOS/nixpkgs/issues/276443

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
