### PR TITLE
ncncd: unstable-2023-10-26 -> unstable-2024-01-16

### DIFF
--- a/pkgs/os-specific/linux/nsncd/default.nix
+++ b/pkgs/os-specific/linux/nsncd/default.nix
@@ -7,19 +7,22 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "nsncd";
-  version = "unstable-2023-10-26";
+  version = "unstable-2024-01-16";
 
-  # https://github.com/twosigma/nsncd/pull/71 has not been upstreamed
-  # to twosigma/nsncd yet. Using the nix-community fork in the
-  # meantime.
   src = fetchFromGitHub {
-    owner = "nix-community";
+    owner = "twosigma";
     repo = "nsncd";
-    rev =  "d6513421f420e407248c6d0aee39ae2f861a7cec";
-    hash = "sha256-PykzwpPxMDHJOr2HubXuw+Krk9Jbi0E3M2lEAOXhx2M=";
+    rev =  "f4706786f26d12c533035fb2916be9be5751150b";
+    hash = "sha256-GbKDWW00eZZwmslkaGIO8hjCyD5xi7h+S2WP6q5ekOQ=";
   };
 
-  cargoSha256 = "sha256-cUM7rYXWpJ0aMiurXBp15IlxAmf/x5uiodxEqBPCQT0=";
+  cargoSha256 = "sha256-jAxcyMPDTBFBrG0cuKm0Tm5p/UEnUgTPQKDgqY2yK7w=";
+  checkFlags = [
+    # Relies on the test environment to be able to resolve "localhost"
+    # on IPv4. That's not the case in the Nix sandbox somehow. Works
+    # when running cargo test impurely on a (NixOS|Debian) machine.
+    "--skip=ffi::test_gethostbyname2_r"
+  ];
 
   meta = with lib; {
     description = "the name service non-caching daemon";


### PR DESCRIPTION
## Description of changes

All our modifications have been merged upstream. There's no need to point to the Nix Community fork anymore, pointing to upstream (twosigma) instead.

Fixes #282485


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
