### PR TITLE
babashka: 1.3.186 -> 1.3.188, buildGraalNativeImage: remove NATIVE_IMAGE_DEPRECATED_BUILDER_SANITATION

### DIFF
--- a/pkgs/build-support/build-graalvm-native-image/default.nix
+++ b/pkgs/build-support/build-graalvm-native-image/default.nix
@@ -49,13 +49,6 @@ stdenv.mkDerivation ({
 
   nativeImageBuildArgs = nativeImageBuildArgs ++ extraNativeImageBuildArgs ++ [ graalvmXmx ];
 
-  # Workaround GraalVM issue where the builder does not have access to the
-  # environment variables since 21.0.0
-  # https://github.com/oracle/graal/pull/6095
-  # https://github.com/oracle/graal/pull/6095
-  # https://github.com/oracle/graal/issues/7502
-  env.NATIVE_IMAGE_DEPRECATED_BUILDER_SANITATION = "true";
-
   buildPhase = args.buildPhase or ''
     runHook preBuild
 

--- a/pkgs/build-support/build-graalvm-native-image/default.nix
+++ b/pkgs/build-support/build-graalvm-native-image/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation ({
   buildPhase = args.buildPhase or ''
     runHook preBuild
 
-    native-image -jar "$jar" ''${nativeImageBuildArgs[@]}
+    native-image -jar "$jar" $(export -p | sed -n 's/^declare -x \([^=]\+\)=.*$/ -E\1/p' | tr -d \\n) ''${nativeImageBuildArgs[@]}
 
     runHook postBuild
   '';

--- a/pkgs/development/interpreters/babashka/clojure-tools.nix
+++ b/pkgs/development/interpreters/babashka/clojure-tools.nix
@@ -6,10 +6,10 @@
 }:
 clojure.overrideAttrs (previousAttrs: {
   pname = "babashka-clojure-tools";
-  version = "1.11.1.1413";
+  version = "1.11.1.1435";
 
   src = fetchurl {
     url = previousAttrs.src.url;
-    hash = "sha256-k8Olo63KUcWFgGNBmr9myD2/JOoV4f2S95v35mI4H+A=";
+    hash = "sha256-RS/FebIED8RYYXRXBKXZPRROO0HqyDo0zhb+p4Q5m8A=";
   };
 })

--- a/pkgs/development/interpreters/babashka/default.nix
+++ b/pkgs/development/interpreters/babashka/default.nix
@@ -9,11 +9,11 @@
 let
   babashka-unwrapped = buildGraalvmNativeImage rec {
     pname = "babashka-unwrapped";
-    version = "1.3.186";
+    version = "1.3.188";
 
     src = fetchurl {
       url = "https://github.com/babashka/babashka/releases/download/v${version}/babashka-${version}-standalone.jar";
-      sha256 = "sha256-T7inTJHSnUySituU0fcgZ0xWjIY3yb8BlSakqym67ew=";
+      sha256 = "sha256-EjsSUPWiLQcCos2oyVXt3VzLlGEfiXK5CqJZ1NMvF/E=";
     };
 
     graalvmDrv = graalvmCEPackages.graalvm-ce;


### PR DESCRIPTION
## Description of changes

Since https://github.com/babashka/babashka/commit/6052b9ba3572ae13b3ae6002d6a4a7c7aab199da babashka uses `-E` arguments to `build-native-image`, which are incompatible with our use of `NATIVE_IMAGE_DEPRECATED_BUILDER_SANITATION`.
Derivations using `buildGraalvmNativeImage` should specify environment variables needed during compliation using `-E` in `nativeImageBuildArgs`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


cc maintainers: @thiagokokada @jlesquembre @bennyandresen @bhougland @DerGuteMoritz @ericdallo @babariviere @stelcodes @rtimush @sg-qwt 

--

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
