### PR TITLE
antlr4.runtime.cpp: fix paths in generated cmakefile

### DIFF
--- a/pkgs/development/tools/parsing/antlr/4.nix
+++ b/pkgs/development/tools/parsing/antlr/4.nix
@@ -104,8 +104,8 @@ let
           ''
             subdir="antlr4${lib.optionalString (builtins.compareVersions version "4.8" != 0) "-runtime"}"
             substituteInPlace $out/lib/cmake/$subdir/antlr4-runtime-config.cmake \
-              --replace $dev/include/antlr4-runtime $\{PACKAGE_PREFIX_DIR}/include/antlr4-runtime \
-              --replace $\{PACKAGE_PREFIX_DIR}/lib $out/lib
+              --replace-fail $dev/include/antlr4-runtime $\{PACKAGE_PREFIX_DIR}/include/antlr4-runtime \
+              --replace-fail $\{PACKAGE_PREFIX_DIR}/lib $out/lib
           '';
 
         meta = with lib; {

--- a/pkgs/development/tools/parsing/antlr/4.nix
+++ b/pkgs/development/tools/parsing/antlr/4.nix
@@ -96,6 +96,18 @@ let
 
         cmakeFlags = extraCppCmakeFlags;
 
+        # Fix CMake paths caused by multiple outputs
+        preFixup = lib.optionalString
+          # v4.9 has a bug where the files are not installed
+          (builtins.compareVersions version "4.10" != -1
+          || builtins.compareVersions version "4.9" == -1)
+          ''
+            subdir="antlr4${lib.optionalString (builtins.compareVersions version "4.8" != 0) "-runtime"}"
+            substituteInPlace $out/lib/cmake/$subdir/antlr4-runtime-config.cmake \
+              --replace $dev/include/antlr4-runtime $\{PACKAGE_PREFIX_DIR}/include/antlr4-runtime \
+              --replace $\{PACKAGE_PREFIX_DIR}/lib $out/lib
+          '';
+
         meta = with lib; {
           description = "C++ target for ANTLR 4";
           homepage = "https://www.antlr.org/";

--- a/pkgs/development/tools/parsing/antlr/4.nix
+++ b/pkgs/development/tools/parsing/antlr/4.nix
@@ -120,9 +120,9 @@ let
 
 in {
   antlr4_13 = (mkAntlr {
-    version = "4.13.0";
-    sourceSha256 = "sha256-s1yAdScMYg1wFpYNsBAtpifIhQsnSAgJg7JjPDx+htc=";
-    jarSha256 = "sha256-vG9KvA0iWidXASbFFAJWnwAKje2jSHtw52QoQOVw5KY=";
+    version = "4.13.2";
+    sourceSha256 = "sha256-DxxRL+FQFA+x0RudIXtLhewseU50aScHKSCDX7DE9bY=";
+    jarSha256 = "sha256-6uLfoRmmQydERnKv9j6ew1ogGA3FuAkLemq4USXfTXY=";
     extraCppCmakeFlags = [
       # Generate CMake config files, which are not installed by default.
       "-DANTLR4_INSTALL=ON"


### PR DESCRIPTION
Fix the paths in the generated `-dev/lib/cmake/antlr4-runtime/antlr4-runtime-config.cmake` file to ensure proper linkage for the multiple outputs. The results of `nixpkgs-review` shows that everything works except `mysql-workbench` which has been failing on `master` branch.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
