### PR TITLE
chrome-remote-desktop: init at 120.0.6099.24

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -157,6 +157,7 @@
   ./programs/ccache.nix
   ./programs/cdemu.nix
   ./programs/cfs-zen-tweaks.nix
+  ./programs/chrome-remote-desktop.nix
   ./programs/chromium.nix
   ./programs/clash-verge.nix
   ./programs/cnping.nix

--- a/nixos/modules/programs/chrome-remote-desktop.nix
+++ b/nixos/modules/programs/chrome-remote-desktop.nix
@@ -1,0 +1,42 @@
+{ lib, config, pkgs, ... }:
+
+let
+  cfg = config.programs.chrome-remote-desktop;
+in
+{
+  options.programs.chrome-remote-desktop = {
+    enable = lib.mkEnableOption "Chrome Remote Desktop";
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment = {
+      etc = {
+        "chromium/native-messaging-hosts/com.google.chrome.remote_assistance.json".source = "${pkgs.chrome-remote-desktop}/etc/opt/chrome/native-messaging-hosts/com.google.chrome.remote_assistance.json";
+        "chromium/native-messaging-hosts/com.google.chrome.remote_desktop.json".source = "${pkgs.chrome-remote-desktop}/etc/opt/chrome/native-messaging-hosts/com.google.chrome.remote_desktop.json";
+      };
+      systemPackages = [ pkgs.chrome-remote-desktop ];
+    };
+
+    security = {
+      wrappers.crd-user-session = {
+        setuid = true;
+        owner = "root";
+        group = "root";
+        source = "${pkgs.chrome-remote-desktop}/opt/google/chrome-remote-desktop/user-session";
+      };
+
+      pam.services.chrome-remote-desktop.text = ''
+        auth        required    pam_unix.so
+        account     required    pam_unix.so
+        password    required    pam_unix.so
+        session     required    pam_unix.so
+      '';
+    };
+
+    users.groups.chrome-remote-desktop = { };
+
+    systemd.packages = [
+      pkgs.chrome-remote-desktop
+    ];
+  };
+}

