### PR TITLE
rtl-sdr-blog: init at 1.3.4

### DIFF
--- a/pkgs/by-name/rt/rtl-sdr-blog/package.nix
+++ b/pkgs/by-name/rt/rtl-sdr-blog/package.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, fetchFromGitHub
+, pkg-config
+, cmake
+, libusb1
+, lib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rtl-sdr-blog";
+  version = "1.3.4";
+
+  src = fetchFromGitHub {
+    owner = "rtlsdrblog";
+    repo = pname;
+    rev = "V${version}";
+    hash = "sha256-4Qeawd8V68j9Gfw+AgLXHhiiTpyJM1/eb16AZCTa0Vc=";
+  };
+
+  nativeBuildInputs = [ pkg-config cmake ];
+  propagatedBuildInputs = [ libusb1 ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace '/etc/udev/rules.d' "$out/etc/udev/rules.d" \
+      --replace "VERSION_INFO_PATCH_VERSION git" "VERSION_INFO_PATCH_VERSION ${lib.versions.patch version}"
+  '';
+
+  cmakeFlags = lib.optionals stdenv.isLinux [
+    "-DINSTALL_UDEV_RULES=ON"
+    "-DWITH_RPC=ON"
+  ];
+
+  meta = with lib; {
+    description = "Modified Osmocom drivers with enhancements for RTL-SDR Blog V3 and V4 units";
+    homepage = "https://github.com/rtlsdrblog/rtl-sdr-blog";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ bddvlpr ];
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}


### PR DESCRIPTION
## Description of changes

Related issue: #279621.
Same packaging as rtl-sdr, almost 1:1. Should still be tested for basic functionality as I only own a RTL2832U.
@nonnull-ca, please test the package and let me know if it works with the hardware.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
