### PR TITLE
bsync: init at 20231221-25f7773

### DIFF
--- a/pkgs/by-name/bs/bsync/package.nix
+++ b/pkgs/by-name/bs/bsync/package.nix
@@ -1,0 +1,50 @@
+{ lib
+, fetchFromGitHub
+, stdenv
+, makeWrapper
+, python3
+, openssh
+, rsync
+, findutils
+, which
+}:
+
+stdenv.mkDerivation {
+  pname = "bsync";
+  version = "unstable-2023-12-21";
+
+  src = fetchFromGitHub {
+    owner  = "dooblem";
+    repo   = "bsync";
+    rev    = "25f77730750720ad68b0ab2773e79d9ca98c3647";
+    hash   = "sha256-k25MjLis0/dp1TTS4aFeJZq/c0T01LmNcWtC+dw/kKY=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 bsync -t $out/bin
+    runHook postInstall
+  '';
+
+nativeBuildInputs = [ makeWrapper ];
+buildInputs = [ python3 ];
+
+fixupPhase = ''
+  runHook preFixup
+
+  patchShebangs $out/bin/bsync
+  wrapProgram $out/bin/bsync \
+    --prefix PATH ":" ${lib.makeLibraryPath [ openssh rsync findutils which ]}
+
+  runHook postFixup
+'';
+
+  meta = with lib; {
+    homepage = "https://github.com/dooblem/bsync";
+    description = "Bidirectional Synchronization using Rsync";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers;  [ dietmarw ];
+    platforms = platforms.unix;
+    mainProgram = "bsync";
+  };
+}


### PR DESCRIPTION
## Description of changes
Initial version for nixpkgs

Bsync is a bidirectional file synchronization tool, using rsync for transfers. Moved files are also synchronized in a smart way.

https://github.com/dooblem/bsync

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
