### PR TITLE
check-by-name/run-local.sh: Make it usable for non-CI platforms

### DIFF
--- a/.github/workflows/check-by-name.yml
+++ b/.github/workflows/check-by-name.yml
@@ -91,8 +91,12 @@ jobs:
           git worktree add "$base" "$(git rev-parse HEAD^1)"
           echo "base=$base" >> "$GITHUB_ENV"
       - uses: cachix/install-nix-action@7ac1ec25491415c381d9b62f0657c7a028df52a7 # v24
-      - name: Fetching the tool
-        run: pkgs/test/nixpkgs-check-by-name/scripts/fetch-pinned-tool.sh result
+      - name: Fetching the pinned tool
+        run: |
+          # Get the direct /nix/store path from the pin to avoid having to evaluate Nixpkgs
+          toolPath=$(jq -r .ci-path pkgs/test/nixpkgs-check-by-name/scripts/pinned-tool.json)
+          # This asks the substituter for the path, which should be there because Hydra will have pre-built and pushed it
+          nix-store --realise "$toolPath" --add-root result
       - name: Running nixpkgs-check-by-name
         run: |
           if result/bin/nixpkgs-check-by-name --base "$base" .; then

--- a/pkgs/test/nixpkgs-check-by-name/scripts/README.md
+++ b/pkgs/test/nixpkgs-check-by-name/scripts/README.md
@@ -22,12 +22,3 @@ Updates the pinned CI tool in [`./pinned-tool.json`](./pinned-tool.json) to the
 [latest version from the `nixos-unstable` channel](https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.tests.nixpkgs-check-by-name.x86_64-linux)
 
 This script is called manually once the CI tooling needs to be updated.
