### PR TITLE
umockdev: enable strictDeps

### DIFF
--- a/pkgs/development/libraries/umockdev/default.nix
+++ b/pkgs/development/libraries/umockdev/default.nix
@@ -12,6 +12,7 @@
 , ninja
 , pkg-config
 , python3
+, substituteAll
 , systemdMinimal
 , usbutils
 , vala
@@ -33,6 +34,14 @@ stdenv.mkDerivation (finalAttrs: {
     # Hardcode absolute paths to libraries so that consumers
     # do not need to set LD_LIBRARY_PATH themselves.
     ./hardcode-paths.patch
+
+    # Replace references to udevadm with an absolute paths, so programs using
+    # umockdev will just work without having to provide it in their test environment
+    # $PATH.
+    (substituteAll {
+      src = ./substitute-udevadm.patch;
+      udevadm = "${systemdMinimal}/bin/udevadm";
+    })
   ];
 
   nativeBuildInputs = [
@@ -59,7 +68,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeCheckInputs = [
     python3
-    systemdMinimal
     usbutils
     which
   ];

--- a/pkgs/development/libraries/umockdev/default.nix
+++ b/pkgs/development/libraries/umockdev/default.nix
@@ -12,7 +12,7 @@
 , ninja
 , pkg-config
 , python3
-, systemd
+, systemdMinimal
 , usbutils
 , vala
 , which
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     glib
-    systemd
+    systemdMinimal
     libpcap
   ];
 
@@ -59,9 +59,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeCheckInputs = [
     python3
-    which
+    systemdMinimal
     usbutils
+    which
   ];
+
+  strictDeps = true;
 
   mesonFlags = [
     "-Dgtk_doc=true"

--- a/pkgs/development/libraries/umockdev/substitute-udevadm.patch
+++ b/pkgs/development/libraries/umockdev/substitute-udevadm.patch
@@ -1,0 +1,41 @@
+From 09efbe8090f501c60975d5467fb587ed633d6a01 Mon Sep 17 00:00:00 2001
+From: Florian Klink <flokli@flokli.de>
+Date: Wed, 24 Jan 2024 14:29:28 +0200
+Subject: [PATCH] substitute udevadm
+
+---
+ src/umockdev-record.vala     | 2 +-
+ tests/test-umockdev-run.vala | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/umockdev-record.vala b/src/umockdev-record.vala
+index 2d49bc8..272f25e 100644
+--- a/src/umockdev-record.vala
++++ b/src/umockdev-record.vala
+@@ -223,7 +223,7 @@ record_device(string dev)
+     int exitcode;
+     try {
+         Process.spawn_sync(null,
+-                           {"udevadm", "info", "--query=all", "--path", dev},
++                           {"@udevadm@", "info", "--query=all", "--path", dev},
+                            null,
+                            SpawnFlags.SEARCH_PATH,
+                            null,
+diff --git a/tests/test-umockdev-run.vala b/tests/test-umockdev-run.vala
+index cd00a08..94616cb 100644
+--- a/tests/test-umockdev-run.vala
++++ b/tests/test-umockdev-run.vala
+@@ -199,8 +199,8 @@ A: size=1048576\n
+ 
+     // unfortunately the udevadm output between distros is not entirely constant
+     assert (get_program_out (
+-            "udevadm",
+-            umockdev_run_command + "-d " + umockdev_file + " -- udevadm info --query=all --name=/dev/loop23",
++            "@udevadm@",
++            umockdev_run_command + "-d " + umockdev_file + " -- @udevadm@ info --query=all --name=/dev/loop23",
+             out sout, out serr, out exit));
+ 
+     assert_cmpstr (serr, CompareOperator.EQ, "");
+-- 
+2.43.0
+


### PR DESCRIPTION
As pointed out in
https://github.com/NixOS/nixpkgs/issues/280697#issuecomment-1906206490, umockdev tests shell out to udevadm, and in both cases, systemdMinimal should be sufficient.

Fixes #280697

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
