### PR TITLE
lzwolf: fix the build against `gcc-13`

### DIFF
--- a/pkgs/games/lzwolf/default.nix
+++ b/pkgs/games/lzwolf/default.nix
@@ -1,6 +1,7 @@
 { stdenv
 , lib
 , fetchFromBitbucket
+, fetchpatch
 , p7zip
 , cmake
 , SDL2
@@ -25,6 +26,16 @@ stdenv.mkDerivation rec {
     rev = "a24190604296e16941c601b57afe4350462fc659";
     sha256 = "sha256-CtBdvk6LXb/ll92Fxig/M4t4QNj8dNFJYd8F99b47kQ=";
   };
+
+  patches = [
+    # Pull fix pending upstream inclusion for `gcc-13` support:
+    #   https://bitbucket.org/linuxwolf6/lzwolf/pull-requests/5
+    (fetchpatch {
+      name = "gcc-13.patch";
+      url = "https://bitbucket.org/soturi/lzwolf/commits/41f212026dff4f089d1c0921cb49ab1a2b81e0d6/raw";
+      hash = "sha256-EgSdDaZovD7DyZ0BkuX8ZdsrX7J7v8/D6y5P1NWGJew=";
+    })
+  ];
 
   postPatch = ''
     # SDL2_net-2.2.0 changed CMake component name slightly.


### PR DESCRIPTION
Without the change build fails against `gcc-13` on `master` as https://hydra.nixos.org/build/246520454:

    In file included from /build/source/src/actor.h:40,
                     from /build/source/src/g_blake/a_smartanim.cpp:36:
    /build/source/src/gamemap.h:255:64: error: 'std::uint16_t' has not been declared
      255 |                 void                    OperateConcession(std::uint16_t concession);
          |                                                                ^~~~~~~~

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
