### PR TITLE
adguardhome: 0.107.36 -> 0.107.43

### DIFF
--- a/pkgs/servers/adguardhome/bins.nix
+++ b/pkgs/servers/adguardhome/bins.nix
@@ -1,31 +1,31 @@
 { fetchurl, fetchzip }:
 {
 x86_64-darwin = fetchzip {
-  sha256 = "sha256-jIrzE1Je2dhMJuq3k8KL1VoHru5qaUAJCR3kumE9aO0=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.36/AdGuardHome_darwin_amd64.zip";
+  sha256 = "sha256-r1ITe9Elt+UaCIQhgZiMvN1mFyipAVXq/zRWYfMMgxg=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.43/AdGuardHome_darwin_amd64.zip";
 };
 aarch64-darwin = fetchzip {
-  sha256 = "sha256-9BgGGCP8n+5Op+S1/yT/kdMvmiNgKkkXLQmqF2plJZY=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.36/AdGuardHome_darwin_arm64.zip";
+  sha256 = "sha256-y42mcgWvvYxTTEthzBkKS0PiOwsmobzGVXLC1DYXVD8=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.43/AdGuardHome_darwin_arm64.zip";
 };
 i686-linux = fetchurl {
-  sha256 = "sha256-yPxLYXtH4bwQk2M2VTS5aJWTJciNaeXRRAcMBHuvkcA=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.36/AdGuardHome_linux_386.tar.gz";
+  sha256 = "sha256-aQNvatBAVu7X/ZxhGNnqLTHMCEmzumqbxxERu4G70cc=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.43/AdGuardHome_linux_386.tar.gz";
 };
 x86_64-linux = fetchurl {
-  sha256 = "sha256-sG64t1x70uKk844dT1g9GzJ+DgHuv7sUEBaVqoEmWOw=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.36/AdGuardHome_linux_amd64.tar.gz";
+  sha256 = "sha256-Ck4+7HTKVuLykwVEX1rAWWJE+6bT/oIWQ1LTB7Qkls8=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.43/AdGuardHome_linux_amd64.tar.gz";
 };
 aarch64-linux = fetchurl {
-  sha256 = "sha256-rUSfo1uJGbxx1n/VcLyq5zqiDo4g0caCpVcL2uZUSkE=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.36/AdGuardHome_linux_arm64.tar.gz";
+  sha256 = "sha256-wDOYVhjF7uNFRwK7fxjdaX/J6xPX9oiz5GjyBKhjDhA=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.43/AdGuardHome_linux_arm64.tar.gz";
 };
 armv6l-linux = fetchurl {
-  sha256 = "sha256-ruICFAGEMXDeLvoOxHg2oEaYDHkoGZI+SozDXmmD9VU=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.36/AdGuardHome_linux_armv6.tar.gz";
+  sha256 = "sha256-mThdHOvZoSXO3OXxmcfCCAUYzdYV5FPPWEXQhLUqs0A=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.43/AdGuardHome_linux_armv6.tar.gz";
 };
 armv7l-linux = fetchurl {
-  sha256 = "sha256-mTGufMIKkj2R7QuNWKSKMt9KdwlZe9ORtJK5hIaeH/E=";
-  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.36/AdGuardHome_linux_armv7.tar.gz";
+  sha256 = "sha256-oz7Akv4zv801QOqSqkIzsaMJ28BC/mgpH/VLWYj+pkk=";
+  url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.43/AdGuardHome_linux_armv7.tar.gz";
 };
 }

--- a/pkgs/servers/adguardhome/default.nix
+++ b/pkgs/servers/adguardhome/default.nix
@@ -7,7 +7,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "adguardhome";
-  version = "0.107.36";
+  version = "0.107.43";
   src = sources.${system} or (throw "Source for ${pname} is not available for ${system}");
 
   installPhase = ''
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = ./update.sh;
-    schema_version = 24;
+    schema_version = 27;
     tests.adguardhome = nixosTests.adguardhome;
   };
 

--- a/pkgs/servers/adguardhome/update.sh
+++ b/pkgs/servers/adguardhome/update.sh
@@ -13,8 +13,11 @@ version=$(jq -r '.tag_name' <<<"$latest_release")
 
 echo "got version $version"
 
-schema_version=$(curl --silent "https://raw.githubusercontent.com/AdguardTeam/AdGuardHome/${version}/internal/home/upgrade.go" \
-    | grep -Po '(?<=const currentSchemaVersion = )[[:digit:]]+$')
+
+# this is already changed in current master, next release will probably have to get schema from
+# https://github.com/AdguardTeam/AdGuardHome/blob/master/internal/configmigrate/configmigrate.go
+schema_version="$(curl --silent "https://raw.githubusercontent.com/AdguardTeam/AdGuardHome/${version}/internal/confmigrate/migrator.go" \
+    | grep -Po '(?<=const LastSchemaVersion uint = )[[:digit:]]+$')"
 
 echo "got schema_version $schema_version"
 


### PR DESCRIPTION
## Description of changes

Version bump for adguard, had to change the update script because the schema version is stored in a different place for the last release (and already again different on adguard master branch, but my change mentions that).

The changes in .nix files are the result of the update.sh

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
