### PR TITLE
cc-wrapper: clean-up post `stdenvAdapters.useLibsFrom: init`

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -277,9 +277,8 @@ stdenv.mkDerivation {
       else if givenLibcxx then
         { kind = "libc++"; package = libcxx;  solib = libcxx_solib;}
       else
-      # We're probably using the `libstdc++` that came with our `gcc`.
-      # TODO: this is maybe not always correct?
-      # TODO: what happens when `nativeTools = true`?
+      # Fallback to assuming libstdc++. This currently doesn't account e.g. for
+      # `nativeTools = true`
         { kind = "libstdc++"; package = cc; solib = cc_solib; }
     ;
 
@@ -462,13 +461,6 @@ stdenv.mkDerivation {
       echo "-L${gccForLibs}/lib/gcc/${targetPlatform.config}/${gccForLibs.version}" >> $out/nix-support/cc-ldflags
       echo "-L${gccForLibs_solib}/lib" >> $out/nix-support/cc-ldflags
     ''
-    # The above "fix" may be incorrect; gcc.cc.lib doesn't contain a
-    # `target-triple` dir but the correct fix may be to just remove the above?
-    #
-    # For clang it's not necessary (see `--gcc-toolchain` below) and for other
-    # situations adding in the above will bring in lots of other gcc libraries
-    # (i.e. sanitizer libraries, `libatomic`, `libquadmath`) besides just
-    # `libstdc++`; this may actually break clang.
 
     # TODO We would like to connect this to `useGccForLibs`, but we cannot yet
     # because `libcxxStdenv` on linux still needs this. Maybe someday we'll


### PR DESCRIPTION
...from "cudaPackages.backendStdenv: useGccForLibs", 210ce3840807a87b7e407fed6ce8ec04e6e318bc

## Description of changes

https://github.com/NixOS/nixpkgs/pull/275947 (based on @rrbutani's suggestions and PoC) introduced (without approval) passthru attributes in the cc-wrapper, the purpose of which is to allow propagating the standard c++ libraries used by another wrapper. These attributes are now (ab)used to fix the libstdc++ compatibility issues in `cudaSupport = true` packages and in `python3Packages.tensorflow`, which use older gcc than the rest of nixpkgs.

As https://github.com/NixOS/nixpkgs/pull/275947#issuecomment-1898043601 points out, this had introduced more junk in the wrapper, lacks longer-term vision, etc.

This draft is a placeholder just removing the not-so-useful comments introduced by the preceding PR, but I'm hoping we can also have a conversation about whether the passthru solution hits a local minima, about what the other cc-wrapper bits touched by the PR were actually intended for, etc.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
