### PR TITLE
feh: 3.10.1 -> 3.10.2

### DIFF
--- a/pkgs/applications/graphics/feh/default.nix
+++ b/pkgs/applications/graphics/feh/default.nix
@@ -1,27 +1,18 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper, fetchpatch
+{ lib, stdenv, fetchFromGitHub, makeWrapper
 , xorg, imlib2, libjpeg, libpng
 , curl, libexif, jpegexiforient, perl
 , enableAutoreload ? !stdenv.hostPlatform.isDarwin }:
 
 stdenv.mkDerivation rec {
   pname = "feh";
-  version = "3.10.1";
+  version = "3.10.2";
 
   src = fetchFromGitHub {
     owner = "derf";
     repo = pname;
     rev = version;
-    hash = "sha256-1dz04RcaoP79EoE+SsatXm2wMRCbNnmAzMECYk3y3jg=";
+    hash = "sha256-378rhZhpcua3UbsY0OcGKGXdMIQCuG84YjJ9vfJhZVs=";
   };
-
-  patches = [
-    # upstream PR: https://github.com/derf/feh/pull/723
-    (fetchpatch {
-      name = "fix-right-click-buffer-overflow.patch";
-      url = "https://github.com/derf/feh/commit/2c31f8863b80030e772a529ade519fc2fee4a991.patch";
-      sha256 = "sha256-sUWS06qt1d1AyGfqKb+1BzZslYxOzur4q0ePEHcTz1g=";
-    })
-  ];
 
   outputs = [ "out" "man" "doc" ];
 

--- a/pkgs/applications/graphics/feh/default.nix
+++ b/pkgs/applications/graphics/feh/default.nix
@@ -1,16 +1,26 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper
-, xorg, imlib2, libjpeg, libpng
-, curl, libexif, jpegexiforient, perl
-, enableAutoreload ? !stdenv.hostPlatform.isDarwin }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+, xorg
+, imlib2
+, libjpeg
+, libpng
+, curl
+, libexif
+, jpegexiforient
+, perl
+, enableAutoreload ? !stdenv.hostPlatform.isDarwin
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "feh";
   version = "3.10.2";
 
   src = fetchFromGitHub {
     owner = "derf";
-    repo = pname;
-    rev = version;
+    repo = "feh";
+    rev = finalAttrs.version;
     hash = "sha256-378rhZhpcua3UbsY0OcGKGXdMIQCuG84YjJ9vfJhZVs=";
   };
 
@@ -21,9 +31,10 @@ stdenv.mkDerivation rec {
   buildInputs = [ xorg.libXt xorg.libX11 xorg.libXinerama imlib2 libjpeg libpng curl libexif ];
 
   makeFlags = [
-    "PREFIX=${placeholder "out"}" "exif=1"
+    "PREFIX=${placeholder "out"}"
+    "exif=1"
   ] ++ lib.optional stdenv.isDarwin "verscmp=0"
-    ++ lib.optional enableAutoreload "inotify=1";
+  ++ lib.optional enableAutoreload "inotify=1";
 
   installTargets = [ "install" ];
   postInstall = ''
@@ -44,4 +55,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     mainProgram = "feh";
   };
-}
+})

--- a/pkgs/applications/graphics/feh/default.nix
+++ b/pkgs/applications/graphics/feh/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     # released under a variant of the MIT license
     # https://spdx.org/licenses/MIT-feh.html
     license = licenses.mit-feh;
-    maintainers = with maintainers; [ viric willibutz globin ];
+    maintainers = with maintainers; [ gepbird globin viric willibutz ];
     platforms = platforms.unix;
     mainProgram = "feh";
   };


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/derf/feh/blob/master/ChangeLog
Diff: https://github.com/derf/feh/compare/3.10.1...3.10.2
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>13 packages built:</summary>
  <ul>
    <li>deco</li>
    <li>farge</li>
    <li>feh</li>
    <li>feh.doc</li>
    <li>feh.man</li>
    <li>multilockscreen</li>
    <li>pywal (python311Packages.pywal)</li>
    <li>pywal.dist (python311Packages.pywal.dist)</li>
    <li>python312Packages.pywal</li>
    <li>python312Packages.pywal.dist</li>
    <li>stylish</li>
    <li>wpgtk</li>
    <li>wpgtk.dist</li>
  </ul>
</details>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
