### PR TITLE
haskell.compiler.ghc96: 9.6.3 -> 9.6.4

### DIFF
--- a/pkgs/development/compilers/ghc/9.6.4.nix
+++ b/pkgs/development/compilers/ghc/9.6.4.nix
@@ -1,0 +1,5 @@
+import ./common-hadrian.nix rec {
+  version = "9.6.4";
+  sha256 = "sha256-EL8luLBxdP3ZhotcDFbBfA7x7ctiR7S4ZL6TNlG/1MA=";
+}
+

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -24,6 +24,7 @@ let
     "ghc948"
     "ghc96"
     "ghc963"
+    "ghc964"
     "ghc98"
     "ghc981"
     "ghcHEAD"
@@ -278,7 +279,25 @@ in {
       buildTargetLlvmPackages = pkgsBuildTarget.llvmPackages_15;
       llvmPackages = pkgs.llvmPackages_15;
     };
-    ghc96 = compiler.ghc963;
+    ghc964 = callPackage ../development/compilers/ghc/9.6.4.nix {
+      bootPkgs =
+        # For GHC 9.2 no armv7l bindists are available.
+        if stdenv.hostPlatform.isAarch32 then
+          packages.ghc928
+        else if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
+          packages.ghc928
+        else
+          packages.ghc924Binary;
+      inherit (buildPackages.python3Packages) sphinx;
+      # Need to use apple's patched xattr until
+      # https://github.com/xattr/xattr/issues/44 and
+      # https://github.com/xattr/xattr/issues/55 are solved.
+      inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
+      # Support range >= 11 && < 16
+      buildTargetLlvmPackages = pkgsBuildTarget.llvmPackages_15;
+      llvmPackages = pkgs.llvmPackages_15;
+    };
+    ghc96 = compiler.ghc964;
     ghc981 = callPackage ../development/compilers/ghc/9.8.1.nix {
       # No bindist packaged for 9.4.* yet
       bootPkgs = packages.ghc947;
@@ -419,6 +438,11 @@ in {
     ghc963 = callPackage ../development/haskell-modules {
       buildHaskellPackages = bh.packages.ghc963;
       ghc = bh.compiler.ghc963;
+      compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.6.x.nix { };
+    };
+    ghc964 = callPackage ../development/haskell-modules {
+      buildHaskellPackages = bh.packages.ghc964;
+      ghc = bh.compiler.ghc964;
       compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.6.x.nix { };
     };
     ghc96 = packages.ghc963;

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -71,6 +71,7 @@ let
     ghc947
     ghc948
     ghc963
+    ghc964
     ghc981
   ];
 
@@ -511,11 +512,11 @@ let
         compilerNames.ghc902
       ] released;
       hoogle = lib.subtractLists [
-        compilerNames.ghc963
+        compilerNames.ghc964
         compilerNames.ghc981
       ] released;
       hlint = lib.subtractLists [
-        compilerNames.ghc963
+        compilerNames.ghc964
         compilerNames.ghc981
       ] released;
       hpack = lib.subtractLists [
@@ -575,6 +576,7 @@ let
         compilerNames.ghc947
         compilerNames.ghc948
         compilerNames.ghc963
+        compilerNames.ghc964
       ];
     })
     {


### PR DESCRIPTION
## Description of changes

This includes a variety of important fixes, including an issue breaking cross-compilation

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] cross armv7-linux
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
