### PR TITLE
rmg: Fix licensing

### DIFF
--- a/pkgs/by-name/rm/rmg/package.nix
+++ b/pkgs/by-name/rm/rmg/package.nix
@@ -20,6 +20,8 @@
 , which
 , xdg-user-dirs
 , zlib
+# Affects final license
+, withAngrylionRdpPlus ? false
 }:
 
 let
@@ -77,6 +79,7 @@ stdenv.mkDerivation rec {
     # mupen64plus-input-gca is written in Rust, so we can't build it with
     # everything else.
     "-DNO_RUST=ON"
+    "-DUSE_ANGRYLION=${lib.boolToString withAngrylionRdpPlus}"
   ];
 
   qtWrapperArgs = lib.optionals stdenv.isLinux [
@@ -90,7 +93,7 @@ stdenv.mkDerivation rec {
       Rosalie's Mupen GUI is a free and open-source mupen64plus front-end
       written in C++. It offers a simple-to-use user interface.
     '';
-    license = licenses.gpl3;
+    license = if withAngrylionRdpPlus then licenses.unfree else licenses.gpl3Only;
     platforms = platforms.linux;
     mainProgram = "RMG";
     maintainers = with maintainers; [ slam-bert ];


### PR DESCRIPTION
## Description of changes

Closes #282736

- Clarify license as `gpl3Only`, `gpl3` attribute is deprecated
- Provide an option to build with license-compromising plugin, default to off

The option to build & include the plugin is exposed for those that want to deal with the licensing mess, but our infrastructure won't build & redistribute such a build for them.

CC @orbea, original reporter. I think this solution is adequate for our needs, any opinions?
CC @slam-bert, rmg package maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  The software launches, and the plugin selection lacks the option for the problematic plugin. Have not tested any ROMs.
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
