### PR TITLE
mujoco: 3.1.0 -> 3.1.1

### DIFF
--- a/pkgs/applications/science/robotics/mujoco/default.nix
+++ b/pkgs/applications/science/robotics/mujoco/default.nix
@@ -129,15 +129,15 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "mujoco";
-  version = "3.1.0";
+  version = "3.1.1";
 
   # Bumping version? Make sure to look though the MuJoCo's commit
   # history for bumped dependency pins!
   src = fetchFromGitHub {
     owner = "google-deepmind";
-    repo = pname;
-    rev = version;
-    hash = "sha256-a8h30psoAlj9dI4j8IfY3WzWjY4MrRosGbvgt79s1BQ=";
+    repo = "mujoco";
+    rev = "refs/tags/${version}";
+    hash = "sha256-+2nt7G8j6Pi60cfMBPYWPGwD8wpxDOSylenm0oCitzM=";
   };
 
   patches = [ ./mujoco-system-deps-dont-fetch.patch ];
@@ -180,6 +180,7 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Multi-Joint dynamics with Contact. A general purpose physics simulator.";
     homepage = "https://mujoco.org/";
+    changelog = "https://github.com/google-deepmind/mujoco/releases/tag/${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ samuela tmplt ];
   };

--- a/pkgs/development/python-modules/mujoco/default.nix
+++ b/pkgs/development/python-modules/mujoco/default.nix
@@ -12,6 +12,7 @@
 , pyopengl
 , python
 , setuptools
+, stdenv
 }:
 
 buildPythonPackage rec {
@@ -56,11 +57,15 @@ buildPythonPackage rec {
       # E.g. 3.11.2 -> "311"
       pythonVersionMajorMinor = with lib.versions;
         "${major python.pythonVersion}${minor python.pythonVersion}";
+
+      # E.g. "linux-aarch64"
+      platform = with stdenv.hostPlatform.parsed;
+        "${kernel.name}-${cpu.name}";
     in ''
       ${perl}/bin/perl -0777 -i -pe "s/GIT_REPO\n.*\n.*GIT_TAG\n.*\n//gm" mujoco/CMakeLists.txt
       ${perl}/bin/perl -0777 -i -pe "s/(FetchContent_Declare\(\n.*lodepng\n.*)(GIT_REPO.*\n.*GIT_TAG.*\n)(.*\))/\1\3/gm" mujoco/simulate/CMakeLists.txt
 
-      build="/build/${pname}-${version}/build/temp.linux-x86_64-cpython-${pythonVersionMajorMinor}/"
+      build="/build/${pname}-${version}/build/temp.${platform}-cpython-${pythonVersionMajorMinor}/"
       mkdir -p $build/_deps
       ln -s ${mujoco.pin.lodepng} $build/_deps/lodepng-src
       ln -s ${mujoco.pin.eigen3} $build/_deps/eigen-src

--- a/pkgs/development/python-modules/mujoco/default.nix
+++ b/pkgs/development/python-modules/mujoco/default.nix
@@ -1,13 +1,15 @@
-{ buildPythonPackage
+{ absl-py
+, buildPythonPackage
 , cmake
+, etils
 , fetchPypi
 , glfw
 , lib
 , mujoco
 , numpy
 , perl
-, pkgs
 , pybind11
+, pyopengl
 , python
 , setuptools
 }:
@@ -30,7 +32,13 @@ buildPythonPackage rec {
   nativeBuildInputs = [ cmake setuptools ];
   dontUseCmakeConfigure = true;
   buildInputs = [ mujoco pybind11 ];
-  propagatedBuildInputs = [ glfw numpy ];
+  propagatedBuildInputs = [
+    absl-py
+    etils
+    glfw
+    numpy
+    pyopengl
+  ];
 
   pythonImportsCheck = [ "${pname}" ];
 

--- a/pkgs/development/python-modules/mujoco/default.nix
+++ b/pkgs/development/python-modules/mujoco/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "mujoco";
-  version = "3.1.0";
+  version = "3.1.1";
 
   pyproject = true;
 
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   # in the project's CI.
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-rZNVihIuvNJnQWqA5tV9DG5r3/LttWNW6fN2js+fDb8=";
+    hash = "sha256-ESEnPeL79O0wnllEo9s50B84WyINIOeMRg7E78BpRbM=";
   };
 
   nativeBuildInputs = [ cmake setuptools ];
@@ -76,6 +76,7 @@ buildPythonPackage rec {
     description =
       "Python bindings for MuJoCo: a general purpose physics simulator.";
     homepage = "https://mujoco.org/";
+    changelog = "https://github.com/google-deepmind/mujoco/releases/tag/${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ tmplt ];
   };


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/google-deepmind/mujoco/releases/tag/3.1.1

cc @tmplt @samuela 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
