### PR TITLE
geoserver: add extensions and update script

### DIFF
--- a/nixos/tests/geoserver.nix
+++ b/nixos/tests/geoserver.nix
@@ -1,4 +1,18 @@
-{ pkgs, lib, ... }: {
+{ pkgs, lib, ... }:
+
+let
+  geoserver = pkgs.geoserver;
+  geoserverWithImporterExtension = pkgs.geoserver.withExtensions (ps: with ps; [ importer ]);
+
+  # Blacklisted extensions:
+  # - wps-jdbc needs a running (Postrgres) db server.
+  blacklist = [ "wps-jdbc" ];
+
+  blacklistedToNull = n: v: if ! builtins.elem n blacklist then v else null;
+  getNonBlackistedExtensionsAsList = ps: builtins.filter (x: x != null) (lib.attrsets.mapAttrsToList blacklistedToNull ps);
+  geoserverWithAllExtensions = pkgs.geoserver.withExtensions (ps: getNonBlackistedExtensionsAsList ps);
+in
+{
 
   name = "geoserver";
   meta = {
@@ -9,16 +23,57 @@
     machine = { pkgs, ... }: {
       virtualisation.diskSize = 2 * 1024;
 
-      environment.systemPackages = [ pkgs.geoserver ];
+      environment.systemPackages = [
+        geoserver
+        geoserverWithImporterExtension
+        geoserverWithAllExtensions
+      ];
     };
   };
 
   testScript = ''
+    from contextlib import contextmanager
+
+    curl_cmd = "curl --fail --connect-timeout 2"
+    curl_cmd_rest = f"{curl_cmd} -u admin:geoserver -X GET"
+    base_url = "http://localhost:8080/geoserver"
+    log_file = "./log.txt"
+
+    @contextmanager
+    def running_geoserver(pkg):
+      try:
+        print(f"Launching geoserver from {pkg}...")
+        machine.execute(f"{pkg}/bin/geoserver-startup > {log_file} 2>&1 &")
+        machine.wait_until_succeeds(f"{curl_cmd} {base_url} 2>&1", timeout=60)
+        yield
+      finally:
+        # We need to wait a little bit to make sure the server is properly
+        # shutdown before launching a new instance.
+        machine.execute(f"{pkg}/bin/geoserver-shutdown; sleep 1")
+
     start_all()
 
-    machine.execute("${pkgs.geoserver}/bin/geoserver-startup > /dev/null 2>&1 &")
-    machine.wait_until_succeeds("curl --fail --connect-timeout 2 http://localhost:8080/geoserver", timeout=60)
+    with running_geoserver("${geoserver}"):
+      machine.succeed(f"{curl_cmd} {base_url}/ows?service=WMS&version=1.3.0&request=GetCapabilities")
 
-    machine.succeed("curl --fail --connect-timeout 2 http://localhost:8080/geoserver/ows?service=WMS&version=1.3.0&request=GetCapabilities")
+      # No extensions yet.
+      machine.fail(f"{curl_cmd_rest} {base_url}/rest/imports")
+      machine.fail(f"{curl_cmd_rest} {base_url}/rest/monitor/requests.csv")
+
+
+    with running_geoserver("${geoserverWithImporterExtension}"):
+      machine.succeed(f"{curl_cmd_rest} {base_url}/rest/imports")
+      machine.fail(f"{curl_cmd_rest} {base_url}/rest/monitor/requests.csv")
+
+    with running_geoserver("${geoserverWithAllExtensions}"):
+      machine.succeed(f"{curl_cmd_rest} {base_url}/rest/imports")
+      machine.succeed(f"{curl_cmd_rest} {base_url}/rest/monitor/requests.csv")
+      _, stdout = machine.execute(f"cat {log_file}")
+      print(stdout.replace("\\n", "\n"))
+      assert "GDAL Native Library loaded" in stdout, "gdal"
+      assert "The turbo jpeg encoder is available for usage" in stdout, "libjpeg-turbo"
+      assert "org.geotools.imageio.netcdf.utilities.NetCDFUtilities" in stdout, "netcdf"
+      assert "Unable to load library 'netcdf'" not in stdout, "netcdf"
+
   '';
 }

--- a/pkgs/servers/geospatial/geoserver/default.nix
+++ b/pkgs/servers/geospatial/geoserver/default.nix
@@ -1,14 +1,13 @@
 { lib
+, callPackage
 , fetchurl
 , makeWrapper
 , nixosTests
 , stdenv
-
 , jre
 , unzip
 }:
-
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: rec {
   pname = "geoserver";
   version = "2.24.2";
 
@@ -25,24 +24,55 @@ stdenv.mkDerivation rec {
   sourceRoot = ".";
   nativeBuildInputs = [ unzip makeWrapper ];
 
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/share/geoserver
-    cp -r . $out/share/geoserver
-    rm -fr $out/share/geoserver/bin/*.bat
+  installPhase =
+    let
+      inputs = finalAttrs.buildInputs or [ ];
+      ldLibraryPathEnvName = if stdenv.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH";
+    in
+    ''
+      runHook preInstall
+      mkdir -p $out/share/geoserver
+      cp -r . $out/share/geoserver
+      rm -fr $out/share/geoserver/bin/*.bat
 
-    makeWrapper $out/share/geoserver/bin/startup.sh $out/bin/geoserver-startup \
-      --set JAVA_HOME "${jre}" \
-      --set GEOSERVER_HOME "$out/share/geoserver"
-    makeWrapper $out/share/geoserver/bin/shutdown.sh $out/bin/geoserver-shutdown \
-      --set JAVA_HOME "${jre}" \
-      --set GEOSERVER_HOME "$out/share/geoserver"
-    runHook postInstall
-  '';
+      makeWrapper $out/share/geoserver/bin/startup.sh $out/bin/geoserver-startup \
+        --prefix PATH : "${lib.makeBinPath inputs}" \
+        --prefix ${ldLibraryPathEnvName} : "${lib.makeLibraryPath inputs}" \
+        --set JAVA_HOME "${jre}" \
+        --set GEOSERVER_HOME "$out/share/geoserver"
+      makeWrapper $out/share/geoserver/bin/shutdown.sh $out/bin/geoserver-shutdown \
+        --prefix PATH : "${lib.makeBinPath inputs}" \
+        --prefix ${ldLibraryPathEnvName} : "${lib.makeLibraryPath inputs}" \
+        --set JAVA_HOME "${jre}" \
+        --set GEOSERVER_HOME "$out/share/geoserver"
+      runHook postInstall
+    '';
 
-  passthru = {
-    tests.geoserver = nixosTests.geoserver;
-  };
+
+  passthru =
+    let
+      geoserver = finalAttrs.finalPackage;
+      extensions = lib.attrsets.filterAttrs (n: v: lib.isDerivation v) (callPackage ./extensions.nix { });
+    in
+    {
+      withExtensions = selector:
+        let
+          selectedExtensions = selector extensions;
+        in
+        geoserver.overrideAttrs (finalAttrs: previousAttrs: {
+          pname = previousAttrs.pname + "-with-extensions";
+          buildInputs = lib.lists.unique ((previousAttrs.buildInputs or [ ]) ++ lib.lists.concatMap (drv: drv.buildInputs) selectedExtensions);
+          postInstall = (previousAttrs.postInstall or "") + ''
+            for extension in ${builtins.toString selectedExtensions} ; do
+              cp -r $extension/* $out
+              # Some files are the same for all/several extensions. We allow overwriting them again.
+              chmod -R +w $out
+            done
+          '';
+        });
+      tests.geoserver = nixosTests.geoserver;
+      passthru.updateScript = ./update.sh;
+    };
 
   meta = with lib; {
     description = "Open source server for sharing geospatial data";
@@ -52,4 +82,4 @@ stdenv.mkDerivation rec {
     maintainers = teams.geospatial.members;
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/servers/geospatial/geoserver/extensions.nix
+++ b/pkgs/servers/geospatial/geoserver/extensions.nix
@@ -1,0 +1,353 @@
+# DO *NOT* MODIFY THE LINES CONTAINING "hash = ..." OR "version = ...".
+# THEY ARE GENERATED. SEE ./update.sh.
+{ fetchzip, libjpeg, netcdf, pkgs, stdenv }:
+
+let
+  mkGeoserverExtension = { name, version, hash, buildInputs ? [ ] }: stdenv.mkDerivation {
+    pname = "geoserver-${name}-extension";
+    inherit buildInputs version;
+
+    src = fetchzip {
+      url = "mirror://sourceforge/geoserver/GeoServer/${version}/extensions/geoserver-${version}-${name}-plugin.zip";
+      inherit hash;
+      # We expect several files.
+      stripRoot = false;
+    };
+
+    installPhase = ''
+      runHook preInstall
+
+      DIR=$out/share/geoserver/webapps/geoserver/WEB-INF/lib
+      mkdir -p $DIR
+      cp -r $src/* $DIR
+
+      runHook postInstall
+    '';
+  };
+in
+
+{
+  app-schema = mkGeoserverExtension {
+    name = "app-schema";
+    version = "2.24.2"; # app-schema
+    hash = "sha256-nwZ+gZZ38nrKmIqe2Wjg8rkh9cq6TFaxjkwS/lw8720="; # app-schema
+  };
+
+  authkey = mkGeoserverExtension {
+    name = "authkey";
+    version = "2.24.2"; # authkey
+    hash = "sha256-R2dL1xAw7PZTAp7asoulfOPWodRD7TnOu8mnSrwxL8I="; # authkey
+  };
+
+  cas = mkGeoserverExtension {
+    name = "cas";
+    version = "2.24.2"; # cas
+    hash = "sha256-oTM+ipYuIefxVFUG7ifNE08GkYbuHkt83PtrOHRw40w="; # cas
+  };
+
+  charts = mkGeoserverExtension {
+    name = "charts";
+    version = "2.24.2"; # charts
+    hash = "sha256-w9e8Ra0iuhtQ45De1T3wztis6ZLey5LuhpmCadbpCp4="; # charts
+  };
+
+  control-flow = mkGeoserverExtension {
+    name = "control-flow";
+    version = "2.24.2"; # control-flow
+    hash = "sha256-XY9YwiMgEay/GhLt6IJQ0gdiVxA0abg/qrnYNW3wiO8="; # control-flow
+  };
+
+  css = mkGeoserverExtension {
+    name = "css";
+    version = "2.24.2"; # css
+    hash = "sha256-GDoRcM8Nx3fZuWgzIHM1vSXLMaCJO3j7/cDmRl7BS2U="; # css
+  };
+
+  csw = mkGeoserverExtension {
+    name = "csw";
+    version = "2.24.2"; # csw
+    hash = "sha256-Ir/ebw87DV1zSLJIN3sMEwMAqfD9rZ3oKvAM62BNWcE="; # csw
+  };
+
+  csw-iso = mkGeoserverExtension {
+    name = "csw-iso";
+    version = "2.24.2"; # csw-iso
+    hash = "sha256-j0rVy5JRwGTs+8esOpMPc79ICccwwtD47vOFsunZAkE="; # csw-iso
+  };
+
+  db2 = mkGeoserverExtension {
+    name = "db2";
+    version = "2.24.2"; # db2
+    hash = "sha256-LKOAdKU+0TJdaxUbluXcxzgJw2fvhkqVjYs+d2c84uk="; # db2
+  };
+
+  # Needs wps extension.
+  dxf = mkGeoserverExtension {
+    name = "dxf";
+    version = "2.24.2"; # dxf
+    hash = "sha256-Et4nCPH6xUChfKRZ35u3/VduEQwCOKeKQXVZZcgJRWc="; # dxf
+  };
+
+  excel = mkGeoserverExtension {
+    name = "excel";
+    version = "2.24.2"; # excel
+    hash = "sha256-Nm4mayt8ofwpiRD5FDbsubrHIzfaOBW+Nv8wUVaIPws="; # excel
+  };
+
+  feature-pregeneralized = mkGeoserverExtension {
+    name = "feature-pregeneralized";
+    version = "2.24.2"; # feature-pregeneralized
+    hash = "sha256-56HA4L1Vfh5Q45lRhjsYfq816YYNkJLmovngF0+3Vbk="; # feature-pregeneralized
+  };
+
+  # Note: The extension name ("gdal") clashes with pkgs.gdal.
+  gdal = mkGeoserverExtension {
+    name = "gdal";
+    version = "2.24.2"; # gdal
+    buildInputs = [ pkgs.gdal ];
+    hash = "sha256-KLIlEUmYUIXAikW+y3iQzGZPpW0N+9FuPTst23Nf9Y4="; # gdal
+  };
+
+  # Throws "java.io.FileNotFoundException: URL [jar:file:/nix/store/.../WEB-INF/lib/gs-geofence-server-2.24.1.jar!/geofence-default-override.properties] cannot be resolved to absolute file path because it does not reside in the file system: jar:file:/nix/store/.../WEB-INF/lib/gs-geofence-server-2.24.1.jar!/geofence-default-override.properties" but seems to work out of the box.
+  #geofence = mkGeoserverExtension {
+  #  name = "geofence";
+  #  version = "2.24.2"; # geofence
+  #  hash = "sha256-5MRUKiC23/XlFr7X4zpsAoDR4JGtZujFnUmtcRlG+9w="; # geofence
+  #};
+
+  #geofence-server = mkGeoserverExtension {
+  #  name = "geofence-server";
+  #  version = "2.24.2"; # geofence-server
+  #  hash = "sha256-MyDQSb7IZ8cTpO9+rV0PdZNHRvIDIr04+HNhyMpx81I="; # geofence-server
+  #};
+
+  #geofence-wps = mkGeoserverExtension {
+  #  name = "geofence-wps";
+  #  version = "2.24.2"; # geofence-wps
+  #  hash = "sha256-uLii8U3UAiF/MQjABBAfHbnXTlf+iYsEOy4kadqc6+k="; # geofence-wps
+  #};
+
+  geopkg-output = mkGeoserverExtension {
+    name = "geopkg-output";
+    version = "2.24.2"; # geopkg-output
+    hash = "sha256-NzsozGYoGOoekX+wY0d5d8I0JefHgSDb/HuEPzwX+YE="; # geopkg-output
+  };
+
+  grib = mkGeoserverExtension {
+    name = "grib";
+    version = "2.24.2"; # grib
+    hash = "sha256-9i+aqQM4GnRXfIjg2R2/NkkQAF9YxNRfbMp7mGO4BgE="; # grib
+    buildInputs = [ netcdf ];
+  };
+
+  gwc-s3 = mkGeoserverExtension {
+    name = "gwc-s3";
+    version = "2.24.2"; # gwc-s3
+    hash = "sha256-fesKzbSnNHxgjwuXghLBJhUkvM2HeCOZY9V0AAiZVWk="; # gwc-s3
+  };
+
+  h2 = mkGeoserverExtension {
+    name = "h2";
+    version = "2.24.2"; # h2
+    hash = "sha256-cMPdNh7Bp7aiAAiuB5E8dDWCuUkd89xQXJbvoYN5Oyk="; # h2
+  };
+
+  iau = mkGeoserverExtension {
+    name = "iau";
+    version = "2.24.2"; # iau
+    hash = "sha256-yIqw1ur2e3haPMXGOFgFdNLguzhMMytcg9aweaBFq5U="; # iau
+  };
+
+  importer = mkGeoserverExtension {
+    name = "importer";
+    version = "2.24.2"; # importer
+    hash = "sha256-/u5m4ljr7kEnRl9sOuYcS8913uPzJjDCXmRiWh7YS2c="; # importer
+  };
+
+  inspire = mkGeoserverExtension {
+    name = "inspire";
+    version = "2.24.2"; # inspire
+    hash = "sha256-3N1LUEu2q3Vy2verkJd9Fiem8V9W0KvsnSTwooO0M6E="; # inspire
+  };
+
+  # Needs Kakadu plugin from
+  # https://github.com/geosolutions-it/imageio-ext
+  #jp2k = mkGeoserverExtension {
+  #  name = "jp2k";
+  #  version = "2.24.2"; # jp2k
+  #  hash = "sha256-ZjPDCMzaXegrzmbI9vwjTt0Osbjjl/31sffU65PPJ3k="; # jp2k
+  #};
+
+  libjpeg-turbo = mkGeoserverExtension {
+    name = "libjpeg-turbo";
+    version = "2.24.2"; # libjpeg-turbo
+    hash = "sha256-aPKXE8STYG0h5OtxrOoTvXagUCBmb7nmEV8ckLRq6GM="; # libjpeg-turbo
+    buildInputs = [ libjpeg.out ];
+  };
+
+  mapml = mkGeoserverExtension {
+    name = "mapml";
+    version = "2.24.2"; # mapml
+    hash = "sha256-vjNoLZEM2CMmxL2JPO0r9PColReWmFdVjMkDxbyrSGg="; # mapml
+  };
+
+  mbstyle = mkGeoserverExtension {
+    name = "mbstyle";
+    version = "2.24.2"; # mbstyle
+    hash = "sha256-zvfoAoVT8hXUETn/GkceP8vLSA8iNUXivXjQUyIJDEs="; # mbstyle
+  };
+
+  metadata = mkGeoserverExtension {
+    name = "metadata";
+    version = "2.24.2"; # metadata
+    hash = "sha256-A6Gai/ExL9FSUQOuUwxqpRcaVtn4H1VwBaAKXMNm6Fg="; # metadata
+  };
+
+  mongodb = mkGeoserverExtension {
+    name = "mongodb";
+    version = "2.24.2"; # mongodb
+    hash = "sha256-R9dp/uOIX7KBp4c2676NXQupqoRahxKkufjCr6sQaA0="; # mongodb
+  };
+
+  monitor = mkGeoserverExtension {
+    name = "monitor";
+    version = "2.24.2"; # monitor
+    hash = "sha256-IB9/4755ePtL/CWIOd28dOyBG6cmddQnhZKVQMQFeIE="; # monitor
+  };
+
+  mysql = mkGeoserverExtension {
+    name = "mysql";
+    version = "2.24.2"; # mysql
+    hash = "sha256-8y3N7+KgA9R5JIw1YuHmTmzK6H2c56469KUTrRpqP4g="; # mysql
+  };
+
+  netcdf = mkGeoserverExtension {
+    name = "netcdf";
+    version = "2.24.2"; # netcdf
+    hash = "sha256-uAhJTCKn/00zDUGtgyYd1v8KxXj1N+vAAosBjQG3rBk="; # netcdf
+    buildInputs = [ netcdf ];
+  };
+
+  netcdf-out = mkGeoserverExtension {
+    name = "netcdf-out";
+    version = "2.24.2"; # netcdf-out
+    hash = "sha256-wMFx+BnEcLy1x9j0K+du7hG9wC+EzA4E4AVjIsyXO3A="; # netcdf-out
+    buildInputs = [ netcdf ];
+  };
+
+  ogr-wfs = mkGeoserverExtension {
+    name = "ogr-wfs";
+    version = "2.24.2"; # ogr-wfs
+    buildInputs = [ pkgs.gdal ];
+    hash = "sha256-jMnc0OnrKHFegEIPtyAG92fC8cLa/X1UUdTmeDyUxSI="; # ogr-wfs
+  };
+
+  # Needs ogr-wfs extension.
+  ogr-wps = mkGeoserverExtension {
+    name = "ogr-wps";
+    version = "2.24.2"; # ogr-wps
+    # buildInputs = [ pkgs.gdal ];
+    hash = "sha256-O0MKOCEV5AjYUg4LL0UAV0KBHg1alOK7WEdEyikqpTs="; # ogr-wps
+  };
+
+  oracle = mkGeoserverExtension {
+    name = "oracle";
+    version = "2.24.2"; # oracle
+    hash = "sha256-OIvwpGt/9jtKAeP7LK/hTZDVbKQnjVGTXDy5q/zVU2k="; # oracle
+  };
+
+  params-extractor = mkGeoserverExtension {
+    name = "params-extractor";
+    version = "2.24.2"; # params-extractor
+    hash = "sha256-z6hMGCHB0I3DS05NvdSmVMfPKNA/1jhx8Mmb6odL6RU="; # params-extractor
+  };
+
+  printing = mkGeoserverExtension {
+    name = "printing";
+    version = "2.24.2"; # printing
+    hash = "sha256-nDkT9x6Va5SNSf8x7OEu7NqQ6qFSJhPavg6eUo5D4HA="; # printing
+  };
+
+  pyramid = mkGeoserverExtension {
+    name = "pyramid";
+    version = "2.24.2"; # pyramid
+    hash = "sha256-HM2ItB34+CHNzhoH3X3Kh1iVNMb+AimvdHrgHHh5SJc="; # pyramid
+  };
+
+  querylayer = mkGeoserverExtension {
+    name = "querylayer";
+    version = "2.24.2"; # querylayer
+    hash = "sha256-7WtAsisMJBpRZqU0nfr4orp36uBmnvat2+DlbnGCjVg="; # querylayer
+  };
+
+  sldservice = mkGeoserverExtension {
+    name = "sldservice";
+    version = "2.24.2"; # sldservice
+    hash = "sha256-m3QJP/u6HZmO0p8d++8EKXXxtkbMDmBFFCzBPctPV5A="; # sldservice
+  };
+
+  sqlserver = mkGeoserverExtension {
+    name = "sqlserver";
+    version = "2.24.2"; # sqlserver
+    hash = "sha256-ZwsO1Yxb3OWCLtYI30l3jnMrAbPI7v0XTGcasJPN1Y8="; # sqlserver
+  };
+
+  vectortiles = mkGeoserverExtension {
+    name = "vectortiles";
+    version = "2.24.2"; # vectortiles
+    hash = "sha256-fQ9qSIHplxt57n45w4MN4e5AFdU8nmtvQ/vTeL/cdzQ="; # vectortiles
+  };
+
+  wcs2_0-eo = mkGeoserverExtension {
+    name = "wcs2_0-eo";
+    version = "2.24.2"; # wcs2_0-eo
+    hash = "sha256-q0cXVjOBmX4vYwzf+3LjsYf9rPAIeCxnOZZadfNlLF0="; # wcs2_0-eo
+  };
+
+  web-resource = mkGeoserverExtension {
+    name = "web-resource";
+    version = "2.24.2"; # web-resource
+    hash = "sha256-v/SnNV6JnWPoYUSFowXFDDuhjZC8b1iPtDeMG8mWqG4="; # web-resource
+  };
+
+  wmts-multi-dimensional = mkGeoserverExtension {
+    name = "wmts-multi-dimensional";
+    version = "2.24.2"; # wmts-multi-dimensional
+    hash = "sha256-ASSGBqTpq9Tk1R3oBTBoi6L1tsXIJpJyez3LXBPmjd8="; # wmts-multi-dimensional
+  };
+
+  wps = mkGeoserverExtension {
+    name = "wps";
+    version = "2.24.2"; # wps
+    hash = "sha256-KJa0yWqO/qyY59U9NMK5/V4EskIqEbe9XnSvGRvODHU="; # wps
+  };
+
+  # Needs hazelcast (https://github.com/hazelcast/hazelcast (?)) which is not
+  # available in nixpgs as of 2024/01.
+  #wps-cluster-hazelcast = mkGeoserverExtension {
+  #  name = "wps-cluster-hazelcast";
+  #  version = "2.24.2"; # wps-cluster-hazelcast
+  #  hash = "sha256-PQcX3AVJy3DluAL4b5vcWvLl0fYLBq+F8cKsvJ/WOyE="; # wps-cluster-hazelcast
+  #};
+
+  wps-download = mkGeoserverExtension {
+    name = "wps-download";
+    version = "2.24.2"; # wps-download
+    hash = "sha256-cjVbQ1R2uit/29axZsu88ZiMuwY7mmR5x8XNb9qX8aM="; # wps-download
+  };
+
+  # Needs Postrgres configuration or similar.
+  # See https://docs.geoserver.org/main/en/user/extensions/wps-jdbc/index.html
+  wps-jdbc = mkGeoserverExtension {
+    name = "wps-jdbc";
+    version = "2.24.2"; # wps-jdbc
+    hash = "sha256-dJUnh8HZmlu5aqVeFxyR3A8fbXYqbgIqPxIENq4rhfs="; # wps-jdbc
+  };
+
+  ysld = mkGeoserverExtension {
+    name = "ysld";
+    version = "2.24.2"; # ysld
+    hash = "sha256-GLUioofwqoGUw7JQeEhzBG1SRwGUzwqjKvhkOt4TUVw="; # ysld
+  };
+
+}

--- a/pkgs/servers/geospatial/geoserver/update.sh
+++ b/pkgs/servers/geospatial/geoserver/update.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I ./. -i bash -p common-updater-scripts jq
+
+set -eEuo pipefail
+test ${DEBUG:-0} -eq 1 && set -x
+
+# Current version.
+LATEST_NIXPKGS_VERSION=$(nix eval --raw .#geoserver.version 2>/dev/null)
+UPDATE_NIX_OLD_VERSION=${UPDATE_NIX_OLD_VERSION:-$LATEST_NIXPKGS_VERSION}
+
+# Maybe future version.
+LATEST_GITHUB_VERSION=$(curl -s "https://api.github.com/repos/geoserver/geoserver/releases/latest" | jq -r '.tag_name')
+UPDATE_NIX_NEW_VERSION=${UPDATE_NIX_NEW_VERSION:-$LATEST_GITHUB_VERSION}
+
+SMALLEST_VERSION=$(printf "$UPDATE_NIX_OLD_VERSION\n$UPDATE_NIX_NEW_VERSION" | sort --version-sort | head -n 1)
+
+if [[ "$SMALLEST_VERSION" == "$UPDATE_NIX_NEW_VERSION" ]]; then
+  echo "geoserver is up-to-date: $SMALLEST_VERSION"
+  exit 0
+fi
+
+echo "Updating geoserver..."
+update-source-version geoserver "$UPDATE_NIX_NEW_VERSION"
+
+cd "$(dirname "$(readlink -f "$0")")"
+
+EXT_NAMES=($(grep -o -E "hash = .*?; # .*$" ./extensions.nix | sed 's/.* # //' | sort))
+
+if [[ $# -gt 0 ]] ; then
+    EXT_NAMES=(${@:1})
+fi
+
+for EXT_NAME in "${EXT_NAMES[@]}" ; do
+    echo "Updating extension $EXT_NAME..."
+    URL="mirror://sourceforge/geoserver/GeoServer/${UPDATE_NIX_NEW_VERSION}/extensions/geoserver-${UPDATE_NIX_NEW_VERSION}-${EXT_NAME}-plugin.zip"
+    HASH=$(nix-hash --to-sri --type sha256 $(nix-prefetch-url --unpack "$URL"))
+    sed -i "s@version = \".*\"; # $EXT_NAME@version = \"$UPDATE_NIX_NEW_VERSION\"; # $EXT_NAME@" ./extensions.nix
+    sed -i "s@hash = \".*\"; # $EXT_NAME@hash = \"$HASH\"; # $EXT_NAME@" ./extensions.nix
+done
+
+cd -


### PR DESCRIPTION
## Description of changes

This PR adds the  possibility to run `geoserver` with extensions. This is achieved by adding the function `geoserver.[passthru.]withExtensions` that expects a `selector` function that selects extensions among a given list and returns a `geoserver` derivation with the selected extensions installed. Example:

```nix
geoserverWithImporterExtension = pkgs.geoserver.withExtensions (ps: with ps; [ importer ]);
```

All extensions are listed in a new file `geoserver/extensions.nix`. They are fed to `withExtensions` upon invocation. The standard procedure to install extensions is followed (i.e. unpack extension content into `geoserver/webapps/geoserver/WEB-INF/lib`). My initial implementation used `symlinkJoin`. While the server starts, trying to access it results in `java.io.FileNotFoundException: Could not open ServletContext resource [/WEB-INF/dispatcher-servlet.xml]`. Besides, the wrappers (`geoserver-startup`, `geoserver-shutdown`) would have to be rewritten. So the current implementation copies the files from the extension's `$out` into geoserver's `$out`. Some extensions have dependencies. This is coped with. Some extensions do not work currently. Those are commented out for now.

Since there are >50 extensions, an `update.sh` script has been added to automatically update both `geoserver` as well as all extensions. The script is designed to work by either fetching the latest Geoserver version from GitHub or by providing specific versions. Example:

```bash
cd nixpkgs
export DEBUG=1
export UPDATE_NIX_OLD_VERSION=2.24.1
export UPDATE_NIX_NEW_VERSION=2.24.2
./pkgs/servers/geospatial/geoserver/update.sh # update geoserver + all plugins
./pkgs/servers/geospatial/geoserver/update.sh importer # update geoserver + importer plugin
```

`passthru.updateScript` is set to this new script and things should work as intended (see Nixpkgs manual [section](https://nixos.org/manual/nixpkgs/stable/#special-variables) on `passthru.updateScript`)

`nixos/tests/geoserver.nix` has been adapted to test several geoserver installations. Crucially, a test is run with (nearly) all extensions enabled. This test checks for known issues in the log file.

I think there is room for improvement in this PR and I'm happy to work in comments. Overall, I think the approach is sound.

ToDos:
* [ ] Add entry to "Other Notable Changes" in the 24.05 release notes?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
