### PR TITLE
sdrpp: 1.0.4 -> 1.1.0-unstable-2024-01-22

### DIFF
--- a/pkgs/applications/radio/sdrpp/default.nix
+++ b/pkgs/applications/radio/sdrpp/default.nix
@@ -1,45 +1,57 @@
 { stdenv, lib, fetchFromGitHub, cmake, pkg-config
-, libX11, glfw, glew, fftwFloat, volk, AppKit
+, libX11, glfw, glew, fftwFloat, volk, zstd, AppKit
 # Sources
 , airspy_source ? true, airspy
 , airspyhf_source ? true, airspyhf
-, bladerf_source ? false, libbladeRF
+, bladerf_source ? true, libbladeRF
 , file_source ? true
 , hackrf_source ? true, hackrf
-, limesdr_source ? false, limesuite
-, sddc_source ? false
-, rtl_sdr_source ? true, rtl-sdr, libusb1
+, limesdr_source ? true, limesuite
+, perseus_source ? false    # needs libperseus-sdr, not yet available in nixpks
+, plutosdr_source ? stdenv.isLinux, libiio, libad9361
+, rfspace_source ? true
+, rtl_sdr_source ? true, rtl-sdr-osmocom, libusb1  # osmocom better w/ rtlsdr v4
 , rtl_tcp_source ? true
 , sdrplay_source ? false, sdrplay
 , soapy_source ? true, soapysdr
 , spyserver_source ? true
-, plutosdr_source ? stdenv.isLinux, libiio, libad9361
+, usrp_source	? false, uhd, boost
+
 # Sinks
 , audio_sink ? true, rtaudio
-, portaudio_sink ? false, portaudio
 , network_sink ? true
+, portaudio_sink ? false, portaudio
+
 # Decoders
 , falcon9_decoder ? false
 , m17_decoder ? false, codec2
 , meteor_demodulator ? true
 , radio ? true
-, weather_sat_decoder ? true
+, weather_sat_decoder ? false  # is missing some dsp/pll.h
+
 # Misc
 , discord_presence ? true
 , frequency_manager ? true
 , recorder ? true
 , rigctl_server ? true
+, scanner ? true
 }:
 
 stdenv.mkDerivation rec {
   pname = "sdrpp";
-  version = "1.0.4";
+
+  # SDR++ uses a rolling release model.
+  # Choose a git hash from head and use the date from that commit as
+  # version qualifier
+  git_hash = "27ab5bf3c194169ddf60ca312723fce96149cc8e";
+  git_date = "2024-01-22";
+  version = "1.1.0-unstable-" + git_date;
 
   src = fetchFromGitHub {
     owner = "AlexandreRouma";
     repo = "SDRPlusPlus";
-    rev = version;
-    hash = "sha256-g9tpWvVRMXRhPfgvOeJhX6IMouF9+tLUr9wo5r35i/c=";
+    rev = git_hash;
+    hash = "sha256-R4xWeqdHEAaje37VQaGlg+L2iYIOH4tXMHvZkZq4SDU=";
   };
 
   patches = [ ./runtime-prefix.patch ];
@@ -50,11 +62,14 @@ stdenv.mkDerivation rec {
       --replace "set(CMAKE_INSTALL_PREFIX" "#set(CMAKE_INSTALL_PREFIX"
     substituteInPlace decoder_modules/m17_decoder/src/m17dsp.h \
       --replace "codec2.h" "codec2/codec2.h"
+    # Since the __TIME_ and __DATE__ is canonicalized in the build,
+    # use our qualified version shown in the programs window title.
+    substituteInPlace core/src/version.h --replace "1.1.0" "$version"
   '';
 
   nativeBuildInputs = [ cmake pkg-config ];
 
-  buildInputs = [ glfw glew fftwFloat volk ]
+  buildInputs = [ glfw glew fftwFloat volk zstd ]
     ++ lib.optional stdenv.isDarwin AppKit
     ++ lib.optional stdenv.isLinux libX11
     ++ lib.optional airspy_source airspy
@@ -62,42 +77,52 @@ stdenv.mkDerivation rec {
     ++ lib.optional bladerf_source libbladeRF
     ++ lib.optional hackrf_source hackrf
     ++ lib.optional limesdr_source limesuite
-    ++ lib.optionals rtl_sdr_source [ rtl-sdr libusb1 ]
+    ++ lib.optionals rtl_sdr_source [ rtl-sdr-osmocom libusb1 ]
     ++ lib.optional sdrplay_source sdrplay
     ++ lib.optional soapy_source soapysdr
     ++ lib.optionals plutosdr_source [ libiio libad9361 ]
+    ++ lib.optionals usrp_source [ uhd boost ]
     ++ lib.optional audio_sink rtaudio
     ++ lib.optional portaudio_sink portaudio
     ++ lib.optional m17_decoder codec2;
 
-  cmakeFlags = lib.mapAttrsToList (k: v: "-D${k}=${if v then "ON" else "OFF"}") {
-    OPT_BUILD_AIRSPY_SOURCE = airspy_source;
-    OPT_BUILD_AIRSPYHF_SOURCE = airspyhf_source;
-    OPT_BUILD_BLADERF_SOURCE = bladerf_source;
-    OPT_BUILD_FILE_SOURCE = file_source;
-    OPT_BUILD_HACKRF_SOURCE = hackrf_source;
-    OPT_BUILD_LIMESDR_SOURCE = limesdr_source;
-    OPT_BUILD_SDDC_SOURCE = sddc_source;
-    OPT_BUILD_RTL_SDR_SOURCE = rtl_sdr_source;
-    OPT_BUILD_RTL_TCP_SOURCE = rtl_tcp_source;
-    OPT_BUILD_SDRPLAY_SOURCE = sdrplay_source;
-    OPT_BUILD_SOAPY_SOURCE = soapy_source;
-    OPT_BUILD_SPYSERVER_SOURCE = spyserver_source;
-    OPT_BUILD_PLUTOSDR_SOURCE = plutosdr_source;
-    OPT_BUILD_AUDIO_SINK = audio_sink;
-    OPT_BUILD_PORTAUDIO_SINK = portaudio_sink;
-    OPT_BUILD_NETWORK_SINK = network_sink;
-    OPT_BUILD_NEW_PORTAUDIO_SINK = portaudio_sink;
-    OPT_BUILD_FALCON9_DECODER = falcon9_decoder;
-    OPT_BUILD_M17_DECODER = m17_decoder;
-    OPT_BUILD_METEOR_DEMODULATOR = meteor_demodulator;
-    OPT_BUILD_RADIO = radio;
-    OPT_BUILD_WEATHER_SAT_DECODER = weather_sat_decoder;
-    OPT_BUILD_DISCORD_PRESENCE = discord_presence;
-    OPT_BUILD_FREQUENCY_MANAGER = frequency_manager;
-    OPT_BUILD_RECORDER = recorder;
-    OPT_BUILD_RIGCTL_SERVER = rigctl_server;
-  };
+  cmakeFlags = [
+    # Sources
+    (lib.cmakeBool "OPT_BUILD_AIRSPYHF_SOURCE" airspyhf_source)
+    (lib.cmakeBool "OPT_BUILD_AIRSPY_SOURCE" airspy_source)
+    (lib.cmakeBool "OPT_BUILD_BLADERF_SOURCE" bladerf_source)
+    (lib.cmakeBool "OPT_BUILD_FILE_SOURCE" file_source)
+    (lib.cmakeBool "OPT_BUILD_HACKRF_SOURCE" hackrf_source)
+    (lib.cmakeBool "OPT_BUILD_LIMESDR_SOURCE" limesdr_source)
+    (lib.cmakeBool "OPT_BUILD_PERSEUS_SOURCE" perseus_source)
+    (lib.cmakeBool "OPT_BUILD_PLUTOSDR_SOURCE" plutosdr_source)
+    (lib.cmakeBool "OPT_BUILD_RFSPACE_SOURCE" rfspace_source)
+    (lib.cmakeBool "OPT_BUILD_RTL_SDR_SOURCE" rtl_sdr_source)
+    (lib.cmakeBool "OPT_BUILD_RTL_TCP_SOURCE" rtl_tcp_source)
+    (lib.cmakeBool "OPT_BUILD_SDRPLAY_SOURCE" sdrplay_source)
+    (lib.cmakeBool "OPT_BUILD_SOAPY_SOURCE" soapy_source)
+    (lib.cmakeBool "OPT_BUILD_SPYSERVER_SOURCE" spyserver_source)
+    (lib.cmakeBool "OPT_BUILD_USRP_SOURCE" usrp_source)
+
+    # Sinks
+    (lib.cmakeBool "OPT_BUILD_AUDIO_SINK" audio_sink)
+    (lib.cmakeBool "OPT_BUILD_NETWORK_SINK" network_sink)
+    (lib.cmakeBool "OPT_BUILD_NEW_PORTAUDIO_SINK" portaudio_sink)
+
+    # Decoders
+    (lib.cmakeBool "OPT_BUILD_FALCON9_DECODER" falcon9_decoder)
+    (lib.cmakeBool "OPT_BUILD_M17_DECODER" m17_decoder)
+    (lib.cmakeBool "OPT_BUILD_METEOR_DEMODULATOR" meteor_demodulator)
+    (lib.cmakeBool "OPT_BUILD_RADIO" radio)
+    (lib.cmakeBool "OPT_BUILD_WEATHER_SAT_DECODER" weather_sat_decoder)
+
+    # Misc
+    (lib.cmakeBool "OPT_BUILD_DISCORD_PRESENCE" discord_presence)
+    (lib.cmakeBool "OPT_BUILD_FREQUENCY_MANAGER" frequency_manager)
+    (lib.cmakeBool "OPT_BUILD_RECORDER" recorder)
+    (lib.cmakeBool "OPT_BUILD_RIGCTL_SERVER" rigctl_server)
+    (lib.cmakeBool "OPT_BUILD_SCANNER" scanner)
+  ];
 
   env.NIX_CFLAGS_COMPILE = "-fpermissive";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24914,9 +24914,9 @@ with pkgs;
 
   sdrplay = callPackage ../applications/radio/sdrplay { };
 
-  sdrpp = pin-to-gcc12-if-gcc13 (callPackage ../applications/radio/sdrpp {
+  sdrpp = callPackage ../applications/radio/sdrpp {
     inherit (darwin.apple_sdk.frameworks) AppKit;
-  });
+  };
 
   sigdigger = libsForQt5.callPackage ../applications/radio/sigdigger { };
 


### PR DESCRIPTION
sdrpp switched to a rolling release, so take a git hash from head.

 * Remove pinning to gcc12, as this will break plug-ins that link against a newer version of libc++ (e.g. audio sink).
 * Organize the built options by category and sort within.
 * Add new build options that have been added since last 1.0.4
 * Link against `rtl-sdr-osmocom` which is a newer superset of `rtl-sdr` (e.g. works better with rtl-sdr V4).


## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
