### PR TITLE
python3.pkgs.sphinxemoji: Fix missing propagated dependency on "setuptools"

### DIFF
--- a/pkgs/development/python-modules/sphinxemoji/default.nix
+++ b/pkgs/development/python-modules/sphinxemoji/default.nix
@@ -27,6 +27,8 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     sphinx
+    # sphinxemoji.py imports pkg_resources directly
+    setuptools
    ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
# python3.pkgs.sphinx-notfound-page: Fix build

```
python3.pkgs.sphinx-notfound-page: Fix build
python3.pkgs.sphinx-version-warning: Fix build
```

## Build info of packages affected directly
### python3.pkgs.sphinx-version-warning

<details><summary>content of python3.pkgs.sphinx-version-warning.dist</summary>

```
/nix/store/7k94rsyas84cdkzrzk91mzhvlm3dsamp-python3.11-sphinx-version-warning-unstable-2019-08-10-dist
└── sphinx_version_warning-1.1.2.dev0-py3-none-any.whl

0 directories, 1 file
```
</details>

<details><summary>content of python3.pkgs.sphinx-version-warning.doc</summary>

```
/nix/store/p6qpkc0zfgnbw5gncsfalab648qimkih-python3.11-sphinx-version-warning-unstable-2019-08-10-doc
└── share
    └── doc
        └── python3.11-sphinx-version-warning-unstable-2019-08-10
            └── html
                ├── _images
                │   ├── cilium-example.png
                │   └── marshmallow-example.png
                ├── _static
                │   ├── _sphinx_javascript_frameworks_compat.js
                │   ├── basic.css
                │   ├── css
                │   │   ├── badge_only.css
                │   │   ├── fonts
                │   │   │   ├── Roboto-Slab-Bold.woff
                │   │   │   ├── Roboto-Slab-Bold.woff2
                │   │   │   ├── Roboto-Slab-Regular.woff
                │   │   │   ├── Roboto-Slab-Regular.woff2
                │   │   │   ├── fontawesome-webfont.eot
                │   │   │   ├── fontawesome-webfont.svg
                │   │   │   ├── fontawesome-webfont.ttf
                │   │   │   ├── fontawesome-webfont.woff
                │   │   │   ├── fontawesome-webfont.woff2
                │   │   │   ├── lato-bold-italic.woff
                │   │   │   ├── lato-bold-italic.woff2
                │   │   │   ├── lato-bold.woff
                │   │   │   ├── lato-bold.woff2
                │   │   │   ├── lato-normal-italic.woff
                │   │   │   ├── lato-normal-italic.woff2
                │   │   │   ├── lato-normal.woff
                │   │   │   └── lato-normal.woff2
                │   │   └── theme.css
                │   ├── data
                │   │   └── versionwarning-data.json
                │   ├── doctools.js
                │   ├── documentation_options.js
                │   ├── file.png
                │   ├── graphviz.css
                │   ├── jquery.js
                │   ├── js
                │   │   ├── badge_only.js
                │   │   ├── html5shiv-printshiv.min.js
                │   │   ├── html5shiv.min.js
                │   │   ├── theme.js
                │   │   └── versionwarning.js
                │   ├── language_data.js
                │   ├── minus.png
                │   ├── plus.png
                │   ├── pygments.css
                │   ├── searchtools.js
                │   ├── sphinx_highlight.js
                │   ├── tabs.css
                │   ├── tabs.js
                │   ├── twemoji.css
                │   └── twemoji.js
                ├── autoapi
                │   └── versionwarning
                │       ├── extension
                │       │   └── index.html
                │       ├── index.html
                │       └── signals
                │           └── index.html
                ├── configuration.html
                ├── genindex.html
                ├── get-involved.html
                ├── index.html
                ├── installation.html
                ├── objects.inv
                ├── py-modindex.html
                ├── releasing.html
                ├── search.html
                ├── searchindex.js
                └── who-is-using-it.html

14 directories, 58 files
```
</details>

<details><summary>content of python3.pkgs.sphinx-version-warning.out</summary>

