### PR TITLE
picom: 10.2 -> 11

### DIFF
--- a/pkgs/applications/window-managers/picom/default.nix
+++ b/pkgs/applications/window-managers/picom/default.nix
@@ -111,7 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = licenses.mit;
     homepage = "https://github.com/yshui/picom";
-    maintainers = with maintainers; [ ertes twey thiagokokada ];
+    maintainers = with maintainers; [ ertes gepbird twey thiagokokada ];
     platforms = platforms.linux;
     mainProgram = "picom";
   };

--- a/pkgs/applications/window-managers/picom/default.nix
+++ b/pkgs/applications/window-managers/picom/default.nix
@@ -12,17 +12,17 @@
 , libxcb
 , libxdg_basedir
 , libXext
-, libXinerama
 , libxml2
 , libxslt
 , makeWrapper
 , meson
 , ninja
-, pcre
+, pcre2
 , pixman
 , pkg-config
 , stdenv
 , uthash
+, xcbutil
 , xcbutilimage
 , xcbutilrenderutil
 , xorgproto
@@ -32,13 +32,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "picom";
-  version = "10.2";
+  version = "11";
 
   src = fetchFromGitHub {
     owner = "yshui";
     repo = "picom";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-C+icJXTkE+XMaU7N6JupsP8xhmRVggX9hY1P7za0pO0=";
+    hash = "sha256-KIblpEEW33ZxxTYuQ/lbUGEJcVdmSWdNOrVCvhOY/OU=";
     fetchSubmodules = true;
   };
 
@@ -63,11 +63,11 @@ stdenv.mkDerivation (finalAttrs: {
     libxcb
     libxdg_basedir
     libXext
-    libXinerama
     libxml2
     libxslt
-    pcre
+    pcre2
     pixman
+    xcbutil
     xcbutilimage
     xcbutilrenderutil
     xorgproto

--- a/pkgs/applications/window-managers/picom/picom-allusive.nix
+++ b/pkgs/applications/window-managers/picom/picom-allusive.nix
@@ -1,4 +1,4 @@
-{ picom, lib, fetchFromGitHub, installShellFiles }:
+{ picom, lib, fetchFromGitHub, installShellFiles, pcre }:
 
 picom.overrideAttrs (oldAttrs: rec {
   pname = "picom-allusive";
@@ -11,7 +11,7 @@ picom.overrideAttrs (oldAttrs: rec {
     hash = "sha256-yM4TJjoVs+i33m/u/oWlx1TDKJrgwlfiGu72DOL/tl8=";
   };
 
-  nativeBuildInputs = [ installShellFiles ] ++ oldAttrs.nativeBuildInputs;
+  nativeBuildInputs = [ installShellFiles pcre ] ++ oldAttrs.nativeBuildInputs;
 
   postInstall = ''
     installManPage $src/man/picom.1.gz

--- a/pkgs/applications/window-managers/picom/picom-jonaburg.nix
+++ b/pkgs/applications/window-managers/picom/picom-jonaburg.nix
@@ -1,4 +1,4 @@
-{ picom, lib, fetchFromGitHub }:
+{ picom, lib, fetchFromGitHub, pcre }:
 
 picom.overrideAttrs (oldAttrs: rec {
   pname = "picom-jonaburg";
@@ -9,6 +9,8 @@ picom.overrideAttrs (oldAttrs: rec {
     rev = "e3c19cd7d1108d114552267f302548c113278d45";
     sha256 = "sha256-4voCAYd0fzJHQjJo4x3RoWz5l3JJbRvgIXn1Kg6nz6Y=";
   };
+
+  nativeBuildInputs = [ pcre ] ++ oldAttrs.nativeBuildInputs;
 
   meta = with lib; {
     description = "A fork of picom featuring animations and improved rounded corners.";


### PR DESCRIPTION
## Description of changes

Changelogs:
- https://github.com/yshui/picom/releases/tag/v11-rc1
- https://github.com/yshui/picom/releases/tag/v11

Diff: https://github.com/yshui/picom/compare/v10.2...v11

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages built:</summary>
  <ul>
    <li>picom</li>
    <li>picom-allusive</li>
    <li>picom-jonaburg</li>
    <li>picom-next</li>
  </ul>
</details>