### PR TITLE
ffmpeg: some clean-up

### DIFF
--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -50,7 +50,6 @@
 , withIconv ? withHeadlessDeps
 , withJack ? withFullDeps && !stdenv.isDarwin # Jack audio
 , withLadspa ? withFullDeps # LADSPA audio filtering
-, withLibplacebo ? withFullDeps && !stdenv.isDarwin # libplacebo video processing library
 , withLzma ? withHeadlessDeps # xz-utils
 , withMfx ? withFullDeps && (with stdenv.hostPlatform; isLinux && !isAarch) # Hardware acceleration via intel-media-sdk/libmfx
 , withModplug ? withFullDeps && !stdenv.isDarwin # ModPlug support
@@ -67,6 +66,7 @@
 , withOpenjpeg ? withFullDeps # JPEG 2000 de/encoder
 , withOpenmpt ? withFullDeps # Tracked music files decoder
 , withOpus ? withHeadlessDeps # Opus de/encoder
+, withPlacebo ? withFullDeps && !stdenv.isDarwin # libplacebo video processing library
 , withPulse ? withSmallDeps && !stdenv.isDarwin # Pulseaudio input support
 , withRav1e ? withFullDeps # AV1 encoder (focused on speed and safety)
 , withRtmp ? false # RTMP[E] support
