### PR TITLE
python311Packages.cypari2: fix build

### DIFF
--- a/pkgs/development/python-modules/cypari2/default.nix
+++ b/pkgs/development/python-modules/cypari2/default.nix
@@ -30,20 +30,13 @@ buildPythonPackage rec {
     })
   ];
 
-  # This differs slightly from the default python installPhase in that it pip-installs
-  # "." instead of "*.whl".
-  # That is because while the default install phase succeeds to build the package,
-  # it fails to generate the file "auto_paridecl.pxd".
-  installPhase = ''
-    export PYTHONPATH="$out/${python.sitePackages}:$PYTHONPATH"
-
-    # install "." instead of "*.whl"
-    pip install . --no-index --no-warn-script-location --prefix="$out" --no-cache
+  preBuild = ''
+    # generate cythonized extensions (auto_paridecl.pxd is crucial)
+    ${python.pythonOnBuildForHost.interpreter} setup.py build_ext --inplace
   '';
 
   nativeBuildInputs = [
     pari
-    python.pythonOnBuildForHost.pkgs.pip
   ];
 
   buildInputs = [
@@ -56,6 +49,7 @@ buildPythonPackage rec {
   ];
 
   checkPhase = ''
+    test -f "$out/${python.sitePackages}/cypari2/auto_paridecl.pxd"
     make check
   '';
 

--- a/pkgs/development/python-modules/cysignals/default.nix
+++ b/pkgs/development/python-modules/cysignals/default.nix
@@ -1,8 +1,9 @@
 { lib
 , autoreconfHook
+, fetchpatch
 , fetchPypi
 , buildPythonPackage
-, cython_3
+, cython
 , pariSupport ? true, pari # for interfacing with the PARI/GP signal handler
 }:
 
@@ -17,6 +18,14 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-Dx4yHlWgf5AchqNqHkSX9v+d/nAGgdATCjjDbk6yOMM=";
   };
+
+  patches = [
+    # https://github.com/sagemath/cysignals/pull/193
+    (fetchpatch {
+      url = "https://github.com/sagemath/cysignals/commit/474179c87ab0ff562fdfd2471b02797e4bdd3148.diff";
+      sha256 = "sha256-qEAmf4kU+QDI/JPFNjQMZIjMBk8dnaLmOpagIBMsh7w=";
+    })
+  ];
 
   # explicit check:
   # build/src/cysignals/implementation.c:27:2: error: #error "cysignals must be compiled without _FORTIFY_SOURCE"
@@ -34,7 +43,7 @@ buildPythonPackage rec {
   '';
 
   propagatedBuildInputs = [
-    cython_3
+    cython
   ] ++ lib.optionals pariSupport [
     # When cysignals is built with pari, including cysignals into the
     # buildInputs of another python package will cause cython to link against

--- a/pkgs/development/python-modules/fpylll/default.nix
+++ b/pkgs/development/python-modules/fpylll/default.nix
@@ -1,10 +1,11 @@
 { lib
 , fetchFromGitHub
+, fetchpatch
 , buildPythonPackage
 
 # build-system
 , cysignals
-, cython_3
+, cython
 , pkgconfig
 , setuptools
 
@@ -30,8 +31,21 @@ buildPythonPackage rec {
     hash = "sha256-EyReCkVRb3CgzIRal5H13OX/UdwWi+evDe7PoS1qP4A=";
   };
 
+  # temporarily revert to cython 0.29
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/fplll/fpylll/commit/528243c6fa6491c8e9652b99bdf9758766273d66.diff";
+      revert = true;
+      sha256 = "sha256-IRppkESy0CRwARhxBAsZxP6JkTe0M91apG4CTSSYNUU=";
+      excludes = ["requirements.txt"];
+    })
+  ];
+  postPatch = ''
+    substituteInPlace requirements.txt --replace "Cython>=3.0" "Cython"
+  '';
+
   nativeBuildInputs = [
-    cython_3
+    cython
     cysignals
     pkgconfig
     setuptools


### PR DESCRIPTION
## Description of changes

Unfortunately requires downgrading the Cython version for `cysignals` and `fpylll`. Sage tests still fail after this, but Sage builds. I am not sure if this is worth merging. I will upgrade Sage as soon as possible to fix the test issues.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
