### PR TITLE
Upgrade openwrt packages

### DIFF
--- a/pkgs/by-name/ud/udebug/package.nix
+++ b/pkgs/by-name/ud/udebug/package.nix
@@ -11,12 +11,12 @@
 
 stdenv.mkDerivation {
   pname = "udebug";
-  version = "unstable-2023-11-28";
+  version = "unstable-2023-12-06";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/udebug.git";
-    rev = "d49aadabb7a147b99a3e6299a77d7fda4e266091";
-    hash = "sha256-5I50q+oUQ5f82ngKl7bX50J+3pBviNk3iVEChNjt5wY=";
+    rev = "6d3f51f9fda706f0cf4732c762e4dbe8c21e12cf";
+    hash = "sha256-5dowoFZn9I2IXMQ3Pz+2Eo3rKfihLzjca84MytQIXcU=";
   };
 
   buildInputs = [

--- a/pkgs/development/libraries/libubox/default.nix
+++ b/pkgs/development/libraries/libubox/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation {
   pname = "libubox";
-  version = "unstable-2023-11-28";
+  version = "unstable-2023-12-18";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/libubox.git";
-    rev = "e80dc00ee90c29ef56ae28f414b0e5bb361206e7";
-    hash = "sha256-R4Yz4C63LQTNBKyNyiLMQHfc5KJBPFldP1trmtEBb9U=";
+    rev = "6339204c212b2c3506554a8842030df5ec6fe9c6";
+    hash = "sha256-QgpORITt6MYgfzUpaI2T0Ge2a0iVHjDhdYI/nZ2HbJ8=";
   };
 
   cmakeFlags = [ "-DBUILD_EXAMPLES=OFF" (if with_lua then "-DLUAPATH=${placeholder "out"}/lib/lua" else "-DBUILD_LUA=OFF") ];

--- a/pkgs/development/libraries/ubus/default.nix
+++ b/pkgs/development/libraries/ubus/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation {
   pname = "ubus";
-  version = "unstable-2023-11-28";
+  version = "unstable-2023-12-18";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/ubus.git";
-    rev = "f84eb5998c6ea2d34989ca2d3254e56c66139313";
-    hash = "sha256-5pIovqIeJczWAA9KQPKFnTnGRrIZVdSNdxBR8AEFtO4=";
+    rev = "65bb027054def3b94a977229fd6ad62ddd32345b";
+    hash = "sha256-n82Ub0IiuvWbnlDCoN+0hjo/1PbplEbc56kuOYMrHxQ=";
   };
 
   cmakeFlags = [ "-DBUILD_LUA=OFF" ];

--- a/pkgs/os-specific/linux/libnl-tiny/default.nix
+++ b/pkgs/os-specific/linux/libnl-tiny/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation {
   pname = "libnl-tiny";
-  version = "unstable-2023-07-27";
+  version = "unstable-2023-12-05";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/libnl-tiny.git";
-    rev = "bc92a280186f9becc53c0f17e4e43cfbdeec7e7b";
-    hash = "sha256-/d6so8hfBOyp8NbUhPZ0aRj6gXO/RLgwCQnAT7N/rF8=";
+    rev = "965c4bf49658342ced0bd6e7cb069571b4a1ddff";
+    hash = "sha256-kegTV7FXMERW7vjRZo/Xp4cbSBZmynBgge2lK71Fx94=";
   };
 
   nativeBuildInputs = [ cmake pkg-config ];

--- a/pkgs/tools/networking/uqmi/default.nix
+++ b/pkgs/tools/networking/uqmi/default.nix
@@ -2,12 +2,12 @@
 
 stdenv.mkDerivation {
   pname = "uqmi";
-  version = "unstable-2023-10-30";
+  version = "unstable-2024-01-16";
 
   src = fetchgit {
     url = "https://git.openwrt.org/project/uqmi.git";
-    rev = "eea292401c388a4eb59c0caf5d00aa046c6059f4";
-    hash = "sha256-Uz5GjGcSKatbii09CsvzsYMz8Vm+Am4RUeCZuFIK1Ag=";
+    rev = "c3488b831ce6285c8107704156b9b8ed7d59deb3";
+    hash = "sha256-O5CeLk0WYuBs3l5xBUk9kXDRMzFvYSRoqP28KJ5Ztos=";
   };
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

- udebug: unstable-2023-11-28 -> unstable-2023-12-06
- libubox: unstable-2023-11-28 -> unstable-2023-12-18
- ubus: unstable-2023-11-28 -> unstable-2023-12-18
- libnl-tiny: unstable-2023-07-27 -> unstable-2023-12-05
- uqmi: unstable-2023-10-30 -> unstable-2024-01-16

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