```
/nix/store/fh61msfd7ll3vsn1zxlkyl5w4v646hh8-python3.11-sphinx-version-warning-unstable-2019-08-10
├── lib
│   └── python3.11
│       └── site-packages
│           ├── sphinx_version_warning-1.1.2.dev0.dist-info
│           │   ├── LICENSE
│           │   ├── METADATA
│           │   ├── RECORD
│           │   ├── WHEEL
│           │   └── top_level.txt
│           └── versionwarning
│               ├── __init__.py
│               ├── __pycache__
│               │   ├── __init__.cpython-311.opt-1.pyc
│               │   ├── __init__.cpython-311.pyc
│               │   ├── extension.cpython-311.opt-1.pyc
│               │   ├── extension.cpython-311.pyc
│               │   ├── signals.cpython-311.opt-1.pyc
│               │   └── signals.cpython-311.pyc
│               ├── _static
│               │   ├── data
│               │   │   └── versionwarning-data.json
│               │   └── js
│               │       └── versionwarning.js
│               ├── extension.py
│               └── signals.py
└── nix-support
    └── propagated-build-inputs

10 directories, 17 files
```
</details>

<details><summary>build log of python3.pkgs.sphinx-version-warning</summary>

```
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing setuptools-build-hook
Using setuptoolsBuildPhase
Using setuptoolsShellHook
Sourcing pypa-install-hook
Using pypaInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing sphinx-hook
Sourcing setuptools-check-hook
Using setuptoolsCheckPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
Running phase: unpackPhase
unpacking source archive /nix/store/5is45d7c5hdip41nrdw2kimyhjipp38i-source
source root is source
setting SOURCE_DATE_EPOCH to timestamp 315619200 of file source/webpack.config.js
@nix { "action": "setPhase", "phase": "patchPhase" }
Running phase: patchPhase
applying patch /nix/store/kdzh1nff2rclaqny52m8s9ikxx7sz3p3-cb1b47becf2a0d3b2570ca9929f42f7d7e472b6f.patch
patching file versionwarning/signals.py
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "configurePhase" }
Running phase: configurePhase
no configure script, doing nothing
@nix { "action": "setPhase", "phase": "buildPhase" }
Running phase: buildPhase
Executing setuptoolsBuildPhase
Warning: 'classifiers' should be a list, got type 'tuple'
running bdist_wheel
running build
running build_py
creating build
creating build/lib
creating build/lib/versionwarning
copying versionwarning/__init__.py -> build/lib/versionwarning
copying versionwarning/extension.py -> build/lib/versionwarning
copying versionwarning/signals.py -> build/lib/versionwarning
running egg_info
creating sphinx_version_warning.egg-info
writing sphinx_version_warning.egg-info/PKG-INFO
writing dependency_links to sphinx_version_warning.egg-info/dependency_links.txt
writing requirements to sphinx_version_warning.egg-info/requires.txt
writing top-level names to sphinx_version_warning.egg-info/top_level.txt
writing manifest file 'sphinx_version_warning.egg-info/SOURCES.txt'
reading manifest file 'sphinx_version_warning.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
adding license file 'LICENSE'
writing manifest file 'sphinx_version_warning.egg-info/SOURCES.txt'
/nix/store/7fnhc3nd125lq9vzw6bghsvbnmcc8mc1-python3.11-setuptools-69.0.2/lib/python3.11/site-packages/setuptools/command/build_py.py:207: _Warning: Package 'versionwarning._static.js' is absent from the `packages` configuration.
!!

        ********************************************************************************
        ############################
        # Package would be ignored #
        ############################
        Python recognizes 'versionwarning._static.js' as an importable package[^1],
        but it is absent from setuptools' `packages` configuration.

        This leads to an ambiguous overall configuration. If you want to distribute this
        package, please make sure that 'versionwarning._static.js' is explicitly added
        to the `packages` configuration field.

        Alternatively, you can also rely on setuptools' discovery methods
        (for example by using `find_namespace_packages(...)`/`find_namespace:`
        instead of `find_packages(...)`/`find:`).

        You can read more about "package discovery" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

        If you don't want 'versionwarning._static.js' to be distributed and are
        already explicitly excluding 'versionwarning._static.js' via
        `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
        you can try to use `exclude_package_data`, or `include-package-data=False` in
        combination with a more fine grained `package-data` configuration.

        You can read more about "package data files" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


        [^1]: For Python, any directory (with suitable naming) can be imported,
              even if it does not contain any `.py` files.
              On the other hand, currently there is no concept of package data
              directory, all directories are treated like packages.
        ********************************************************************************

