### PR TITLE
python311Packages.cwl-upgrader: 1.2.10 -> 1.2.11

### DIFF
--- a/pkgs/development/python-modules/cwl-upgrader/default.nix
+++ b/pkgs/development/python-modules/cwl-upgrader/default.nix
@@ -7,28 +7,32 @@
 , pythonOlder
 , ruamel-yaml
 , schema-salad
+, setuptools
 }:
 
 buildPythonPackage rec {
   pname = "cwl-upgrader";
-  version = "1.2.10";
-  format = "setuptools";
+  version = "1.2.11";
+  pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "common-workflow-language";
-    repo = pname;
+    repo = "cwl-upgrader";
     rev = "refs/tags/v${version}";
-    hash = "sha256-D/MIvn/jyxK++CMgKM8EYDVo94WFgdlTtMZjsXoQ4W4=";
+    hash = "sha256-P8607Io/KIJqAnrValM+rRK59tQITcC/jyGwkge8qN0=";
   };
 
   postPatch = ''
-    substituteInPlace setup.py \
-      --replace "ruamel.yaml >= 0.15, < 0.17.22" "ruamel.yaml" \
-      --replace "setup_requires=PYTEST_RUNNER," ""
-    sed -i "/ruamel.yaml/d" setup.py
+    # Version detection doesn't work for schema_salad
+    substituteInPlace pyproject.toml \
+      --replace '"schema_salad",' ""
   '';
+
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   propagatedBuildInputs = [
     mypy-extensions
@@ -46,9 +50,9 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    description = "Library to interface with Yolink";
-    homepage = "https://github.com/common-workflow-language/cwl-utils";
-    changelog = "https://github.com/common-workflow-language/cwl-utils/releases/tag/v${version}";
+    description = "Library to upgrade CWL syntax to a newer version";
+    homepage = "https://github.com/common-workflow-language/cwl-upgrader";
+    changelog = "https://github.com/common-workflow-language/cwl-upgrader/releases/tag/v${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ fab ];
   };


### PR DESCRIPTION
Diff: https://github.com/common-workflow-language/cwl-upgrader/compare/refs/tags/v1.2.10...v1.2.11

Changelog: https://github.com/common-workflow-language/cwl-upgrader/releases/tag/v1.2.11

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
