### PR TITLE
python3Packages.qtile-extras: 0.23.0 -> 0.24.0

### DIFF
--- a/pkgs/development/python-modules/qtile-extras/default.nix
+++ b/pkgs/development/python-modules/qtile-extras/default.nix
@@ -5,25 +5,27 @@
 , pytestCheckHook
 , xorgserver
 , imagemagick
+, gobject-introspection
 , pulseaudio
 , pytest-asyncio
 , pytest-lazy-fixture
 , qtile
 , keyring
 , requests
-, stravalib
+, librsvg
+, gtk3
 }:
 
 buildPythonPackage rec {
   pname = "qtile-extras";
-  version = "0.23.0";
+  version = "0.24.0";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "elParaguayo";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-WI1z8vrbZiJw6fDHK27mKA+1FyZEQTMttIDNzSIX+PU=";
+    hash = "sha256-DJmnJcqhfCfl39SF3Ypv0PGtI4r8heaVv9JmpiCBGJo=";
   };
 
   nativeBuildInputs = [ setuptools-scm ];
@@ -32,6 +34,7 @@ buildPythonPackage rec {
     pytestCheckHook
     xorgserver
     imagemagick
+    gobject-introspection
   ];
   checkInputs = [
     pytest-asyncio
@@ -40,58 +43,40 @@ buildPythonPackage rec {
     pulseaudio
     keyring
     requests
-    stravalib
+    # stravalib  # marked as broken due to https://github.com/stravalib/stravalib/issues/379
   ];
   disabledTests = [
-    # AttributeError: 'ImgMask' object has no attribute '_default_size'. Did you mean: 'default_size'?
-    # cairocffi.pixbuf.ImageLoadingError: Pixbuf error: Unrecognized image file format
-    "test_draw"
-    "test_icons"
-    "1-x11-GithubNotifications-kwargs3"
-    "1-x11-SnapCast-kwargs8"
-    "1-x11-TVHWidget-kwargs10"
-    "test_tvh_widget_not_recording"
-    "test_tvh_widget_recording"
-    "test_tvh_widget_popup"
-    "test_snapcast_options"
-    "test_snapcast_icon"
-    "test_snapcast_icon_colour"
-    "test_snapcast_http_error"
-    "test_syncthing_not_syncing"
-    "test_syncthing_is_syncing"
-    "test_syncthing_http_error"
-    "test_githubnotifications_colours"
-    "test_githubnotifications_logging"
-    "test_githubnotifications_icon"
-    "test_githubnotifications_reload_token"
-    "test_image_size_horizontal"
-    "test_image_size_vertical"
-    "test_image_size_mask"
-    # ValueError: Namespace Gdk not available
-    # AssertionError: Window never appeared...
-    "test_statusnotifier_menu"
-    # AttributeError: 'str' object has no attribute 'canonical'
-    "test_strava_widget_display"
-    "test_strava_widget_popup"
     # Needs a running DBUS
     "test_brightness_power_saving"
-    "test_upower_all_batteries"
-    "test_upower_named_battery"
-    "test_upower_low_battery"
-    "test_upower_critical_battery"
-    "test_upower_charging"
-    "test_upower_show_text"
     "test_global_menu"
     "test_mpris2_popup"
+    "test_statusnotifier_menu"
     # No network connection
     "test_wifiicon_internet_check"
-    # AssertionErrors
-    "test_widget_init_config"
+    # Image difference is outside tolerance
     "test_decoration_output"
+    # Needs github token
+    "test_githubnotifications_reload_token"
+    # AttributeError: 'NoneType' object has no attribute 'theta'
+    "test_image_size_horizontal"
+    "test_image_size_vertical"
+  ];
+  disabledTestPaths = [
+    # Needs a running DBUS
+    "test/widget/test_iwd.py"
+    "test/widget/test_upower.py"
+    # Marked as broken due to https://github.com/stravalib/stravalib/issues/379
+    "test/widget/test_strava.py"
   ];
   preCheck = ''
     export HOME=$(mktemp -d)
+    export GDK_PIXBUF_MODULE_FILE=${librsvg}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache
+    sed -i 's#/usr/bin/sleep#sleep#' test/widget/test_snapcast.py
   '';
+
+  propagatedBuildInputs = [
+    gtk3
+  ];
 
   pythonImportsCheck = [ "qtile_extras" ];
 


### PR DESCRIPTION
Diff: https://github.com/elParaguayo/qtile-extras/compare/v0.23.0...v0.24.0
Changelog: https://github.com/elParaguayo/qtile-extras/blob/v0.24.0/CHANGELOG

Additionally, this commit fixes a lot of previously failing (skipped) tests.

Edit: rebased after https://github.com/NixOS/nixpkgs/pull/282629 was merged.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
