### PR TITLE
bkcrack: 1.6.0 -> 1.6.1

### DIFF
--- a/pkgs/tools/security/bkcrack/default.nix
+++ b/pkgs/tools/security/bkcrack/default.nix
@@ -2,27 +2,36 @@
 , stdenv
 , fetchFromGitHub
 , cmake
+, nix-update-script
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "bkcrack";
-  version = "1.6.0";
+  version = "1.6.1";
 
   src = fetchFromGitHub {
     owner = "kimci86";
-    repo = pname;
-    rev = "v${version}";
-    hash = "sha256-VfPRX9lOPyen8CujiBtTCbD5e7xd9X2OQ1uZ6JWKwtY=";
+    repo = "bkcrack";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-x7JK7+DcD2uSWZRTJQPGCcF2mHBlu6FwYUbuYzbvD+s=";
   };
+
+  passthru.updateScript = nix-update-script { };
 
   nativeBuildInputs = [ cmake ];
 
+  cmakeFlags = [
+    "-DBKCRACK_BUILD_TESTING=${if finalAttrs.doCheck then "ON" else "OFF"}"
+  ];
+
   postInstall = ''
-    mkdir -p $out/bin $out/share/licenses/bkcrack
+    mkdir -p $out/bin $out/share/doc/bkcrack $out/share/licenses/bkcrack
     mv $out/bkcrack $out/bin/
     mv $out/license.txt $out/share/licenses/bkcrack
-    rm -r $out/example $out/tools $out/readme.md
+    mv $out/example $out/tools $out/readme.md $out/share/doc/bkcrack
   '';
+
+  doCheck = true;
 
   meta = with lib; {
     description = "Crack legacy zip encryption with Biham and Kocher's known plaintext attack";
@@ -30,5 +39,6 @@ stdenv.mkDerivation rec {
     license = licenses.zlib;
     platforms = platforms.unix;
     maintainers = with maintainers; [ erdnaxe ];
+    mainProgram = "bkcrack";
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Regular update plus a few cleanups.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
