### PR TITLE
ares: 133 -> 135

### DIFF
--- a/pkgs/applications/emulators/bsnes/ares/002-fix-ruby.diff
+++ b/pkgs/applications/emulators/bsnes/ares/002-fix-ruby.diff
@@ -1,11 +1,11 @@
 diff -Naur source-old/ruby/GNUmakefile source-new/ruby/GNUmakefile
---- source-old/ruby/GNUmakefile	1969-12-31 21:00:01.000000000 -0300
-+++ source-new/ruby/GNUmakefile	2022-11-13 22:43:09.700197748 -0300
-@@ -11,17 +11,9 @@
-     ruby += audio.openal
-     ruby += input.quartz #input.carbon
+--- source-old/ruby/GNUmakefile    2024-01-23 16:12:41.009951705 +0000
++++ source-new/ruby/GNUmakefile    2024-01-23 16:13:54.619174062 +0000
+@@ -29,20 +29,9 @@
+       ruby += input.sdl
+     endif
    else ifeq ($(platform),linux)
--    pkg_check = $(if $(shell pkg-config $1 && echo 1),$2)
+-    pkg_check = $(if $(shell $(pkg_config) $1 && echo 1),$2)
 -    ruby += video.glx video.glx2 video.xshm
 -    ruby += $(call pkg_check,xv,video.xvideo)
 -    ruby += audio.oss audio.alsa
@@ -15,10 +15,13 @@ diff -Naur source-old/ruby/GNUmakefile source-new/ruby/GNUmakefile
 -    ruby += $(call pkg_check,ao,audio.ao)
 -    ruby += input.xlib
 -    ruby += $(call pkg_check,libudev,input.udev)
--    ruby += $(call pkg_check,sdl2,input.sdl)
+-    ifeq ($(sdl2),true)
+-      ruby += $(call pkg_check,sdl2,input.sdl)
+-      ruby += $(call pkg_check,sdl2,audio.sdl)
+-    endif
 +    ruby += video.glx video.glx2 video.xshm video.xvideo
 +    ruby += audio.oss audio.alsa audio.openal audio.pulseaudio audio.pulseaudiosimple audio.ao
 +    ruby += input.xlib input.udev input.sdl
    else ifeq ($(platform),bsd)
-     pkg_check = $(if $(shell pkg-config $1 && echo 1),$2)
+     pkg_check = $(if $(shell $(pkg_config) $1 && echo 1),$2)
      ruby += video.glx video.glx2 video.xshm

--- a/pkgs/applications/emulators/bsnes/ares/default.nix
+++ b/pkgs/applications/emulators/bsnes/ares/default.nix
@@ -22,13 +22,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ares";
-  version = "133";
+  version = "135";
 
   src = fetchFromGitHub {
     owner = "ares-emulator";
     repo = "ares";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-KCpHiIdid5h5CU2uyMOo+p5h50h3Ki5/4mUpdTAPKQA=";
+    hash = "sha256-SZhsMKjNxmT2eHsXAZcyMGoMhwWGgvXpDeZGGVn58Sc=";
   };
 
   patches = [


### PR DESCRIPTION
## Description of changes

ares v135: [changelog](https://ares-emu.net/news/ares-v134-released)
ares v134: [changelog](https://ares-emu.net/news/ares-v134-released) - had crash issue on aarch64-darwin that was fixed in v135

I believe these changes are nonbreaking and are insignificant enough to be backported.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. **No packages depend on this package**
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
