### PR TITLE
sudachi-rs: 0.6.7 -> 0.6.8; add updateScript

### DIFF
--- a/pkgs/by-name/su/sudachi-rs/package.nix
+++ b/pkgs/by-name/su/sudachi-rs/package.nix
@@ -9,13 +9,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "sudachi-rs";
-  version = "0.6.7";
+  version = "0.6.8";
 
   src = fetchFromGitHub {
     owner = "WorksApplications";
     repo = "sudachi.rs";
     rev = "refs/tags/v${version}";
-    hash = "sha256-VzNOI6PP9sKBsNfB5yIxAI8jI8TEdM4tD49Jl/2tkSE=";
+    hash = "sha256-9GXU+YDPuQ+roqQfUE5q17Hl6AopsvGhRPjZ+Ui+n24=";
   };
 
   postPatch = ''
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
       --replace '"resources"' '"${placeholder "out"}/share/resources"'
   '';
 
-  cargoHash = "sha256-b2NtgHcMkimzFFuqohAo9KdSaIq6oi3qo/k8/VugyFs=";
+  cargoHash = "sha256-Ufo3dB2KGDDNiebp7hLhQrUMLsefO8wRpJQDz57Yb8Y=";
 
   # prepare the resources before the build so that the binary can find sudachidict
   preBuild = ''

--- a/pkgs/by-name/su/sudachi-rs/package.nix
+++ b/pkgs/by-name/su/sudachi-rs/package.nix
@@ -4,6 +4,7 @@
 , sudachidict
 , runCommand
 , sudachi-rs
+, writeScript
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -30,12 +31,22 @@ rustPlatform.buildRustPackage rec {
     install -Dm644 resources/* -t $out/share/resources
   '';
 
-  passthru.tests = {
-    # detects an error that sudachidict is not found
-    cli = runCommand "${pname}-cli-test" { } ''
-      mkdir $out
-      echo "高輪ゲートウェイ駅" | ${lib.getExe sudachi-rs} > $out/result
+  passthru = {
+    updateScript = writeScript "update.sh" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p nix-update
+
+      set -eu -o pipefail
+      nix-update sudachi-rs
+      nix-update --version=skip python3Packages.sudachipy
     '';
+    tests = {
+      # detects an error that sudachidict is not found
+      cli = runCommand "${pname}-cli-test" { } ''
+        mkdir $out
+        echo "高輪ゲートウェイ駅" | ${lib.getExe sudachi-rs} > $out/result
+      '';
+    };
   };
 
   meta = with lib; {

--- a/pkgs/development/python-modules/sudachidict/default.nix
+++ b/pkgs/development/python-modules/sudachidict/default.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , sudachidict
 , setuptools
+, sudachipy
 }:
 
 buildPythonPackage rec {
@@ -31,6 +32,10 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools
+  ];
+
+  propagatedBuildInputs = [
+    sudachipy
   ];
 
   # we need to prepare some files before the build

--- a/pkgs/development/python-modules/sudachipy/default.nix
+++ b/pkgs/development/python-modules/sudachipy/default.nix
@@ -47,6 +47,10 @@ buildPythonPackage rec {
     "sudachipy"
   ];
 
+  passthru = {
+    inherit (sudachi-rs) updateScript;
+  };
+
   meta = sudachi-rs.meta // {
     homepage = "https://github.com/WorksApplications/sudachi.rs/tree/develop/python";
     mainProgram = "sudachipy";

--- a/pkgs/development/python-modules/sudachipy/default.nix
+++ b/pkgs/development/python-modules/sudachipy/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-Am+ae2lgnndSDzf0GF8R1i6OPLdIlm2dLThqYqXbscA=";
+    hash = "sha256-ARwvThfATDdzBTjPFr9yjbE/0eYvp/TCZOEGbUupJmU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/sudachipy/default.nix
+++ b/pkgs/development/python-modules/sudachipy/default.nix
@@ -10,6 +10,7 @@
 , pytestCheckHook
 , sudachidict-core
 , tokenizers
+, sudachipy
 }:
 
 buildPythonPackage rec {
@@ -37,6 +38,9 @@ buildPythonPackage rec {
     cd python
   '';
 
+  # avoid infinite recursion due to sudachidict
+  doCheck = false;
+
   nativeCheckInputs = [
     pytestCheckHook
     sudachidict-core
@@ -49,6 +53,16 @@ buildPythonPackage rec {
 
   passthru = {
     inherit (sudachi-rs) updateScript;
+    tests = {
+      pytest = sudachipy.overridePythonAttrs (
+        _: {
+          doCheck = true;
+          # avoid catchConflicts of sudachipy
+          # we don't need to install this package since it is just a test
+          dontInstall = true;
+        }
+      );
+    };
   };
 
   meta = sudachi-rs.meta // {


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/WorksApplications/sudachi.rs/blob/refs/tags/v0.6.8/CHANGELOG.md

closes #276827

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
