### PR TITLE
nixos/installation-device: enable polkit

### DIFF
--- a/nixos/modules/profiles/installation-device.nix
+++ b/nixos/modules/profiles/installation-device.nix
@@ -39,6 +39,9 @@ with lib;
     # Allow the user to log in as root without a password.
     users.users.root.initialHashedPassword = "";
 
+    # Don't require sudo/root to `reboot` or `poweroff`.
+    security.polkit.enable = true;
+
     # Allow passwordless sudo from nixos user
     security.sudo = {
       enable = mkDefault true;


### PR DESCRIPTION
## Description of changes

Polkit enables running 'reboot' and 'poweroff' in the installer without
being root, and non-root is the default login for a few NixOS releases
now.

Without this change you'll get `Access denied` when trying to run `reboot` or `poweroff`, without prefixing the commands with sudo.

There's no size increase in the minimal ISO:

```
  $ git checkout nixpkgs-unstable
  $ nix-build -A config.system.build.isoImage -I nixos-config=nixos/modules/installer/cd-dvd/installation-cd-minimal.nix nixos/default.nix && du -sc ./result/iso/*.iso
  /nix/store/bfvbvrrqjmnqqhyqyxc0w32gagdz2rya-nixos-24.05.git.1149dab64e7-x86_64-linux.iso
  998404  ./result/iso/nixos-24.05.git.1149dab64e7-x86_64-linux.iso
  998404  total
```

```
  $ git checkout THIS_COMMIT
  $ nix-build -A config.system.build.isoImage -I nixos-config=nixos/modules/installer/cd-dvd/installation-cd-minimal.nix nixos/default.nix && du -sc ./result/iso/*.iso
  /nix/store/l9x9rwlvfddnri70h1ifx865q0cvka5l-nixos-24.05.git.1149dab64e7-x86_64-linux.iso
  998404  ./result/iso/nixos-24.05.git.1149dab64e7-x86_64-linux.iso
  998404  total
```
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
