### PR TITLE
libwpd: 0.10.0 -> 0.10.3

### DIFF
--- a/pkgs/development/libraries/libwpd/default.nix
+++ b/pkgs/development/libraries/libwpd/default.nix
@@ -1,15 +1,17 @@
-{ lib, stdenv, fetchurl, zlib, pkg-config, glib, libgsf, libxml2, librevenge }:
+{ lib, stdenv, fetchurl, zlib, pkg-config, glib, libgsf, libxml2, librevenge, boost }:
 
 stdenv.mkDerivation rec {
   pname = "libwpd";
-  version = "0.10.0";
+  version = "0.10.3";
 
   src = fetchurl {
     url = "mirror://sourceforge/libwpd/libwpd-${version}.tar.xz";
-    sha256 = "0b6krzr6kxzm89g6bapn805kdayq70hn16n5b5wfs2lwrf0ag2wx";
+    hash = "sha256-JGWwtmL9xdTjvrzcmnkCdxP7Ypyiv/BKPJJR/exC3Qk=";
   };
 
-  buildInputs = [ glib libgsf libxml2 zlib librevenge ];
+  patches = [ ./gcc-1.0.patch ];
+
+  buildInputs = [ glib libgsf libxml2 zlib librevenge boost ];
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/libraries/libwpd/gcc-1.0.patch
+++ b/pkgs/development/libraries/libwpd/gcc-1.0.patch
@@ -1,0 +1,12 @@
+diff -Naur libwpd-0.10.3/src/lib/WPXTable.h libwpd-0.10.3-modified/src/lib/WPXTable.h
+--- libwpd-0.10.3/src/lib/WPXTable.h	2018-12-25 16:19:19.000000000 +0000
++++ libwpd-0.10.3-modified/src/lib/WPXTable.h	2024-01-21 05:41:23.623457028 +0000
+@@ -53,7 +53,7 @@
+ 	~WPXTable();
+ 	void insertRow();
+ 	void insertCell(unsigned char colSpan, unsigned char rowSpan, unsigned char borderBits);
+-	const WPXTableCell  *getCell(size_t i, size_t j)
++	const WPXTableCell  *getCell(std::size_t i, std::size_t j)
+ 	{
+ 		return &(m_tableRows[i])[j];
+ 	}


### PR DESCRIPTION
## Description of changes

I have found no good changelog for this library.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
