### PR TITLE
spotube: init at 3.4.0

### DIFF
--- a/pkgs/by-name/sp/spotube/package.nix
+++ b/pkgs/by-name/sp/spotube/package.nix
@@ -1,0 +1,111 @@
+{ fetchurl
+, stdenv
+, lib
+, atk
+, cairo
+, ffmpeg_4
+, fontconfig
+, gdk-pixbuf
+, glib
+, gtk3
+, harfbuzz
+, jsoncpp
+, libappindicator-gtk3
+, libass
+, libdbusmenu-gtk3
+, libepoxy
+, libnotify
+, libsecret
+, mpv
+, pango
+, makeWrapper
+, patchelf
+, wrapGAppsHook
+}:
+let
+  version = "3.4.0";
+
+  src = fetchurl {
+    url = "https://github.com/KRTirtho/spotube/releases/download/v${version}/spotube-linux-${version}-x86_64.tar.xz";
+    name = "spotube-linux-${version}-x86_64.tar.xz";
+    sha256 = "sha256-vTK3aWM1Aly3yCNEpQS0y+4dHTjsn2VWJAI9Sk518rg=";
+  };
+
+  buildInputs = [
+    atk
+    cairo
+    ffmpeg_4
+    fontconfig
+    gdk-pixbuf
+    glib
+    gtk3
+    harfbuzz
+    jsoncpp
+    libappindicator-gtk3
+    libass
+    libdbusmenu-gtk3
+    libepoxy
+    libnotify
+    libsecret
+    mpv
+    pango
+  ];
+in
+stdenv.mkDerivation {
+  pname = "spotube";
+  inherit version src buildInputs;
+
+  nativeBuildInputs = [
+    makeWrapper
+    patchelf
+    stdenv.cc.cc.lib
+    wrapGAppsHook
+  ];
+
+  unpackPhase = ''
+    mkdir -p $out/dist
+    tar -C $out/dist -xf $src
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/applications
+    mkdir -p $out/share/icons/spotube/
+
+    install -Dm644 $out/dist/spotube.desktop $out/share/applications/
+    install -Dm644 $out/dist/spotube-logo.png $out/share/icons/spotube/spotube-logo.png
+
+    substituteInPlace $out/share/applications/spotube.desktop \
+      --replace "Exec=/usr/bin/spotube" "Exec=$out/bin/spotube" \
+      --replace "Icon=/usr/share/icons/spotube/spotube-logo.png" "Icon=$out/share/icons/spotube/spotube-logo.png"
+  '';
+
+  postFixup = ''
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath ${lib.makeLibraryPath [ stdenv.cc.cc ]} \
+      $out/dist/spotube
+    makeWrapper $out/dist/spotube $out/bin/spotube \
+      --set LD_LIBRARY_PATH ${lib.makeLibraryPath buildInputs} \
+      --suffix LD_LIBRARY_PATH : $out/dist/lib
+  '';
+
+  doCheck = false;
+  dontBuild = true;
+
+  meta = with lib; {
+    description = "An open source, cross-platform Spotify client.";
+    longDescription = ''
+      An open source, cross-platform Spotify client compatible across multiple platforms
+      utilizing Spotify's data API and YouTube (or Piped.video or JioSaavn) as an audio source,
+      eliminating the need for Spotify Premium
+
+      Btw it's not another Electron app.
+    '';
+    homepage = "https://github.com/KRTirtho/spotube";
+    license = licenses.bsdOriginal;
+    maintainers = [ maintainers.massimogengarelli ];
+    platforms = platforms.linux;
+  };
+}
+


### PR DESCRIPTION
## Description of changes

New music client, alternative to Spotify

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
