### PR TITLE
svndumpsanitizer: init at 2.0.7

### DIFF
--- a/pkgs/by-name/sv/svndumpsanitizer/package.nix
+++ b/pkgs/by-name/sv/svndumpsanitizer/package.nix
@@ -1,0 +1,33 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation {
+  pname = "svndumpsanitizer";
+  version = "2.0.7";
+  src = fetchFromGitHub {
+    owner = "dsuni";
+    repo = "svndumpsanitizer";
+    rev = "cbf917c000ee42fbb31a8667014a4357bbfdd6a6";
+    hash = "sha256-lkVX11t0AF4y1EQQFXjPTrJmsfJhgx5Y1xj1VDlsbH0=";
+  };
+  buildPhase = ''
+    runHook preBuild
+    cc svndumpsanitizer.c -o svndumpsanitizer
+    runHook postBuild
+  '';
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 svndumpsanitizer -t $out/bin
+    runHook postInstall
+  '';
+  meta = with lib; {
+    description = "Alternative to svndumpfilter that discovers which nodes should actually be kept";
+    homepage = "https://miria.homelinuxserver.org/svndumpsanitizer";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ lafrenierejm ];
+    mainProgram = "svndumpsanitizer";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/by-name/sv/svndumpsanitizer/package.nix
+++ b/pkgs/by-name/sv/svndumpsanitizer/package.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Alternative to svndumpfilter that discovers which nodes should actually be kept";
     homepage = "https://miria.homelinuxserver.org/svndumpsanitizer";
+    downloadPage = "https://github.com/dsuni/svndumpsanitizer";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ lafrenierejm ];
     mainProgram = "svndumpsanitizer";

--- a/pkgs/by-name/sv/svndumpsanitizer/package.nix
+++ b/pkgs/by-name/sv/svndumpsanitizer/package.nix
@@ -9,6 +9,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "dsuni";
     repo = "svndumpsanitizer";
+    # https://github.com/dsuni/svndumpsanitizer/issues/22
     rev = "cbf917c000ee42fbb31a8667014a4357bbfdd6a6";
     hash = "sha256-lkVX11t0AF4y1EQQFXjPTrJmsfJhgx5Y1xj1VDlsbH0=";
   };


### PR DESCRIPTION
## Description of changes

Homepage: <https://miria.homelinuxserver.org/svndumpsanitizer/>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
