### PR TITLE
keycloak.plugins.keycloak-restrict-client-auth: init at 23.0.0

### DIFF
--- a/pkgs/servers/keycloak/all-plugins.nix
+++ b/pkgs/servers/keycloak/all-plugins.nix
@@ -5,4 +5,5 @@
   scim-keycloak-user-storage-spi = callPackage ./scim-keycloak-user-storage-spi {};
   keycloak-discord = callPackage ./keycloak-discord {};
   keycloak-metrics-spi = callPackage ./keycloak-metrics-spi {};
+  keycloak-restrict-client-auth = callPackage ./keycloak-restrict-client-auth {};
 }

--- a/pkgs/servers/keycloak/keycloak-restrict-client-auth/default.nix
+++ b/pkgs/servers/keycloak/keycloak-restrict-client-auth/default.nix
@@ -1,0 +1,28 @@
+{ maven, lib, fetchFromGitHub }:
+
+maven.buildMavenPackage rec {
+  pname = "keycloak-restrict-client-auth";
+  version = "23.0.0";
+
+  src = fetchFromGitHub {
+    owner = "sventorben";
+    repo = "keycloak-restrict-client-auth";
+    rev = "v${version}";
+    hash = "sha256-JA3DvLdBKyn2VE1pYSCcRV9Cl7ZAWsRG5MAp548Rl+g=";
+  };
+
+  mvnHash = "sha256-W1YvX1P/mshGYoTUO5XMlOcpu2KiujwLludaC3miak4=";
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm444 -t "$out" target/keycloak-restrict-client-auth.jar
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/sventorben/keycloak-restrict-client-auth";
+    description = "A Keycloak authenticator to restrict authorization on clients";
+    license = licenses.mit;
+    maintainers = with maintainers; [ leona ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The [keycloak-restrict-client-auth](https://github.com/sventorben/keycloak-restrict-client-auth) plugin allows to restrict authorization on clients based on policies (e.g. groups). Since it is relatively sensitive to major keycloak updates, I would like to have it directly in the nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Tested manually on my keycloak instance.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
