### PR TITLE
keycloak-restrict-client-auth: init at 23.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10715,6 +10715,15 @@
     githubId = 169170;
     name = "Mathias Schreck";
   };
+  loc = {
+    matrix = "@loc:locrealloc.de";
+    github = "LoCrealloc";
+    githubId = 64095253;
+    name = "LoC";
+    keys = [{
+      fingerprint = "DCCE F73B 209A 6024 CAE7  F926 5563 EB4A 8634 4F15";
+    }];
+  };
   locallycompact = {
     email = "dan.firth@homotopic.tech";
     github = "locallycompact";

--- a/pkgs/servers/keycloak/all-plugins.nix
+++ b/pkgs/servers/keycloak/all-plugins.nix
@@ -5,4 +5,5 @@
   scim-keycloak-user-storage-spi = callPackage ./scim-keycloak-user-storage-spi {};
   keycloak-discord = callPackage ./keycloak-discord {};
   keycloak-metrics-spi = callPackage ./keycloak-metrics-spi {};
+  keycloak-restrict-client-auth = callPackage ./keycloak-restrict-client-auth {};
 }

--- a/pkgs/servers/keycloak/keycloak-restrict-client-auth/default.nix
+++ b/pkgs/servers/keycloak/keycloak-restrict-client-auth/default.nix
@@ -1,0 +1,28 @@
+{ maven, lib, fetchFromGitHub }:
+
+maven.buildMavenPackage rec {
+  pname = "keycloak-restrict-client-auth";
+  version = "23.0.0";
+
+  src = fetchFromGitHub {
+    owner = "sventorben";
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-JA3DvLdBKyn2VE1pYSCcRV9Cl7ZAWsRG5MAp548Rl+g=";
+  };
+
+  mvnHash = "sha256-W1YvX1P/mshGYoTUO5XMlOcpu2KiujwLludaC3miak4=";
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm444 -t "$out" target/keycloak-restrict-client-auth.jar
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/sventorben/keycloak-restrict-client-auth";
+    description = "A Keycloak authenticator to restrict authentication on clients";
+    license = licenses.mit;
+    maintainers = with maintainers; [ loc ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Added the keycloak plugin `keycloak-restrict-client-auth`, which allows for restricting user authorization on clients: https://github.com/sventorben/keycloak-restrict-client-auth

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
