### PR TITLE
shipwright: 7.1.1 -> 8.0.4, refactor

### DIFF
--- a/pkgs/games/shipwright/default.nix
+++ b/pkgs/games/shipwright/default.nix
@@ -5,6 +5,7 @@
 , lib
 , fetchFromGitHub
 , fetchurl
+, copyDesktopItems
 , makeDesktopItem
 , python3
 , libX11
@@ -21,87 +22,19 @@
 , libpulseaudio
 , libpng
 , imagemagick
-, requireFile
-
-, oot ? rec {
-    enable = true;
-    variant = "debug";
-
-    rom = requireFile {
-      name = "oot-${variant}.z64";
-      message = ''
-        This nix expression requires that oot-${variant}.z64 is already part of the store.
-        To get this file you can dump your Ocarina of Time's cartridge to a file,
-        and add it to the nix store with nix-store --add-fixed sha1 <FILE>, or override the package:
-          shipwright.override { oot = { enable = true; variant = "debug"; rom = path/to/oot-debug-mq.z64; } }
-
-        The supported variants are:
-         - debug: Ocarina of Time Debug PAL GC (not Master Quest)
-         - pal-gc: Ocarina of Time PAL GameCube (may lead to crashes and instability)
-
-        This is optional if you have imported an Ocarina of Time Master Quest ROM.
-        If so, please set oot.enable to false and ootMq.enable to true.
-        If both are enabled, Ship of Harkinian will be built with both ROMs.
-      '';
-
-      # From upstream: https://github.com/HarbourMasters/Shipwright/blob/e46c60a7a1396374e23f7a1f7122ddf9efcadff7/README.md#1-check-your-sha1
-      sha1 = {
-        debug = "cee6bc3c2a634b41728f2af8da54d9bf8cc14099";
-        pal-gc = "0227d7c0074f2d0ac935631990da8ec5914597b4";
-      }.${variant} or (throw "Unsupported romVariant ${variant}. Valid options are 'debug' and 'pal-gc'.");
-    };
-  }
-
-, ootMq ? rec {
-    enable = false;
-    variant = "debug-mq";
-
-    rom = requireFile {
-      name = "oot-${variant}.z64";
-      message = ''
-        This nix expression requires that oot-${variant}.z64 is already part of the store.
-        To get this file you can dump your Ocarina of Time Master Quest's cartridge to a file,
-        and add it to the nix store with nix-store --add-fixed sha1 <FILE>, or override the package:
-          shipwright.override { ootMq = { enable = true; variant = "debug-mq"; rom = path/to/oot-debug-mq.z64; } }
-
-        The supported variants are:
-         - debug-mq: Ocarina of Time Debug PAL GC MQ (Dungeons will be Master Quest)
-         - debug-mq-alt: Alternate ROM, not produced by decompilation.
-
-        This is optional if you have imported an Ocarina of Time ROM.
-        If so, please set oot.enable to true and ootMq.enable to false.
-        If both are enabled, Ship of Harkinian will be built with both ROMs.
-      '';
-
-      # From upstream: https://github.com/HarbourMasters/Shipwright/blob/e46c60a7a1396374e23f7a1f7122ddf9efcadff7/README.md#1-check-your-sha1
-      sha1 = {
-        debug-mq = "079b855b943d6ad8bd1eb026c0ed169ecbdac7da";
-        debug-mq-alt = "50bebedad9e0f10746a52b07239e47fa6c284d03";
-      }.${variant} or (throw "Unsupported mqRomVariant ${variant}. Valid options are 'debug-mq' and 'debug-mq-alt'.");
-    };
-  }
+, gnome
+, makeWrapper
 }:
 
-let
-  checkAttrs = attrs:
-    let
-      validAttrs = [ "enable" "rom" "variant" ];
-    in
-    lib.all (name: lib.elem name validAttrs) (lib.attrNames attrs);
-in
-assert (lib.assertMsg (checkAttrs oot) "oot must have the attributes 'enable' and 'rom', and none other");
-assert (lib.assertMsg (checkAttrs ootMq) "ootMq must have the attributes 'enable' and 'rom', and none other");
-assert (lib.assertMsg (oot.enable || ootMq.enable) "At least one of 'oot.enable' and 'ootMq.enable' must be true");
-
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "shipwright";
-  version = "7.1.1";
+  version = "8.0.4";
 
   src = fetchFromGitHub {
     owner = "harbourmasters";
     repo = "shipwright";
-    rev = version;
-    hash = "sha256-zgxJj65wKsQWvVxeCspyHG9YqoYqZxd6GrYptOA8Byk=";
+    rev = finalAttrs.version;
+    hash = "sha256-OoDToHCVNzccbKdsmek1kqCsW2HmVzA2vy3BtVW1DuM=";
     fetchSubmodules = true;
   };
 
