### PR TITLE
python311Packages.openai: 1.7.1 -> 1.9.0

### DIFF
--- a/pkgs/development/python-modules/openai/default.nix
+++ b/pkgs/development/python-modules/openai/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pythonOlder
-, pythonRelaxDepsHook
 , hatchling
 # propagated
 , httpx
@@ -11,6 +10,7 @@
 , anyio
 , distro
 , sniffio
+, cached-property
 , tqdm
 # optional
 , numpy
@@ -26,9 +26,8 @@
 
 buildPythonPackage rec {
   pname = "openai";
-  version = "1.7.1";
+  version = "1.9.0";
   pyproject = true;
-
 
   disabled = pythonOlder "3.7.1";
 
@@ -36,28 +35,23 @@ buildPythonPackage rec {
     owner = "openai";
     repo = "openai-python";
     rev = "refs/tags/v${version}";
-    hash = "sha256-NXZ+7gDA3gMGSrmgceHxcR45LrXdazXbYuhcoUsNXew=";
+    hash = "sha256-+3tCttKWbWt3Nsf5E6NWYt0yLRV0kfj7Qz6PhaOmBsY=";
   };
 
   nativeBuildInputs = [
     hatchling
-    pythonRelaxDepsHook
-  ];
-
-  pythonRelaxDeps = [
-    # https://github.com/openai/openai-python/issues/921
-    "anyio"
   ];
 
   propagatedBuildInputs = [
     httpx
     pydantic
+    typing-extensions
     anyio
     distro
     sniffio
     tqdm
   ] ++ lib.optionals (pythonOlder "3.8") [
-    typing-extensions
+    cached-property
   ];
 
   passthru.optional-dependencies = {
@@ -80,15 +74,13 @@ buildPythonPackage rec {
     dirty-equals
   ];
 
-  pytestFlagsArray = [
-    "-W" "ignore::DeprecationWarning"
+  disabledTests = [
+    # makes network requests
+    "test_streaming_response"
   ];
-
-  OPENAI_API_KEY = "sk-foo";
 
   disabledTestPaths = [
     # makes network requests
-    "tests/test_client.py"
     "tests/api_resources"
   ];
 


### PR DESCRIPTION
## Description of changes

Updated to latest version, and did a little bit of cleanup.

Diff: https://github.com/openai/openai-python/compare/refs/tags/v1.7.1...v1.9.0
Changelog: https://github.com/openai/openai-python/releases/tag/v1.9.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
