### PR TITLE
rust.envVars: use wrapped LLD for aarch64 musl

### DIFF
--- a/pkgs/build-support/rust/lib/default.nix
+++ b/pkgs/build-support/rust/lib/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
-, buildPackages
-, targetPackages
+, pkgsBuildHost
+, pkgsTargetTarget
 }:
 
 rec {
@@ -16,26 +16,26 @@ rec {
     # As a workaround for https://github.com/rust-lang/rust/issues/89626 use lld on pkgsStatic aarch64
     shouldUseLLD = platform: platform.isAarch64 && platform.isStatic && !stdenv.isDarwin;
 
-    ccForBuild = "${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}cc";
-    cxxForBuild = "${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}c++";
+    ccForBuild = "${pkgsBuildHost.stdenv.cc}/bin/${pkgsBuildHost.stdenv.cc.targetPrefix}cc";
+    cxxForBuild = "${pkgsBuildHost.stdenv.cc}/bin/${pkgsBuildHost.stdenv.cc.targetPrefix}c++";
     linkerForBuild = ccForBuild;
 
     ccForHost = "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc";
     cxxForHost = "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}c++";
     linkerForHost = if shouldUseLLD stdenv.targetPlatform
       && !stdenv.cc.bintools.isLLVM
-      then "${buildPackages.lld}/bin/ld.lld"
+      then "${pkgsBuildHost.lld}/bin/ld.lld"
       else ccForHost;
 
-    # Unfortunately we must use the dangerous `targetPackages` here
+    # Unfortunately we must use the dangerous `pkgsTargetTarget` here
     # because hooks are artificially phase-shifted one slot earlier
     # (they go in nativeBuildInputs, so the hostPlatform looks like
     # a targetPlatform to them).
-    ccForTarget = "${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc";
-    cxxForTarget = "${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}c++";
-    linkerForTarget = if shouldUseLLD targetPackages.stdenv.targetPlatform
-      && !targetPackages.stdenv.cc.bintools.isLLVM # whether stdenv's linker is lld already
-      then "${buildPackages.lld}/bin/ld.lld"
+    ccForTarget = "${pkgsTargetTarget.stdenv.cc}/bin/${pkgsTargetTarget.stdenv.cc.targetPrefix}cc";
+    cxxForTarget = "${pkgsTargetTarget.stdenv.cc}/bin/${pkgsTargetTarget.stdenv.cc.targetPrefix}c++";
+    linkerForTarget = if shouldUseLLD pkgsTargetTarget.stdenv.targetPlatform
+      && !pkgsTargetTarget.stdenv.cc.bintools.isLLVM # whether stdenv's linker is lld already
+      then "${pkgsBuildHost.lld}/bin/ld.lld"
       else ccForTarget;
 
     rustBuildPlatform = stdenv.buildPlatform.rust.rustcTarget;
@@ -56,9 +56,9 @@ rec {
     setEnv = ''
     env \
     ''
-    # Due to a bug in how splicing and targetPackages works, in
-    # situations where targetPackages is irrelevant
-    # targetPackages.stdenv.cc is often simply wrong.  We must omit
+    # Due to a bug in how splicing and pkgsTargetTarget works, in
+    # situations where pkgsTargetTarget is irrelevant
+    # pkgsTargetTarget.stdenv.cc is often simply wrong.  We must omit
     # the following lines when rustTargetPlatform collides with
     # rustHostPlatform.
     + lib.optionalString (rustTargetPlatform != rustHostPlatform) ''
@@ -74,8 +74,8 @@ rec {
       "CXX_${stdenv.buildPlatform.rust.cargoEnvVarTarget}=${cxxForBuild}" \
       "CARGO_TARGET_${stdenv.buildPlatform.rust.cargoEnvVarTarget}_LINKER=${linkerForBuild}" \
       "CARGO_BUILD_TARGET=${rustBuildPlatform}" \
-      "HOST_CC=${buildPackages.stdenv.cc}/bin/cc" \
-      "HOST_CXX=${buildPackages.stdenv.cc}/bin/c++" \
+      "HOST_CC=${pkgsBuildHost.stdenv.cc}/bin/cc" \
+      "HOST_CXX=${pkgsBuildHost.stdenv.cc}/bin/c++" \
     '';
   };
 } // lib.mapAttrs (old: new: platform:

--- a/pkgs/build-support/rust/lib/default.nix
+++ b/pkgs/build-support/rust/lib/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , pkgsBuildHost
+, pkgsBuildTarget
 , pkgsTargetTarget
 }:
 
@@ -24,7 +25,7 @@ rec {
     cxxForHost = "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}c++";
     linkerForHost = if shouldUseLLD stdenv.targetPlatform
       && !stdenv.cc.bintools.isLLVM
-      then "${pkgsBuildHost.lld}/bin/ld.lld"
+      then "${pkgsBuildHost.llvmPackages.bintools}/bin/${stdenv.cc.targetPrefix}ld.lld"
       else ccForHost;
 
     # Unfortunately we must use the dangerous `pkgsTargetTarget` here
@@ -35,7 +36,7 @@ rec {
     cxxForTarget = "${pkgsTargetTarget.stdenv.cc}/bin/${pkgsTargetTarget.stdenv.cc.targetPrefix}c++";
     linkerForTarget = if shouldUseLLD pkgsTargetTarget.stdenv.targetPlatform
       && !pkgsTargetTarget.stdenv.cc.bintools.isLLVM # whether stdenv's linker is lld already
-      then "${pkgsBuildHost.lld}/bin/ld.lld"
+      then "${pkgsBuildTarget.llvmPackages.bintools}/bin/${pkgsTargetTarget.stdenv.cc.targetPrefix}ld.lld"
       else ccForTarget;
 
     rustBuildPlatform = stdenv.buildPlatform.rust.rustcTarget;

--- a/pkgs/development/compilers/rust/1_75.nix
+++ b/pkgs/development/compilers/rust/1_75.nix
@@ -56,4 +56,4 @@ import ./default.nix {
   rustcPatches = [ ];
 }
 
-(builtins.removeAttrs args [ "pkgsBuildTarget" "llvmPackages_17" "llvm_17"])
+(builtins.removeAttrs args [ "llvmPackages_17" "llvm_17"])

--- a/pkgs/development/compilers/rust/1_75.nix
+++ b/pkgs/development/compilers/rust/1_75.nix
@@ -10,11 +10,9 @@
 # 3. Firefox and Thunderbird should still build on x86_64-linux.
 
 { stdenv, lib
-, buildPackages
-, targetPackages
 , newScope, callPackage
 , CoreFoundation, Security, SystemConfiguration
-, pkgsBuildTarget, pkgsBuildBuild, pkgsBuildHost
+, pkgsBuildTarget, pkgsBuildBuild, pkgsBuildHost, pkgsTargetTarget
 , makeRustPlatform
 , wrapRustcWith
 , llvmPackages_17, llvm_17
@@ -58,4 +56,4 @@ import ./default.nix {
   rustcPatches = [ ];
 }
 
-(builtins.removeAttrs args [ "pkgsBuildTarget" "pkgsBuildHost" "llvmPackages_17" "llvm_17"])
+(builtins.removeAttrs args [ "pkgsBuildTarget" "llvmPackages_17" "llvm_17"])

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -12,18 +12,18 @@
 , llvmPackages # Exposed through rustc for LTO in Firefox
 }:
 { stdenv, lib
-, buildPackages
-, targetPackages
 , newScope, callPackage
 , CoreFoundation, Security, SystemConfiguration
 , pkgsBuildBuild
+, pkgsBuildHost
+, pkgsTargetTarget
 , makeRustPlatform
 , wrapRustcWith
 }:
 
 let
   # Use `import` to make sure no packages sneak in here.
-  lib' = import ../../../build-support/rust/lib { inherit lib stdenv buildPackages targetPackages; };
+  lib' = import ../../../build-support/rust/lib { inherit lib stdenv pkgsBuildHost pkgsTargetTarget; };
   # Allow faster cross compiler generation by reusing Build artifacts
   fastCross = (stdenv.buildPlatform == stdenv.hostPlatform) && (stdenv.hostPlatform != stdenv.targetPlatform);
 in
@@ -58,11 +58,11 @@ in
       else
         self.buildRustPackages.overrideScope (_: _:
         lib.optionalAttrs (stdenv.buildPlatform == stdenv.hostPlatform)
-          (selectRustPackage buildPackages).packages.prebuilt);
+          (selectRustPackage pkgsBuildHost).packages.prebuilt);
       bootRustPlatform = makeRustPlatform bootstrapRustPackages;
     in {
       # Packages suitable for build-time, e.g. `build.rs`-type stuff.
-      buildRustPackages = (selectRustPackage buildPackages).packages.stable // { __attrsFailEvaluation = true; };
+      buildRustPackages = (selectRustPackage pkgsBuildHost).packages.stable // { __attrsFailEvaluation = true; };
       # Analogous to stdenv
       rustPlatform = makeRustPlatform self.buildRustPackages;
       rustc-unwrapped = self.callPackage ./rustc.nix ({

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -16,6 +16,7 @@
 , CoreFoundation, Security, SystemConfiguration
 , pkgsBuildBuild
 , pkgsBuildHost
+, pkgsBuildTarget
 , pkgsTargetTarget
 , makeRustPlatform
 , wrapRustcWith
@@ -23,7 +24,9 @@
 
 let
   # Use `import` to make sure no packages sneak in here.
-  lib' = import ../../../build-support/rust/lib { inherit lib stdenv pkgsBuildHost pkgsTargetTarget; };
+  lib' = import ../../../build-support/rust/lib {
+    inherit lib stdenv pkgsBuildHost pkgsBuildTarget pkgsTargetTarget;
+  };
   # Allow faster cross compiler generation by reusing Build artifacts
   fastCross = (stdenv.buildPlatform == stdenv.hostPlatform) && (stdenv.hostPlatform != stdenv.targetPlatform);
 in


### PR DESCRIPTION
## Description of changes

The unwrapped version doesn't know where to look for libraries, so this is required to e.g. build anything that uses openssl-sys with OPENSSL_NO_VENDOR.  A randomly chosen example package that's fixed by this change is pkgsStatic.gitoxide.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
