### PR TITLE
sgx-sdk: 2.21 -> 2.23

### DIFF
--- a/pkgs/os-specific/linux/sgx/azure-dcap-client/default.nix
+++ b/pkgs/os-specific/linux/sgx/azure-dcap-client/default.nix
@@ -35,13 +35,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "azure-dcap-client";
-  version = "1.12.1";
+  version = "1.12.3";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = pname;
     rev = version;
-    hash = "sha256-q0dI4WdA1ue4sw+QfSherh31Ldf9gnhoft66o3E9gnU=";
+    hash = "sha256-zTDaICsSPXctgFRCZBiZwXV9dLk2pFL9kp5a8FkiTZA=";
   };
 
   patches = [

--- a/pkgs/os-specific/linux/sgx/azure-dcap-client/default.nix
+++ b/pkgs/os-specific/linux/sgx/azure-dcap-client/default.nix
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Interfaces between SGX SDKs and the Azure Attestation SGX Certification Cache";
     homepage = "https://github.com/microsoft/azure-dcap-client";
-    maintainers = with maintainers; [ trundle veehaitch ];
+    maintainers = with maintainers; [ phlip9 trundle veehaitch ];
     platforms = [ "x86_64-linux" ];
     license = [ licenses.mit ];
   };

--- a/pkgs/os-specific/linux/sgx/psw/default.nix
+++ b/pkgs/os-specific/linux/sgx/psw/default.nix
@@ -14,7 +14,7 @@
 , debug ? false
 }:
 stdenv.mkDerivation rec {
-  inherit (sgx-sdk) version versionTag src;
+  inherit (sgx-sdk) patches src version versionTag;
   pname = "sgx-psw";
 
   postUnpack =

--- a/pkgs/os-specific/linux/sgx/psw/default.nix
+++ b/pkgs/os-specific/linux/sgx/psw/default.nix
@@ -24,16 +24,16 @@ stdenv.mkDerivation rec {
       # attestation quotes, and do platform certification.
       ae.prebuilt = fetchurl {
         url = "https://download.01.org/intel-sgx/sgx-linux/${versionTag}/prebuilt_ae_${versionTag}.tar.gz";
-        hash = "sha256-IckW4p1XWkWCDCErXyTtnKYKeAUaCrp5iAMsRBMjLX0=";
+        hash = "sha256-IGV9VEwY/cQBV4Vz2sps4JgRweWRl/l08ocb9P4SH8Q=";
       };
       # Also include the Data Center Attestation Primitives (DCAP) platform
       # enclaves.
       dcap = rec {
-        version = "1.18";
+        version = "1.20";
         filename = "prebuilt_dcap_${version}.tar.gz";
         prebuilt = fetchurl {
           url = "https://download.01.org/intel-sgx/sgx-dcap/${version}/linux/${filename}";
-          hash = "sha256-9ceys7ozOEienug+9MTZ6dw3nx7VBfxLNiwhZYv4SzY=";
+          hash = "sha256-nPsI89KSBA3cSNTMWyktZP5dkf+BwL3NZ4MuUf6G98o=";
         };
       };
     in

--- a/pkgs/os-specific/linux/sgx/psw/default.nix
+++ b/pkgs/os-specific/linux/sgx/psw/default.nix
@@ -181,7 +181,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Intel SGX Architectural Enclave Service Manager";
     homepage = "https://github.com/intel/linux-sgx";
-    maintainers = with maintainers; [ veehaitch citadelcore ];
+    maintainers = with maintainers; [ phlip9 veehaitch citadelcore ];
     platforms = [ "x86_64-linux" ];
     license = with licenses; [ bsd3 ];
   };

--- a/pkgs/os-specific/linux/sgx/sdk/cppmicroservices-no-mtime.patch
+++ b/pkgs/os-specific/linux/sgx/sdk/cppmicroservices-no-mtime.patch
@@ -1,0 +1,26 @@
+diff --git a/external/CppMicroServices/framework/src/bundle/BundleResourceContainer.cpp b/external/CppMicroServices/framework/src/bundle/BundleResourceContainer.cpp
+index aee499e9..13fa89d4 100644
+--- a/external/CppMicroServices/framework/src/bundle/BundleResourceContainer.cpp
++++ b/external/CppMicroServices/framework/src/bundle/BundleResourceContainer.cpp
+@@ -105,7 +105,7 @@ bool BundleResourceContainer::GetStat(int index,
+                    const_cast<mz_zip_archive*>(&m_ZipArchive), index)
+                    ? true
+                    : false;
+-    stat.modifiedTime = zipStat.m_time;
++    stat.modifiedTime = 0;
+     stat.crc32 = zipStat.m_crc32;
+     // This will limit the size info from uint64 to uint32 on 32-bit
+     // architectures. We don't care because we assume resources > 2GB
+diff --git a/external/CppMicroServices/third_party/miniz.c b/external/CppMicroServices/third_party/miniz.c
+index 6b0ebd7a..fa2aebca 100644
+--- a/external/CppMicroServices/third_party/miniz.c
++++ b/external/CppMicroServices/third_party/miniz.c
+@@ -170,7 +170,7 @@
+ // If MINIZ_NO_TIME is specified then the ZIP archive functions will not be able to get the current time, or
+ // get/set file times, and the C run-time funcs that get/set times won't be called.
+ // The current downside is the times written to your archives will be from 1979.
+-//#define MINIZ_NO_TIME
++#define MINIZ_NO_TIME
+
+ // Define MINIZ_NO_ARCHIVE_APIS to disable all ZIP archive API's.
+ //#define MINIZ_NO_ARCHIVE_APIS

--- a/pkgs/os-specific/linux/sgx/sdk/default.nix
+++ b/pkgs/os-specific/linux/sgx/sdk/default.nix
@@ -49,6 +49,15 @@ stdenv.mkDerivation rec {
     # and applies some patches to the in-repo git submodules. This patch removes
     # the parts that download things, since we can't do that inside the sandbox.
     ./disable-downloads.patch
+
+    # This patch disable mtime in bundled zip file for reproducible builds.
+    #
+    # Context: The `aesm_service` binary depends on a vendored library called
+    # `CppMicroServices`. At build time, this lib creates and then bundles
+    # service resources into a zip file and then embeds this zip into the
+    # binary. Without changes, the `aesm_service` will be different after every
+    # build because the embedded zip file contents have different modified times.
+    ./cppmicroservices-no-mtime.patch
   ];
 
   postPatch = ''

--- a/pkgs/os-specific/linux/sgx/sdk/default.nix
+++ b/pkgs/os-specific/linux/sgx/sdk/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , autoconf
 , automake
 , binutils
@@ -27,15 +26,15 @@
 stdenv.mkDerivation rec {
   pname = "sgx-sdk";
   # Version as given in se_version.h
-  version = "2.21.100.1";
+  version = "2.23.100.2";
   # Version as used in the Git tag
-  versionTag = "2.21";
+  versionTag = "2.23";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "linux-sgx";
     rev = "sgx_${versionTag}";
-    hash = "sha256-Yo2G0H0XUI2p9W7lDRLkFHw2t8X1220brGohQJ0r2WY=";
+    hash = "sha256-i+fE6xKiuljG8LY8TIHgrW15DVpdp46bZdNo/BjgT/I=";
     fetchSubmodules = true;
   };
 
@@ -46,39 +45,19 @@ stdenv.mkDerivation rec {
   '';
 
   patches = [
-    # Fix missing pthread_compat.h, see https://github.com/intel/linux-sgx/pull/784
-    (fetchpatch {
-      url = "https://github.com/intel/linux-sgx/commit/254b58f922a6bd49c308a4f47f05f525305bd760.patch";
-      sha256 = "sha256-sHU++K7NJ+PdITx3y0PwstA9MVh10rj2vrLn01N9F4w=";
-    })
+    # There's a `make preparation` step that downloads some prebuilt binaries
+    # and applies some patches to the in-repo git submodules. This patch removes
+    # the parts that download things, since we can't do that inside the sandbox.
+    ./disable-downloads.patch
   ];
 
-  # There's a `make preparation` step that downloads some prebuilt binaries and
-  # applies some patches to the in-repo git submodules. We can't just run it,
-  # since it downloads things, so this step just extracts the patching steps.
   postPatch = ''
     patchShebangs linux/installer/bin/build-installpkg.sh \
       linux/installer/common/sdk/createTarball.sh \
       linux/installer/common/sdk/install.sh \
       external/sgx-emm/create_symlink.sh
 
-    echo "Running 'make preparation' but without download steps"
-
-    # Seems to download something. Build currently uses ipp-crypto and not
-    # sgxssl so probably not an issue.
-    # $ ./external/dcap_source/QuoteVerification/prepare_sgxssl.sh nobuild
-
-    pushd external/openmp/openmp_code
-      git apply ../0001-Enable-OpenMP-in-SGX.patch >/dev/null 2>&1 \
-        || git apply ../0001-Enable-OpenMP-in-SGX.patch --check -R
-    popd
-
-    pushd external/protobuf/protobuf_code
-      git apply ../sgx_protobuf.patch >/dev/null 2>&1 \
-        || git apply ../sgx_protobuf.patch --check -R
-    popd
-
-    ./external/sgx-emm/create_symlink.sh
+    make preparation
   '';
 
   # We need `cmake` as a build input but don't use it to kick off the build phase

--- a/pkgs/os-specific/linux/sgx/sdk/default.nix
+++ b/pkgs/os-specific/linux/sgx/sdk/default.nix
@@ -279,7 +279,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Intel SGX SDK for Linux built with IPP Crypto Library";
     homepage = "https://github.com/intel/linux-sgx";
-    maintainers = with maintainers; [ sbellem arturcygan veehaitch ];
+    maintainers = with maintainers; [ phlip9 sbellem arturcygan veehaitch ];
     platforms = [ "x86_64-linux" ];
     license = with licenses; [ bsd3 ];
   };

--- a/pkgs/os-specific/linux/sgx/sdk/disable-downloads.patch
+++ b/pkgs/os-specific/linux/sgx/sdk/disable-downloads.patch
@@ -1,0 +1,26 @@
+diff --git a/Makefile b/Makefile
+index 32433051..2e480efb 100644
+--- a/Makefile
++++ b/Makefile
+@@ -50,8 +50,8 @@ tips:
+ preparation:
+ # As SDK build needs to clone and patch openmp, we cannot support the mode that download the source from github as zip.
+ # Only enable the download from git
+-	git submodule update --init --recursive
+-	./external/dcap_source/QuoteVerification/prepare_sgxssl.sh nobuild
++	# git submodule update --init --recursive
++	# ./external/dcap_source/QuoteVerification/prepare_sgxssl.sh nobuild
+ 	cd external/openmp/openmp_code && git apply ../0001-Enable-OpenMP-in-SGX.patch >/dev/null 2>&1 ||  git apply ../0001-Enable-OpenMP-in-SGX.patch --check -R
+ 	cd external/protobuf/protobuf_code && git apply ../sgx_protobuf.patch >/dev/null 2>&1 ||  git apply ../sgx_protobuf.patch --check -R
+ 	./external/sgx-emm/create_symlink.sh
+@@ -59,8 +59,8 @@ preparation:
+ 	cd external/cbor && cp -r libcbor sgx_libcbor
+ 	cd external/cbor/libcbor && git apply ../raw_cbor.patch >/dev/null 2>&1 || git apply ../raw_cbor.patch --check -R
+ 	cd external/cbor/sgx_libcbor && git apply ../sgx_cbor.patch >/dev/null 2>&1 || git apply ../sgx_cbor.patch --check -R
+-	./download_prebuilt.sh
+-	./external/dcap_source/QuoteGeneration/download_prebuilt.sh
++	# ./download_prebuilt.sh
++	# ./external/dcap_source/QuoteGeneration/download_prebuilt.sh
+ 
+ psw:
+ 	$(MAKE) -C psw/ USE_OPT_LIBS=$(USE_OPT_LIBS)

--- a/pkgs/os-specific/linux/sgx/sdk/ipp-crypto.nix
+++ b/pkgs/os-specific/linux/sgx/sdk/ipp-crypto.nix
@@ -8,13 +8,13 @@
 }:
 gcc11Stdenv.mkDerivation rec {
   pname = "ipp-crypto";
-  version = "2021.9.0";
+  version = "2021.10.0";
 
   src = fetchFromGitHub {
     owner = "intel";
     repo = "ipp-crypto";
     rev = "ippcp_${version}";
-    hash = "sha256-+ITnxyrkDQp4xRa+PVzXdYsSkI5sMNwQGfGU+lFJ6co=";
+    hash = "sha256-DfXsJ+4XqyjCD+79LUD53Cx8D46o1a4fAZa2UxGI1Xg=";
   };
 
   cmakeFlags = [ "-DARCH=intel64" ] ++ extraCmakeFlags;

--- a/pkgs/os-specific/linux/sgx/ssl/default.nix
+++ b/pkgs/os-specific/linux/sgx/ssl/default.nix
@@ -1,8 +1,8 @@
 { stdenv
+, callPackage
 , fetchFromGitHub
 , fetchurl
 , lib
-, openssl
 , perl
 , sgx-sdk
 , which
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
   postPatch = ''
     patchShebangs Linux/build_openssl.sh
 
-    # Run the test in the `installCheckPhase`, not the `buildPhase`
+    # Skip the tests. Build and run separately (see below).
     substituteInPlace Linux/sgx/Makefile \
       --replace '$(MAKE) -C $(TEST_DIR) all' \
                 'bash -c "true"'
@@ -46,7 +46,6 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     perl
     sgx-sdk
-    stdenv.cc.libc
     which
   ];
 
@@ -60,16 +59,17 @@ stdenv.mkDerivation {
     "DESTDIR=$(out)"
   ];
 
-  # Build the test app
-  doInstallCheck = true;
-  installCheckTarget = "test";
-  installCheckFlags = [
-    "SGX_MODE=SIM"
-    "-j 1" # Makefile doesn't support multiple jobs
-  ];
-  nativeInstallCheckInputs = [
-    openssl
-  ];
+  # These tests build on any x86_64-linux but BOTH SIM and HW will only _run_ on
+  # real Intel hardware. Split these out so OfBorg doesn't choke on this pkg.
+  #
+  # ```
+  # nix run .#sgx-ssl.tests.HW
+  # nix run .#sgx-ssl.tests.SIM
+  # ```
+  passthru.tests = {
+    HW = callPackage ./tests.nix { sgxMode = "HW"; inherit opensslVersion; };
+    SIM = callPackage ./tests.nix { sgxMode = "SIM"; inherit opensslVersion; };
+  };
 
   meta = with lib; {
     description = "Cryptographic library for Intel SGX enclave applications based on OpenSSL";

--- a/pkgs/os-specific/linux/sgx/ssl/default.nix
+++ b/pkgs/os-specific/linux/sgx/ssl/default.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "Cryptographic library for Intel SGX enclave applications based on OpenSSL";
     homepage = "https://github.com/intel/intel-sgx-ssl";
-    maintainers = with maintainers; [ trundle veehaitch ];
+    maintainers = with maintainers; [ phlip9 trundle veehaitch ];
     platforms = [ "x86_64-linux" ];
     license = [ licenses.bsd3 licenses.openssl ];
   };

--- a/pkgs/os-specific/linux/sgx/ssl/default.nix
+++ b/pkgs/os-specific/linux/sgx/ssl/default.nix
@@ -10,7 +10,7 @@
 }:
 let
   sgxVersion = sgx-sdk.versionTag;
