### PR TITLE
jupyter related packages updates 2024-01-20

### DIFF
--- a/pkgs/development/python-modules/comm/default.nix
+++ b/pkgs/development/python-modules/comm/default.nix
@@ -8,7 +8,7 @@
 
 let
   pname = "comm";
-  version = "0.2.0";
+  version = "0.2.1";
 in
 buildPythonPackage {
   inherit pname version;
@@ -18,7 +18,7 @@ buildPythonPackage {
     owner = "ipython";
     repo = "comm";
     rev = "refs/tags/v${version}";
-    hash = "sha256-bErZNTm0spO0A/Lc8kq5u7sB0FMXm/WMWtFbCNGJVXE=";
+    hash = "sha256-iyO3q9E2lYU1rMYTnsa+ZJYh+Hq72LEvE9ynebFIBUk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/ipykernel/default.nix
+++ b/pkgs/development/python-modules/ipykernel/default.nix
@@ -22,14 +22,14 @@
 
 buildPythonPackage rec {
   pname = "ipykernel";
-  version = "6.28.0";
+  version = "6.29.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-acEUA9Jt5p3wIiWRb5FrN+pLmvQX2gqMgn+EMo2I5fM=";
+    hash = "sha256-td0wE8q3szDfcSiRyWzRq4aMJ6cVnmBvdiAV6b+M6z8=";
   };
 
   # debugpy is optional, see https://github.com/ipython/ipykernel/pull/767

--- a/pkgs/development/python-modules/ipython-sql/default.nix
+++ b/pkgs/development/python-modules/ipython-sql/default.nix
@@ -1,32 +1,29 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
+, fetchPypi
 , pythonOlder
+, setuptools
 , ipython
 , ipython-genutils
-, pandas
 , prettytable
-, pytest
 , sqlalchemy
 , sqlparse
 }:
 buildPythonPackage rec {
   pname = "ipython-sql";
-  version = "0.4.0";
-  format = "setuptools";
+  version = "0.5.0";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
-  src = fetchFromGitHub {
-    owner = "catherinedevlin";
-    repo = "ipython-sql";
-    rev = "117764caf099d80100ed4b09fc004b55eed6f121";
-    hash = "sha256-ScQihsvRSnC7VIgy8Tzi1z4x6KIZo0SAeLPvHAVdrfA=";
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-PbPOf5qV369Dh2+oCxa9u5oE3guhIELKsT6fWW/P/b4=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py --replace 'prettytable<1' prettytable
-  '';
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   propagatedBuildInputs = [
     ipython
@@ -36,17 +33,8 @@ buildPythonPackage rec {
     sqlparse
   ];
 
-  nativeCheckInputs = [ ipython pandas pytest ];
-
-  checkPhase = ''
-    runHook preCheck
-
-    # running with ipython is required because the tests use objects available
-    # only inside of ipython, for example the global `get_ipython()` function
-    ipython -c 'import pytest; pytest.main()'
-
-    runHook postCheck
-  '';
+  # pypi tarball has no tests
+  doCheck = false;
 
   pythonImportsCheck = [ "sql" ];
 

--- a/pkgs/development/python-modules/jupyter-lsp/default.nix
+++ b/pkgs/development/python-modules/jupyter-lsp/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "jupyter-lsp";
-  version = "2.2.1";
+  version = "2.2.2";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-sX+rbXD+g8iJawz/WSN2QAOCR8GWBWtDaEoJArap4Ps=";
+    hash = "sha256-JW0kYgVCrku6BKUPwfb/4ggJOgfY5pf+oKjRuMobfls=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/jupyter-server/default.nix
+++ b/pkgs/development/python-modules/jupyter-server/default.nix
@@ -34,14 +34,14 @@
 
 buildPythonPackage rec {
   pname = "jupyter-server";
-  version = "2.12.4";
+  version = "2.12.5";
   pyproject = true;
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     pname = "jupyter_server";
     inherit version;
-    hash = "sha256-QfSh5rkSzCSnxsaUhRs309hBKxgPQ9cjFf5CLLK4XMI=";
+    hash = "sha256-DttibJS6oigJvhMj+XcM8cAKlSsXCXWS5A0D5qOVFok=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/nbconvert/default.nix
+++ b/pkgs/development/python-modules/nbconvert/default.nix
@@ -32,14 +32,14 @@ let
   };
 in buildPythonPackage rec {
   pname = "nbconvert";
-  version = "7.14.1";
+  version = "7.14.2";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-IMuhDgRI3Hazvr/hrfkjZj47mDONr3e5e0JRHvWohhg=";
+    hash = "sha256-p/iAj9TggkMWc6xThAAhjdRe/QdvvrB8xuWqWjpOlJ4=";
   };
 
   # Add $out/share/jupyter to the list of paths that are used to search for

--- a/pkgs/development/python-modules/notebook/default.nix
+++ b/pkgs/development/python-modules/notebook/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "notebook";
-  version = "7.0.6";
+  version = "7.0.7";
   disabled = pythonOlder "3.8";
 
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-7GETsGUpAZ9/KHgZrwbJeiuvepWsIaj24yGSiY6fmlg=";
+    hash = "sha256-O8/wDBezrBQu9fQ21QY32TaydM+gtB9qwBdTY96bTgk=";
   };
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

Update jupyter-related packages at once to avoid building hundreds of packages over and over again.

This PR is based on the commits generated by the following command.

```
nix search nixpkgs#python311Packages 'ipython|jupyter|notebook' --json | jq -r 'keys | .[]' | cut -d . -f 3,4 | xargs -n 1 nix-update --commit
```
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
