### PR TITLE
luksroot:  allow extra activation commands for complex  storage layering cases

### DIFF
--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -867,8 +867,8 @@ in
             type = types.lines;
             default = "";
             example = ''
-              integritysetup open /dev/sda integ-left
-              integritysetup open /dev/sdb integ-right
+              $${cryptsetup}/bin/integritysetup open /dev/sda integ-left
+              $${cryptsetup}/bin/integritysetup open /dev/sdb integ-right
               $${systemd}/bin/udevadm trigger /dev/md126
               $${systemd}/bin/udevadm settle
             '';
@@ -934,6 +934,14 @@ in
       type = types.bool;
       description = lib.mdDoc ''
         Enables support for authenticating with a GPG encrypted password.
+      '';
+    };
+
+    boot.initrd.luks.withIntegritySetup = mkOption {
+      default = false;
+      type = types.bool;
+      description = lib.mdDoc ''
+        Include the dm-integrity's integritysetup control binary into the initramfs.
       '';
     };
 
@@ -1030,6 +1038,9 @@ in
     in
     mkIf (!config.boot.initrd.systemd.enable) ''
       copy_bin_and_libs ${pkgs.cryptsetup}/bin/cryptsetup
+      ${optionalString luks.withIntegritySetup ''
+        copy_bin_and_libs ${pkgs.cryptsetup}/bin/integritysetup
+        ''}
       copy_bin_and_libs ${askPass}/bin/cryptsetup-askpass
       sed -i s,/bin/sh,$out/bin/sh, $out/bin/cryptsetup-askpass
 

--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -152,6 +152,9 @@ let
     cschange = "cryptsetup luksChangeKey ${dev.device} ${optionalString (dev.header != null) "--header=${dev.header}"}";
     fido2luksCredentials = dev.fido2.credentials ++ optional (dev.fido2.credential != null) dev.fido2.credential;
   in ''
+    # Custom device activation commands
+    ${dev.activationCommands}
+
     # Wait for luksRoot (and optionally keyFile and/or header) to appear, e.g.
     # if on a USB drive.
     wait_target "device" ${dev.device} || die "${dev.device} is unavailable"
@@ -858,6 +861,20 @@ in
                 };
               };
             });
+          };
+
+          activationCommands = mkOption {
+            type = types.lines;
+            default = "";
+            example = ''
+              integritysetup open /dev/sda integ-left
+              integritysetup open /dev/sdb integ-right
+              $${systemd}/bin/udevadm trigger /dev/md126
+              $${systemd}/bin/udevadm settle
+            '';
+            description = ''
+              Commands that should be run to activate our LUKS device, before we wait for it to appear.
+            '';
           };
 
           preOpenCommands = mkOption {


### PR DESCRIPTION
## Description of changes

Allow arbitrary commands to be executed prior to waiting for the rootfs block device.

This is necessary for more complicated layering setups where the kernel doesn't do the necessary assembly automatically.

This enables, e.g.  raid1-over-integrity-over-luks, with a sister PR https://github.com/NixOS/nixpkgs/pull/281894

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
