### PR TITLE
ffmpeg: general option improvements

### DIFF
--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -42,7 +42,7 @@
 , withFdkAac ? withFullDeps && withUnfree # Fraunhofer FDK AAC de/encoder
 , withFontconfig ? withHeadlessDeps # Needed for drawtext filter
 , withFreetype ? withHeadlessDeps # Needed for drawtext filter
-, withFrei0r ? withFullDeps # frei0r video filtering
+, withFrei0r ? withFullDeps && withGPL # frei0r video filtering
 , withFribidi ? withFullDeps # Needed for drawtext filter
 , withGme ? withFullDeps # Game Music Emulator
 , withGnutls ? withHeadlessDeps
@@ -61,7 +61,7 @@
 , withOgg ? withHeadlessDeps # Ogg container used by vorbis & theora
 , withOpenal ? withFullDeps # OpenAL 1.1 capture support
 , withOpencl ? withFullDeps
-, withOpencoreAmrnb ? withFullDeps # AMR-NB de/encoder & AMR-WB decoder
+, withOpencoreAmrnb ? withFullDeps && withVersion3 # AMR-NB de/encoder & AMR-WB decoder
 , withOpengl ? false # OpenGL rendering
 , withOpenh264 ? withFullDeps # H.264/AVC encoder
 , withOpenjpeg ? withFullDeps # JPEG 2000 de/encoder
@@ -70,7 +70,7 @@
 , withPulse ? withSmallDeps && !stdenv.isDarwin # Pulseaudio input support
 , withRav1e ? withFullDeps # AV1 encoder (focused on speed and safety)
 , withRtmp ? false # RTMP[E] support
-, withSamba ? withFullDeps && !stdenv.isDarwin # Samba protocol
+, withSamba ? withFullDeps && !stdenv.isDarwin && withGPLv3 # Samba protocol
 , withSdl2 ? withSmallDeps
 , withShaderc ? withFullDeps && !stdenv.isDarwin && lib.versionAtLeast version "5.0"
 , withSoxr ? withHeadlessDeps # Resampling via soxr
@@ -85,23 +85,23 @@
 , withV4l2M2m ? withV4l2
 , withVaapi ? withHeadlessDeps && (with stdenv; isLinux || isFreeBSD) # Vaapi hardware acceleration
 , withVdpau ? withSmallDeps # Vdpau hardware acceleration
-, withVidStab ? withFullDeps # Video stabilization
-, withVmaf ? withFullDeps && withGPLv3 && !stdenv.isAarch64 && lib.versionAtLeast version "5" # Netflix's VMAF (Video Multi-Method Assessment Fusion)
-, withVoAmrwbenc ? withFullDeps # AMR-WB encoder
+, withVidStab ? withFullDeps && withGPL # Video stabilization
+, withVmaf ? withFullDeps && !stdenv.isAarch64 && lib.versionAtLeast version "5" # Netflix's VMAF (Video Multi-Method Assessment Fusion)
+, withVoAmrwbenc ? withFullDeps && withVersion3 # AMR-WB encoder
 , withVorbis ? withHeadlessDeps # Vorbis de/encoding, native encoder exists
 , withVpx ? withHeadlessDeps && stdenv.buildPlatform == stdenv.hostPlatform # VP8 & VP9 de/encoding
 , withVulkan ? withFullDeps && !stdenv.isDarwin
 , withWebp ? withFullDeps # WebP encoder
-, withX264 ? withHeadlessDeps # H.264/AVC encoder
-, withX265 ? withHeadlessDeps # H.265/HEVC encoder
-, withXavs ? withFullDeps # AVS encoder
+, withX264 ? withHeadlessDeps && withGPL # H.264/AVC encoder
+, withX265 ? withHeadlessDeps && withGPL # H.265/HEVC encoder
+, withXavs ? withFullDeps && withGPL # AVS encoder
 , withXcb ? withXcbShm || withXcbxfixes || withXcbShape # X11 grabbing using XCB
 , withXcbShape ? withFullDeps # X11 grabbing shape rendering
 , withXcbShm ? withFullDeps # X11 grabbing shm communication
 , withXcbxfixes ? withFullDeps # X11 grabbing mouse rendering
 , withXlib ? withFullDeps # Xlib support
 , withXml2 ? withFullDeps # libxml2 support, for IMF and DASH demuxers
-, withXvid ? withHeadlessDeps # Xvid encoder, native encoder exists
+, withXvid ? withHeadlessDeps && withGPL # Xvid encoder, native encoder exists
 , withZimg ? withHeadlessDeps
 , withZlib ? withHeadlessDeps
 , withZmq ? withFullDeps # Message passing
