### PR TITLE
stratisd: fix build due to unused imports

### DIFF
--- a/pkgs/tools/filesystems/stratisd/default.nix
+++ b/pkgs/tools/filesystems/stratisd/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , rustPlatform
 , cargo
 , rustc
@@ -42,6 +43,22 @@ stdenv.mkDerivation rec {
       "loopdev-0.4.0" = "sha256-YS0hqxphxbbImT/mn/XBzkgabK2kbIym5VqG3XDVAx8=";
     };
   };
+
+  patches = [
+    # Can be removed with the next release after v. 3.6.3
+    (fetchpatch {
+      name = "remove-unused-imports.patch";
+      url = "https://github.com/stratis-storage/stratisd/commit/78440de6e6ed8eab5ddd25dbdfb7804d0698f2a2.patch";
+      hash = "sha256-RW2nyAWaoIbqrgbhCApQsMXkJWtWoOWL3VO7fIImJgY=";
+    })
+
+    # Can be removed with the next release after v. 3.6.3
+    (fetchpatch {
+      name = "flag-import-not-used-in-build-as-test-only.patch";
+      url = "https://github.com/stratis-storage/stratisd/commit/0d1c67f71338d0ee6c1e6aa06f7fd6264ce9a4c5.patch";
+      hash = "sha256-6Nb8izUqYUirjy0dTFhITxoM/AKoChoc0w6Qm9K6+7I=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace udev/61-stratisd.rules \


### PR DESCRIPTION
With `rustc` 1.75, many rust project that use `#[deny(warnings)]` stopped building due to unused imports that didn't trigger build failures before for some reason.

`stratisd` now also fails to build because of a couple of those, but they have already been fixed upstream.  This PR pulls in the respective two upstream commits via `fetchpatch` until the next version gets released.

Failing Hydra build: https://hydra.nixos.org/build/245589489
Hydra log: https://hydra.nixos.org/build/245589489/nixlog/8

Relevant log excerpt:
```
error: unused imports: `StratSectorSizes`, `initialize_devices`
  --> src/engine/strat_engine/backstore/mod.rs:19:31
   |
19 |     blockdev::{StratBlockDev, StratSectorSizes, UnderlyingDevice},
   |                               ^^^^^^^^^^^^^^^^
...
24 |     devices::{find_stratis_devs_by_uuid, initialize_devices, ProcessedPathInfos, UnownedDevices},
   |                                          ^^^^^^^^^^^^^^^^^^
   |
   = note: `-D unused-imports` implied by `-D unused`
   = help: to override `-D unused` add `#[allow(unused_imports)]`

error: unused imports: `DeviceInfo`, `LInfo`
  --> src/engine/strat_engine/liminal/mod.rs:12:30
   |
12 |     device_info::{DeviceSet, LInfo},
   |                              ^^^^^
13 |     identify::{find_all, DeviceInfo},
   |                          ^^^^^^^^^^

error: unused import: `StaticHeaderSize`
 --> src/engine/strat_engine/metadata/sizes.rs:9:26
  |
9 |     static_header_size::{StaticHeaderSize, STATIC_HEADER_SIZE},
  |                          ^^^^^^^^^^^^^^^^

error: unused import: `ThinPoolState`
  --> src/engine/strat_engine/thinpool/mod.rs:15:46
   |
15 |     thinpool::{ThinPool, ThinPoolSizeParams, ThinPoolState, DATA_BLOCK_SIZE},
   |                                              ^^^^^^^^^^^^^

error: unused import: `Engine`
  --> src/engine/types/mod.rs:22:14
   |
22 |     engine::{Engine, StateDiff},
   |              ^^^^^^

error: could not compile `stratisd` (lib) due to 5 previous errors
make: *** [Makefile:200: build] Error 101
```

## Description of changes

Apply two upstream commits that clean up unused imports.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
