### PR TITLE
etebase: fix runtime crash due to wrong pydantic..

### DIFF
--- a/nixos/modules/services/misc/etebase-server.nix
+++ b/nixos/modules/services/misc/etebase-server.nix
@@ -5,8 +5,8 @@ with lib;
 let
   cfg = config.services.etebase-server;
 
-  pythonEnv = pkgs.python3.withPackages (ps: with ps;
-    [ etebase-server daphne ]);
+  pythonEnv = cfg.pythonPackage.withPackages (ps: with ps;
+    [ cfg.package daphne ]);
 
   iniFmt = pkgs.formats.ini {};
 
@@ -44,6 +44,20 @@ in
           the user specified by the `user` option or a superuser.
           Then you can login and create accounts on your-etebase-server.com/admin
         '';
+      };
+
+      package = mkOption {
+        type = types.package;
+        default = cfg.pythonPackage.pkgs.etebase-server;
+        defaultText = literalExpression "pkgs.etebase-server";
+        description = lib.mdDoc "etebase-server package to use.";
+      };
+
+      pythonPackage = mkOption {
+        type = types.package;
+        default = pkgs.python3;
+        defaultText = literalExpression "pkgs.python3";
+        description = lib.mdDoc "python interpreter to run etebase-server with.";
       };
 
       dataDir = mkOption {
@@ -191,10 +205,10 @@ in
       preStart = ''
         # Auto-migrate on first run or if the package has changed
         versionFile="${cfg.dataDir}/src-version"
-        if [[ $(cat "$versionFile" 2>/dev/null) != ${pkgs.etebase-server} ]]; then
+        if [[ $(cat "$versionFile" 2>/dev/null) != ${cfg.package} ]]; then
           etebase-server migrate --no-input
           etebase-server collectstatic --no-input --clear
-          echo ${pkgs.etebase-server} > "$versionFile"
+          echo ${cfg.package} > "$versionFile"
         fi
       '';
       script =

--- a/pkgs/servers/etebase/default.nix
+++ b/pkgs/servers/etebase/default.nix
@@ -1,17 +1,8 @@
 { lib
 , fetchFromGitHub
-, aiofiles
-, django_3
-, fastapi
-, msgpack
-, pynacl
-, redis
-, typing-extensions
 , withLdap ? true
 , python3
-, python-ldap
 , withPostgres ? true
-, psycopg2
 , nix-update-script
 , nixosTests
 }:
@@ -38,12 +29,20 @@ python.pkgs.buildPythonPackage rec {
   patches = [ ./secret.patch ];
 
   propagatedBuildInputs = [
+  propagatedBuildInputs = with python.pkgs; [
     aiofiles
     django_3
     fastapi
     msgpack
     pynacl
     redis
+    uvicorn
+    websockets
+    watchfiles
+    uvloop
+    pyyaml
+    python-dotenv
+    httptools
     typing-extensions
   ] ++ lib.optional withLdap python-ldap
     ++ lib.optional withPostgres psycopg2;

--- a/pkgs/servers/etebase/default.nix
+++ b/pkgs/servers/etebase/default.nix
@@ -17,7 +17,6 @@ in
 python.pkgs.buildPythonPackage rec {
   pname = "etebase-server";
   version = "0.11.0";
-  format = "other";
 
   src = fetchFromGitHub {
     owner = "etesync";
@@ -28,7 +27,8 @@ python.pkgs.buildPythonPackage rec {
 
   patches = [ ./secret.patch ];
 
-  propagatedBuildInputs = [
+  doCheck = false;
+
   propagatedBuildInputs = with python.pkgs; [
     aiofiles
     django_3
@@ -47,15 +47,17 @@ python.pkgs.buildPythonPackage rec {
   ] ++ lib.optional withLdap python-ldap
     ++ lib.optional withPostgres psycopg2;
 
-  installPhase = ''
+  postInstall = ''
     mkdir -p $out/bin $out/lib
-    cp -r . $out/lib/etebase-server
-    ln -s $out/lib/etebase-server/manage.py $out/bin/etebase-server
+    cp manage.py $out/bin/etebase-server
     wrapProgram $out/bin/etebase-server --prefix PYTHONPATH : "$PYTHONPATH"
     chmod +x $out/bin/etebase-server
   '';
 
   passthru.updateScript = nix-update-script {};
+  passthru.python = python;
+  # PYTHONPATH of all dependencies used by the package
+  passthru.pythonPath = python.pkgs.makePythonPath propagatedBuildInputs;
   passthru.tests = {
     nixosTest = nixosTests.etebase-server;
   };

--- a/pkgs/servers/etebase/default.nix
+++ b/pkgs/servers/etebase/default.nix
@@ -66,6 +66,6 @@ python.pkgs.buildPythonPackage rec {
     description = "An Etebase (EteSync 2.0) server so you can run your own";
     changelog = "https://github.com/etesync/server/blob/${version}/ChangeLog.md";
     license = licenses.agpl3Only;
-    maintainers = with maintainers; [ felschr ];
+    maintainers = with maintainers; [ felschr phaer ];
   };
 }

--- a/pkgs/servers/etebase/default.nix
+++ b/pkgs/servers/etebase/default.nix
@@ -1,6 +1,5 @@
 { lib
 , fetchFromGitHub
-, buildPythonPackage
 , aiofiles
 , django_3
 , fastapi
@@ -9,13 +8,22 @@
 , redis
 , typing-extensions
 , withLdap ? true
+, python3
 , python-ldap
 , withPostgres ? true
 , psycopg2
 , nix-update-script
+, nixosTests
 }:
 
-buildPythonPackage rec {
+let
+  python = python3.override {
+    packageOverrides = self: super: {
+      pydantic = super.pydantic_1;
+    };
+  };
+in
+python.pkgs.buildPythonPackage rec {
   pname = "etebase-server";
   version = "0.11.0";
   format = "other";
@@ -49,6 +57,9 @@ buildPythonPackage rec {
   '';
 
   passthru.updateScript = nix-update-script {};
+  passthru.tests = {
+    nixosTest = nixosTests.etebase-server;
+  };
 
   meta = with lib; {
     homepage = "https://github.com/etesync/server";


### PR DESCRIPTION
...version. Upstream still uses pydantic 1, which it implicitly imports via fastapi. Overriding 
that and its pydantic-using dependencies fixes it, until upstream updates.

also:
* exposes the existing nixos integration test via passthru.nixosTests
* adds myself as a maintainer
* makes the package and pythonPackage used for the service configurable.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
