### PR TITLE
pcsclite: move binaries, polkit, systemd files to out, move libraries to lib

### DIFF
--- a/nixos/modules/services/hardware/pcscd.nix
+++ b/nixos/modules/services/hardware/pcscd.nix
@@ -46,8 +46,8 @@ in
   config = mkIf config.services.pcscd.enable {
     environment.etc."reader.conf".source = cfgFile;
 
-    environment.systemPackages = [ package.out ];
-    systemd.packages = [ (getBin package) ];
+    environment.systemPackages = [ package ];
+    systemd.packages = [ package ];
 
     services.pcscd.plugins = [ pkgs.ccid ];
 
@@ -64,7 +64,7 @@ in
       # around it, we force the path to the cfgFile.
       #
       # https://github.com/NixOS/nixpkgs/issues/121088
-      serviceConfig.ExecStart = [ "" "${getBin package}/bin/pcscd -f -x -c ${cfgFile}" ];
+      serviceConfig.ExecStart = [ "" "${package}/bin/pcscd -f -x -c ${cfgFile}" ];
     };
   };
 }

--- a/pkgs/development/tools/global-platform-pro/default.nix
+++ b/pkgs/development/tools/global-platform-pro/default.nix
@@ -47,7 +47,7 @@ mavenJdk8.buildMavenPackage rec {
     cp tool/target/gp.jar "$out/share/java"
     makeWrapper "${jre8_headless}/bin/java" "$out/bin/gp" \
       --add-flags "-jar '$out/share/java/gp.jar'" \
-      --prefix LD_LIBRARY_PATH : "${pcsclite.out}/lib"
+      --prefix LD_LIBRARY_PATH : "${lib.getLib pcsclite}/lib"
   '';
 
   meta = with lib; {

--- a/pkgs/tools/security/pcsclite/default.nix
+++ b/pkgs/tools/security/pcsclite/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   inherit pname;
   version = "2.0.1";
 
-  outputs = [ "bin" "out" "dev" "doc" "man" ];
+  outputs = [ "out" "lib" "dev" "doc" "man" ];
 
   src = fetchFromGitLab {
     domain = "salsa.debian.org";
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.enableFeature polkitSupport "polkit")
   ] ++ lib.optionals stdenv.isLinux [
     "--enable-ipcdir=/run/pcscd"
-    "--with-systemdsystemunitdir=${placeholder "bin"}/lib/systemd/system"
+    "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
   ];
 
   makeFlags = [


### PR DESCRIPTION
## Description of changes

This should make the things related to the udev rules and binaries a lot simpler and more expected.

based on feedback in #280826

Closes #280826

Before:

```
 ▶ tree result*
 result ⇒ /nix/store/jx5yidqpzyb7x6wb24s17jssg94ifbdg-pcsclite-with-polkit-2.0.1
├──  lib
│   ├──  libpcsclite.la
│   ├──  libpcsclite.so ⇒ libpcsclite.so.1.0.0
│   ├──  libpcsclite.so.1 ⇒ libpcsclite.so.1.0.0
│   ├──  libpcsclite.so.1.0.0
│   ├──  libpcscspy.la
│   ├──  libpcscspy.so ⇒ libpcscspy.so.0.0.0
│   ├──  libpcscspy.so.0 ⇒ libpcscspy.so.0.0.0
│   └──  libpcscspy.so.0.0.0
└──  share
    └──  polkit-1
        └──  actions
            └──  org.debian.pcsc-lite.policy
 result-bin ⇒ /nix/store/m546wyabfa3pqykgy2nf8w8n29yvm1ff-pcsclite-with-polkit-2.0.1-bin
├──  bin
│   └──  pcscd
├──  lib
│   └──  systemd
│       └──  system
│           ├──  pcscd.service
│           └──  pcscd.socket
└──  sbin ⇒ bin
 result-dev ⇒ /nix/store/38rf0slm04pa8pli1my4161cxf6q93mi-pcsclite-with-polkit-2.0.1-dev
├──  bin
│   └──  pcsc-spy
├──  include
│   └──  PCSC
│       ├──  debuglog.h
│       ├──  ifdhandler.h
│       ├──  pcsclite.h
│       ├──  reader.h
│       ├──  winscard.h
│       └──  wintypes.h
├──  lib
│   └──  pkgconfig
│       └──  libpcsclite.pc
└──  nix-support
    └──  propagated-build-inputs
 result-doc ⇒ /nix/store/hddg5c5bngr3dr9z7ll6y7gg0ygpj8kf-pcsclite-with-polkit-2.0.1-doc
└──  share
    └──  doc
        └──  pcsc-lite
            ├──  install_spy.sh
            ├──  README.polkit
            └──  uninstall_spy.sh
 result-man ⇒ /nix/store/yqjd5312lbr2jar2l9cjr5mq205d543j-pcsclite-with-polkit-2.0.1-man
└──  share
    └──  man
        ├──  man1
        │   └──  pcsc-spy.1.gz
        ├──  man5
        │   └──  reader.conf.5.gz
        └──  man8
            └──  pcscd.8.gz
```

after

```
 result
├──  bin
│   └──  pcscd
├──  lib
│   └──  systemd
│       └──  system
│           ├──  pcscd.service
│           └──  pcscd.socket
├──  sbin
│   └──  pcscd
└──  share
    └──  polkit-1
        └──  actions
            └──  org.debian.pcsc-lite.policy
 result-dev
├──  bin
│   └──  pcsc-spy
├──  include
│   └──  PCSC
│       ├──  debuglog.h
│       ├──  ifdhandler.h
│       ├──  pcsclite.h
│       ├──  reader.h
│       ├──  winscard.h
│       └──  wintypes.h
├──  lib
│   └──  pkgconfig
│       └──  libpcsclite.pc
└──  nix-support
    └──  propagated-build-inputs
 result-doc
└──  share
    └──  doc
        └──  pcsc-lite
            ├──  install_spy.sh
            ├──  README.polkit
            └──  uninstall_spy.sh
 result-lib
└──  lib
    ├──  libpcsclite.la
    ├──  libpcsclite.so
    ├──  libpcsclite.so.1
    ├──  libpcsclite.so.1.0.0
    ├──  libpcscspy.la
    ├──  libpcscspy.so
    ├──  libpcscspy.so.0
    └──  libpcscspy.so.0.0.0
 result-man
└──  share
    └──  man
        ├──  man1
        │   └──  pcsc-spy.1.gz
        ├──  man5
        │   └──  reader.conf.5.gz
        └──  man8
            └──  pcscd.8.gz
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
