### PR TITLE
backblaze2-b2: support alternative executable name

### DIFF
--- a/pkgs/development/tools/backblaze-b2/default.nix
+++ b/pkgs/development/tools/backblaze-b2/default.nix
@@ -1,4 +1,7 @@
-{ lib, python3Packages, fetchPypi, installShellFiles, testers, backblaze-b2 }:
+{ lib, python3Packages, fetchPypi, installShellFiles, testers, backblaze-b2
+# executable is renamed to backblaze-b2 by default, to avoid collision with boost's 'b2'
+, execName ? "backblaze-b2"
+}:
 
 python3Packages.buildPythonApplication rec {
   pname = "backblaze-b2";
@@ -68,17 +71,18 @@ python3Packages.buildPythonApplication rec {
     "test/unit/console_tool"
   ];
 
-  postInstall = ''
-    mv "$out/bin/b2" "$out/bin/backblaze-b2"
-
-    installShellCompletion --cmd backblaze-b2 \
-      --bash <(${python3Packages.argcomplete}/bin/register-python-argcomplete backblaze-b2) \
-      --zsh <(${python3Packages.argcomplete}/bin/register-python-argcomplete backblaze-b2)
+  postInstall = lib.optionalString (execName != "b2") ''
+    mv "$out/bin/b2" "$out/bin/${execName}"
+  ''
+  + ''
+    installShellCompletion --cmd ${execName} \
+      --bash <(${python3Packages.argcomplete}/bin/register-python-argcomplete ${execName}) \
+      --zsh <(${python3Packages.argcomplete}/bin/register-python-argcomplete ${execName})
   '';
 
   passthru.tests.version = (testers.testVersion {
     package = backblaze-b2;
-    command = "backblaze-b2 version --short";
+    command = "${execName} version --short";
   }).overrideAttrs (old: {
     # workaround the error: Permission denied: '/homeless-shelter'
     # backblaze-b2 fails to create a 'b2' directory under the XDG config path


### PR DESCRIPTION
according to official doc backblaze.com/docs/cloud-storage-command-line-tools mentions the executable is supposed to be called `b2`. Several distributions including nixpkgs renamed it to `backblaze-b2` but it is annoying if you dont use boost's b2.
This commit makes it possible to override the executable name to something else.

see https://github.com/NixOS/nixpkgs/issues/278098

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
