### PR TITLE
pkgsStatic: Pass hostPlatform.gcc attribute

### DIFF
--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -272,8 +272,8 @@ let
           if stdenv.isLinux
           then makeMuslParsedPlatform stdenv.hostPlatform.parsed
           else stdenv.hostPlatform.parsed;
-      } // lib.optionalAttrs (stdenv.hostPlatform.system == "powerpc64-linux") {
-        gcc.abi = "elfv2";
+        gcc = lib.optionalAttrs (stdenv.hostPlatform.system == "powerpc64-linux") { abi = "elfv2"; } //
+          stdenv.hostPlatform.gcc or {};
       };
     });
   };


### PR DESCRIPTION
To build the security wrappers[1] the pkgsStatic stdenv is used, so the binaries are static. However, the hostPlatform may have gcc attributes that are *required* to build binaries so they can run on the host platform. In particular, this is the case when using gcc.arch, which ends up injecting -march=... in the gcc wrapper. Those attributes are not contained in hostPlatform.parsed.

This change sets the same gcc attributes found in the hostPlatform for the pkgsStatic cross system, so it can build binaries with the same gcc flags.

---

This problem has ocurred to me while cross compiling a RISC-V NixOS system from an x86 machine to run in QEMU with the compressed instructions disabled (using `-cpu rv64,c=false`). What happens when the -march flags are not propagated to the gcc wrapper is that the binaries end up being compiled with compressed instructions which cause a SIGILL like the following:

```
$ mount
[52637.699560] mount[2334]: unhandled signal 4 code 0x1 at 0x000000000001048c in mount[10000+e000]
[52637.702177] CPU: 19 PID: 2334 Comm: mount Not tainted 6.1.72 #1-NixOS
[52637.703517] Hardware name: riscv-virtio,qemu (DT)
[52637.705091] epc : 000000000001048c ra : 000000000004a0dc sp : 00ffffffc5588bf0
[52637.706789]  gp : 000000000001f800 tp : 00ffffffabed63a0 t0 : ffffffffffffffff
[52637.708603]  t1 : 0000000000030a8c t2 : 00000000001952a8 s0 : 00000000001f29c0
[52637.710191]  s1 : 00000000001f29c0 a0 : 0000000000000000 a1 : 00000000001807c0
[52637.711965]  a2 : 0000000000180af0 a3 : 0000000000000000 a4 : 0000000000116010
[52637.713687]  a5 : 0000000000000000 a6 : 00000000001807c0 a7 : 00000000000000dd
[52637.715348]  s2 : 000000000010cefc s3 : 00000000001805c0 s4 : 00000000001807c0
[52637.717137]  s5 : 00ffffffac1a8d50 s6 : 0000000000180af0 s7 : 00000000001807c0
[52637.718808]  s8 : 0000000000117890 s9 : 0000000000000000 s10: 00000000001134c0
[52637.720686]  s11: 00000000001134cc t3 : 00ffffffabf9f348 t4 : 918a9092d091969d
[52637.722370]  t5 : 0000000000000010 t6 : 0000000000000007
[52637.723562] status: 0000000200004020 badaddr: 000000000000850a cause: 0000000000000002
Illegal instruction (core dumped)
```

[1]: https://github.com/NixOS/nixpkgs/blob/cd2b5c1cc2b48a900421db55ee7d71f8bbf76bf6/nixos/modules/security/wrappers/default.nix#L12

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (cross compilation to RISC-V)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of *some* binary files (usually in `./result/bin/`)
  - I tested `mount` and `sudo` which run okay now.
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
