### PR TITLE
python3.pkgs: opentelemetry-api: 1.21.0 -> 1.22.0, opentelemetry-instrumentation: 1.16.0 -> 0.43b0 (sic), opentelemetry-instrumentation-flask: init at 0.43b0

### DIFF
--- a/pkgs/development/python-modules/opentelemetry-api/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-api/default.nix
@@ -14,7 +14,7 @@
 let
   self = buildPythonPackage rec {
     pname = "opentelemetry-api";
-    version = "1.21.0";
+    version = "1.22.0";
     disabled = pythonOlder "3.7";
 
     # to avoid breakage, every package in opentelemetry-python must inherit this version, src, and meta
@@ -22,7 +22,7 @@ let
       owner = "open-telemetry";
       repo = "opentelemetry-python";
       rev = "refs/tags/v${version}";
-      hash = "sha256-igG0oHRa6M4d7pMp7fgBo13x5XADZeYgFAL8WzDXsyw=";
+      hash = "sha256-6BmBmooVaH1FOpgXpFlYth0r9XaNtmb9UezeP8hWEok=";
     };
 
     sourceRoot = "${src.name}/opentelemetry-api";

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-flask/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-flask/default.nix
@@ -1,0 +1,45 @@
+{ buildPythonPackage
+, flask
+, hatchling
+, opentelemetry-api
+, opentelemetry-instrumentation
+, opentelemetry-instrumentation-wsgi
+, opentelemetry-semantic-conventions
+, opentelemetry-test-utils
+, opentelemetry-util-http
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage {
+  inherit (opentelemetry-instrumentation) version src;
+  pname = "opentelemetry-instrumentation-flask";
+  disabled = pythonOlder "3.7";
+
+  sourceRoot = "${opentelemetry-instrumentation.src.name}/instrumentation/opentelemetry-instrumentation-flask";
+
+  format = "pyproject";
+
+  nativeBuildInputs = [ hatchling ];
+
+  propagatedBuildInputs = [
+    flask
+    opentelemetry-api
+    opentelemetry-instrumentation
+    opentelemetry-instrumentation-wsgi
+    opentelemetry-semantic-conventions
+    opentelemetry-util-http
+  ];
+
+  nativeCheckInputs = [
+    opentelemetry-test-utils
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "opentelemetry.instrumentation.flask" ];
+
+  meta = opentelemetry-instrumentation.meta // {
+    homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/opentelemetry-instrumentation-flask";
+    description = "Flask Middleware for OpenTelemetry based on the WSGI middleware";
+  };
+}

--- a/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "opentelemetry-instrumentation";
-  version = "1.16.0";
+  version = "0.43b0";
   disabled = pythonOlder "3.7";
 
   # to avoid breakage, every package in opentelemetry-python-contrib must inherit this version, src, and meta
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "open-telemetry";
     repo = "opentelemetry-python-contrib";
     rev = "refs/tags/v${version}";
-    hash = "sha256-6tGQjPBej2zv5yJN0S46le3kyD7q3TELYyDmyxlp5Wo=";
+    hash = "sha256-fUyA3cPXAxO506usEWxOUX9xiapc8Ocnbx73LP6ghRE=";
   };
 
   sourceRoot = "${src.name}/opentelemetry-instrumentation";

--- a/pkgs/development/python-modules/opentelemetry-util-http/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-util-http/default.nix
@@ -33,6 +33,12 @@ buildPythonPackage {
     pytestCheckHook
   ];
 
+  # https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1940
+  disabledTests = [
+    "test_nonstandard_method"
+    "test_nonstandard_method_allowed"
+  ];
+
   pythonImportsCheck = [ "opentelemetry.util.http" ];
 
   meta = opentelemetry-instrumentation.meta // {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8760,6 +8760,8 @@ self: super: with self; {
 
   opentelemetry-instrumentation-django = callPackage ../development/python-modules/opentelemetry-instrumentation-django { };
 
+  opentelemetry-instrumentation-flask = callPackage ../development/python-modules/opentelemetry-instrumentation-flask { };
+
   opentelemetry-instrumentation-grpc = callPackage ../development/python-modules/opentelemetry-instrumentation-grpc { };
 
   opentelemetry-instrumentation-wsgi = callPackage ../development/python-modules/opentelemetry-instrumentation-wsgi { };


### PR DESCRIPTION
## Description of changes

Update `opentelemetry-python` (and `-contrib`) to latest versions available.
cc @mweinelt I guess the python package updater needs some fixup for `opentelemetry-instrumentation` (or just exclude it), see c913a0bc0da401762630277afe845ff2cf8289a3 for context.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
