### PR TITLE
dockerTools: use epoch for layers and mtime

### DIFF
--- a/doc/build-helpers/images/dockertools.section.md
+++ b/doc/build-helpers/images/dockertools.section.md
@@ -373,7 +373,7 @@ See [](#ex-dockerTools-buildLayeredImage-hello) to see how to do that.
 # Building a layered Docker image
 
 The following package builds a layered Docker image that runs the `hello` executable from the `hello` package.
-The Docker image will have name `hello` and tag `latest`.
+The Docker image will have name `hello` and tag `latest`. The created image can have a current timestamp when setting the `created` parameter to "now" - this will only affect the image, not the individual layers.
 
 ```nix
 { dockerTools, hello }:

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -49,6 +49,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - `himalaya` was updated to v1.0.0-beta, which introduces breaking changes. Check out the [release note](https://github.com/soywod/himalaya/releases/tag/v1.0.0-beta) for details.
 
+- `dockerTools.streamLayeredImage` created layers with mtimes using the "now" argument for the `created` parameter. It now uses UNIX time of "1" for the mtime of layers. It will still use "now" for the last customization layer and for setting the creation date of the image itself. This leads to greater re-use of layers between different images.
+
 - The `power.ups` module now generates `upsd.conf`, `upsd.users` and `upsmon.conf` automatically from a set of new configuration options. This breaks compatibility with existing `power.ups` setups where these files were created manually. Back up these files before upgrading NixOS.
 
 - `k9s` was updated to v0.31. There have been various breaking changes in the config file format,

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -499,6 +499,13 @@ rec {
     contents = pkgs.bashInteractive;
   };
 
+  # streamLayeredImage with unstable date
+  unstableDateStreamLayered = pkgs.dockerTools.streamLayeredImage {
+    name = "bash-no-tag-stream-layered-unstable-date";
+    contents = pkgs.bashInteractive;
+    created = "now";
+  };
+
   # buildLayeredImage with non-root user
   bashLayeredWithUser =
   let

--- a/pkgs/build-support/docker/stream_layered_image.py
+++ b/pkgs/build-support/docker/stream_layered_image.py
@@ -324,6 +324,7 @@ def main():
       else datetime.fromisoformat(conf["created"])
     )
     mtime = int(created.timestamp())
+    epoch = int(datetime.fromisoformat("1970-01-01T00:00:01Z").timestamp())
     store_dir = conf["store_dir"]
 
     from_image = load_from_image(conf["from_image"])
@@ -336,7 +337,7 @@ def main():
         for num, store_layer in enumerate(conf["store_layers"], start=start):
             print("Creating layer", num, "from paths:", store_layer,
                   file=sys.stderr)
-            info = add_layer_dir(tar, store_layer, store_dir, mtime=mtime)
+            info = add_layer_dir(tar, store_layer, store_dir, mtime=epoch)
             layers.append(info)
 
         print("Creating layer", len(layers) + 1, "with customisation...",

--- a/pkgs/build-support/docker/stream_layered_image.py
+++ b/pkgs/build-support/docker/stream_layered_image.py
@@ -324,7 +324,9 @@ def main():
       else datetime.fromisoformat(conf["created"])
     )
     mtime = int(created.timestamp())
-    epoch = int(datetime.fromisoformat("1970-01-01T00:00:01Z").timestamp())
+
+    # int(datetime.fromisoformat("1970-01-01T00:00:01Z").timestamp())
+    epochPlus1 = 1
     store_dir = conf["store_dir"]
 
     from_image = load_from_image(conf["from_image"])
@@ -337,7 +339,7 @@ def main():
         for num, store_layer in enumerate(conf["store_layers"], start=start):
             print("Creating layer", num, "from paths:", store_layer,
                   file=sys.stderr)
-            info = add_layer_dir(tar, store_layer, store_dir, mtime=epoch)
+            info = add_layer_dir(tar, store_layer, store_dir, mtime=epochPlus1)
             layers.append(info)
 
         print("Creating layer", len(layers) + 1, "with customisation...",


### PR DESCRIPTION
The UX improvement of a recent time is primarily for the image itself and seldom used for layers and individual file.

## Description of changes

The discussion in https://github.com/NixOS/nixpkgs/pull/47005 is about the date of an image, but there is far less usage of the time of a layer. This change makes all layers use epoch as mtime and for creation date, but still allows for overriding with "now" for the image itself. The intent is to allow greater re-use of image layers in a container storage subsystem.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
