### PR TITLE
beets: mkPlugin: change default testPaths to fit unstable beets as well

### DIFF
--- a/pkgs/tools/audio/beets/builtin-plugins.nix
+++ b/pkgs/tools/audio/beets/builtin-plugins.nix
@@ -9,6 +9,7 @@
 , mp3gain
 , mp3val
 , python3Packages
+, version
 , ...
 }: {
   absubmit = {
@@ -122,4 +123,16 @@
   unimported.testPaths = [ ];
   web.propagatedBuildInputs = [ python3Packages.flask ];
   zero = { };
+  # NOTE: Condition can be removed once stable beets updates
+} // lib.optionalAttrs ((lib.versions.majorMinor version) != "1.6") {
+  limit = { };
+  substitute = {
+    testPaths = [ ];
+  };
+  advancedrewrite = {
+    testPaths = [ ];
+  };
+  autobpm = {
+    testPaths = [ ];
+  };
 }

--- a/pkgs/tools/audio/beets/common.nix
+++ b/pkgs/tools/audio/beets/common.nix
@@ -36,7 +36,21 @@
 let
   inherit (lib) attrNames attrValues concatMap;
 
-  mkPlugin = { name, enable ? !disableAllPlugins, builtin ? false, propagatedBuildInputs ? [ ], testPaths ? [ "test/test_${name}.py" ], wrapperBins ? [ ] }: {
+  mkPlugin = { name
+  , enable ? !disableAllPlugins
+  , builtin ? false
+  , propagatedBuildInputs ? [ ]
+  , testPaths ? [
+    # NOTE: This conditional can be removed when beets-stable is updated and
+    # the default plugins test path is changed
+    (if (lib.versions.majorMinor version) == "1.6" then
+      "test/test_${name}.py"
+    else
+      "test/plugins/test_${name}.py"
+    )
+  ]
+  , wrapperBins ? [ ]
+  }: {
     inherit name enable builtin propagatedBuildInputs testPaths wrapperBins;
   };
 

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -22,6 +22,8 @@ lib.makeExtensible (self: {
 
   beets-stable = callPackage ./common.nix rec {
     inherit python3Packages;
+    # NOTE: ./builtin-plugins.nix and ./common.nix can have some conditionals
+    # be removed when stable version updates
     version = "1.6.0";
     src = fetchFromGitHub {
       owner = "beetbox";


### PR DESCRIPTION
###### Motivation for this change

If one is using `overridePlugins` with the unstable flavor, they may encounter errors regarding non existing `testPaths`. If you already use an overlay, it may not annoy you too much to write many `testPaths = []`, but this makes such an overlay that much cleaner.

In my personal configuration, I managed to do this change:

```diff
diff --git c/overlays/mpd.nix i/overlays/mpd.nix
index a1c5118..ee4f9fe 100644
--- c/overlays/mpd.nix
+++ i/overlays/mpd.nix
@@ -4,77 +4,24 @@ self: super: {
     pluginOverrides = {
       absubmit = { enable = true; };
       mbsubmit = { enable = true; };
-      # See
-      # https://github.com/NixOS/nixpkgs/pull/268598#issuecomment-1837532382,
-      # TODO: talk at Nixpkgs about the annoying testPaths experience
-      acousticbrainz = {
-        enable = false;
-        testPaths = [
-          "test/plugins/test_acousticbrainz.py"
-        ];
-      };
+      acousticbrainz = { enable = false; };
       acoustid = { enable = true; };
       badfiles = { enable = false; };
-      convert = { enable = false; testPaths = []; };
-      discogs = {
-        enable = false;
-        testPaths = [
-          "test/plugins/test_discogs.py"
-        ];
-      };
-      embyupdate = {
-        enable = false;
-        testPaths = [
-          "test/plugins/test_discogs.py"
-        ];
-      };
+      convert = { enable = false; };
+      discogs = { enable = false; };
+      embyupdate = { enable = false; };
       fetchart = { enable = true; };
       keyfinder = { enable = true; };
       kodiupdate = { enable = false; };
-      # unstable has new plugins, so we register them here.
-      limit = {
-        builtin = true;
-        enable = false;
-        testPaths = [
-          "test/plugins/test_limit.py"
-        ];
-      };
-      substitute = {
-        builtin = true;
-        enable = false;
-        testPaths = [
-          # No test exists for this one 
-        ];
-      };
-      advancedrewrite = {
-        builtin = true;
-        enable = false;
-        testPaths = [
-          # No test exists for this one 
-        ];
-      };
-      autobpm = {
-        builtin = true;
-        enable = false;
-        testPaths = [
-          # No test exists for this one 
-        ];
-      };
+      limit = { enable = false; };
+      substitute = { enable = false; };
+      advancedrewrite = { enable = false; };
+      autobpm = { enable = false; };
       lastfm = { enable = true; };
       mpd = { enable = true; };
       replaygain = { enable = true; };
-      sonosUpdate = {
-        enable = false;
-        testPaths = [
-          # No test exists for this one
-        ];
-      };
-      thumbnails = {
-        enable = false;
-        testPaths = [
-          "test/plugins/test_thumbnails.py"
-        ];
-      };
+      sonosupdate = { enable = false; };
+      thumbnails = { enable = false; };
     };
     extraNativeBuildInputs = [
       super.python3Packages.pydata-sphinx-theme
```

And I tested the change with my overlay which is available fully here:

https://gitlab.com/doronbehar/nixos-configs/-/blob/cde9cd5104d50ad932823f126feb30f79eb55a1d/overlays/mpd.nix#L1-40

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
