### PR TITLE
python311Packages.linien-common: fix build by using rpyc4

### DIFF
--- a/pkgs/development/python-modules/linien-common/default.nix
+++ b/pkgs/development/python-modules/linien-common/default.nix
@@ -4,7 +4,7 @@
 , setuptools
 , importlib-metadata
 , numpy
-, rpyc
+, rpyc4
 , scipy
 , appdirs
 , callPackage
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     importlib-metadata
     numpy
-    rpyc
+    rpyc4
     scipy
     appdirs
   ];

--- a/pkgs/development/python-modules/rpyc4/default.nix
+++ b/pkgs/development/python-modules/rpyc4/default.nix
@@ -1,0 +1,74 @@
+{ lib
+, stdenv
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, hatchling
+, plumbum
+, pytestCheckHook
+, pythonOlder
+, pythonAtLeast
+}:
+
+buildPythonPackage rec {
+  pname = "rpyc4";
+  # Pinned version for linien, see also:
+  # https://github.com/linien-org/pyrp3/pull/10#discussion_r1302816237
+  version = "4.1.5";
+  format = "pyproject";
+
+  # Since this is an outdated version, upstream might have fixed the
+  # compatibility issues with Python3.12, but we can't enjoy them yet.
+  disabled = pythonOlder "3.7" || pythonAtLeast "3.12";
+
+  src = fetchFromGitHub {
+    owner = "tomerfiliba";
+    repo = "rpyc";
+    rev = version;
+    hash = "sha256-8NOcXZDR3w0TNj1+LZ7lzQAt7yDgspjOp2zk1bsbVls=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    plumbum
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Disable tests that requires network access
+    "test_api"
+    "test_close_timeout"
+    "test_deploy"
+    "test_listing"
+    "test_pruning"
+    "test_rpyc"
+    # Test is outdated
+    # ssl.SSLError: [SSL: NO_CIPHERS_AVAILABLE] no ciphers available (_ssl.c:997)
+    "test_ssl_conenction"
+  ];
+  disabledTestPaths = [
+    "tests/test_ssh.py"
+    "tests/test_teleportation.py"
+  ];
+
+  pythonImportsCheck = [
+    "rpyc"
+  ];
+
+  doCheck = !stdenv.isDarwin;
+
+  meta = with lib; {
+    description = "Remote Python Call (RPyC), a transparent and symmetric RPC library";
+    homepage = "https://rpyc.readthedocs.org";
+    changelog = "https://github.com/tomerfiliba-org/rpyc/blob/${version}/CHANGELOG.rst";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12774,6 +12774,8 @@ self: super: with self; {
 
   rpyc = callPackage ../development/python-modules/rpyc { };
 
+  rpyc4 = callPackage ../development/python-modules/rpyc4 { };
+
   rq = callPackage ../development/python-modules/rq { };
 
   rsa = callPackage ../development/python-modules/rsa { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
