### PR TITLE
{mpich,openmpi}: optionally link against slurm's libpmi2

### DIFF
--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -280,6 +280,16 @@ in
         contents = [ hello cowsay ];
         singularity = finalAttrs.finalPackage;
       };
+      image-mpich-samples = callPackage
+        ({ singularity-tools, mpich }:
+          singularity-tools.buildImage {
+            name = mpich.tests.samples.name;
+            contents = [ mpich.tests.samples ];
+            memSize = 4096;
+            diskSize = 4096;
+            singularity = finalAttrs.finalPackage;
+          })
+        { };
     };
     gpuChecks = lib.optionalAttrs (projectName == "apptainer") {
       # Should be in tests, but Ofborg would skip image-hello-cowsay because

--- a/pkgs/development/libraries/mpich/default.nix
+++ b/pkgs/development/libraries/mpich/default.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchurl,
+  callPackage,
   perl,
   gfortran,
   openssh,
@@ -109,6 +110,8 @@ stdenv.mkDerivation  rec {
     sed -i 's:CXX="g++":CXX=${stdenv.cc}/bin/g++:' $out/bin/mpicxx
     sed -i 's:FC="gfortran":FC=${gfortran}/bin/gfortran:' $out/bin/mpifort
   '';
+
+  passthru.tests.samples = callPackage ./tests { };
 
   meta = with lib; {
     broken =

--- a/pkgs/development/libraries/mpich/default.nix
+++ b/pkgs/development/libraries/mpich/default.nix
@@ -14,16 +14,34 @@
   # cf. https://github.com/pmodels/mpich/blob/b80a6d7c24defe7cdf6c57c52430f8075a0a41d6/README.vin#L562-L586
   withPm ? [
     "hydra"
+  ] ++ lib.optionals (withPmi == "pmi1") [
     "gforker"
   ],
   pmix,
   # PMIX support is likely incompatible with process managers (`--with-pm`)
   # https://github.com/NixOS/nixpkgs/pull/274804#discussion_r1432601476
-  pmixSupport ? false,
+  enablePmix ? false,
+  withPmi ? if enablePmix then "pmix" else "pmi2",
+  # --with-pmilib is a transitionary interface, update with 4.2.0
+  withPmilib ? if enablePmix then "default" else "slurm",
+  enablePmi1 ? false,
+  enablePmi2 ? !enablePmix,
+  slurm,
 }:
 
 let
   withPmStr = if withPm != [ ] then builtins.concatStringsSep ":" withPm else "no";
+
+  # MPICH doesn't support the autoconf-style --without-feature and
+  # --disable-feature flags:
+  mpichWith =
+    cond: feature:
+    assert builtins.isBool cond;
+    if cond then "--with-${feature}" else "--with-${feature}=no";
+  mpichWithAs =
+    cond: feature: value:
+    assert builtins.isBool cond;
+    if cond then "--with-${feature}=${value}" else "--with-${feature}=no";
 in
 
 assert (ch4backend.pname == "ucx" || ch4backend.pname == "libfabric");
@@ -39,23 +57,49 @@ stdenv.mkDerivation  rec {
 
   outputs = [ "out" "doc" "man" ];
 
-  configureFlags = [
-    "--enable-shared"
-    "--with-pm=${withPmStr}"
-  ] ++ lib.optionals (lib.versionAtLeast gfortran.version "10") [
-    "FFLAGS=-fallow-argument-mismatch" # https://github.com/pmodels/mpich/issues/4300
-    "FCFLAGS=-fallow-argument-mismatch"
-  ] ++ lib.optionals pmixSupport [
-    "--with-pmix"
-  ];
+  configureFlags =
+    [
+      "--enable-shared"
+      (mpichWithAs true "pm" withPmStr)
+      (mpichWithAs true "pmi" withPmi)
+      (mpichWithAs true "pmilib" withPmilib)
+
+      # --with-pmi{1,2,x} declared at
+      # https://github.com/pmodels/mpich/blob/c2f04da1b3371b0e85c77761649adfa30a0f5269/configure.ac#L1537-L1539
+      (mpichWith enablePmix "pmix")
+    ]
+    ++ lib.optionals (enablePmi1 != null) [
+      (mpichWith enablePmi1 "pmi1")
+    ]
+    ++ lib.optionals (enablePmi2 != null) [
+      (mpichWith enablePmi2 "pmi2")
+    ]
+    ++ lib.optionals (lib.versionAtLeast gfortran.version "10") [
+      "FFLAGS=-fallow-argument-mismatch" # https://github.com/pmodels/mpich/issues/4300
+      "FCFLAGS=-fallow-argument-mismatch"
+    ];
 
   enableParallelBuilding = true;
 
-  nativeBuildInputs = [ gfortran python3 ];
-  buildInputs = [ perl openssh hwloc ]
-    ++ lib.optional (!stdenv.isDarwin) ch4backend
-    ++ lib.optional pmixSupport pmix;
-
+  nativeBuildInputs = [
+    gfortran
+    python3
+  ];
+  buildInputs =
+    [
+      perl
+      openssh
+      hwloc
+      (lib.getLib slurm)
+      (lib.getDev slurm)
+    ]
+    ++ lib.optionals (enablePmi1 != null && enablePmi1) [
+      # Slurm's libpmi.so currently hard-codes a path to $out,
+      # so we put it in the same output as the binaries
+      (lib.getBin slurm)
+    ]
+    ++ lib.optionals (!stdenv.isDarwin) [ ch4backend ]
+    ++ lib.optionals enablePmix [ pmix ];
 
   doCheck = true;
 
@@ -67,8 +111,45 @@ stdenv.mkDerivation  rec {
   '';
 
   meta = with lib; {
-    # As far as we know, --with-pmix silently disables all of `--with-pm`
-    broken = pmixSupport && withPm != [ ];
+    broken =
+      let
+        anyFailed = builtins.any (x: !x);
+      in
+      anyFailed [
+        # As far as we know, --with-pmix silently disables all of `--with-pm`
+        (enablePmix -> withPm == [ ])
+        (enablePmix -> !(enablePmi1 || enablePmi2))
+
+        (!(enablePmi1 && enablePmi2)) # Reconsider with 4.2.*
+
+        # Mirroring
+        # https://github.com/pmodels/mpich/blob/v4.1.2/configure.ac#L1476-L1514
+        #
+        # This gets simplified with 4.2.*
+        (builtins.elem withPmi [
+          null
+          "bgq"
+          "cray"
+          "default"
+          "pmi1"
+          "pmi2"
+          "pmi2/simple"
+          "pmix"
+          "simple"
+          "slurm"
+        ])
+
+        (builtins.elem enablePmi1 [
+          null
+          true
+          false
+        ])
+        (builtins.elem enablePmi2 [
+          null
+          true
+          false
+        ])
+      ];
 
     description = "Implementation of the Message Passing Interface (MPI) standard";
 

--- a/pkgs/development/libraries/mpich/default.nix
+++ b/pkgs/development/libraries/mpich/default.nix
@@ -1,16 +1,26 @@
-{ stdenv, lib, fetchurl, perl, gfortran
-, openssh, hwloc, python3
-# either libfabric or ucx work for ch4backend on linux. On darwin, neither of
-# these libraries currently build so this argument is ignored on Darwin.
-, ch4backend
-# Process managers to build (`--with-pm`),
-# cf. https://github.com/pmodels/mpich/blob/b80a6d7c24defe7cdf6c57c52430f8075a0a41d6/README.vin#L562-L586
-, withPm ? [ "hydra" "gforker" ]
-, pmix
-# PMIX support is likely incompatible with process managers (`--with-pm`)
-# https://github.com/NixOS/nixpkgs/pull/274804#discussion_r1432601476
-, pmixSupport ? false
-} :
+{
+  stdenv,
+  lib,
+  fetchurl,
+  perl,
+  gfortran,
+  openssh,
+  hwloc,
+  python3,
+  # either libfabric or ucx work for ch4backend on linux. On darwin, neither of
+  # these libraries currently build so this argument is ignored on Darwin.
+  ch4backend,
+  # Process managers to build (`--with-pm`),
+  # cf. https://github.com/pmodels/mpich/blob/b80a6d7c24defe7cdf6c57c52430f8075a0a41d6/README.vin#L562-L586
+  withPm ? [
+    "hydra"
+    "gforker"
+  ],
+  pmix,
+  # PMIX support is likely incompatible with process managers (`--with-pm`)
+  # https://github.com/NixOS/nixpkgs/pull/274804#discussion_r1432601476
+  pmixSupport ? false,
+}:
 
 let
   withPmStr = if withPm != [ ] then builtins.concatStringsSep ":" withPm else "no";

--- a/pkgs/development/libraries/mpich/tests/CMakeLists.txt
+++ b/pkgs/development/libraries/mpich/tests/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.17)
+project(mpich-tests LANGUAGES C)
+find_package(MPI REQUIRED)
+
+add_executable(cpi ./cpi.c)
+add_executable(cpi-asan ./cpi.c)
+
+target_link_libraries(cpi PRIVATE MPI::MPI_C)
+target_link_libraries(cpi-asan PRIVATE MPI::MPI_C -fsanitize=address)
+install(TARGETS cpi cpi-asan)

--- a/pkgs/development/libraries/mpich/tests/default.nix
+++ b/pkgs/development/libraries/mpich/tests/default.nix
@@ -1,0 +1,27 @@
+{
+  stdenv,
+  cmake,
+  mpi,
+  mpich,
+}:
+stdenv.mkDerivation {
+  pname = "${mpich.pname}-samples-${mpi.pname}";
+  inherit (mpich) version src;
+
+  # Interacting with autotools is cumbersome, so we build a small subset of
+  # examples using CMake instead.
+  postPatch = ''
+    cd examples
+    cat ${./CMakeLists.txt} > CMakeLists.txt
+  '';
+
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ mpi ];
+
+  passthru = {
+    inherit mpi;
+  };
+
+  # A simple MPI program that approximates Pi
+  meta.mainProgram = "cpi";
+}

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -46,7 +46,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ zlib ]
     ++ lib.optionals (withPmi == "slurm") [ (lib.getLib slurm) ]
-    ++ lib.optionals stdenv.isLinux [ libnl numactl pmix ucx ucc ]
+    ++ lib.optionals stdenv.isLinux [
+      libnl
+      numactl
+      pmix
+      (lib.getDev ucc)
+      (lib.getLib ucc)
+      (lib.getDev ucx)
+      (lib.getLib ucx)
+    ]
     ++ lib.optionals cudaSupport [ cudaPackages.cuda_cudart ]
     ++ [ libevent hwloc ]
     ++ lib.optional (stdenv.isLinux || stdenv.isFreeBSD) rdma-core
@@ -64,7 +72,6 @@ stdenv.mkDerivation rec {
       (lib.withFeature true "ucc")
       (lib.withFeature true "ucx")
 
-      (lib.enableFeature (!cudaSupport) "mca-dso")
       (lib.withFeatureAs cudaSupport "cuda" (lib.getDev cudaPackages.cuda_cudart))
       (lib.withFeatureAs cudaSupport "cuda-libdir" (lib.getLib cudaPackages.cuda_cudart))
       (lib.enableFeature cudaSupport "dlopen")

--- a/pkgs/servers/computing/slurm/default.nix
+++ b/pkgs/servers/computing/slurm/default.nix
@@ -10,6 +10,7 @@
 # enable internal X11 support via libssh2
 , enableX11 ? true
 , enableGtk2 ? false, gtk2
+, buildPackages
 }:
 
 stdenv.mkDerivation rec {
@@ -26,13 +27,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-dfCQKKw44bD5d7Sv7e40Qm3df9Mzz7WvmWf7SP8R1KQ=";
   };
 
-  outputs = [ "out" "dev" ];
-
-  patches = [
-    # increase string length to allow for full
-    # path of 'echo' in nix store
-    ./common-env-echo.patch
-  ];
+  outputs = [ "out" "lib" "dev" "doc" ];
 
   prePatch = ''
     substituteInPlace src/common/env.c \
@@ -49,12 +44,32 @@ stdenv.mkDerivation rec {
         --replace '"/usr/bin/xauth"' '"${xorg.xauth}/bin/xauth"'
   '');
 
+  patches = [
+    # increase string length to allow for full
+    # path of 'echo' in nix store
+    ./common-env-echo.patch
+  ];
+
+  # Install the plugins into the same output as the binaries
+  # when splitting libpmi2 out.
+  postPatch = ''
+    substituteInPlace src/common/Makefile.{am,in} \
+      --replace \
+        'default_plugin_path = \"$(pkglibdir)\"' \
+        "default_plugin_path = \\\"''${!outputBin}/lib/slurm\\\""
+  '';
+
   # nixos test fails to start slurmd with 'undefined symbol: slurm_job_preempt_mode'
   # https://groups.google.com/forum/#!topic/slurm-devel/QHOajQ84_Es
   # this doesn't fix tests completely at least makes slurmd to launch
   hardeningDisable = [ "bindnow" ];
 
-  nativeBuildInputs = [ pkg-config libtool python3 perl ];
+  nativeBuildInputs = [
+    pkg-config
+    libtool
+    python3
+    perl
+  ];
   buildInputs = [
     curl python3 munge pam
     libmysqlclient ncurses lz4 rdma-core
@@ -83,12 +98,53 @@ stdenv.mkDerivation rec {
 
 
   preConfigure = ''
-    patchShebangs ./doc/html/shtml2html.py
-    patchShebangs ./doc/man/man2html.py
+   # We're going to move the internal libraries that cause cyclic dependencies to $out,
+   # and only keep things like libpmi2 in $lib:
+   export NIX_LDFLAGS="-rpath ''${!outputLib}/lib/slurm -rpath ''${!outputBin}/lib/slurm ''${NIX_LDFLAGS-}"
+
+    while IFS= read -r -d ''$'\0' path ; do
+      patchShebangs "$path"
+    done < <( find -print0 -iname '*.py' -or -iname '*.sh')
   '';
 
-  postInstall = ''
-    rm -f $out/lib/*.la $out/lib/slurm/*.la
+  makeFlags = [
+    # Build scripts reference /usr/lib/perl otherwise
+    "perlpath=${lib.getExe buildPackages.perl}"
+  ];
+
+  installTargets = [
+    "install-recursive"
+    "install-contrib" # libpmi2
+    "PAM_DIR=${placeholder "out"}/lib/security"
+  ];
+
+  # At the time of writing, the primary motivation for splitting out $lib is to
+  # expose `libpmi2.so`, which we do. Several of the produced DSOs, however,
+  # contain references to $out (the absolute paths to $out/bin/srun, the path
+  # to $out/sbin, etc). These are cyclic references which Nix refuses to put in
+  # the store, so we move them back to $out.
+  outputBinReferences = [
+    "lib/libpmi.so*"
+    "lib/libslurm.so*"
+    "lib/slurm/libslurmfull.so*"
+    "lib/slurm/libslurm_pmi.so*"
+    "lib/slurm/mpi_pmi2.so*"
+  ];
+
+  # Note that the libtool (.la) files contain a ton of references, but we put
+  # them in a separate output so they don't affect the $out's runtime closure
+  # size
+  preFixup = ''
+    moveToOutput 'lib/slurm' "''${!outputBin}"
+    while read -r -d' ' pattern || [[ -n "$pattern" ]] ; do
+      echo "moveToOutput \"$pattern\" \"''${!outputBin}\"" >&2
+      moveToOutput "$pattern" "''${!outputBin}"
+    done <<< "$outputBinReferences"
+
+    moveToOutput '**/*.la' "''${!outputDev}"
+
+    moveToOutput share/doc/ "''${!outputDoc}"
+    moveToOutput share/man/ "''${!outputMan}"
   '';
 
   enableParallelBuilding = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24049,7 +24049,10 @@ with pkgs;
     ch4backend = libfabric;
   };
 
-  mpich-pmix = mpich.override { pmixSupport = true; withPm = [ ]; };
+  mpich-pmix = mpich.override {
+    enablePmix = true;
+    withPm = [ ];
+  };
 
   mstpd = callPackage ../os-specific/linux/mstpd { };
 


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/280406. Partially addresses https://github.com/NixOS/nixpkgs/issues/274584 (memory leaks are still there, but segfaults seem to be gone, at least on aalto's triton) 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
