### PR TITLE
lomiri.trust-store: unstable-2023-10-17 -> 0-unstable-2023-12-27

### DIFF
--- a/pkgs/desktops/lomiri/development/trust-store/default.nix
+++ b/pkgs/desktops/lomiri/development/trust-store/default.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "trust-store";
-  version = "unstable-2023-10-17";
+  version = "0-unstable-2023-12-27";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/trust-store";
-    rev = "7aa7ab5b7f3843e24c13ae6d9b8607455296d60e";
-    hash = "sha256-j+4FZzbG3qh1pGRapFuuMiwT4Lv9P6Ji9/3Z0uGvXmw=";
+    rev = "c91e5ac54c4032525f930f0651d673ad3a1095a2";
+    hash = "sha256-zqs40tKo2AOd9yL2Xfbk52Uh8hy4uT1XDT6YtKufAaY=";
   };
 
   outputs = [
@@ -86,8 +86,10 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     # Requires mirclient API, unavailable in Mir 2.x
     # https://gitlab.com/ubports/development/core/trust-store/-/issues/2
-    "-DTRUST_STORE_MIR_AGENT_ENABLED=OFF"
-    "-DTRUST_STORE_ENABLE_DOC_GENERATION=ON"
+    (lib.cmakeBool "TRUST_STORE_MIR_AGENT_ENABLED" false)
+    (lib.cmakeBool "TRUST_STORE_ENABLE_DOC_GENERATION" true)
+    # error: moving a temporary object prevents copy elision
+    (lib.cmakeBool "ENABLE_WERROR" false)
   ];
 
   # Not working


### PR DESCRIPTION
## Description of changes

To fix build failure on Hydra: https://hydra.nixos.org/build/246564463

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
