### PR TITLE
qt5, qt6: fix QML path search order

### DIFF
--- a/pkgs/development/libraries/qt-5/5.15/qtdeclarative-qml-paths.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qtdeclarative-qml-paths.patch
@@ -1,5 +1,5 @@
 diff --git a/src/qml/qml/qqmlimport.cpp b/src/qml/qml/qqmlimport.cpp
-index 289f11d006..80c422403c 100644
+index 289f11d006..9b0a48c6c7 100644
 --- a/src/qml/qml/qqmlimport.cpp
 +++ b/src/qml/qml/qqmlimport.cpp
 @@ -1897,17 +1897,22 @@ QQmlImportDatabase::QQmlImportDatabase(QQmlEngine *e)
@@ -26,8 +26,8 @@ index 289f11d006..80c422403c 100644
 +        }
 +    };
 +
-+    addEnvImportPath("NIXPKGS_QT5_QML_IMPORT_PATH");
 +    addEnvImportPath("QML2_IMPORT_PATH");
++    addEnvImportPath("NIXPKGS_QT5_QML_IMPORT_PATH");
  
      addImportPath(QStringLiteral("qrc:/qt-project.org/imports"));
      addImportPath(QCoreApplication::applicationDirPath());

--- a/pkgs/development/libraries/qt-6/patches/qtdeclarative-qml-paths.patch
+++ b/pkgs/development/libraries/qt-6/patches/qtdeclarative-qml-paths.patch
@@ -1,12 +1,12 @@
 diff --git a/src/qml/qml/qqmlimport.cpp b/src/qml/qml/qqmlimport.cpp
-index a7d1a3f77f..aac7392d4f 100644
+index 2e482c220d..4873809bec 100644
 --- a/src/qml/qml/qqmlimport.cpp
 +++ b/src/qml/qml/qqmlimport.cpp
-@@ -1515,6 +1515,7 @@ QQmlImportDatabase::QQmlImportDatabase(QQmlEngine *e)
-     };
- 
+@@ -1517,6 +1517,7 @@ QQmlImportDatabase::QQmlImportDatabase(QQmlEngine *e)
      // env import paths
-+    addEnvImportPath("NIXPKGS_QT6_QML_IMPORT_PATH");
      addEnvImportPath("QML_IMPORT_PATH");
      addEnvImportPath("QML2_IMPORT_PATH");
++    addEnvImportPath("NIXPKGS_QT6_QML_IMPORT_PATH");
  
+     addImportPath(QStringLiteral("qrc:/qt/qml"));
+     addImportPath(QStringLiteral("qrc:/qt-project.org/imports"));


### PR DESCRIPTION
## Description of changes

`QQmlImportDatabase::addImportPath` _prepends_ to the search path, so our version specific search paths need to be added in last.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
