### PR TITLE
  livebook: Use `mix release` to build instead of escript

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -202,6 +202,13 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
   - `nomad_1_4` has been removed, as it is now unsupported upstream.
 
+- The `livebook` package is now built as a `mix release` instead of an `escript`.
+  This means that configuration now has to be done using [environment variables](https://hexdocs.pm/livebook/readme.html#environment-variables) instead of command line arguments.
+  This has the further implication that the `livebook` service configuration has changed:
+
+  - The `erlang_node_short_name`, `erlang_node_name`, `port` and `options` configuration parameters are gone, and have been replaced with an `environment` parameter.
+    Use the appropriate [environment variables](https://hexdocs.pm/livebook/readme.html#environment-variables) inside `environment` to configure the service instead.
+
 ## Other Notable Changes {#sec-release-24.05-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/services/development/livebook.md
+++ b/nixos/modules/services/development/livebook.md
@@ -15,11 +15,12 @@ which runs the server.
 {
   services.livebook = {
     enableUserService = true;
-    port = 20123;
+    environment = {
+      LIVEBOOK_PORT = 20123;
+      LIVEBOOK_PASSWORD = "mypassword";
+    };
     # See note below about security
-    environmentFile = pkgs.writeText "livebook.env" ''
-      LIVEBOOK_PASSWORD = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    '';
+    environmentFile = "/var/lib/livebook.env";
   };
 }
 ```
@@ -30,13 +31,18 @@ The Livebook server has the ability to run any command as the user it
 is running under, so securing access to it with a password is highly
 recommended.
 
-Putting the password in the Nix configuration like above is an easy
-way to get started but it is not recommended in the real world because
-the `livebook.env` file will be added to the world-readable Nix store.
-A better approach would be to put the password in some secure
-user-readable location and set `environmentFile = /home/user/secure/livebook.env`.
+Putting the password in the Nix configuration like above is an easy way to get
+started but it is not recommended in the real world because the resulting
+environment variables can be read by unprivileged users.  A better approach
+would be to put the password in some secure user-readable location and set
+`environmentFile = /home/user/secure/livebook.env`.
 
 :::
+
+The [Livebook
+documentation](https://hexdocs.pm/livebook/readme.html#environment-variables)
+lists all the applicable environment variables. It is recommended to at least
+set `LIVEBOOK_PASSWORD` or `LIVEBOOK_TOKEN_ENABLED=false`.
 
 ### Extra dependencies {#module-services-livebook-extra-dependencies}
 

--- a/nixos/modules/services/development/livebook.nix
+++ b/nixos/modules/services/development/livebook.nix
@@ -88,6 +88,7 @@ in
         Restart = "always";
         EnvironmentFile = cfg.environmentFile;
         ExecStart = "${cfg.package}/bin/livebook start";
+        KillMode = "mixed";
       };
       environment = mapAttrs (name: value:
         if isBool value then boolToString value else toString value)

--- a/nixos/modules/services/development/livebook.nix
+++ b/nixos/modules/services/development/livebook.nix
@@ -14,56 +14,62 @@ in
 
     package = mkPackageOption pkgs "livebook" { };
 
-    environmentFile = mkOption {
-      type = types.path;
-      description = lib.mdDoc ''
-        Environment file as defined in {manpage}`systemd.exec(5)` passed to the service.
-
-        This must contain at least `LIVEBOOK_PASSWORD` or
-        `LIVEBOOK_TOKEN_ENABLED=false`.  See `livebook server --help`
-        for other options.'';
-    };
-
-    erlang_node_short_name = mkOption {
-      type = with types; nullOr str;
-      default = null;
-      example = "livebook";
-      description = "A short name for the distributed node.";
-    };
-
-    erlang_node_name = mkOption {
-      type = with types; nullOr str;
-      default = null;
-      example = "livebook@127.0.0.1";
-      description = "The name for the app distributed node.";
-    };
-
-    port = mkOption {
-      type = types.port;
-      default = 8080;
-      description = "The port to start the web application on.";
-    };
-
-    address = mkOption {
-      type = types.str;
-      default = "127.0.0.1";
-      description = lib.mdDoc ''
-        The address to start the web application on.  Must be a valid IPv4 or
-        IPv6 address.
-      '';
-    };
-
-    options = mkOption {
-      type = with types; attrsOf str;
+    environment = mkOption {
+      type = with types; attrsOf (nullOr (oneOf [ bool int str ]));
       default = { };
       description = lib.mdDoc ''
-        Additional options to pass as command-line arguments to the server.
+        Environment variables to set.
+
+        Livebook is configured through the use of environment variables. The
+        available configuration options can be found in the [Livebook
+        documentation](https://hexdocs.pm/livebook/readme.html#environment-variables).
+
+        Note that all environment variables set through this configuration
+        parameter will be readable by anyone with access to the host
+        machine. Therefore, sensitive information like {env}`LIVEBOOK_PASSWORD`
+        or {env}`LIVEBOOK_COOKIE` should never be set using this configuration
+        option, but should instead use
+        [](#opt-services.livebook.environmentFile). See the documentation for
+        that option for more information.
+
+        Any environment variables specified in the
+        [](#opt-services.livebook.environmentFile) will supersede environment
+        variables specified in this option.
       '';
+
       example = literalExpression ''
         {
-          cookie = "a value shared by all nodes in this cluster";
+          LIVEBOOK_PORT = 8080;
         }
       '';
+    };
+
+    environmentFile = mkOption {
+      type = with types; nullOr types.path;
+      default = null;
+      description = lib.mdDoc ''
+        Additional dnvironment file as defined in {manpage}`systemd.exec(5)`.
+
+        Secrets like {env}`LIVEBOOK_PASSWORD` (which is used to specify the
+        password needed to access the livebook site) or {env}`LIVEBOOK_COOKIE`
+        (which is used to specify the
+        [cookie](https://www.erlang.org/doc/reference_manual/distributed.html#security)
+        used to connect to the running Elixir system) may be passed to the
+        service without making them readable to everyone with access to
+        systemctl by using this configuration parameter.
+
+        Note that this file needs to be available on the host on which
+        `livebook` is running.
+
+        For security purposes, this file should contain at least
+        {env}`LIVEBOOK_PASSWORD` or {env}`LIVEBOOK_TOKEN_ENABLED=false`.
+
+        See the [Livebook
+        documentation](https://hexdocs.pm/livebook/readme.html#environment-variables)
+        and the [](#opt-services.livebook.environment) configuration parameter
+        for further options.
+      '';
+      example = "/var/lib/livebook.env";
     };
 
     extraPackages = mkOption {
@@ -81,17 +87,11 @@ in
       serviceConfig = {
         Restart = "always";
         EnvironmentFile = cfg.environmentFile;
-        ExecStart =
-          let
-            args = lib.cli.toGNUCommandLineShell { } ({
-              inherit (cfg) port;
-              ip = cfg.address;
-              name = cfg.erlang_node_name;
-              sname = cfg.erlang_node_short_name;
-            } // cfg.options);
-          in
-            "${cfg.package}/bin/livebook server ${args}";
+        ExecStart = "${cfg.package}/bin/livebook start";
       };
+      environment = mapAttrs (name: value:
+        if isBool value then boolToString value else toString value)
+        cfg.environment;
       path = [ pkgs.bash ] ++ cfg.extraPackages;
       wantedBy = [ "default.target" ];
     };

--- a/nixos/tests/livebook-service.nix
+++ b/nixos/tests/livebook-service.nix
@@ -9,13 +9,15 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
 
       services.livebook = {
         enableUserService = true;
-        port = 20123;
+        environment = {
+          LIVEBOOK_PORT = 20123;
+          LIVEBOOK_COOKIE = "chocolate chip";
+          LIVEBOOK_TOKEN_ENABLED = true;
+
+        };
         environmentFile = pkgs.writeText "livebook.env" ''
           LIVEBOOK_PASSWORD = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
         '';
-        options = {
-          cookie = "chocolate chip";
-        };
       };
     };
   };

--- a/pkgs/servers/web-apps/livebook/default.nix
+++ b/pkgs/servers/web-apps/livebook/default.nix
@@ -22,15 +22,11 @@ beamPackages.mixRelease rec {
     hash = "sha256-dyKhrbb7vazBV6LFERtGHLQXEx29vTgn074mY4fsHy4=";
   };
 
-  installPhase = ''
-    mix escript.build
-    mkdir -p $out/bin
-    mv ./livebook $out/bin
-
+  postInstall = ''
     wrapProgram $out/bin/livebook \
-      --prefix PATH : ${lib.makeBinPath [ elixir ]} \
+      --prefix PATH : ${lib.makeBinPath [ elixir erlang ]} \
       --set MIX_REBAR3 ${rebar3}/bin/rebar3
-  '';
+    '';
 
   passthru.tests = {
     livebook-service = nixosTests.livebook-service;


### PR DESCRIPTION
## Description of changes

The current build of livebook does not work with the new [Livebook Teams](https://livebook.dev/teams/) features. The problem can be observed by running the current version of livebook, adding a new team and going to the team page. The process will crash and the team page will show a 500 error.

The base of the problem is that the escript build method is not officially supported. This commit changes the livebook package to use the `mix release` workflow, which is also the one used to build the official Docker container.

Unfortunately, the binary built with `mix release` does not support command line arguments like the `escript` binary does. Instead, users need to pass in most of the configuration as environment variables, as documented [here](https://hexdocs.pm/livebook/readme.html#environment-variables). As a result, this commit also changes the Livebook service to reflect this new way of configuring Livebook.

Finally, the Livebook release configuration specifically excludes the ERTS (Erlang Runtime System), which means that the resulting release cannot run without Erlang installed.

I have tested the results (both of the package and the service) locally.

cc. @NixOS/beam 


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
