### PR TITLE
Revert "CODEOWNERS: Watch the maintainers lists"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -84,7 +84,6 @@ nixos/modules/installer/tools/nix-fallback-paths.nix  @raitobezarius
 /nixos/README.md @infinisil
 /pkgs/README.md @infinisil
 /maintainers/README.md @infinisil
-/maintainers/* @piegamesde @Janik-Haag
 
 # User-facing development documentation
 /doc/development.md @infinisil


### PR DESCRIPTION
Reverts NixOS/nixpkgs#275443. The signal to noise ratio on the notifications is just horrible, and the workload is a multiple of the expected due to various miscalculations. Hopefully there will soon be a CI which takes over the job anyways.