!!
  check.warn(importable)
creating build/lib/versionwarning/_static
creating build/lib/versionwarning/_static/js
copying versionwarning/_static/js/versionwarning.js -> build/lib/versionwarning/_static/js
/nix/store/7fnhc3nd125lq9vzw6bghsvbnmcc8mc1-python3.11-setuptools-69.0.2/lib/python3.11/site-packages/setuptools/_distutils/cmd.py:66: SetuptoolsDeprecationWarning: setup.py install is deprecated.
!!

        ********************************************************************************
        Please avoid running ``setup.py`` directly.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
        ********************************************************************************

!!
  self.initialize_options()
installing to build/bdist.linux-x86_64/wheel
running install
running install_lib
creating build/bdist.linux-x86_64
creating build/bdist.linux-x86_64/wheel
creating build/bdist.linux-x86_64/wheel/versionwarning
copying build/lib/versionwarning/__init__.py -> build/bdist.linux-x86_64/wheel/versionwarning
copying build/lib/versionwarning/extension.py -> build/bdist.linux-x86_64/wheel/versionwarning
copying build/lib/versionwarning/signals.py -> build/bdist.linux-x86_64/wheel/versionwarning
creating build/bdist.linux-x86_64/wheel/versionwarning/_static
creating build/bdist.linux-x86_64/wheel/versionwarning/_static/js
copying build/lib/versionwarning/_static/js/versionwarning.js -> build/bdist.linux-x86_64/wheel/versionwarning/_static/js
running install_egg_info
Copying sphinx_version_warning.egg-info to build/bdist.linux-x86_64/wheel/sphinx_version_warning-1.1.2.dev0-py3.11.egg-info
running install_scripts
creating build/bdist.linux-x86_64/wheel/sphinx_version_warning-1.1.2.dev0.dist-info/WHEEL
creating 'dist/sphinx_version_warning-1.1.2.dev0-py3-none-any.whl' and adding 'build/bdist.linux-x86_64/wheel' to it
adding 'versionwarning/__init__.py'
adding 'versionwarning/extension.py'
adding 'versionwarning/signals.py'
adding 'versionwarning/_static/js/versionwarning.js'
adding 'sphinx_version_warning-1.1.2.dev0.dist-info/LICENSE'
adding 'sphinx_version_warning-1.1.2.dev0.dist-info/METADATA'
adding 'sphinx_version_warning-1.1.2.dev0.dist-info/WHEEL'
adding 'sphinx_version_warning-1.1.2.dev0.dist-info/top_level.txt'
adding 'sphinx_version_warning-1.1.2.dev0.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel
Finished executing setuptoolsBuildPhase
@nix { "action": "setPhase", "phase": "installPhase" }
Running phase: installPhase
Executing pypaInstallPhase
Successfully installed sphinx_version_warning-1.1.2.dev0-py3-none-any.whl
Finished executing pypaInstallPhase
@nix { "action": "setPhase", "phase": "pythonOutputDistPhase" }
Running phase: pythonOutputDistPhase
Executing pythonOutputDistPhase
Finished executing pythonOutputDistPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
Running phase: fixupPhase
shrinking RPATHs of ELF executables and libraries in /nix/store/fh61msfd7ll3vsn1zxlkyl5w4v646hh8-python3.11-sphinx-version-warning-unstable-2019-08-10
checking for references to /build/ in /nix/store/fh61msfd7ll3vsn1zxlkyl5w4v646hh8-python3.11-sphinx-version-warning-unstable-2019-08-10...
patching script interpreter paths in /nix/store/fh61msfd7ll3vsn1zxlkyl5w4v646hh8-python3.11-sphinx-version-warning-unstable-2019-08-10
stripping (with command strip and flags -S -p) in  /nix/store/fh61msfd7ll3vsn1zxlkyl5w4v646hh8-python3.11-sphinx-version-warning-unstable-2019-08-10/lib
shrinking RPATHs of ELF executables and libraries in /nix/store/7k94rsyas84cdkzrzk91mzhvlm3dsamp-python3.11-sphinx-version-warning-unstable-2019-08-10-dist
checking for references to /build/ in /nix/store/7k94rsyas84cdkzrzk91mzhvlm3dsamp-python3.11-sphinx-version-warning-unstable-2019-08-10-dist...
patching script interpreter paths in /nix/store/7k94rsyas84cdkzrzk91mzhvlm3dsamp-python3.11-sphinx-version-warning-unstable-2019-08-10-dist
Executing pythonRemoveTestsDir
Finished executing pythonRemoveTestsDir
@nix { "action": "setPhase", "phase": "installCheckPhase" }
Running phase: installCheckPhase
no Makefile or custom installCheckPhase, doing nothing
@nix { "action": "setPhase", "phase": "pythonCatchConflictsPhase" }
Running phase: pythonCatchConflictsPhase
@nix { "action": "setPhase", "phase": "pythonRemoveBinBytecodePhase" }
Running phase: pythonRemoveBinBytecodePhase
@nix { "action": "setPhase", "phase": "pythonImportsCheckPhase" }
Running phase: pythonImportsCheckPhase
Executing pythonImportsCheckPhase
Check whether the following modules can be imported: versionwarning
@nix { "action": "setPhase", "phase": "buildSphinxPhase" }
Running phase: buildSphinxPhase
Executing buildSphinxPhase
Sphinx documentation found in docs
Executing sphinx-build with html builder
Running Sphinx v7.2.6
WARNING: Invalid configuration value found: 'language = None'. Update your configuration to a valid language code. Falling back to 'en' (English).
WARNING: html_static_path entry '_static' does not exist
locale_dir /build/source/docs/locales/en/LC_MESSAGES does not exist
[AutoAPI] Reading files... [ 33%] /build/source/versionwarning/__init__.py
[AutoAPI] Reading files... [ 67%] /build/source/versionwarning/extension.py
[AutoAPI] Reading files... [100%] /build/source/versionwarning/signals.py
[AutoAPI] Mapping Data... [ 33%] /build/source/versionwarning/__init__.py
[AutoAPI] Mapping Data... [ 67%] /build/source/versionwarning/extension.py
[AutoAPI] Mapping Data... [100%] /build/source/versionwarning/signals.py
[AutoAPI] Rendering Data... [ 33%] versionwarning
Rendering versionwarning
Rendering versionwarning.name
Rendering versionwarning.version
[AutoAPI] Rendering Data... [ 67%] versionwarning.extension
Rendering versionwarning.extension
Rendering versionwarning.extension.setup
[AutoAPI] Rendering Data... [100%] versionwarning.signals
Rendering versionwarning.signals
Rendering versionwarning.signals.STATIC_PATH
Rendering versionwarning.signals.JSON_DATA_FILENAME
Rendering versionwarning.signals.generate_versionwarning_data_json

