### PR TITLE
snapcast: fix build failure due to missing `#include <cstdint>`

### DIFF
--- a/pkgs/applications/audio/snapcast/default.nix
+++ b/pkgs/applications/audio/snapcast/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, cmake, pkg-config
+{ stdenv, lib, fetchFromGitHub, fetchpatch, cmake, pkg-config
 , alsa-lib, asio, avahi, boost179, flac, libogg, libvorbis, soxr
 , IOKit, AudioToolbox
 , aixlog, popl
@@ -17,6 +17,15 @@ stdenv.mkDerivation rec {
     rev    = "v${version}";
     sha256 = "sha256-dlK1xQQqst4VQjioC7MZzqXwMC+JfqtvnD5lrOqGhYI=";
   };
+
+  patches = [
+    # Can be removed with next release after 0.27.0
+    (fetchpatch {
+      name = "include-cstdint.patch";
+      url = "https://github.com/badaix/snapcast/commit/481f08199ca31c60c9a3475f1064e6b06a503d12.patch";
+      hash = "sha256-klpvmBpBAlBMtcgnNfW6X6vDbJFnOuOsPUDXcNf5tGc=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake pkg-config ];
   # snapcast also supports building against tremor but as we have libogg, that's


### PR DESCRIPTION
`snapcast` fails to build with GCC 13 because of a missing include of `cstdint` (that got transitively included in older versions). This issue has already been fixed upstream some months ago, but there have been no new releases after that, so this change pulls in the upstream commit using `fetchpatch` for now.

Failing Hydra build: https://hydra.nixos.org/build/247256048
Hydra log: https://hydra.nixos.org/build/247256048/nixlog/1

Relevant log excerpt:
```
[  3%] Building CXX object common/CMakeFiles/common.dir/sample_format.cpp.o
In file included from /build/source/common/message/pcm_chunk.hpp:23,
                 from /build/source/common/resampler.hpp:22,
                 from /build/source/common/resampler.cpp:19:
/build/source/common/sample_format.hpp:42:26: error: expected ')' before 'rate'
   42 |     SampleFormat(uint32_t rate, uint16_t bits, uint16_t channels);
      |                 ~        ^~~~~
      |                          )
/build/source/common/sample_format.hpp:47:20: error: 'uint32_t' has not been declared
   47 |     void setFormat(uint32_t rate, uint16_t bits, uint16_t channels);
      |                    ^~~~~~~~
/build/source/common/sample_format.hpp:47:35: error: 'uint16_t' has not been declared
   47 |     void setFormat(uint32_t rate, uint16_t bits, uint16_t channels);
      |                                   ^~~~~~~~
/build/source/common/sample_format.hpp:47:50: error: 'uint16_t' has not been declared
   47 |     void setFormat(uint32_t rate, uint16_t bits, uint16_t channels);
      |                                                  ^~~~~~~~
/build/source/common/sample_format.hpp:54:5: error: 'uint32_t' does not name a type
   54 |     uint32_t rate() const
      |     ^~~~~~~~
/build/source/common/sample_format.hpp:23:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   22 | #include <string>
  +++ |+#include <cstdint>
   23 | 
/build/source/common/sample_format.hpp:59:5: error: 'uint16_t' does not name a type
   59 |     uint16_t bits() const
      |     ^~~~~~~~

...and so on.
```

## Description of changes

Pull in upstream patch to fix build failures.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
