### PR TITLE
s6-overlay: init at 3.1.6.2

### DIFF
--- a/pkgs/tools/virtualization/s6-overlay/default.nix
+++ b/pkgs/tools/virtualization/s6-overlay/default.nix
@@ -1,63 +1,89 @@
-{ lib, stdenv, fetchFromGitHub, fetchurl, glibc, makeWrapper, musl, fetchgit, system, ... }:
+{ lib, stdenv, symlinkJoin,fetchzip, fetchFromGitHub, fetchurl, glibc, makeWrapper, musl, fetchgit, system, ... }:
 
 let
-  arch = "${system}-musl";
-  skaToolchain = fetchurl {
-    url = "https://skarnet.org/toolchains/cross/${arch}_pc-13.2.0.tar.xz";
-    sha256 = "06nfa8gs9dmsjqhml5hq35ddc7zg4yg1ak1q4sjv5xjpwnp6id4s";
-  };
-  skaLibs = fetchgit {
-    url = "git://git.skarnet.org/skalibs";
-    rev = "v2.14.0.1";
-    sha256 = "sha256-kfJXF41p2jyHt/1m5xNv1QRSvE8sxnSIYfCoFN4xrEk=";
-  };
-  skaExecline = fetchgit {
-    url = "git://git.skarnet.org/execline";
-    rev = "v2.9.4.0";
-    sha256 = "sha256-eettzy++UsE834AfRstEFk61fDpbQxckZFZD00vU4xo=";
-  };
-  skaS6 = fetchgit {
-    url = "git://git.skarnet.org/s6";
-    rev = "v2.12.0.2";
-    sha256 = "sha256-AjptMPiuI0vrGhDXW0Xa0AhVpzHVw2C5vMazBf3yGds=";
-  };
-in
-stdenv.mkDerivation rec {
-  pname = "s6-overlay";
   version = "3.1.6.2";
-
-  src = fetchFromGitHub {
-    owner = "just-containers";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-S0WSGuWLHtIr47vHeYkMd2SBo+ez6UlQCBT/cxIE7Xw=";
+  archParts = lib.splitString "-" stdenv.hostPlatform.system;
+  arch = lib.head archParts; # we only need e.g. `x86_64`
+  overlayNoarch = fetchzip {
+    url = "https://github.com/just-containers/s6-overlay/releases/download/v${version}/s6-overlay-noarch.tar.xz";
+    hash = "sha256-la2Q2wKkJ2v2oHhr+phfMfYvYbuwjLN2FLZHwc3R1Ao=";
+    stripRoot = false;
+  };
+  overlayForArch = fetchzip {
+    url = "https://github.com/just-containers/s6-overlay/releases/download/v${version}/s6-overlay-${arch}.tar.xz";
+    hash = "sha256-WT8MaqECqlurFGzL1EHk+eJ7DNidf2E5A577fH2cYAk=";
+    stripRoot = false;
+  };
+  merged = symlinkJoin { 
+    name = "s6-overlay-merged";
+    paths = [ overlayNoarch overlayForArch ];
   };
 
-  buildInputs = [ makeWrapper 
-  #glibc glibc.static
-  musl ];
-  # attempt at gettings deps from nix: (was too finicky)
-  # buildPhase = ''
-    # mkdir -p $out/sources/${arch}_pc-13.2.0/bin
-    # # Link the actual gcc binary
-    # ln -sf ${gcc}/bin/gcc $out/sources/${arch}_pc-13.2.0/bin/${arch}-gcc
-    # # Create a dummy .tar.xz file & set the modification time .tar.xz file to match the gcc binary (to not trigger make)
-    # touch -r $out/sources/${arch}_pc-13.2.0/bin/${arch}-gcc $out/sources/${arch}_pc-13.2.0.tar.xz
-  buildPhase = ''
-    mkdir -p $out/sources $out/build-x86_64-linux-musl/
-    ln -s ${skaToolchain} $out/sources/${arch}_pc-13.2.0.tar.xz
-    ln -s ${skaLibs} $out/sources/skalibs
-    cp -r ${skaLibs} $out/build-x86_64-linux-musl/skalibs-v2.14.0.1 && rm -rf $out/build-x86_64-linux-musl/skalibs-v2.14.0.1/.git
-    chmod -R u+w $out/build-x86_64-linux-musl/skalibs-v2.14.0.1
-    ln -s ${skaExecline} $out/sources/execline
-    cp -r ${skaExecline} $out/build-x86_64-linux-musl/execline-v2.9.4.0 && rm -rf $out/build-x86_64-linux-musl/execline-v2.9.4.0/.git
-    chmod -R u+w $out/build-x86_64-linux-musl/execline-v2.9.4.0
-    ln -s ${skaS6} $out/sources/s6
-    cp -r ${skaS6} $out/build-x86_64-linux-musl/s6-v2.12.0.2 && rm -rf $out/build-x86_64-linux-musl/s6-v2.12.0.2/.git
-    chmod -R u+w $out/build-x86_64-linux-musl/s6-v2.12.0.2
+  # Attempt 2: fetch individual deps (was complicated - and if we fetch deps outside nix, we might as well fetch the release tarball, right?)
+  # arch = "${system}-musl";
+  # skaToolchain = fetchurl {
+  #   url = "https://skarnet.org/toolchains/cross/${arch}_pc-13.2.0.tar.xz";
+  #   sha256 = "06nfa8gs9dmsjqhml5hq35ddc7zg4yg1ak1q4sjv5xjpwnp6id4s";
+  # };
+  # skaLibs = fetchgit {
+  #   url = "git://git.skarnet.org/skalibs";
+  #   rev = "v2.14.0.1";
+  #   sha256 = "sha256-kfJXF41p2jyHt/1m5xNv1QRSvE8sxnSIYfCoFN4xrEk=";
+  # };
+  # skaExecline = fetchgit {
+  #   url = "git://git.skarnet.org/execline";
+  #   rev = "v2.9.4.0";
+  #   sha256 = "sha256-eettzy++UsE834AfRstEFk61fDpbQxckZFZD00vU4xo=";
+  # };
+  # skaS6 = fetchgit {
+  #   url = "git://git.skarnet.org/s6";
+  #   rev = "v2.12.0.2";
+  #   sha256 = "sha256-AjptMPiuI0vrGhDXW0Xa0AhVpzHVw2C5vMazBf3yGds=";
+  # };
+in
+stdenv.mkDerivation {
+  inherit version;
+  pname = "s6-overlay";
 
-    # false
-    make -d all ARCH=${arch} OUTPUT=$out
+  src = merged;
+  # ? or this: 
+  #srcs = [ overlayNoarch overlayForArch ];
+  dontUnpack = true;
+  
+  # src = fetchFromGitHub {
+  #   owner = "just-containers";
+  #   repo = pname;
+  #   rev = "v${version}";
+  #   sha256 = "sha256-S0WSGuWLHtIr47vHeYkMd2SBo+ez6UlQCBT/cxIE7Xw=";
+  # };
+
+  # Attempt 1: at gettings deps from nix (was too finicky, lots of deps with specific versions)
+  # buildInputs = [ makeWrapper ];
+  # buildPhase = ''
+  # mkdir -p $out/sources/${arch}_pc-13.2.0/bin
+  # # Link the actual gcc binary
+  # ln -sf ${gcc}/bin/gcc $out/sources/${arch}_pc-13.2.0/bin/${arch}-gcc
+  # # Create a dummy .tar.xz file & set the modification time .tar.xz file to match the gcc binary (to not trigger make)
+  # touch -r $out/sources/${arch}_pc-13.2.0/bin/${arch}-gcc $out/sources/${arch}_pc-13.2.0.tar.xz
+
+  # Attempt 2
+  # buildInputs = [ makeWrapper musl ];
+  # buildPhase = ''
+  # mkdir -p $out/sources $out/build-x86_64-linux-musl/
+  # ln -s ${skaToolchain} $out/sources/${arch}_pc-13.2.0.tar.xz
+  # ln -s ${skaLibs} $out/sources/skalibs
+  # cp -r ${skaLibs} $out/build-x86_64-linux-musl/skalibs-v2.14.0.1 && rm -rf $out/build-x86_64-linux-musl/skalibs-v2.14.0.1/.git
+  # chmod -R u+w $out/build-x86_64-linux-musl/skalibs-v2.14.0.1
+  # ln -s ${skaExecline} $out/sources/execline
+  # cp -r ${skaExecline} $out/build-x86_64-linux-musl/execline-v2.9.4.0 && rm -rf $out/build-x86_64-linux-musl/execline-v2.9.4.0/.git
+  # chmod -R u+w $out/build-x86_64-linux-musl/execline-v2.9.4.0
+  # ln -s ${skaS6} $out/sources/s6
+  # cp -r ${skaS6} $out/build-x86_64-linux-musl/s6-v2.12.0.2 && rm -rf $out/build-x86_64-linux-musl/s6-v2.12.0.2/.git
+  # chmod -R u+w $out/build-x86_64-linux-musl/s6-v2.12.0.2
+
+  installPhase = ''
+    # tried ln -s but that didn't work
+    cp -r ${merged} $out
   '';
 
   meta = with lib; {

--- a/pkgs/tools/virtualization/s6-overlay/default.nix
+++ b/pkgs/tools/virtualization/s6-overlay/default.nix
@@ -1,0 +1,70 @@
+{ lib, stdenv, fetchFromGitHub, fetchurl, glibc, makeWrapper, musl, fetchgit, system, ... }:
+
+let
+  arch = "${system}-musl";
+  skaToolchain = fetchurl {
+    url = "https://skarnet.org/toolchains/cross/${arch}_pc-13.2.0.tar.xz";
+    sha256 = "06nfa8gs9dmsjqhml5hq35ddc7zg4yg1ak1q4sjv5xjpwnp6id4s";
+  };
+  skaLibs = fetchgit {
+    url = "git://git.skarnet.org/skalibs";
+    rev = "v2.14.0.1";
+    sha256 = "sha256-kfJXF41p2jyHt/1m5xNv1QRSvE8sxnSIYfCoFN4xrEk=";
+  };
+  skaExecline = fetchgit {
+    url = "git://git.skarnet.org/execline";
+    rev = "v2.9.4.0";
+    sha256 = "sha256-eettzy++UsE834AfRstEFk61fDpbQxckZFZD00vU4xo=";
+  };
+  skaS6 = fetchgit {
+    url = "git://git.skarnet.org/s6";
+    rev = "v2.12.0.2";
+    sha256 = "sha256-AjptMPiuI0vrGhDXW0Xa0AhVpzHVw2C5vMazBf3yGds=";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "s6-overlay";
+  version = "3.1.6.2";
+
+  src = fetchFromGitHub {
+    owner = "just-containers";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-S0WSGuWLHtIr47vHeYkMd2SBo+ez6UlQCBT/cxIE7Xw=";
+  };
+
+  buildInputs = [ makeWrapper 
+  #glibc glibc.static
+  musl ];
+  # attempt at gettings deps from nix: (was too finicky)
+  # buildPhase = ''
+    # mkdir -p $out/sources/${arch}_pc-13.2.0/bin
+    # # Link the actual gcc binary
+    # ln -sf ${gcc}/bin/gcc $out/sources/${arch}_pc-13.2.0/bin/${arch}-gcc
+    # # Create a dummy .tar.xz file & set the modification time .tar.xz file to match the gcc binary (to not trigger make)
+    # touch -r $out/sources/${arch}_pc-13.2.0/bin/${arch}-gcc $out/sources/${arch}_pc-13.2.0.tar.xz
+  buildPhase = ''
+    mkdir -p $out/sources $out/build-x86_64-linux-musl/
+    ln -s ${skaToolchain} $out/sources/${arch}_pc-13.2.0.tar.xz
+    ln -s ${skaLibs} $out/sources/skalibs
+    cp -r ${skaLibs} $out/build-x86_64-linux-musl/skalibs-v2.14.0.1 && rm -rf $out/build-x86_64-linux-musl/skalibs-v2.14.0.1/.git
+    chmod -R u+w $out/build-x86_64-linux-musl/skalibs-v2.14.0.1
+    ln -s ${skaExecline} $out/sources/execline
+    cp -r ${skaExecline} $out/build-x86_64-linux-musl/execline-v2.9.4.0 && rm -rf $out/build-x86_64-linux-musl/execline-v2.9.4.0/.git
+    chmod -R u+w $out/build-x86_64-linux-musl/execline-v2.9.4.0
+    ln -s ${skaS6} $out/sources/s6
+    cp -r ${skaS6} $out/build-x86_64-linux-musl/s6-v2.12.0.2 && rm -rf $out/build-x86_64-linux-musl/s6-v2.12.0.2/.git
+    chmod -R u+w $out/build-x86_64-linux-musl/s6-v2.12.0.2
+
+    # false
+    make -d all ARCH=${arch} OUTPUT=$out
+  '';
+
+  meta = with lib; {
+    description = "s6-overlay -  s6 overlay for containers (includes execline, s6-linux-utils & a custom init)";
+    homepage = "https://github.com/just-containers/s6-overlay";
+    license = licenses.isc;
+    maintainers = with maintainers; [ tennox ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/tools/virtualization/s6-overlay/default.nix
+++ b/pkgs/tools/virtualization/s6-overlay/default.nix
@@ -1,9 +1,11 @@
-{ lib, stdenv, symlinkJoin,fetchzip, fetchFromGitHub, fetchurl, glibc, makeWrapper, musl, fetchgit, system, ... }:
+{ lib, stdenv, symlinkJoin, fetchzip, ... }:
 
 let
-  version = "3.1.6.2";
+  version = "3.1.6.2"; # https://github.com/just-containers/s6-overlay/releases
   archParts = lib.splitString "-" stdenv.hostPlatform.system;
   arch = lib.head archParts; # we only need e.g. `x86_64`
+
+  # Installation docs: https://github.com/just-containers/s6-overlay?tab=readme-ov-file#installation
   overlayNoarch = fetchzip {
     url = "https://github.com/just-containers/s6-overlay/releases/download/v${version}/s6-overlay-noarch.tar.xz";
     hash = "sha256-la2Q2wKkJ2v2oHhr+phfMfYvYbuwjLN2FLZHwc3R1Ao=";
@@ -14,75 +16,20 @@ let
     hash = "sha256-WT8MaqECqlurFGzL1EHk+eJ7DNidf2E5A577fH2cYAk=";
     stripRoot = false;
   };
-  merged = symlinkJoin { 
+  merged = symlinkJoin {
     name = "s6-overlay-merged";
     paths = [ overlayNoarch overlayForArch ];
   };
 
-  # Attempt 2: fetch individual deps (was complicated - and if we fetch deps outside nix, we might as well fetch the release tarball, right?)
-  # arch = "${system}-musl";
-  # skaToolchain = fetchurl {
-  #   url = "https://skarnet.org/toolchains/cross/${arch}_pc-13.2.0.tar.xz";
-  #   sha256 = "06nfa8gs9dmsjqhml5hq35ddc7zg4yg1ak1q4sjv5xjpwnp6id4s";
-  # };
-  # skaLibs = fetchgit {
-  #   url = "git://git.skarnet.org/skalibs";
-  #   rev = "v2.14.0.1";
-  #   sha256 = "sha256-kfJXF41p2jyHt/1m5xNv1QRSvE8sxnSIYfCoFN4xrEk=";
-  # };
-  # skaExecline = fetchgit {
-  #   url = "git://git.skarnet.org/execline";
-  #   rev = "v2.9.4.0";
-  #   sha256 = "sha256-eettzy++UsE834AfRstEFk61fDpbQxckZFZD00vU4xo=";
-  # };
-  # skaS6 = fetchgit {
-  #   url = "git://git.skarnet.org/s6";
-  #   rev = "v2.12.0.2";
-  #   sha256 = "sha256-AjptMPiuI0vrGhDXW0Xa0AhVpzHVw2C5vMazBf3yGds=";
-  # };
 in
 stdenv.mkDerivation {
   inherit version;
   pname = "s6-overlay";
 
   src = merged;
-  # ? or this: 
-  #srcs = [ overlayNoarch overlayForArch ];
   dontUnpack = true;
-  
-  # src = fetchFromGitHub {
-  #   owner = "just-containers";
-  #   repo = pname;
-  #   rev = "v${version}";
-  #   sha256 = "sha256-S0WSGuWLHtIr47vHeYkMd2SBo+ez6UlQCBT/cxIE7Xw=";
-  # };
-
-  # Attempt 1: at gettings deps from nix (was too finicky, lots of deps with specific versions)
-  # buildInputs = [ makeWrapper ];
-  # buildPhase = ''
-  # mkdir -p $out/sources/${arch}_pc-13.2.0/bin
-  # # Link the actual gcc binary
-  # ln -sf ${gcc}/bin/gcc $out/sources/${arch}_pc-13.2.0/bin/${arch}-gcc
-  # # Create a dummy .tar.xz file & set the modification time .tar.xz file to match the gcc binary (to not trigger make)
-  # touch -r $out/sources/${arch}_pc-13.2.0/bin/${arch}-gcc $out/sources/${arch}_pc-13.2.0.tar.xz
-
-  # Attempt 2
-  # buildInputs = [ makeWrapper musl ];
-  # buildPhase = ''
-  # mkdir -p $out/sources $out/build-x86_64-linux-musl/
-  # ln -s ${skaToolchain} $out/sources/${arch}_pc-13.2.0.tar.xz
-  # ln -s ${skaLibs} $out/sources/skalibs
-  # cp -r ${skaLibs} $out/build-x86_64-linux-musl/skalibs-v2.14.0.1 && rm -rf $out/build-x86_64-linux-musl/skalibs-v2.14.0.1/.git
-  # chmod -R u+w $out/build-x86_64-linux-musl/skalibs-v2.14.0.1
-  # ln -s ${skaExecline} $out/sources/execline
-  # cp -r ${skaExecline} $out/build-x86_64-linux-musl/execline-v2.9.4.0 && rm -rf $out/build-x86_64-linux-musl/execline-v2.9.4.0/.git
-  # chmod -R u+w $out/build-x86_64-linux-musl/execline-v2.9.4.0
-  # ln -s ${skaS6} $out/sources/s6
-  # cp -r ${skaS6} $out/build-x86_64-linux-musl/s6-v2.12.0.2 && rm -rf $out/build-x86_64-linux-musl/s6-v2.12.0.2/.git
-  # chmod -R u+w $out/build-x86_64-linux-musl/s6-v2.12.0.2
 
   installPhase = ''
-    # tried ln -s but that didn't work
     cp -r ${merged} $out
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25014,6 +25014,8 @@ with pkgs;
     tipidee
     utmps;
 
+  s6-overlay = callPackage ../tools/virtualization/s6-overlay { };
+
   kgt = callPackage ../development/tools/kgt {
     inherit (skawarePackages) cleanPackaging;
   };


### PR DESCRIPTION
## Description of changes

I want to use s6 in a docker image, and figured s6-overlay is probably an easy solution... until I figured out it's not in nixpkgs :sweat_smile: 

So I tried to package it:
### Attempt 1 - the "nix way"
trying to link dependencies from nixpkgs and build from source - but that has proven to be difficult, because there is a lot, and it needs specific versions... I didn't manage
### Attempt 2 - fetch deps from skaware & build from source
Trying to give the makefile everything it needs and linking it so that the makefile would think it fetched it.... felt like a good idea in the beginning, but it wasn't :sweat_smile: 
_(made an [interim commit](https://github.com/NixOS/nixpkgs/pull/283230/commits/26cb71024030a72a5504b6f94fb808b33ef00a78) before starting with:)_

### Attempt 3 - just fetch release tarball
So that's what I ended up with as a "fair enough" situation, but I'm also not sure with `symlinkJoin` & `srcs` and `installPhase` - if that's a good way to do it.

Feedback appreciated :tipping_hand_man: 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
