### PR TITLE
openmolcas: fix pyparsing >= 3.11 compatibility

### DIFF
--- a/pkgs/applications/science/chemistry/openmolcas/default.nix
+++ b/pkgs/applications/science/chemistry/openmolcas/default.nix
@@ -59,6 +59,9 @@ stdenv.mkDerivation {
 
     # Required for a local QCMaquis build
     ./qcmaquis.patch
+
+    # PyParsing >= 3.11 compatibility, can be removed on next release
+    ./pyparsing.patch
   ];
 
   postPatch = ''

--- a/pkgs/applications/science/chemistry/openmolcas/pyparsing.patch
+++ b/pkgs/applications/science/chemistry/openmolcas/pyparsing.patch
@@ -1,0 +1,37 @@
+diff --git a/Tools/pymolcas/emil_grammar.py b/Tools/pymolcas/emil_grammar.py
+index acbbae8..509c56f 100644
+--- a/Tools/pymolcas/emil_grammar.py
++++ b/Tools/pymolcas/emil_grammar.py
+@@ -15,6 +15,14 @@
+ 
+ from __future__ import (unicode_literals, division, absolute_import, print_function)
+ 
++try:
++  u = unicode
++  del u
++  py2 = True
++except NameError:
++  pass
++
++
+ from re import sub
+ from pyparsing import *
+ 
+@@ -24,6 +32,8 @@ def chomp(s):
+ 
+ def chompAction(s, l, t):
+   try:
++    if (py2):
++      pass
+     return list(map(lambda s: chomp(unicode(s)), t))
+   except NameError:
+     return list(map(chomp, t))
+@@ -33,6 +43,8 @@ def removeEMILEnd(s):
+ 
+ def removeEMILEndAction(s, l, t):
+   try:
++    if (py2):
++      pass
+     return list(map(lambda s: removeEMILEnd(unicode(s)), t))
+   except NameError:
+     return list(map(removeEMILEnd, t))


### PR DESCRIPTION
## Description of changes

Pyparsing >= 3.11 breaks the molcas input file interpreter (EMIL). This backports a [fix from upstream](https://gitlab.com/Molcas/OpenMolcas/-/commit/df2d6a459b648ecf4f11f0af995e445ab7feb6b4?merge_request_iid=660.diff) to make OpenMolcas compatible with Python 3.11. The patch can be removed at next release.

See also https://github.com/Nix-QChem/NixOS-QChem/issues/388

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
