### PR TITLE
cosmic-comp: optional XWayland and Systemd

### DIFF
--- a/pkgs/by-name/co/cosmic-comp/package.nix
+++ b/pkgs/by-name/co/cosmic-comp/package.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , rustPlatform
 , fetchFromGitHub
 , makeBinaryWrapper
@@ -13,6 +14,8 @@
 , wayland
 , xorg
 , useXWayland ? true
+, systemd
+, useSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd
 }:
 
 rustPlatform.buildRustPackage {
@@ -42,7 +45,18 @@ rustPlatform.buildRustPackage {
   separateDebugInfo = true;
 
   nativeBuildInputs = [ makeBinaryWrapper pkg-config ];
-  buildInputs = [ libglvnd libinput libxkbcommon mesa seatd udev wayland ];
+  buildInputs = [
+      libglvnd
+      libinput
+      libxkbcommon
+      mesa
+      seatd
+      udev
+      wayland
+    ] ++ lib.optional useSystemd systemd;
+
+  # Only default feature is systemd
+  buildNoDefaultFeatures = !useSystemd;
 
   # Force linking to libEGL, which is always dlopen()ed, and to
   # libwayland-client, which is always dlopen()ed except by the

--- a/pkgs/by-name/co/cosmic-comp/package.nix
+++ b/pkgs/by-name/co/cosmic-comp/package.nix
@@ -12,6 +12,7 @@
 , xwayland
 , wayland
 , xorg
+, useXWayland ? true
 }:
 
 rustPlatform.buildRustPackage {
@@ -56,11 +57,13 @@ rustPlatform.buildRustPackage {
   # These libraries are only used by the X11 backend, which will not
   # be the common case, so just make them available, don't link them.
   postInstall = ''
-    wrapProgram $out/bin/cosmic-comp \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
+    wrapProgramArgs=(--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
         xorg.libX11 xorg.libXcursor xorg.libXi xorg.libXrandr
-      ]} \
-      --prefix PATH : ${lib.makeBinPath [ xwayland ]}
+    ]})
+  '' + lib.optionalString useXWayland ''
+    wrapProgramArgs+=(--prefix PATH : ${lib.makeBinPath [ xwayland ]})
+  '' + ''
+    wrapProgram $out/bin/cosmic-comp "''${wrapProgramArgs[@]}"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Two new optionals:

- useXWayland
- useSystemd

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
