### PR TITLE
libuv: work around test breaks on macOS < 10.15

### DIFF
--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -69,6 +69,9 @@ stdenv.mkDerivation (finalAttrs: {
         "fs_event_watch_dir_recursive" "fs_event_watch_file"
         "fs_event_watch_file_current_dir" "fs_event_watch_file_exact_path"
         "process_priority" "udp_create_early_bad_bind"
+    ] ++ lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [
+        # fail on macos < 10.15 (starting in libuv 1.47.0)
+        "fs_write_alotof_bufs_with_offset" "fs_write_multiple_bufs" "fs_read_bufs"
     ] ++ lib.optionals stdenv.isAarch32 [
       # I observe this test failing with some regularity on ARMv7:
       # https://github.com/libuv/libuv/issues/1871


### PR DESCRIPTION
## Description of changes

I'm a little skeptical that this is the "right" change, but the most-recent bump of libuv updated it to a version that intentionally drops support for macos < 10.15, while nix (at least per the installer) still purports to support 10.12.6+ (not sure if nixpkgs has an equivalent minver declared somewhere).

I've disabled the failing tests here (these all fail around the absence of `pwritev` and `preadv` and then confirmed that I can build libuv (and most of the packages in its `passthru.tests`, but I'll list those later). 

These test failures look like:

```
not ok 78 - fs_read_bufs
# exit code 6
# Output from process `fs_read_bufs`:
# dyld: lazy symbol binding failed: Symbol not found: _preadv
#   Referenced from: /private/tmp/nix-build-libuv-1.47.0.drv-0/source/.libs/libuv.1.dylib
#   Expected in: /usr/lib/libSystem.B.dylib
# 
# dyld: Symbol not found: _preadv
#   Referenced from: /private/tmp/nix-build-libuv-1.47.0.drv-0/source/.libs/libuv.1.dylib
#   Expected in: /usr/lib/libSystem.B.dylib
# 
...
ok 101 - fs_write_alotof_bufs
not ok 102 - fs_write_alotof_bufs_with_offset
# exit code 6
# Output from process `fs_write_alotof_bufs_with_offset`:
# dyld: lazy symbol binding failed: Symbol not found: _pwritev
#   Referenced from: /private/tmp/nix-build-libuv-1.47.0.drv-0/source/.libs/libuv.1.dylib
#   Expected in: /usr/lib/libSystem.B.dylib
# 
# dyld: Symbol not found: _pwritev
#   Referenced from: /private/tmp/nix-build-libuv-1.47.0.drv-0/source/.libs/libuv.1.dylib
#   Expected in: /usr/lib/libSystem.B.dylib
# 
not ok 103 - fs_write_multiple_bufs
# exit code 6
# Output from process `fs_write_multiple_bufs`:
# dyld: lazy symbol binding failed: Symbol not found: _pwritev
#   Referenced from: /private/tmp/nix-build-libuv-1.47.0.drv-0/source/.libs/libuv.1.dylib
#   Expected in: /usr/lib/libSystem.B.dylib
# 
# dyld: Symbol not found: _pwritev
#   Referenced from: /private/tmp/nix-build-libuv-1.47.0.drv-0/source/.libs/libuv.1.dylib
#   Expected in: /usr/lib/libSystem.B.dylib
# 
```

Once this built, I built everything in its passthru.tests that I could (I skipped nodejs because this system doesn't have enough free space to build it, knot-resolver because it was linux only, and the static build of libuv because it wouldn't eval):

```
$ nix-build -A libuv.tests
/nix/store/xfdmy9bgxnrvzw9gry8ikysj3ysm2csj-bind-9.18.19
/nix/store/pw2c3bsnpvsr97yq5iqxarq97jcqazcq-lisp-cl-libuv-20200610-git
/nix/store/c154i6ms6dml5d0xrxxn0c6i0y8mmya4-cmake-3.27.7
/nix/store/r8icfjlmhmixiys8dcsxzcn84lzaxfq9-libluv-1.44.2-1
/nix/store/w3zkbd4ibkm66ngax4164j3imrylk0vz-luajit2.1-luv-1.44.2-1
/nix/store/7lry6796qxa1icid6myxphqc7xyzxa13-mosquitto-2.0.18
/nix/store/1a7qmfh56c4sy1s468nk75ak9ms6xyan-neovim-0.9.4
/nix/store/sip6ys6a6xrp5y8z0mq5w84ks92l8pgh-ocaml4.14.1-luv-0.5.11
/nix/store/waj494qasw6m8zxhn4x85jfcnimlxfps-check-meta-pkg-config-modules-for-libuv-1.47.0
/nix/store/ngj39dwb1rzinwip29cd3akn2bz9qjnx-python3.11-pyuv-1.4.0
/nix/store/pfxfi38ny8n98wic01b3wciyjn961wng-python3.11-uvloop-0.19.0
```

I wasn't able to induce a break doing the above, but obviously this isn't exactly ~safe.

cc: @reckenrode 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
