### PR TITLE
Initial Magewell MWEcoCapture driver support

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7561,6 +7561,12 @@
       fingerprint = "A236 785D 59F1 9076 1E9C E8EC 7828 3DB3 D233 E1F9";
     }];
   };
+	hmelder = {
+    email = "contact@hugomelder.com";
+    github = "hmelder";
+    githubId = 45601940;
+    name = "Hugo Melder";
+	};
   hmenke = {
     name = "Henri Menke";
     email = "henri@henrimenke.de";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7561,12 +7561,12 @@
       fingerprint = "A236 785D 59F1 9076 1E9C E8EC 7828 3DB3 D233 E1F9";
     }];
   };
-	hmelder = {
+  hmelder = {
     email = "contact@hugomelder.com";
     github = "hmelder";
     githubId = 45601940;
     name = "Hugo Melder";
-	};
+  };
   hmenke = {
     name = "Henri Menke";
     email = "henri@henrimenke.de";

--- a/nixos/modules/hardware/video/capture/mwecocapture.nix
+++ b/nixos/modules/hardware/video/capture/mwecocapture.nix
@@ -1,0 +1,59 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+
+  cfg = config.hardware.mwEcoCapture;
+
+  kernelPackages = config.boot.kernelPackages;
+
+in
+
+{
+
+  options.hardware.mwEcoCapture.enable = mkEnableOption (lib.mdDoc "Magewell Eco Capture family kernel module");
+
+  config = mkIf cfg.enable {
+
+    boot.kernelModules = [ "MWEcoCapture" ];
+
+    environment.systemPackages = [ kernelPackages.mwecocapture ];
+
+    boot.extraModulePackages = [ kernelPackages.mwecocapture ];
+
+    boot.extraModprobeConfig = ''
+      # Set the png picture to be displayed when no input signal is detected.
+      options MWEcoCapture nosignal_file=${kernelPackages.mwecocapture}/res/NoSignal.png
+
+      # Set the png picture to be displayed when an unsupported input signal is detected.
+      options MWEcoCapture unsupported_file=${kernelPackages.mwecocapture}/res/Unsupported.png
+
+      # Set the png picture to be displayed when an loking input signal is detected.
+      options MWEcoCapture locking_file=${kernelPackages.mwecocapture}/res/Locking.png
+	  
+	  # Set the png picture to be displayed when the bandwidth is limited.
+	  options MWEcoCapture limited_bandwidth_file=${kernelPackages.mwecocapture}/res/LimitedBandwidth.png
+ 
+      # Message signaled interrupts switch
+      #options MWEcoCapture disable_msi=0
+
+      # Set the debug level
+      #options MWEcoCapture debug_level=0
+
+      # Min frame interval for VIDIOC_ENUM_FRAMEINTERVALS (default: 166666(100ns))
+      #options MWEcoCapture enum_frameinterval_min=166666
+
+      # VIDIOC_ENUM_FRAMESIZES type (1: DISCRETE; 2: STEPWISE; otherwise: CONTINUOUS )
+      #options MWEcoCapture enum_framesizes_type=0
+
+      # Enable raw mode of video for V4L2
+      #options MWEcoCapture enable_raw_mode=0
+
+      # Parameters for internal usage
+      #options MWEcoCapture internal_params=""
+    '';
+
+  };
+
+}

--- a/nixos/modules/hardware/video/capture/mwecocapture.nix
+++ b/nixos/modules/hardware/video/capture/mwecocapture.nix
@@ -31,10 +31,10 @@ in
 
       # Set the png picture to be displayed when an loking input signal is detected.
       options MWEcoCapture locking_file=${kernelPackages.mwecocapture}/res/Locking.png
-	  
-	  # Set the png picture to be displayed when the bandwidth is limited.
-	  options MWEcoCapture limited_bandwidth_file=${kernelPackages.mwecocapture}/res/LimitedBandwidth.png
- 
+
+      # Set the png picture to be displayed when the bandwidth is limited.
+      options MWEcoCapture limited_bandwidth_file=${kernelPackages.mwecocapture}/res/LimitedBandwidth.png
+
       # Message signaled interrupts switch
       #options MWEcoCapture disable_msi=0
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -103,6 +103,7 @@
   ./hardware/video/amdgpu-pro.nix
   ./hardware/video/bumblebee.nix
   ./hardware/video/capture/mwprocapture.nix
+  ./hardware/video/capture/mwecocapture.nix
   ./hardware/video/displaylink.nix
   ./hardware/video/nvidia.nix
   ./hardware/video/switcheroo-control.nix

--- a/pkgs/os-specific/linux/mwecocapture/default.nix
+++ b/pkgs/os-specific/linux/mwecocapture/default.nix
@@ -1,0 +1,57 @@
+{ lib, stdenv, fetchurl, kernel, alsa-lib }:
+
+with lib;
+
+let
+  bits =
+    if stdenv.is64bit then "64"
+    else "32";
+
+  libpath = makeLibraryPath [ stdenv.cc.cc stdenv.cc.libc alsa-lib ];
+
+in
+stdenv.mkDerivation rec {
+  pname = "mwecocapture";
+  driverVersion = "1.4.227";
+  version = "${driverVersion}-${kernel.version}";
+
+  src = fetchurl {
+    url = "https://www.magewell.com/files/drivers/EcoCaptureForLinuxX86_${driverVersion}.tar.gz";
+    sha256 = "sha256-ANnXCNNvdo0PzzzE9XDZWCqKu5NM5SGSMs5IgXJTkIk=";
+  };
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  preConfigure = ''
+    cd ./driver
+    export INSTALL_MOD_PATH="$out"
+  '';
+
+  hardeningDisable = [ "pic" "format" ];
+
+  makeFlags = [
+    "KERNELDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=implicit-fallthrough";
+
+  postInstall = ''
+    cd ../
+    mkdir -p $out/bin
+    cp bin/mweco-info_${bits} $out/bin/mweco-info
+    cp -r res $out
+
+    patchelf \
+      --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) \
+      --set-rpath "${libpath}" \
+      "$out"/bin/mweco-info
+  '';
+
+  meta = {
+    homepage = "https://www.magewell.com/";
+    description = "Linux driver for the Magewell Eco Capture family";
+    license = licenses.unfreeRedistributable;
+    maintainers = with maintainers; [ hmelder ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/os-specific/linux/mwecocapture/default.nix
+++ b/pkgs/os-specific/linux/mwecocapture/default.nix
@@ -53,5 +53,6 @@ stdenv.mkDerivation rec {
     license = licenses.unfreeRedistributable;
     maintainers = with maintainers; [ hmelder ];
     platforms = platforms.linux;
+    mainProgram = "mweco-info";
   };
 }

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -467,7 +467,7 @@ in {
     mba6x_bl = callPackage ../os-specific/linux/mba6x_bl { };
 
     mwprocapture = callPackage ../os-specific/linux/mwprocapture { };
-    
+
     mwecocapture = callPackage ../os-specific/linux/mwecocapture { };
 
     mxu11x0 = callPackage ../os-specific/linux/mxu11x0 { };

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -467,6 +467,8 @@ in {
     mba6x_bl = callPackage ../os-specific/linux/mba6x_bl { };
 
     mwprocapture = callPackage ../os-specific/linux/mwprocapture { };
+    
+    mwecocapture = callPackage ../os-specific/linux/mwecocapture { };
 
     mxu11x0 = callPackage ../os-specific/linux/mxu11x0 { };
 


### PR DESCRIPTION
## Description of changes

This pull request adds the driver for Magewell Eco Capture Cards. It was tested with the `Nanjing Magewell Electronics Co., Ltd. Eco Capture Dual HDMI M.2 (rev 01)`.

The driver can be enabled by adding the following lines to `/etc/nixos/configuration.nix`.
```nix
  boot.kernelPackages = pkgs.linuxPackages_latest;
  
  # Enable Magewell Kernel Driver
  hardware.mwEcoCapture.enable = true;
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
