### PR TITLE
influxdb-cxx: init at 0.7.2

### DIFF
--- a/pkgs/by-name/in/influxdb-cxx/package.nix
+++ b/pkgs/by-name/in/influxdb-cxx/package.nix
@@ -1,0 +1,45 @@
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, boost, catch2_3, libcpr, trompeloeil }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "influxdb-cxx";
+  version = "0.7.2";
+
+  src = fetchFromGitHub {
+    owner = "offa";
+    repo = "influxdb-cxx";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-DFslPrbgqS3JGx62oWlsC+AN5J2CsFjGcDaDRCadw7E=";
+  };
+
+  patches = [
+    # Fix unclosed test case tag
+    (fetchpatch {
+      url = "https://github.com/offa/influxdb-cxx/commit/b31f94982fd1d50e89ce04f66c694bec108bf470.patch";
+      hash = "sha256-oSdpNlWV744VpzfiWzp0ziNKaReLTlyfJ+SF2qyH+TU=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace "-Werror" ""
+  '';
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ boost libcpr ]
+    ++ lib.optionals finalAttrs.doCheck [ catch2_3 trompeloeil ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "INFLUXCXX_TESTING" finalAttrs.doCheck)
+    (lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" "-E;BoostSupportTest") # requires network access
+  ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "InfluxDB C++ client library";
+    homepage = "https://github.com/offa/influxdb-cxx";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sikmir ];
+    platforms = platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description of changes
[**influxdb-cxx**](https://github.com/offa/influxdb-cxx) - InfluxDB C++ client library.

[![Packaging status](https://repology.org/badge/tiny-repos/influxdb-cxx.svg)](https://repology.org/project/influxdb-cxx/versions)

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
