### PR TITLE
rPackages.xml2: fix build

### DIFF
--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -955,6 +955,7 @@ let
     });
 
     xml2 = old.xml2.overrideAttrs (attrs: {
+      patches = [ ./patches/xml2.patch ];
       preConfigure = ''
         export LIBXML_INCDIR=${pkgs.libxml2.dev}/include/libxml2
         patchShebangs configure

--- a/pkgs/development/r-modules/patches/xml2.patch
+++ b/pkgs/development/r-modules/patches/xml2.patch
@@ -1,0 +1,26 @@
+diff --git a/src/xml2_init.cpp b/src/xml2_init.cpp
+index b89c64a..146d802 100644
+--- a/src/xml2_init.cpp
++++ b/src/xml2_init.cpp
+@@ -10,7 +10,7 @@
+ #include <string>
+ #include "xml2_utils.h"
+ 
+-void handleStructuredError(void* userData, xmlError* error) {
++void handleStructuredError(void* userData, const xmlError* error) {
+ 
+   BEGIN_CPP
+   std::string message = std::string(error->message);
+diff --git a/src/xml2_schema.cpp b/src/xml2_schema.cpp
+index 345ca50..60b4463 100644
+--- a/src/xml2_schema.cpp
++++ b/src/xml2_schema.cpp
+@@ -9,7 +9,7 @@
+ #include "xml2_types.h"
+ #include "xml2_utils.h"
+ 
+-void handleSchemaError(void* userData, xmlError* error) {
++void handleSchemaError(void* userData, const xmlError* error) {
+   std::vector<std::string> * vec = (std::vector<std::string> *) userData;
+   std::string message = std::string(error->message);
+   message.resize(message.size() - 1);


### PR DESCRIPTION
## Description of changes

This PR adds a quick fix for `rPackages.xml2`, which was left broken after a `libxml2` update.

I could have used `substituteInPlace` but that can silently fail.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
