### PR TITLE
Wofi emoji: 2023-06-19 -> 2023-12-22 & fix paths in shell script

### DIFF
--- a/pkgs/applications/misc/wofi-emoji/default.nix
+++ b/pkgs/applications/misc/wofi-emoji/default.nix
@@ -21,6 +21,10 @@ stdenv.mkDerivation rec {
   postPatch = ''
     substituteInPlace build.sh \
       --replace 'curl ${emojiJSON.url}' 'cat ${emojiJSON}'
+    substituteInPlace wofi-emoji \
+      --replace 'wofi' '${wofi}/bin/wofi' \
+      --replace 'wtype' '${wtype}/bin/wtype' \
+      --replace 'wl-copy' '${wl-clipboard}/bin/wl-copy'
   '';
 
   buildPhase = ''

--- a/pkgs/applications/misc/wofi-emoji/default.nix
+++ b/pkgs/applications/misc/wofi-emoji/default.nix
@@ -6,13 +6,13 @@ let emojiJSON = fetchurl {
 in
 stdenv.mkDerivation rec {
   pname = "wofi-emoji";
-  version = "unstable-2023-06-19";
+  version = "unstable-2023-12-22";
 
   src = fetchFromGitHub {
     owner = "Zeioth";
     repo = pname;
-    rev = "796d688b71ac9fa1e5b2c1b9a3fa11dba801b02b";
-    hash = "sha256-HBsqekNuKqxaKaSeLboukLm4Lkg9JakPO7uN3Z8QBC8=";
+    rev = "2cc95880848134a3bbe0675bcb62a0dae1d0f572";
+    hash = "sha256-t9M8z8JxuvBDzNs98L7YTNUfTK23W1DYGdHDiXNQOgk=";
   };
 
   nativeBuildInputs = [ jq ];


### PR DESCRIPTION
## Description of changes
Updated the script & fixed #278502 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
