### PR TITLE
linuxPackages.nvidiaPackages.beta: 545.23.06 -> 550.40.07

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -48,12 +48,12 @@ rec {
   });
 
   beta = selectHighestVersion latest (generic {
-    version = "545.23.06";
-    sha256_64bit = "sha256-QTnTKAGfcvKvKHik0BgAemV3PrRqRlM3B9jjZeupCC8=";
-    sha256_aarch64 = "sha256-qkVP6AiXNoRTqgqPvs/AfErEq8BTQw25rtJ6GS06JTM=";
-    openSha256 = "sha256-m7D5LZdhFCZYAIbhrgZ0pN2z19LsU3I3Q7qsKX7Z6mM=";
-    settingsSha256 = "sha256-+X6gDeU8Qlvprb05aB2quM55y0zEcBXtb65e3Rq9gKg=";
-    persistencedSha256 = "sha256-RQJAIwPqOUI5FB3uf0/Y4K/iwFfoLpU1/+BOK/KF5VA=";
+    version = "550.40.07";
+    sha256_64bit = "sha256-KYk2xye37v7ZW7h+uNJM/u8fNf7KyGTZjiaU03dJpK0=";
+    sha256_aarch64 = "sha256-AV7KgRXYaQGBFl7zuRcfnTGr8rS5n13nGUIe3mJTXb4=";
+    openSha256 = "sha256-mRUTEWVsbjq+psVe+kAT6MjyZuLkG2yRDxCMvDJRL1I=";
+    settingsSha256 = "sha256-c30AQa4g4a1EHmaEu1yc05oqY01y+IusbBuq+P6rMCs=";
+    persistencedSha256 = "sha256-11tLSY8uUIl4X/roNnxf5yS2PQvHvoNjnd2CB67e870=";
   });
 
   # Vulkan developer beta driver


### PR DESCRIPTION
## Description of changes

- Fixed an issue that sometimes caused Wayland applications to run at less than one frame per second on Maxwell, Volta, and Pascal series GPUs.
- Fixed a bug that caused an intermittent drop in desktop framerate.
- Fixed a bug that caused "Flip event timeout" messages to be printed to the system log when displays are hotplugged when nvidia-drm is loaded with the`fbdev=1` kernel module parameter.
- Fixed intermittent Xid errors on Horizon Zero Dawn, Metro Exodus,Forza Horizon 5, and Halo Infinite.
- Fixed a bug which prevented the "NoMaxPClkCheck" mode validation token from working on single-link TMDS (e.g. DVI, HDMI) outputs.
- Fixed a bug that allowed VRR displays to be driven below their minimum refresh rate, resulting in a blank or flickering image.
- Added an application profile to improve Kwin performance on hybrid GPU systems by setting OGL_DEDICATED_HW_STATE_PER_CONTEXT=ENABLE_ROBUST.
- Updated the build process for NVIDIA kernel modules to honor the INSTALL_MOD_DIR Kbuild environment variable.
- Added support for R8, GR88 and YCbCr GBM formats.
- Optimized the X driver headless framerate limiter to more closely mimic upstream behavior and prevent it from activating in inconvenient situations. Added a new X config option "LimitFrameRateWhenHeadless" to disable the headless framerate limiter.
- Fixed a bug that prevented Gamescope from running when using the NVIDIA Open GPU Kernel modules.
- Fixed a bug that prevented the installer package from being unpacked on systems where zstd is not installed, when /tmp is mounted noexec.
- Use transparent huge pages when available for the .text section. This is done through madvise() calls, and requires CONFIG_READ_ONLY_THP_FOR_FS.
- Fixed a regression that prevented setting backlight brightness levels.
- Fixed a bug that could lead to UI corruption in nvidia-installer on systems with more than one initramfs file per kernel.
- Fixed a bug that caused games built on the Source 2 engine to hang when running under Xwayland.
- Added experimental HDMI 10 bits per component support; enable by loading nvidia-modeset with `hdmi_deepcolor=1`.
- Added support for HDR signaling via the HDR_OUTPUT_METADATA and Colorspace per-connector DRM properties when nvidia-drm is loaded with the `modeset=1` parameter.
- Added support for PRIME render offload to Vulkan Wayland WSI.
- Added support for the CTM, DEGAMMA_LUT, and GAMMA_LUT DRM-KMS CRTC properties. These are used by features such as the "Night Light" feature in GNOME and the "Night Color" feature in KDE, when they are used as Wayland compositors.
- Added beta-quality support for GeForce and Workstation GPUs to open kernel modules. Please see the "Open Linux Kernel Modules" chapter in the README for details.
- Added initial experimental support for runtime D3 (RTD3) powermanagement on Desktop GPUs.  Please see the 'PCI-Express Runtime D3 (RTD3) Power Management' chapter in the README for more details.
- Added support for the EGL_ANDROID_native_fence_sync EGL extension and the VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT and VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT Vulkan external handle types when the nvidia-drm kernel module is loaded with the modeset=1 parameter.
- Added experimental support for framebuffer consoles provided by nvidia-drm. On kernels that implement drm_fbdev_generic_setup anddrm_aperture_remove_conflicting_pci_framebuffers, nvidia-drm will install a framebuffer console when loaded with both `modeset=1` and `fbdev=1` kernel module parameters. This will replace the Linux boot console driven by a system framebuffer driver such as efifb or vesafb.
- Note that when an nvidia-drm framebuffer console is enabled, unloading nvidia-drm will cause the screen to turn off.
- Updated nvidia-installer to allow installing the driver while an existing NVIDIA driver is already loaded.
- Added support for virtual reality displays, such as the SteamVR platform, on Wayland compositors that support DRM leasing. Support requires xwayland version 22.1.0 and wayland-protocols version 1.22, or later. Tested on sway, minimum version 1.7 with wlroots version 0.15, and also on Kwin, minimum version 5.24.
- Note: Before xwayland 23.2, there is a known issue with HDMI displays where the headset will fail to start a second time after closing SteamVR. This can be worked around by unplugging and replugging in the headset.
- Fixed a bug that prevented VRR (Variable Refresh Rate) from working with Wayland.
- Changed the name visible in /proc/devices of NVIDIA devices and the NVIDIA control device from "nvidia-frontend" to "nvidia" and "nvidiactl". Scripts which parse /proc/devices (such as udev rules) may need to be updated. Note that the conventional /dev device paths like /dev/nvidia0 and /dev/nvidiactl remain unchanged.
- Added support to the NVIDIA VDPAU driver for running in Xwayland. Please refer to the "Xwayland support in VDPAU" section of the README for further details.
- Added libnvidia-gpucomp.so to the driver package. This is a helper library used for GPU shader compilation.
- Removed libnvidia-vulkan-producer.so from the driver package. This helper library is no longer needed by the Wayland WSI.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
