### PR TITLE
nixos: fix some remaining consequences of network-online.target dep fix

### DIFF
--- a/doc/languages-frameworks/beam.section.md
+++ b/doc/languages-frameworks/beam.section.md
@@ -237,7 +237,7 @@ in
 {
   systemd.services.${release_name} = {
     wantedBy = [ "multi-user.target" ];
-    after = [ "network.target" "postgresql.service" ];
+    after = [ "network-online.target" "postgresql.service" ];
     # note that if you are connecting to a postgres instance on a different host
     # postgresql.service should not be included in the requires.
     requires = [ "network-online.target" "postgresql.service" ];

--- a/nixos/modules/services/audio/liquidsoap.nix
+++ b/nixos/modules/services/audio/liquidsoap.nix
@@ -10,6 +10,7 @@ let
     let stream = builtins.getAttr name config.services.liquidsoap.streams; in
     { inherit name;
       value = {
+        wants = [ "network-online.target" ];
         after = [ "network-online.target" "sound.target" ];
         description = "${name} liquidsoap stream";
         wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/audio/mopidy.nix
+++ b/nixos/modules/services/audio/mopidy.nix
@@ -76,6 +76,7 @@ in {
 
     systemd.services.mopidy = {
       wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
       after = [ "network-online.target" "sound.target" ];
       description = "mopidy music player daemon";
       serviceConfig = {

--- a/nixos/modules/services/audio/tts.nix
+++ b/nixos/modules/services/audio/tts.nix
@@ -87,6 +87,7 @@ in
     systemd.services = mapAttrs' (server: options:
       nameValuePair "tts-${server}" {
         description = "Coqui TTS server instance ${server}";
+        wants = [ "network-online.target" ];
         after = [
           "network-online.target"
         ];

--- a/nixos/modules/services/audio/wyoming/faster-whisper.nix
+++ b/nixos/modules/services/audio/wyoming/faster-whisper.nix
@@ -123,6 +123,7 @@ in
       nameValuePair "wyoming-faster-whisper-${server}" {
         inherit (options) enable;
         description = "Wyoming faster-whisper server instance ${server}";
+        wants = [ "network-online.target" ];
         after = [
           "network-online.target"
         ];

--- a/nixos/modules/services/audio/wyoming/openwakeword.nix
+++ b/nixos/modules/services/audio/wyoming/openwakeword.nix
@@ -109,6 +109,7 @@ in
   config = mkIf cfg.enable {
     systemd.services."wyoming-openwakeword" = {
       description = "Wyoming openWakeWord server";
+      wants = [ "network-online.target" ];
       after = [
         "network-online.target"
       ];

--- a/nixos/modules/services/audio/wyoming/piper.nix
+++ b/nixos/modules/services/audio/wyoming/piper.nix
@@ -118,6 +118,7 @@ in
       nameValuePair "wyoming-piper-${server}" {
         inherit (options) enable;
         description = "Wyoming Piper server instance ${server}";
+        wants = [ "network-online.target" ];
         after = [
           "network-online.target"
         ];

--- a/nixos/modules/services/backup/borgbackup.nix
+++ b/nixos/modules/services/backup/borgbackup.nix
@@ -123,6 +123,7 @@ let
       };
       # if remote-backup wait for network
       after = optional (cfg.persistentTimer && !isLocalPath cfg.repo) "network-online.target";
+      wants = optional (cfg.persistentTimer && !isLocalPath cfg.repo) "network-online.target";
     };
 
   # utility function around makeWrapper

--- a/nixos/modules/services/backup/tarsnap.nix
+++ b/nixos/modules/services/backup/tarsnap.nix
@@ -355,6 +355,7 @@ in
 
       (mapAttrs' (name: cfg: nameValuePair "tarsnap-restore-${name}"{
         description = "Tarsnap restore '${name}'";
+        after       = [ "network-online.target" ];
         requires    = [ "network-online.target" ];
 
         path = with pkgs; [ iputils gcfg.package util-linux ];

--- a/nixos/modules/services/misc/errbot.nix
+++ b/nixos/modules/services/misc/errbot.nix
@@ -88,6 +88,7 @@ in {
         "/var/lib/errbot/${name}";
     in {
       after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
       preStart = ''
         mkdir -p ${dataDir}

--- a/nixos/modules/services/misc/lifecycled.nix
+++ b/nixos/modules/services/misc/lifecycled.nix
@@ -135,7 +135,9 @@ in
 
       systemd.packages = [ pkgs.lifecycled ];
       systemd.services.lifecycled = {
-        wantedBy = [ "network-online.target" ];
+        after = [ "network-online.target" ];
+        wants = [ "network-online.target" ];
+        wantedBy = [ "multi-user.target" ];
         restartTriggers = [ configFile ];
       };
     })

--- a/nixos/modules/services/misc/lifecycled.nix
+++ b/nixos/modules/services/misc/lifecycled.nix
@@ -153,6 +153,7 @@ in
       systemd.timers.lifecycled-queue-cleaner = {
         description = "Lifecycle Daemon Queue Cleaner Timer";
         wantedBy = [ "timers.target" ];
+        wants = [ "network-online.target" ];
         after = [ "network-online.target" ];
         timerConfig = {
           Unit = "lifecycled-queue-cleaner.service";

--- a/nixos/modules/services/monitoring/prometheus/alertmanager-irc-relay.nix
+++ b/nixos/modules/services/monitoring/prometheus/alertmanager-irc-relay.nix
@@ -55,6 +55,7 @@ in
       description = "Alertmanager IRC Relay";
 
       wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
       after = [ "network-online.target" ];
 
       serviceConfig = {

--- a/nixos/modules/services/monitoring/prometheus/sachet.nix
+++ b/nixos/modules/services/monitoring/prometheus/sachet.nix
@@ -64,6 +64,7 @@ in
 
     systemd.services.sachet = {
       wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
       after = [ "network.target" "network-online.target" ];
       script = ''
         ${pkgs.envsubst}/bin/envsubst -i "${configFile}" > /tmp/sachet.yaml

--- a/nixos/modules/services/network-filesystems/samba.nix
+++ b/nixos/modules/services/network-filesystems/samba.nix
@@ -216,7 +216,7 @@ in
         systemd = {
           targets.samba = {
             description = "Samba Server";
-            after = [ "network.target" ];
+            after = [ "network-online.target" ];
             wants = [ "network-online.target" ];
             wantedBy = [ "multi-user.target" ];
           };

--- a/nixos/modules/services/networking/chisel-server.nix
+++ b/nixos/modules/services/networking/chisel-server.nix
@@ -53,7 +53,11 @@ in {
   config = mkIf cfg.enable {
     systemd.services.chisel-server = {
       description = "Chisel Tunnel Server";
-      wantedBy = [ "network-online.target" ];
+
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+
+      after = [ "network-online.target" ];
 
       serviceConfig = {
         ExecStart = "${pkgs.chisel}/bin/chisel server " + concatStringsSep " " (

--- a/nixos/modules/services/networking/connman.nix
+++ b/nixos/modules/services/networking/connman.nix
@@ -100,7 +100,13 @@ in {
     systemd.services.connman = {
       description = "Connection service";
       wantedBy = [ "multi-user.target" ];
-      after = [ "syslog.target" ] ++ lib.optional enableIwd "iwd.service";
+
+      # see systemd.special(7): since we are a provider, we pull in
+      # network.target, while ordered before it.
+      before = [ "network.target" "NetworkManager-wait-online.service" ];
+      wants = [ "network.target" ];
+      after = [ "syslog.target" "network-pre.target" ] ++ lib.optional enableIwd "iwd.service";
+
       requires = lib.optional enableIwd "iwd.service";
       serviceConfig = {
         Type = "dbus";

--- a/nixos/modules/services/networking/iodine.nix
+++ b/nixos/modules/services/networking/iodine.nix
@@ -130,7 +130,12 @@ in
         createIodineClientService = name: cfg:
           {
             description = "iodine client - ${name}";
-            after = [ "network.target" ];
+
+            # Seems to save bad network state, breaking it if it is started too
+            # early relative to the network.
+            wants = [ "network-online.target" ];
+            after = [ "network-online.target" ];
+
             wantedBy = [ "multi-user.target" ];
             script = "exec ${pkgs.iodine}/bin/iodine -f -u ${iodinedUser} ${cfg.extraConfig} ${optionalString (cfg.passwordFile != "") "< \"${builtins.toString cfg.passwordFile}\""} ${cfg.relay} ${cfg.server}";
             serviceConfig = {
@@ -164,7 +169,12 @@ in
         ) // {
           iodined = mkIf (cfg.server.enable) {
             description = "iodine, ip over dns server daemon";
-            after = [ "network.target" ];
+
+            # Seems to save bad network state, breaking it if it is started too
+            # early relative to the network.
+            wants = [ "network-online.target" ];
+            after = [ "network-online.target" ];
+
             wantedBy = [ "multi-user.target" ];
             script = "exec ${pkgs.iodine}/bin/iodined -f -u ${iodinedUser} ${cfg.server.extraConfig} ${optionalString (cfg.server.passwordFile != "") "< \"${builtins.toString cfg.server.passwordFile}\""} ${cfg.server.ip} ${cfg.server.domain}";
             serviceConfig = {

--- a/nixos/modules/services/networking/kea.nix
+++ b/nixos/modules/services/networking/kea.nix
@@ -283,6 +283,7 @@ in
         "network-online.target"
         "time-sync.target"
       ];
+      wants = [ "network-online.target" ];
       wantedBy = [
         "kea-dhcp4-server.service"
         "kea-dhcp6-server.service"

--- a/nixos/modules/services/networking/netclient.nix
+++ b/nixos/modules/services/networking/netclient.nix
@@ -14,6 +14,7 @@ in
     environment.systemPackages = [ cfg.package ];
     systemd.services.netclient = {
       wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
       after = [ "network-online.target" ];
       description = "Netclient Daemon";
       serviceConfig = {

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -550,7 +550,13 @@ in
     ];
 
     systemd.services.NetworkManager = {
-      wantedBy = [ "network.target" ];
+      # see systemd.special(7): since we are a provider, we pull in
+      # network.target, while ordered before it.
+      before = [ "network.target" "NetworkManager-wait-online.service" ];
+      after = [ "network-pre.target" ];
+      wants = [ "network.target" ];
+
+      wantedBy = [ "multi-user.target" ];
       restartTriggers = [ configFile ];
 
       aliases = [ "dbus-org.freedesktop.NetworkManager.service" ];
@@ -582,7 +588,7 @@ in
     systemd.services.NetworkManager-ensure-profiles = mkIf (cfg.ensureProfiles.profiles != { }) {
       description = "Ensure that NetworkManager declarative profiles are created";
       wantedBy = [ "multi-user.target" ];
-      before = [ "network-online.target" ];
+      before = [ "network-pre.target" ];
       script = let
         path = id: "/run/NetworkManager/system-connections/${id}.nmconnection";
       in ''

--- a/nixos/modules/services/networking/pptpd.nix
+++ b/nixos/modules/services/networking/pptpd.nix
@@ -93,6 +93,7 @@ with lib;
     in {
       description = "pptpd server";
 
+      after    = [ "network-online.target" ];
       requires = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
 

--- a/nixos/modules/services/networking/xl2tpd.nix
+++ b/nixos/modules/services/networking/xl2tpd.nix
@@ -100,6 +100,7 @@ with lib;
     in {
       description = "xl2tpd server";
 
+      after    = [ "network-online.target" ];
       requires = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
 

--- a/nixos/modules/services/security/bitwarden-directory-connector-cli.nix
+++ b/nixos/modules/services/security/bitwarden-directory-connector-cli.nix
@@ -260,6 +260,7 @@ in {
       timers.bitwarden-directory-connector-cli = {
         description = "Sync timer for Bitwarden Directory Connector";
         wantedBy = ["timers.target"];
+        wants = ["network-online.target"];
         after = ["network-online.target"];
         timerConfig = {
           OnCalendar = cfg.interval;

--- a/nixos/modules/virtualisation/amazon-init.nix
+++ b/nixos/modules/virtualisation/amazon-init.nix
@@ -72,7 +72,7 @@ in {
       description = "Reconfigure the system from EC2 userdata on startup";
 
       wantedBy = [ "multi-user.target" ];
-      after = [ "multi-user.target" ];
+      after = [ "multi-user.target" "network-online.target" ];
       requires = [ "network-online.target" ];
 
       restartIfChanged = false;

--- a/nixos/tests/jool.nix
+++ b/nixos/tests/jool.nix
@@ -197,6 +197,9 @@ in
 
       for node in [client, homeserver, server]:
         node.wait_for_unit("network-addresses-eth1.service")
+        # Ensure interfaces come up
+        node.systemctl("start network-online.target")
+        node.wait_for_unit("network-online.target")
 
       with subtest("Client can ping the WAN server"):
         router.wait_for_unit("jool-nat64-default.service")

--- a/nixos/tests/jool.nix
+++ b/nixos/tests/jool.nix
@@ -16,7 +16,6 @@ let
   webserver = ip: msg: {
     systemd.services.webserver = {
       description = "Mock webserver";
-      wants = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
       script = ''
         while true; do

--- a/nixos/tests/kea.nix
+++ b/nixos/tests/kea.nix
@@ -178,6 +178,7 @@ import ./make-test-python.nix ({ pkgs, lib, ...}: {
   testScript = { ... }: ''
     start_all()
     router.wait_for_unit("kea-dhcp4-server.service")
+    client.systemctl("start systemd-networkd-wait-online.service")
     client.wait_for_unit("systemd-networkd-wait-online.service")
     client.wait_until_succeeds("ping -c 5 10.0.0.1")
     router.wait_until_succeeds("ping -c 5 10.0.0.3")

--- a/nixos/tests/mediamtx.nix
+++ b/nixos/tests/mediamtx.nix
@@ -23,6 +23,8 @@ import ./make-test-python.nix ({ pkgs, lib, ...} :
           DynamicUser = true;
           Restart = "on-failure";
           RestartSec = "1s";
+          # restart service without going through failed/inactive state that confuses wait_for_unit
+          RestartMode = "direct";
           TimeoutStartSec = "10s";
           ExecStart = "${lib.getBin pkgs.ffmpeg-headless}/bin/ffmpeg -re -f lavfi -i smptebars=size=800x600:rate=10 -c libx264 -f flv rtmp://localhost:1935/test";
         };
@@ -37,6 +39,8 @@ import ./make-test-python.nix ({ pkgs, lib, ...} :
           DynamicUser = true;
           Restart = "on-failure";
           RestartSec = "1s";
+          # restart service without going through failed/inactive state that confuses wait_for_unit
+          RestartMode = "direct";
           TimeoutStartSec = "10s";
           ExecStart = "${lib.getBin pkgs.ffmpeg-headless}/bin/ffmpeg -y -re -i rtmp://localhost:1935/test -f flv /dev/null";
         };

--- a/nixos/tests/rss2email.nix
+++ b/nixos/tests/rss2email.nix
@@ -60,7 +60,8 @@ import ./make-test-python.nix {
     server.wait_for_unit("opensmtpd")
     server.wait_for_unit("dovecot2")
     server.wait_for_unit("nginx")
-    server.wait_for_unit("rss2email")
+    # rss2email finishes its work and then exits, so it may not still be running; thus we just wait till it exits success.
+    server.wait_until_succeeds("systemctl show rss2email.service | grep Result=success")
 
     server.wait_until_succeeds("check-mail-landed >&2")
   '';

--- a/nixos/tests/rsyncd.nix
+++ b/nixos/tests/rsyncd.nix
@@ -30,6 +30,13 @@ import ./make-test-python.nix ({ pkgs, ... }: {
     start_all()
     a.wait_for_unit("rsync")
     b.wait_for_unit("sockets.target")
+
+    # the network has to be "online" for the hosts to be reachable over IP
+    a.systemctl("start network-online.target")
+    b.systemctl("start network-online.target")
+    a.wait_for_unit("network-online.target")
+    b.wait_for_unit("network-online.target")
+
     b.succeed("rsync a::")
     a.succeed("rsync b::")
   '';

--- a/nixos/tests/systemd-bpf.nix
+++ b/nixos/tests/systemd-bpf.nix
@@ -31,6 +31,8 @@ import ./make-test-python.nix ({ lib, ... }: {
 
   testScript = ''
     start_all()
+    node1.systemctl("start network-online.target")
+    node2.systemctl("start network-online.target")
     node1.wait_for_unit("systemd-networkd-wait-online.service")
     node2.wait_for_unit("systemd-networkd-wait-online.service")
 

--- a/nixos/tests/systemd-machinectl.nix
+++ b/nixos/tests/systemd-machinectl.nix
@@ -69,7 +69,8 @@ import ./make-test-python.nix ({ pkgs, ... }:
 
       # Test machinectl start
       machine.succeed("machinectl start ${containerName}");
-      machine.wait_until_succeeds("systemctl -M ${containerName} is-active default.target");
+      machine.wait_until_succeeds("systemctl -M ${containerName} start network-online.target");
+      machine.wait_until_succeeds("systemctl -M ${containerName} is-active network-online.target");
 
       # Test nss_mymachines without nscd
       machine.succeed('LD_LIBRARY_PATH="/run/current-system/sw/lib" getent -s hosts:mymachines hosts ${containerName}');

--- a/nixos/tests/systemd-networkd.nix
+++ b/nixos/tests/systemd-networkd.nix
@@ -88,7 +88,9 @@ in import ./make-test-python.nix ({pkgs, ... }: {
   };
 testScript = ''
     start_all()
+    node1.systemctl("start network-online.target")
     node1.wait_for_unit("systemd-networkd-wait-online.service")
+    node2.systemctl("start network-online.target")
     node2.wait_for_unit("systemd-networkd-wait-online.service")
 
     # ================================


### PR DESCRIPTION
Fixes #282640

Consequence of: https://github.com/NixOS/nixpkgs/pull/258680

You can see the failed tests here: https://hydra.nixos.org/eval/1803728#tabs-now-fail

Some of these seem to just be flakiness that might be exposed by the change, some are baffling (like firefox), and some are weird timeouts that make no sense but might be related.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
