### PR TITLE
spotube: init at 3.4.1

### DIFF
--- a/pkgs/by-name/sp/spotube/package.nix
+++ b/pkgs/by-name/sp/spotube/package.nix
@@ -1,0 +1,109 @@
+{ lib
+, stdenv
+, fetchurl
+
+, autoPatchelfHook
+, dpkg
+, makeWrapper
+, undmg
+, wrapGAppsHook
+
+, libappindicator
+, libnotify
+, libsecret
+, mpv-unwrapped
+, xdg-user-dirs
+}:
+
+let
+  pname = "spotube";
+  version = "3.4.1";
+
+  meta = {
+    description = "An open source, cross-platform Spotify client compatible across multiple platforms";
+    longDescription = ''
+      Spotube is an open source, cross-platform Spotify client compatible across
+      multiple platforms utilizing Spotify's data API and YouTube (or Piped.video or JioSaavn)
+      as an audio source, eliminating the need for Spotify Premium
+    '';
+    downloadPage = "https://github.com/KRTirtho/spotube/releases";
+    homepage = "https://spotube.netlify.app/";
+    license = lib.licenses.bsdOriginal;
+    mainProgram = "spotube";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+
+  fetchArtifact = { filename, hash }:
+    fetchurl {
+      url = "https://github.com/KRTirtho/spotube/releases/download/v${version}/${filename}";
+      inherit hash;
+    };
+
+  darwin = stdenv.mkDerivation {
+    inherit pname version meta;
+
+    src = fetchArtifact {
+      filename = "Spotube-macos-universal.dmg";
+      hash = "sha256-VobLCxsmE5kGIlDDa3v5xIHkw2x2YV14fgHHcDb+bLo=";
+    };
+
+    sourceRoot = ".";
+
+    nativeBuildInputs = [ undmg ];
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/Applications $out/bin
+      cp -r spotube.app $out/Applications
+      ln -s $out/Applications/spotube.app/Contents/MacOS/spotube $out/bin/spotube
+      runHook postInstall
+    '';
+  };
+
+  linux = stdenv.mkDerivation {
+    inherit pname version meta;
+
+    src = fetchArtifact {
+      filename = "Spotube-linux-x86_64.deb";
+      hash = "sha256-NEGhzNz0E8jK2NPmigzoPAvYcU7zN9YHikuXHpzWfx0=";
+    };
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+      dpkg
+      makeWrapper
+      wrapGAppsHook
+    ];
+
+    buildInputs = [
+      libappindicator
+      libnotify
+      libsecret
+      mpv-unwrapped
+    ];
+
+    dontWrapGApps = true;
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      cp -r usr/* $out
+      runHook postInstall
+    '';
+
+    preFixup = ''
+      patchelf $out/share/spotube/lib/libmedia_kit_native_event_loop.so \
+          --replace-needed libmpv.so.1 libmpv.so
+    '';
+
+    postFixup = ''
+      makeWrapper $out/share/spotube/spotube $out/bin/spotube \
+          "''${gappsWrapperArgs[@]}" \
+          --prefix LD_LIBRARY_PATH : $out/share/spotube/lib:${lib.makeLibraryPath [ mpv-unwrapped ]} \
+          --prefix PATH : ${lib.makeBinPath [ xdg-user-dirs ]}
+    '';
+  };
+in
+if stdenv.isDarwin then darwin else linux


### PR DESCRIPTION
## Description of changes

Related issue: https://github.com/NixOS/nixpkgs/issues/200120

This PR adds 1 package: `spotube`

I used the prebuilt binary distribution, as the `flutter` version of Nixpkgs is not low enough for building from source.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
