### PR TITLE
fcitx5-custom-pinyin-dictionary: init at 20240101

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19953,6 +19953,13 @@
     github = "wamserma";
     githubId = 60148;
   };
+  Wanten = {
+    name = "Wanten";
+    email = "WantenMN@gmail.com";
+    matrix = "@wanten:matrix.org";
+    github = "WantenMN";
+    githubId = 41904684;
+  };
   water-sucks = {
     email = "varun@snare.dev";
     name = "Varun Narravula";

--- a/pkgs/by-name/fc/fcitx5-custom-pinyin-dictionary/package.nix
+++ b/pkgs/by-name/fc/fcitx5-custom-pinyin-dictionary/package.nix
@@ -1,0 +1,27 @@
+{ lib, fetchurl, stdenv }:
+
+stdenv.mkDerivation {
+  pname = "fcitx5-custom-pinyin-dictionary";
+  version = "20240101";
+
+  src = fetchurl {
+    url = "https://github.com/wuhgit/CustomPinyinDictionary/releases/download/assets/CustomPinyinDictionary_Fcitx_20240101.tar.gz";
+    hash = "sha256-8rgPHf4JvndWVUbSoOxMZAHrjRmzdGRJciplXnPCw3M=";
+  };
+
+  unpackPhase = ''
+    tar -xf $src
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/fcitx5/pinyin/dictionaries/
+    cp CustomPinyinDictionary_Fcitx.dict $out/share/fcitx5/pinyin/dictionaries/
+  '';
+
+  meta = with lib; {
+    description = "Custom Pinyin Dictionary for Fcitx. Please log out or reboot to apply the dictionary changes.";
+    homepage = " https://github.com/wuhgit/CustomPinyinDictionary ";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Wanten ];
+  };
+}


### PR DESCRIPTION
## Description of changes

fcitx5-custom-pinyin-dictionary: provides pinyin dictionary for fcitx5 users.

Source: https://github.com/wuhgit/CustomPinyinDictionary

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
