### PR TITLE
qt5, qt6: use versioned QML import paths in wrappers

### DIFF
--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -51,6 +51,8 @@ let
       ./qtdeclarative.patch
       # prevent headaches from stale qmlcache data
       ./qtdeclarative-default-disable-qmlcache.patch
+      # add version specific QML import path
+      ./qtdeclarative-qml-paths.patch
     ];
     qtlocation = lib.optionals stdenv.cc.isClang [
       # Fix build with Clang 16

--- a/pkgs/development/libraries/qt-5/5.15/qtdeclarative-qml-paths.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qtdeclarative-qml-paths.patch
@@ -1,0 +1,33 @@
+diff --git a/src/qml/qml/qqmlimport.cpp b/src/qml/qml/qqmlimport.cpp
+index 289f11d006..80c422403c 100644
+--- a/src/qml/qml/qqmlimport.cpp
++++ b/src/qml/qml/qqmlimport.cpp
+@@ -1897,17 +1897,22 @@ QQmlImportDatabase::QQmlImportDatabase(QQmlEngine *e)
+     addImportPath(installImportsPath);
+ 
+     // env import paths
+-    if (Q_UNLIKELY(!qEnvironmentVariableIsEmpty("QML2_IMPORT_PATH"))) {
+-        const QString envImportPath = qEnvironmentVariable("QML2_IMPORT_PATH");
++    auto addEnvImportPath = [this](const char *var) {
+ #if defined(Q_OS_WIN)
+         QLatin1Char pathSep(';');
+ #else
+         QLatin1Char pathSep(':');
+ #endif
+-        QStringList paths = envImportPath.split(pathSep, Qt::SkipEmptyParts);
+-        for (int ii = paths.count() - 1; ii >= 0; --ii)
+-            addImportPath(paths.at(ii));
+-    }
++        if (Q_UNLIKELY(!qEnvironmentVariableIsEmpty(var))) {
++            const QString envImportPath = qEnvironmentVariable(var);
++            QStringList paths = envImportPath.split(pathSep, Qt::SkipEmptyParts);
++            for (int ii = paths.count() - 1; ii >= 0; --ii)
++                addImportPath(paths.at(ii));
++        }
++    };
++
++    addEnvImportPath("NIXPKGS_QT5_QML_IMPORT_PATH");
++    addEnvImportPath("QML2_IMPORT_PATH");
+ 
+     addImportPath(QStringLiteral("qrc:/qt-project.org/imports"));
+     addImportPath(QCoreApplication::applicationDirPath());

--- a/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/wrap-qt-apps-hook.sh
@@ -31,7 +31,7 @@ qtHostPathHook() {
     local qmlDir="$1/${qtQmlPrefix:?}"
     if [ -d "$qmlDir" ]
     then
-        qtWrapperArgs+=(--prefix QML2_IMPORT_PATH : "$qmlDir")
+        qtWrapperArgs+=(--prefix NIXPKGS_QT5_QML_IMPORT_PATH : "$qmlDir")
     fi
 }
 addEnvHooks "$targetOffset" qtHostPathHook

--- a/pkgs/development/libraries/qt-6/hooks/wrap-qt-apps-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/wrap-qt-apps-hook.sh
@@ -31,7 +31,7 @@ if [[ -z "${__nix_wrapQtAppsHook-}" ]]; then
 
         local qmlDir="$1/${qtQmlPrefix:?}"
         if [ -d "$qmlDir" ]; then
-            qtWrapperArgs+=(--prefix QML2_IMPORT_PATH : "$qmlDir")
+            qtWrapperArgs+=(--prefix NIXPKGS_QT6_QML_IMPORT_PATH : "$qmlDir")
         fi
     }
     addEnvHooks "$targetOffset" qtHostPathHook

--- a/pkgs/development/libraries/qt-6/modules/qtdeclarative.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdeclarative.nix
@@ -12,5 +12,7 @@ qtModule {
   patches = [
     # prevent headaches from stale qmlcache data
     ../patches/qtdeclarative-default-disable-qmlcache.patch
+    # add version specific QML import path
+    ../patches/qtdeclarative-qml-paths.patch
   ];
 }

--- a/pkgs/development/libraries/qt-6/patches/qtdeclarative-qml-paths.patch
+++ b/pkgs/development/libraries/qt-6/patches/qtdeclarative-qml-paths.patch
@@ -1,0 +1,12 @@
+diff --git a/src/qml/qml/qqmlimport.cpp b/src/qml/qml/qqmlimport.cpp
+index a7d1a3f77f..aac7392d4f 100644
+--- a/src/qml/qml/qqmlimport.cpp
++++ b/src/qml/qml/qqmlimport.cpp
+@@ -1515,6 +1515,7 @@ QQmlImportDatabase::QQmlImportDatabase(QQmlEngine *e)
+     };
+ 
+     // env import paths
++    addEnvImportPath("NIXPKGS_QT6_QML_IMPORT_PATH");
+     addEnvImportPath("QML_IMPORT_PATH");
+     addEnvImportPath("QML2_IMPORT_PATH");
+ 


### PR DESCRIPTION
## Description of changes

Qt is smart enough to figure out the target Qt version for native plugins. However, Qt is _not_ smart enough to figure out the target Qt version for QML imports, which causes all kinds of funny breakage when you start running Qt 5 applications from Qt 6 ones and vice versa.

So, do some minimally invasive surgery to make different Qt versions pick up different QML import path variables, so they don't mess with each other.

This is kind of very cursed, but what can you do.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
