### PR TITLE
anbox: fix build

### DIFF
--- a/pkgs/os-specific/linux/anbox/default.nix
+++ b/pkgs/os-specific/linux/anbox/default.nix
@@ -80,10 +80,13 @@ stdenv.mkDerivation rec {
     systemd
   ];
 
-  # Flag needed by GCC 12 but unrecognized by GCC 9 (aarch64-linux default now)
-  env.NIX_CFLAGS_COMPILE = toString (lib.optionals (with stdenv; cc.isGNU && lib.versionAtLeast cc.version "12") [
-    "-Wno-error=mismatched-new-delete"
-  ]);
+  env.CXXFLAGS = toString [ "-include cstdint" ];
+
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isGNU (toString [
+    "-Wno-error=redundant-move"
+    # Flag needed by GCC 12 but unrecognized by GCC 9 (aarch64-linux default now)
+    (lib.optionalString (lib.versionAtLeast stdenv.cc.version "12") "-Wno-error=mismatched-new-delete")
+   ]);
 
   prePatch = ''
     patchShebangs scripts


### PR DESCRIPTION
anbox: fix build

Errors as:

>  error: redundant move in initialization

fixes https://github.com/NixOS/nixpkgs/issues/282601

Possible fix:

> env.CXXFLAGS = toString [ "-include cstdint" ];

> env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error=redundant-move" ];

Problems:
* fails to build with:
  - other GCC versions
  - clang
    > error: no matching constructor for initialization of 'std::unique_lock<std::mutex>'
    > std::unique_lock<std::mutex> lock(mutex);
