### PR TITLE
lorem: init at 1.3

### DIFF
--- a/pkgs/by-name/lo/lorem/package.nix
+++ b/pkgs/by-name/lo/lorem/package.nix
@@ -1,0 +1,61 @@
+{ lib
+, cargo
+, desktop-file-utils
+, fetchFromGitLab
+, glib
+, gtk4
+, libadwaita
+, meson
+, ninja
+, pkg-config
+, rustPlatform
+, rustc
+, stdenv
+, wrapGAppsHook4
+}:
+
+stdenv.mkDerivation rec {
+  pname = "lorem";
+  version = "1.3";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "World/design";
+    repo = pname;
+    rev = version;
+    hash = "sha256-+Dp/o1rZSHWihLLLe6CzV6c7uUnSsE8Ct3tbLNqlGF0=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-YYjPhlPp211i+ECPu1xgDumz8nVqWRO8YzcZXy8uunI=";
+  };
+
+  nativeBuildInputs = [
+    cargo
+    desktop-file-utils
+    meson
+    ninja
+    pkg-config
+    rustPlatform.cargoSetupHook
+    rustc
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    glib
+    gtk4
+    libadwaita
+  ];
+
+  meta = with lib; {
+    description = "Generate placeholder text";
+    homepage = "https://gitlab.gnome.org/World/design/lorem";
+    changelog = "https://gitlab.gnome.org/World/design/lorem/-/releases/${version}";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ michaelgrahamevans ];
+    mainProgram = "lorem";
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds [Lorem](https://apps.gnome.org/Lorem/), an app for generating Lorem Ipsum text.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
