### PR TITLE
fixup-yarn-lock: split out from prefetch-yarn-deps

### DIFF
--- a/pkgs/applications/audio/muzika/default.nix
+++ b/pkgs/applications/audio/muzika/default.nix
@@ -2,7 +2,7 @@
 , desktop-file-utils
 , fetchFromGitHub
 , fetchYarnDeps
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , gjs
 , glib-networking
 , gobject-introspection
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     ninja
     nodejs
     pkg-config
-    prefetch-yarn-deps
+    fixup-yarn-lock
     wrapGAppsHook4
     yarn
   ];

--- a/pkgs/applications/graphics/drawio/default.nix
+++ b/pkgs/applications/graphics/drawio/default.nix
@@ -4,7 +4,7 @@
 , fetchYarnDeps
 , makeDesktopItem
 , copyDesktopItems
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , makeWrapper
 , autoSignDarwinBinariesHook
 , nodejs
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    prefetch-yarn-deps
+    fixup-yarn-lock
     makeWrapper
     nodejs
     yarn

--- a/pkgs/applications/misc/tandoor-recipes/frontend.nix
+++ b/pkgs/applications/misc/tandoor-recipes/frontend.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchYarnDeps, prefetch-yarn-deps, callPackage, nodejs }:
+{ stdenv, fetchYarnDeps, fixup-yarn-lock, callPackage, nodejs }:
 let
   common = callPackage ./common.nix { };
 in
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [
-    prefetch-yarn-deps
+    fixup-yarn-lock
     nodejs
     nodejs.pkgs.yarn
   ];

--- a/pkgs/applications/networking/cluster/tilt/assets.nix
+++ b/pkgs/applications/networking/cluster/tilt/assets.nix
@@ -2,7 +2,7 @@
 , stdenvNoCC
 , version, src
 , fetchYarnDeps
-, prefetch-yarn-deps, yarn, nodejs
+, fixup-yarn-lock, yarn, nodejs
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -10,7 +10,7 @@ stdenvNoCC.mkDerivation rec {
 
   inherit src version;
 
-  nativeBuildInputs = [ prefetch-yarn-deps yarn nodejs ];
+  nativeBuildInputs = [ fixup-yarn-lock yarn nodejs ];
 
   yarnOfflineCache = fetchYarnDeps {
     yarnLock = "${src}/web/yarn.lock";

--- a/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-desktop.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , makeWrapper
 , makeDesktopItem
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , yarn
 , nodejs
 , fetchYarnDeps
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: builtins.removeAttrs pinData [ "hashes" ] // {
     sha256 = desktopYarnHash;
   };
 
-  nativeBuildInputs = [ yarn prefetch-yarn-deps nodejs makeWrapper jq ]
+  nativeBuildInputs = [ yarn fixup-yarn-lock nodejs makeWrapper jq ]
     ++ lib.optionals stdenv.isDarwin [ desktopToDarwinBundle ];
 
   inherit seshat;

--- a/pkgs/applications/networking/instant-messengers/element/element-web.nix
+++ b/pkgs/applications/networking/instant-messengers/element/element-web.nix
@@ -6,7 +6,7 @@
 , writeText
 , jq
 , yarn
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , nodejs
 , jitsi-meet
 }:
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: builtins.removeAttrs pinData [ "hashes" ] // {
     sha256 = webYarnHash;
   };
 
-  nativeBuildInputs = [ yarn prefetch-yarn-deps jq nodejs ];
+  nativeBuildInputs = [ yarn fixup-yarn-lock jq nodejs ];
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/applications/networking/instant-messengers/element/seshat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/element/seshat/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, rustPlatform, fetchFromGitHub, callPackage, sqlcipher, nodejs, python3, yarn, prefetch-yarn-deps, CoreServices, fetchYarnDeps, removeReferencesTo }:
+{ lib, stdenv, rustPlatform, fetchFromGitHub, callPackage, sqlcipher, nodejs, python3, yarn, fixup-yarn-lock, CoreServices, fetchYarnDeps, removeReferencesTo }:
 
 let
   pinData = lib.importJSON ./pin.json;
