### PR TITLE
mangayomi: init at 0.1.61

### DIFF
--- a/pkgs/by-name/ma/mangayomi/package.nix
+++ b/pkgs/by-name/ma/mangayomi/package.nix
@@ -1,0 +1,85 @@
+{ lib
+, stdenv
+, fetchzip
+
+, autoPatchelfHook
+, copyDesktopItems
+, makeDesktopItem
+, makeWrapper
+, wrapGAppsHook
+
+, gtk3
+, webkitgtk_4_1
+, libsoup
+, mpv-unwrapped
+, xdg-user-dirs
+, gnome
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mangayomi";
+  version = "0.1.61";
+
+  src = fetchzip {
+    url = "https://github.com/kodjodevf/mangayomi/releases/download/v${finalAttrs.version}/Mangayomi-v${finalAttrs.version}-linux.zip";
+    hash = "sha256-BdbSiKWPajEYSWzK9dLS6AA8dW3bdnO6mEPVqD78HRE=";
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+    makeWrapper
+  ];
+
+  buildInputs = [
+    gtk3
+    webkitgtk_4_1
+    libsoup
+    mpv-unwrapped
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "mangayomi";
+      exec = "mangayomi %u";
+      icon = "mangayomi";
+      desktopName = "Mangayomi";
+      comment = finalAttrs.meta.description;
+      categories = [ "Utility" ];
+      terminal = false;
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/mangayomi
+    cp -r * $out/share/mangayomi
+
+    install -Dm644 data/flutter_assets/assets/app_icons/icon-red.png $out/share/pixmaps/mangayomi.png
+
+    makeWrapper $out/share/mangayomi/mangayomi $out/bin/mangayomi \
+        --prefix LD_LIBRARY_PATH : $out/share/mangayomi/lib \
+        --prefix PATH : ${lib.makeBinPath [ xdg-user-dirs gnome.zenity ]}
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    patchelf $out/share/mangayomi/lib/libmedia_kit_{native_event_loop,video_plugin}.so \
+        --replace-needed libmpv.so.1 libmpv.so
+  '';
+
+  meta = {
+    changelog = "https://github.com/kodjodevf/mangayomi/releases/tag/v${finalAttrs.version}";
+    description = "Free and open source application for reading manga and watching anime";
+    downloadPage = "https://github.com/kodjodevf/mangayomi/releases";
+    homepage = "https://github.com/kodjodevf/mangayomi";
+    license = lib.licenses.asl20;
+    mainProgram = "mangayomi";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Related issue: https://github.com/NixOS/nixpkgs/issues/282266

This PR adds 1 package: `mangayomi`

This PR currently only supports `x86_64-linux`, as I am packaging the prebuilt binaries.

Packaging this was pretty similar to https://github.com/NixOS/nixpkgs/pull/282975


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
