### PR TITLE
ephemeralpg: 3.1 -> 3.3, fix for nixos-update's runner

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11897,6 +11897,12 @@
     githubId = 4641445;
     name = "Carlo Nucera";
   };
+  medv = {
+    email = "mikhail.advent@gmail.com";
+    github = "medv";
+    githubId = 1631737;
+    name = "Mikhail Medvedev";
+  };
   megheaiulian = {
     email = "iulian.meghea@gmail.com";
     github = "megheaiulian";

--- a/pkgs/development/tools/database/ephemeralpg/default.nix
+++ b/pkgs/development/tools/database/ephemeralpg/default.nix
@@ -3,7 +3,7 @@ stdenv.mkDerivation rec {
   pname = "ephemeralpg";
   version = "3.1";
   src = fetchurl {
-    url = "http://ephemeralpg.org/code/${pname}-${version}.tar.gz";
+    url = "https://eradman.com/ephemeralpg/code/${pname}-${version}.tar.gz";
     sha256 = "1ap22ki8yz6agd0qybcjgs4b9izw1rwwcgpxn3jah2ccfyax34s6";
   };
   nativeBuildInputs = [ makeWrapper ];
@@ -15,8 +15,8 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Run tests on an isolated, temporary PostgreSQL database";
     license = licenses.isc;
-    homepage = "http://ephemeralpg.org/";
+    homepage = "https://eradman.com/ephemeralpg/";
     platforms = platforms.all;
-    maintainers = with maintainers; [ hrdinka ];
+    maintainers = with maintainers; [ hrdinka medv ];
   };
 }

--- a/pkgs/development/tools/database/ephemeralpg/default.nix
+++ b/pkgs/development/tools/database/ephemeralpg/default.nix
@@ -1,10 +1,10 @@
 { lib, stdenv, fetchurl, postgresql, getopt, makeWrapper }:
 stdenv.mkDerivation rec {
   pname = "ephemeralpg";
-  version = "3.1";
+  version = "3.3";
   src = fetchurl {
     url = "https://eradman.com/ephemeralpg/code/${pname}-${version}.tar.gz";
-    sha256 = "1ap22ki8yz6agd0qybcjgs4b9izw1rwwcgpxn3jah2ccfyax34s6";
+    hash = "sha256-pVQrfSpwJnxCRXAUpZQZsb0Z/wlLbjdaYmhVevgHrgo=";
   };
   nativeBuildInputs = [ makeWrapper ];
   installPhase = ''


### PR DESCRIPTION
## Description of changes

Relevant issue where I was instructed to submit this PR: https://github.com/ryantm/nixpkgs-update/issues/380

The old homepage for this project was replaced some time ago, breaking @r-ryantm and resulting in a very outdated version of this excellent package in nixpkgs.

## Things done

1. Updated homepage from http://ephemeralpg.org to https://eradman.com/ephemeralpg which is the official link from the project's [repository](https://github.com/eradman/ephemeralpg/).
2. Upgraded package from 3.1 to 3.3
3. Added myself to maintainers? Unsure if I had to do that, I see it often asked in other PRs

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
