### PR TITLE
forgejo: 1.21.3-0 -> 1.21.4-0

### DIFF
--- a/pkgs/applications/version-management/forgejo/default.nix
+++ b/pkgs/applications/version-management/forgejo/default.nix
@@ -24,7 +24,7 @@ let
     pname = "forgejo-frontend";
     inherit (forgejo) src version;
 
-    npmDepsHash = "sha256-bxgkJODph88aXYYj50gNNP4gpsd18uOj0dQEX6GqEsc=";
+    npmDepsHash = "sha256-nXQew6PR5z+FGzmD15WBclnOYxzNZxTmHypuzh5+7Ew=";
 
     patches = [
       ./package-json-npm-build-frontend.patch
@@ -39,17 +39,17 @@ let
 in
 buildGoModule rec {
   pname = "forgejo";
-  version = "1.21.3-0";
+  version = "1.21.4-0";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "forgejo";
     repo = "forgejo";
     rev = "v${version}";
-    hash = "sha256-iBZIn2VGagG1RMBKm9qyg4RRscStr+PsdxOpprrInyo=";
+    hash = "sha256-m5y9lg1XAyOWA9jyeieGhzgJ9FaNorS45GCJPwMftXI=";
   };
 
-  vendorHash = "sha256-+ukS9+SxymwnMSnr/BaL4lhc83wYC6+4BWYTbBTrWy8=";
+  vendorHash = "sha256-eL3wxoRjxpkv012SqqifNLN9IOez5TbfGfZRgEX0AEM=";
 
   subPackages = [ "." ];
 


### PR DESCRIPTION
## Description of changes

https://codeberg.org/forgejo/forgejo/releases/tag/v1.21.4-0

https://codeberg.org/forgejo/forgejo/src/commit/c4675549c93c30d96c04b0dfb684aea5026f8f9e/RELEASE-NOTES.md#1-21-4-0

This release fixes a very tiny, uncritical `nil` pointer exception in `GET /api/v1/repos/<owner>/<repo>/subscription`.

The 1.20.x series (present in `nixos-23.11`) won't get a release due to the extremely low severity.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).