### PR TITLE
yosys: 0.36 -> 0.37

### DIFF
--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -77,13 +77,13 @@ let
 
 in stdenv.mkDerivation (finalAttrs: {
   pname   = "yosys";
-  version = "0.36";
+  version = "0.37";
 
   src = fetchFromGitHub {
     owner = "YosysHQ";
     repo  = "yosys";
     rev   = "refs/tags/${finalAttrs.pname}-${finalAttrs.version}";
-    hash  = "sha256-jcaXn77OuKeC3AQTicILP3ABkJ3qBccM+uGbj1wn2Vw=";
+    hash  = "sha256-JRztXMZMBFhdZMeVHkRxFulRrFzyuNaLzcRlmgAz6Gc=";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/development/compilers/yosys/fix-clang-build.patch
+++ b/pkgs/development/compilers/yosys/fix-clang-build.patch
@@ -1,5 +1,3 @@
-diff --git a/Makefile b/Makefile
-index fa95b7b70..4d15ed721 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -215,7 +215,7 @@ ABC_ARCHFLAGS += "-DABC_NO_RLIMIT"
@@ -11,8 +9,17 @@ index fa95b7b70..4d15ed721 100644
  LD = clang++
  CXXFLAGS += -std=$(CXXSTD) -Os
  ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H -Wno-c++11-narrowing $(ABC_ARCHFLAGS)"
-diff --git a/tests/fmt/run-test.sh b/tests/fmt/run-test.sh
-index 914a72347..bc0b129d2 100644
+--- a/tests/cxxrtl/run-test.sh
++++ b/tests/cxxrtl/run-test.sh
+@@ -5,7 +5,7 @@ set -ex
+ run_subtest () {
+     local subtest=$1; shift
+ 
+-    ${CC:-gcc} -std=c++11 -O2 -o cxxrtl-test-${subtest} -I../../backends/cxxrtl/runtime test_${subtest}.cc -lstdc++
++    ${CXX:-gcc} -std=c++11 -O2 -o cxxrtl-test-${subtest} -I../../backends/cxxrtl/runtime test_${subtest}.cc -lstdc++
+     ./cxxrtl-test-${subtest}
+ }
+ 
 --- a/tests/fmt/run-test.sh
 +++ b/tests/fmt/run-test.sh
 @@ -51,7 +51,7 @@ test_cxxrtl () {


### PR DESCRIPTION
## Description of changes
https://github.com/YosysHQ/yosys/releases/tag/yosys-0.37

The change to the patch is needed to fix this error on macOS:
```
+ clang -std=c++11 -O2 -o cxxrtl-test-value -I../../backends/cxxrtl/runtime test_value.cc -lstdc++
test_value.cc:1:10: fatal error: 'cassert' file not found
         ^~~~~~~~~
1 error generated.
make: *** [Makefile:891: test] Error 1
```
@hzeller this update breaks the package `yosys-synlig`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
