### PR TITLE
Enable enforcement of `pkgs/by-name` for new packages (by updating the pinned version)

### DIFF
--- a/pkgs/test/nixpkgs-check-by-name/scripts/pinned-tool.json
+++ b/pkgs/test/nixpkgs-check-by-name/scripts/pinned-tool.json
@@ -1,4 +1,4 @@
 {
-  "rev": "9b19f5e77dd906cb52dade0b7bd280339d2a1f3d",
-  "ci-path": "/nix/store/qlls5ca8q88qpyygg9ddi60gl1nmvpij-nixpkgs-check-by-name"
+  "rev": "842d9d80cfd4560648c785f8a4e6f3b096790e19",
+  "ci-path": "/nix/store/8habk3j25bs2a34zn5q5p17b9dl3fywg-nixpkgs-check-by-name"
 }

--- a/pkgs/test/nixpkgs-check-by-name/scripts/run-local.sh
+++ b/pkgs/test/nixpkgs-check-by-name/scripts/run-local.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p jq
+#!nix-shell -i bash -p jq -I nixpkgs=../../../..
 
 set -o pipefail -o errexit -o nounset
 

--- a/pkgs/test/nixpkgs-check-by-name/scripts/update-pinned-tool.sh
+++ b/pkgs/test/nixpkgs-check-by-name/scripts/update-pinned-tool.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p jq
+#!nix-shell -i bash -p jq -I nixpkgs=../../../..
 
 set -o pipefail -o errexit -o nounset
 


### PR DESCRIPTION
## Context

This is the final follow-up to https://github.com/NixOS/nixpkgs/pull/275539, which has much more context. At the time of that PR, the changes were supposed to be automatically used in the next channel update, but after discovering a problem (https://github.com/NixOS/nixpkgs/pull/281390), I quickly changed how this works in https://github.com/NixOS/nixpkgs/pull/281374: Now one needs to manually update the pinned version of the tooling before it ends up getting used in CI.

## Description of changes

This is the first PR that updates the pinned tooling. This is done by running `update-pinned-tool.sh`.

Immediately following the merge of this PR, all CI runs against `master` will start to enforce `pkgs/by-name` for new packages.

Note that CI will test the new tooling right inside this PR itself as well, so if CI is green, this should be good to merge.

## Things done
- Confirmed that CI for this very PR uses the new tooling and succeeds
  - https://github.com/NixOS/nixpkgs/actions/runs/7574031596/job/20627512813?pr=281835
- Checked that PRs adding new packages not to `pkgs/by-name` fail:
  - https://github.com/tweag/nixpkgs/pull/82

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
