### PR TITLE
efivar: pull `gcc-13` fix pending upstream inclusion

### DIFF
--- a/pkgs/tools/system/efivar/default.nix
+++ b/pkgs/tools/system/efivar/default.nix
@@ -29,6 +29,13 @@ stdenv.mkDerivation rec {
       url = "https://github.com/rhboot/efivar/commit/cece3ffd5be2f8641eb694513f2b73e5eb97ffd3.patch";
       sha256 = "7/E0gboU0A45/BY6jGPLuvds6qKtNjzpgKgdNTaVaZQ=";
     })
+
+    # Fix build against gcc-13: https://github.com/rhboot/efivar/pull/242
+    (fetchpatch {
+      name = "gcc-13.patch";
+      url = "https://github.com/rhboot/efivar/commit/52fece47d4f3ebd588bd85598bfc7a0142365f7e.patch";
+      hash = "sha256-tOmxbY7kD6kzbBZ2RhQ5gCCpHtu+2gRNa7VUAWdCKu0=";
+    })
   ];
 
   nativeBuildInputs = [ pkg-config mandoc ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7944,7 +7944,7 @@ with pkgs;
 
   efibootmgr = callPackage ../tools/system/efibootmgr { };
 
-  efivar = disable-warnings-if-gcc13 (callPackage ../tools/system/efivar { });
+  efivar = callPackage ../tools/system/efivar { };
 
   eget = callPackage ../tools/misc/eget { };
 


### PR DESCRIPTION
Without the change (and without disabled warnings) the build fails as:

    esl-iter.c:84:1: error: conflicting types for 'esl_iter_next_with_size_correction' due to enum/integer mismatch; have 'esl_iter_status_t(esl_iter *, efi_guid_t *, efi_guid_t *, uint8_t **, size_t *, _Bool)' {aka 'enum esl_iter_status(esl_iter *, efi_guid_t *, efi_guid_t *, unsigned char **, long unsigned int *, _Bool)'} [-Werror=enum-int-mismatch]
       84 | esl_iter_next_with_size_correction(esl_iter *iter, efi_guid_t *type,
          | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    In file included from efisec.h:25,
                     from esl-iter.c:7:
    esl-iter.h:61:12: note: previous declaration of 'esl_iter_next_with_size_correction' with type 'int(esl_iter *, efi
    *, efi_guid_t *, uint8_t **, size_t *, _Bool)' {aka 'int(esl_iter *, efi_guid_t *, efi_guid_t *, unsigned char **, long unsigned int *, _Bool)'}
       61 | extern int esl_iter_next_with_size_correction(esl_iter *iter, efi_guid_t *type,
          |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
