### PR TITLE
python311Packages.pykwalify: fix tests with ruamel.yaml 0.18+

### DIFF
--- a/pkgs/development/python-modules/pykwalify/default.nix
+++ b/pkgs/development/python-modules/pykwalify/default.nix
@@ -1,10 +1,10 @@
 { lib
 , buildPythonPackage
+, fetchpatch
 , python-dateutil
 , docopt
 , fetchPypi
 , pytestCheckHook
-, pyyaml
 , ruamel-yaml
 , testfixtures
 }:
@@ -19,20 +19,24 @@ buildPythonPackage rec {
     hash = "sha256-eWsq0+1MuZuIMItTP7L1WcMPpu+0+p/aETR/SD0kWIQ=";
   };
 
+  patches = [
+    # fix test failures with ruamel.yaml 0.18+
+    (fetchpatch {
+      name = "pykwalify-fix-tests-ruamel-yaml-0.18.patch";
+      url = "https://github.com/Grokzen/pykwalify/commit/57bb2ba5c28b6928edb3f07ef581a5a807524baf.diff";
+      hash = "sha256-XUiebDzFSvNrPpRMoc2lv9m+30cfFh0N0rznMiSdQ/0=";
+    })
+  ];
+
   propagatedBuildInputs = [
     python-dateutil
     docopt
-    pyyaml
     ruamel-yaml
   ];
 
   nativeCheckInputs = [
     pytestCheckHook
     testfixtures
-  ];
-
-  disabledTests = [
-    "test_multi_file_support"
   ];
 
   pythonImportsCheck = [ "pykwalify" ];


### PR DESCRIPTION
## Description of changes

Pull in upstream fix from https://github.com/Grokzen/pykwalify/pull/199

Currently failing in Hydra otherwise: https://hydra.nixos.org/build/246491825

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

###### nixpkgs-review

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>6 packages marked as broken and skipped:</summary>
  <ul>
    <li>python312Packages.pykwalify</li>
    <li>python312Packages.pykwalify.dist</li>
    <li>python312Packages.pyradiomics</li>
    <li>python312Packages.pyradiomics.dist</li>
    <li>python312Packages.west</li>
    <li>python312Packages.west.dist</li>
  </ul>
</details>
<details>
  <summary>6 packages built:</summary>
  <ul>
    <li>python311Packages.pykwalify</li>
    <li>python311Packages.pykwalify.dist</li>
    <li>python311Packages.pyradiomics</li>
    <li>python311Packages.pyradiomics.dist</li>
    <li>python311Packages.west</li>
    <li>python311Packages.west.dist</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
