### PR TITLE
qemu-esp32c3: init at 8.1.3-20231206

### DIFF
--- a/pkgs/applications/virtualization/qemu/qemu-esp32c3.nix
+++ b/pkgs/applications/virtualization/qemu/qemu-esp32c3.nix
@@ -1,0 +1,88 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, fetchFromGitHub
+, qemu
+, libgcrypt
+}:
+let
+  keycodemapdb = fetchFromGitLab {
+    owner = "qemu-project";
+    repo = "keycodemapdb";
+    rev = "f5772a62ec52591ff6870b7e8ef32482371f22c6";
+    hash = "sha256-EQrnBAXQhllbVCHpOsgREzYGncMUPEIoWFGnjo+hrH4=";
+    fetchSubmodules = true;
+  };
+
+  berkeley-softfloat-3 = fetchFromGitLab {
+    owner = "qemu-project";
+    repo = "berkeley-softfloat-3";
+    rev = "b64af41c3276f97f0e181920400ee056b9c88037";
+    hash = "sha256-Yflpx+mjU8mD5biClNpdmon24EHg4aWBZszbOur5VEA=";
+    fetchSubmodules = true;
+  };
+
+  berkeley-testfloat-3 = fetchFromGitLab {
+    owner = "qemu-project";
+    repo = "berkeley-testfloat-3";
+    rev = "e7af9751d9f9fd3b47911f51a5cfd08af256a9ab";
+    hash = "sha256-inQAeYlmuiRtZm37xK9ypBltCJ+ycyvIeIYZK8a+RYU=";
+    fetchSubmodules = true;
+  };
+in
+
+qemu.overrideAttrs (oldAttrs: rec {
+  pname = "${oldAttrs.pname}-esp32c3";
+  version = "8.1.3-20231206";
+
+  src = fetchFromGitHub {
+    owner = "espressif";
+    repo = "qemu";
+    rev = "refs/tags/esp-develop-${version}";
+    sha256 = "sha256-9oC4xL/XRsttJ/qoUL32ZHkpYjQaDMLcm2FMw57svHg=";
+  };
+
+  buildInputs = oldAttrs.buildInputs ++ [ libgcrypt ];
+
+  postPatch = oldAttrs.postPatch + ''
+    # Correctly detect libgcrypt
+    sed -i "s/config-tool/auto/" meson.build
+
+    # Prefetch Meson subprojects
+    rm subprojects/keycodemapdb.wrap
+    ln -s ${keycodemapdb} subprojects/keycodemapdb
+
+    rm subprojects/berkeley-softfloat-3.wrap
+    cp -r ${berkeley-softfloat-3} subprojects/berkeley-softfloat-3
+    chmod a+w subprojects/berkeley-softfloat-3
+    cp subprojects/packagefiles/berkeley-softfloat-3/* subprojects/berkeley-softfloat-3
+
+    rm subprojects/berkeley-testfloat-3.wrap
+    cp -r ${berkeley-testfloat-3} subprojects/berkeley-testfloat-3
+    chmod a+w subprojects/berkeley-testfloat-3
+    cp subprojects/packagefiles/berkeley-testfloat-3/* subprojects/berkeley-testfloat-3
+  '';
+
+  # This patch is for 8.2.0 and doesn't fit on the fork
+  patches = builtins.filter (x: (x.name or "") != "9d5b42beb6978dc6219d5dc029c9d453c6b8d503.diff") oldAttrs.patches;
+
+  configureFlags = [
+    "--disable-strip" # We'll strip ourselves after separating debug info.
+    "--enable-tools"
+    "--localstatedir=/var"
+    "--sysconfdir=/etc"
+    "--cross-prefix=${stdenv.cc.targetPrefix}"
+    "--enable-linux-aio"
+    # Based on https://github.com/espressif/esp-toolchain-docs/tree/main/qemu/esp32c3
+    "--target-list=riscv32-softmmu"
+    "--enable-gcrypt"
+    "--enable-slirp"
+    "--enable-debug"
+    "--enable-sdl"
+    "--disable-strip"
+    "--disable-user"
+    "--disable-capstone"
+    "--disable-vnc"
+    "--disable-gtk"
+  ];
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34818,6 +34818,8 @@ with pkgs;
     inherit (darwin) sigtool;
   };
 
+  qemu-esp32c3 = callPackage ../applications/virtualization/qemu/qemu-esp32c3.nix { };
+
   qemu-utils = qemu.override {
     toolsOnly = true;
   };


### PR DESCRIPTION
## Description of changes

A new variant of qemu based on [Espressif's fork of qemu](https://github.com/espressif/qemu) with support for the esp32-c3 target https://github.com/espressif/esp-toolchain-docs/tree/main/qemu/esp32c3 .

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