-
-## `./fetch-pinned-tool.sh OUTPUT_PATH`
-
-Fetches the pinned tooling specified in [`./pinned-tool.json`](./pinned-tool.json).
-
-This script is used both by [`./run-local.sh`](#run-local-sh-base-branch-repository) and CI.
-
-Arguments:
-- `OUTPUT_PATH`: The output symlink path for the tool

--- a/pkgs/test/nixpkgs-check-by-name/scripts/fetch-pinned-tool.sh
+++ b/pkgs/test/nixpkgs-check-by-name/scripts/fetch-pinned-tool.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# Legacy script, can be removed once the PR removing its use is merged.
+# It's not used anymore because CI and local runs both use pinned-tool.json as their source of truth now,
+# though in different ways since local runs need to support arbitrary platforms
+
 # Try to not use nix-shell here to avoid fetching Nixpkgs,
 # especially since this is used in CI
 # The only dependency is `jq`, which in CI is implicitly available
@@ -22,7 +26,7 @@ output=$1
 trace "Reading $pin_file.. "
 rev=$(jq -r .rev "$SCRIPT_DIR"/pinned-tool.json)
 trace -e "Git revision is \e[34m$rev\e[0m"
-path=$(jq -r .path "$SCRIPT_DIR"/pinned-tool.json)
+path=$(jq -r '."ci-path"' "$SCRIPT_DIR"/pinned-tool.json)
 trace "Tooling path is $path"
 
 trace -n "Fetching the prebuilt version of nixpkgs-check-by-name.. "

--- a/pkgs/test/nixpkgs-check-by-name/scripts/pinned-tool.json
+++ b/pkgs/test/nixpkgs-check-by-name/scripts/pinned-tool.json
@@ -1,4 +1,4 @@
 {
   "rev": "9b19f5e77dd906cb52dade0b7bd280339d2a1f3d",
-  "path": "/nix/store/qlls5ca8q88qpyygg9ddi60gl1nmvpij-nixpkgs-check-by-name"
+  "ci-path": "/nix/store/qlls5ca8q88qpyygg9ddi60gl1nmvpij-nixpkgs-check-by-name"
 }

--- a/pkgs/test/nixpkgs-check-by-name/scripts/run-local.sh
+++ b/pkgs/test/nixpkgs-check-by-name/scripts/run-local.sh
@@ -14,6 +14,7 @@ cleanup() {
 
     [[ -e "$tmp/base" ]] && git worktree remove --force "$tmp/base"
     [[ -e "$tmp/merged" ]] && git worktree remove --force "$tmp/merged"
+    [[ -e "$tmp/tool-nixpkgs" ]] && git worktree remove --force "$tmp/tool-nixpkgs"
 
     rm -rf "$tmp"
 
@@ -62,7 +63,20 @@ trace -n "Merging base branch into the HEAD commit in $tmp/merged.. "
 git -C "$tmp/merged" merge -q --no-edit "$baseSha"
 trace -e "\e[34m$(git -C "$tmp/merged" rev-parse HEAD)\e[0m"
 
-"$tmp/merged/pkgs/test/nixpkgs-check-by-name/scripts/fetch-pinned-tool.sh" "$tmp/tool"
+trace -n "Reading pinned nixpkgs-check-by-name revision from pinned-tool.json.. "
+toolSha=$(jq -r .rev "$tmp/merged/pkgs/test/nixpkgs-check-by-name/scripts/pinned-tool.json")
+trace -e "\e[34m$toolSha\e[0m"
+
+trace -n "Creating Git worktree for the nixpkgs-check-by-name revision in $tmp/tool-nixpkgs.. "
+git worktree add -q "$tmp/tool-nixpkgs" "$toolSha"
+trace "Done"
+
+trace "Building/fetching nixpkgs-check-by-name.."
+nix-build -o "$tmp/tool" "$tmp/tool-nixpkgs" \
+    -A tests.nixpkgs-check-by-name \
+    --arg config '{}' \
+    --arg overlays '[]' \
+    -j 0
 
 trace "Running nixpkgs-check-by-name.."
 "$tmp/tool/bin/nixpkgs-check-by-name" --base "$tmp/base" "$tmp/merged"

--- a/pkgs/test/nixpkgs-check-by-name/scripts/update-pinned-tool.sh
+++ b/pkgs/test/nixpkgs-check-by-name/scripts/update-pinned-tool.sh
@@ -7,6 +7,9 @@ trace() { echo >&2 "$@"; }
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
+# Determined by `runs-on: ubuntu-latest` in .github/workflows/check-by-name.yml
+CI_SYSTEM=x86_64-linux
+
 channel=nixos-unstable
 pin_file=$SCRIPT_DIR/pinned-tool.json
 
@@ -19,13 +22,19 @@ trace "$nixpkgs"
 rev=$(<"$nixpkgs/.git-revision")
 trace -e "Git revision of channel $channel is \e[34m$rev\e[0m"
 
-
-trace -n "Fetching the prebuilt version of nixpkgs-check-by-name.. "
-path=$(nix-build --no-out-link "$nixpkgs" -A tests.nixpkgs-check-by-name -j 0 | tee /dev/stderr)
+trace -n "Fetching the prebuilt version of nixpkgs-check-by-name for $CI_SYSTEM.. "
+# This is the architecture used by CI, we want to prefetch the exact path to avoid having to evaluate Nixpkgs
+ci_path=$(nix-build --no-out-link "$nixpkgs" \
+    -A tests.nixpkgs-check-by-name \
+    --arg config '{}' \
+    --argstr system "$CI_SYSTEM" \
+    --arg overlays '[]' \
+    -j 0 \
+    | tee /dev/stderr)
 
 trace "Updating $pin_file"
 jq -n \
     --arg rev "$rev" \
-    --arg path "$path" \
+    --arg ci-path "$ci_path" \
     '$ARGS.named' \
     > "$pin_file"


### PR DESCRIPTION
## Description of changes

Since https://github.com/NixOS/nixpkgs/pull/281374, the nixpkgs-check-by-name tooling is pinned to a specific /nix/store path to avoid having to evaluate Nixpkgs in CI.

The same path is used for local runs, but that doesn't actually work when you're trying to run it on a platform different from CI:

```
$ ./pkgs/tests/nixpkgs-check-by-name/scripts/run-local.sh master 
Running nixpkgs-check-by-name..
/tmp/tmp.kynXWxE3nr/tool/bin/nixpkgs-check-by-name: line 3: /nix/store/qlls5ca8q88qpyygg9ddi60gl1nmvpij-nixpkgs-check-by-name/bin/.nixpkgs-check-by-name-wrapped:
  cannot execute binary file: Exec format error
/tmp/tmp.kynXWxE3nr/tool/bin/nixpkgs-check-by-name: line 3: /nix/store/qlls5ca8q88qpyygg9ddi60gl1nmvpij-nixpkgs-check-by-name/bin/.nixpkgs-check-by-name-wrapped:
  Undefined error: 0
```

This PR makes it work by being clearer about platforms and making local runs check out the correct Nixpkgs to evaluate the tool from.

## Things done

- [x] Ran `run-local.sh master` successfully on `x86_64-linux` and `aarch64-darwin`
- [x] Ran `update-pinned-tool.sh` for the new format.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
