### PR TITLE
inetutils: set priority lower than util-linux

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -63,6 +63,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - Invidious has changed its default database username from `kemal` to `invidious`. Setups involving an externally provisioned database (i.e. `services.invidious.database.createLocally == false`) should adjust their configuration accordingly. The old `kemal` user will not be removed automatically even when the database is provisioned automatically.(https://github.com/NixOS/nixpkgs/pull/265857)
 
+- `inetutils` now has a lower priority to avoid shadowing the commonly used `util-linux`. If one wishes to restore the default priority, simply use `lib.setPrio 5 inetutils` or override with `meta.priority = 5`.
+
 - `paperless`' `services.paperless.extraConfig` setting has been removed and converted to the freeform type and option named `services.paperless.settings`.
 
 - The legacy and long deprecated systemd target `network-interfaces.target` has been removed. Use `network.target` instead.

--- a/pkgs/tools/networking/inetutils/default.nix
+++ b/pkgs/tools/networking/inetutils/default.nix
@@ -7,6 +7,7 @@
 , help2man
 , apparmorRulesFromClosure
 , libxcrypt
+, util-linux
 }:
 
 stdenv.mkDerivation rec {
@@ -93,5 +94,15 @@ stdenv.mkDerivation rec {
 
     maintainers = with maintainers; [ matthewbauer ];
     platforms = platforms.unix;
+
+    /**
+      The `logger` binary from `util-linux` is preferred over `inetutils`.
+      To instead prioritize this package, set a _lower_ `meta.priority`, or
+      use e.g. `lib.setPrio 5 inetutils`.
+
+      Note that the default `meta.priority` is defined in `buildEnv` and is
+      currently 5.
+    */
+    priority = (util-linux.meta.priority or 5) + 1;
   };
 }


### PR DESCRIPTION
**Warning:** although seemingly innocuous (trivial `nixpkgs-review`), this might be a breaking change for some people, but should reduce the confusion for most others.

The `inetutils` package provides the `telnet` command, along with some lesser known binaries such as `logger`.

However, `util-linux` also provides `logger` with a `meta.priority = 6`, while inetutils has a default priority of 5 (so inetutils wins; note that smaller `meta.priority` wins). If inetutils is installed, the `logger` binary from `inetutils` would shadow the one from `util-linux`, which is unexpected for most users.

In this PR, we demote inetutils such that the `logger` binary from `util-linux` (instead of `inetutils`) is now preferred. This has been the default for many linux distributions, including in:

- Arch: `logger` from inetutils is simply disabled:
	- https://gitlab.archlinux.org/archlinux/packaging/packages/inetutils/-/blob/24578966983e0ec3e62eb6574594b440c3180893/PKGBUILD#L71
- Debian:
	- `logger` from inetutils is not installed by default: https://packages.debian.org/en/bookworm/inetutils-tools
	- ... while the `logger` from util-linux is essential: https://packages.debian.org/en/bookworm/util-linux

If anyone would like to keep the old behavior, i.e. prioritize `inetutils`, they can simply set a _lower_ `meta.priority` for `inetutils`, or use e.g. `lib.setPrio 5 inetutils`. This is documented with doc comments around this change. Note that the default `meta.priority` is defined in [`buildEnv`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/buildenv/default.nix) and is currently 5.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