--- a/pkgs/by-name/ch/chrome-remote-desktop/package.nix
+++ b/pkgs/by-name/ch/chrome-remote-desktop/package.nix
@@ -1,0 +1,114 @@
+{ stdenvNoCC
+, lib
+, autoPatchelfHook
+, dpkg
+, fetchurl
+, glib
+, gtk3
+, libdrm
+, libutempter
+, mesa
+, nss
+, pam
+, python3
+, shadow
+, xorg
+}:
+
+let
+  replacePrefix = "/opt/google/chrome-remote-desktop";
+in
+stdenvNoCC.mkDerivation rec {
+  name = "chrome-remote-desktop";
+  # Get the latest version from:
+  # https://dl.google.com/linux/chrome-remote-desktop/deb/dists/stable/main/binary-amd64/Packages
+  version = "120.0.6099.24";
+  src = fetchurl {
+    url = "https://dl.google.com/linux/chrome-remote-desktop/deb/pool/main/c/chrome-remote-desktop/chrome-remote-desktop_${version}_amd64.deb";
+    hash = "sha256-HA1sMR/v3b7u1GaCTzqdAV4Ov5mrRoYU4vPdyEYnX2Y=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    glib
+    gtk3
+    libdrm
+    libutempter
+    mesa
+    nss
+    pam
+    xorg.libX11
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXrandr
+    xorg.libXtst
+  ];
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    ${dpkg}/bin/dpkg -x $src $out
+
+    runHook postUnpack
+  '';
+
+  patchPhase = ''
+    runHook prePatch
+
+    sed \
+      -e '/^.*sudo_command =/ s/"gksudo .*"/"pkexec"/' \
+      -e '/^.*command =/ s/s -- sh -c/s sh -c/' \
+      -i $out/opt/google/chrome-remote-desktop/chrome-remote-desktop
+
+    substituteInPlace $out/lib/systemd/system/chrome-remote-desktop@.service \
+      --replace /opt/google/chrome-remote-desktop/chrome-remote-desktop '${placeholder "out"}/bin/chrome-remote-desktop'
+
+    substituteInPlace $out/etc/opt/chrome/native-messaging-hosts/com.google.chrome.remote_desktop.json \
+      --replace ${replacePrefix}/native-messaging-host $out/${replacePrefix}/native-messaging-host \
+      --replace ${replacePrefix}/remote-assistance-host $out/${replacePrefix}/remote-assistance-host
+
+    substituteInPlace $out/${replacePrefix}/chrome-remote-desktop \
+      --replace /usr/bin/python3 ${python3.withPackages (ps: with ps; [ psutil pyxdg packaging ])}/bin/python3 \
+      --replace '"Xvfb"' '"${xorg.xorgserver}/bin/Xvfb"' \
+      --replace '"Xorg"' '"${xorg.xorgserver}/bin/Xorg"' \
+      --replace '"xrandr"' '"${xorg.xrandr}/bin/xrandr"' \
+      --replace /usr/lib/xorg/modules ${xorg.xorgserver}/lib/xorg/modules \
+      --replace xdpyinfo ${xorg.xdpyinfo}/bin/xdpyinfo \
+      --replace /usr/bin/sudo /run/wrappers/bin/sudo \
+      --replace /usr/bin/pkexec /run/wrappers/bin/pkexec \
+      --replace /usr/bin/gpasswd ${shadow}/bin/gpasswd \
+      --replace /usr/bin/groupadd ${shadow}/bin/groupadd
+
+    runHook postPatch
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    for i in "$out/opt/google/chrome-remote-desktop/"*; do
+      if [[ ! -x "$i" ]]; then
+        continue
+      fi
+      ln -s "$i" "$out/bin/"
+    done
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Access your computer or share your screen with others using your phone, tablet, or another device";
+    homepage = "https://remotedesktop.google.com/";
+    platforms = [ "x86_64-linux" ];
+    license = with lib.licenses; [ unfree ];
+    mainProgram = "chrome-remote-desktop";
+    maintainers = with lib.maintainers; [ thiagokokada ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Fixes: https://github.com/NixOS/nixpkgs/issues/34084.

Previous attempt: https://github.com/NixOS/nixpkgs/pull/157962

Based on this [gist](https://gist.github.com/sepiabrown/0dbca7da5610055991ad04bbeb461fed) from @sepiabrown.

There are some differences between this approach and the previous attempt from @sepiabrown. This one will not use our own infrastructure to create a systemd service, instead relying on the files shipped upstream. So you can use `systemctl start chrome-remote-desktop@<user>.service` to start it for `user`.

Not working yet, the following issues needs to be fixed:

```console
# Trying to start directly or by the service
$ sudo systemctl start chrome-remote-desktop@thiagoko.service 
# Fails with the following error
Failed to load config: [Errno 2] No such file or directory: '/home/thiagoko/.config/chrome-remote-desktop/host#fa3e834c51b16b6f8dedf23cba86f50d.json'

# Trying to go to https://remotedesktop.google.com/headless to generate the <code> and manually register the host
$ DISPLAY= ./result/opt/google/chrome-remote-desktop/chrome-remote-desktop-host --code="<code>" --redirect-url="https://remotedesktop.google.com/_/oauthredirect" --name=sankyuu-nixos
[0123/190246.589371:ERROR:usage_stats_consent_linux.cc(37)] No host config file found.
[0123/190246.591763:INFO:remoting_me2me_host.cc(1999)] Starting host process: version 118.0.5993.9
[0123/190246.687651:ERROR:shared_x_display.cc(39)] Unable to open display
[0123/190246.687722:ERROR:remoting_me2me_host.cc(625)] Can't find host config at /home/thiagoko/.config/chrome-remote-desktop/host.json
```

The whole issue seems to be the `~/.config/chrome-remote-desktop/host#<hash>.json` configuration file, that I have zero ideas on how to generate. Would like some help here.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
