### PR TITLE
sarif-tools: init at 2.0.0

### DIFF
--- a/pkgs/by-name/sa/sarif-tools/package.nix
+++ b/pkgs/by-name/sa/sarif-tools/package.nix
@@ -1,0 +1,4 @@
+{ python3Packages }:
+
+with python3Packages;
+toPythonApplication sarif-tools

--- a/pkgs/development/python-modules/sarif-tools/default.nix
+++ b/pkgs/development/python-modules/sarif-tools/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, poetry-core
+, jsonpath-ng
+, jinja2
+, python
+, python-docx
+, matplotlib
+, pyyaml
+, pytestCheckHook
+, pythonOlder
+, pythonRelaxDepsHook
+}:
+
+buildPythonPackage rec {
+  pname = "sarif-tools";
+  version = "2.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-80amYGnf7xZdpxzTjBGwgg39YN/jJsEkTm0uAlVbH0w=";
+  };
+
+  disabled = pythonOlder "3.8";
+
+  nativeBuildInputs = [
+    poetry-core
+    pythonRelaxDepsHook
+  ];
+
+  propagatedBuildInputs = [
+    jsonpath-ng
+    jinja2
+    python
+    python-docx
+    matplotlib
+    pyyaml
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonRelaxDeps = [
+    "python-docx"
+  ];
+
+  disabledTests = [
+    # Broken, re-enable once https://github.com/microsoft/sarif-tools/pull/41 is merged
+    "test_version"
+  ];
+
+  pythonImportsCheck = [
+    "sarif"
+  ];
+
+  meta = {
+    description = "A set of command line tools and Python library for working with SARIF files";
+    homepage = "https://github.com/microsoft/sarif-tools";
+    changelog = "https://github.com/microsoft/sarif-tools/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ puzzlewolf ];
+    mainProgram = "sarif";
+  };
+}

--- a/pkgs/development/python-modules/sarif-tools/default.nix
+++ b/pkgs/development/python-modules/sarif-tools/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "microsoft";
-    repo = pname;
+    repo = "sarif-tools";
     rev = "v${version}";
     hash = "sha256-80amYGnf7xZdpxzTjBGwgg39YN/jJsEkTm0uAlVbH0w=";
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13560,6 +13560,8 @@ self: super: with self; {
 
   sarif-om = callPackage ../development/python-modules/sarif-om { };
 
+  sarif-tools = callPackage ../development/python-modules/sarif-tools { };
+
   sarge = callPackage ../development/python-modules/sarge { };
 
   sasmodels = callPackage ../development/python-modules/sasmodels { };


### PR DESCRIPTION
## Description of changes

Add https://github.com/microsoft/sarif-tools, a collection of tools for working with [Static Analysis Results Interchange Format (SARIF)](https://sarifweb.azurewebsites.net/) files.

This is a draft because it requires https://github.com/NixOS/nixpkgs/pull/282347 to fix the failing tests of the `python-docx` dependency (https://github.com/NixOS/nixpkgs/issues/282180). I made sure `sarif-tools` itself is fine by skipping `python-docx`'s tests.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
