### PR TITLE
python311Packages.asyncinotify: 4.0.2 -> 4.0.6 

### DIFF
--- a/pkgs/development/python-modules/asyncinotify/default.nix
+++ b/pkgs/development/python-modules/asyncinotify/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage rec {
   pname = "asyncinotify";
-  version = "4.0.2";
+  version = "4.0.6";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     owner = "absperf";
     repo = "asyncinotify";
     rev = "refs/tags/v${version}";
-    hash = "sha256-Q7b406UENCmD9SGbaml+y2YLDi7VLZBmDkYMo8CLuVw=";
+    hash = "sha256-RXx6i5dIB2oySVaLoHPRGD9VKgiO5OAXmrzVBq8Ad18=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/asyncinotify/default.nix
+++ b/pkgs/development/python-modules/asyncinotify/default.nix
@@ -1,19 +1,22 @@
 { lib
 , buildPythonPackage
-, fetchFromGitLab
+, fetchFromGitHub
 , flit-core
-, python
+, pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "asyncinotify";
   version = "4.0.2";
-  format = "pyproject";
+  pyproject = true;
 
-  src = fetchFromGitLab {
-    owner = "Taywee";
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "absperf";
     repo = "asyncinotify";
-    rev = "v${version}";
+    rev = "refs/tags/v${version}";
     hash = "sha256-Q7b406UENCmD9SGbaml+y2YLDi7VLZBmDkYMo8CLuVw=";
   };
 
@@ -21,15 +24,22 @@ buildPythonPackage rec {
     flit-core
   ];
 
-  checkPhase = ''
-    ${python.pythonOnBuildForHost.interpreter} ${src}/test.py
-  '';
-  pythonImportsCheck = ["asyncinotify"];
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "asyncinotify"
+  ];
+
+  pytestFlagsArray = [
+    "test.py"
+  ];
 
   meta = with lib; {
-    description = "A simple optionally-async python inotify library, focused on simplicity of use and operation, and leveraging modern Python features";
-    homepage = "https://pypi.org/project/asyncinotify/";
-    changelog = "https://gitlab.com/Taywee/asyncinotify/-/blob/master/CHANGELOG.md";
+    description = "Module for inotify";
+    homepage = "https://github.com/absperf/asyncinotify/";
+    changelog = "https://github.com/absperf/asyncinotify/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ cynerd ];
   };


### PR DESCRIPTION
Diff: https://github.com/absperf/asyncinotify/compare/refs/tags/v4.0.2...v4.0.6

Changelog: https://github.com/absperf/asyncinotify/releases/tag/v4.0.6

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