@@ -110,7 +110,8 @@
  *  Licensing options (yes some are listed twice, filters and such are not listed)
  */
 , withGPL ? true
-, withGPLv3 ? true
+, withVersion3 ? true # When withGPL is set this implies GPLv3 otherwise it is LGPLv3
+, withGPLv3 ? withGPL && withVersion3
 , withUnfree ? false
 
 /*
@@ -306,8 +307,8 @@ assert lib.elem ffmpegVariant [ "headless" "small" "full" ];
 /*
  *  Licensing dependencies
  */
-assert withGPLv3 -> withGPL;
-assert withUnfree -> withGPL && withGPLv3;
+assert withGPLv3 -> withGPL && withVersion3;
+
 /*
  *  Build dependencies
  */
@@ -381,7 +382,7 @@ stdenv.mkDerivation (finalAttrs: {
      *  Licensing flags
      */
     (enableFeature withGPL "gpl")
-    (enableFeature withGPLv3 "version3")
+    (enableFeature withVersion3 "version3")
     (enableFeature withUnfree "nonfree")
     /*
      *  Build flags
@@ -707,8 +708,10 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = with licenses; [ lgpl21Plus ]
       ++ optional withGPL gpl2Plus
+      ++ optional withVersion3 lgpl3Plus
       ++ optional withGPLv3 gpl3Plus
-      ++ optional withUnfree unfreeRedistributable;
+      ++ optional withUnfree unfreeRedistributable
+      ++ optional (withGPL && withUnfree) unfree;
     pkgConfigModules = [ "libavutil" ];
     platforms = platforms.all;
     maintainers = with maintainers; [ atemu arthsmn ];

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -125,6 +125,11 @@
 , withMultithread ? true # Multithreading via pthreads/win32 threads
 , withNetwork ? withHeadlessDeps # Network support
 , withPixelutils ? withHeadlessDeps # Pixel utils in libavutil
+, withStatic ? stdenv.hostPlatform.isStatic
+, withShared ? !stdenv.hostPlatform.isStatic
+, withPic ? true
+, withThumb ? false # On some ARM platforms
+
 /*
  *  Program options
  */
@@ -381,9 +386,10 @@ stdenv.mkDerivation (finalAttrs: {
     /*
      *  Build flags
      */
-    # On some ARM platforms --enable-thumb
-    "--enable-shared"
-    "--enable-pic"
+    (enableFeature withStatic "static")
+    (enableFeature withShared "shared")
+    (enableFeature withPic "pic")
+    (enableFeature withThumb "thumb")
 
     (enableFeature withSmallBuild "small")
     (enableFeature withRuntimeCPUDetection "runtime-cpudetect")

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -564,10 +564,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ removeReferencesTo addOpenGLRunpath perl pkg-config texinfo yasm ]
   ++ optionals withCudaLLVM [ clang ];
 
-  # TODO This was always in buildInputs before, why?
-  buildInputs = optionals withFullDeps [ libdc1394 ]
-  ++ optionals (withFullDeps && !stdenv.isDarwin) [ libraw1394 ] # TODO where does this belong to
-  ++ optionals (withNvdec || withNvenc) [ (if (lib.versionAtLeast finalAttrs.version "6") then nv-codec-headers-12 else nv-codec-headers) ]
+  buildInputs = optionals (withNvdec || withNvenc) [ (if (lib.versionAtLeast finalAttrs.version "6") then nv-codec-headers-12 else nv-codec-headers) ]
   ++ optionals withAlsa [ alsa-lib ]
   ++ optionals withAom [ libaom ]
   ++ optionals withAribcaption [ libaribcaption ]
@@ -578,6 +575,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optionals withCaca [ libcaca ]
   ++ optionals withCelt [ celt ]
   ++ optionals withDav1d [ dav1d ]
+  ++ optionals withDc1394 [ libdc1394 libraw1394 ]
   ++ optionals withDrm [ libdrm ]
   ++ optionals withFdkAac [ fdk_aac ]
   ++ optionals withFontconfig [ fontconfig ]


### PR DESCRIPTION
## Description of changes

- add options for some build features (static, shared, pic, thumb)
- move libdc1394 and libraw1394 features flag (only needed when dc1394 enabled)
- remove gplv3 option (this is the case if version3 and gpl are both activated)
- add version3 option (doesn't need to be gpl3 lpgl3 also can be the case)
- added the right license requirements to options form (https://git.ffmpeg.org/gitweb/ffmpeg.git/blob/8e23ebe6f971ec4177be73b453960d83c264b7b5:/configure#l1804)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
