### PR TITLE
nixops_plugged:  attrset of nixops builds, with varying plugin sets included

### DIFF
--- a/pkgs/applications/networking/cluster/nixops/default.nix
+++ b/pkgs/applications/networking/cluster/nixops/default.nix
@@ -1,4 +1,4 @@
-{ python3 }:
+{ lib, python3 }:
 
 let
   python = python3.override {
@@ -43,14 +43,26 @@ let
       inherit withPlugins python;
     };
   }));
-in withPlugins (ps: [
-  ps.nixops-aws
-  ps.nixops-digitalocean
-  ps.nixops-encrypted-links
-  ps.nixops-gce
-  ps.nixops-hercules-ci
-  ps.nixops-hetzner
-  ps.nixops-hetznercloud
-  ps.nixops-libvirtd
-  ps.nixops-vbox
-])
+in lib.mapAttrs
+  (name: plugnames: withPlugins (ps: map (k: builtins.getAttr k ps) plugnames) )
+  {
+    minimal      = [];
+    aws          = [ "nixops-aws" ];
+    digitalocean = [ "nixops-digitalocean" ];
+    gce          = [ "nixops-gce" ];
+    hercules-ci  = [ "nixops-hercules-ci" ];
+    hetzner      = [ "nixops-hetzner" "nixops-hetznercloud" ];
+    libvirtd     = [ "nixops-libvirtd" ];
+    vbox         = [ "nixops-vbox" ];
+    full         = [
+      "nixops-aws"
+      "nixops-digitalocean"
+      "nixops-encrypted-links"
+      "nixops-gce"
+      "nixops-hercules-ci"
+      "nixops-hetzner"
+      "nixops-hetznercloud"
+      "nixops-libvirtd"
+      "nixops-vbox"
+    ];
+  }

--- a/pkgs/applications/networking/cluster/nixops/default.nix
+++ b/pkgs/applications/networking/cluster/nixops/default.nix
@@ -44,7 +44,7 @@ let
     };
   }));
 in lib.mapAttrs
-  (name: plugnames: withPlugins (ps: map (k: builtins.getAttr k ps) plugnames) )
+  (name: plugnames: withPlugins (ps: map (k: ps.${k}) plugnames) )
   {
     minimal      = [];
     aws          = [ "nixops-aws" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40523,7 +40523,9 @@ with pkgs;
 
   nixStatic = pkgsStatic.nix;
 
-  nixops_unstable = callPackage ../applications/networking/cluster/nixops { };
+  nixops_plugged = callPackage ../applications/networking/cluster/nixops { };
+
+  nixops_unstable = nixops_plugged.full;
 
   /*
     Evaluate a NixOS configuration using this evaluation of Nixpkgs.


### PR DESCRIPTION
## Description of changes

As `nixops_unstable` receives very little maintenance, it's important to keep the remnants working for as many people as possible.

The current `nixops_unstable` is extremely brittle, as it includes every plugin available -- which means it breaks very easily.

This PR provides an attrset with a bunch of specialised nixops builds, for various backends, as well as the full and minimal options.

This way people can fix whatever plugins they care about and get things rolling, without being forced to deal with plugins they don't care and have no context about.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
