### PR TITLE
workflows/check-by-name: Trigger on base branch changes

### DIFF
--- a/.github/workflows/check-by-name.yml
+++ b/.github/workflows/check-by-name.yml
@@ -8,7 +8,15 @@ name: Check pkgs/by-name
 # see pkgs/test/nixpkgs-check-by-name/scripts/README.md
 on:
   # Using pull_request_target instead of pull_request avoids having to approve first time contributors
-  pull_request_target
+  pull_request_target:
+    # This workflow depends on the base branch of the PR,
+    # but changing the base branch is not included in the default trigger events,
+    # which would be `opened`, `synchronize` or `reopened`.
+    # Instead it causes an `edited` event, so we need to add it explicitly here
+    # While `edited` is also triggered when the PR title/body is changed,
+    # this PR action is fairly quick, and PR's don't get edited that often,
+    # so it shouldn't be a problem
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   # We need this permission to cancel the workflow run if there's a merge conflict


### PR DESCRIPTION
## Context

[In a PR](https://github.com/NixOS/nixpkgs/pull/282473#issuecomment-1902555467) there was an [odd failure](https://github.com/NixOS/nixpkgs/actions/runs/7600068348/job/20697863923) of the `pkgs/by-name` check: After a base branch change, it seemingly complained about new non-`pkgs/by-name` packages introduced by the PR (see https://github.com/NixOS/nixpkgs/pull/275539 that introduced this new check). Even though the PR only had a single unrelated commit on top of staging at that point.

Why did this happen? Here's the series of events leading to that:
- PR opened with `master` as the base branch
  This triggered CI, [completing successfully](https://github.com/NixOS/nixpkgs/actions/runs/7598742770/job/20695031439)
- [Marked as draft](https://github.com/NixOS/nixpkgs/pull/282473#event-11548528895), presumably to avoid the many review requests when changing the base branch in the next step
- [Force pushed](https://github.com/NixOS/nixpkgs/pull/282473#event-11548533205), presumably to staging + the changes
  At this point, master is still the base branch, and if the PR were merged at that point, master would've gotten all commits from staging.
  Since the `pkgs/by-name` checker compares the PR against the _base branch_ of it, it [correctly failed](https://github.com/NixOS/nixpkgs/actions/runs/7600068348/job/20697863923) with the packages that would've been new on master and aren't using `pkgs/by-name` yet!
  
  Also this can only cause failures right now because the two new relevant packages in staging were merged before `pkgs/by-name` started being enforced (https://github.com/NixOS/nixpkgs/pull/281591 and https://github.com/NixOS/nixpkgs/pull/269415). Now that `pkgs/by-name` is being enforced (notably for all base branches), it's going to get very improbable.
- Only afterwards, the base branch was [changed to staging](https://github.com/NixOS/nixpkgs/pull/282473#event-11548536103). 
  However, the `pull_request_target` GitHub Actions event doesn't trigger for base branch changes by default!

One way to "fix" that is to instead [push the merge base](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#rebasing-between-branches-ie-from-master-to-staging) of the old and new base branch before switching. This way you also won't have to mark it as a draft to avoid requesting reviews by everybody.

But the better fix is to make CI retrigger when the base branch changes!

This work is sponsored by [Tweag](https://www.tweag.io/) and [Antithesis](https://antithesis.com/) :sparkles:

## Changes

This PR changes the `pkgs/by-name` check workflow to also trigger when the base branch changes. This type of event doesn't trigger CI [by default](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target):

> By default, a workflow only runs when a `pull_request_target` event's activity type is `opened`, `synchronize`, or `reopened`.

Instead it's part of the [`edited` event](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=edited#pull_request), which however also triggers in other cases:

> The title or body of a pull request was edited, or the base branch of a pull request was changed.

However, this workflow is fairly quick, and PR's don't get edited that often, so it shouldn't be a problem.

Ping @zeuner

## Things done

- [x] Tested that it works:
  - https://github.com/tweag/nixpkgs/pull/83

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
