### PR TITLE
f3d: 2.2.1 -> 2.3.0, unbreak

### DIFF
--- a/pkgs/applications/graphics/f3d/default.nix
+++ b/pkgs/applications/graphics/f3d/default.nix
@@ -14,7 +14,7 @@
 
 stdenv.mkDerivation rec {
   pname = "f3d";
-  version = "2.2.1";
+  version = "2.3.0";
 
   outputs = [ "out" "man" ];
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     owner = "f3d-app";
     repo = "f3d";
     rev = "refs/tags/v${version}";
-    hash = "sha256-3Pg8uvrUGPKPmsn24q5HPMg9dgvukAXBgSVTW0NiCME=";
+    hash = "sha256-pr2xuCy5yoUuj2cjkTh3Xwpg3g7zBspjErEi5luRD6Y=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/graphics/f3d/default.nix
+++ b/pkgs/applications/graphics/f3d/default.nix
@@ -1,4 +1,14 @@
-{ lib, stdenv, fetchFromGitHub, cmake, vtk_9, libX11, libGL, Cocoa, OpenGL }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, vtk_9
+, autoPatchelfHook
+, libX11
+, libGL
+, Cocoa
+, OpenGL
+}:
 
 stdenv.mkDerivation rec {
   pname = "f3d";
@@ -11,7 +21,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-3Pg8uvrUGPKPmsn24q5HPMg9dgvukAXBgSVTW0NiCME=";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    # https://github.com/f3d-app/f3d/pull/1217
+    autoPatchelfHook
+  ];
 
   buildInputs = [ vtk_9 ] ++ lib.optionals stdenv.isDarwin [ Cocoa OpenGL ];
 
@@ -30,9 +44,5 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     maintainers = with maintainers; [ bcdarwin ];
     platforms = with platforms; unix;
-    # As of 2024-01-20, this fails with:
-    # error while loading shared libraries: libvtkInteractionWidgets.so.1: cannot open shared object file: No such file or directory
-    # Tracking issue: https://github.com/NixOS/nixpkgs/issues/262328
-    broken = true;
   };
 }

--- a/pkgs/applications/graphics/f3d/default.nix
+++ b/pkgs/applications/graphics/f3d/default.nix
@@ -2,6 +2,8 @@
 , stdenv
 , fetchFromGitHub
 , cmake
+, help2man
+, gzip
 , vtk_9
 , autoPatchelfHook
 , libX11
@@ -14,6 +16,8 @@ stdenv.mkDerivation rec {
   pname = "f3d";
   version = "2.2.1";
 
+  outputs = [ "out" "man" ];
+
   src = fetchFromGitHub {
     owner = "f3d-app";
     repo = "f3d";
@@ -23,18 +27,22 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
+    help2man
+    gzip
     # https://github.com/f3d-app/f3d/pull/1217
     autoPatchelfHook
   ];
 
   buildInputs = [ vtk_9 ] ++ lib.optionals stdenv.isDarwin [ Cocoa OpenGL ];
 
-  # conflict between VTK and Nixpkgs;
-  # see https://github.com/NixOS/nixpkgs/issues/89167
   cmakeFlags = [
+    # conflict between VTK and Nixpkgs;
+    # see https://github.com/NixOS/nixpkgs/issues/89167
     "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
     "-DCMAKE_INSTALL_BINDIR=bin"
+
+    "-DF3D_LINUX_GENERATE_MAN=ON"
   ];
 
   meta = with lib; {

--- a/pkgs/applications/graphics/f3d/default.nix
+++ b/pkgs/applications/graphics/f3d/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     homepage = "https://f3d-app.github.io/f3d";
     changelog = "https://github.com/f3d-app/f3d/releases/tag/v${version}";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ bcdarwin ];
+    maintainers = with maintainers; [ bcdarwin pbsds ];
     platforms = with platforms; unix;
   };
 }


### PR DESCRIPTION
## Description of changes

Diff: https://github.com/f3d-app/f3d/compare/refs/tags/v2.2.1...v2.3.0

Changelog: https://github.com/f3d-app/f3d/releases/tag/v2.3.0

unbreak by ~~partially reverting https://github.com/f3d-app/f3d/commit/a8fdf79e6e7b4006e71ae8a5db0592796a0a1477, tracked in https://github.com/f3d-app/f3d/pull/1217.~~ using `autoPatchelfHook`.

fixes https://github.com/NixOS/nixpkgs/issues/262328


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
