### PR TITLE
libbsd: unstable-2023-04-29 -> 0.11.8

### DIFF
--- a/pkgs/development/libraries/libbsd/default.nix
+++ b/pkgs/development/libraries/libbsd/default.nix
@@ -1,25 +1,18 @@
 { lib
 , stdenv
-, fetchFromGitLab
-, fetchpatch
+, fetchurl
 , autoreconfHook
 , libmd
 , gitUpdater
 }:
 
-# Run `./get-version` for the new value when bumping the Git revision.
-let gitVersion = "0.11.7-55-g73b2"; in
-
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "libbsd";
-  version = "unstable-2023-04-29";
+  version = "0.11.8";
 
-  src = fetchFromGitLab {
-    domain = "gitlab.freedesktop.org";
-    owner = "libbsd";
-    repo = "libbsd";
-    rev = "73b25a8f871b3a20f6ff76679358540f95d7dbfd";
-    hash = "sha256-LS28taIMjRCl6xqg75eYOIrTDl8PzSa+OvrdiEOP1+U=";
+  src = fetchurl {
+    url = "https://libbsd.freedesktop.org/releases/${pname}-${version}.tar.xz";
+    hash = "sha256-Vf36Jpb7TVWlkvqa0Uqd+JfHsACN2zswxBmRSEH4XzM=";
   };
 
   outputs = [ "out" "dev" "man" ];
@@ -31,23 +24,11 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ autoreconfHook ];
   propagatedBuildInputs = [ libmd ];
 
-  patches = [
-    # Fix `{get,set}progname(3bsd)` conditionalization
-    # https://gitlab.freedesktop.org/libbsd/libbsd/-/issues/24
-    (fetchpatch {
-      url = "https://github.com/emilazy/libbsd/commit/0381f8d92873c5a19ced3ff861ee8ffe7825953e.patch";
-      hash = "sha256-+RMg5eHLgC4gyX9zXM0ttNf7rd9E3UzJX/7UVCYGXx4=";
-    })
-  ] ++ lib.optionals stdenv.isDarwin [
+  patches = lib.optionals stdenv.isDarwin [
     # Temporary build system hack from upstream maintainer
     # https://gitlab.freedesktop.org/libbsd/libbsd/-/issues/19#note_2017684
     ./darwin-fix-libbsd.sym.patch
   ];
-
-  postPatch = ''
-    substituteInPlace configure.ac \
-      --replace 'm4_esyscmd([./get-version])' '[${gitVersion}]'
-  '';
 
   passthru.updateScript = gitUpdater {
     # No nicer place to find latest release.


### PR DESCRIPTION
## Description of changes

In essence, I'm backing out all the code changes you made when swapping from 0.11.7 to the "-unstable" git commit.  This then means you don't have to deal with things like injecting the right version number (of course, I could have just had you tracking a git tag and left some of that code in!).

(@r-ryantm has been refusing to update you because you're not on a current stable tag)

Note that I am not aware if the darwin patch can be removed or not.  My build was on linux.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
