### PR TITLE
python311Packages.mne-python: 1.6.0 -> 1.6.1; unbreak

### DIFF
--- a/pkgs/development/python-modules/h5io/default.nix
+++ b/pkgs/development/python-modules/h5io/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, setuptools
+, numpy
+, h5py
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "h5io";
+  version = "0.2.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "h5io";
+    repo = "h5io";
+    rev = "refs/tags/h5io-${version}";
+    hash = "sha256-3mrHIkfaXq06mMzUwudRO81DWTk0TO/e15IQA5fxxNc=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml  \
+      --replace "--cov-report=" ""  \
+      --replace "--cov-branch" ""  \
+      --replace "--cov=h5io" ""
+  '';
+
+  nativeBuildInputs = [ setuptools ];
+
+  propagatedBuildInputs = [
+    numpy
+    h5py
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "h5io" ];
+
+  meta = with lib; {
+    description = "Read and write simple Python objects using HDF5";
+    homepage = "https://github.com/h5io/h5io";
+    changelog = "https://github.com/h5io/h5io/releases/tag/${src.rev}";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ mbalatsko ];
+  };
+}

--- a/pkgs/development/python-modules/mne-python/default.nix
+++ b/pkgs/development/python-modules/mne-python/default.nix
@@ -1,65 +1,83 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, setuptools
+, setuptools-scm
 , numpy
 , scipy
 , pytestCheckHook
 , pytest-timeout
-, h5py
+, pytest-harvest
 , matplotlib
-, nibabel
-, pandas
-, scikit-learn
 , decorator
 , jinja2
 , pooch
 , tqdm
-, setuptools
+, packaging
+, importlib-resources
+, lazy-loader
+, h5io
+, pymatreader
 , pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "mne-python";
-  version = "1.6.0";
-  format = "setuptools";
+  version = "1.6.1";
+  pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "mne-tools";
-    repo = pname;
+    repo = "mne-python";
     rev = "refs/tags/v${version}";
-    hash = "sha256-OoaXNHGL2svOpNL5GHcVRfQc9GxIRpZRhpZ5Hi1JTzM=";
+    hash = "sha256-U1aMqcUZ3BcwqwOYh/qfG5PhacwBVioAgNc52uaoJL0";
   };
 
-  propagatedBuildInputs = [
-    decorator
-    jinja2
-    matplotlib
-    numpy
-    pooch
-    scipy
+  postPatch = ''
+    substituteInPlace pyproject.toml  \
+      --replace "--cov-report=" ""  \
+      --replace "--cov-branch" ""
+  '';
+
+  nativeBuildInputs = [
     setuptools
-    tqdm
+    setuptools-scm
   ];
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    matplotlib
+    tqdm
+    pooch
+    decorator
+    packaging
+    jinja2
+    lazy-loader
+  ] ++ lib.optionals (pythonOlder "3.9") [
+    importlib-resources
+  ];
+
+  passthru.optional-dependencies = {
+    hdf5 = [
+      h5io
+      pymatreader
+    ];
+  };
 
   nativeCheckInputs = [
-    h5py
-    nibabel
-    pandas
     pytestCheckHook
-    scikit-learn
     pytest-timeout
-  ];
+    pytest-harvest
+  ] ++ lib.flatten (builtins.attrValues passthru.optional-dependencies);
 
   preCheck = ''
-    export HOME=$TMP
+    export HOME=$(mktemp -d)
     export MNE_SKIP_TESTING_DATASET_TESTS=true
     export MNE_SKIP_NETWORK_TESTS=1
   '';
-
-  # All tests pass, but Pytest hangs afterwards - probably some thread hasn't terminated
-  doCheck = false;
 
   pythonImportsCheck = [
     "mne"
@@ -68,6 +86,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Magnetoencephelography and electroencephalography in Python";
     homepage = "https://mne.tools";
+    changelog = "https://mne.tools/stable/changes/v${version}.html";
     license = licenses.bsd3;
     maintainers = with maintainers; [ bcdarwin ];
   };

