### PR TITLE
Update vimPlugins.lazy-nvim -> 10.16.0

### DIFF
--- a/pkgs/applications/editors/vim/plugins/generated.nix
+++ b/pkgs/applications/editors/vim/plugins/generated.nix
@@ -4788,12 +4788,12 @@ final: prev:
 
   lazy-nvim = buildVimPlugin {
     pname = "lazy.nvim";
-    version = "2023-11-04";
+    version = "2024-01-21";
     src = fetchFromGitHub {
       owner = "folke";
       repo = "lazy.nvim";
-      rev = "96584866b9c5e998cbae300594d0ccfd0c464627";
-      sha256 = "11s0ddi1zcnyrh1q73jp2a4whvpajiwjd6dv8igfwj4jr21mrl39";
+      rev = "28126922c9b54e35a192ac415788f202c3944c9f";
+      sha256 = "sha256-Qicyec1ZvSb5JVVTW8CrTjndHCLso8Rb2V5IA6D4Rps=";
     };
     meta.homepage = "https://github.com/folke/lazy.nvim/";
   };


### PR DESCRIPTION
dev.paths now accepts a function, allowing for a lot more nix shenanigans

## Description of changes

Updated hash in generated.nix for lazy.nvim