### PR TITLE
dart-sass: add passthru.updateScript, 1.69.0 -> 1.70.0

### DIFF
--- a/pkgs/development/tools/misc/dart-sass/default.nix
+++ b/pkgs/development/tools/misc/dart-sass/default.nix
@@ -10,10 +10,12 @@
 }:
 
 let
-  sass-language = fetchFromGitHub {
+  embedded-protocol-version = "2.3.0";
+
+  embedded-protocol = fetchFromGitHub {
     owner = "sass";
     repo = "sass";
-    rev = "refs/tags/embedded-protocol-2.3.0";
+    rev = "refs/tags/embedded-protocol-${embedded-protocol-version}";
     hash = "sha256-J2heASfIwj4lxjsRs/0zRHSaF2tij9bO7IgXp0u/eiI=";
   };
 in
@@ -37,7 +39,7 @@ buildDartApplication rec {
 
   preConfigure = ''
     mkdir -p build
-    ln -s ${sass-language} build/language
+    ln -s ${embedded-protocol} build/language
     HOME="$TMPDIR" buf generate
   '';
 
@@ -51,31 +53,35 @@ buildDartApplication rec {
     maintainers = with maintainers; [ lelgenio ];
   };
 
-  passthru.tests = {
-    version = testers.testVersion {
-      package = dart-sass;
-      command = "dart-sass --version";
-    };
+  passthru = {
+    inherit embedded-protocol-version embedded-protocol;
+    updateScript = ./update.sh;
+    tests = {
+      version = testers.testVersion {
+        package = dart-sass;
+        command = "dart-sass --version";
+      };
 
-    simple = testers.testEqualContents {
-      assertion = "dart-sass compiles a basic scss file";
-      expected = writeText "expected" ''
-        body h1{color:#123}
-      '';
-      actual = runCommand "actual"
-        {
-          nativeBuildInputs = [ dart-sass ];
-          base = writeText "base" ''
-            body {
-              $color: #123;
-              h1 {
-                color: $color;
+      simple = testers.testEqualContents {
+        assertion = "dart-sass compiles a basic scss file";
+        expected = writeText "expected" ''
+          body h1{color:#123}
+        '';
+        actual = runCommand "actual"
+          {
+            nativeBuildInputs = [ dart-sass ];
+            base = writeText "base" ''
+              body {
+                $color: #123;
+                h1 {
+                  color: $color;
+                }
               }
-            }
-          '';
-        } ''
-        dart-sass --style=compressed $base > $out
-      '';
+            '';
+          } ''
+          dart-sass --style=compressed $base > $out
+        '';
+      };
     };
   };
 }

--- a/pkgs/development/tools/misc/dart-sass/default.nix
+++ b/pkgs/development/tools/misc/dart-sass/default.nix
@@ -10,24 +10,24 @@
 }:
 
 let
-  embedded-protocol-version = "2.3.0";
+  embedded-protocol-version = "2.4.0";
 
   embedded-protocol = fetchFromGitHub {
     owner = "sass";
     repo = "sass";
     rev = "refs/tags/embedded-protocol-${embedded-protocol-version}";
-    hash = "sha256-J2heASfIwj4lxjsRs/0zRHSaF2tij9bO7IgXp0u/eiI=";
+    hash = "sha256-19YQTda5su2PI2vLzVRCn7fQoH5vEg3539gXEeLLvV8=";
   };
 in
 buildDartApplication rec {
   pname = "dart-sass";
-  version = "1.69.0";
+  version = "1.70.0";
 
   src = fetchFromGitHub {
     owner = "sass";
     repo = pname;
     rev = version;
-    hash = "sha256-kn3cwi1k2CkzbS+Q/JaYy8Nq3Ej0GyWifG1Bq5ZEVHA=";
+    hash = "sha256-JLVcoDAngP1y8EC4K6fIJdPu2Xm8LLAxUm8BTK5tSVk=";
   };
 
   pubspecLock = lib.importJSON ./pubspec.lock.json;

--- a/pkgs/development/tools/misc/dart-sass/pubspec.lock.json
+++ b/pkgs/development/tools/misc/dart-sass/pubspec.lock.json
@@ -4,31 +4,31 @@
       "dependency": "transitive",
       "description": {
         "name": "_fe_analyzer_shared",
-        "sha256": "ae92f5d747aee634b87f89d9946000c2de774be1d6ac3e58268224348cd0101a",
+        "sha256": "36a321c3d2cbe01cbcb3540a87b8843846e0206df3e691fa7b23e19e78de6d49",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "61.0.0"
+      "version": "65.0.0"
     },
     "analyzer": {
       "dependency": "direct dev",
       "description": {
         "name": "analyzer",
-        "sha256": "ea3d8652bda62982addfd92fdc2d0214e5f82e43325104990d4f4c4a2a313562",
+        "sha256": "dfe03b90ec022450e22513b5e5ca1f01c0c01de9c3fba2f7fd233cb57a6b9a07",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "5.13.0"
+      "version": "6.3.0"
     },
     "archive": {
       "dependency": "direct dev",
       "description": {
         "name": "archive",
-        "sha256": "e0902a06f0e00414e4e3438a084580161279f137aeb862274710f29ec10cf01e",
+        "sha256": "22600aa1e926be775fa5fe7e6894e7fb3df9efda8891c73f70fb3262399a432d",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.3.9"
+      "version": "3.4.10"
     },
     "args": {
       "dependency": "direct main",
@@ -84,11 +84,11 @@
       "dependency": "direct main",
       "description": {
         "name": "cli_pkg",
-        "sha256": "009e19944bbfb07c3b97f2f8c9941aa01ca70a7d3d0018e813303b4c3905c9b9",
+        "sha256": "7b088621eb3d486c17a4122389d8b3f36658450d5a405fa229166b1a71a7ce4a",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.5.0"
+      "version": "2.7.2"
     },
     "cli_repl": {
       "dependency": "direct main",
@@ -104,11 +104,11 @@
       "dependency": "direct dev",
       "description": {
         "name": "cli_util",
-        "sha256": "b8db3080e59b2503ca9e7922c3df2072cf13992354d5e944074ffa836fba43b7",
+        "sha256": "c05b7406fdabc7a49a3929d4af76bcaccbbffcbcdcf185b082e1ae07da323d19",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.4.0"
+      "version": "0.4.1"
     },
     "collection": {
       "dependency": "direct main",
@@ -134,11 +134,11 @@
       "dependency": "transitive",
       "description": {
         "name": "coverage",
-        "sha256": "2fb815080e44a09b85e0f2ca8a820b15053982b2e714b59267719e8a9ff17097",
+        "sha256": "8acabb8306b57a409bf4c83522065672ee13179297a6bb0cb9ead73948df7c76",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.6.3"
+      "version": "1.7.2"
     },
     "crypto": {
       "dependency": "direct dev",
@@ -164,21 +164,21 @@
       "dependency": "direct dev",
       "description": {
         "name": "dart_style",
-        "sha256": "1efa911ca7086affd35f463ca2fc1799584fb6aa89883cf0af8e3664d6a02d55",
+        "sha256": "40ae61a5d43feea6d24bd22c0537a6629db858963b99b4bc1c3db80676f32368",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.3.2"
+      "version": "2.3.4"
     },
     "dartdoc": {
       "dependency": "direct dev",
       "description": {
         "name": "dartdoc",
-        "sha256": "d9bab893c9f42615f62bf2d3ff2b89d5905952d1d42cc7890003537249cb472e",
+        "sha256": "cbc4520cf486395741209693c3e7ef70653b1879b5a73e010815bf50431d330c",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "6.3.0"
+      "version": "8.0.3"
     },
     "ffi": {
       "dependency": "transitive",
@@ -234,11 +234,11 @@
       "dependency": "direct dev",
       "description": {
         "name": "grinder",
-        "sha256": "48495acdb3df702c55c952c6536faf11631b8401a292eb0d182ef332fc568b56",
+        "sha256": "e1996e485d2b56bb164a8585679758d488fbf567273f51c432c8733fee1f6188",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.9.4"
+      "version": "0.9.5"
     },
     "html": {
       "dependency": "transitive",
@@ -314,11 +314,11 @@
       "dependency": "direct dev",
       "description": {
         "name": "lints",
-        "sha256": "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452",
+        "sha256": "cbf8d4b858bb0134ef3ef87841abdf8d63bfc255c266b7bf6b39daa1085c4290",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "2.1.1"
+      "version": "3.0.0"
     },
     "logging": {
       "dependency": "transitive",
@@ -334,31 +334,31 @@
       "dependency": "transitive",
       "description": {
         "name": "markdown",
-        "sha256": "acf35edccc0463a9d7384e437c015a3535772e09714cf60e07eeef3a15870dcd",
+        "sha256": "1b134d9f8ff2da15cb298efe6cd8b7d2a78958c1b00384ebcbdf13fe340a6c90",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "7.1.1"
+      "version": "7.2.1"
     },
     "matcher": {
       "dependency": "transitive",
       "description": {
         "name": "matcher",
-        "sha256": "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e",
+        "sha256": "d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.12.16"
+      "version": "0.12.16+1"
     },
     "meta": {
       "dependency": "direct main",
       "description": {
         "name": "meta",
-        "sha256": "a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e",
+        "sha256": "d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.10.0"
+      "version": "1.11.0"
     },
     "mime": {
       "dependency": "transitive",
@@ -424,11 +424,11 @@
       "dependency": "direct main",
       "description": {
         "name": "path",
-        "sha256": "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917",
+        "sha256": "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.8.3"
+      "version": "1.9.0"
     },
     "petitparser": {
       "dependency": "transitive",
@@ -444,11 +444,11 @@
       "dependency": "transitive",
       "description": {
         "name": "pointycastle",
-        "sha256": "7c1e5f0d23c9016c5bbd8b1473d0d3fb3fc851b876046039509e18e0c7485f2c",
+        "sha256": "43ac87de6e10afabc85c445745a7b799e04de84cebaa4fd7bf55a5e1e9604d29",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.7.3"
+      "version": "3.7.4"
     },
     "pool": {
       "dependency": "direct main",
@@ -474,11 +474,11 @@
       "dependency": "direct dev",
       "description": {
         "name": "protoc_plugin",
-        "sha256": "a800528e47f6efd31a57213dd11b6036f36cbd6677785742a2121e96f7c7a2b9",
+        "sha256": "fb0554851c9eca30bd18405fbbfe81e39166d4a2f0e5b770606fd69da3da0b2f",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "21.1.1"
+      "version": "21.1.2"
     },
     "pub_api_client": {
       "dependency": "direct dev",
@@ -664,31 +664,31 @@
       "dependency": "direct dev",
       "description": {
         "name": "test",
-        "sha256": "9b0dd8e36af4a5b1569029949d50a52cb2a2a2fdaa20cebb96e6603b9ae241f9",
+        "sha256": "694c108e13c6b35b15fcb0f8f03eddf8373f93b044c9497b5e81ce09f7381bda",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "1.24.6"
+      "version": "1.25.1"
     },
     "test_api": {
       "dependency": "transitive",
       "description": {
         "name": "test_api",
-        "sha256": "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b",
+        "sha256": "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.6.1"
+      "version": "0.7.0"
     },
     "test_core": {
       "dependency": "transitive",
       "description": {
         "name": "test_core",
-        "sha256": "4bef837e56375537055fdbbbf6dd458b1859881f4c7e6da936158f77d61ab265",
+        "sha256": "2bc4b4ecddd75309300d8096f781c0e3280ca1ef85beda558d33fcbedc2eead4",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.5.6"
+      "version": "0.6.0"
     },
     "test_descriptor": {
       "dependency": "direct dev",
@@ -734,11 +734,11 @@
       "dependency": "transitive",
       "description": {
         "name": "vm_service",
-        "sha256": "c538be99af830f478718b51630ec1b6bee5e74e52c8a802d328d9e71d35d2583",
+        "sha256": "a2662fb1f114f4296cf3f5a50786a2d888268d7776cf681aa17d660ffa23b246",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "11.10.0"
+      "version": "14.0.0"
     },
     "watcher": {
       "dependency": "direct main",
@@ -792,6 +792,6 @@
     }
   },
   "sdks": {
-    "dart": ">=3.0.0 <4.0.0"
+    "dart": ">=3.1.0 <4.0.0"
   }
 }

--- a/pkgs/development/tools/misc/dart-sass/update.sh
+++ b/pkgs/development/tools/misc/dart-sass/update.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p yq ripgrep common-updater-scripts dart
+
+set -xeu -o pipefail
+
+PACKAGE_DIR="$(realpath "$(dirname "$0")")"
+cd "$PACKAGE_DIR/.."
+while ! test -f default.nix; do cd .. ; done
+NIXPKGS_DIR="$PWD"
+
+dart_sass_version="$(
+  list-git-tags --url=https://github.com/sass/dart-sass \
+  | rg '^\d' \
+  | sort --version-sort \
+  | tail -n1
+)"
+
+embedded_protocol_version="$(
+  list-git-tags --url=https://github.com/sass/sass \
+  | rg '^embedded-protocol-(.*)' -r '$1' \
+  | sort --version-sort \
+  | tail -n1
+)"
+
+cd "$NIXPKGS_DIR"
+update-source-version dart-sass "$dart_sass_version"
+update-source-version dart-sass "$embedded_protocol_version" \
+  --version-key=embedded-protocol-version \
+  --source-key=embedded-protocol
+
+TMPDIR="$(mktemp -d)"
+cd "$TMPDIR"
+
+src="$(nix-build --no-link "$NIXPKGS_DIR" -A dart-sass.src)"
+cp $src/pubspec.* .
+
+# Maybe one day upstream will ship a pubspec.lock,
+# until then we must generate a fresh one
+if ! test -f pubspec.lock; then
+  dart pub update
+fi
+
+yq . pubspec.lock > "$PACKAGE_DIR/pubspec.lock.json"
+
+rm -rf "$TMPDIR"


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages marked as broken and skipped:</summary>
  <ul>
    <li>python312Packages.nbdev</li>
    <li>python312Packages.nbdev.dist</li>
  </ul>
</details>
<details>
  <summary>2 packages failed to build:</summary>
  <ul>
    <li>discourse</li>
    <li>discourseAllPlugins</li>
  </ul>
</details>
<details>
  <summary>11 packages built:</summary>
  <ul>
    <li>dart-sass</li>
    <li>dart-sass.pubcache</li>
    <li>python311Packages.nbdev</li>
    <li>python311Packages.nbdev.dist</li>
    <li>quarto</li>
    <li>quartoMinimal</li>
    <li>rstudio</li>
    <li>rstudio-server</li>
    <li>rstudioServerWrapper</li>
    <li>rstudioWrapper</li>
    <li>shopware-cli</li>
  </ul>
</details>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
