### PR TITLE
gtest: 1.12.1 -> 1.14.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -153,6 +153,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
   - The bundled Lua was updated to Lua v5.2, which includes breaking changes. See the [Lua manual](https://www.lua.org/manual/5.2/manual.html#8) for more information.
   - The WebSocket API [was rewritten](https://github.com/MCJack123/craftos2/issues/337), which introduced breaking changes.
 
+- The `gtest` package has been updated past v1.13.0, which requires C++14 or higher.
+
 - The latest available version of Nextcloud is v28 (available as `pkgs.nextcloud28`). The installation logic is as follows:
   - If [`services.nextcloud.package`](#opt-services.nextcloud.package) is specified explicitly, this package will be installed (**recommended**)
   - If [`system.stateVersion`](#opt-system.stateVersion) is >=24.05, `pkgs.nextcloud28` will be installed by default.

--- a/pkgs/development/libraries/gtest/default.nix
+++ b/pkgs/development/libraries/gtest/default.nix
@@ -8,15 +8,15 @@
 
 stdenv.mkDerivation rec {
   pname = "gtest";
-  version = "1.12.1";
+  version = "1.14.0";
 
   outputs = [ "out" "dev" ];
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "googletest";
-    rev = "release-${version}";
-    hash = "sha256-W+OxRTVtemt2esw4P7IyGWXOonUN5ZuscjvzqkYvZbM=";
+    rev = "v${version}";
+    hash = "sha256-t0RchAHTJbuI5YW4uyBPykTvcjy90JW9AOPNjIhwh6U=";
   };
 
   patches = [

--- a/pkgs/development/libraries/gtest/fix-cmake-config-includedir.patch
+++ b/pkgs/development/libraries/gtest/fix-cmake-config-includedir.patch
@@ -1,34 +1,34 @@
 diff --git a/googlemock/CMakeLists.txt b/googlemock/CMakeLists.txt
-index 5c1f0daf..ed8aae58 100644
+index 428bd9f8..04b84539 100644
 --- a/googlemock/CMakeLists.txt
 +++ b/googlemock/CMakeLists.txt
-@@ -108,10 +108,10 @@ if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
-   string(REPLACE ";" "$<SEMICOLON>" dirs "${gmock_build_include_dirs}")
-   target_include_directories(gmock SYSTEM INTERFACE
-     "$<BUILD_INTERFACE:${dirs}>"
--    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
-+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
-   target_include_directories(gmock_main SYSTEM INTERFACE
-     "$<BUILD_INTERFACE:${dirs}>"
--    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
-+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
- endif()
+@@ -104,10 +104,10 @@ endif()
+ string(REPLACE ";" "$<SEMICOLON>" dirs "${gmock_build_include_dirs}")
+ target_include_directories(gmock SYSTEM INTERFACE
+   "$<BUILD_INTERFACE:${dirs}>"
+-  "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
++  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+ target_include_directories(gmock_main SYSTEM INTERFACE
+   "$<BUILD_INTERFACE:${dirs}>"
+-  "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
++  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
  
  ########################################################################
+ #
 diff --git a/googletest/CMakeLists.txt b/googletest/CMakeLists.txt
-index aa00a5f3..50434fed 100644
+index 51a67c91..fb09e978 100644
 --- a/googletest/CMakeLists.txt
 +++ b/googletest/CMakeLists.txt
-@@ -134,10 +134,10 @@ if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
-   string(REPLACE ";" "$<SEMICOLON>" dirs "${gtest_build_include_dirs}")
-   target_include_directories(gtest SYSTEM INTERFACE
-     "$<BUILD_INTERFACE:${dirs}>"
--    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
-+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
-   target_include_directories(gtest_main SYSTEM INTERFACE
-     "$<BUILD_INTERFACE:${dirs}>"
--    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
-+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
- endif()
+@@ -143,10 +143,10 @@ set_target_properties(gtest_main PROPERTIES VERSION ${GOOGLETEST_VERSION})
+ string(REPLACE ";" "$<SEMICOLON>" dirs "${gtest_build_include_dirs}")
+ target_include_directories(gtest SYSTEM INTERFACE
+   "$<BUILD_INTERFACE:${dirs}>"
+-  "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
++  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+ target_include_directories(gtest_main SYSTEM INTERFACE
+   "$<BUILD_INTERFACE:${dirs}>"
+-  "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
++  "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
  if(CMAKE_SYSTEM_NAME MATCHES "QNX")
    target_link_libraries(gtest PUBLIC regex)
+ endif()


### PR DESCRIPTION
## Description of changes

From v1.13.0 onwards, C++14 or later is required.  v1.12.1 supported C++11.

https://github.com/google/googletest/releases/tag/v1.13.0
https://github.com/google/googletest/releases/tag/v1.14.0

As this will require a large rebuild, this change is targeting staging.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
