### PR TITLE
python311Packages.msgraph-core: 0.2.2 -> 1.0.0

### DIFF
--- a/nixos/modules/services/monitoring/parsedmarc.nix
+++ b/nixos/modules/services/monitoring/parsedmarc.nix
@@ -438,7 +438,7 @@ in
             ];
         dashboards.settings.providers = lib.mkIf cfg.provision.grafana.dashboard [{
           name = "parsedmarc";
-          options.path = "${pkgs.python3Packages.parsedmarc.dashboard}";
+          options.path = "${pkgs.parsedmarc.dashboard}";
         }];
       };
     };
@@ -530,7 +530,7 @@ in
             MemoryDenyWriteExecute = true;
             LockPersonality = true;
             SystemCallArchitectures = "native";
-            ExecStart = "${pkgs.python3Packages.parsedmarc}/bin/parsedmarc -c /run/parsedmarc/parsedmarc.ini";
+            ExecStart = "${lib.getExe pkgs.parsedmarc} -c /run/parsedmarc/parsedmarc.ini";
           };
         };
 

--- a/pkgs/by-name/pa/parsedmarc/package.nix
+++ b/pkgs/by-name/pa/parsedmarc/package.nix
@@ -1,0 +1,41 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+
+let
+  python = python3.override {
+    packageOverrides = self: super: {
+      # https://github.com/domainaware/parsedmarc/issues/464
+      msgraph-core = super.msgraph-core.overridePythonAttrs (old: rec {
+        version = "0.2.2";
+
+        src = fetchFromGitHub {
+          owner = "microsoftgraph";
+          repo = "msgraph-sdk-python-core";
+          rev = "v${version}";
+          hash = "sha256-eRRlG3GJX3WeKTNJVWgNTTHY56qiUGOlxtvEZ2xObLA=";
+        };
+
+        nativeBuildInputs = with self; [
+          flit-core
+        ];
+
+        propagatedBuildInputs = with self; [
+          requests
+        ];
+
+        nativeCheckInputs = with self; [
+          pytestCheckHook
+          responses
+        ];
+
+        disabledTestPaths = [
+          "tests/integration"
+        ];
+
+        pythonImportsCheck = [ "msgraph.core" ];
+      });
+    };
+  };
+in with python.pkgs; toPythonApplication parsedmarc

