### PR TITLE
spacedrive: 0.1.4 -> 0.2.0

### DIFF
--- a/pkgs/by-name/sp/spacedrive/package.nix
+++ b/pkgs/by-name/sp/spacedrive/package.nix
@@ -9,20 +9,20 @@
 
 let
   pname = "spacedrive";
-  version = "0.1.4";
+  version = "0.2.0";
 
   src = fetchurl {
     aarch64-darwin = {
       url = "https://github.com/spacedriveapp/spacedrive/releases/download/${version}/Spacedrive-darwin-aarch64.dmg";
-      hash = "sha256-gKboB5W0vW6ssZHRRivqbVPE0d0FCUdiNCsP0rKKtNo=";
+      hash = "sha256-4G8L7eDSHBu0oHTrhhcxKpH7euPPlobewvMIBqvSong=";
     };
     x86_64-darwin = {
       url = "https://github.com/spacedriveapp/spacedrive/releases/download/${version}/Spacedrive-darwin-x86_64.dmg";
-      hash = "sha256-KD1hw6aDyqCsXLYM8WrOTI2AfFx7t++UWV7SaCmtypI=";
+      hash = "sha256-6FuVKqMskOB/sG7MH6IpxzOEVXn4TPJS8xBwklJ3qRA=";
     };
     x86_64-linux = {
       url = "https://github.com/spacedriveapp/spacedrive/releases/download/${version}/Spacedrive-linux-x86_64.AppImage";
-      hash = "sha256-iBdW8iPuvztP0L5xLyVs7/K8yFe7kD7QwdTuKJLhB+c=";
+      hash = "sha256-ZzkQVLA1bNsUNPqIuRNUEma73SmOvymGvz74P7wKYwY=";
     };
   }.${stdenv.system} or (throw "${pname}-${version}: ${stdenv.system} is unsupported.");
 
@@ -69,9 +69,9 @@ else appimageTools.wrapType2 {
       mv $out/bin/spacedrive-"${version}" $out/bin/spacedrive
 
       # Install .desktop files
-      install -Dm444 ${appimageContents}/spacedrive.desktop -t $out/share/applications
+      install -Dm444 ${appimageContents}/com.spacedrive.desktop -t $out/share/applications
       install -Dm444 ${appimageContents}/spacedrive.png -t $out/share/pixmaps
-      substituteInPlace $out/share/applications/spacedrive.desktop \
+      substituteInPlace $out/share/applications/com.spacedrive.desktop \
         --replace 'Exec=AppRun --no-sandbox %U' 'Exec=spacedrive'
     '';
 }


### PR DESCRIPTION
## Description of changes

```diff
diff --git a/pkgs/by-name/sp/spacedrive/package.nix b/pkgs/by-name/sp/spacedrive/package.nix
index bf281e372709..d6cf21cbe845 100644
--- a/pkgs/by-name/sp/spacedrive/package.nix
+++ b/pkgs/by-name/sp/spacedrive/package.nix
@@ -9,20 +9,20 @@

 let
   pname = "spacedrive";
-  version = "0.1.4";
+  version = "0.2.0";

   src = fetchurl {
     aarch64-darwin = {
       url = "https://github.com/spacedriveapp/spacedrive/releases/download/${version}/Spacedrive-darwin-aarch64.dmg";
-      hash = "sha256-gKboB5W0vW6ssZHRRivqbVPE0d0FCUdiNCsP0rKKtNo=";
+      hash = "sha256-4G8L7eDSHBu0oHTrhhcxKpH7euPPlobewvMIBqvSong=";
     };
     x86_64-darwin = {
       url = "https://github.com/spacedriveapp/spacedrive/releases/download/${version}/Spacedrive-darwin-x86_64.dmg";
-      hash = "sha256-KD1hw6aDyqCsXLYM8WrOTI2AfFx7t++UWV7SaCmtypI=";
+      hash = "sha256-6FuVKqMskOB/sG7MH6IpxzOEVXn4TPJS8xBwklJ3qRA=";
     };
     x86_64-linux = {
       url = "https://github.com/spacedriveapp/spacedrive/releases/download/${version}/Spacedrive-linux-x86_64.AppImage";
-      hash = "sha256-iBdW8iPuvztP0L5xLyVs7/K8yFe7kD7QwdTuKJLhB+c=";
+      hash = "sha256-ZzkQVLA1bNsUNPqIuRNUEma73SmOvymGvz74P7wKYwY=";
     };
   }.${stdenv.system} or (throw "${pname}-${version}: ${stdenv.system} is unsupported.");

@@ -69,9 +69,9 @@ else appimageTools.wrapType2 {
       mv $out/bin/spacedrive-"${version}" $out/bin/spacedrive

       # Install .desktop files
-      install -Dm444 ${appimageContents}/spacedrive.desktop -t $out/share/applications
+      install -Dm444 ${appimageContents}/com.spacedrive.desktop -t $out/share/applications
       install -Dm444 ${appimageContents}/spacedrive.png -t $out/share/pixmaps
-      substituteInPlace $out/share/applications/spacedrive.desktop \
+      substituteInPlace $out/share/applications/com.spacedrive.desktop \
         --replace 'Exec=AppRun --no-sandbox %U' 'Exec=spacedrive'
     '';
 }
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
