### PR TITLE
nixos/obs-studio: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -230,6 +230,7 @@
   ./programs/npm.nix
   ./programs/ns-usbloader.nix
   ./programs/oblogout.nix
+  ./programs/obs-studio.nix
   ./programs/oddjobd.nix
   ./programs/openvpn3.nix
   ./programs/pantheon-tweaks.nix

--- a/nixos/modules/programs/obs-studio.nix
+++ b/nixos/modules/programs/obs-studio.nix
@@ -1,0 +1,47 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.obs-studio;
+in
+{
+  options.programs.obs-studio = {
+    enable = mkEnableOption (lib.mdDoc "obs-studio");
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.obs-studio;
+      defaultText = literalExpression "pkgs.obs-studio";
+      description = lib.mdDoc ''
+        Which package to use for `obs-studio`.
+      '';
+    };
+
+    finalPackage = mkOption {
+      type = types.package;
+      visible = false;
+      readOnly = true;
+      description = "Resulting customized OBS Studio package.";
+    };
+
+    plugins = mkOption {
+      default = [ ];
+      example = literalExpression "[ pkgs.obs-studio-plugins.wlrobs ]";
+      description = "Optional OBS plugins.";
+      type = types.listOf types.package;
+    };
+  };
+
+  config = mkIf cfg.enable {
+    programs.obs-studio.finalPackage = pkgs.wrapOBS.override { obs-studio = cfg.package; } {
+      plugins = cfg.plugins;
+    };
+
+    environment.systemPackages = [
+      cfg.finalPackage
+    ];
+  };
+
+  meta.maintainers = with maintainers; [ GaetanLepage ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -627,6 +627,7 @@ in {
   ntpd-rs = handleTest ./ntpd-rs.nix {};
   nzbget = handleTest ./nzbget.nix {};
   nzbhydra2 = handleTest ./nzbhydra2.nix {};
+  obs-studio = handleTest ./obs-studio.nix {};
   oh-my-zsh = handleTest ./oh-my-zsh.nix {};
   ombi = handleTest ./ombi.nix {};
   openarena = handleTest ./openarena.nix {};

--- a/nixos/tests/obs-studio.nix
+++ b/nixos/tests/obs-studio.nix
@@ -1,0 +1,24 @@
+import ./make-test-python.nix ({ ... }:
+
+{
+  name = "obs-studio";
+
+  nodes.machine = { pkgs, ... }: {
+    imports = [ ./common/x11.nix ./common/user-account.nix ];
+
+    programs.obs-studio = {
+      enable = true;
+      plugins = [
+        pkgs.obs-studio-plugins.wlrobs
+      ];
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_x()
+    machine.succeed("obs >&2 &")
+    machine.wait_for_window("OBS")
+    machine.sleep(1)
+    machine.screenshot("obs")
+  '';
+})


### PR DESCRIPTION
## Description of changes

Add the `programs.obs-studio` module.
It lets you add third-party plugins (e.g. `pkgs.obs-studio-plugins.wlrobs`) to make a wrapped OBS package.
This is basically a port of the [equivalent home-manager module](https://github.com/nix-community/home-manager/blob/2d47379ad591bcb14ca95a90b6964b8305f6c913/modules/programs/obs-studio.nix).

cc @eclairevoyant @jb55 @MP2E @materusPL @fpletz 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
