### PR TITLE
obs-studio-plugins.obs-ndi: Fix build

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/obs-ndi/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-ndi/default.nix
@@ -4,7 +4,7 @@ stdenv.mkDerivation rec {
   pname = "obs-ndi";
   version = "4.13.0";
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake qtbase ];
   buildInputs = [ obs-studio qtbase ndi ];
 
   src = fetchFromGitHub {
@@ -28,12 +28,7 @@ stdenv.mkDerivation rec {
     ln -s ${ndi}/include lib/ndi
   '';
 
-  postInstall = ''
-    mkdir $out/lib $out/share
-    mv $out/obs-plugins/64bit $out/lib/obs-plugins
-    rm -rf $out/obs-plugins
-    mv $out/data $out/share/obs
-  '';
+  cmakeFlags = [ "-DENABLE_QT=ON" ];
 
   dontWrapQtApps = true;
 

--- a/pkgs/applications/video/obs-studio/plugins/obs-ndi/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-ndi/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Palakis";
     repo = "obs-ndi";
-    rev = "dummy-tag-${version}";
+    rev = version;
     sha256 = "sha256-ugAMSTXbbIZ61oWvoggVJ5kZEgp/waEcWt89AISrSdE=";
   };
 
@@ -19,8 +19,8 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = ''
-    # Add path (variable added in hardcode-ndi-path.patch)
-    sed -i -e s,@NDI@,${ndi},g src/obs-ndi.cpp
+    # Add path (variable added in hardcode-ndi-path.patch
+    sed -i -e s,@NDI@,${ndi},g src/plugin-main.cpp
 
     # Replace bundled NDI SDK with the upstream version
     # (This fixes soname issues)

--- a/pkgs/applications/video/obs-studio/plugins/obs-ndi/hardcode-ndi-path.patch
+++ b/pkgs/applications/video/obs-studio/plugins/obs-ndi/hardcode-ndi-path.patch
@@ -10,7 +10,7 @@ index 0d94add..617af73 100644
 -	locations << "/usr/lib";
 -	locations << "/usr/local/lib";
 -#endif
-+	locations << "@NDI@/lib"
++	locations << "@NDI@/lib";
  	for (QString location : locations) {
  		path = QDir::cleanPath(
  			QDir(location).absoluteFilePath(NDILIB_LIBRARY_NAME));

--- a/pkgs/applications/video/obs-studio/plugins/obs-ndi/hardcode-ndi-path.patch
+++ b/pkgs/applications/video/obs-studio/plugins/obs-ndi/hardcode-ndi-path.patch
@@ -1,19 +1,16 @@
-diff --git a/src/obs-ndi.cpp b/src/obs-ndi.cpp
-index 1a8aeb3..9a36ea9 100644
---- a/src/obs-ndi.cpp
-+++ b/src/obs-ndi.cpp
-@@ -132,13 +132,7 @@ const NDIlib_v5 *load_ndilib()
- 	const char *redistFolder = std::getenv(NDILIB_REDIST_FOLDER);
- 	if (redistFolder)
- 		libraryLocations.push_back(redistFolder);
+diff --git a/src/plugin-main.cpp b/src/plugin-main.cpp
+index 0d94add..617af73 100644
+--- a/src/plugin-main.cpp
++++ b/src/plugin-main.cpp
+@@ -244,10 +244,7 @@ const NDIlib_v4 *load_ndilib()
+ 	if (!path.isEmpty()) {
+ 		locations << path;
+ 	}
 -#if defined(__linux__) || defined(__APPLE__)
--	libraryLocations.push_back("/usr/lib");
--	libraryLocations.push_back("/usr/lib64");
--	libraryLocations.push_back("/usr/lib/x86_64-linux-gnu");
--	libraryLocations.push_back("/usr/local/lib");
--	libraryLocations.push_back("/usr/local/lib64");
+-	locations << "/usr/lib";
+-	locations << "/usr/local/lib";
 -#endif
-+	libraryLocations.push_back("@NDI@/lib");
- 
- 	for (std::string path : libraryLocations) {
- 		blog(LOG_DEBUG, "[load_ndilib] Trying library path: '%s'", path.c_str());
++	locations << "@NDI@/lib"
+ 	for (QString location : locations) {
+ 		path = QDir::cleanPath(
+ 			QDir(location).absoluteFilePath(NDILIB_LIBRARY_NAME));


### PR DESCRIPTION
## Description of changes

The package `obs-studio-plugins.obs-ndi` is currently broken as there have been major changes upstream and I forgot to update the patch when updating the package. 

This build is on top of https://github.com/NixOS/nixpkgs/pull/272073 which is not merged yet.

To test this I did:

- merge https://github.com/NixOS/nixpkgs/pull/272073 into a local branch
- merge this PR into the branch
- Build obs with: `nix-build --expr 'with import ./. {}; wrapOBS { plugins = [ obs-studio-plugins.obs-ndi ]; }'`
- Ran obs with plugin and added a source 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
