### PR TITLE
fcast-receiver: init at 1.0.14; nixos/fcast-receiver: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -106,6 +106,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - [transfer-sh](https://github.com/dutchcoders/transfer.sh), a tool that supports easy and fast file sharing from the command-line. Available as [services.transfer-sh](#opt-services.transfer-sh.enable).
 
+- [FCast Receiver](https://fcast.org), an open-source alternative to Chromecast and AirPlay. Available as [programs.fcast-receiver](#opt-programs.fcast-receiver.enable).
+
 - [MollySocket](https://github.com/mollyim/mollysocket) which allows getting Signal notifications via UnifiedPush.
 
 - [Suwayomi Server](https://github.com/Suwayomi/Suwayomi-Server), a free and open source manga reader server that runs extensions built for [Tachiyomi](https://tachiyomi.org). Available as [services.suwayomi-server](#opt-services.suwayomi-server.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -177,6 +177,7 @@
   ./programs/environment.nix
   ./programs/evince.nix
   ./programs/extra-container.nix
+  ./programs/fcast-receiver.nix
   ./programs/feedbackd.nix
   ./programs/file-roller.nix
   ./programs/firefox.nix

--- a/nixos/modules/programs/fcast-receiver.nix
+++ b/nixos/modules/programs/fcast-receiver.nix
@@ -1,0 +1,31 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.programs.fcast-receiver;
+in
+{
+  meta = {
+    maintainers = pkgs.fcast-receiver.meta.maintainers;
+  };
+
+  options.programs.fcast-receiver = {
+    enable = mkEnableOption (lib.mdDoc "FCast Receiver");
+    openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      description = lib.mdDoc ''
+        Open ports needed for the functionality of the program.
+      '';
+    };
+    package = mkPackageOption pkgs "fcast-receiver" { };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ 46899 ];
+    };
+  };
+}

--- a/pkgs/by-name/fc/fcast-receiver/package.nix
+++ b/pkgs/by-name/fc/fcast-receiver/package.nix
@@ -1,0 +1,64 @@
+{ lib
+, buildNpmPackage
+, fetchFromGitLab
+, makeDesktopItem
+, copyDesktopItems
+, makeWrapper
+, electron
+}:
+
+buildNpmPackage rec {
+  pname = "fcast-receiver";
+  version = "1.0.14";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.futo.org";
+    owner = "videostreaming";
+    repo = "fcast";
+    rev = "c7a1cb27c470870df50dbf0de00a133061298d46";
+    hash = "sha256-9xF1DZ2wt6zMoUQywmvnNN3Z8m4GhOFJElENhozF9c8=";
+  };
+
+  sourceRoot = "${src.name}/receivers/electron";
+
+  makeCacheWritable = true;
+
+  npmDepsHash = "sha256-gpbFZ8rKYR/GUY1l4eH5io/lz6FpJLUTl5h8q3haxvw=";
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      desktopName = "FCast Receiver";
+      genericName = "Media Streaming Receiver";
+      exec = "fcast-receiver";
+      icon = "fcast-receiver";
+      comment = "FCast Receiver, an open-source media streaming receiver";
+    })
+  ];
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
+
+  postInstall = ''
+    install -Dm644 $out/lib/node_modules/fcast-receiver/app.png $out/share/pixmaps/fcast-receiver.png
+
+    makeWrapper ${electron}/bin/electron $out/bin/fcast-receiver \
+      --add-flags $out/lib/node_modules/fcast-receiver/dist/bundle.js
+  '';
+
+  meta = with lib; {
+    description = "FCast Receiver, an open-source media streaming receiver";
+    longDescription = ''
+      FCast Receiver is a receiver for an open-source media streaming protocol, FCast, an alternative to Chromecast and AirPlay.
+    '';
+    homepage = "https://fcast.org/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ ymstnt ];
+    mainProgram = "fcast-receiver";
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- [FCast Receiver](https://gitlab.futo.org/videostreaming/fcast/-/tree/master/receivers/electron) is a receiver application for an open-source media streaming protocol, [FCast](https://fcast.org/), which is an alternative to Chromecast and AirPlay.
- The program requires port `46899` open in the firewall to function correctly, so I've created a module that has an `openFirewall` option that opens the port for the user.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
