### PR TITLE
openvpn: cleanup unnecessary generic function

### DIFF
--- a/pkgs/tools/networking/openvpn/default.nix
+++ b/pkgs/tools/networking/openvpn/default.nix
@@ -2,7 +2,6 @@
 , stdenv
 , fetchurl
 , pkg-config
-, iproute2
 , libcap_ng
 , libnl
 , lz4
@@ -18,73 +17,51 @@
 }:
 
 let
-  inherit (lib) versionOlder optional optionals optionalString;
-
-  generic = { version, sha256, extraBuildInputs ? [ ] }:
-    let
-      withIpRoute = stdenv.isLinux && (versionOlder version "2.5.4");
-    in
-    stdenv.mkDerivation
-      rec {
-        pname = "openvpn";
-        inherit version;
-
-        src = fetchurl {
-          url = "https://swupdate.openvpn.net/community/releases/${pname}-${version}.tar.gz";
-          inherit sha256;
-        };
-
-        nativeBuildInputs = [ pkg-config ];
-
-        buildInputs = [ lz4 lzo ]
-          ++ optionals stdenv.isLinux [ libcap_ng libnl pam ]
-          ++ optional withIpRoute iproute2
-          ++ optional useSystemd systemd
-          ++ optional pkcs11Support pkcs11helper
-          ++ extraBuildInputs;
-
-        configureFlags = optionals withIpRoute [
-          "--enable-iproute2"
-          "IPROUTE=${iproute2}/sbin/ip"
-        ]
-        ++ optional useSystemd "--enable-systemd"
-        ++ optional pkcs11Support "--enable-pkcs11"
-        ++ optional stdenv.isDarwin "--disable-plugin-auth-pam";
-
-        # We used to vendor the update-systemd-resolved script inside libexec,
-        # but a separate package was made, that uses libexec/openvpn. Copy it
-        # into libexec in case any consumers expect it to be there even though
-        # they should use the update-systemd-resolved package instead.
-        postInstall = ''
-          mkdir -p $out/share/doc/openvpn/examples
-          cp -r sample/sample-{config-files,keys,scripts}/ $out/share/doc/openvpn/examples
-        '' + optionalString useSystemd ''
-          install -Dm555 -t $out/libexec ${update-systemd-resolved}/libexec/openvpn/*
-        '';
-
-        enableParallelBuilding = true;
-
-        meta = with lib; {
-          description = "A robust and highly flexible tunneling application";
-          mainProgram = "openvpn";
-          downloadPage = "https://openvpn.net/community-downloads/";
-          homepage = "https://openvpn.net/";
-          license = licenses.gpl2Only;
-          maintainers = with maintainers; [ viric peterhoeg ];
-          platforms = platforms.unix;
-        };
-      };
-
+  inherit (lib) optional optionals optionalString;
 in
-{
-  openvpn = (generic {
-    version = "2.6.8";
-    sha256 = "sha256-Xt4VZcim2IAQD38jUxen7p7qg9UFLbVUfxOp52r3gF0=";
-    extraBuildInputs = [ openssl ];
-  }).overrideAttrs
-    (_: {
-      passthru.tests = {
-        inherit (nixosTests) initrd-network-openvpn systemd-initrd-networkd-openvpn;
-      };
-    });
-}
+stdenv.mkDerivation (finalAttrs: {
+  pname = "openvpn";
+  version = "2.6.8";
+
+  src = fetchurl {
+    url = "https://swupdate.openvpn.net/community/releases/openvpn-${finalAttrs.version}.tar.gz";
+    hash = "sha256-Xt4VZcim2IAQD38jUxen7p7qg9UFLbVUfxOp52r3gF0=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ lz4 lzo openssl ]
+    ++ optionals stdenv.isLinux [ libcap_ng libnl pam ]
+    ++ optional useSystemd systemd
+    ++ optional pkcs11Support pkcs11helper;
+
+  configureFlags = optional useSystemd "--enable-systemd"
+    ++ optional pkcs11Support "--enable-pkcs11"
+    ++ optional stdenv.isDarwin "--disable-plugin-auth-pam";
+
+  # We used to vendor the update-systemd-resolved script inside libexec,
+  # but a separate package was made, that uses libexec/openvpn. Copy it
+  # into libexec in case any consumers expect it to be there even though
+  # they should use the update-systemd-resolved package instead.
+  postInstall = ''
+    mkdir -p $out/share/doc/openvpn/examples
+    cp -r sample/sample-{config-files,keys,scripts}/ $out/share/doc/openvpn/examples
+  '' + optionalString useSystemd ''
+    install -Dm555 -t $out/libexec ${update-systemd-resolved}/libexec/openvpn/*
+  '';
+
+  enableParallelBuilding = true;
+
+  passthru.tests = {
+    inherit (nixosTests) initrd-network-openvpn systemd-initrd-networkd-openvpn;
+  };
+
+  meta = with lib; {
+    description = "A robust and highly flexible tunneling application";
+    downloadPage = "https://openvpn.net/community-downloads/";
+    homepage = "https://openvpn.net/";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ viric peterhoeg ];
+    platforms = platforms.unix;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11669,8 +11669,7 @@ with pkgs;
 
   opentsdb = callPackage ../tools/misc/opentsdb { };
 
-  inherit (callPackages ../tools/networking/openvpn {})
-    openvpn;
+  openvpn = callPackage ../tools/networking/openvpn {};
 
   openvpn3 = callPackage ../tools/networking/openvpn3 { };
 


### PR DESCRIPTION
## Description of changes

- The generic function was added in #103019 to support packaging both 2.5.x and 2.4.x in nixpkgs, but `openvpn_24` has since been removed in #212184.
- While I was at it, removed `${pname}` (#277994)
 - Rebuilds are due to reordering of `openssl` in buildInputs

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