[autosummary] generating autosummary for: configuration.rst, get-involved.rst, index.rst, installation.rst, releasing.rst, who-is-using-it.rst
locale_dir /build/source/docs/locales/en/LC_MESSAGES does not exist
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 6 source files that are out of date
updating environment: locale_dir /build/source/docs/locales/en/LC_MESSAGES does not exist
[new config] 9 added, 0 changed, 0 removed
reading sources... [ 11%] autoapi/versionwarning/extension/index
reading sources... [ 22%] autoapi/versionwarning/index
reading sources... [ 33%] autoapi/versionwarning/signals/index
reading sources... [ 44%] configuration
reading sources... [ 56%] get-involved
reading sources... [ 67%] index
reading sources... [ 78%] installation
reading sources... [ 89%] releasing
reading sources... [100%] who-is-using-it

looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... copying static files... done
copying extra files... done
done
writing output... [ 11%] autoapi/versionwarning/extension/index
writing output... [ 22%] autoapi/versionwarning/index
writing output... [ 33%] autoapi/versionwarning/signals/index
writing output... [ 44%] configuration
writing output... [ 56%] get-involved
writing output... [ 67%] index
writing output... [ 78%] installation
writing output... [ 89%] releasing
writing output... [100%] who-is-using-it

generating indices... genindex py-modindex done
writing additional pages... search done
copying images... [ 50%] marshmallow-example.png
copying images... [100%] cilium-example.png

dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 2 warnings.

The HTML pages are in .sphinx/html/html.
@nix { "action": "setPhase", "phase": "installSphinxPhase" }
Running phase: installSphinxPhase
Executing installSphinxPhase
@nix { "action": "setPhase", "phase": "setuptoolsCheckPhase" }
Running phase: setuptoolsCheckPhase
Executing setuptoolsCheckPhase
Warning: 'classifiers' should be a list, got type 'tuple'
running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
/nix/store/7fnhc3nd125lq9vzw6bghsvbnmcc8mc1-python3.11-setuptools-69.0.2/lib/python3.11/site-packages/setuptools/command/test.py:193: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.
!!

        ********************************************************************************
        Requirements should be satisfied by a PEP 517 installer.
        If you are using pip, you can try `pip install --use-pep517`.
        ********************************************************************************

!!
  ir_d = dist.fetch_build_eggs(dist.install_requires)
/nix/store/7fnhc3nd125lq9vzw6bghsvbnmcc8mc1-python3.11-setuptools-69.0.2/lib/python3.11/site-packages/setuptools/command/test.py:194: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.
!!

        ********************************************************************************
        Requirements should be satisfied by a PEP 517 installer.
        If you are using pip, you can try `pip install --use-pep517`.
        ********************************************************************************

!!
  tr_d = dist.fetch_build_eggs(dist.tests_require or [])
/nix/store/7fnhc3nd125lq9vzw6bghsvbnmcc8mc1-python3.11-setuptools-69.0.2/lib/python3.11/site-packages/setuptools/command/test.py:195: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.
!!

        ********************************************************************************
        Requirements should be satisfied by a PEP 517 installer.
        If you are using pip, you can try `pip install --use-pep517`.
        ********************************************************************************

