### PR TITLE
wimlib: 1.13.6 -> 1.14.3

### DIFF
--- a/pkgs/tools/archivers/wimlib/default.nix
+++ b/pkgs/tools/archivers/wimlib/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, makeWrapper
-, pkg-config, openssl, fuse, libxml2
+, pkg-config, fuse3
 , cabextract ? null
 , cdrkit ? null
 , mtools ? null
@@ -8,16 +8,18 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.13.6";
+  version = "1.14.3";
   pname = "wimlib";
 
   nativeBuildInputs = [ pkg-config makeWrapper ];
-  buildInputs = [ openssl fuse libxml2 ntfs3g ];
+  buildInputs = [ fuse3 ntfs3g ];
 
   src = fetchurl {
     url = "https://wimlib.net/downloads/${pname}-${version}.tar.gz";
-    sha256 = "sha256-Cg+cHA06KnZkVTWusPYuA/xVkUymXzpNVZm7iwJg29k=";
+    hash = "sha256-ESjGx5FtLyLagDQfhNh9d8Yg3mUA+7I6dB+nm9CM0e8=";
   };
+
+  enableParallelBuilding = true;
 
   preBuild = lib.optionalString (!stdenv.isDarwin) ''
     substituteInPlace programs/mkwinpeimg.in \
@@ -28,7 +30,7 @@ stdenv.mkDerivation rec {
     path = lib.makeBinPath  ([ cabextract mtools ntfs3g ] ++ lib.optionals (!stdenv.isDarwin) [ cdrkit syslinux ]);
   in ''
     for prog in $out/bin/*; do
-      wrapProgram $prog --prefix PATH : ${path}
+      wrapProgram $prog --prefix PATH : $out/bin:${path}
     done
   '';
 
@@ -43,6 +45,6 @@ stdenv.mkDerivation rec {
     description = "A library and program to extract, create, and modify WIM files";
     platforms = platforms.unix;
     maintainers = with maintainers; [ ];
-    license = with licenses; [ gpl3 lgpl3 cc0 ];
+    license = with licenses; [ gpl3 lgpl3 mit ];
   };
 }


### PR DESCRIPTION
## Description of changes

https://wimlib.net/git/?p=wimlib;a=blob;f=NEWS.md;hb=v1.14.3

* libxml2 and openssl dependencies dropped
* license of examples changed from CC0 to MIT (already in previous release v1.13.6)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>bootiso</li>
    <li>wimlib</li>
    <li>woeusb</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
