### PR TITLE
xremap: init at 0.8.14

### DIFF
--- a/pkgs/by-name/xr/xremap/package.nix
+++ b/pkgs/by-name/xr/xremap/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  stdenv,
+  wayland,
+  kdeSupport ? true,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "xremap";
+  version = "0.8.14";
+
+  src = fetchFromGitHub {
+    owner = "k0kubun";
+    repo = "xremap";
+    rev = "v${version}";
+    hash = "sha256-GexVY76pfmHalJPiCfVe9C9CXtlojG/H6JjOiA0GF1c=";
+  };
+
+  cargoHash = "sha256-ABzt8PMsas9+NRvpgtZlsoYjjvwpU8f6lqhceHxq91M=";
+
+  cargoBuildFlags = lib.optional kdeSupport "--features kde";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = lib.optionals stdenv.isLinux [
+    wayland
+  ];
+
+  meta = with lib; {
+    description = "Key remapper for X11 and Wayland";
+    homepage = "https://github.com/k0kubun/xremap";
+    changelog = "https://github.com/k0kubun/xremap/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    mainProgram = "xremap";
+    maintainers = with maintainers; [ _0x4A6F ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/by-name/xr/xremap/package.nix
+++ b/pkgs/by-name/xr/xremap/package.nix
@@ -4,8 +4,10 @@
   fetchFromGitHub,
   pkg-config,
   stdenv,
-  wayland,
-  kdeSupport ? true,
+  gnomeSupport ? false,
+  kdeSupport ? false,
+  wlrootsSupport ? false,
+  x11Support ? false,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -21,14 +23,14 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-ABzt8PMsas9+NRvpgtZlsoYjjvwpU8f6lqhceHxq91M=";
 
-  cargoBuildFlags = lib.optional kdeSupport "--features kde";
+  cargoBuildFlags =
+    lib.optional gnomeSupport "--features gnome"
+    ++ lib.optional kdeSupport "--features kde"
+    ++ lib.optional wlrootsSupport "--features wlroots"
+    ++ lib.optional x11Support "--features x11";
 
   nativeBuildInputs = [
     pkg-config
-  ];
-
-  buildInputs = lib.optionals stdenv.isLinux [
-    wayland
   ];
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Add [xremap](https://github.com/k0kubun/xremap) a key remapper for X11 and Wayland.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
