### PR TITLE
vep: init at 110

### DIFF
--- a/pkgs/by-name/ve/vep/package.nix
+++ b/pkgs/by-name/ve/vep/package.nix
@@ -1,0 +1,134 @@
+# Instructions:http://www.ensembl.org/info/docs/api/api_installation.html,
+# Do not use https://github.com/Ensembl/ensembl-vep/archive/release/${version}.zip
+# We cannot use INSTALL.pl but it’s not that bad:install the dependencies and copies the .pm files should be ok
+{
+  lib,
+  htslib,
+  perlPackages,
+  stdenv,
+  fetchFromGitHub,
+  perl,
+  makeWrapper,
+}:
+
+let
+  version = "110";
+  customInstallPhase = ''
+    mkdir -p $out/${perl.libPrefix}/${perl.version}/
+    tests=$(find modules/ -mindepth 1 -maxdepth 1 -type d | grep -v t)
+    cp -r $tests $out/${perl.libPrefix}/${perl.version}/
+  '';
+
+  ensemblGit =
+    name: sha256:
+    # Copy modules directly
+    stdenv.mkDerivation {
+      inherit name version;
+      src = fetchFromGitHub {
+        inherit sha256 version;
+        owner = "Ensembl";
+        repo = name;
+        rev = "release/${version}";
+      };
+      installPhase = ''
+        runHook preInstall
+
+        ${customInstallPhase}
+
+        runHook postInstall'';
+    };
+
+  vepPlugins = fetchFromGitHub {
+    owner = "Ensembl";
+    repo = "VEP_plugins";
+    rev = "8f271c4848338dc7d504881ff71fdf2892c3d096";
+    sha256 = "sha256-LbaXwLFDP3m1QhRHwO9uh36BEFHE2NzL4xdxTb7/S5Q=";
+  };
+
+  # Install ensembl-xs, faster run using re-implementation in C of some of the Perl subroutines
+  ensembl-xs = perlPackages.buildPerlPackage rec {
+    pname = "ensembl-xs";
+    version = "2.3.2";
+    src = fetchFromGitHub {
+      inherit version;
+      owner = "Ensembl";
+      repo = "ensembl-xs";
+      rev = version;
+      sha256 = "1qqnski532f4bz32wxbqd9w1sz40rjh81ipp9p02k3rlaf1gp1fa";
+    };
+    # PREFIX is important
+    configurePhase = ''
+      perl Makefile.PL PREFIX=$out INSTALLDIRS=site
+    '';
+    # Test do not work -- wrong include path
+    doCheck = false;
+  };
+
+  # it contains compiled versions of certain key subroutines used in VEP
+  ensembl = ensemblGit "ensembl" "sha256-ZhI4VNxIY+53RX2uYRNlFeo/ydAmlwGx00WDXaxv6h4=";
+  ensembl-io = ensemblGit "ensembl-io" "sha256-r3RvN5U2kcyghoKM0XuiBRe54t1U4FaZ0QEeYIFiG0w=";
+  ensembl-variation = ensemblGit "ensembl-variation" "sha256-UjrLHF9EqI+Mp+SZR4sLNZUCGiA/UYhoFWtpwiKF8tM=";
+  ensembl-funcgen = ensemblGit "ensembl-funcgen" "sha256-a9hxLBoXJsF5JWuRdpyOac1u033M8ivEjEQecuncghs=";
+in
+perlPackages.buildPerlModule rec {
+  inherit version;
+  pname = "vep";
+  buildInputs =
+    (with perlPackages; [
+      ArchiveZip
+      BioBigFile
+      BioDBHTS
+      BioExtAlign
+      BioPerl
+      DBI
+      DBDmysql
+      LWP
+      JSON
+    ])
+    ++ [
+      ensembl-xs
+      ensembl
+      ensembl-funcgen
+      ensembl-io
+      ensembl-variation
+    ];
+  propagatedBuildInputs = [ htslib ];
+  src = fetchFromGitHub {
+    owner = "Ensembl";
+    repo = "ensembl-${pname}";
+    rev = "release/${version}";
+    sha256 = "sha256-6lRdWV2ispl+mpBhkZez/d9PxOw1fkNUWeG8mUIqBJc=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  dontBuild = true;
+  doCheck = false;
+
+  outputs = [ "out" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    install -D -m755 filter_vep vep $out/bin/
+
+    wrapProgram $out/bin/vep \
+      --prefix PERL5LIB : $out/${perl.libPrefix}/${perl.version}/ \
+      --add-flags "--dir_plugins ${vepPlugins}"
+
+    wrapProgram $out/bin/filter_vep \
+      --prefix PERL5LIB : $out/${perl.libPrefix}/${perl.version}/
+    ${customInstallPhase}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://www.ensembl.org/info/docs/tools/vep/index.html";
+    description = "Annotate genetics variants based on genes, transcripts, and protein sequence, as well as regulatory regions";
+    license = lib.licenses.asl20;
+    mainProgram = "vep";
+    maintainers = with lib.maintainers; [ apraga ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
This software has required significant work to package and need other PR to be merge beforehand : #185691 #186459 #186464 and the infamous  #186462.
The package has been formatted with nixpkgs-fmt. I was not able to run tests but this software has been used for hundred of runs in research setting.

## Description of changes

New packages for Variant Effect Predictor.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
