### PR TITLE
ayatana-indicator-session: init at 23.10.3

### DIFF
--- a/nixos/tests/ayatana-indicators.nix
+++ b/nixos/tests/ayatana-indicators.nix
@@ -29,6 +29,7 @@ in {
       packages = with pkgs; [
         ayatana-indicator-datetime
         ayatana-indicator-messages
+        ayatana-indicator-session
       ] ++ (with pkgs.lomiri; [
         lomiri-indicator-network
         telephony-service

--- a/pkgs/by-name/ay/ayatana-indicator-session/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-session/package.nix
@@ -1,0 +1,112 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, gitUpdater
+, nixosTests
+, cmake
+, dbus
+, glib
+, gnome
+, gsettings-desktop-schemas
+, gtest
+, intltool
+, libayatana-common
+, librda
+, lomiri
+, mate
+, pkg-config
+, systemd
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ayatana-indicator-session";
+  version = "23.10.3";
+
+  src = fetchFromGitHub {
+    owner = "AyatanaIndicators";
+    repo = "ayatana-indicator-session";
+    rev = finalAttrs.version;
+    hash = "sha256-m2+qZxBrarenR41M41mCteFRXIEGkVDavRWQwM3G4tk=";
+  };
+
+  postPatch = ''
+    # Queries systemd user unit dir via pkg_get_variable, can't override prefix
+    substituteInPlace data/CMakeLists.txt \
+      --replace-fail 'pkg_get_variable(SYSTEMD_USER_DIR systemd systemduserunitdir)' 'set(SYSTEMD_USER_DIR "''${CMAKE_INSTALL_PREFIX}/lib/systemd/user")' \
+      --replace-fail '/etc' "\''${CMAKE_INSTALL_SYSCONFDIR}"
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    intltool
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    lomiri.cmake-extras
+    glib
+    gsettings-desktop-schemas
+    libayatana-common
+    librda
+    systemd
+
+    # TODO these bloat the closure size alot, just so the indicator doesn't have the potential to crash.
+    # is there a better way to give it access to DE-specific schemas as needed?
+    # https://github.com/AyatanaIndicators/ayatana-indicator-session/blob/88846bad7ee0aa8e0bb122816d06f9bc887eb464/src/service.c#L1387-L1413
+    gnome.gnome-settings-daemon
+    mate.mate-settings-daemon
+  ];
+
+  nativeCheckInputs = [
+    dbus
+  ];
+
+  checkInputs = [
+    gtest
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "GSETTINGS_LOCALINSTALL" true)
+    (lib.cmakeBool "GSETTINGS_COMPILE" true)
+    (lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" (lib.concatStringsSep ";" [
+      # Exclude tests
+      "-E" (lib.strings.escapeShellArg "(${lib.concatStringsSep "|" [
+        # Currently broken: https://github.com/AyatanaIndicators/ayatana-indicator-session/issues/90
+        "^test-service"
+      ]})")
+    ]))
+  ];
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  # DBus communication
+  enableParallelChecking = false;
+
+  passthru = {
+    ayatana-indicators = [ "ayatana-indicator-session" ];
+    tests.vm = nixosTests.ayatana-indicators;
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Ayatana Indicator showing session management, status and user switching";
+    longDescription = ''
+      This Ayatana Indicator is designed to be placed on the right side of a
+      panel and give the user easy control for
+      - changing their instant message status,
+      - switching to another user,
+      - starting a guest session, or
+      - controlling the status of their own session.
+    '';
+    homepage = "https://github.com/AyatanaIndicators/ayatana-indicator-session";
+    changelog = "https://github.com/AyatanaIndicators/ayatana-indicator-session/blob/${finalAttrs.version}/ChangeLog";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Working towards https://github.com/NixOS/nixpkgs/issues/99090.

[`ayatana-indicator-session`](https://github.com/AyatanaIndicators/ayatana-indicator-session), an indicator interface for session information & control.

In Lomiri this is used to provide quick information & links about the current distro, link into the Lomiri System Settings app for configuration, and offer the only graphical way of ending the session (that I'm aware of).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
