### PR TITLE
sparrow: 1.8.1 -> 1.8.4

### DIFF
--- a/pkgs/applications/blockchains/sparrow/default.nix
+++ b/pkgs/applications/blockchains/sparrow/default.nix
@@ -21,45 +21,47 @@
 
 let
   pname = "sparrow";
-  version = "1.8.1";
+  version = "1.8.4";
 
   src = fetchurl {
     url = "https://github.com/sparrowwallet/${pname}/releases/download/${version}/${pname}-${version}-x86_64.tar.gz";
-    sha256 = "sha256-dpYGMclYMjxjUbIcSZ7V54I1LTVfHxAKH9+7CaprD4U=";
+    sha256 = "0w6z84w9spwfpqrf5m9bcq30xqp94c27jw3qzxfdyisp8n22xvd8";
   };
 
   launcher = writeScript "sparrow" ''
     #! ${bash}/bin/bash
     params=(
       --module-path @out@/lib:@jdkModules@/modules
-      --add-opens javafx.graphics/com.sun.javafx.css=org.controlsfx.controls
-      --add-opens javafx.graphics/javafx.scene=org.controlsfx.controls
-      --add-opens javafx.controls/com.sun.javafx.scene.control.behavior=org.controlsfx.controls
-      --add-opens javafx.controls/com.sun.javafx.scene.control.inputmap=org.controlsfx.controls
-      --add-opens javafx.graphics/com.sun.javafx.scene.traversal=org.controlsfx.controls
-      --add-opens javafx.base/com.sun.javafx.event=org.controlsfx.controls
-      --add-opens javafx.controls/javafx.scene.control.cell=com.sparrowwallet.sparrow
-      --add-opens org.controlsfx.controls/impl.org.controlsfx.skin=com.sparrowwallet.sparrow
-      --add-opens org.controlsfx.controls/impl.org.controlsfx.skin=javafx.fxml
-      --add-opens javafx.graphics/com.sun.javafx.tk=centerdevice.nsmenufx
-      --add-opens javafx.graphics/com.sun.javafx.tk.quantum=centerdevice.nsmenufx
-      --add-opens javafx.graphics/com.sun.glass.ui=centerdevice.nsmenufx
-      --add-opens javafx.controls/com.sun.javafx.scene.control=centerdevice.nsmenufx
-      --add-opens javafx.graphics/com.sun.javafx.menu=centerdevice.nsmenufx
-      --add-opens javafx.graphics/com.sun.glass.ui=com.sparrowwallet.sparrow
+      --add-opens=javafx.graphics/com.sun.javafx.css=org.controlsfx.controls
+      --add-opens=javafx.graphics/javafx.scene=org.controlsfx.controls
+      --add-opens=javafx.controls/com.sun.javafx.scene.control.behavior=org.controlsfx.controls
+      --add-opens=javafx.controls/com.sun.javafx.scene.control.inputmap=org.controlsfx.controls
+      --add-opens=javafx.graphics/com.sun.javafx.scene.traversal=org.controlsfx.controls
+      --add-opens=javafx.base/com.sun.javafx.event=org.controlsfx.controls
+      --add-opens=javafx.controls/javafx.scene.control.cell=com.sparrowwallet.sparrow
+      --add-opens=org.controlsfx.controls/impl.org.controlsfx.skin=com.sparrowwallet.sparrow
+      --add-opens=org.controlsfx.controls/impl.org.controlsfx.skin=javafx.fxml
+      --add-opens=javafx.graphics/com.sun.javafx.tk=centerdevice.nsmenufx
+      --add-opens=javafx.graphics/com.sun.javafx.tk.quantum=centerdevice.nsmenufx
+      --add-opens=javafx.graphics/com.sun.glass.ui=centerdevice.nsmenufx
+      --add-opens=javafx.controls/com.sun.javafx.scene.control=centerdevice.nsmenufx
+      --add-opens=javafx.graphics/com.sun.javafx.menu=centerdevice.nsmenufx
+      --add-opens=javafx.graphics/com.sun.glass.ui=com.sparrowwallet.sparrow
       --add-opens=javafx.graphics/javafx.scene.input=com.sparrowwallet.sparrow
-      --add-opens javafx.graphics/com.sun.javafx.application=com.sparrowwallet.sparrow
-      --add-opens java.base/java.net=com.sparrowwallet.sparrow
-      --add-opens java.base/java.io=com.google.gson
+      --add-opens=javafx.graphics/com.sun.javafx.application=com.sparrowwallet.sparrow
+      --add-opens=java.base/java.net=com.sparrowwallet.sparrow
+      --add-opens=java.base/java.io=com.google.gson
       --add-opens=java.smartcardio/sun.security.smartcardio=com.sparrowwallet.sparrow
-      --add-reads com.sparrowwallet.merged.module=java.desktop
-      --add-reads com.sparrowwallet.merged.module=java.sql
-      --add-reads com.sparrowwallet.merged.module=com.sparrowwallet.sparrow
-      --add-reads com.sparrowwallet.merged.module=logback.classic
-      --add-reads com.sparrowwallet.merged.module=com.fasterxml.jackson.databind
-      --add-reads com.sparrowwallet.merged.module=com.fasterxml.jackson.annotation
-      --add-reads com.sparrowwallet.merged.module=com.fasterxml.jackson.core
-      --add-reads com.sparrowwallet.merged.module=co.nstant.in.cbor
+      --add-reads=com.sparrowwallet.merged.module=java.desktop
+      --add-reads=com.sparrowwallet.merged.module=java.sql
+      --add-reads=com.sparrowwallet.merged.module=com.sparrowwallet.sparrow
+      --add-reads=com.sparrowwallet.merged.module=ch.qos.logback.classic
+      --add-reads=com.sparrowwallet.merged.module=org.slf4j
+      --add-reads=com.sparrowwallet.merged.module=com.fasterxml.jackson.databind
+      --add-reads=com.sparrowwallet.merged.module=com.fasterxml.jackson.annotation
+      --add-reads=com.sparrowwallet.merged.module=com.fasterxml.jackson.core
+      --add-reads=com.sparrowwallet.merged.module=co.nstant.in.cbor
+      --add-reads=kotlin.stdlib=kotlinx.coroutines.core
       -m com.sparrowwallet.sparrow
     )
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13351,7 +13351,7 @@ with pkgs;
 
   sparrow-unwrapped = callPackage ../applications/blockchains/sparrow {
     openimajgrabber = callPackage ../applications/blockchains/sparrow/openimajgrabber.nix {};
-    openjdk = openjdk.override { enableJavaFX = true; };
+    openjdk = openjdk21.override { enableJavaFX = true; };
   };
 
   sparrow = callPackage ../applications/blockchains/sparrow/fhsenv.nix { };


### PR DESCRIPTION
## Description of changes

This is a version bump of sparrow (bitcoin wallet) from 1.8.1 to 1.8.4. See the release notes: 

- https://github.com/sparrowwallet/sparrow/releases/tag/1.8.2
- https://github.com/sparrowwallet/sparrow/releases/tag/1.8.3
- https://github.com/sparrowwallet/sparrow/releases/tag/1.8.4

A noteworthy change is that now upstream uses JDK21, which is now reflected in this package. I also updated the JVM runtime arguments as per upstream. There aren't that many changes, it's just that I copy-pasted from upstream, so the ordering is different.

It's also worth mentioning that the download verification feature added in 1.8.3 does not work on NixOS; A different process would be needed.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