!!
  er_d = dist.fetch_build_eggs(
running egg_info
writing sphinx_version_warning.egg-info/PKG-INFO
writing dependency_links to sphinx_version_warning.egg-info/dependency_links.txt
writing requirements to sphinx_version_warning.egg-info/requires.txt
writing top-level names to sphinx_version_warning.egg-info/top_level.txt
reading manifest file 'sphinx_version_warning.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
adding license file 'LICENSE'
writing manifest file 'sphinx_version_warning.egg-info/SOURCES.txt'
running build_ext

----------------------------------------------------------------------
Ran 0 tests in 0.000s

OK
Finished executing setuptoolsCheckPhase
```
</details>
### python3.pkgs.sphinx-notfound-page

<details><summary>content of python3.pkgs.sphinx-notfound-page.dist</summary>

```
/nix/store/s36q921m5yycvxmxyi40ycfvahp9nf4r-python3.11-sphinx-notfound-page-1.0.0-dist
└── sphinx_notfound_page-1.0.0-py3-none-any.whl

0 directories, 1 file
```
</details>

<details><summary>content of python3.pkgs.sphinx-notfound-page.doc</summary>

```
/nix/store/5046a4lfv8n6p0r5lq5m194400cnlms4-python3.11-sphinx-notfound-page-1.0.0-doc
└── share
    └── doc
        └── python3.11-sphinx-notfound-page-1.0.0
            └── html
                ├── 404.html
                ├── _images
                │   ├── 404-using-this-extension.png
                │   ├── 404-without-this-extension.png
                │   ├── docs.carpentries.org.png
                │   ├── docs.jina.ai.png
                │   ├── docs.pyvista.org.png
                │   ├── docs.readthedocs.io.png
                │   ├── loudly-crying-face.png
                │   ├── www.attrs.org.png
                │   ├── www.nengo.ai.png
                │   └── www.writethedocs.org.png
                ├── _static
                │   ├── _sphinx_javascript_frameworks_compat.js
                │   ├── basic.css
                │   ├── css
                │   │   ├── badge_only.css
                │   │   ├── fonts
                │   │   │   ├── Roboto-Slab-Bold.woff
                │   │   │   ├── Roboto-Slab-Bold.woff2
                │   │   │   ├── Roboto-Slab-Regular.woff
                │   │   │   ├── Roboto-Slab-Regular.woff2
                │   │   │   ├── fontawesome-webfont.eot
                │   │   │   ├── fontawesome-webfont.svg
                │   │   │   ├── fontawesome-webfont.ttf
                │   │   │   ├── fontawesome-webfont.woff
                │   │   │   ├── fontawesome-webfont.woff2
                │   │   │   ├── lato-bold-italic.woff
                │   │   │   ├── lato-bold-italic.woff2
                │   │   │   ├── lato-bold.woff
                │   │   │   ├── lato-bold.woff2
                │   │   │   ├── lato-normal-italic.woff
                │   │   │   ├── lato-normal-italic.woff2
                │   │   │   ├── lato-normal.woff
                │   │   │   └── lato-normal.woff2
                │   │   └── theme.css
                │   ├── doctools.js
                │   ├── documentation_options.js
                │   ├── file.png
                │   ├── graphviz.css
                │   ├── jquery.js
                │   ├── js
                │   │   ├── badge_only.js
                │   │   ├── html5shiv-printshiv.min.js
                │   │   ├── html5shiv.min.js
                │   │   └── theme.js
                │   ├── language_data.js
                │   ├── minus.png
                │   ├── plus.png
                │   ├── pygments.css
                │   ├── searchtools.js
                │   ├── sphinx_highlight.js
                │   ├── tabs.css
                │   ├── tabs.js
                │   ├── twemoji.css
                │   └── twemoji.js
                ├── autoapi
                │   └── notfound
                │       ├── extension
                │       │   └── index.html
                │       ├── index.html
                │       └── utils
                │           └── index.html
                ├── configuration.html
                ├── faq.html
                ├── genindex.html
                ├── get-involved.html
                ├── how-it-works.html
                ├── index.html
                ├── installation.html
                ├── objects.inv
                ├── py-modindex.html
                ├── search.html
                ├── searchindex.js
                └── who-is-using-it.html

13 directories, 66 files
```
</details>

<details><summary>content of python3.pkgs.sphinx-notfound-page.out</summary>

```
/nix/store/qkkj2nxajyvd1iw5fd9mmqlrnaawcpzk-python3.11-sphinx-notfound-page-1.0.0
├── lib
│   └── python3.11
│       └── site-packages
│           ├── notfound
│           │   ├── __init__.py
│           │   ├── __pycache__
│           │   │   ├── __init__.cpython-311.opt-1.pyc
│           │   │   ├── __init__.cpython-311.pyc
│           │   │   ├── extension.cpython-311.opt-1.pyc
│           │   │   ├── extension.cpython-311.pyc
│           │   │   ├── utils.cpython-311.opt-1.pyc
│           │   │   └── utils.cpython-311.pyc
│           │   ├── extension.py
│           │   └── utils.py
│           └── sphinx_notfound_page-1.0.0.dist-info
│               ├── LICENSE
│               ├── METADATA
│               ├── RECORD
│               └── WHEEL
└── nix-support
    └── propagated-build-inputs

7 directories, 14 files
```
</details>

<details><summary>build log of python3.pkgs.sphinx-notfound-page</summary>

```
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing pypa-build-hook
Using pypaBuildPhase
Sourcing python-runtime-deps-check-hook
Using pythonRuntimeDepsCheckHook
Sourcing pypa-install-hook
Using pypaInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing sphinx-hook
@nix { "action": "setPhase", "phase": "unpackPhase" }
Running phase: unpackPhase
unpacking source archive /nix/store/r6g6jc724xj2lc7fv2k8r35f7ff11pc8-source
source root is source
setting SOURCE_DATE_EPOCH to timestamp 315619200 of file source/tox.ini
@nix { "action": "setPhase", "phase": "patchPhase" }
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "configurePhase" }
Running phase: configurePhase
no configure script, doing nothing
@nix { "action": "setPhase", "phase": "buildPhase" }
Running phase: buildPhase
Executing pypaBuildPhase
Creating a wheel...
* Getting build dependencies for wheel...
* Building wheel...
Successfully built sphinx_notfound_page-1.0.0-py3-none-any.whl
Finished creating a wheel...
Finished executing pypaBuildPhase
@nix { "action": "setPhase", "phase": "pythonRuntimeDepsCheckHook" }
Running phase: pythonRuntimeDepsCheckHook
Executing pythonRuntimeDepsCheck
Checking runtime dependencies for sphinx_notfound_page-1.0.0-py3-none-any.whl
Finished executing pythonRuntimeDepsCheck
@nix { "action": "setPhase", "phase": "installPhase" }
Running phase: installPhase
Executing pypaInstallPhase
Successfully installed sphinx_notfound_page-1.0.0-py3-none-any.whl
Finished executing pypaInstallPhase
@nix { "action": "setPhase", "phase": "pythonOutputDistPhase" }
Running phase: pythonOutputDistPhase
Executing pythonOutputDistPhase
Finished executing pythonOutputDistPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
Running phase: fixupPhase
shrinking RPATHs of ELF executables and libraries in /nix/store/qkkj2nxajyvd1iw5fd9mmqlrnaawcpzk-python3.11-sphinx-notfound-page-1.0.0
checking for references to /build/ in /nix/store/qkkj2nxajyvd1iw5fd9mmqlrnaawcpzk-python3.11-sphinx-notfound-page-1.0.0...
patching script interpreter paths in /nix/store/qkkj2nxajyvd1iw5fd9mmqlrnaawcpzk-python3.11-sphinx-notfound-page-1.0.0
stripping (with command strip and flags -S -p) in  /nix/store/qkkj2nxajyvd1iw5fd9mmqlrnaawcpzk-python3.11-sphinx-notfound-page-1.0.0/lib
shrinking RPATHs of ELF executables and libraries in /nix/store/s36q921m5yycvxmxyi40ycfvahp9nf4r-python3.11-sphinx-notfound-page-1.0.0-dist
checking for references to /build/ in /nix/store/s36q921m5yycvxmxyi40ycfvahp9nf4r-python3.11-sphinx-notfound-page-1.0.0-dist...
patching script interpreter paths in /nix/store/s36q921m5yycvxmxyi40ycfvahp9nf4r-python3.11-sphinx-notfound-page-1.0.0-dist
Executing pythonRemoveTestsDir
Finished executing pythonRemoveTestsDir
@nix { "action": "setPhase", "phase": "installCheckPhase" }
Running phase: installCheckPhase
no Makefile or custom installCheckPhase, doing nothing
@nix { "action": "setPhase", "phase": "pythonCatchConflictsPhase" }
Running phase: pythonCatchConflictsPhase
@nix { "action": "setPhase", "phase": "pythonRemoveBinBytecodePhase" }
Running phase: pythonRemoveBinBytecodePhase
@nix { "action": "setPhase", "phase": "pythonImportsCheckPhase" }
Running phase: pythonImportsCheckPhase
Executing pythonImportsCheckPhase
Check whether the following modules can be imported: notfound
@nix { "action": "setPhase", "phase": "buildSphinxPhase" }
Running phase: buildSphinxPhase
Executing buildSphinxPhase
Sphinx documentation found in docs
Executing sphinx-build with html builder
Running Sphinx v7.2.6
making output directory... done
locale_dir /build/source/docs/locales/en/LC_MESSAGES does not exist
[AutoAPI] Reading files... [ 33%] /build/source/notfound/__init__.py
[AutoAPI] Reading files... [ 67%] /build/source/notfound/extension.py
[AutoAPI] Reading files... [100%] /build/source/notfound/utils.py
[AutoAPI] Mapping Data... [ 33%] /build/source/notfound/__init__.py
[AutoAPI] Mapping Data... [ 67%] /build/source/notfound/extension.py
[AutoAPI] Mapping Data... [100%] /build/source/notfound/utils.py
[AutoAPI] Rendering Data... [ 33%] notfound
Rendering notfound
Rendering notfound.__version__
[AutoAPI] Rendering Data... [ 67%] notfound.extension
Rendering notfound.extension
Rendering notfound.extension.BaseURIError
Rendering notfound.extension.html_collect_pages
Rendering notfound.extension.finalize_media
Rendering notfound.extension.doctree_resolved
Rendering notfound.extension.OrphanMetadataCollector
Rendering notfound.extension.OrphanMetadataCollector.clear_doc
Rendering notfound.extension.OrphanMetadataCollector.process_doc
Rendering notfound.extension.OrphanMetadataCollector.merge_other
Rendering notfound.extension.validate_configs
Rendering notfound.extension.setup
[AutoAPI] Rendering Data... [100%] notfound.utils
Rendering notfound.utils
Rendering notfound.utils.replace_uris

