### PR TITLE
youtube-upnext: init at 1.1

### DIFF
--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -84,6 +84,7 @@ let
     visualizer = callPackage ./visualizer.nix { };
     vr-reversal = callPackage ./vr-reversal.nix { };
     webtorrent-mpv-hook = callPackage ./webtorrent-mpv-hook.nix { };
+    youtube-upnext = callPackage ./youtube-upnext.nix { };
   };
 
   aliases = {

--- a/pkgs/applications/video/mpv/scripts/youtube-upnext.nix
+++ b/pkgs/applications/video/mpv/scripts/youtube-upnext.nix
@@ -1,0 +1,27 @@
+{ buildLua, fetchFromGitHub, curl, unstableGitUpdater, lib }:
+
+buildLua rec {
+  pname = "youtube-upnext";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "cvzi";
+    repo = "mpv-youtube-upnext";
+    rev = "v${version}";
+    hash = "sha256-x9mfyc8JIlOpbSfGEwxXoUtsH0A+K3JPwT/8MHq7ks4=";
+  };
+
+  postPatch = ''
+    substituteInPlace youtube-upnext.lua \
+      --replace '"curl"' '"${lib.getExe curl}"'
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = with lib; {
+    description = "A userscript that allows you to play 'up next'/recommended youtube videos";
+    homepage = "https://github.com/cvzi/mpv-youtube-upnext";
+    maintainers = with maintainers; [ bddvlpr ];
+    license = licenses.unfree;
+  };
+}


### PR DESCRIPTION
## Description of changes

Related issue: #281512.
License is rather confusing, discussed in Matrix chat and set to unfree for the time being.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
