### PR TITLE
vesktop: add disable update checking patch

### DIFF
--- a/pkgs/by-name/ve/vesktop/disable_update_checking.patch
+++ b/pkgs/by-name/ve/vesktop/disable_update_checking.patch
@@ -1,0 +1,12 @@
+diff --git a/src/updater/main.ts b/src/updater/main.ts
+index 059afb9..274802e 100644
+--- a/src/updater/main.ts
++++ b/src/updater/main.ts
+@@ -77,6 +77,7 @@ function isOutdated(oldVersion: string, newVersion: string) {
+ }
+ 
+ export async function checkUpdates() {
++    return;
+     if (Settings.store.checkUpdates === false) return;
+ 
+     try {

--- a/pkgs/by-name/ve/vesktop/package.nix
+++ b/pkgs/by-name/ve/vesktop/package.nix
@@ -87,6 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     (substituteAll { inherit vencord; src = ./use_system_vencord.patch; })
+    ./disable_update_checking.patch
   ];
 
   ELECTRON_SKIP_BINARY_DOWNLOAD = 1;


### PR DESCRIPTION
## Description of changes

As discussed in [#281669](https://github.com/NixOS/nixpkgs/pull/281669#issuecomment-1899451746), it might be more beneficial to disable the update checker and prevent the users from being annoyed to update to a version that's not yet built in Nixpkgs.

A builtin option for disabling the update checker does exist, however it's buried very deeply within Vesktop settings and normal users may not ever be aware of its existence — better to do it in Nixpkgs itself

May conflict with #279983! Whichever PR gets merged first will have to be updated to accommodate the other

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
