### PR TITLE
forge-sparks: init at 0.2.0

### DIFF
--- a/pkgs/by-name/fo/forge-sparks/package.nix
+++ b/pkgs/by-name/fo/forge-sparks/package.nix
@@ -1,0 +1,70 @@
+{ lib
+, blueprint-compiler
+, desktop-file-utils
+, fetchFromGitHub
+, gjs
+, glib
+, glib-networking
+, gtk4
+, libadwaita
+, libportal
+, libsecret
+, libsoup_3
+, meson
+, ninja
+, pkg-config
+, stdenv
+, wrapGAppsHook4
+}:
+
+stdenv.mkDerivation rec {
+  pname = "forge-sparks";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "rafaelmardojai";
+    repo = pname;
+    rev = version;
+    hash = "sha256-kUvUAJLCqIQpjm8RzAZaHVkdDCD9uKSQz9cYN60xS+4=";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    # XdpGtk4 is imported but not used so we remove it to avoid the dependence on libportal-gtk4
+    ./remove-xdpgtk4-import.patch
+  ];
+
+  postPatch = ''
+    patchShebangs troll/gjspack/bin/gjspack
+  '';
+
+  nativeBuildInputs = [
+    blueprint-compiler
+    desktop-file-utils
+    gjs
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    glib
+    glib-networking
+    gtk4
+    libadwaita
+    libportal
+    libsecret
+    libsoup_3
+  ];
+
+  meta = with lib; {
+    description = "Get Git forges notifications";
+    homepage = "https://github.com/rafaelmardojai/forge-sparks";
+    changelog = "https://github.com/rafaelmardojai/forge-sparks/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ michaelgrahamevans ];
+    mainProgram = "forge-sparks";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/by-name/fo/forge-sparks/remove-xdpgtk4-import.patch
+++ b/pkgs/by-name/fo/forge-sparks/remove-xdpgtk4-import.patch
@@ -1,0 +1,12 @@
+diff --git a/src/util.js b/src/util.js
+index d37e42f..9e57ad5 100644
+--- a/src/util.js
++++ b/src/util.js
+@@ -4,7 +4,6 @@ import Gio from 'gi://Gio';
+ import GLib from 'gi://GLib';
+ import Soup from 'gi://Soup';
+ import Xdp from 'gi://Xdp';
+-import XdpGtk4 from 'gi://XdpGtk4';
+ import { gettext as _, ngettext } from 'gettext';
+ 
+ const Format = imports.format;


### PR DESCRIPTION
## Description of changes

Adds [Forge Sparks](https://apps.gnome.org/ForgeSparks/), an app for receiving notifications from different code forges.

I have tested the GitHub integration only.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
