### PR TITLE
foxotron: fix build due to deprecated C stdint import in vendored dependency

### DIFF
--- a/pkgs/applications/graphics/foxotron/default.nix
+++ b/pkgs/applications/graphics/foxotron/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
+, fetchpatch
 , nix-update-script
 , cmake
 , pkg-config
@@ -35,9 +36,24 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-s1eWZMVitVSP7nJJ5wXvnV8uI6yto7LmvlvocOwVAxw=";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "0001-assimp-Include-cstdint-for-std-uint32_t.patch";
+      url = "https://github.com/assimp/assimp/commit/108e3192a201635e49e99a91ff2044e1851a2953.patch";
+      stripLen = 1;
+      extraPrefix = "externals/assimp/";
+      hash = "sha256-rk0EFmgeZVwvx3NJOOob5Jwj9/J+eOtuAzfwp88o+J4=";
+    })
+  ];
+
   postPatch = ''
     substituteInPlace CMakeLists.txt \
       --replace "set(CMAKE_OSX_ARCHITECTURES x86_64)" ""
+
+    # Outdated vendored assimp, many warnings with newer compilers, too old for CMake option to control this
+    # Note that this -Werror caused issues on darwin, so make sure to re-check builds there before removing this
+    substituteInPlace externals/assimp/code/CMakeLists.txt \
+      --replace 'TARGET_COMPILE_OPTIONS(assimp PRIVATE -Werror)' ""
   '';
 
   nativeBuildInputs = [ cmake pkg-config makeWrapper ];


### PR DESCRIPTION
Foxotron vendors a lot of dependencies (see the `external` directory and the various submodules it contains). One of them (`FBX`) fails to build with current versions of GCC because the compiler cannot resolve the type `std::uint32_t`. The affected file still imports the type via `#include <stdint.h>`, which has been superseded by `#include <cstdint>` in C++11. Patching the respective line fixes the build for now.

Failing Hydra build: https://hydra.nixos.org/build/246285179#tabs-summary
Hydra log: https://hydra.nixos.org/build/246285179/nixlog/1

Relevant log excerpt:

```
[ 48%] Building CXX object externals/assimp/code/CMakeFiles/assimp.dir/AssetLib/STL/STLLoader.cpp.o
/build/source/externals/assimp/code/AssetLib/FBX/FBXBinaryTokenizer.cpp: In function 'void Assimp::FBX::TokenizeBinary(TokenList&, const char*, size_t)':
/build/source/externals/assimp/code/AssetLib/FBX/FBXBinaryTokenizer.cpp:475:61: error: 'uint32_t' is not a member of 'std'; did you mean 'wint_t'?
  475 |         if (!is64bits && (length > std::numeric_limits<std::uint32_t>::max())) {
      |                                                             ^~~~~~~~
      |                                                             wint_t
/build/source/externals/assimp/code/AssetLib/FBX/FBXBinaryTokenizer.cpp:475:61: error: 'uint32_t' is not a member of 'std'; did you mean 'wint_t'?
  475 |         if (!is64bits && (length > std::numeric_limits<std::uint32_t>::max())) {
      |                                                             ^~~~~~~~
      |                                                             wint_t
/build/source/externals/assimp/code/AssetLib/FBX/FBXBinaryTokenizer.cpp:475:69: error: template argument 1 is invalid
  475 |         if (!is64bits && (length > std::numeric_limits<std::uint32_t>::max())) {
      |                                                                     ^
make[2]: *** [externals/assimp/code/CMakeFiles/assimp.dir/build.make:2162: externals/assimp/code/CMakeFiles/assimp.dir/AssetLib/FBX/FBXBinaryTokenizer.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```

## Description of changes

Added a patch to switch `#include <stdint.h>` to `#include <cstdint>` in the affected vendored file.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
