### PR TITLE
vkeybd: fix ALSA plugins load path

### DIFF
--- a/pkgs/applications/audio/vkeybd/default.nix
+++ b/pkgs/applications/audio/vkeybd/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, alsa-lib, libX11, makeWrapper, tcl, tk }:
+{ lib, stdenv, fetchurl, alsa-lib-with-plugins, libX11, tcl, tk }:
 
 stdenv.mkDerivation  rec {
   pname = "vkeybd";
@@ -9,8 +9,7 @@ stdenv.mkDerivation  rec {
     sha256 = "0107b5j1gf7dwp7qb4w2snj4bqiyps53d66qzl2rwj4jfpakws5a";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ alsa-lib libX11 tcl tk ];
+  buildInputs = [ alsa-lib-with-plugins libX11 tcl tk ];
 
   configurePhase = ''
     mkdir -p $out/bin

--- a/pkgs/by-name/al/alsa-lib-with-plugins/package.nix
+++ b/pkgs/by-name/al/alsa-lib-with-plugins/package.nix
@@ -1,0 +1,52 @@
+{ lib
+, pkgs
+, alsa-lib
+, plugins ? [ pkgs.alsa-plugins ]
+, lndir
+, symlinkJoin
+, runCommand
+}:
+let
+  merged = symlinkJoin { name = "alsa-plugins-merged"; paths = plugins; };
+in
+runCommand "${alsa-lib.pname}-${alsa-lib.version}" {
+  meta = with lib; {
+    description = "wrapper to ease access to ALSA plugins";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ gm6k ];
+  };
+  outputs = alsa-lib.outputs;
+} (
+    (
+      lib.concatMapStringsSep "\n" (
+        output: ''
+          mkdir ${builtins.placeholder output}
+          ${lndir}/bin/lndir ${lib.attrByPath [output] null alsa-lib} \
+            ${builtins.placeholder output}
+        ''
+      ) alsa-lib.outputs
+    ) + ''
+    cp -r ${merged}/lib/alsa-lib $out/lib
+    (
+      echo $out | wc -c
+      echo ${alsa-lib} | wc -c
+    ) | xargs echo | grep -q "^\(.*\) \1$" || (
+      echo cannot binary patch
+      exit 1
+    )
+    rm $out/lib/libasound.la
+    rm $out/lib/libasound.so.?.?.?
+    rm $dev/lib/pkgconfig/alsa.pc
+    rm $dev/nix-support/propagated-build-inputs
+    cp ${alsa-lib}/lib/libasound.la $out/lib
+    cp ${alsa-lib}/lib/libasound.so.?.?.? $out/lib
+    cp ${alsa-lib.dev}/lib/pkgconfig/alsa.pc $dev/lib/pkgconfig
+    cp ${alsa-lib.dev}/nix-support/propagated-build-inputs $dev/nix-support
+    sed -i \
+        $out/lib/libasound.la \
+        $out/lib/libasound.so.?.?.? \
+        $dev/lib/pkgconfig/alsa.pc \
+        $dev/nix-support/propagated-build-inputs \
+      -e "s@${alsa-lib}@$out@g"
+  ''
+)


### PR DESCRIPTION
## Description of changes

`vkeybd` tries to load ALSA plugins from the output path of `alsa-lib`, while they would actually built in `alsa-plugins`. This leads to plugin load failures.

```
ALSA lib conf.c:4005:(snd_config_hooks_call) Cannot open shared library libasound_module_conf_pulse.so (/nix/store/sfpk1p4sknqnhlfdlv13kzpvhlwjia16-alsa-lib-1.2.9/lib/alsa-lib/libasound_module_conf_pulse.so: cannot open shared object file: No such file or directory)
ALSA lib seq.c:935:(snd_seq_open_noupdate) Unknown SEQ hw
ERROR: can't open sequencer device
```

This PR fixes it by using an `alsa-lib` wrapper fixing the plugin load path issue. To allow CI, this includes the commit from https://github.com/NixOS/nixpkgs/pull/277180 it depends on.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
