### PR TITLE
dopewars: init at 1.6.2

### DIFF
--- a/pkgs/by-name/do/dopewars/0001-remove_setuid.patch
+++ b/pkgs/by-name/do/dopewars/0001-remove_setuid.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 4b0c466..ce008fa 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -54,7 +54,7 @@
+ 	@chgrp games ${DOPEBIN} || chgrp wheel ${DOPEBIN} || \
+ 	  ( echo "WARNING: Cannot change group of dopewars binary - the high"; \
+ 	    echo "score file may be unreadable or unwriteable by some users" )
+-	chmod 2755 ${DOPEBIN}
++	chmod 755 ${DOPEBIN}
+ 
+ install-data-local:
+ 	${mkinstalldirs} ${PIXDIR}

--- a/pkgs/by-name/do/dopewars/package.nix
+++ b/pkgs/by-name/do/dopewars/package.nix
@@ -1,0 +1,54 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, makeWrapper
+, curl
+, ncurses
+, gtk3
+, pkg-config
+, scoreDirectory ? "$HOME/.local/share"
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dopewars";
+  version = "1.6.2";
+
+  src = fetchFromGitHub {
+    owner = "benmwebb";
+    repo = "dopewars";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-CpgqRYmrfOFxhC7yAS2OqRBi4r3Vesq3+7a0q5rc3vM=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    curl
+    gtk3
+    ncurses
+  ];
+
+  # remove the denied setting of setuid bit permission
+  patches = [ ./0001-remove_setuid.patch ];
+
+  # run dopewars with -f so that it finds its scoreboard file in ~/.local/share
+  postInstall = ''
+    wrapProgram $out/bin/dopewars \
+      --run 'mkdir -p ${scoreDirectory}' \
+      --add-flags '-f ${scoreDirectory}/dopewars.sco'
+  '';
+
+  meta = with lib; {
+    description = "Game simulating the life of a drug dealer in New York";
+    homepage = "https://dopewars.sourceforge.io";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ geri1701 ];
+    mainProgram = "dopewars";
+    platforms = platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description of changes
Adds new package: `dopewars`.

Closes  #251175

~~The source code stipulates that a high score file `dopewars.sco` can be read and written by all users. I don't have a solution for this yet. Can someone with more experience please help me with this? In any case, you can start the game if you explicitly specify an alternative file when calling the program.~~

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
