### PR TITLE
cal3d: init at 0.120

### DIFF
--- a/pkgs/by-name/ca/cal3d/fix-boolean-ptr-conversion.patch
+++ b/pkgs/by-name/ca/cal3d/fix-boolean-ptr-conversion.patch
@@ -1,0 +1,259 @@
+diff --git a/src/cal3d/loader.cpp b/src/cal3d/loader.cpp
+index 005296f..9032810 100644
+--- a/src/cal3d/loader.cpp
++++ b/src/cal3d/loader.cpp
+@@ -1308,7 +1308,7 @@ CalCoreKeyframe* CalLoader::loadCoreKeyframe(
+   if(!dataSrc.ok())
+   {
+     dataSrc.setError();
+-    return false;
++    return 0;
+   }
+ 
+   // allocate a new core keyframe instance
+@@ -1928,11 +1928,11 @@ CalCoreSubmesh *CalLoader::loadCoreSubmesh(CalDataSource& dataSrc, int version)
+       CalCoreSubMorphTarget * morphTarget = new CalCoreSubMorphTarget();
+       if( !morphTarget ) {
+          dataSrc.setError();
+-         return false;
++         return 0;
+       }
+       if( !morphTarget->reserve(vertexCount) ) {
+          dataSrc.setError();
+-         return false;
++         return 0;
+       }
+ 
+       std::string morphName;
+@@ -1974,7 +1974,7 @@ CalCoreSubmesh *CalLoader::loadCoreSubmesh(CalDataSource& dataSrc, int version)
+             }
+             if( ! dataSrc.ok() ) {
+                dataSrc.setError();
+-               return false;
++               return 0;
+             }
+ 
+             morphTarget->setBlendVertex(blendVertI, Vertex);
+diff --git a/src/cal3d/xmlformat.cpp b/src/cal3d/xmlformat.cpp
+index 2e882ac..ec11444 100644
+--- a/src/cal3d/xmlformat.cpp
++++ b/src/cal3d/xmlformat.cpp
+@@ -89,16 +89,16 @@ static inline bool TexCoordFromXml( cal3d::TiXmlElement * texcoord, char const *
+   CalCoreMesh * pCoreMesh, CalCoreSubmesh * pCoreSubmesh)
+ {
+   if( !ValidateTag(texcoord, tag, pCoreMesh, pCoreSubmesh) ) {
+-    return false;
++    return 0;
+   }
+   cal3d::TiXmlNode * node = texcoord->FirstChild();
+   if( !ValidateTag(node, NULL, pCoreMesh, pCoreSubmesh) ) {
+-    return false;
++    return 0;
+   }
+   cal3d::TiXmlText* texcoorddata = node->ToText();
+   if(!ValidateTag(texcoorddata , NULL, pCoreMesh, pCoreSubmesh))
+   {
+-    return false;
++    return 0;
+   }
+ 
+   ReadPair( texcoorddata->Value(), &texCoord->u, &texCoord->v );
+@@ -362,13 +362,13 @@ CalCoreSkeletonPtr CalLoader::loadXmlCoreSkeleton(cal3d::TiXmlDocument & doc)
+      if(stricmp(firstChild->Attribute("MAGIC"),Cal::SKELETON_XMLFILE_EXTENSION)!=0)
+      {
+         CalError::setLastError(CalError::INVALID_FILE_FORMAT, __FILE__, __LINE__, strFilename);
+-        return false;
++        return 0;
+      }
+ 
+      if(atoi(firstChild->Attribute("VERSION")) < Cal::EARLIEST_COMPATIBLE_FILE_VERSION )
+      {
+         CalError::setLastError(CalError::INCOMPATIBLE_FILE_VERSION, __FILE__, __LINE__, strFilename);
+-        return false;
++        return 0;
+      }
+ 
+      skeleton = firstChild->NextSiblingElement();
+@@ -382,7 +382,7 @@ CalCoreSkeletonPtr CalLoader::loadXmlCoreSkeleton(cal3d::TiXmlDocument & doc)
+   if(!skeleton || stricmp(skeleton->Value(),"SKELETON")!=0)
+   {
+     CalError::setLastError(CalError::INVALID_FILE_FORMAT, __FILE__, __LINE__, strFilename);
+-      return false;
++      return 0;
+   }
+ 
+   // allocate a new core skeleton instance
+@@ -408,7 +408,7 @@ CalCoreSkeletonPtr CalLoader::loadXmlCoreSkeleton(cal3d::TiXmlDocument & doc)
+     if(stricmp(bone->Value(),"BONE")!=0)
+     {
+     CalError::setLastError(CalError::INVALID_FILE_FORMAT, __FILE__, __LINE__, strFilename);
+-        return false;
++        return 0;
+     }
+ 
+     std::string strName=bone->Attribute("NAME");
+@@ -433,7 +433,7 @@ CalCoreSkeletonPtr CalLoader::loadXmlCoreSkeleton(cal3d::TiXmlDocument & doc)
+     if(!translation || stricmp( translation->Value(),"TRANSLATION")!=0)
+     {
+       CalError::setLastError(CalError::INVALID_FILE_FORMAT, __FILE__, __LINE__, strFilename);
+-      return false;
++      return 0;
+     }
+ 
+     float tx, ty, tz;
+@@ -442,13 +442,13 @@ CalCoreSkeletonPtr CalLoader::loadXmlCoreSkeleton(cal3d::TiXmlDocument & doc)
+     if(!node)
+     {
+     CalError::setLastError(CalError::INVALID_FILE_FORMAT, __FILE__, __LINE__, strFilename);
+-        return false;
++        return 0;
+     }
+     cal3d::TiXmlText* translationdata = node->ToText();
+     if(!translationdata)
+     {
+     CalError::setLastError(CalError::INVALID_FILE_FORMAT, __FILE__, __LINE__, strFilename);
+-        return false;
++        return 0;
+     }
+     str.clear();
+     str.str("");
+@@ -461,7 +461,7 @@ CalCoreSkeletonPtr CalLoader::loadXmlCoreSkeleton(cal3d::TiXmlDocument & doc)
+     if(!rotation || stricmp(rotation->Value(),"ROTATION")!=0)
+     {
+       CalError::setLastError(CalError::INVALID_FILE_FORMAT, __FILE__, __LINE__, strFilename);
+-      return false;
++      return 0;
+     }
+ 
+     float rx, ry, rz, rw;
+@@ -470,13 +470,13 @@ CalCoreSkeletonPtr CalLoader::loadXmlCoreSkeleton(cal3d::TiXmlDocument & doc)
+     if(!node)
+     {
+     CalError::setLastError(CalError::INVALID_FILE_FORMAT, __FILE__, __LINE__, strFilename);
+-        return false;
++        return 0;
+     }
+     cal3d::TiXmlText* rotationdata = node->ToText();
+     if(!rotationdata)
+     {
+     CalError::setLastError(CalError::INVALID_FILE_FORMAT, __FILE__, __LINE__, strFilename);
+-        return false;
++        return 0;
+     }
+     str.clear();
+     str.str("");
+@@ -490,7 +490,7 @@ CalCoreSkeletonPtr CalLoader::loadXmlCoreSkeleton(cal3d::TiXmlDocument & doc)
+     if(!rotation || stricmp(translationBoneSpace->Value(),"LOCALTRANSLATION")!=0)
+     {
+       CalError::setLastError(CalError::INVALID_FILE_FORMAT, __FILE__, __LINE__, strFilename);
+-      return false;
++      return 0;
+     }
+ 
+     float txBoneSpace, tyBoneSpace, tzBoneSpace;
+@@ -499,13 +499,13 @@ CalCoreSkeletonPtr CalLoader::loadXmlCoreSkeleton(cal3d::TiXmlDocument & doc)
+     if(!node)
+     {
+     CalError::setLastError(CalError::INVALID_FILE_FORMAT, __FILE__, __LINE__, strFilename);
+-        return false;
++        return 0;
+     }
+     cal3d::TiXmlText* translationBoneSpacedata = node->ToText();
+     if(!translationBoneSpacedata)
+     {
+     CalError::setLastError(CalError::INVALID_FILE_FORMAT, __FILE__, __LINE__, strFilename);
+-        return false;
++        return 0;
+     }
+     str.clear();
+     str.str("");
+@@ -518,7 +518,7 @@ CalCoreSkeletonPtr CalLoader::loadXmlCoreSkeleton(cal3d::TiXmlDocument & doc)
+     if(!rotationBoneSpace || stricmp(rotationBoneSpace->Value(),"LOCALROTATION")!=0)
+     {
+       CalError::setLastError(CalError::INVALID_FILE_FORMAT, __FILE__, __LINE__, strFilename);
+-      return false;
++      return 0;
+     }
+ 
+     float rxBoneSpace, ryBoneSpace, rzBoneSpace, rwBoneSpace;
+@@ -527,13 +527,13 @@ CalCoreSkeletonPtr CalLoader::loadXmlCoreSkeleton(cal3d::TiXmlDocument & doc)
+     if(!node)
+     {
+     CalError::setLastError(CalError::INVALID_FILE_FORMAT, __FILE__, __LINE__, strFilename);
+-        return false;
++        return 0;
+     }
+     cal3d::TiXmlText* rotationBoneSpacedata = node->ToText();
+     if(!rotationBoneSpacedata)
+     {
+     CalError::setLastError(CalError::INVALID_FILE_FORMAT, __FILE__, __LINE__, strFilename);
+-        return false;
++        return 0;
+     }
+     str.clear();
+     str.str("");
+@@ -546,7 +546,7 @@ CalCoreSkeletonPtr CalLoader::loadXmlCoreSkeleton(cal3d::TiXmlDocument & doc)
+     if(!parent ||stricmp(parent->Value(),"PARENTID")!=0)
+     {
+       CalError::setLastError(CalError::INVALID_FILE_FORMAT, __FILE__, __LINE__, strFilename);
+-      return false;
++      return 0;
+     }
+ 
+ 
+@@ -556,13 +556,13 @@ CalCoreSkeletonPtr CalLoader::loadXmlCoreSkeleton(cal3d::TiXmlDocument & doc)
+     if(!node)
+     {
+     CalError::setLastError(CalError::INVALID_FILE_FORMAT, __FILE__, __LINE__, strFilename);
+-        return false;
++        return 0;
+     }
+     cal3d::TiXmlText* parentid = node->ToText();
+       if(!parentid)
+     {
+     CalError::setLastError(CalError::INVALID_FILE_FORMAT, __FILE__, __LINE__, strFilename);
+-        return false;
++        return 0;
+     }
+     parentId = atoi(parentid->Value());
+ 
+@@ -610,20 +610,20 @@ CalCoreSkeletonPtr CalLoader::loadXmlCoreSkeleton(cal3d::TiXmlDocument & doc)
+       if(stricmp(child->Value(),"CHILDID")!=0)
+       {
+         CalError::setLastError(CalError::INVALID_FILE_FORMAT, __FILE__, __LINE__, strFilename);
+-        return false;
++        return 0;
+       }
+ 
+       cal3d::TiXmlNode *node= child->FirstChild();
+       if(!node)
+       {
+         CalError::setLastError(CalError::INVALID_FILE_FORMAT, __FILE__, __LINE__, strFilename);
+-        return false;
++        return 0;
+       }
+       cal3d::TiXmlText* childid = node->ToText();
+       if(!childid)
+       {
+         CalError::setLastError(CalError::INVALID_FILE_FORMAT, __FILE__, __LINE__, strFilename);
+-        return false;
++        return 0;
+       }
+ 
+       int childId = atoi(childid->Value());
+@@ -1058,13 +1058,13 @@ CalCoreAnimatedMorph *CalLoader::loadXmlCoreAnimatedMorph(cal3d::TiXmlDocument &
+      if(stricmp(firstChild->Attribute("MAGIC"),Cal::ANIMATEDMORPH_XMLFILE_EXTENSION)!=0)
+      {
+         CalError::setLastError(CalError::INVALID_FILE_FORMAT, __FILE__, __LINE__, strFilename);
+-        return false;
++        return 0;
+      }
+ 
+      if(atoi(firstChild->Attribute("VERSION")) < Cal::EARLIEST_COMPATIBLE_FILE_VERSION )
+      {
+         CalError::setLastError(CalError::INCOMPATIBLE_FILE_VERSION, __FILE__, __LINE__, strFilename);
+-        return false;
++        return 0;
+      }
+ 
+      animatedMorph = firstChild->NextSiblingElement();

--- a/pkgs/by-name/ca/cal3d/package.nix
+++ b/pkgs/by-name/ca/cal3d/package.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkg-config
+, freeglut
+, glew
+, unittest-cpp
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cal3d";
+  version = "0.120"; # actually 0.12.0
+
+  src = fetchFromGitHub {
+    owner = "mp3butcher";
+    repo = "Cal3D";
+    rev = finalAttrs.version;
+    hash = "sha256-974pqfgLBmEEC3/jNwP+fa4ENDTEBkqbffnbKrBcBfc=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/cal3d";
+
+  outputs = [ "out" "dev" ];
+
+  patches = [
+    ./fix-boolean-ptr-conversion.patch
+  ];
+
+  postPatch = ''
+    sed -i "/AM_USE_UNITTESTCPP/d" configure.in
+  '';
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
+
+  buildInputs = [ freeglut glew ];
+
+  meta = {
+    changelog = "https://github.com/mp3butcher/Cal3D/blob/${finalAttrs.src.rev}/cal3d/ChangeLog";
+    description = "3D character animation library";
+    homepage = "https://mp3butcher.github.io/Cal3D";
+    license = lib.licenses.lgpl3;
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = lib.platforms.all;
+  };
+})
+
+


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/283332

Dependency of https://github.com/NixOS/nixpkgs/issues/219441

This PR adds 1 library: `cal3d`

Note: the project is pretty old.

I disabled the usage of `unittest-cpp` as it was failing 4 out of 43 tests.

> hardwaremodel_test.cpp:31:1: error: Failure in CalHardwareModel_getRotationBoneSpace: Unhandled exception: test crashed
> hardwaremodel_test.cpp:91:1: error: Failure in CalHardwareModel_getTranslationBoneSpace: Unhandled exception: test crashed
> loader_saver_test.cpp:51:1: error: Failure in CalSaver_CalLoader_CoreAnimation: NULL != CalLoader::loadCoreAnimation( "tmp.cov" , m_pCoreSkel)
> physique_test.cpp:256:1: error: Failure in CalPhysique_calculateTangentSpaces: Unhandled exception: test crashed

I could try to disable only these test, but than again, this package is not likely to get updates very soon.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
