### PR TITLE
simulide: add generic builder for other versions

### DIFF
--- a/pkgs/applications/science/electronics/simulide/default.nix
+++ b/pkgs/applications/science/electronics/simulide/default.nix
@@ -109,4 +109,13 @@ in
       cp bin/simulide $out/bin/simulide
     '';
   };
+
+  simulide_1_0_0 = generic {
+    version = "1.0.0";
+    release = "SR2";
+    branch = "1.0.0";
+    rev = "1449";
+    sha256 = "sha256-rJWZvnjVzaKXU2ktbde1w8LSNvu0jWkDIk4dq2l7t5g=";
+    extraBuildInputs = [ qtscript ];
+  };
 }

--- a/pkgs/applications/science/electronics/simulide/default.nix
+++ b/pkgs/applications/science/electronics/simulide/default.nix
@@ -9,78 +9,104 @@
 }:
 
 let
-  version = "0.4.15";
-  release = "SR10";
-  branch = "simulide_0.4.14"; # the branch name does not mach the version for some reason
-  rev = "291";
-  sha256 = "sha256-BBoZr/S2pif0Jft5wrem8y00dXl08jq3kFiIUtOr3LM=";
+  generic =
+    { version
+    , release
+    , branch
+    , rev
+    , sha256
+    , extraPostPatch ? ""
+    , extraBuildInputs ? [ ]
+    , iconPath ? "resources/icons/simulide.png"
+    , installFiles ? ''
+        cp -r data examples $out/share/simulide
+        cp simulide $out/bin/simulide
+      ''
+    }:
+    mkDerivation {
+      pname = "simulide";
+      version = "${version}-${release}";
+
+      src = fetchbzr {
+        url = "https://code.launchpad.net/~arcachofo/simulide/${branch}";
+        inherit rev sha256;
+      };
+
+      postPatch = ''
+        sed -i resources/simulide.desktop \
+          -e "s|^Exec=.*$|Exec=simulide|" \
+          -e "s|^Icon=.*$|Icon=simulide|"
+
+        # Note: older versions don't have REV_NO
+        sed -i SimulIDE.pro \
+          -e "s|^VERSION = .*$|VERSION = ${version}|" \
+          -e "s|^RELEASE = .*$|RELEASE = -${release}|" \
+          -e "s|^REV_NO = .*$|REV_NO = ${rev}|" \
+          -e "s|^BUILD_DATE = .*$|BUILD_DATE = ??-??-??|"
+
+        ${extraPostPatch}
+      '';
+
+      preConfigure = ''
+        cd build_XX
+      '';
+
+      nativeBuildInputs = [
+        qmake
+      ];
+
+      buildInputs = [
+        qtserialport
+        qtmultimedia
+        qttools
+      ] ++ extraBuildInputs;
+
+      installPhase = ''
+        runHook preInstall
+
+        install -Dm644 ../resources/simulide.desktop $out/share/applications/simulide.desktop
+        install -Dm644 ../${iconPath} $out/share/icons/hicolor/256x256/apps/simulide.png
+
+        mkdir -p $out/share/simulide $out/bin
+        pushd executables/SimulIDE_*
+        ${installFiles}
+        popd
+
+        runHook postInstall
+      '';
+
+      meta = {
+        description = "A simple real time electronic circuit simulator";
+        longDescription = ''
+          SimulIDE is a simple real time electronic circuit simulator, intended for hobbyist or students
+          to learn and experiment with analog and digital electronic circuits and microcontrollers.
+          It supports PIC, AVR, Arduino and other MCUs and MPUs.
+        '';
+        homepage = "https://simulide.com/";
+        license = lib.licenses.gpl3Only;
+        mainProgram = "simulide";
+        maintainers = with lib.maintainers; [ carloscraveiro tomasajt ];
+        platforms = [ "x86_64-linux" ];
+      };
+    };
 in
