### PR TITLE
qt5.qtwebkit: fix build with GCC13 and libxml 2.12

### DIFF
--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -212,6 +212,7 @@ let
       ./qtwebkit.patch
       ./qtwebkit-icu68.patch
       ./qtwebkit-cstdint.patch
+      ./qtwebkit-libxml2-api-change-webkit-1bad176b2496579d760852c80cff3ad9fb7c3a4b.patch
     ] ++ lib.optionals stdenv.isDarwin [
       ./qtwebkit-darwin-no-readline.patch
       ./qtwebkit-darwin-no-qos-classes.patch

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -211,6 +211,7 @@ let
       })
       ./qtwebkit.patch
       ./qtwebkit-icu68.patch
+      ./qtwebkit-cstdint.patch
     ] ++ lib.optionals stdenv.isDarwin [
       ./qtwebkit-darwin-no-readline.patch
       ./qtwebkit-darwin-no-qos-classes.patch

--- a/pkgs/development/libraries/qt-5/5.15/qtwebkit-cstdint.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qtwebkit-cstdint.patch
@@ -1,0 +1,11 @@
+diff -up qtwebkit-5.212.0-alpha4/Source/ThirdParty/ANGLE/src/common/mathutil.h.me qtwebkit-5.212.0-alpha4/Source/ThirdParty/ANGLE/src/common/mathutil.h
+--- qtwebkit-5.212.0-alpha4/Source/ThirdParty/ANGLE/src/common/mathutil.h.me	2023-02-20 15:40:04.045911245 +0100
++++ qtwebkit-5.212.0-alpha4/Source/ThirdParty/ANGLE/src/common/mathutil.h	2023-02-20 15:40:39.038549787 +0100
+@@ -16,6 +16,7 @@
+ #include <algorithm>
+ #include <string.h>
+ #include <stdlib.h>
++#include <cstdint>
+ 
+ namespace gl
+ {

--- a/pkgs/development/libraries/qt-5/5.15/qtwebkit-libxml2-api-change-webkit-1bad176b2496579d760852c80cff3ad9fb7c3a4b.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qtwebkit-libxml2-api-change-webkit-1bad176b2496579d760852c80cff3ad9fb7c3a4b.patch
@@ -1,0 +1,56 @@
+From 1bad176b2496579d760852c80cff3ad9fb7c3a4b Mon Sep 17 00:00:00 2001
+From: Adrian Perez de Castro <aperez@igalia.com>
+Date: Mon, 20 Nov 2023 07:42:30 -0800
+Subject: [PATCH] Build fails with libxml2 version 2.12.0 due to API change
+ https://bugs.webkit.org/show_bug.cgi?id=265128
+
+Reviewed by Philippe Normand.
+
+Starting with libxml2 2.12.0, the API has changed the const-ness of the
+xmlError pointers, which results in a build error due to a mismatched
+type in the parsing error callback. This papers over the difference by
+using preprocessor conditionals.
+
+* Source/WebCore/xml/XSLTProcessor.h: Use const when building against
+  libxml2 2.12.0 or newer.
+* Source/WebCore/xml/XSLTProcessorLibxslt.cpp:
+(WebCore::XSLTProcessor::parseErrorFunc): Ditto.
+
+Canonical link: https://commits.webkit.org/270977@main
+---
+ Source/WebCore/xml/XSLTProcessor.h          | 4 ++++
+ Source/WebCore/xml/XSLTProcessorLibxslt.cpp | 4 ++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/Source/WebCore/xml/XSLTProcessor.h b/Source/WebCore/xml/XSLTProcessor.h
+index 21bb45b5cbe16..5cf20557918fa 100644
+--- a/Source/WebCore/xml/XSLTProcessor.h
++++ b/Source/WebCore/xml/XSLTProcessor.h
+@@ -61,7 +61,11 @@ class XSLTProcessor : public RefCounted<XSLTProcessor> {
+ 
+     void reset();
+ 
++#if LIBXML_VERSION >= 21200
++    static void parseErrorFunc(void* userData, const xmlError*);
++#else
+     static void parseErrorFunc(void* userData, xmlError*);
++#endif
+     static void genericErrorFunc(void* userData, const char* msg, ...);
+     
+     // Only for libXSLT callbacks
+diff --git a/Source/WebCore/xml/XSLTProcessorLibxslt.cpp b/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
+index a65691087e3c5..9f6b363dfc6c9 100644
+--- a/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
++++ b/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
+@@ -59,7 +59,11 @@ void XSLTProcessor::genericErrorFunc(void*, const char*, ...)
+     // It would be nice to do something with this error message.
+ }
+ 
++#if LIBXML_VERSION >= 21200
++void XSLTProcessor::parseErrorFunc(void* userData, const xmlError* error)
++#else
+ void XSLTProcessor::parseErrorFunc(void* userData, xmlError* error)
++#endif
+ {
+     PageConsoleClient* console = static_cast<PageConsoleClient*>(userData);
+     if (!console)


### PR DESCRIPTION
## Description of changes

- Fix build failure with GCC13 due to a missing `#include <cstdint>` as per the [patch from Fedora](https://src.fedoraproject.org/rpms/qt5-qtwebkit/raw/rawhide/f/qtwebkit-cstdint.patch)
- Fix build with libxml >= 2.12 (patch taken from upstream WebKit, not QtWebKit, https://github.com/WebKit/WebKit/commit/1bad176b2496579d760852c80cff3ad9fb7c3a4b)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
  - [x] tested by running Trojita with this
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
