### PR TITLE
libhwy: disable RVV

### DIFF
--- a/pkgs/development/libraries/libhwy/default.nix
+++ b/pkgs/development/libraries/libhwy/default.nix
@@ -4,6 +4,7 @@
 , ninja
 , gtest
 , fetchFromGitHub
+, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
@@ -16,6 +17,15 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-Z+mAR9nSAbCskUvo6oK79Yd85bu0HtI2aR5THS1EozM=";
   };
+
+  patches = lib.optional stdenv.hostPlatform.isRiscV
+    # Adds CMake option HWY_CMAKE_RVV
+    # https://github.com/google/highway/pull/1743
+    (fetchpatch {
+      name = "libhwy-add-rvv-optout.patch";
+      url = "https://github.com/google/highway/commit/5d58d233fbcec0c6a39df8186a877329147324b3.patch";
+      hash = "sha256-ileSNYddOt1F5rooRB0fXT20WkVlnG+gP5w7qJdBuww=";
+    });
 
   nativeBuildInputs = [ cmake ninja ];
 
@@ -43,6 +53,11 @@ stdenv.mkDerivation rec {
     #   HwyMathTestGroup/HwyMathTest.TestAllAtanh/EMU128
     #   HwyMathTestGroup/HwyMathTest.TestAllLog1p/EMU128
     "-DHWY_CMAKE_SSE2=ON"
+  ] ++ lib.optionals stdenv.hostPlatform.isRiscV [
+    # Runtime dispatch is not implemented https://github.com/google/highway/issues/838
+    # so tests (and likely normal operation) fail with SIGILL on processors without V.
+    # Until the issue is resolved, we disable RVV completely.
+    "-DHWY_CMAKE_RVV=OFF"
   ];
 
   # hydra's darwin machines run into https://github.com/libjxl/libjxl/issues/408


### PR DESCRIPTION
It will not work on processors that lack the V extension until runtime dispatch is implemented: https://github.com/google/highway/issues/838

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] riscv64-linux
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