[autosummary] generating autosummary for: 404.rst, configuration.rst, faq.rst, get-involved.rst, how-it-works.rst, index.rst, installation.rst, who-is-using-it.rst
locale_dir /build/source/docs/locales/en/LC_MESSAGES does not exist
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 8 source files that are out of date
updating environment: locale_dir /build/source/docs/locales/en/LC_MESSAGES does not exist
[new config] 11 added, 0 changed, 0 removed
reading sources... [  9%] 404
reading sources... [ 18%] autoapi/notfound/extension/index
reading sources... [ 27%] autoapi/notfound/index
reading sources... [ 36%] autoapi/notfound/utils/index
reading sources... [ 45%] configuration
reading sources... [ 55%] faq
reading sources... [ 64%] get-involved
reading sources... [ 73%] how-it-works
reading sources... [ 82%] index
reading sources... [ 91%] installation
reading sources... [100%] who-is-using-it

looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... copying static files... done
copying extra files... done
done
writing output... [  9%] 404
writing output... [ 18%] autoapi/notfound/extension/index
writing output... [ 27%] autoapi/notfound/index
writing output... [ 36%] autoapi/notfound/utils/index
writing output... [ 45%] configuration
writing output... [ 55%] faq
writing output... [ 64%] get-involved
writing output... [ 73%] how-it-works
writing output... [ 82%] index
writing output... [ 91%] installation
writing output... [100%] who-is-using-it

generating indices... genindex py-modindex done
writing additional pages... search done
copying images... [ 10%] loudly-crying-face.png
copying images... [ 20%] 404-using-this-extension.png
copying images... [ 30%] 404-without-this-extension.png
copying images... [ 40%] _static/who-is-using-it/docs.readthedocs.io.png
copying images... [ 50%] _static/who-is-using-it/docs.pyvista.org.png
copying images... [ 60%] _static/who-is-using-it/www.writethedocs.org.png
copying images... [ 70%] _static/who-is-using-it/docs.carpentries.org.png
copying images... [ 80%] _static/who-is-using-it/www.attrs.org.png
copying images... [ 90%] _static/who-is-using-it/docs.jina.ai.png
copying images... [100%] _static/who-is-using-it/www.nengo.ai.png

dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in .sphinx/html/html.
@nix { "action": "setPhase", "phase": "installSphinxPhase" }
Running phase: installSphinxPhase
Executing installSphinxPhase
```
</details>
