### PR TITLE
ghc/hadrian: Respect patches argument

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -148,11 +148,15 @@
     inherit rev;
   })
 
+  # Patches applied to both GHC and Hadrian.
+, patches ? []
+
   # GHC's build system hadrian built from the GHC-to-build's source tree
   # using our bootstrap GHC.
 , hadrian ? import ../../tools/haskell/hadrian/make-hadrian.nix { inherit bootPkgs lib; } {
     ghcSrc = ghcSrc;
     ghcVersion = version;
+    inherit patches;
     userSettings = hadrianUserSettings;
     # Disable haddock generating pretty source listings to stay under 3GB on aarch64-linux
     enableHyperlinkedSource =
@@ -277,7 +281,7 @@ stdenv.mkDerivation ({
     # elimination on aarch64-darwin. (see
     # https://github.com/NixOS/nixpkgs/issues/140774 for details).
     ./Cabal-at-least-3.6-paths-fix-cycle-aarch64-darwin.patch
-  ];
+  ] ++ patches;
 
   postPatch = ''
     patchShebangs --build .

--- a/pkgs/development/tools/haskell/hadrian/disable-hyperlinked-source.patch
+++ b/pkgs/development/tools/haskell/hadrian/disable-hyperlinked-source.patch
@@ -1,7 +1,7 @@
 diff --git a/hadrian/src/Settings/Builders/Haddock.hs b/hadrian/src/Settings/Builders/Haddock.hs
 index 902b2f85e2..429a441c3b 100644
---- a/src/Settings/Builders/Haddock.hs
-+++ b/src/Settings/Builders/Haddock.hs
+--- a/hadrian/src/Settings/Builders/Haddock.hs
++++ b/hadrian/src/Settings/Builders/Haddock.hs
 @@ -57,7 +57,6 @@ haddockBuilderArgs = mconcat
              , arg $ "--odir=" ++ takeDirectory output
              , arg $ "--dump-interface=" ++ output

--- a/pkgs/development/tools/haskell/hadrian/hadrian.nix
+++ b/pkgs/development/tools/haskell/hadrian/hadrian.nix
@@ -9,6 +9,7 @@
   # GHC source tree to build hadrian from
 , ghcSrc
 , ghcVersion
+, patches ? []
   # Customization
 , userSettings ? null
 , enableHyperlinkedSource
@@ -18,15 +19,13 @@ mkDerivation {
   pname = "hadrian";
   version = ghcVersion;
   src = ghcSrc;
-  postUnpack = ''
-    sourceRoot="$sourceRoot/hadrian"
-  '';
-  patches = lib.optionals (!enableHyperlinkedSource) [
+  patches = patches ++ lib.optionals (!enableHyperlinkedSource) [
     ./disable-hyperlinked-source.patch
   ];
   # Overwrite UserSettings.hs with a provided custom one
   postPatch = lib.optionalString (userSettings != null) ''
-    install -m644 "${writeText "UserSettings.hs" userSettings}" src/UserSettings.hs
+    install -m644 "${writeText "UserSettings.hs" userSettings}" hadrian/src/UserSettings.hs
+    cd hadrian
   '';
   configureFlags = [
     # avoid QuickCheck dep which needs shared libs / TH

--- a/pkgs/development/tools/haskell/hadrian/make-hadrian.nix
+++ b/pkgs/development/tools/haskell/hadrian/make-hadrian.nix
@@ -29,6 +29,7 @@
   # These are passed on to the actual package expressions.
   ghcSrc
 , ghcVersion
+, patches
   # Contents of a non-default UserSettings.hs to use when building hadrian, if any.
   # Should be a string or null.
 , userSettings ? null
@@ -50,7 +51,7 @@ let
 in
 
 callPackage' ./hadrian.nix ({
-  inherit userSettings enableHyperlinkedSource;
+  inherit userSettings enableHyperlinkedSource patches;
 } // lib.optionalAttrs (lib.versionAtLeast ghcVersion "9.9") {
   # Starting with GHC 9.9 development, additional in tree packages are required
   # to build hadrian. (Hackage-released conditional dependencies are handled


### PR DESCRIPTION
## Description of changes

Previously any attempt to patch GHC would be subject to the restriction that patches would not be applied to the source tree used to build Hadrian. This is problematic as frequently Hadrian is evolved in conjunction with the compiler proper. Here we introduce a new `patches` argument to the common Hadrian derivation, allowing the user to specify patches that affect both Hadrian and the compiler build, e.g.:
```nix
haskell.compiler.ghc961.override { patches = [ ./wombat.patch ]; }
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