-mkDerivation {
-  pname = "simulide";
-  version = "${version}-${release}";
-
-  src = fetchbzr {
-    url = "https://code.launchpad.net/~arcachofo/simulide/${branch}";
-    inherit rev sha256;
-  };
-
-  postPatch = ''
-    # GCC 13 needs this header explicitly included
-    sed -i src/gpsim/value.h -e '1i #include <cstdint>'
-    sed -i src/gpsim/modules/watchdog.h -e '1i #include <cstdint>'
-
-    sed -i resources/simulide.desktop \
-      -e "s|^Exec=.*$|Exec=simulide|" \
-      -e "s|^Icon=.*$|Icon=simulide|"
-    sed -i SimulIDE.pro \
-      -e "s|^VERSION = .*$|VERSION = ${version}|" \
-      -e "s|^RELEASE = .*$|RELEASE = -${release}|" \
-      -e "s|^REV_NO = .*$|REV_NO = ${rev}|" \
-      -e "s|^BUILD_DATE = .*$|BUILD_DATE = ??-??-??|"
-  '';
-
-  preConfigure = ''
-    cd build_XX
-  '';
-
-  nativeBuildInputs = [
-    qmake
-  ];
-
-  buildInputs = [
-    qtserialport
-    qtmultimedia
-    qttools
-    qtscript
-  ];
-
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm644 ../resources/simulide.desktop $out/share/applications/simulide.desktop
-    install -Dm644 ../resources/icons/hicolor/256x256/simulide.png $out/share/icons/hicolor/256x256/apps/simulide.png
-
-    mkdir -p $out/share/simulide $out/bin
-
-    pushd executables/SimulIDE_*
-    cp -r share/simulide/* $out/share/simulide
-    cp bin/simulide $out/bin/simulide
-    popd
-
-    runHook postInstall
-  '';
-
-  meta = with lib; {
-    description = "A simple real time electronic circuit simulator";
-    longDescription = ''
-      SimulIDE is a simple real time electronic circuit simulator, intended for hobbyist or students
-      to learn and experiment with analog and digital electronic circuits and microcontrollers.
-      It supports PIC, AVR, Arduino and other MCUs and MPUs.
+{
+  simulide_0_4_15 = generic {
+    version = "0.4.15";
+    release = "SR10";
+    branch = "simulide_0.4.14"; # the branch name does not mach the version for some reason
+    rev = "291";
+    sha256 = "sha256-BBoZr/S2pif0Jft5wrem8y00dXl08jq3kFiIUtOr3LM=";
+    extraPostPatch = ''
+      # GCC 13 needs the <cstdint> header explicitly included
+      sed -i src/gpsim/value.h -e '1i #include <cstdint>'
+      sed -i src/gpsim/modules/watchdog.h -e '1i #include <cstdint>'
     '';
-    homepage = "https://simulide.com/";
-    license = licenses.gpl3Only;
-    mainProgram = "simulide";
-    maintainers = with maintainers; [ carloscraveiro tomasajt ];
-    platforms = ["x86_64-linux"];
+    extraBuildInputs = [ qtscript ];
+    iconPath = "resources/icons/hicolor/256x256/simulide.png"; # upstream had a messed up icon path in this release
+    installFiles = ''
+      cp -r share/simulide/* $out/share/simulide
+      cp bin/simulide $out/bin/simulide
+    '';
   };
 }

--- a/pkgs/applications/science/electronics/simulide/default.nix
+++ b/pkgs/applications/science/electronics/simulide/default.nix
@@ -118,4 +118,14 @@ in
     sha256 = "sha256-rJWZvnjVzaKXU2ktbde1w8LSNvu0jWkDIk4dq2l7t5g=";
     extraBuildInputs = [ qtscript ];
   };
+
+  simulide_1_1_0 = generic {
+    version = "1.1.0";
+    release = "RC1";
+    # The 1.1.0 branch didn't get merged correctly from trunk
+    # See: https://simulide.com/p/forum/topic/new-files-missing-from-1-1-0-rc1-after-merge
+    branch = "trunk";
+    rev = "2162";
+    sha256 = "sha256-bgRAqt7h2LtU2Ze6Jiz8APhyPcV15v4ofxIilIeZV9E=";
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39673,7 +39673,10 @@ with pkgs;
 
   appcsxcad = libsForQt5.callPackage ../applications/science/electronics/appcsxcad { };
 
-  simulide = libsForQt5.callPackage ../applications/science/electronics/simulide { };
+  inherit (libsForQt5.callPackage ../applications/science/electronics/simulide { })
+    simulide_0_4_15;
+
+  simulide = simulide_0_4_15;
 
   eagle = libsForQt5.callPackage ../applications/science/electronics/eagle/eagle.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39674,7 +39674,7 @@ with pkgs;
   appcsxcad = libsForQt5.callPackage ../applications/science/electronics/appcsxcad { };
 
   inherit (libsForQt5.callPackage ../applications/science/electronics/simulide { })
-    simulide_0_4_15 simulide_1_0_0;
+    simulide_0_4_15 simulide_1_0_0 simulide_1_1_0;
 
   simulide = simulide_1_0_0;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39674,9 +39674,9 @@ with pkgs;
   appcsxcad = libsForQt5.callPackage ../applications/science/electronics/appcsxcad { };
 
   inherit (libsForQt5.callPackage ../applications/science/electronics/simulide { })
-    simulide_0_4_15;
+    simulide_0_4_15 simulide_1_0_0;
 
-  simulide = simulide_0_4_15;
+  simulide = simulide_1_0_0;
 
   eagle = libsForQt5.callPackage ../applications/science/electronics/eagle/eagle.nix { };
 


### PR DESCRIPTION
## Description of changes

@CarlosCraveiro

This is a continuation of https://github.com/NixOS/nixpkgs/pull/273641, which only added the `0_4_15` version of this package.

This PR separates simulide into 3 versions: `simulide_0_4_15`, `simulide_1_0_0` and `simulide_1_1_0`
Just writing `simulide` will use `simulide_1_0_0` as that is latest version marked as stable.

The git diff is quite horrible, the indentation messes it up a lot.



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
