### PR TITLE
lib.derivationOf: init

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -95,7 +95,7 @@ let
       drop sublist last init crossLists unique allUnique intersectLists
       subtractLists mutuallyExclusive groupBy groupBy';
     inherit (self.strings) concatStrings concatMapStrings concatImapStrings
-      intersperse concatStringsSep concatMapStringsSep
+      derivationOf intersperse concatStringsSep concatMapStringsSep
       concatImapStringsSep concatLines makeSearchPath makeSearchPathOutput
       makeLibraryPath makeBinPath optionalString
       hasInfix hasPrefix hasSuffix stringToCharacters stringAsChars escape

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -6,8 +6,43 @@ let
 
   inherit (lib.trivial) warnIf;
 
+  inherit (lib)
+    attrNames
+    attrsToList
+    concatMap
+    isDerivation
+    mapAttrsToList
+    optional
+    throwIf
+    ;
+  inherit (lib.strings)
+    concatStringsSep
+    hasPrefix
+    hasSuffix
+    ;
+
 asciiTable = import ./ascii-table.nix;
 
+  showContextItemList = context:
+    concatStringsSep
+      "\n"
+      (concatMap
+        ({ path, items }:
+          optional (items?allOutputs) "  - ${path} as derivation and closure including closure outputs"
+          ++ map (outName: "  - ${path}^${outName}") items.outputs or []
+          ++ optional (items?path)
+              (if hasSuffix ".drv" path
+                then "  - ${path} as derivation file and closure"
+                else "  - ${path} as store path closure")
+        )
+        (mapAttrsToList (k: v: { path = k; items = v; }) context)
+      );
+  countPathsInContextGroup = v:
+    (if v?outputs
+    then length v.outputs
+    else 0)
+    + (if v?path then 1 else 0)
+    + (if v?allOutputs then 1 else 0);
 in
 
 rec {
@@ -1320,4 +1355,44 @@ rec {
         else if k == 2 then infixDifferAtMost2 ainfix binfix
         else levenshtein ainfix binfix <= k;
       in f;
+
+  /*
+    Return the derivation path that has the given path as an output.
+
+    Not all paths are constructed by derivations, so this function may throw.
+
+    Design note:
+    While this function is close to being the inverse of the RFC 92 `outputOf`
+    function, it does not return the output name. This is intentional, because
+    the output name *of a derivation* is not meant to carry meaning, unlike
+    the output *attribute* of a package. Hence, bundling the output name into
+    this return value would almost always be inconvenient.
+  */
+  derivationOf =
+    v:
+    let
+      outputString =
+        if isDerivation v
+        then "${v.outPath}"
+        else if isString v
+        then v
+        else if isPath v
+        then throw "derivationOf: The passed argument is a path value, and path values are not outputs, so we can't find the derivation that produced it."
+        else throw "derivationOf: Expected a string containing a derivation output, but got a ${typeOf v} instead.";
+      ctx = builtins.getContext outputString;
+      items = attrsToList ctx;
+      drv = (head items).name;
+      group = (head items).value;
+      drvAsSource = builtins.appendContext drv { ${drv} = { path = true; }; };
+    in
+      throwIf (! hasPrefix builtins.storeDir outputString)
+        "lib.derivationOf: To retrieve the derivation of an output, the passed string must reference a store path. The passed string does not reference a store path."
+      throwIf (length items != 1)
+        (if length items == 0
+         then "lib.derivationOf: To retrieve the derivation of an output, the passed string must reference a store path. The passed string does not reference any store path."
+         else "lib.derivationOf: To retrieve the derivation of an output, the passed string must only reference a single store path. The passed string appears to be constructed from multiple outputs. It refers to the following:\n" + showContextItemList ctx)
+      throwIf (countPathsInContextGroup group != 1)
+        "lib.derivationOf: To retrieve the derivation of an output, the passed string must only reference a single output, rather than multiple paths referring to the same derivation. The passed string references:\n${showContextItemList ctx}"
+      drvAsSource;
+
 }

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -490,6 +490,63 @@ runTests {
     ( builtins.tryEval (toIntBase10 " foo00123 ") == { success = false; value = false; } )
   ];
 
+  # Manual tests for error messages:
+  # derivationOf "hi"
+  # derivationOf (hello.outPath + hello.drvPath + bind)
+  # derivationOf (bind + dig)     # These are outputs of the same drv. While not impossible to return something, this is almost certainly a mistake.
+  # derivationOf (hello.drvPath)  # Unless hello.outPath is an `outputOf` an output, it does not have a deriver.
+  testDerivationOf =
+    let
+      drv = derivation { name = "dummy"; builder = "x"; system = "x"; };
+      drvPathNoContext = builtins.unsafeDiscardStringContext drv.drvPath;
+      result = derivationOf drv;
+    in
+    {
+      expr = {
+        rawStr = builtins.unsafeDiscardStringContext result;
+        context = builtins.getContext result;
+      };
+      expected = {
+        rawStr = drvPathNoContext;
+        context.${drvPathNoContext} = { path = true; };
+      };
+    };
+
+  testDerivationOfSelectedOutput =
+    let
+      drv = derivation { name = "dummy"; builder = "x"; system = "x"; outputs = [ "foo" "bar" "baz" ]; };
+      drvPathNoContext = builtins.unsafeDiscardStringContext drv.drvPath;
+      result = derivationOf drv.bar;
+    in
+    {
+      expr = {
+        rawStr = builtins.unsafeDiscardStringContext result;
+        context = builtins.getContext result;
+      };
+      expected = {
+        rawStr = drvPathNoContext;
+        context.${drvPathNoContext} = { path = true; };
+      };
+    };
+
+  testDerivationOfOutputPathString =
+    let
+      drv = derivation { name = "dummy"; builder = "x"; system = "x"; };
+      drvPathNoContext = builtins.unsafeDiscardStringContext drv.drvPath;
+      outString = "${drv}";
+      result = derivationOf outString;
+    in
+    {
+      expr = {
+        rawStr = builtins.unsafeDiscardStringContext result;
+        context = builtins.getContext result;
+      };
+      expected = {
+        rawStr = drvPathNoContext;
+        context.${drvPathNoContext} = { path = true; };
+      };
+    };
+
 # LISTS
 
   testFilter = {


### PR DESCRIPTION
## Description of changes

Return the derivation path that has the given path as an output.
This "packages" the planned [`^..` CLI syntax](https://github.com/NixOS/nix/issues/10121) for use within the Nix language in a convenient way. We may also add a builtin, for ever so slightly better checking, and ever so slightly wider availability.

See committed documentation.

  - This is a better alternative to #281161
  
Comparative benefits:
  - Works for any output
  - No junk attrs like `pkg.derivation`
    - Less uncollectable memory
    - Less attention lost on rarely used features
  - Does not creates habits that don't work for
    - RFC 92 dynamic derivations
    - multi-derivation packages (e.g. `doc` in a separate build to save rebuilds and bootstrap better)




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
