### PR TITLE
_9base: mark broken for x86_64-darwin

### DIFF
--- a/pkgs/by-name/_9/_9base/package.nix
+++ b/pkgs/by-name/_9/_9base/package.nix
@@ -70,8 +70,11 @@ stdenv.mkDerivation {
     license = with licenses; [ mit /* and */ lpl-102 ];
     maintainers = with maintainers; [ jk ];
     platforms = platforms.unix;
+    # Broken for x86_64-darwin at 2024-01-21
+    # error: call to undeclared function 'p9mbtowc'
+    # Tracking issue: https://github.com/NixOS/nixpkgs/issues/282641
     # needs additional work to support aarch64-darwin
     # due to usage of _DARWIN_NO_64_BIT_INODE
-    broken = stdenv.isAarch64 && stdenv.isDarwin;
+    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
_9base: mark broken for x86_64-darwin

Tracking issue: https://github.com/NixOS/nixpkgs/issues/282641

error: call to undeclared function 'p9mbtowc'

Log: https://hydra.nixos.org/build/246581677/nixlog/1

~~CC @jk~~

(A fix is available in PR 282669)