### PR TITLE
nixos/pam: replace deprecated lastlog with lastlog2

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -813,7 +813,7 @@ let
             skel = config.security.pam.makeHomeDir.skelDirectory;
             inherit (config.security.pam.makeHomeDir) umask;
           }; }
-          { name = "lastlog"; enable = cfg.updateWtmp; control = "required"; modulePath = "${pkgs.pam}/lib/security/pam_lastlog.so"; settings = {
+          { name = "lastlog"; enable = cfg.updateWtmp; control = "required"; modulePath = "${pkgs.pam_lastlog2}/lib/security/pam_lastlog2.so"; settings = {
             silent = true;
           }; }
           { name = "ecryptfs"; enable = config.security.pam.enableEcryptfs; control = "optional"; modulePath = "${pkgs.ecryptfs}/lib/security/pam_ecryptfs.so"; }
@@ -1519,6 +1519,10 @@ in
     };
 
     environment.etc = mapAttrs' makePAMService config.security.pam.services;
+
+    systemd.packages = optionals config.security.pam.services.login.updateWtmp [ pkgs.pam_lastlog2 ];
+    systemd.services.lastlog2-import.enable = config.security.pam.services.login.updateWtmp;
+    systemd.tmpfiles.packages = optionals config.security.pam.services.login.updateWtmp [ pkgs.pam_lastlog2 ];
 
     security.pam.services =
       { other.text =

--- a/pkgs/by-name/pa/pam_lastlog2/package.nix
+++ b/pkgs/by-name/pa/pam_lastlog2/package.nix
@@ -1,0 +1,63 @@
+{ lib
+, nixosTests
+, stdenv
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, pam
+, sqlite
+, libxslt
+, docbook5
+, docbook_xsl
+, docbook_xsl_ns
+, coreutils
+}:
+
+stdenv.mkDerivation rec {
+  pname = "pam_lastlog2";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "thkukuk";
+    repo = "lastlog2";
+    rev = "v${version}";
+    sha256 = "2qGRV5ihJAdg/pfKHSvR57iEAAw0r39FbTmS3w47kcs=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    pkg-config
+    ninja
+    libxslt
+    docbook5
+    docbook_xsl
+    docbook_xsl_ns
+  ];
+
+  buildInputs = [
+    pam
+    sqlite
+   ];
+
+  mesonFlags = [
+    "--prefix=${placeholder "out"}"
+    "-Drootprefix=${placeholder "out"}"
+    "-Dpamlibdir=${placeholder "out"}/lib/security"
+    "-Dman=true"
+  ];
+
+  postInstall = ''
+    substituteInPlace $out/lib/systemd/system/lastlog2-import.service \
+      --replace /usr/bin/lastlog2 $out/bin/lastlog2 \
+      --replace /usr/bin/mv ${coreutils}/bin/mv
+  '';
+
+  meta = with lib; {
+    description = "Y2038 safe version of lastlog";
+    homepage = "https://github.com/thkukuk/lastlog2";
+    changelog = "https://github.com/thkukuk/lastlog2/releases/tag/v${version}";
+    license = licenses.bsd2;
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

As of pam 1.5.3, lastlog is considered deprecated (see also #267447 and #281182). This PR attempts to introduce `pam_lastlog2` and switch the configuration over. Tested full functionality.

cc @trofi 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