-  opensslVersion = "1.1.1u";
+  opensslVersion = "3.0.12";
 in
 stdenv.mkDerivation {
   pname = "sgx-ssl" + lib.optionalString debug "-debug";
@@ -19,15 +19,15 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "intel";
     repo = "intel-sgx-ssl";
-    rev = "lin_${sgxVersion}_${opensslVersion}";
-    hash = "sha256-zbXEQz72VUPqnGrboX6oXliaLpbcos7tV6K9lX+zleg=";
+    rev = "3.0_Rev2";
+    hash = "sha256-dmLyaG6v+skjSa0KxLAfIfSBOxp9grrI7ds6WdGPe0I=";
   };
 
   postUnpack =
     let
       opensslSourceArchive = fetchurl {
         url = "https://www.openssl.org/source/openssl-${opensslVersion}.tar.gz";
-        hash = "sha256-4vjYS1I+7NBse+diaDA3AwD7zBU4a/UULXJ1j2lj68Y=";
+        hash = "sha256-+Tyejt3l6RZhGd4xdV/Ie0qjSGNmL2fd/LoU0La2m2E=";
       };
     in
     ''

--- a/pkgs/os-specific/linux/sgx/ssl/tests.nix
+++ b/pkgs/os-specific/linux/sgx/ssl/tests.nix
@@ -1,0 +1,95 @@
+# This package _builds_ (but doesn't run!) the sgx-ssl test enclave + harness.
+# The whole package effectively does:
+#
+# ```
+# SGX_MODE=${sgxMode} make -C Linux/sgx/test_app
+# cp Linux/sgx/{TestApp,TestEnclave.signed.so} $out/bin
+# ```
+#
+# OfBorg fails to run these tests since they require real Intel HW. That
+# includes the simulation mode! The tests appears to do something fancy with
+# cpuid and exception trap handlers that make them very non-portable.
+#
+# These tests are split out from the parent pkg since recompiling the parent
+# takes like 30 min : )
+
+{ lib
+, openssl
+, sgx-psw
+, sgx-sdk
+, sgx-ssl
+, stdenv
+, which
+, opensslVersion ? throw "required parameter"
+, sgxMode ? throw "required parameter" # "SIM" or "HW"
+}:
+stdenv.mkDerivation {
+  inherit (sgx-ssl) postPatch src version;
+  pname = sgx-ssl.pname + "-tests-${sgxMode}";
+
+  postUnpack = sgx-ssl.postUnpack + ''
+    sourceRootAbs=$(readlink -e $sourceRoot)
+    packageDir=$sourceRootAbs/Linux/package
+
+    # Do the inverse of 'make install' and symlink built artifacts back into
+    # '$src/Linux/package/' to avoid work.
+    mkdir $packageDir/lib $packageDir/lib64
+    ln -s ${lib.getLib sgx-ssl}/lib/* $packageDir/lib/
+    ln -s ${lib.getLib sgx-ssl}/lib64/* $packageDir/lib64/
+    ln -sf ${lib.getDev sgx-ssl}/include/* $packageDir/include/
+
+    # test_app needs some internal openssl headers.
+    # See: tail end of 'Linux/build_openssl.sh'
+    tar -C $sourceRootAbs/openssl_source -xf $sourceRootAbs/openssl_source/openssl-${opensslVersion}.tar.gz
+    echo '#define OPENSSL_VERSION_STR "${opensslVersion}"' > $sourceRootAbs/Linux/sgx/osslverstr.h
+    ln -s $sourceRootAbs/openssl_source/openssl-${opensslVersion}/include/crypto $sourceRootAbs/Linux/sgx/test_app/enclave/
+    ln -s $sourceRootAbs/openssl_source/openssl-${opensslVersion}/include/internal $sourceRootAbs/Linux/sgx/test_app/enclave/
+  '';
+
+  nativeBuildInputs = [
+    openssl.bin
+    sgx-sdk
+    which
+  ];
+
+  preBuild = ''
+    # Need to regerate the edl header
+    make -C Linux/sgx/libsgx_tsgxssl sgx_tsgxssl_t.c
+  '';
+
+  makeFlags = [
+    "-C Linux/sgx/test_app"
+    "SGX_MODE=${sgxMode}"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    # Enclaves can't be stripped after signing.
+    install -Dm 755 Linux/sgx/test_app/TestEnclave.signed.so -t $TMPDIR/enclaves
+
+    install -Dm 755 Linux/sgx/test_app/TestApp -t $out/bin
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    # Move the enclaves where they actually belong.
+    mv $TMPDIR/enclaves/*.signed.so* $out/bin/
+
+    # HW SGX must runs against sgx-psw, not sgx-sdk.
+    if [[ "${sgxMode}" == "HW" ]]; then
+      patchelf \
+        --set-rpath "$( \
+          patchelf --print-rpath $out/bin/TestApp \
+            | sed 's|${lib.getLib sgx-sdk}|${lib.getLib sgx-psw}|' \
+        )" \
+        $out/bin/TestApp
+    fi
+  '';
+
+  meta = {
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "TestApp";
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updates the sgx-* package family to the latest 2.23 release. These packages are used (1) by devs to build Intel SGX enclaves and (2) by operators running the NixOS `aesmd` service to easily run enclaves on servers. Intel SGX is a Confidential Computing technology for running enclaves and confidential VMs (Intel TDX) on Intel server CPUs alongside an untrusted hypervisor/Linux/userspace software stack.

These changes were tested on an Azure gen2 VM (DCSv3) running NixOS.

- sgx-sdk/ipp-crypto: 2021.9.0 -> 2021.10.0
  - gcc 13 still failing to compile w/o warnings...
  - Diff: <https://github.com/intel/ipp-crypto/compare/ippcp_2021.9.0...ippcp_2021.10.0>
  - Changelog: <https://github.com/intel/ipp-crypto/blob/ippcp_2021.10.0/CHANGELOG.md>
- sgx-sdk: 2.21 -> 2.23
  - `make preparation` step keeps changing; use a more maintainable .patch
    approach instead of copying over steps from Makefile.
  - Remove stale patch.
  - Add build reproducibility patch for binary-bundled zip files, courtesy of @haraldh <3
  - Diff: <https://github.com/intel/linux-sgx/compare/sgx_2.21...sgx_2.23>
  - Changelog (2.22): <https://github.com/intel/linux-sgx/releases/tag/sgx_2.22>
  - Changelog (2.23): <https://github.com/intel/linux-sgx/releases/tag/sgx_2.23>
- sgx-psw: 2.21 -> 2.23
- sgx-azure-dcap-client: 1.12.1 -> 1.12.3
  - Diff: <https://github.com/microsoft/Azure-DCAP-Client/compare/1.12.1...1.12.3>
- sgx-ssl: 1.1.1u -> 3.0.12
  - Extract tests into separate build-only derivation, since SIM mode tests don't work on non-Intel hardware.
  - Diff: <https://github.com/intel/intel-sgx-ssl/compare/lin_2.21_1.1.1u...3.0_Rev2>
- sgx-sdk: add 'phlip9' as maintainer of sgx packages


For additional context, see also my previous update PR (2.16 -> 2.21): <https://github.com/NixOS/nixpkgs/pull/254845>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
