### PR TITLE
Revert "Dovecot: Do not include empty sieve_extensions and sieve_global_extensions"

### DIFF
--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -119,10 +119,9 @@ let
     ''
       plugin {
         sieve_plugins = ${concatStringsSep " " cfg.sieve.plugins}
+        sieve_extensions = ${concatStringsSep " " (map (el: "+${el}") cfg.sieve.extensions)}
+        sieve_global_extensions = ${concatStringsSep " " (map (el: "+${el}") cfg.sieve.globalExtensions)}
     ''
-    (optionalString (cfg.sieve.extensions != []) ''sieve_extensions = ${concatMapStringsSep " " (el: "+${el}") cfg.sieve.extensions}'')
-    (optionalString (cfg.sieve.globalExtensions != []) ''sieve_global_extensions = ${concatMapStringsSep " " (el: "+${el}") cfg.sieve.globalExtensions}'')
-
     (optionalString (cfg.imapsieve.mailbox != []) ''
       ${
         concatStringsSep "\n" (flatten (imap1 (


### PR DESCRIPTION
Reverts NixOS/nixpkgs#281915