### PR TITLE
pkgs/stdenv/linux: update riscv64 bootstrap-files

### DIFF
--- a/pkgs/stdenv/linux/bootstrap-files/riscv64-unknown-linux-gnu.nix
+++ b/pkgs/stdenv/linux/bootstrap-files/riscv64-unknown-linux-gnu.nix
@@ -1,12 +1,26 @@
+#
+# Files came from this Hydra build:
+#
+#   https://hydra.nixos.org/build/246376732
+#
+# Which used nixpkgs revision 160cedc144aced7a35a91440b46b74ffacd52682
+# to instantiate:
+#
+#   /nix/store/cpiajh4l83b08pynwiwkpxj53d78pcxr-stdenv-bootstrap-tools-riscv64-unknown-linux-gnu.drv
+#
+# and then built:
+#
+#   /nix/store/8a92pj40awdw585mcb9dvm4nyb03k3q3-stdenv-bootstrap-tools-riscv64-unknown-linux-gnu
+#
 {
   busybox = import <nix/fetchurl.nix> {
-    url = "http://tarballs.nixos.org/stdenv-linux/riscv64/9bd3cf0063b80428bd85a286205adab4b6ffcbd6/busybox";
-    sha256 = "6f61912f94bc4ef287d1ff48a9521ed16bd07d8d8ec775e471f32c64d346583d";
+    url = "http://tarballs.nixos.org/stdenv-linux/riscv64/160cedc144aced7a35a91440b46b74ffacd52682/busybox";
+    sha256 = "sha256-OGO96QUzs2n5pGipn/V87AxzUY9OWKZl417nE8HdZIE=";
     executable = true;
   };
 
   bootstrapTools = import <nix/fetchurl.nix> {
-    url = "http://tarballs.nixos.org/stdenv-linux/riscv64/9bd3cf0063b80428bd85a286205adab4b6ffcbd6/bootstrap-tools.tar.xz";
-    sha256 = "5466b19288e980125fc62ebb864d09908ffe0bc50cebe52cfee89acff14d5b9f";
+    url = "http://tarballs.nixos.org/stdenv-linux/riscv64/160cedc144aced7a35a91440b46b74ffacd52682/bootstrap-tools.tar.xz";
+    sha256 = "sha256-0LxRd7fdafQezNJ+N2tuOfm0KEwgfRSts5fhP0e0r0s=";
   };
 }


### PR DESCRIPTION
###### Description of changes

This PR updates the bootstrap tarballs for riscv64-linux with new Hydra-generated ones.

Fixes #275848 (bootstrap assembler too old to build gcc 13).

I'll be following the script used in #151399, #168199, #183487, and #188334.

Files came from [this](https://hydra.nixos.org/build/246376732#tabs-summary) Hydra build, which used nixpkgs revision 160cedc144aced7a35a91440b46b74ffacd52682 to instantiate:

```
/nix/store/cpiajh4l83b08pynwiwkpxj53d78pcxr-stdenv-bootstrap-tools-riscv64-unknown-linux-gnu.drv
```

and then built:

```
/nix/store/8a92pj40awdw585mcb9dvm4nyb03k3q3-stdenv-bootstrap-tools-riscv64-unknown-linux-gnu
```

I downloaded these files from Hydra and prefetched them into the nix store with the following commands:

```
STOREPATH=8a92pj40awdw585mcb9dvm4nyb03k3q3-stdenv-bootstrap-tools-riscv64-unknown-linux-gnu
OPTIONS="--option binary-caches https://cache.nixos.org --option trusted-public-keys cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
nix store prefetch-file \
  file://$(nix store add-file --name bootstrap-tools.tar.xz  $(nix-store ${OPTIONS} -r /nix/store/${STOREPATH})/on-server/bootstrap-tools.tar.xz)
nix store prefetch-file --executable \
  file://$(nix store add-path --name busybox $(nix-store ${OPTIONS} -r /nix/store/${STOREPATH})/on-server/busybox)
```

These commands produced the following output:

```
Downloaded 'file:///nix/store/xs74wcxq3qc12plfc70fds8inbndhcfm-bootstrap-tools.tar.xz' to '/nix/store/3fal4gikp92013kac6rdmfbrch2s859b-xs74wcxq3qc12plfc70fds8inbndhcfm-bootstrap-tools.tar.xz' (hash 'sha256-0LxRd7fdafQezNJ+N2tuOfm0KEwgfRSts5fhP0e0r0s=').
Downloaded 'file:///nix/store/9ndpna6jrlac4y9fappdjm0sxx0g2bja-busybox' to '/nix/store/kb7wyy30y1gxcmdajljr26kxxac606qa-9ndpna6jrlac4y9fappdjm0sxx0g2bja-busybox' (hash 'sha256-OGO96QUzs2n5pGipn/V87AxzUY9OWKZl417nE8HdZIE=').
```

I used the hashes from the output above to create the `fetchurl` invocation which is part of this commit.

I then started the bootstrap with the following command:

```
nix build -L -f . --arg localSystem '(import ./lib).systems.examples.riscv64' hello
```

As @lovesegfault requested, here are the the `sha256sum`s of all the `on-server` components for extra verification:

```
sha256sum /nix/store/${STOREPATH}/on-server/*
```

which produced the following output:

```
d0bc5177b7dd69f41eccd27e376b6e39f9b4284c207d14adb397e13f47b4af4b  /nix/store/8a92pj40awdw585mcb9dvm4nyb03k3q3-stdenv-bootstrap-tools-riscv64-unknown-linux-gnu/on-server/bootstrap-tools.tar.xz
65f9433abb598f63c932d33351b14f686551512b1cece1e64c2d0e76aa0ec52e  /nix/store/8a92pj40awdw585mcb9dvm4nyb03k3q3-stdenv-bootstrap-tools-riscv64-unknown-linux-gnu/on-server/busybox
```

###### Things done

- Built on platform(s)
  - [x] riscv64-linux (`nix build -L hello`)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).