### PR TITLE
unFTP: init at 0.14.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15378,6 +15378,12 @@
     github = "rafaelrc7";
     githubId = 5376043;
   };
+  rafaelsgirao = {
+    email = "git-nixpkgs@rafael.ovh";
+    github = "rafaelsgirao";
+    githubId = 7544832;
+    name = "Rafael Girão";
+  };
   ragge = {
     email = "r.dahlen@gmail.com";
     github = "ragnard";

--- a/pkgs/servers/unftp/default.nix
+++ b/pkgs/servers/unftp/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, linux-pam
+, rustPlatform
+, fetchFromGitHub
+, buildFeatures ? [ "gnu" ]
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "unFTP";
+  version = "0.14.5";
+
+  src = fetchFromGitHub {
+    owner = "bolcom";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-CPq4CH7reS5AI145l8U1nekm2MKnmoBfVqENR9QOKF4";
+  };
+
+  #Extra cargo Build Features
+  inherit buildFeatures;
+
+  buildInputs = [
+    linux-pam
+  ];
+
+  cargoSha256 = "sha256-vFu1D2GYItVGeTmd/rwmZHM/mf4zQ3tzBLux7vb+yZ0=";
+
+  meta = with lib; {
+    description = "A FTP(S) server with a couple of twists written in Rust";
+    homepage = "https://unftp.rs";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ rafaelsgirao ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26838,6 +26838,8 @@ with pkgs;
 
   system-sendmail = lowPrio (callPackage ../servers/mail/system-sendmail { });
 
+  unFTP = callPackage ../servers/unftp { };
+
   # PulseAudio daemons
 
   hsphfpd = callPackage ../servers/pulseaudio/hsphfpd.nix { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

> unFTP is an open-source FTP(S) (not SFTP) server aimed at the Cloud that allows bespoke extension through its pluggable authenticator, storage back-end and user detail store architectures.

https://unftp.rs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