--- a/pkgs/development/python-modules/mne-python/default.nix
+++ b/pkgs/development/python-modules/mne-python/default.nix
@@ -88,6 +88,6 @@ buildPythonPackage rec {
     homepage = "https://mne.tools";
     changelog = "https://mne.tools/stable/changes/v${version}.html";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ bcdarwin ];
+    maintainers = with maintainers; [ bcdarwin mbalatsko ];
   };
 }

--- a/pkgs/development/python-modules/pymatreader/default.nix
+++ b/pkgs/development/python-modules/pymatreader/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitLab
+, setuptools
+, h5py
+, numpy
+, scipy
+, xmltodict
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pymatreader";
+  version = "0.0.31";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    owner = "obob";
+    repo = "pymatreader";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-pYObmvqA49sHjpZcwXkN828R/N5CSpmr0OyyxzDiodQ=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  propagatedBuildInputs = [
+    h5py
+    numpy
+    scipy
+    xmltodict
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "pymatreader" ];
+
+  meta = with lib; {
+    description = "A python package to read all kinds and all versions of Matlab mat files";
+    homepage = "https://gitlab.com/obob/pymatreader/";
+    changelog = "https://gitlab.com/obob/pymatreader/-/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ mbalatsko ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-harvest/default.nix
+++ b/pkgs/development/python-modules/pytest-harvest/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools-scm
+, pytest-runner
+, pytest
+, decopatch
+, makefun
+, six
+, pytestCheckHook
+, numpy
+, pandas
+, tabulate
+, pytest-cases
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-harvest";
+  version = "1.10.4";
+  pyproject = true;
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "smarie";
+    repo = "python-pytest-harvest";
+    rev = "refs/tags/${version}";
+    hash = "sha256-ebzE63d7zt9G9HgbLHaE/USZZpUd3y3vd0kNdT/wWw0=";
+  };
+
+  # create file, that is created by setuptools_scm
+  # we disable this file creation as it touches internet
+  postPatch = ''
+    echo "version = '${version}'" > pytest_harvest/_version.py
+  '';
+
+  nativeBuildInputs = [
+    setuptools-scm
+    pytest-runner
+  ];
+
+  buildInputs = [ pytest ];
+
+  propagatedBuildInputs = [
+    decopatch
+    makefun
+    six
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    numpy
+    pandas
+    tabulate
+    pytest-cases
+  ];
+
+  pythonImportsCheck = [ "pytest_harvest" ];
+
+  meta = with lib; {
+    description = "Store data created during your `pytest` tests execution, and retrieve it at the end of the session, e.g. for applicative benchmarking purposes";
+    homepage = "https://github.com/smarie/python-pytest-harvest";
+    changelog = "https://github.com/smarie/python-pytest-harvest/releases/tag/${src.rev}";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ mbalatsko ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5037,6 +5037,8 @@ self: super: with self; {
     inherit (pkgs) h3;
   };
 
+  h5io = callPackage ../development/python-modules/h5io { };
+
   h5netcdf = callPackage ../development/python-modules/h5netcdf { };
 
   h5py = callPackage ../development/python-modules/h5py { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10758,6 +10758,8 @@ self: super: with self; {
 
   pymatgen = callPackage ../development/python-modules/pymatgen { };
 
+  pymatreader = callPackage ../development/python-modules/pymatreader { };
+
   pymatting = callPackage ../development/python-modules/pymatting { };
 
   pymaven-patch = callPackage ../development/python-modules/pymaven-patch { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11528,6 +11528,8 @@ self: super: with self; {
 
   pytest-grpc = callPackage ../development/python-modules/pytest-grpc { };
 
+  pytest-harvest = callPackage ../development/python-modules/pytest-harvest { };
+
   pytest-helpers-namespace = callPackage ../development/python-modules/pytest-helpers-namespace { };
 
   pytest-html = callPackage ../development/python-modules/pytest-html { };


### PR DESCRIPTION
python3Packages.h5io: init at 0.2.1
python3Packages.pytest-harvest: init at 1.10.4
python3Packages.pymatreader: init at 0.0.31

## Description of changes

Cherry-pick and lightly update/revise commits from #258422 by @mbalatsko.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
