### PR TITLE
turbo: 1.10.16 -> 1.11.3

### DIFF
--- a/pkgs/tools/misc/turbo/default.nix
+++ b/pkgs/tools/misc/turbo/default.nix
@@ -4,6 +4,7 @@
 , buildGo120Module
 , git
 , nodejs
+, capnproto
 , protobuf
 , protoc-gen-go
 , protoc-gen-go-grpc
@@ -25,12 +26,12 @@
 , CoreFoundation
 }:
 let
-  version = "1.10.16";
+  version = "1.11.3";
   src = fetchFromGitHub {
     owner = "vercel";
     repo = "turbo";
     rev = "v${version}";
-    sha256 = "sha256-7bEHE/bHRVOXMP7+oo+4k8yn6d+LkXBi8JcDeR0ajww";
+    hash = "sha256-hjJXbGct9ZmriKdVjB7gwfmFsV1Tv57V7DfUMFZ8Xv0=";
   };
 
   ffi = rustPlatform.buildRustPackage {
@@ -38,7 +39,7 @@ let
     inherit src version;
     cargoBuildFlags = [ "--package" "turborepo-ffi" ];
 
-    cargoHash = "sha256-Mj46yNOYTqt732d7SJ3sAeXbgDkoh7o7S23lKVgpvKY=";
+    cargoHash = "sha256-3eN8/nBARuaezlzPjAL0YPEPvNqm6jNQAREth8PgcSQ=";
 
     RUSTC_BOOTSTRAP = 1;
     nativeBuildInputs = [
@@ -64,7 +65,8 @@ let
     pname = "go-turbo";
     modRoot = "cli";
 
-    vendorHash = "sha256-8quDuT8VwT3B56jykkbX8ov+DNFZwxPf31+NLdfX1p0=";
+    proxyVendor = true;
+    vendorHash = "sha256-JHTg9Gcc0DVdltTGCUaOPSVxL0XVkwPJQm/LoKffU/o=";
 
     nativeBuildInputs = [
       git
@@ -110,22 +112,6 @@ let
       # expected: env.DetailedMap{All:env.EnvironmentVariableMap(nil), BySource:env.BySource{Explicit:env.EnvironmentVariableMap{}, Matching:env.EnvironmentVariableMap{}}}
       #  actual  : env.DetailedMap{All:env.EnvironmentVariableMap{}, BySource:env.BySource{Explicit:env.EnvironmentVariableMap{}, Matching:env.EnvironmentVariableMap{}}}
       rm ./internal/run/global_hash_test.go
-    '' + lib.optionalString stdenv.isLinux ''
-      #  filewatcher_test.go:122: got event {/build/TestFileWatching1921149570/001/test-1689172679812 1}
-      # filewatcher_test.go:122: got event {/build/TestFileWatching1921149570/001/parent/test-1689172679812 1}
-      # filewatcher_test.go:122: got event {/build/TestFileWatching1921149570/001/parent/child/test-1689172679812 1}
-      # filewatcher_test.go:122: got event {/build/TestFileWatching1921149570/001/parent/sibling/test-1689172679812 1}
-      # filewatcher_test.go:127: got event {/build/TestFileWatching1921149570/001/parent/child/foo 1}
-      # filewatcher_test.go:137: got event {/build/TestFileWatching1921149570/001/parent/sibling/deep 1}
-      # filewatcher_test.go:141: got event {/build/TestFileWatching1921149570/001/parent/sibling/deep/path 1}
-      # filewatcher_test.go:146: got event {/build/TestFileWatching1921149570/001/parent/sibling/deep 1}
-      # filewatcher_test.go:146: Timed out waiting for filesystem event at /build/TestFileWatching1921149570/001/test-1689172679812
-      # filewatcher_test.go:146: Timed out waiting for filesystem event at /build/TestFileWatching1921149570/001/parent/test-1689172679812
-      # filewatcher_test.go:146: Timed out waiting for filesystem event at /build/TestFileWatching1921149570/001/parent/child/test-1689172679812
-      # filewatcher_test.go:146: Timed out waiting for filesystem event at /build/TestFileWatching1921149570/001/parent/sibling/test-1689172679812
-      # filewatcher_test.go:146: got event {/build/TestFileWatching1921149570/001/parent/sibling/deep/path/test-1689172679812 1}
-      # filewatcher_test.go:146: got event {/build/TestFileWatching1921149570/001/parent/sibling/deep/test-1689172679812 1}
-      rm ./internal/filewatcher/filewatcher_test.go
     '';
 
   };
@@ -139,13 +125,14 @@ rustPlatform.buildRustPackage {
   ];
   RELEASE_TURBO_CLI = "true";
 
-  cargoHash = "sha256-F+mEDkP7GismosXj+ICJCE4SHhCpWK7FiSyqjJM6LJ4=";
+  cargoHash = "sha256-bAXO4Lqv4ibo+fz3679MjNgP2MMY8TbxhG0+DRy0xcA=";
 
   RUSTC_BOOTSTRAP = 1;
   nativeBuildInputs = [
     pkg-config
     extra-cmake-modules
     protobuf
+    capnproto
   ];
   buildInputs = [
     openssl


### PR DESCRIPTION
## Description of changes

Old version is broken (issue #282183)
Update to recent which succeeds.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
