### PR TITLE
nixos/avahi: fix mDNS name resolution

### DIFF
--- a/nixos/modules/services/networking/avahi-daemon.nix
+++ b/nixos/modules/services/networking/avahi-daemon.nix
@@ -265,7 +265,7 @@ in
 
     system.nssModules = optional cfg.nssmdns pkgs.nssmdns;
     system.nssDatabases.hosts = optionals cfg.nssmdns (mkMerge [
-      (mkBefore [ "mdns_minimal [NOTFOUND=return]" ]) # before resolve
+      (mkBefore [ "mdns4_minimal [NOTFOUND=return] mdns6_minimal [NOTFOUND=return]" ]) # before resolve
       (mkAfter [ "mdns" ]) # after dns
     ]);
 


### PR DESCRIPTION
The underlying Avahi program was updated in 23.11, but it changed the names of "mdns_minimal" to "mdns4_minimal" and "mdns6_minimal". This is fixed in unstable, but for 23.11 it means there is a regression since DNS name resolution for mDNS hosts (e.g., foo.local) won't work any more.

This changeset fixes the issue by using the new configuration syntax.

Resolves issue #281445

## Description of changes

When nssmdns is enabled, use mdns4_minimal and mdns6_minimal in nsswitch.conf. The configuration syntax has been redesigned in the master branch for the next release, but this will work for 23.11 for now.

Even though mdns6_minimal is included in nsswitch.conf, it will work fine (be ignored) on systems that have disabled IPv6 (I tested this).

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [X] Tested that "ping otherhost.local" works after applying this patch.
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
