### PR TITLE
postgresqlPackages.citus: init at 12.1.0

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/citus.nix
+++ b/pkgs/servers/sql/postgresql/ext/citus.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, curl
+, fetchFromGitHub
+, lz4
+, postgresql
+}:
+
+stdenv.mkDerivation rec {
+  pname = "citus";
+  version = "12.1.0";
+
+  src = fetchFromGitHub {
+    owner = "citusdata";
+    repo = "citus";
+    rev = "v${version}";
+    hash = "sha256-ypuinDOHvgjRdbnTTFBpALy6rIR3rrP00JDvlHtmCTk=";
+  };
+
+  buildInputs = [
+    curl
+    lz4
+    postgresql
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -t $out/lib src/backend/columnar/citus_columnar${postgresql.dlSuffix}
+    install -D -t $out/share/postgresql/extension src/backend/columnar/build/sql/*.sql
+    install -D -t $out/share/postgresql/extension src/backend/columnar/*.control
+
+    install -D -t $out/lib src/backend/distributed/citus${postgresql.dlSuffix}
+    install -D -t $out/share/postgresql/extension src/backend/distributed/build/sql/*.sql
+    install -D -t $out/share/postgresql/extension src/backend/distributed/*.control
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    # "Our soft policy for Postgres version compatibilty is to support Citus'
+    # latest release with Postgres' 3 latest releases."
+    # https://www.citusdata.com/updates/v12-0/#deprecated_features
+    broken = versionOlder postgresql.version "14";
+    description = "Distributed PostgreSQL as an extension";
+    homepage = "https://www.citusdata.com/";
+    changelog = "https://github.com/citusdata/citus/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ marsam ];
+    inherit (postgresql.meta) platforms;
+  };
+}

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -4,6 +4,8 @@ self: super: {
 
     apache_datasketches = super.callPackage ./ext/apache_datasketches.nix { };
 
+    citus = super.callPackage ./ext/citus.nix { };
+
     h3-pg = super.callPackage ./ext/h3-pg.nix { };
 
     hypopg = super.callPackage ./ext/hypopg.nix { };


### PR DESCRIPTION
## Description of changes
Add https://www.citusdata.com/

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes https://github.com/NixOS/nixpkgs/pull/129284
Closes https://github.com/NixOS/nixpkgs/pull/191204
Closes https://github.com/NixOS/nixpkgs/pull/235441

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
