### PR TITLE
tests.nixpkgs-check-by-name: Fix for aliases to packages in `pkgs/by-name` and better testing

### DIFF
--- a/pkgs/test/nixpkgs-check-by-name/default.nix
+++ b/pkgs/test/nixpkgs-check-by-name/default.nix
@@ -6,6 +6,7 @@
   clippy,
   mkShell,
   makeWrapper,
+  runCommand,
 }:
 let
   runtimeExprPath = ./src/eval.nix;
@@ -52,6 +53,19 @@ let
         env.NIXPKGS_LIB_PATH = toString nixpkgsLibPath;
         inputsFrom = [ package ];
       };
+
+      # Tests the tool on the current Nixpkgs tree, this is a good sanity check
+      passthru.tests.nixpkgs = runCommand "test-nixpkgs-check-by-name" {
+        nativeBuildInputs = [
+          package
+          nix
+        ];
+        nixpkgsPath = lib.cleanSource ../../..;
+      } ''
+        ${initNix}
+        nixpkgs-check-by-name --base "$nixpkgsPath" "$nixpkgsPath"
+        touch $out
+      '';
     };
 in
 package

--- a/pkgs/test/nixpkgs-check-by-name/default.nix
+++ b/pkgs/test/nixpkgs-check-by-name/default.nix
@@ -10,6 +10,21 @@
 let
   runtimeExprPath = ./src/eval.nix;
   nixpkgsLibPath = ../../../lib;
+
+  # Needed to make Nix evaluation work inside nix builds
+  initNix = ''
+    export TEST_ROOT=$(pwd)/test-tmp
+    export NIX_CONF_DIR=$TEST_ROOT/etc
+    export NIX_LOCALSTATE_DIR=$TEST_ROOT/var
+    export NIX_LOG_DIR=$TEST_ROOT/var/log/nix
+    export NIX_STATE_DIR=$TEST_ROOT/var/nix
+    export NIX_STORE_DIR=$TEST_ROOT/store
+
+    # Ensure that even if tests run in parallel, we don't get an error
+    # We'd run into https://github.com/NixOS/nix/issues/2706 unless the store is initialised first
+    nix-store --init
+  '';
+
   package =
     rustPlatform.buildRustPackage {
       name = "nixpkgs-check-by-name";
@@ -22,21 +37,8 @@ let
         makeWrapper
       ];
       env.NIX_CHECK_BY_NAME_EXPR_PATH = "${runtimeExprPath}";
-      # Needed to make Nix evaluation work inside the nix build
-      preCheck = ''
-        export TEST_ROOT=$(pwd)/test-tmp
-        export NIX_CONF_DIR=$TEST_ROOT/etc
-        export NIX_LOCALSTATE_DIR=$TEST_ROOT/var
-        export NIX_LOG_DIR=$TEST_ROOT/var/log/nix
-        export NIX_STATE_DIR=$TEST_ROOT/var/nix
-        export NIX_STORE_DIR=$TEST_ROOT/store
-
-        export NIXPKGS_LIB_PATH=${nixpkgsLibPath}
-
-        # Ensure that even if tests run in parallel, we don't get an error
-        # We'd run into https://github.com/NixOS/nix/issues/2706 unless the store is initialised first
-        nix-store --init
-      '';
+      env.NIXPKGS_LIB_PATH = "${nixpkgsLibPath}";
+      preCheck = initNix;
       postCheck = ''
         cargo fmt --check
         cargo clippy -- -D warnings

--- a/pkgs/test/nixpkgs-check-by-name/src/nixpkgs_problem.rs
+++ b/pkgs/test/nixpkgs-check-by-name/src/nixpkgs_problem.rs
@@ -88,9 +88,6 @@ pub enum NixpkgsProblem {
         text: String,
         io_error: io::Error,
     },
