### PR TITLE
vimPlugins.sniprun: 1.3.10 -> 1.3.11

### DIFF
--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -1136,12 +1136,12 @@
 
   sniprun =
     let
-      version = "1.3.10";
+      version = "1.3.11";
       src = fetchFromGitHub {
         owner = "michaelb";
         repo = "sniprun";
         rev = "refs/tags/v${version}";
-        hash = "sha256-7tDREZ8ZXYySHrXVOh+ANT23CknJQvZJ8WtU5r0pOOQ=";
+        hash = "sha256-f/EifFvlHr41wP0FfkwSGVdXLyz739st/XtnsSbzNT4=";
       };
       sniprun-bin = rustPlatform.buildRustPackage {
         pname = "sniprun-bin";
@@ -1151,7 +1151,7 @@
           darwin.apple_sdk.frameworks.Security
         ];
 
-        cargoHash = "sha256-n/HW+q4Xrme/ssS9Th5uFEUsDgkxRxKt2wSR8k08uHY=";
+        cargoHash = "sha256-SmhfjOnw89n/ATGvmyvd5clQSucIh7ky3v9JsSjtyfI=";
 
         nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/applications/editors/vim/plugins/patches/sniprun/fix-paths.patch
+++ b/pkgs/applications/editors/vim/plugins/patches/sniprun/fix-paths.patch
@@ -1,5 +1,5 @@
 diff --git a/lua/sniprun.lua b/lua/sniprun.lua
-index c9b811f..459cf07 100644
+index fe29d1e..92d4729 100644
 --- a/lua/sniprun.lua
 +++ b/lua/sniprun.lua
 @@ -4,9 +4,7 @@ M.custom_highlight=false
@@ -13,42 +13,3 @@ index c9b811f..459cf07 100644
  
  local sniprun_path = vim.fn.fnamemodify( vim.api.nvim_get_runtime_file("lua/sniprun.lua", false)[1], ":p:h") .. "/.."
  
-@@ -145,7 +143,7 @@ function M.setup_highlights()
-       highlight(group, styles)
-     end
-     vim.cmd('augroup END')
--  else 
-+  else
-     for group, styles in pairs(colors_table) do
-       local gui = styles.gui and 'gui='..styles.gui or 'gui=NONE'
-       local sp = styles.sp and 'guisp='..styles.sp or 'guisp=NONE'
-@@ -354,7 +352,7 @@ function M.health()
-   -- check if the log is recreated
-   if pcall(M.ping) then health_ok("Sent a ping to the sniprun binary")
-   else health_warn("Could not send a ping to the sniprun binary - is it present, executable and compatible with your CPU architecture?") end
--    
-+
- 
-   os.execute("sleep 0.2")
-   if not M.file_exists(path_log_file) and not M.file_exists(path_log_file_mac)  then health_error("sniprun binary incompatible or crash at start", {"Compile sniprun locally, with a clean reinstall and 'bash ./install.sh 1' as post-install command."})
-diff --git a/ressources/init_repl.sh b/ressources/init_repl.sh
-index eb51dbe..1382b5c 100755
---- a/ressources/init_repl.sh
-+++ b/ressources/init_repl.sh
-@@ -35,7 +35,7 @@ mkfifo $working_dir/$pipe
- touch $working_dir/$out
- sleep 36000 > $working_dir/$pipe &
- 
--echo "/bin/cat " $working_dir/$pipe " | " $repl  > $working_dir/real_launcher.sh
-+echo "cat " $working_dir/$pipe " | " $repl  > $working_dir/real_launcher.sh
- chmod +x $working_dir/real_launcher.sh
- 
- echo $repl " process started at $(date +"%F %T")." >> $log
-diff --git a/ressources/launcher_repl.sh b/ressources/launcher_repl.sh
-index feaa91e..749c55e 100755
---- a/ressources/launcher_repl.sh
-+++ b/ressources/launcher_repl.sh
-@@ -1,2 +1,2 @@
- #!/bin/bash
--/bin/cat $1 > $2
-+cat $1 > $2


### PR DESCRIPTION
## Description of changes

With this release, I was able to remove some parts of the patch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
