### PR TITLE
wch-isp: 0.4.0 -> 0.4.1, move source to sr.ht

### DIFF
--- a/pkgs/development/embedded/wch-isp/default.nix
+++ b/pkgs/development/embedded/wch-isp/default.nix
@@ -1,14 +1,14 @@
-{ lib, stdenv, fetchFromGitHub, pkg-config, libusb1 }:
+{ lib, stdenv, fetchFromSourcehut, pkg-config, libusb1 }:
 
 stdenv.mkDerivation rec {
   pname = "wch-isp";
-  version = "0.4.0";
+  version = "0.4.1";
 
-  src = fetchFromGitHub {
-    owner = "jmaselbas";
+  src = fetchFromSourcehut {
+    owner = "~jmaselbas";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-cTePTpzvWf2DdInhBxFY72aVNb0SAlCHb/tUwNqqX1U=";
+    hash = "sha256-JB7cvZPzRhYJ8T3QJkguHOzZFrLOft5rRz0F0sVav/k=";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Firmware programmer for WCH microcontrollers over USB";
     license = lib.licenses.gpl2Only;
-    homepage = "https://github.com/jmaselbas/wch-isp";
+    homepage = "https://git.sr.ht/~jmaselbas/wch-isp";
     maintainers = with lib.maintainers; [ lesuisse ];
     platforms = lib.platforms.unix;
   };


### PR DESCRIPTION
## Description of changes

Primary development seems to be on sr.ht. 0.4.1 tag is not present on GH and the project maintainer use the sr.ht URL in the Alpine and AUR packages.

Changes:
https://git.sr.ht/~jmaselbas/wch-isp/log/a6851b2b7e9a48a7041cfb66f0f8c2e7a3f112d8
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
