### PR TITLE
obs-studio-plugins.obs-composite-blur: init at 1.1.0

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -20,6 +20,8 @@
 
   obs-command-source = callPackage ./obs-command-source.nix { };
 
+  obs-composite-blur = callPackage ./obs-composite-blur.nix { };
+
   obs-freeze-filter = qt6Packages.callPackage ./obs-freeze-filter.nix { };
 
   obs-gradient-source = callPackage ./obs-gradient-source.nix { };

--- a/pkgs/applications/video/obs-studio/plugins/obs-composite-blur.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-composite-blur.nix
@@ -1,0 +1,35 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, obs-studio
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "obs-composite-blur";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "FiniteSingularity";
+    repo = "obs-composite-blur";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-icn0X+c7Uf0nTFaVDVTPi26sfWTSeoAj7+guEn9gi9Y=";
+  };
+
+  buildInputs = [
+    obs-studio
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  meta = with lib; {
+    description = "A comprehensive blur plugin for OBS that provides several different blur algorithms, and proper compositing";
+    homepage = "https://github.com/FiniteSingularity/obs-composite-blur";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ GaetanLepage ];
+    mainProgram = "obs-composite-blur";
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Add the [obs-composite-blur](https://github.com/FiniteSingularity/) plugin for OBS.

This is my first OBS plugin so I do not really have experience on that.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
