### PR TITLE
docker_24: remove `LimitNOFILE=infinity` from `docker.service` unit

### DIFF
--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -106,6 +106,17 @@ rec {
           url = "https://github.com/moby/moby/pull/43136.patch";
           hash = "sha256-1WZfpVnnqFwLMYqaHLploOodls0gHF8OCp7MrM26iX8=";
         })
+      ] ++ lib.optionals (lib.versions.major version == "24") [
+        # docker_24 has LimitNOFILE set to "infinity", which causes a wide variety of issues in containers.
+        # Issues range from higher-than-usual ressource usage, to containers not starting at all.
+        # This patch (part of the release candidates for docker_25) simply removes this unit option
+        # making systemd use its default "1024:524288", which is sane. See commit message and/or the PR for
+        # more details: https://github.com/moby/moby/pull/45534
+        (fetchpatch {
+          name = "LimitNOFILE-systemd-default.patch";
+          url = "https://github.com/moby/moby/pull/45534/commits/c8930105bc9fc3c1a8a90886c23535cc6c41e130.patch";
+          hash = "sha256-nyGLxFrJaD0TrDqsAwOD6Iph0aHcFH9sABj1Fy74sec=";
+        })
       ];
 
       postPatch = ''


### PR DESCRIPTION
## Description of changes

This makes systemd use its default, which is `"1024:524288"`. This is recommended by upstream now and part of the `docker_25` release candidates.

`docker_20_10` will continue to use `"1048576"`, which is also fine. Patching `docker_24` specifically, not our `nixos/docker` module, allows us to keep `docker_20_10`'s different `LimitNOFILE` value.

Motivation: https://github.com/NixOS/nixpkgs/pull/278531#discussion_r1451611629

Supersedes/closes #278531.

Upstream: https://github.com/moby/moby/pull/45534

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).