### PR TITLE
python311Packages.scipy: 1.11.4 -> 1.12.0

### DIFF
--- a/pkgs/development/libraries/xsimd/default.nix
+++ b/pkgs/development/libraries/xsimd/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "C++ wrappers for SIMD intrinsics";
     homepage = "https://github.com/xtensor-stack/xsimd";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ tobim ];
+    maintainers = with maintainers; [ tobim doronbehar ];
     platforms = platforms.all;
   };
 })

--- a/pkgs/development/python-modules/meson-python/default.nix
+++ b/pkgs/development/python-modules/meson-python/default.nix
@@ -48,6 +48,6 @@ buildPythonPackage rec {
     description = "Meson Python build backend (PEP 517)";
     homepage = "https://github.com/mesonbuild/meson-python";
     license = [ lib.licenses.mit ];
-    maintainers = [ lib.maintainers.fridh ];
+    maintainers = with lib.maintainers; [ fridh doronbehar ];
   };
 }

--- a/pkgs/development/python-modules/pythran/default.nix
+++ b/pkgs/development/python-modules/pythran/default.nix
@@ -79,5 +79,6 @@ in buildPythonPackage rec {
     description = "Ahead of Time compiler for numeric kernels";
     homepage = "https://github.com/serge-sans-paille/pythran";
     license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ doronbehar ];
   };
 }

--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -13,6 +13,9 @@
 , pkg-config
 , pythran
 , wheel
+, nose
+, setuptools
+, hypothesis
 , pytestCheckHook
 , pytest-xdist
 , numpy
@@ -31,8 +34,8 @@ let
   #     nix-shell maintainers/scripts/update.nix --argstr package python3.pkgs.scipy
   #
   # The update script uses sed regexes to replace them with the updated hashes.
-  version = "1.11.4";
-  srcHash = "sha256-hNAZOMDFYqZpb67Pzg/WALWagFYvqYO1jOmcipDDRbE=";
+  version = "1.12.0";
+  srcHash = "sha256-PuiyYTgSegDTV9Kae5N68FOXT1jyJrNv9p2aFP70Z20=";
   datasetsHashes = {
     ascent = "1qjp35ncrniq9rhzb14icwwykqg2208hcssznn3hz27w39615kh3";
     ecg = "1bwbjp43b7znnwha5hv6wiz3g0bhwrpqpi75s12zidxrbwvd62pj";
@@ -75,13 +78,11 @@ in buildPythonPackage {
     })
   ];
 
-  # Relax deps a bit
+  # Upstream complicated numpy version pinning is causing issues in the
+  # configurePhase, so we pass on it.
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'meson-python>=0.12.1,<0.15.0' 'meson-python' \
       --replace 'numpy==' 'numpy>=' \
-      --replace "pybind11>=2.10.4,<2.11.1" "pybind11>=2.10.4,<2.12.0" \
-      --replace 'wheel<0.41.0' 'wheel'
   '';
 
   nativeBuildInputs = [
@@ -91,6 +92,7 @@ in buildPythonPackage {
     pythran
     pkg-config
     wheel
+    setuptools
   ];
 
   buildInputs = [
@@ -108,6 +110,8 @@ in buildPythonPackage {
   __darwinAllowLocalNetworking = true;
 
   nativeCheckInputs = [
+    nose
+    hypothesis
     pytestCheckHook
     pytest-xdist
   ];

--- a/pkgs/development/python-modules/scipy/default.nix
+++ b/pkgs/development/python-modules/scipy/default.nix
@@ -82,7 +82,7 @@ in buildPythonPackage {
   # configurePhase, so we pass on it.
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'numpy==' 'numpy>=' \
+      --replace-fail 'numpy==' 'numpy>=' \
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
###### Motivation for this change

Closes #277306

###### Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
