### PR TITLE
nautilus-open-any-terminal: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/tools/misc/nautilus-open-any-terminal/default.nix
+++ b/pkgs/tools/misc/nautilus-open-any-terminal/default.nix
@@ -14,13 +14,14 @@
 
 python3.pkgs.buildPythonPackage rec {
   pname = "nautilus-open-any-terminal";
-  version = "0.4.0";
+  version = "0.5.0";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Stunkymonkey";
     repo = pname;
     rev = version;
-    sha256 = "sha256-EAI60Mw+OTPfjOS6lkGMul7QvTR7NXyNfevWY2JP1yI=";
+    hash = "sha256-fcTbt8O/7KEme5+GlDD7hMMcE2RaYqFdfojzJ1KhnA0=";
   };
 
   patches = [ ./hardcode-gsettings.patch ];
@@ -30,6 +31,7 @@ python3.pkgs.buildPythonPackage rec {
     gobject-introspection
     pkg-config
     wrapGAppsHook
+    python3.pkgs.setuptools
   ];
 
   buildInputs = [
@@ -43,7 +45,7 @@ python3.pkgs.buildPythonPackage rec {
   ];
 
   postPatch = ''
-    substituteInPlace nautilus_open_any_terminal/open_any_terminal_extension.py \
+    substituteInPlace nautilus_open_any_terminal/nautilus_open_any_terminal.py \
       --subst-var-by gsettings_path ${glib.makeSchemaPath "$out" "$name"}
   '';
 

--- a/pkgs/tools/misc/nautilus-open-any-terminal/hardcode-gsettings.patch
+++ b/pkgs/tools/misc/nautilus-open-any-terminal/hardcode-gsettings.patch
@@ -1,22 +1,22 @@
-diff --git a/nautilus_open_any_terminal/open_any_terminal_extension.py b/nautilus_open_any_terminal/open_any_terminal_extension.py
+diff --git a/nautilus_open_any_terminal/nautilus_open_any_terminal.py b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
 index b02a995..a616399 100644
---- a/nautilus_open_any_terminal/open_any_terminal_extension.py
-+++ b/nautilus_open_any_terminal/open_any_terminal_extension.py
-@@ -205,9 +205,10 @@ def set_terminal_args(*args):
- 
-     class OpenAnyTerminalShortcutProvider(GObject.GObject, Nautilus.LocationWidgetProvider):
+--- a/nautilus_open_any_terminal/nautilus_open_any_terminal.py
++++ b/nautilus_open_any_terminal/nautilus_open_any_terminal.py
+@@ -228,9 +228,10 @@ def set_terminal_args(*args):
+         """Provide keyboard shortcuts for opening terminals in Nautilus."""
+
          def __init__(self):
--            source = Gio.SettingsSchemaSource.get_default()
--            if source.lookup(GSETTINGS_PATH, True):
+-            gsettings_source = Gio.SettingsSchemaSource.get_default()
+-            if gsettings_source.lookup(GSETTINGS_PATH, True):
 -                self._gsettings = Gio.Settings.new(GSETTINGS_PATH)
-+            source = Gio.SettingsSchemaSource.new_from_directory("@gsettings_path@", Gio.SettingsSchemaSource.get_default(), True)
++            gsettings_source = Gio.SettingsSchemaSource.new_from_directory("@gsettings_path@", Gio.SettingsSchemaSource.get_default(), True)
 +            if True:
-+                _schema = source.lookup(GSETTINGS_PATH, False)
++                _schema = gsettings_source.lookup(GSETTINGS_PATH, False)
 +                self._gsettings = Gio.Settings.new_full(_schema, None, None);
                  self._gsettings.connect("changed", self._bind_shortcut)
                  self._create_accel_group()
              self._window = None
-@@ -232,9 +233,10 @@ class OpenAnyTerminalExtension(GObject.GObject, Nautilus.MenuProvider):
+@@ -326,9 +327,10 @@ class OpenAnyTerminalExtension(GObject.GObject, Nautilus.MenuProvider):
          return items
  
  


### PR DESCRIPTION
## Description of changes

https://github.com/Stunkymonkey/nautilus-open-any-terminal/releases/tag/0.5.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
