### PR TITLE
ddcci-plasmoid: init at 0.1.10

### DIFF
--- a/pkgs/by-name/dd/ddcci-plasmoid/package.nix
+++ b/pkgs/by-name/dd/ddcci-plasmoid/package.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, callPackage
+, python3Packages
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "ddcci-plasmoid";
+  version = "0.1.10-kf6";
+
+  src = fetchFromGitHub {
+    owner = "davidhi7";
+    repo = "ddcci-plasmoid";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-/UTIflcUyPHMQ2CQG0d2R0MaKuXYmlvnYnLNQ+nMWvw=";
+  };
+
+  postPatch = ''
+    substituteInPlace plasmoid/contents/config/main.xml \
+      --replace "<default>python3 -m ddcci_plasmoid_backend</default>" \
+                "<default>${python3Packages.ddcci-plasmoid-backend}/bin/ddcci_plasmoid_backend</default>"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/plasma/plasmoids/de.davidhi.ddcci-brightness
+    cp -r ./plasmoid/* $out/share/plasma/plasmoids/de.davidhi.ddcci-brightness/
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "KDE Plasma Widget for external monitor brightness adjustment using ddcutil";
+    homepage = "https://github.com/davidhi7/ddcci-plasmoid";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ sund3RRR ];
+  };
+}

--- a/pkgs/development/python-modules/ddcci-plasmoid-backend/default.nix
+++ b/pkgs/development/python-modules/ddcci-plasmoid-backend/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, fetchFromGitHub
+, python3Packages
+, ddcutil
+}:
+
+python3Packages.buildPythonPackage rec {
+  pname = "ddcci-plasmoid-backend";
+  version = "0.1.10-kf6";
+
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "davidhi7";
+    repo = "ddcci-plasmoid";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-/UTIflcUyPHMQ2CQG0d2R0MaKuXYmlvnYnLNQ+nMWvw=";
+  } + "/backend";
+
+  nativeBuildInputs = with python3Packages; [
+    pythonRelaxDepsHook
+    poetry-core
+  ];
+
+  pythonRelaxDeps = [
+    "fasteners"
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    fasteners
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+  ];
+
+  preFixup = ''
+    makeWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ ddcutil ]})
+  '';
+
+  meta = with lib; {
+    description = "ddcci python backend for KDE plasma ddcci-plasmoid";
+    homepage = "https://github.com/davidhi7/ddcci-plasmoid";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ sund3RRR ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2760,6 +2760,8 @@ self: super: with self; {
 
   dctorch = callPackage ../development/python-modules/dctorch { };
 
+  ddcci-plasmoid-backend = callPackage ../development/python-modules/ddcci-plasmoid-backend { };
+
   ddt = callPackage ../development/python-modules/ddt { };
 
   deal = callPackage ../development/python-modules/deal { };


### PR DESCRIPTION
## Description of changes
[ddcci-plasmoid](https://github.com/davidhi7/ddcci-plasmoid) - KDE Plasma Widget for external monitor brightness adjustment using `ddcutil`
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
