### PR TITLE
elmPackages.elm: fix compilation with stackage LTS 22.4

### DIFF
--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -36,6 +36,10 @@ let
     };
     in elmPkgs // {
       inherit elmPkgs;
+
+      ansi-wl-pprint = overrideCabal (drv: {
+        jailbreak = true;
+      }) (self.callPackage ./packages/ansi-wl-pprint.nix {});
     };
   };
 

--- a/pkgs/development/compilers/elm/packages/ansi-wl-pprint.nix
+++ b/pkgs/development/compilers/elm/packages/ansi-wl-pprint.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, ansi-terminal, base, fetchgit, lib }:
+mkDerivation {
+  pname = "ansi-wl-pprint";
+  version = "0.6.8.1";
+  src = fetchgit {
+    url = "https://github.com/ekmett/ansi-wl-pprint";
+    sha256 = "00pgxgkramz6y1bgdlm00rsh6gd6mdaqllh6riax2rc2sa35kip4";
+    rev = "d16e2f6896d76b87b72af7220c2e93ba15c53280";
+    fetchSubmodules = true;
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [ ansi-terminal base ];
+  homepage = "http://github.com/ekmett/ansi-wl-pprint";
+  description = "The Wadler/Leijen Pretty Printer for colored ANSI terminal output";
+  license = lib.licenses.bsd3;
+}

--- a/pkgs/development/compilers/elm/update.sh
+++ b/pkgs/development/compilers/elm/update.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -p cabal2nix elm2nix -i bash ../../..
 
+cabal2nix https://github.com/ekmett/ansi-wl-pprint --revision d16e2f6896d76b87b72af7220c2e93ba15c53280 > packages/ansi-wl-pprint.nix
+
 # We're building binaries from commit that npm installer is using since
 # November 1st release called 0.19.1-6 in npm registry.
 # These binaries are built with newer ghc version and also support Aarch64 for Linux and Darwin.


### PR DESCRIPTION
Fixes elm compiler build.

Unblocks #279413 

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