@@ -16,7 +16,7 @@ in rustPlatform.buildRustPackage rec {
 
   sourceRoot = "${src.name}/seshat-node/native";
 
-  nativeBuildInputs = [ nodejs python3 yarn prefetch-yarn-deps ];
+  nativeBuildInputs = [ nodejs python3 yarn fixup-yarn-lock ];
   buildInputs = [ sqlcipher ] ++ lib.optional stdenv.isDarwin CoreServices;
 
   npm_config_nodedir = nodejs;

--- a/pkgs/applications/networking/instant-messengers/hydrogen-web/unwrapped.nix
+++ b/pkgs/applications/networking/instant-messengers/hydrogen-web/unwrapped.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , fetchYarnDeps
 , yarn
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , nodejs
 }:
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-N9lUAhfYLlEAIaWSNS3Ecq+aBTz+f7Z22Sclwj9rp6w=";
   };
 
-  nativeBuildInputs = [ yarn prefetch-yarn-deps nodejs ];
+  nativeBuildInputs = [ yarn fixup-yarn-lock nodejs ];
 
   configurePhase = ''
     runHook preConfigure

--- a/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
+++ b/pkgs/applications/networking/instant-messengers/teams-for-linux/default.nix
@@ -7,7 +7,7 @@
 , yarn
 , nodejs
 , fetchYarnDeps
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , electron
 , libnotify
 , libpulseaudio
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-jBwyIyiWeqNmOnxmVOr7c4oMWwHElEjM25sShhTMi78=";
   };
 
-  nativeBuildInputs = [ yarn prefetch-yarn-deps nodejs copyDesktopItems makeWrapper ];
+  nativeBuildInputs = [ yarn fixup-yarn-lock nodejs copyDesktopItems makeWrapper ];
 
   configurePhase = ''
     runHook preConfigure

--- a/pkgs/applications/networking/irc/thelounge/default.nix
+++ b/pkgs/applications/networking/irc/thelounge/default.nix
@@ -4,7 +4,7 @@
 , fetchYarnDeps
 , nodejs
 , yarn
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , python3
 , npmHooks
 , darwin
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-MM6SgVT7Pjdu96A4eWRucEzT7uNPxBqUDgHKl8mH2C0=";
   };
 
-  nativeBuildInputs = [ nodejs yarn prefetch-yarn-deps python3 npmHooks.npmInstallHook ] ++ lib.optional stdenv.isDarwin darwin.cctools;
+  nativeBuildInputs = [ nodejs yarn fixup-yarn-lock python3 npmHooks.npmInstallHook ] ++ lib.optional stdenv.isDarwin darwin.cctools;
   buildInputs = [ sqlite ];
 
   configurePhase = ''

--- a/pkgs/applications/version-management/gitlab/default.nix
+++ b/pkgs/applications/version-management/gitlab/default.nix
@@ -2,7 +2,7 @@
 , ruby_3_1, tzdata, git, nettools, nixosTests, nodejs, openssl
 , defaultGemConfig, buildRubyGem
 , gitlabEnterprise ? false, callPackage, yarn
-, prefetch-yarn-deps, replace, file, cacert, fetchYarnDeps, makeWrapper, pkg-config
+, fixup-yarn-lock, replace, file, cacert, fetchYarnDeps, makeWrapper, pkg-config
 , cargo, rustc, rustPlatform
 }:
 
@@ -94,7 +94,7 @@ let
       sha256 = data.yarn_hash;
     };
 