@@ -479,7 +479,6 @@ stdenv.mkDerivation (finalAttrs: {
     (enableFeature withIconv "iconv")
     (enableFeature withJack "libjack")
     (enableFeature withLadspa "ladspa")
-    (optionalString (versionAtLeast finalAttrs.version "5.0" && withLibplacebo) "--enable-libplacebo")
     (enableFeature withLzma "lzma")
     (enableFeature withMfx "libmfx")
     (enableFeature withModplug "libmodplug")
@@ -496,6 +495,7 @@ stdenv.mkDerivation (finalAttrs: {
     (enableFeature withOpenjpeg "libopenjpeg")
     (enableFeature withOpenmpt "libopenmpt")
     (enableFeature withOpus "libopus")
+    (optionalString (versionAtLeast finalAttrs.version "5.0" && withPlacebo) "--enable-libplacebo")
     (enableFeature withPulse "libpulse")
     (enableFeature withRav1e "librav1e")
     (enableFeature withRtmp "librtmp")
@@ -589,7 +589,6 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optionals withIconv [ libiconv ] # On Linux this should be in libc, do we really need it?
   ++ optionals withJack [ libjack2 ]
   ++ optionals withLadspa [ ladspaH ]
-  ++ optionals withLibplacebo [ (if (lib.versionAtLeast finalAttrs.version "6.1") then libplacebo else libplacebo_5) vulkan-headers ]
   ++ optionals withLzma [ xz ]
   ++ optionals withMfx [ intel-media-sdk ]
   ++ optionals withModplug [ libmodplug ]
@@ -604,6 +603,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optionals withOpenjpeg [ openjpeg ]
   ++ optionals withOpenmpt [ libopenmpt ]
   ++ optionals withOpus [ libopus ]
+  ++ optionals withPlacebo [ (if (lib.versionAtLeast finalAttrs.version "6.1") then libplacebo else libplacebo_5) vulkan-headers ]
   ++ optionals withPulse [ libpulseaudio ]
   ++ optionals withRav1e [ rav1e ]
   ++ optionals withRtmp [ rtmpdump ]

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -455,8 +455,9 @@ stdenv.mkDerivation (finalAttrs: {
      */
     (enableFeature withAlsa "alsa")
     (enableFeature withAom "libaom")
-    # FIXME: see if jellyfin-ffmpeg is already on a version >= 6.1 to use enableFeature
-    (optionalString (withAribcaption && lib.versionAtLeast finalAttrs.version "6.1") "--enable-libaribcaption")
+  ] ++ optionals (versionAtLeast finalAttrs.version "6.1") [
+    (enableFeature withAribcaption "libaribcaption")
+  ] ++ [
     (enableFeature withAss "libass")
     (enableFeature withBluray "libbluray")
     (enableFeature withBs2b "libbs2b")
@@ -495,13 +496,17 @@ stdenv.mkDerivation (finalAttrs: {
     (enableFeature withOpenjpeg "libopenjpeg")
     (enableFeature withOpenmpt "libopenmpt")
     (enableFeature withOpus "libopus")
-    (optionalString (versionAtLeast finalAttrs.version "5.0" && withPlacebo) "--enable-libplacebo")
+  ] ++ optionals (versionAtLeast finalAttrs.version "5.0") [
+    (enableFeature withPlacebo "libplacebo")
+  ] ++ [
     (enableFeature withPulse "libpulse")
     (enableFeature withRav1e "librav1e")
     (enableFeature withRtmp "librtmp")
     (enableFeature withSamba "libsmbclient")
     (enableFeature withSdl2 "sdl2")
-    (optionalString (lib.versionAtLeast finalAttrs.version "5") (enableFeature withShaderc "libshaderc"))
+  ] ++ optionals (versionAtLeast finalAttrs.version "5.0") [
+    (enableFeature withShaderc "libshaderc")
+  ] ++ [
     (enableFeature withSoxr "libsoxr")
     (enableFeature withSpeex "libspeex")
     (enableFeature withSrt "libsrt")

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -40,6 +40,7 @@
 , withDc1394 ? withFullDeps && !stdenv.isDarwin # IIDC-1394 grabbing (ieee 1394)
 , withDrm ? withHeadlessDeps && (with stdenv; isLinux || isFreeBSD) # libdrm support
 , withFdkAac ? withFullDeps && withUnfree # Fraunhofer FDK AAC de/encoder
+, withFlite ? withFullDeps # Voice Synthesis
 , withFontconfig ? withHeadlessDeps # Needed for drawtext filter
 , withFreetype ? withHeadlessDeps # Needed for drawtext filter
 , withFrei0r ? withFullDeps && withGPL # frei0r video filtering
@@ -190,6 +191,7 @@
 , clang
 , dav1d
 , fdk_aac
+, flite
 , fontconfig
 , freetype
 , frei0r
@@ -469,7 +471,7 @@ stdenv.mkDerivation (finalAttrs: {
     (enableFeature withDc1394 "libdc1394")
     (enableFeature withDrm "libdrm")
     (enableFeature withFdkAac "libfdk-aac")
-    "--disable-libflite" # Force disable until a solution is found
+    (enableFeature withFlite "libflite")
     (enableFeature withFontconfig "fontconfig")
     (enableFeature withFreetype "libfreetype")
     (enableFeature withFrei0r "frei0r")
@@ -584,6 +586,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optionals withDc1394 [ libdc1394 libraw1394 ]
   ++ optionals withDrm [ libdrm ]
   ++ optionals withFdkAac [ fdk_aac ]
+  ++ optionals withFlite [ flite ]
   ++ optionals withFontconfig [ fontconfig ]
   ++ optionals withFreetype [ freetype ]
   ++ optionals withFrei0r [ frei0r ]

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -454,13 +454,19 @@ stdenv.mkDerivation (finalAttrs: {
      *  External libraries
      */
     (enableFeature withAlsa "alsa")
+    (enableFeature withAom "libaom")
     # FIXME: see if jellyfin-ffmpeg is already on a version >= 6.1 to use enableFeature
     (optionalString (withAribcaption && lib.versionAtLeast finalAttrs.version "6.1") "--enable-libaribcaption")
+    (enableFeature withAss "libass")
+    (enableFeature withBluray "libbluray")
+    (enableFeature withBs2b "libbs2b")
     (enableFeature withBzlib "bzlib")
     (enableFeature withCelt "libcelt")
     (enableFeature withCuda "cuda")
     (enableFeature withCudaLLVM "cuda-llvm")
     (enableFeature withDav1d "libdav1d")
+    (enableFeature withDc1394 "libdc1394")
+    (enableFeature withDrm "libdrm")
     (enableFeature withFdkAac "libfdk-aac")
     "--disable-libflite" # Force disable until a solution is found
     (enableFeature withFontconfig "fontconfig")
@@ -470,41 +476,15 @@ stdenv.mkDerivation (finalAttrs: {
     (enableFeature withGme "libgme")
     (enableFeature withGnutls "gnutls")
     (enableFeature withGsm "libgsm")
-    (enableFeature withLadspa "ladspa")
-    (enableFeature withMp3lame "libmp3lame")
-    (enableFeature withAom "libaom")
-    (enableFeature withAss "libass")
-    (enableFeature withBluray "libbluray")
-    (enableFeature withBs2b "libbs2b")
-    (enableFeature withDc1394 "libdc1394")
-    (enableFeature withDrm "libdrm")
     (enableFeature withIconv "iconv")
     (enableFeature withJack "libjack")
+    (enableFeature withLadspa "ladspa")
+    (optionalString (versionAtLeast finalAttrs.version "5.0" && withLibplacebo) "--enable-libplacebo")
+    (enableFeature withLzma "lzma")
     (enableFeature withMfx "libmfx")
     (enableFeature withModplug "libmodplug")
+    (enableFeature withMp3lame "libmp3lame")
     (enableFeature withMysofa "libmysofa")
-    (enableFeature withOpus "libopus")
-    (optionalString (versionAtLeast finalAttrs.version "5.0" && withLibplacebo) "--enable-libplacebo")
-    (enableFeature withSvg "librsvg")
-    (enableFeature withSrt "libsrt")
-    (enableFeature withSsh "libssh")
-    (enableFeature withTensorflow "libtensorflow")
-    (enableFeature withTheora "libtheora")
-    (enableFeature withV4l2 "libv4l2")
-    (enableFeature withV4l2M2m "v4l2-m2m")
-    (enableFeature withVaapi "vaapi")
-    (enableFeature withVdpau "vdpau")
-    (enableFeature withVorbis "libvorbis")
-    (enableFeature withVmaf "libvmaf")
-    (enableFeature withVpx "libvpx")
-    (enableFeature withWebp "libwebp")
-    (enableFeature withXlib "xlib")
-    (enableFeature withXcb "libxcb")
-    (enableFeature withXcbShm "libxcb-shm")
-    (enableFeature withXcbxfixes "libxcb-xfixes")
-    (enableFeature withXcbShape "libxcb-shape")
-    (enableFeature withXml2 "libxml2")
-    (enableFeature withLzma "lzma")
     (enableFeature withNvdec "cuvid")
     (enableFeature withNvdec "nvdec")
     (enableFeature withNvenc "nvenc")
@@ -515,25 +495,45 @@ stdenv.mkDerivation (finalAttrs: {
     (enableFeature withOpenh264 "libopenh264")
     (enableFeature withOpenjpeg "libopenjpeg")
     (enableFeature withOpenmpt "libopenmpt")
+    (enableFeature withOpus "libopus")
     (enableFeature withPulse "libpulse")
     (enableFeature withRav1e "librav1e")
-    (enableFeature withSvtav1 "libsvtav1")
     (enableFeature withRtmp "librtmp")
+    (enableFeature withSamba "libsmbclient")
     (enableFeature withSdl2 "sdl2")
+    (optionalString (lib.versionAtLeast finalAttrs.version "5") (enableFeature withShaderc "libshaderc"))
     (enableFeature withSoxr "libsoxr")
     (enableFeature withSpeex "libspeex")
+    (enableFeature withSrt "libsrt")
+    (enableFeature withSsh "libssh")
+    (enableFeature withSvg "librsvg")
+    (enableFeature withSvtav1 "libsvtav1")
+    (enableFeature withTensorflow "libtensorflow")
+    (enableFeature withTheora "libtheora")
+    (enableFeature withV4l2 "libv4l2")
+    (enableFeature withV4l2M2m "v4l2-m2m")
+    (enableFeature withVaapi "vaapi")
+    (enableFeature withVdpau "vdpau")
     (enableFeature withVidStab "libvidstab") # Actual min. version 2.0
+    (enableFeature withVmaf "libvmaf")
     (enableFeature withVoAmrwbenc "libvo-amrwbenc")
+    (enableFeature withVorbis "libvorbis")
+    (enableFeature withVpx "libvpx")
+    (enableFeature withVulkan "vulkan")
+    (enableFeature withWebp "libwebp")
     (enableFeature withX264 "libx264")
     (enableFeature withX265 "libx265")
     (enableFeature withXavs "libxavs")
+    (enableFeature withXcb "libxcb")
+    (enableFeature withXcbShape "libxcb-shape")
+    (enableFeature withXcbShm "libxcb-shm")
+    (enableFeature withXcbxfixes "libxcb-xfixes")
+    (enableFeature withXlib "xlib")
+    (enableFeature withXml2 "libxml2")
     (enableFeature withXvid "libxvid")
-    (enableFeature withZmq "libzmq")
     (enableFeature withZimg "libzimg")
     (enableFeature withZlib "zlib")
-    (enableFeature withVulkan "vulkan")
-    (optionalString (lib.versionAtLeast finalAttrs.version "5") (enableFeature withShaderc "libshaderc"))
-    (enableFeature withSamba "libsmbclient")
+    (enableFeature withZmq "libzmq")
     /*
      * Developer flags
      */
@@ -618,6 +618,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optionals withSvtav1 [ svt-av1 ]
   ++ optionals withTensorflow [ libtensorflow ]
   ++ optionals withTheora [ libtheora ]
+  ++ optionals withV4l2 [ libv4l ]
   ++ optionals withVaapi [ (if withSmallDeps then libva else libva-minimal) ]
   ++ optionals withVdpau [ libvdpau ]
   ++ optionals withVidStab [ vid-stab ]
@@ -625,7 +626,6 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optionals withVoAmrwbenc [ vo-amrwbenc ]
   ++ optionals withVorbis [ libvorbis ]
   ++ optionals withVpx [ libvpx ]
-  ++ optionals withV4l2 [ libv4l ]
   ++ optionals withVulkan [ vulkan-headers vulkan-loader ]
   ++ optionals withWebp [ libwebp ]
   ++ optionals withX264 [ x264 ]

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -34,6 +34,7 @@
 , withBzlib ? withHeadlessDeps
 , withCaca ? withFullDeps # Textual display (ASCII art)
 , withCelt ? withFullDeps # CELT decoder
+, withChromaprint ? withFullDeps # Audio fingerprinting
 , withCuda ? withFullDeps && (with stdenv; (!isDarwin && !hostPlatform.isAarch && !hostPlatform.isRiscV))
 , withCudaLLVM ? withFullDeps
 , withDav1d ? withHeadlessDeps # AV1 decoder (focused on speed and correctness)
@@ -188,6 +189,7 @@
 , alsa-lib
 , bzip2
 , celt
+, chromaprint
 , clang
 , dav1d
 , fdk_aac
@@ -465,6 +467,7 @@ stdenv.mkDerivation (finalAttrs: {
     (enableFeature withBs2b "libbs2b")
     (enableFeature withBzlib "bzlib")
     (enableFeature withCelt "libcelt")
+    (enableFeature withChromaprint "chromaprint")
     (enableFeature withCuda "cuda")
     (enableFeature withCudaLLVM "cuda-llvm")
     (enableFeature withDav1d "libdav1d")
@@ -582,6 +585,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optionals withBzlib [ bzip2 ]
   ++ optionals withCaca [ libcaca ]
   ++ optionals withCelt [ celt ]
+  ++ optionals withChromaprint [ chromaprint ]
   ++ optionals withDav1d [ dav1d ]
   ++ optionals withDc1394 [ libdc1394 libraw1394 ]
   ++ optionals withDrm [ libdrm ]

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -726,7 +726,7 @@ stdenv.mkDerivation (finalAttrs: {
       ++ optional (withGPL && withUnfree) unfree;
     pkgConfigModules = [ "libavutil" ];
     platforms = platforms.all;
-    maintainers = with maintainers; [ atemu arthsmn ];
+    maintainers = with maintainers; [ atemu arthsmn jopejoe1 ];
     mainProgram = "ffmpeg";
   };
 })

--- a/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
+++ b/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
@@ -1,5 +1,4 @@
 { ffmpeg_6-full
-, chromaprint
 , fetchFromGitHub
 , lib
 }:
@@ -18,12 +17,9 @@ ffmpeg_6-full.overrideAttrs (old: rec {
   # Clobber upstream patches as they don't apply to the Jellyfin fork
   patches = [];
 
-  buildInputs = old.buildInputs ++ [ chromaprint ];
-
   configureFlags = old.configureFlags ++ [
     "--extra-version=Jellyfin"
     "--disable-ptx-compression" # https://github.com/jellyfin/jellyfin/issues/7944#issuecomment-1156880067
-    "--enable-chromaprint"
   ];
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes
depends on #281605 

- sorted enableFeatureList
- rename withLibplacebo to withPlacebo (all the other options got the lib prefix removed)
- move options that are only available in a specific ffmpeg version into an optional list so that they can be explicitly be disabled
- turn flite into option
- move chromaprint from jellyfin variant into full variant

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
