### PR TITLE
stirling-pdf: init at 0.22.3

### DIFF
--- a/pkgs/by-name/st/stirling-pdf/disable-spotless.patch
+++ b/pkgs/by-name/st/stirling-pdf/disable-spotless.patch
@@ -1,0 +1,34 @@
+diff --git a/build.gradle b/build.gradle
+index c206e2f..b1fda33 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -69,19 +69,7 @@ launch4j {
+   messagesInstanceAlreadyExists="Stirling-PDF is already running."
+ }
+ 
+-spotless {
+-    java {
+-        target project.fileTree('src/main/java')
+ 
+-        googleJavaFormat('1.19.1').aosp().reorderImports(false)
+-
+-        importOrder('java', 'javax', 'org', 'com', 'net', 'io')
+-        toggleOffOn()
+-        trimTrailingWhitespace()
+-        indentWithSpaces()
+-        endWithNewline()
+-    }
+-}
+ 
+ dependencies {
+     //security updates
+@@ -163,9 +151,6 @@ dependencies {
+     annotationProcessor 'org.projectlombok:lombok:1.18.28'
+ }
+ 
+-tasks.withType(JavaCompile) {
+-    dependsOn 'spotlessApply'
+-}
+ compileJava {
+     options.compilerArgs << '-parameters'
+ }

--- a/pkgs/by-name/st/stirling-pdf/fix-jar-timestamp.patch
+++ b/pkgs/by-name/st/stirling-pdf/fix-jar-timestamp.patch
@@ -1,0 +1,16 @@
+diff --git a/build.gradle b/build.gradle
+index 7025b2b..d063da3 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -20,6 +20,11 @@ repositories {
+ }
+
+
++tasks.withType(AbstractArchiveTask) {
++    preserveFileTimestamps = false
++    reproducibleFileOrder = true
++}
++
+
+ licenseReport {
+     renderers = [new JsonReportRenderer()]

--- a/pkgs/by-name/st/stirling-pdf/package.nix
+++ b/pkgs/by-name/st/stirling-pdf/package.nix
@@ -1,0 +1,118 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  substituteAll,
+  gradle_7,
+  perl,
+  makeWrapper,
+  jre,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "stirling-pdf";
+  version = "0.22.3";
+
+  src = fetchFromGitHub {
+    owner = "Stirling-Tools";
+    repo = "Stirling-PDF";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-8zXTapFAXw4+KLLirxBeEBmqNw6ILFHtbsaBSP3Ehyg=";
+  };
+
+  patches = [
+    # disable spotless because it tries to fetch files not in the FOD
+    # and also because it slows down the build process
+    ./disable-spotless.patch
+    # remove timestamp from the header of a generated .properties file
+    ./remove-props-file-timestamp.patch
+    # use gradle's built-in method of zeroing out timestamps,
+    # because stripJavaArchivesHook can't patch signed JAR files
+    ./fix-jar-timestamp.patch
+    # set the FOD as the only repository gradle can resolve from
+    (substituteAll {
+      src = ./use-fod-maven-repo.patch;
+      inherit (finalAttrs) deps;
+    })
+  ];
+
+  # fake build to pre-download deps into fixed-output derivation
+  deps = stdenv.mkDerivation {
+    name = "${finalAttrs.pname}-${finalAttrs.version}-deps";
+    inherit (finalAttrs) src;
+
+    patches = [ ./disable-spotless.patch ];
+
+    nativeBuildInputs = [
+      gradle_7
+      perl
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      export GRADLE_USER_HOME=$(mktemp -d)
+      gradle --no-daemon --console=plain build
+
+      runHook postBuild
+    '';
+
+    # perl code mavenizes pathes (com.squareup.okio/okio/1.13.0/a9283170b7305c8d92d25aff02a6ab7e45d06cbe/okio-1.13.0.jar -> com/squareup/okio/okio/1.13.0/okio-1.13.0.jar)
+    installPhase = ''
+      runHook preInstall
+
+      find $GRADLE_USER_HOME/caches/modules-2 -type f -regex '.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
+        | sh
+
+      # Mimic existence of okio-3.6.0.jar, originally known as okio-jvm-3.6.0 (and renamed).
+      # Gradle doesn't detect such renames and only fetches the latter.
+      # Whenever this package gets updated, please check if this hack is obsolete.
+      ln -s $out/com/squareup/okio/okio-jvm/3.6.0/okio-jvm-3.6.0.jar $out/com/squareup/okio/okio/3.6.0/okio-3.6.0.jar
+
+      runHook postInstall
+    '';
+
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "sha256-zUzKSa7zuIoXE77Hk/Xr5iMF4CEumV9horW2BTFRdtE=";
+  };
+
+  nativeBuildInputs = [
+    gradle_7
+    makeWrapper
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    export GRADLE_USER_HOME=$(mktemp -d)
+    gradle --offline --no-daemon --console=plain build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 build/libs/Stirling-PDF-*.jar $out/share/stirling-pdf/Stirling-PDF.jar
+    makeWrapper ${jre}/bin/java $out/bin/Stirling-PDF \
+        --add-flags "-jar $out/share/stirling-pdf/Stirling-PDF.jar"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    changelog = "https://github.com/Stirling-Tools/Stirling-PDF/releases/tag/${finalAttrs.src.rev}";
+    description = "A locally hosted web application that allows you to perform various operations on PDF files";
+    homepage = "https://github.com/Stirling-Tools/Stirling-PDF";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "Stirling-PDF";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = jre.meta.platforms;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode # deps
+    ];
+  };
+})

--- a/pkgs/by-name/st/stirling-pdf/remove-props-file-timestamp.patch
+++ b/pkgs/by-name/st/stirling-pdf/remove-props-file-timestamp.patch
@@ -1,0 +1,12 @@
+diff --git a/build.gradle b/build.gradle
+index e12cbd3..094a219 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -173,6 +173,7 @@ task writeVersion {
+     def props = new Properties()
+     props.setProperty('version', version)
+     props.store(propsFile.newWriter(), null)
++    propsFile.text = propsFile.readLines().tail().join('\n')
+ }
+ 
+ swaggerhubUpload {

--- a/pkgs/by-name/st/stirling-pdf/use-fod-maven-repo.patch
+++ b/pkgs/by-name/st/stirling-pdf/use-fod-maven-repo.patch
@@ -1,0 +1,25 @@
+diff --git a/build.gradle b/build.gradle
+index c206e2f..cdaddf7 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -16,7 +16,7 @@ version = '0.22.3'
+ sourceCompatibility = '17'
+ 
+ repositories {
+-    mavenCentral()
++    maven { url '@deps@' }
+ }
+ 
+ 
+diff --git a/settings.gradle b/settings.gradle
+index f813993..2c87f3c 100644
+--- a/settings.gradle
++++ b/settings.gradle
+@@ -1 +1,7 @@
++pluginManagement {
++    repositories {
++        maven { url '@deps@' }
++    }
++}
++
+ rootProject.name = 'Stirling-PDF'


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/282169

This PR adds 1 package: `stirling-pdf`

This is a gradle app, so it got the typical gradle treatment: prefetch deps, then use them as a fake maven repository

The package generates a signed jar file, which is apparently not supported by the backend of `stripJavaArchivesHook`, so I had to use the built-in gradle way of fixing the timestamps of the jar files.

Other than this patch there's one which removes the `spotless`, because it couldn't resolve all its dependencies correctly. There's another one, which removes the timestamp header from a `.properties` file

 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
