### PR TITLE
haskellPackages.arbtt: Drop already-applied patch

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -112,15 +112,6 @@ self: super: {
     })
     (doJailbreak super.xmonad-contrib);
 
-  # Patch 0.12.0.1 for support of unix-2.8.0.0
-  arbtt = appendPatch
-    (pkgs.fetchpatch {
-      name = "arbtt-unix-2.8.0.0.patch";
-      url = "https://github.com/nomeata/arbtt/pull/168/commits/ddaac94395ac50e3d3cd34c133dda4a8e5a3fd6c.patch";
-      sha256 = "sha256-5Gmz23f4M+NfgduA5O+9RaPmnneAB/lAlge8MrFpJYs=";
-    })
-    super.arbtt;
-
   # Jailbreaks for servant <0.20
   servant-lucid = doJailbreak super.servant-lucid;
 


### PR DESCRIPTION
This is for merging into `haskell-updates`, PR #279413. cc: @sternenseemann 

It fixes the build of arbtt.
