### PR TITLE
typora: 1.7.6. -> 1.8.6

### DIFF
--- a/pkgs/applications/editors/typora/default.nix
+++ b/pkgs/applications/editors/typora/default.nix
@@ -22,10 +22,10 @@
 
 let
   pname = "typora";
-  version = "1.7.6";
+  version = "1.8.6";
   src = fetchurl {
     url = "https://download.typora.io/linux/typora_${version}_amd64.deb";
-    hash = "sha256-o91elUN8sFlzVfIQj29amsiUdSBjZc51tLCO+Qfar6c=";
+    hash = "sha256-5hA9wEP3Hf3RxYC6KKe6JCiMEYKIHk9YhcA9tnSvirc=";
   };
 
   typoraBase = stdenv.mkDerivation {


### PR DESCRIPTION
## Description of changes

Update from version 1.7.6 to 1.8.6. 

As described in the [releases page](https://typora.io/releases/all):

### New
* Add support for Github style alerts / callouts.
* Add option to enable zoom with command or ctrl key and mouse wheel.
* Upgrade mermaid library with XY charts support.

### Improvements
* Linux version now also support separate theme for light and dark mode.
* Quicker way to add “New Markdown” menu item in Windows Explorer
* Now, typora uses mermaid's own dark theme when rendering mermaid in dark mode.
* Improve performance and stability.
* Update translation for Spanish, French, Galician, Slovenian, Vietnamese and Chinese.
* Add Norwegian Nynorsk language interface.

### Bug Fix
* Fix window position in multiple monitor.
* Fix save as image for diagrams.
* Hide “copy as HTML” for unsupported blocks.
* Add “copy as HTML” support for mermaid diagrams.
* Fix “PicList not found” error when using PicList to upload images.
* Fix cursor misplaced when editing emoji.
* Fix issues on image syntax parse and convert.
* Other bug fix.

<!--
For package updates please link to a changelog or d
escribe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>typora</li>
  </ul>
</details>





