### PR TITLE
frogmouth: use same xdg package as upstream

### DIFF
--- a/pkgs/tools/text/frogmouth/default.nix
+++ b/pkgs/tools/text/frogmouth/default.nix
@@ -15,13 +15,6 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-0fcCON/M9JklE7X9aRfzTkEFG4ckJqLoQlYCSrWHHGQ=";
   };
 
-  # Per <https://github.com/srstevenson/xdg-base-dirs/tree/6.0.0#xdg-base-dirs>, the package is
-  # renamed from `xdg` to `xdg_base_dirs`, but upstream isn't amenable to performing that rename.
-  # See <https://github.com/Textualize/frogmouth/pull/59>. So this is a minimal fix.
-  postUnpack = ''
-    sed -i -e "s,from xdg import,from xdg_base_dirs import," $sourceRoot/frogmouth/data/{config,data_directory}.py
-  '';
-
   nativeBuildInputs = [
     python3.pkgs.poetry-core
     python3.pkgs.pythonRelaxDepsHook
@@ -31,13 +24,12 @@ python3.pkgs.buildPythonApplication rec {
     httpx
     textual
     typing-extensions
-    xdg-base-dirs
+    xdg
   ];
 
   pythonRelaxDeps = [
     "httpx"
     "textual"
-    "xdg-base-dirs"
   ];
 
   pythonImportsCheck = [ "frogmouth" ];


### PR DESCRIPTION
[edit] just use the xdg package, same as upstream, rather than `xdg-base-dirs`

The build for `frogmouth` already contains a `postUnpack` patch that replaces the `xdg` dependency with `xdg-base-dirs`, but that's unfortunately not enough for the Nixpkgs build to succeed: The python dependency check hook relies on the specifications within `pyproject.toml` (or the resulting wheel files) to determine whether all dependencies are present and fails because it still checks for `xdg` unless the project declaration is also patched.


See Hydra build: https://hydra.nixos.org/build/246124305
Hydra log: https://hydra.nixos.org/build/246124305/nixlog/2

Relevant log excerpt:

```
OK
/build/source
Finished executing pypaBuildPhase
Running phase: pythonRuntimeDepsCheckHook
Executing pythonRuntimeDepsCheck
Checking runtime dependencies for frogmouth-0.9.1-py3-none-any.whl
  - xdg not installed
```

## Description of changes

Added a second `sed` line that patches `pyproject.toml` accordingly.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
  - [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
