### PR TITLE
home-assistant-custom-components.gpio: init at 0.0.2

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -6,6 +6,8 @@
 
   govee-lan = callPackage ./govee-lan {};
 
+  gpio = callPackage ./gpio {};
+
   miele = callPackage ./miele {};
 
   prometheus_sensor = callPackage ./prometheus_sensor {};

--- a/pkgs/servers/home-assistant/custom-components/gpio/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/gpio/default.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildHomeAssistantComponent
+, fetchFromGitea
+, libgpiod
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "raboof";
+  domain = "gpio";
+  version = "0.0.2";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "raboof";
+    repo = "ha-gpio";
+    rev = "v${version}";
+    hash = "sha256-oito5W7uQYgxUQFIynW9G7jbIpmFONWC8FslRdX3gsE=";
+  };
+
+  propagatedBuildInputs = [ libgpiod ];
+
+  meta = with lib; {
+    description = "Home Assistant GPIO custom integration";
+    homepage = "https://codeberg.org/raboof/ha-gpio";
+    maintainers = with maintainers; [ raboof ];
+    license = licenses.asl20;
+  };
+}


### PR DESCRIPTION
## Description of changes

Introduce a custom module for local GPIO, like for example on a raspberry pi 3 b+

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