@@ -109,8 +42,8 @@ stdenv.mkDerivation rec {
   # https://github.com/HarbourMasters/Shipwright/blob/e46c60a7a1396374e23f7a1f7122ddf9efcadff7/soh/CMakeLists.txt#L736
   gamecontrollerdb = fetchurl {
     name = "gamecontrollerdb.txt";
-    url = "https://raw.githubusercontent.com/gabomdq/SDL_GameControllerDB/c5b4df0e1061175cb11e3ebbf8045178339864a5/gamecontrollerdb.txt";
-    hash = "sha256-2VFCsaalXoe+JYWCH6IbgjnLXNKxe0UqSyJNGZMn5Ko=";
+    url = "https://raw.githubusercontent.com/gabomdq/SDL_GameControllerDB/81d89fd1e2bd5878e57dfa629abeed3a8feea438/gamecontrollerdb.txt";
+    hash = "sha256-m1XzDc2dS0hkBTEGABgW4J/jjIw1TXtvHHtsvui6Bcc=";
   };
 
   nativeBuildInputs = [
@@ -120,6 +53,8 @@ stdenv.mkDerivation rec {
     lsb-release
     python3
     imagemagick
+    copyDesktopItems
+    makeWrapper
   ];
 
   buildInputs = [
@@ -135,10 +70,12 @@ stdenv.mkDerivation rec {
     SDL2_net
     libpulseaudio
     libpng
+    gnome.zenity
   ];
 
   cmakeFlags = [
     "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}/lib"
+    (lib.cmakeBool "NON_PORTABLE" true)
   ];
 
   dontAddPrefix = true;
@@ -147,11 +84,9 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "format" ];
 
   postBuild = ''
-    cp ${gamecontrollerdb} ${gamecontrollerdb.name}
-
+    cp ${finalAttrs.gamecontrollerdb} ${finalAttrs.gamecontrollerdb.name}
     pushd ../OTRExporter
-    ${lib.optionalString oot.enable "python3 ./extract_assets.py -z ../build/ZAPD/ZAPD.out ${oot.rom}"}
-    ${lib.optionalString ootMq.enable "python3 ./extract_assets.py -z ../build/ZAPD/ZAPD.out ${ootMq.rom}"}
+    python3 ./extract_assets.py -z ../build/ZAPD/ZAPD.out --norom --xml-root ../soh/assets/xml --custom-assets-path ../soh/assets/custom --custom-otr-file soh.otr --port-ver ${finalAttrs.version}
     popd
   '';
 
@@ -162,12 +97,12 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     mkdir -p $out/bin
-
-    # Copy the extracted assets, required to be in the same directory as the executable
-    ${lib.optionalString oot.enable "cp ../OTRExporter/oot.otr $out/lib"}
-    ${lib.optionalString ootMq.enable "cp ../OTRExporter/oot-mq.otr $out/lib"}
-
     ln -s $out/lib/soh.elf $out/bin/soh
+    install -Dm644 ../soh/macosx/sohIcon.png $out/share/pixmaps/soh.png
+  '';
+
+  fixupPhase = ''
+    wrapProgram $out/lib/soh.elf --prefix PATH ":" ${lib.makeBinPath [ gnome.zenity ]}
   '';
 
   desktopItems = [
@@ -175,42 +110,24 @@ stdenv.mkDerivation rec {
       name = "soh";
       icon = "soh";
       exec = "soh";
+      comment = finalAttrs.meta.description;
       genericName = "Ship of Harkinian";
       desktopName = "soh";
       categories = [ "Game" ];
     })
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/HarbourMasters/Shipwright";
     description = "A PC port of Ocarina of Time with modern controls, widescreen, high-resolution, and more";
-    longDescription = ''
-      An PC port of Ocarina of Time with modern controls, widescreen, high-resolution and more, based off of decompilation.
-      Note that you must supply an OoT rom yourself to use this package because propietary assets are extracted from it.
-
-      You can change the game variant like this:
-        shipwright.override { oot.enable = false; ootMq.enable = true }
-
-      The default ROM variants for Oot and OotMq are debug and debug-mq respectively.
-      If you have a pal-gc rom, you should override like this:
-        shipwright.override { oot = { enable = true; variant = "pal-gc"; rom = path/to/oot-pal-gc.z64; } }
-
-      The supported Oot variants are:
-       - debug: Ocarina of Time Debug PAL GC (not Master Quest)
-       - pal-gc: Ocarina of Time PAL GameCube (may lead to crashes and instability)
-
-      The supported OotMq variants are:
-       - debug-mq: Ocarina of Time Debug PAL GC MQ (Dungeons will be Master Quest)
-       - debug-mq-alt: Alternate ROM, not produced by decompilation.
-    '';
     mainProgram = "soh";
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ ivar j0lol ];
-    license = with licenses; [
+    maintainers = with lib.maintainers; [ ivar j0lol ];
+    license = with lib.licenses; [
       # OTRExporter, OTRGui, ZAPDTR, libultraship
       mit
       # Ship of Harkinian itself
       unfree
     ];
   };
-}
+})


### PR DESCRIPTION
Closes #276209

https://www.shipofharkinian.com/changelog

- Updated shipwright to 8.0.4
- Refactor - only generate soh.otr and allow users to select rom to generate otr instead of adding to nix store
- Migrate to finalAttrs
- Update gamecontrollerdb
- Install desktop file and icon
- soh working directory is under $HOME/.local/share/soh
- mod support - ``mkdir $HOME/.local/share/soh/mods`` and place otr mods. Tested with a few graphic mods.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
