### PR TITLE
cudaPackages.cuda_nvcc: don't inspect the cc wrapper

### DIFF
--- a/pkgs/development/cuda-modules/backend-stdenv.nix
+++ b/pkgs/development/cuda-modules/backend-stdenv.nix
@@ -19,34 +19,6 @@ let
   assertCondition = true;
 in
 
-/*
-# We should use libstdc++ at least as new as nixpkgs' stdenv's one.
-assert let
-  cxxStdlibCuda = cudaStdenv.cc.cxxStdlib.package;
-  cxxStdlibNixpkgs = stdenv.cc.cxxStdlib.package;
-
-  # Expose the C++ standard library we're using. See the comments on "General
-  # libc++ support". This is also relevant when using older gcc than the
-  # stdenv's, as may be required e.g. by CUDAToolkit's nvcc.
-  cxxStdlib = libcxx:
-    let
-      givenLibcxx = libcxx != null && (libcxx.isLLVM or false);
-      givenGccForLibs = libcxx != null && !(libcxx.isLLVM or false) && (libcxx.isGNU or false);
-      libcxx_solib = "${lib.getLib libcxx}/lib";
-    in
-      if (!givenLibcxx) && givenGccForLibs then
-        { kind = "libstdc++"; package = libcxx; solib = libcxx_solib; }
-      else if givenLibcxx then
-        { kind = "libc++"; package = libcxx;  solib = libcxx_solib;}
-      else
-        # We're probably using the `libstdc++` that came with our `gcc`.
-        # TODO: this is maybe not always correct?
-        # TODO: what happens when `nativeTools = true`?
-        { kind = "libstdc++"; package = cc; solib = cc_solib; }
-  ;
-in
-((stdenv.cc.cxxStdlib.kind or null) == "libstdc++")
--> lib.versionAtLeast cxxStdlibCuda.version cxxStdlibNixpkgs.version;
-*/
+  /* TODO: Consider testing whether we in fact use the newer libstdc++ */
 
 lib.extendDerivation assertCondition passthruExtra cudaStdenv

--- a/pkgs/development/cuda-modules/cuda/overrides.nix
+++ b/pkgs/development/cuda-modules/cuda/overrides.nix
@@ -112,7 +112,6 @@ attrsets.filterAttrs (attr: _: (builtins.hasAttr attr prev)) {
         useCcForLibs = true;
         gccForLibs = ccForLibs-wrapper.cc;
       };
-      cxxStdlibDir = ccForLibs-wrapper.cxxStdlib.solib or (throw "necessary to fix CI");
     in
     {
 
@@ -149,7 +148,6 @@ attrsets.filterAttrs (attr: _: (builtins.hasAttr attr prev)) {
 
           # Fix a compatible backend compiler
           PATH += ${lib.getBin cc}/bin:
-          LIBRARIES += "-L${cxxStdlibDir}/lib"
 
           # Expose the split-out nvvm
           LIBRARIES =+ -L''${!outputBin}/nvvm/lib


### PR DESCRIPTION
Adjust the evaluation after the refactoring in 86c28ee650c4393ec1b6f8815a0e1ddc010cd6cb (https://github.com/NixOS/nixpkgs/pull/282220).

The way I explicitly extended `nvcc.profile`'s LIBRARIES may have been redundant (building something mildly cursed like jaxlib may be necessary to verify). We should also strive to avoid looking inside the wrapper (e.g. the `useLibsFrom` interface should be mostly sufficient for our purposes). Basic things like `saxpy` do work.

Previously:
```
❯ NIXPKGS_ALLOW_UNFREE=1 nix-instantiate '.' -A tests.cuda
...
       error: necessary to fix CI
❯ nix build -f '.' --arg config '{ allowUnfree = true; }' -L python3Packages.torchWithCuda
...
       error: necessary to fix CI
```

Now:
```
❯ NIXPKGS_ALLOW_UNFREE=1 nix-instantiate '.' -A tests.cuda
/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-cuda-samples-12.2.drv
/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-saxpy-unstable-2023-07-11.drv
...
```

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

CC @NixOS/cuda-maintainers 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