-    nativeBuildInputs = [ rubyEnv.wrappedRuby rubyEnv.bundler nodejs yarn git cacert prefetch-yarn-deps ];
+    nativeBuildInputs = [ rubyEnv.wrappedRuby rubyEnv.bundler nodejs yarn git cacert fixup-yarn-lock ];
 
     patches = [
       # Since version 12.6.0, the rake tasks need the location of git,

--- a/pkgs/applications/version-management/sapling/default.nix
+++ b/pkgs/applications/version-management/sapling/default.nix
@@ -13,7 +13,7 @@
 , fetchYarnDeps
 , yarn
 , nodejs
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , glibcLocales
 , libiconv
 , Cocoa
@@ -66,7 +66,7 @@ let
     inherit version;
 
     nativeBuildInputs = [
-      prefetch-yarn-deps
+      fixup-yarn-lock
       nodejs
       yarn
     ];

--- a/pkgs/applications/virtualization/podman-desktop/default.nix
+++ b/pkgs/applications/virtualization/podman-desktop/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , fetchYarnDeps
 , yarn
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , nodejs
 , makeWrapper
 , copyDesktopItems
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     yarn
-    prefetch-yarn-deps
+    fixup-yarn-lock
     nodejs
     makeWrapper
     copyDesktopItems

--- a/pkgs/build-support/node/fetch-yarn-deps/default.nix
+++ b/pkgs/build-support/node/fetch-yarn-deps/default.nix
@@ -13,29 +13,49 @@ in {
     name = "prefetch-yarn-deps";
 
     dontUnpack = true;
+    dontBuild = true;
 
     nativeBuildInputs = [ makeWrapper ];
-    buildInputs = [ coreutils nix-prefetch-git nodejs-slim nix ];
-
-    buildPhase = ''
-      runHook preBuild
-
-      mkdir libexec
-      tar --strip-components=1 -xf ${yarnpkg-lockfile-tar} package/index.js
-      mv index.js libexec/yarnpkg-lockfile.js
-      cp ${./.}/*.js libexec/
-      patchShebangs libexec
-
-      runHook postBuild
-    '';
+    buildInputs = [ nodejs-slim ];
 
     installPhase = ''
       runHook preInstall
 
-      mkdir -p $out/bin
-      cp -r libexec $out
+      mkdir -p $out/bin $out/libexec
+
+      tar --strip-components=1 -xf ${yarnpkg-lockfile-tar} package/index.js
+      mv index.js $out/libexec/yarnpkg-lockfile.js
+      cp ${./.}/common.js ${./.}/index.js $out/libexec/
+
+      patchShebangs $out/libexec
       makeWrapper $out/libexec/index.js $out/bin/prefetch-yarn-deps \
         --prefix PATH : ${lib.makeBinPath [ coreutils nix-prefetch-git nix ]}
+
+      runHook postInstall
+    '';
+
+    passthru = { inherit tests; };
+  };
+
+  fixup-yarn-lock = stdenv.mkDerivation {
+    name = "fixup-yarn-lock";
+
+    dontUnpack = true;
+    dontBuild = true;
+
+    nativeBuildInputs = [ makeWrapper ];
+    buildInputs = [ nodejs-slim ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/bin $out/libexec
+
+      tar --strip-components=1 -xf ${yarnpkg-lockfile-tar} package/index.js
+      mv index.js $out/libexec/yarnpkg-lockfile.js
+      cp ${./.}/common.js ${./.}/fixup.js $out/libexec/
+
+      patchShebangs $out/libexec
       makeWrapper $out/libexec/fixup.js $out/bin/fixup-yarn-lock
 
       runHook postInstall

--- a/pkgs/by-name/aw/aws-azure-login/package.nix
+++ b/pkgs/by-name/aw/aws-azure-login/package.nix
@@ -6,7 +6,7 @@
 , fetchYarnDeps
 , makeWrapper
 , nodejs
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , yarn
 }:
 stdenv.mkDerivation (finalAttrs: {
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     makeWrapper
     nodejs
-    prefetch-yarn-deps
+    fixup-yarn-lock
     yarn
   ];
 

--- a/pkgs/by-name/de/devcontainer/package.nix
+++ b/pkgs/by-name/de/devcontainer/package.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchYarnDeps
 , fetchFromGitHub
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , nodejs
 , python3
 , makeWrapper
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Wy0UP8QaQzZ1par7W5UhnRLc5DF2PAif0JIZJtRokBk=";
   };
 
-  nativeBuildInputs = [ yarn prefetch-yarn-deps python3 makeWrapper ];
+  nativeBuildInputs = [ yarn fixup-yarn-lock python3 makeWrapper ];
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/by-name/fe/fernglas/package.nix
+++ b/pkgs/by-name/fe/fernglas/package.nix
@@ -3,7 +3,7 @@
 , rustPlatform
 , fetchFromGitHub
 , fetchYarnDeps
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , python3
 , jq
 , yarn
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-0wj5AS8RLVr+S/QWWxCsMvmVjmXUWGfR9kPaZimJEss=";
   };
 
-  nativeBuildInputs = [ yarn nodejs-slim prefetch-yarn-deps python3 jq ];
+  nativeBuildInputs = [ yarn nodejs-slim fixup-yarn-lock python3 jq ];
 
   nlnog_communities = fetchFromGitHub {
     owner = "NLNOG";

--- a/pkgs/by-name/gi/gitmoji-cli/package.nix
+++ b/pkgs/by-name/gi/gitmoji-cli/package.nix
@@ -4,7 +4,7 @@
 , fetchYarnDeps
 , makeWrapper
 , nodejs
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , yarn
 , testers
 }:
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     makeWrapper
     nodejs
-    prefetch-yarn-deps
+    fixup-yarn-lock
     yarn
   ];
 

--- a/pkgs/by-name/in/incus/ui.nix
+++ b/pkgs/by-name/in/incus/ui.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , fetchYarnDeps
 , nodejs
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , yarn
 , nixosTests
 , git
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     nodejs
-    prefetch-yarn-deps
+    fixup-yarn-lock
     yarn
     git
   ];

--- a/pkgs/by-name/lx/lxd-ui/package.nix
+++ b/pkgs/by-name/lx/lxd-ui/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   fetchYarnDeps,
   nodejs,
-  prefetch-yarn-deps,
+  fixup-yarn-lock,
   yarn,
   nixosTests,
   nix-update-script,
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     nodejs
-    prefetch-yarn-deps
+    fixup-yarn-lock
     yarn
   ];
 

--- a/pkgs/by-name/me/mealie/mealie-frontend.nix
+++ b/pkgs/by-name/me/mealie/mealie-frontend.nix
@@ -1,5 +1,5 @@
 src: version:
-{ lib, fetchYarnDeps, nodejs_18, prefetch-yarn-deps, stdenv }: stdenv.mkDerivation {
+{ lib, fetchYarnDeps, nodejs_18, fixup-yarn-lock, stdenv }: stdenv.mkDerivation {
   name = "mealie-frontend";
   inherit version;
   src = "${src}/frontend";
@@ -10,7 +10,7 @@ src: version:
   };
 
   nativeBuildInputs = [
-    prefetch-yarn-deps
+    fixup-yarn-lock
     nodejs_18
     nodejs_18.pkgs.yarn
   ];

--- a/pkgs/by-name/me/mermaid-cli/package.nix
+++ b/pkgs/by-name/me/mermaid-cli/package.nix
@@ -4,7 +4,7 @@
 , fetchYarnDeps
 , makeWrapper
 , nodejs
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , yarn
 , chromium
 }:
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs  = [
     makeWrapper
     nodejs
-    prefetch-yarn-deps
+    fixup-yarn-lock
     yarn
   ];
 

--- a/pkgs/by-name/no/node-hp-scan-to/package.nix
+++ b/pkgs/by-name/no/node-hp-scan-to/package.nix
@@ -4,7 +4,7 @@
 , fetchYarnDeps
 , makeWrapper
 , nodejs
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , yarn
 }:
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     makeWrapper
     nodejs
-    prefetch-yarn-deps
+    fixup-yarn-lock
     yarn
   ];
 

--- a/pkgs/by-name/px/pxder/package.nix
+++ b/pkgs/by-name/px/pxder/package.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , fetchYarnDeps
 , makeWrapper
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , yarn
 , nodejs
 }:
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs  = [
     makeWrapper
-    prefetch-yarn-deps
+    fixup-yarn-lock
     yarn
   ];
 

--- a/pkgs/by-name/sh/shepherd/package.nix
+++ b/pkgs/by-name/sh/shepherd/package.nix
@@ -4,7 +4,7 @@
 , fetchYarnDeps
 , makeWrapper
 , nodejs
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , yarn
 }:
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs  = [
     makeWrapper
     nodejs
-    prefetch-yarn-deps
+    fixup-yarn-lock
     yarn
   ];
 

--- a/pkgs/by-name/ve/vercel-pkg/package.nix
+++ b/pkgs/by-name/ve/vercel-pkg/package.nix
@@ -4,7 +4,7 @@
 , fetchYarnDeps
 , makeWrapper
 , nodejs
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , yarn
 }:
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs  = [
     makeWrapper
     nodejs
-    prefetch-yarn-deps
+    fixup-yarn-lock
     yarn
   ];
 

--- a/pkgs/development/python-modules/dash/default.nix
+++ b/pkgs/development/python-modules/dash/default.nix
@@ -6,7 +6,7 @@
 , setuptools
 , nodejs
 , yarn
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , fetchYarnDeps
 
 , flask
@@ -52,7 +52,7 @@ buildPythonPackage rec {
     setuptools
     nodejs
     yarn
-    prefetch-yarn-deps
+    fixup-yarn-lock
   ];
 
   yarnOfflineCache = fetchYarnDeps {

--- a/pkgs/development/tools/electron-fiddle/default.nix
+++ b/pkgs/development/tools/electron-fiddle/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , fetchYarnDeps
 , fetchurl
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , git
 , lib
 , makeDesktopItem
@@ -51,7 +51,7 @@ let
     pname = "${pname}-unwrapped";
     inherit version src;
 
-    nativeBuildInputs = [ prefetch-yarn-deps git nodejs util-linux yarn zip ];
+    nativeBuildInputs = [ fixup-yarn-lock git nodejs util-linux yarn zip ];
 
     configurePhase = ''
       export HOME=$TMPDIR

--- a/pkgs/development/tools/electron/common.nix
+++ b/pkgs/development/tools/electron/common.nix
@@ -5,7 +5,7 @@
 , python3
 , fetchYarnDeps
 , fetchNpmDeps
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , npmHooks
 , yarn
 , substituteAll
@@ -29,7 +29,7 @@ in (chromium.override { upstream-info = info.chromium; }).mkDerivation (base: {
   inherit (info) version;
   buildTargets = [ "electron:electron_dist_zip" ];
 
-  nativeBuildInputs = base.nativeBuildInputs ++ [ nodejs yarn prefetch-yarn-deps unzip npmHooks.npmConfigHook ];
+  nativeBuildInputs = base.nativeBuildInputs ++ [ nodejs yarn fixup-yarn-lock unzip npmHooks.npmConfigHook ];
   buildInputs = base.buildInputs ++ [ libnotify ];
 
   electronOfflineCache = fetchYarnDeps {

--- a/pkgs/games/anki/default.nix
+++ b/pkgs/games/anki/default.nix
@@ -12,7 +12,7 @@
 , nixosTests
 , nodejs
 , nodejs-slim
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , protobuf
 , python3
 , qt6
@@ -103,7 +103,7 @@ let
 
     nativeBuildInputs = [
       nodejs-slim
-      prefetch-yarn-deps
+      fixup-yarn-lock
       yarn
     ];
 
@@ -138,7 +138,7 @@ python3.pkgs.buildPythonApplication {
   nativeBuildInputs = [
     fakeGit
     offlineYarn
-    prefetch-yarn-deps
+    fixup-yarn-lock
 
     cargo
     installShellFiles

--- a/pkgs/games/heroic/default.nix
+++ b/pkgs/games/heroic/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , fetchYarnDeps
 , yarn
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , nodejs
 , python3
 , makeWrapper
@@ -33,7 +33,7 @@ in stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     yarn
-    prefetch-yarn-deps
+    fixup-yarn-lock
     nodejs
     python3
     makeWrapper

--- a/pkgs/games/r2modman/default.nix
+++ b/pkgs/games/r2modman/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , yarn
 , fetchYarnDeps
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , nodejs
 , electron
 , fetchFromGitHub
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     yarn
-    prefetch-yarn-deps
+    fixup-yarn-lock
     nodejs
     makeWrapper
     copyDesktopItems

--- a/pkgs/servers/akkoma/admin-fe/default.nix
+++ b/pkgs/servers/akkoma/admin-fe/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitea, fetchYarnDeps
-, prefetch-yarn-deps, yarn, nodejs
+, fixup-yarn-lock, yarn, nodejs
 , python3, pkg-config, libsass
 }:
 
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    prefetch-yarn-deps
+    fixup-yarn-lock
     yarn
     nodejs
     pkg-config

--- a/pkgs/servers/akkoma/akkoma-fe/default.nix
+++ b/pkgs/servers/akkoma/akkoma-fe/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitea, fetchYarnDeps
-, prefetch-yarn-deps, yarn, nodejs
+, fixup-yarn-lock, yarn, nodejs
 , jpegoptim, oxipng, nodePackages
 }:
 
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    prefetch-yarn-deps
+    fixup-yarn-lock
     yarn
     nodejs
     jpegoptim

--- a/pkgs/servers/alice-lg/default.nix
+++ b/pkgs/servers/alice-lg/default.nix
@@ -6,7 +6,7 @@
 , yarn
 , nodejs
 , nixosTests
-, prefetch-yarn-deps
+, fixup-yarn-lock
 }:
 
 buildGoModule rec {
@@ -32,7 +32,7 @@ buildGoModule rec {
       hash = "sha256-PwByNIegKYTOT8Yg3nDMDFZiLRVkbX07z99YaDiBsIY=";
     };
 
-    nativeBuildInputs = [ nodejs yarn prefetch-yarn-deps ];
+    nativeBuildInputs = [ nodejs yarn fixup-yarn-lock ];
     configurePhase = ''
       runHook preConfigure
 

--- a/pkgs/servers/gotify/ui.nix
+++ b/pkgs/servers/gotify/ui.nix
@@ -1,6 +1,6 @@
 { stdenv
 , yarn
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , nodejs-slim
 , fetchFromGitHub
 , fetchYarnDeps
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-ejHzo6NHCMlNiYePWvfMY9Blb58pj3UQ5PFI0V84flI=";
   };
 
-  nativeBuildInputs = [ yarn prefetch-yarn-deps nodejs-slim ];
+  nativeBuildInputs = [ yarn fixup-yarn-lock nodejs-slim ];
 
   postPatch = ''
     export HOME=$NIX_BUILD_TOP/fake_home

--- a/pkgs/servers/mastodon/default.nix
+++ b/pkgs/servers/mastodon/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, nodejs-slim, bundlerEnv, nixosTests
 , yarn, callPackage, ruby, writeShellScript
-, fetchYarnDeps, prefetch-yarn-deps
+, fetchYarnDeps, fixup-yarn-lock
 , brotli
 
   # Allow building a fork or custom version of Mastodon:
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
       hash = yarnHash;
     };
 
-    nativeBuildInputs = [ prefetch-yarn-deps nodejs-slim yarn mastodonGems mastodonGems.wrappedRuby brotli ];
+    nativeBuildInputs = [ fixup-yarn-lock nodejs-slim yarn mastodonGems mastodonGems.wrappedRuby brotli ];
 
     RAILS_ENV = "production";
     NODE_ENV = "production";

--- a/pkgs/servers/matrix-synapse/matrix-appservice-irc/default.nix
+++ b/pkgs/servers/matrix-synapse/matrix-appservice-irc/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , fetchYarnDeps
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , nodejs
 , nodejs-slim
 , matrix-sdk-crypto-nodejs
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
   strictDeps = true;
 
   nativeBuildInputs = [
-    prefetch-yarn-deps
+    fixup-yarn-lock
     nodejs-slim
     nodejs.pkgs.yarn
     nodejs.pkgs.node-gyp-build

--- a/pkgs/servers/monitoring/grafana-agent/default.nix
+++ b/pkgs/servers/monitoring/grafana-agent/default.nix
@@ -2,11 +2,11 @@
 , buildGoModule
 , fetchFromGitHub
 , fetchYarnDeps
+, fixup-yarn-lock
 , grafana-agent
 , nix-update-script
 , nixosTests
 , nodejs
-, prefetch-yarn-deps
 , stdenv
 , systemd
 , testers
@@ -44,7 +44,7 @@ buildGoModule rec {
     "-X ${prefix}.BuildDate=1980-01-01T00:00:00Z"
   ];
 
-  nativeBuildInputs = [ prefetch-yarn-deps nodejs yarn ];
+  nativeBuildInputs = [ fixup-yarn-lock nodejs yarn ];
 
   tags = [
     "builtinassets"

--- a/pkgs/servers/peertube/default.nix
+++ b/pkgs/servers/peertube/default.nix
@@ -6,7 +6,7 @@
 , fetchYarnDeps
 , nixosTests
 , brotli
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , jq
 , nodejs
 , which
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
 
   outputs = [ "out" "cli" "runner" ];
 
-  nativeBuildInputs = [ brotli prefetch-yarn-deps jq which yarn ];
+  nativeBuildInputs = [ brotli fixup-yarn-lock jq which yarn ];
 
   buildInputs = [ nodejs ];
 

--- a/pkgs/servers/rmfakecloud/webui.nix
+++ b/pkgs/servers/rmfakecloud/webui.nix
@@ -1,4 +1,4 @@
-{ version, src, stdenv, lib, fetchYarnDeps, prefetch-yarn-deps, yarn, nodejs }:
+{ version, src, stdenv, lib, fetchYarnDeps, fixup-yarn-lock, yarn, nodejs }:
 
 stdenv.mkDerivation rec {
   inherit version src;
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-JLCrpzytMKejmW+WlM6yybsoIZiimiJdPG5dSIn1L14=";
   };
 
-  nativeBuildInputs = [ prefetch-yarn-deps yarn nodejs ];
+  nativeBuildInputs = [ fixup-yarn-lock yarn nodejs ];
 
   buildPhase = ''
     export HOME=$(mktemp -d)

--- a/pkgs/servers/teleport/generic.nix
+++ b/pkgs/servers/teleport/generic.nix
@@ -19,7 +19,7 @@
 , yarn
 , wasm-bindgen-cli
 , wasm-pack
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , nixosTests
 
 , withRdpClient ? true
@@ -80,7 +80,7 @@ let
       "-C linker=lld"
     ];
 
-    nativeBuildInputs = [ nodejs yarn prefetch-yarn-deps ] ++
+    nativeBuildInputs = [ nodejs yarn fixup-yarn-lock ] ++
       lib.optional (lib.versionAtLeast version "15") [
         binaryen
         cargo

--- a/pkgs/servers/web-apps/discourse/default.nix
+++ b/pkgs/servers/web-apps/discourse/default.nix
@@ -35,7 +35,7 @@
 , icu
 , fetchYarnDeps
 , yarn
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , nodePackages
 , nodejs_18
 , jq
@@ -215,7 +215,7 @@ let
       nodejs_18
       jq
       moreutils
-      prefetch-yarn-deps
+      fixup-yarn-lock
     ];
 
     outputs = [ "out" "javascripts" ];

--- a/pkgs/servers/web-apps/outline/default.nix
+++ b/pkgs/servers/web-apps/outline/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , fetchYarnDeps
 , makeWrapper
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , nodejs
 , yarn
 , nixosTests
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-jK1jZ9NyBl3Dioh/7gXWx6XyyI6xJKt2a/XXzbhllZM=";
   };
 
-  nativeBuildInputs = [ makeWrapper prefetch-yarn-deps ];
+  nativeBuildInputs = [ makeWrapper fixup-yarn-lock ];
   buildInputs = [ yarn nodejs ];
 
   yarnOfflineCache = fetchYarnDeps {

--- a/pkgs/tools/admin/pgadmin/default.nix
+++ b/pkgs/tools/admin/pgadmin/default.nix
@@ -7,7 +7,7 @@
 , postgresqlTestHook
 , postgresql
 , yarn
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , nodejs
 , stdenv
 , server-mode ? true
@@ -151,7 +151,7 @@ pythonPackages.buildPythonApplication rec {
     cp -v ../pkg/pip/setup_pip.py setup.py
   '';
 
-  nativeBuildInputs = with pythonPackages; [ cython pip sphinx yarn prefetch-yarn-deps nodejs ];
+  nativeBuildInputs = with pythonPackages; [ cython pip sphinx yarn fixup-yarn-lock nodejs ];
   buildInputs = [
     zlib
     pythonPackages.wheel

--- a/pkgs/tools/networking/ratman/default.nix
+++ b/pkgs/tools/networking/ratman/default.nix
@@ -6,7 +6,7 @@
 , protobuf
 , rustPlatform
 , fetchYarnDeps
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , stdenv
 , yarn
 , nodejs
@@ -49,7 +49,7 @@ rustPlatform.buildRustPackage rec {
       sha256 = "sha256-pWjKL41r/bTvWv+5qCgCFVL9+o64BiV2/ISdLeKEOqE=";
     };
 
-    nativeBuildInputs = [ yarn nodejs prefetch-yarn-deps ];
+    nativeBuildInputs = [ yarn nodejs fixup-yarn-lock ];
 
     outputs = [ "out" "dist" ];
 

--- a/pkgs/tools/typesetting/marp/default.nix
+++ b/pkgs/tools/typesetting/marp/default.nix
@@ -4,7 +4,7 @@
 , fetchYarnDeps
 , makeWrapper
 , nodejs
-, prefetch-yarn-deps
+, fixup-yarn-lock
 , yarn
 }:
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     makeWrapper
     nodejs
-    prefetch-yarn-deps
+    fixup-yarn-lock
     yarn
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1022,6 +1022,7 @@ with pkgs;
   fetchpijul = callPackage ../build-support/fetchpijul { };
 
   inherit (callPackages ../build-support/node/fetch-yarn-deps { })
+    fixup-yarn-lock
     prefetch-yarn-deps
     fetchYarnDeps;
 


### PR DESCRIPTION
## Description of changes

Verified by building all packages

```
NIXPKGS_ALLOW_UNFREE=1 NIXPKGS_ALLOW_NONSOURCE=1 nix build --impure .#akkoma-frontends.admin-fe .#akkoma-frontends.akkoma-fe .#alice-lg .#anki .#authy .#aws-azure-login .#bilibili .#bitwarden .#bruno .#camunda-modeler .#das .#deltachat-desktop .#drawio .#drawio-headless .#electron .#electron_26 .#electron_27 .#electron_28 .#element-desktop .#element-desktop-wayland .#element-web .#element-web-unwrapped .#fixup-yarn-lock .#freetube .#gitlab .#gitlab-ee .#gitmoji-cli .#gotify-server .#grafana-agent .#headset .#heroic .#heroic-unwrapped .#hydrogen-web .#hydrogen-web-unwrapped .#itch .#jitsi-meet-electron .#logseq .#marp-cli .#mastodon .#matrix-appservice-irc .#mattermost-desktop .#mermaid-cli .#micropad .#mnemosyne .#morgen .#muzika .#nix-tour .#open-stage-control .#outline .#pandoc-drawio-filter .#peertube .#pgadmin4 .#pgadmin4-desktopmode .#picosnitch .#pocket-casts .#podman-desktop .#prefetch-yarn-deps .#pritunl-client .#pxder .#python311Packages.dash .#python311Packages.mkdocs-drawio-exporter .#python312Packages.dash .#python312Packages.mkdocs-drawio-exporter .#r2modman .#ratman .#redisinsight .#revolt-desktop .#rmfakecloud .#sapling .#sharedown .#shepherd .#standardnotes .#stretchly .#super-productivity .#tandoor-recipes .#teams-for-linux .#teleport .#teleport_12 .#teleport_13 .#teleport_14 .#terra-station .#thedesk .#threema-desktop .#tilt .#tutanota-desktop .#uhk-agent .#uhk-udev-rules .#uivonim .#vercel-pkg .#vesktop .#vieb .#webcord .#webcord-vencord .#webtorrent_desktop .#youtube-music
```

redisinsight-electron and recipe-scrapers failed because of unrelated reasons.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
