### PR TITLE
hiawatha: 10.11 -> 11.5

### DIFF
--- a/pkgs/servers/http/hiawatha/default.nix
+++ b/pkgs/servers/http/hiawatha/default.nix
@@ -1,5 +1,6 @@
 { lib, stdenv
 , fetchFromGitLab
+, callPackage
 
 , cmake
 , ninja
@@ -16,14 +17,14 @@
 , enableToolkit   ? true     # The URL Toolkit.
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "hiawatha";
   version = "10.11";
 
   src = fetchFromGitLab {
     owner = "hsleisink";
     repo = "hiawatha";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "10a7dqj37zrbmgnhwsw0mqm5x25kasl8p95g01rzakviwxkdrkid";
   };
 
@@ -46,12 +47,18 @@ stdenv.mkDerivation rec {
     ( if enableToolkit   then "-DENABLE_TOOLKIT=on"     else "-DENABLE_TOOLKIT=off"     )
   ];
 
+  passthru.tests.serve-static-files = callPackage ./test.nix {
+    hiawatha = finalAttrs.finalPackage;
+    inherit enableTls;
+  };
+
   meta = with lib; {
     homepage = "https://www.hiawatha-webserver.org";
     description = "Advanced and secure webserver";
     license = licenses.gpl2Only;
     platforms = platforms.unix;    # "Hiawatha runs perfectly on Linux, BSD and MacOS X"
+    mainProgram = "hiawatha";
     maintainers = [];
   };
 
-}
+})

--- a/pkgs/servers/http/hiawatha/default.nix
+++ b/pkgs/servers/http/hiawatha/default.nix
@@ -4,7 +4,7 @@
 
 , cmake
 , ninja
-, mbedtls_2
+, mbedtls
 , libxcrypt
 
 , enableCache     ? true     # Internal cache support.
@@ -19,17 +19,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hiawatha";
-  version = "10.11";
+  version = "11.5";
 
   src = fetchFromGitLab {
     owner = "hsleisink";
     repo = "hiawatha";
     rev = "v${finalAttrs.version}";
-    sha256 = "10a7dqj37zrbmgnhwsw0mqm5x25kasl8p95g01rzakviwxkdrkid";
+    hash = "sha256-kswVBVL/QUQmCwH74qWwSwLz4uwDymuHIr8NokrrgEM=";
   };
 
   nativeBuildInputs = [ cmake ninja ];
-  buildInputs = [ mbedtls_2 libxcrypt ] ++ lib.optionals enableXslt [ libxslt libxml2 ];
+  buildInputs = [ mbedtls libxcrypt ] ++ lib.optionals enableXslt [ libxslt libxml2 ];
 
   prePatch = ''
     substituteInPlace CMakeLists.txt --replace SETUID ""
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = with lib; {
-    homepage = "https://www.hiawatha-webserver.org";
+    homepage = "https://hiawatha.leisink.net/";
     description = "Advanced and secure webserver";
     license = licenses.gpl2Only;
     platforms = platforms.unix;    # "Hiawatha runs perfectly on Linux, BSD and MacOS X"

--- a/pkgs/servers/http/hiawatha/test.nix
+++ b/pkgs/servers/http/hiawatha/test.nix
@@ -1,0 +1,84 @@
+{ lib
+, stdenvNoCC
+, hiawatha
+, curl
+, mbedtls
+, enableTls
+}:
+
+stdenvNoCC.mkDerivation {
+  name = "hiawatha-test";
+
+  nativeBuildInputs = [
+    hiawatha
+    curl
+  ] ++ lib.optional enableTls mbedtls;
+
+  env = {
+    inherit enableTls;
+  };
+
+  buildCommand = ''
+    cp -r --no-preserve=mode ${hiawatha}/etc/hiawatha config
+    sed "1i set TEST_DIR = $(pwd)" $serverConfigPath > config/hiawatha.conf
+
+    mkdir www
+    echo "it works" > www/index.html
+
+    if [ -n "$enableTls" ]; then
+      echo "Generating self-signed certificate"
+      gen_key type=ec filename=server.key
+      cert_write selfsign=1 issuer_key=server.key output_file=server.crt
+      cat server.crt server.key > config/server.crt
+    fi
+
+    echo "Checking server configuration"
+    hiawatha -c ./config -k
+
+    echo "Starting server"
+    hiawatha -c ./config
+
+    testUrl() {
+      echo "Testing $1"
+      curl --verbose --insecure --fail "$1" | tee response
+      grep -q "it works" response
+    }
+
+    testUrl http://127.0.0.1:8000
+    if [ -n "$enableTls" ]; then
+      testUrl https://127.0.0.1:8443
+    fi
+
+    touch $out
+  '';
+
+  serverConfig = ''
+    # By default the server uses read-only directories like /var/lib and /etc
+    WorkDirectory = TEST_DIR
+    PIDfile = TEST_DIR/hiawatha.pid
+    SystemLogfile = TEST_DIR/system.log
+    GarbageLogfile = TEST_DIR/garbage.log
+    ExploitLogfile = TEST_DIR/exploit.log
+    AccessLogfile = TEST_DIR/access.log
+    ErrorLogfile = TEST_DIR/error.log
+
+    Binding {
+      Interface = 127.0.0.1
+      Port = 8000
+    }
+
+    ${lib.optionalString enableTls ''
+      Binding {
+        Interface = 127.0.0.1
+        Port = 8443
+        TLScertFile = TEST_DIR/config/server.crt
+      }
+    ''}
+
+    Hostname = 127.0.0.1
+    WebsiteRoot = TEST_DIR/www
+    StartFile = index.html
+  '';
+
+  passAsFile = [ "serverConfig" ];
+}


### PR DESCRIPTION
## Description of changes

Changelog: https://www.hiawatha-webserver.org/changelog

This adds compatibility with mbedtls 3. mbedtls 2 is slowly but surely reaching its [scheduled EOL](https://github.com/Mbed-TLS/mbedtls/blob/development/BRANCHES.md#current-branches).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