--- a/pkgs/development/python-modules/microsoft-kiota-abstractions/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-abstractions/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flit-core
+, opentelemetry-api
+, opentelemetry-sdk
+, std-uritemplate
+, pytest-asyncio
+, pytest-mock
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "microsoft-kiota-abstractions";
+  version = "1.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "kiota-abstractions-python";
+    rev = "v${version}";
+    hash = "sha256-lIhVBEZsxq6VnldlgpEknfF3/sOnATCYzvY4V6wZCz4=";
+  };
+
+  nativeBuildInputs = [
+    flit-core
+  ];
+
+  propagatedBuildInputs = [
+    opentelemetry-api
+    opentelemetry-sdk
+    std-uritemplate
+  ];
+
+  pythonImportsCheck = [ "kiota_abstractions" ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  meta = {
+    changelog = "https://github.com/microsoft/kiota-abstractions-python/blob/${src.rev}/CHANGELOG.md";
+    description = "Abstractions library for Kiota generated Python clients";
+    homepage = "https://github.com/microsoft/kiota-abstractions-python";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/microsoft-kiota-authentication-azure/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-authentication-azure/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flit-core
+, aiohttp
+, azure-core
+, microsoft-kiota-abstractions
+, opentelemetry-api
+, opentelemetry-sdk
+, pytest-asyncio
+, pytest-mock
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "microsoft-kiota-authentication-azure";
+  version = "1.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "kiota-authentication-azure-python";
+    rev = "v${version}";
+    hash = "sha256-RA0BbIwDs3cXiH4tQsvCGUO1OAg+DWjEeWd7MEVIC8E=";
+  };
+
+  nativeBuildInputs = [
+    flit-core
+  ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    azure-core
+    microsoft-kiota-abstractions
+    opentelemetry-api
+    opentelemetry-sdk
+  ];
+
+  pythonImportsCheck = [ "kiota_authentication_azure" ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  meta = {
+    changelog = "https://github.com/microsoft/kiota-authentication-azure-python/blob/${src.rev}/CHANGELOG.md";
+    description = "Kiota Azure authentication provider for python clients";
+    homepage = "https://github.com/microsoft/kiota-authentication-azure-python";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/microsoft-kiota-http/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-http/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flit-core
+, httpx
+, microsoft-kiota-abstractions
+, opentelemetry-api
+, opentelemetry-sdk
+, pytest-asyncio
+, pytest-mock
+, pytestCheckHook
+, urllib3
+}:
+
+buildPythonPackage rec {
+  pname = "microsoft-kiota-http";
+  version = "1.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "kiota-http-python";
+    rev = "v${version}";
+    hash = "sha256-BGMEndYa1ZMKWw18Fs9S/ieMhu+e4tKQW57CC3g0P0Q=";
+  };
+
+  nativeBuildInputs = [
+    flit-core
+  ];
+
+  propagatedBuildInputs = [
+    httpx
+    microsoft-kiota-abstractions
+    opentelemetry-api
+    opentelemetry-sdk
+  ] ++ httpx.optional-dependencies.http2;
+
+  pythonImportsCheck = [ "kiota_http" ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-mock
+    pytestCheckHook
+    urllib3
+  ];
+
+  meta = {
+    changelog = "https://github.com/microsoft/kiota-http-python/blob/${src.rev}/CHANGELOG.md";
+    description = "HTTP request adapter implementation for Kiota clients for Python";
+    homepage = "https://github.com/microsoft/kiota-http-python";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/msgraph-core/default.nix
+++ b/pkgs/development/python-modules/msgraph-core/default.nix
@@ -2,47 +2,50 @@
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
-, flit-core
-, requests
+, setuptools
+, httpx
+, microsoft-kiota-abstractions
+, microsoft-kiota-authentication-azure
+, microsoft-kiota-http
+, azure-identity
 , pytestCheckHook
-, responses
 }:
 
 buildPythonPackage rec {
   pname = "msgraph-core";
-  version = "0.2.2";
+  version = "1.0.0";
 
-  disabled = pythonOlder "3.5";
+  disabled = pythonOlder "3.8";
 
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "microsoftgraph";
     repo = "msgraph-sdk-python-core";
     rev = "v${version}";
-    hash = "sha256-eRRlG3GJX3WeKTNJVWgNTTHY56qiUGOlxtvEZ2xObLA=";
+    hash = "sha256-VizjN7sXqPvo9VOSaaUnogTlUDJ1OA2COYNTcVRqhJA=";
   };
 
   nativeBuildInputs = [
-    flit-core
+    setuptools
   ];
 
   propagatedBuildInputs = [
-    requests
-  ];
+    httpx
+    microsoft-kiota-abstractions
+    microsoft-kiota-authentication-azure
+    microsoft-kiota-http
+  ] ++ httpx.optional-dependencies.http2;
 
   nativeCheckInputs = [
+    azure-identity
     pytestCheckHook
-    responses
   ];
 
-  disabledTestPaths = [
-    "tests/integration"
-  ];
-
-  pythonImportsCheck = [ "msgraph.core" ];
+  pythonImportsCheck = [ "msgraph_core" ];
 
   meta = {
+    changelog = "https://github.com/microsoftgraph/msgraph-sdk-python-core/blob/${src.rev}/CHANGELOG.md";
     description = "Core component of the Microsoft Graph Python SDK";
     homepage = "https://github.com/microsoftgraph/msgraph-sdk-python-core";
     license = lib.licenses.mit;

--- a/pkgs/development/python-modules/parsedmarc/default.nix
+++ b/pkgs/development/python-modules/parsedmarc/default.nix
@@ -108,5 +108,7 @@ buildPythonPackage rec {
     license = licenses.asl20;
     maintainers = with maintainers; [ talyz ];
     mainProgram = "parsedmarc";
+    # https://github.com/domainaware/parsedmarc/issues/464
+    broken = lib.versionAtLeast msgraph-core.version "1.0.0";
   };
 }

--- a/pkgs/development/python-modules/std-uritemplate/default.nix
+++ b/pkgs/development/python-modules/std-uritemplate/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, poetry-core
+}:
+
+buildPythonPackage rec {
+  pname = "std-uritemplate";
+  version = "0.0.50";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "std_uritemplate";
+    inherit version;
+    hash = "sha256-ZeMNxtZm+rltW4pD9/46lHEVFdExSL7b5N02T3AYk+k=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  pythonImportsCheck = [ "stduritemplate" ];
+
+  # tests not shipped on PyPI, no tags on GitHub
+  doCheck = false;
+
+  meta = {
+    description = "Std-uritemplate implementation for Python";
+    homepage = "https://github.com/andreaTP/std-uritemplate";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40838,8 +40838,6 @@ with pkgs;
 
   OSCAR = qt5.callPackage ../applications/misc/OSCAR { };
 
-  parsedmarc = with python3Packages; toPythonApplication parsedmarc;
-
   pgmanage = callPackage ../applications/misc/pgmanage { };
 
   pgadmin4 = callPackage ../tools/admin/pgadmin { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7036,6 +7036,8 @@ self: super: with self; {
 
   microsoft-kiota-authentication-azure = callPackage ../development/python-modules/microsoft-kiota-authentication-azure { };
 
+  microsoft-kiota-http = callPackage ../development/python-modules/microsoft-kiota-http { };
+
   midiutil = callPackage ../development/python-modules/midiutil { };
 
   mido = callPackage ../development/python-modules/mido { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13834,6 +13834,8 @@ self: super: with self; {
 
   statsmodels = callPackage ../development/python-modules/statsmodels { };
 
+  std-uritemplate = callPackage ../development/python-modules/std-uritemplate { };
+
   std2 = callPackage ../development/python-modules/std2 { };
 
   stdiomask = callPackage ../development/python-modules/stdiomask { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7034,6 +7034,8 @@ self: super: with self; {
 
   microsoft-kiota-abstractions = callPackage ../development/python-modules/microsoft-kiota-abstractions { };
 
+  microsoft-kiota-authentication-azure = callPackage ../development/python-modules/microsoft-kiota-authentication-azure { };
+
   midiutil = callPackage ../development/python-modules/midiutil { };
 
   mido = callPackage ../development/python-modules/mido { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7032,6 +7032,8 @@ self: super: with self; {
 
   microdata = callPackage ../development/python-modules/microdata { };
 
+  microsoft-kiota-abstractions = callPackage ../development/python-modules/microsoft-kiota-abstractions { };
+
   midiutil = callPackage ../development/python-modules/midiutil { };
 
   mido = callPackage ../development/python-modules/mido { };


### PR DESCRIPTION
breaks parsedmarc because of https://github.com/domainaware/parsedmarc/issues/464

## Description of changes
Diff: https://github.com/microsoftgraph/msgraph-sdk-python-core/compare/v0.2.2...v1.0.0

Changelog: https://github.com/microsoftgraph/msgraph-sdk-python-core/blob/v1.0.0/CHANGELOG.md
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
cc @peterablehmann

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
