### PR TITLE
jellyfin: move pins of dotnet-runtime and dotnet-sdk to top-level

### DIFF
--- a/pkgs/servers/jellyfin/default.nix
+++ b/pkgs/servers/jellyfin/default.nix
@@ -1,15 +1,16 @@
-{ lib
+{ buildDotnetModule
+, dotnet-runtime
+, dotnet-sdk
 , fetchFromGitHub
 , fetchurl
-, nixosTests
-, stdenv
-, dotnetCorePackages
-, buildDotnetModule
 , ffmpeg
 , fontconfig
 , freetype
 , jellyfin-web
+, lib
+, nixosTests
 , sqlite
+, stdenv
 }:
 
 buildDotnetModule rec {
@@ -40,8 +41,7 @@ buildDotnetModule rec {
     fontconfig
     freetype
   ];
-  dotnet-sdk = dotnetCorePackages.sdk_6_0;
-  dotnet-runtime = dotnetCorePackages.aspnetcore_6_0;
+
   dotnetBuildFlags = [ "--no-self-contained" ];
 
   preInstall = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5753,6 +5753,8 @@ with pkgs;
   jellycli = callPackage ../applications/audio/jellycli { };
 
   jellyfin = callPackage ../servers/jellyfin {
+    dotnet-runtime = dotnetCorePackages.aspnetcore_6_0;
+    dotnet-sdk = dotnetCorePackages.sdk_6_0;
     ffmpeg = jellyfin-ffmpeg;
   };
 


### PR DESCRIPTION
jellyfin: move pins of dotnet-runtime and dotnet-sdk to top-level

(This makes possible to override parameters)

- Alphabetically order parameters. (I know this is debatable, but shouldn't be IMO. Does not get more objective than this.)