### PR TITLE
sway-contrib: unstable-2023-06-30 -> 0-unstable-2024-01-20

### DIFF
--- a/pkgs/applications/misc/sway-contrib/default.nix
+++ b/pkgs/applications/misc/sway-contrib/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv
+{ lib, stdenvNoCC
 , fetchFromGitHub
 , coreutils
 , makeWrapper
@@ -31,7 +31,7 @@ let
 in
 {
 
-grimshot = stdenv.mkDerivation rec {
+grimshot = stdenvNoCC.mkDerivation {
   inherit version src;
 
   pname = "grimshot";
@@ -70,7 +70,7 @@ grimshot = stdenv.mkDerivation rec {
     fi
   '';
 
-  meta = with lib; {
+  meta = with lib; meta // {
     description = "A helper for screenshots within sway";
     maintainers = with maintainers; [ evils ];
     mainProgram = "grimshot";
@@ -78,11 +78,12 @@ grimshot = stdenv.mkDerivation rec {
 };
 
 
-inactive-windows-transparency = python3Packages.buildPythonApplication rec {
-  inherit version src;
-
+inactive-windows-transparency = let
   # long name is long
   lname = "inactive-windows-transparency";
+in python3Packages.buildPythonApplication {
+  inherit version src;
+
   pname = "sway-${lname}";
 
   format = "other";
@@ -95,7 +96,7 @@ inactive-windows-transparency = python3Packages.buildPythonApplication rec {
     install -Dm 0755 $src/${lname}.py $out/bin/${lname}.py
   '';
 
-  meta = with lib; {
+  meta = with lib; meta // {
     description = "It makes inactive sway windows transparent";
     mainProgram = "${lname}.py";
     maintainers = with maintainers; [

--- a/pkgs/applications/misc/sway-contrib/default.nix
+++ b/pkgs/applications/misc/sway-contrib/default.nix
@@ -15,12 +15,12 @@
 }:
 
 let
-  version = "unstable-2023-06-30";
+  version = "0-unstable-2024-01-20";
   src = fetchFromGitHub {
     owner = "OctopusET";
     repo = "sway-contrib";
-    rev = "7e138bfc112872b79ac9fd766bc57c0f125b96d4";
-    hash = "sha256-u4sw1NeAhl4FJCG2YOeY45SHoN7tw6cSJwEL5iqr0uQ=";
+    rev = "b7825b218e677c65f6849be061b93bd5654991bf";
+    hash = "sha256-ZTfItJ77mrNSzXFVcj7OV/6zYBElBj+1LcLLHxBFypk=";
   };
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Upstream doesn't have a changelog that I could see.

More scripts have been added to the repo (which as of now are not packaged), along with updates to the existing ones.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

CC: @evils 

Planning on doing more testing tomorrow when I'm back at the desktop. :+1:

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
