### PR TITLE
mailcore2: fix build

### DIFF
--- a/pkgs/development/libraries/libetpan/default.nix
+++ b/pkgs/development/libraries/libetpan/default.nix
@@ -95,5 +95,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.etpan.org/libetpan.html";
     license = licenses.bsd3;
     maintainers = with maintainers; [ oxzi ];
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/mailcore2/default.nix
+++ b/pkgs/development/libraries/mailcore2/default.nix
@@ -1,5 +1,6 @@
 { stdenv, lib, fetchFromGitHub, cmake, libetpan, icu, cyrus_sasl, libctemplate
 , libuchardet, pkg-config, glib, html-tidy, libxml2, libuuid, openssl
+, darwin
 }:
 
 stdenv.mkDerivation rec {
@@ -16,8 +17,14 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkg-config ];
   buildInputs = [
-    libetpan icu cyrus_sasl libctemplate libuchardet glib
-    html-tidy libxml2 libuuid openssl
+    libetpan cyrus_sasl libctemplate libuchardet
+    html-tidy libxml2 openssl
+  ] ++ lib.optionals stdenv.isLinux [
+    glib
+    icu
+    libuuid
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Foundation
   ];
 
   postPatch = ''
@@ -28,13 +35,14 @@ stdenv.mkDerivation rec {
        --replace "/usr/include/libxml2" "${libxml2.dev}/include/libxml2"
     substituteInPlace src/core/basetypes/MCHTMLCleaner.cpp \
       --replace buffio.h tidybuffio.h
-    substituteInPlace src/core/basetypes/MCICUTypes.h \
-      --replace "__CHAR16_TYPE__ UChar" "char16_t UChar"
     substituteInPlace src/core/basetypes/MCString.cpp \
       --replace "xmlErrorPtr" "const xmlError *"
+  '' + lib.optionalString (!stdenv.isDarwin) ''
+    substituteInPlace src/core/basetypes/MCICUTypes.h \
+      --replace "__CHAR16_TYPE__ UChar" "char16_t UChar"
   '';
 
-  cmakeFlags = [
+  cmakeFlags = lib.optionals (!stdenv.isDarwin) [
     "-DBUILD_SHARED_LIBS=ON"
   ];
 
@@ -43,10 +51,10 @@ stdenv.mkDerivation rec {
     cp -r src/include $out
 
     mkdir $out/lib
-    cp src/libMailCore.so $out/lib
+    cp src/libMailCore.* $out/lib
   '';
 
-  doCheck = true;
+  doCheck = !stdenv.isDarwin;
   checkPhase = ''
     (
       cd unittest
@@ -59,5 +67,6 @@ stdenv.mkDerivation rec {
     homepage    = "http://libmailcore.com";
     license     = licenses.bsd3;
     maintainers = with maintainers; [ ];
+    platforms   = platforms.unix;
   };
 }

--- a/pkgs/development/libraries/mailcore2/default.nix
+++ b/pkgs/development/libraries/mailcore2/default.nix
@@ -28,6 +28,10 @@ stdenv.mkDerivation rec {
        --replace "/usr/include/libxml2" "${libxml2.dev}/include/libxml2"
     substituteInPlace src/core/basetypes/MCHTMLCleaner.cpp \
       --replace buffio.h tidybuffio.h
+    substituteInPlace src/core/basetypes/MCICUTypes.h \
+      --replace "__CHAR16_TYPE__ UChar" "char16_t UChar"
+    substituteInPlace src/core/basetypes/MCString.cpp \
+      --replace "xmlErrorPtr" "const xmlError *"
   '';
 
   cmakeFlags = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40490,7 +40490,7 @@ with pkgs;
   loop = callPackage ../tools/misc/loop { };
 
   mailcore2 = callPackage ../development/libraries/mailcore2 {
-    icu = icu58;
+    icu = icu71;
   };
 
   mamba = callPackage ../applications/audio/mamba { };


### PR DESCRIPTION
## Description of changes

Broken by the last libxml2 update. Also bumps ICU to 71.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