-    InternalCallPackageUsed {
-        attr_name: String,
-    },
     MovedOutOfByName {
         package_name: String,
         call_package_path: Option<PathBuf>,
@@ -226,11 +223,6 @@ impl fmt::Display for NixpkgsProblem {
                     relative_package_dir.display(),
                     subpath.display(),
                     text,
-                ),
-            NixpkgsProblem::InternalCallPackageUsed { attr_name } =>
-                write!(
-                    f,
-                    "pkgs.{attr_name}: This attribute is defined using `_internalCallByNamePackageFile`, which is an internal function not intended for manual use.",
                 ),
             NixpkgsProblem::MovedOutOfByName { package_name, call_package_path, empty_arg } => {
                 let call_package_arg =

--- a/pkgs/test/nixpkgs-check-by-name/tests/aliases/aliases.nix
+++ b/pkgs/test/nixpkgs-check-by-name/tests/aliases/aliases.nix
@@ -1,0 +1,3 @@
+self: super: {
+  baz = self.foo;
+}

--- a/pkgs/test/nixpkgs-check-by-name/tests/aliases/all-packages.nix
+++ b/pkgs/test/nixpkgs-check-by-name/tests/aliases/all-packages.nix
@@ -1,0 +1,3 @@
+self: super: {
+  bar = self.foo;
+}

--- a/pkgs/test/nixpkgs-check-by-name/tests/aliases/default.nix
+++ b/pkgs/test/nixpkgs-check-by-name/tests/aliases/default.nix
@@ -1,0 +1,1 @@
+import <test-nixpkgs> { root = ./.; }

--- a/pkgs/test/nixpkgs-check-by-name/tests/aliases/pkgs/by-name/fo/foo/package.nix
+++ b/pkgs/test/nixpkgs-check-by-name/tests/aliases/pkgs/by-name/fo/foo/package.nix
@@ -1,0 +1,1 @@
+{ someDrv }: someDrv

--- a/pkgs/test/nixpkgs-check-by-name/tests/internalCallPackage/expected
+++ b/pkgs/test/nixpkgs-check-by-name/tests/internalCallPackage/expected
@@ -1,1 +1,0 @@
-pkgs.foo: This attribute is defined using `_internalCallByNamePackageFile`, which is an internal function not intended for manual use.

--- a/pkgs/test/nixpkgs-check-by-name/tests/mock-nixpkgs.nix
+++ b/pkgs/test/nixpkgs-check-by-name/tests/mock-nixpkgs.nix
@@ -77,12 +77,21 @@ let
     else
       [ ];
 
+  # A list optionally containing the `aliases.nix` file from the test case as an overlay
+  # But only if config.allowAliases is not false
+  optionalAliasesOverlay =
+    if (config.allowAliases or true) && builtins.pathExists (root + "/aliases.nix") then
+      [ (import (root + "/aliases.nix")) ]
+    else
+      [ ];
+
   # All the overlays in the right order, including the user-supplied ones
   allOverlays =
     [
       autoCalledPackages
     ]
     ++ optionalAllPackagesOverlay
+    ++ optionalAliasesOverlay
     ++ overlays;
 
   # Apply all the overlays in order to the base fixed-point function pkgsFun


### PR DESCRIPTION
## Context
In https://github.com/NixOS/nixpkgs/pull/275539 I made an oversight which shows itself when you run the tool on the current Nixpkgs:

```
❯ nix-build -A tests.nixpkgs-check-by-name
/nix/store/k7wwnxbrb2r05g5pw7hxw71gg1gls1dr-nixpkgs-check-by-name
❯ result/bin/nixpkgs-check-by-name --base . .
pkgs.NSPlist: This attribute is defined using `_internalCallByNamePackageFile`, which is an internal function not intended for manual use.
[...]
pkgs.uclibc: This attribute is defined using `_internalCallByNamePackageFile`, which is an internal function not intended for manual use.
pkgs.win-virtio: This attribute is defined using `_internalCallByNamePackageFile`, which is an internal function not intended for manual use.
Validation failed, see above errors
```

See https://github.com/NixOS/nixpkgs/pull/281374 to prevent the broken tooling from being used on master, that should be merged fairly soon before the nixos-unstable channel updates in like a day.

## The problem

The problem is that there's some detection logic that makes sure the [internal `_internalCallByNamePackageFile` attribute](https://github.com/NixOS/nixpkgs/blob/5df0c94c5ed9c4b9664d63047f2f3a7f93c0bb43/pkgs/top-level/by-name-overlay.nix#L49-L55) isn't used by packages.

If such a top-level attribute that's not in `pkgs/by-name` was detected to use this, an error is thrown. However, the detection logic can't distinguish between aliases and non-aliases.

So it gives errors even for aliases to packages defined in `pkgs/by-name`, e.g.
https://github.com/NixOS/nixpkgs/blob/5df0c94c5ed9c4b9664d63047f2f3a7f93c0bb43/pkgs/top-level/aliases.nix#L1099
https://github.com/NixOS/nixpkgs/blob/5df0c94c5ed9c4b9664d63047f2f3a7f93c0bb43/pkgs/top-level/all-packages.nix#L28854

## The solution

It would be non-trivial to improve the detection logic, so instead this PR just changes the tool to not give an error in these cases.

Furthermore, a `passthru.tests` is added, addressing https://github.com/NixOS/nixpkgs/issues/256789 and preventing future such problems. It should be triggered automatically after ofborg finishes evaluation of a PR with a `tests.nixpkgs-check-by-name: ...` commit.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
