### PR TITLE
openfortivpn-webview-qt: init at 1.1.2

### DIFF
--- a/pkgs/by-name/op/openfortivpn-webview-qt/package.nix
+++ b/pkgs/by-name/op/openfortivpn-webview-qt/package.nix
@@ -1,0 +1,39 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  qt6Packages,
+}:
+stdenv.mkDerivation rec {
+  pname = "openfortivpn-webview-qt";
+  version = "1.1.2";
+
+  src = fetchFromGitHub {
+    owner = "gm-vm";
+    repo = "openfortivpn-webview";
+    rev = "v${version}-electron";
+    hash = "sha256-BNotbb2pL7McBm0SQwcgEvjgS2GId4HVaxWUz/ODs6w=";
+  };
+  sourceRoot = "source/openfortivpn-webview-qt";
+
+  nativeBuildInputs = [
+    qt6Packages.wrapQtAppsHook
+    qt6Packages.qmake
+  ];
+  buildInputs = [ qt6Packages.qtwebengine ];
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp openfortivpn-webview $out/bin/
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Perform the SAML single sign-on and easily retrieve the SVPNCOOKIE needed by openfortivpn";
+    homepage = "https://github.com/gm-vm/openfortivpn-webview/tree/main";
+    license = licenses.mit;
+    maintainers = [ lib.maintainers.jonboh ];
+    platforms = platforms.linux;
+    mainProgram = "openfortivpn-webview";
+  };
+}


### PR DESCRIPTION
## Description of changes

Added `openfortivpn-webview-qt`. This allows running a minimal browser to login through SAML in `openfortivpn`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
