### PR TITLE
string-machine: fix build against `gcc-13`

### DIFF
--- a/pkgs/applications/audio/string-machine/default.nix
+++ b/pkgs/applications/audio/string-machine/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, boost, cairo, libGL, lv2, pkg-config }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, boost, cairo, libGL, lv2, pkg-config }:
 
 stdenv.mkDerivation rec {
   pname = "string-machine";
@@ -11,6 +11,16 @@ stdenv.mkDerivation rec {
     sha256 = "0l9xrzp3f0hk6h320qh250a0n1nbd6qhjmab21sjmrlb4ngy672v";
     fetchSubmodules = true;
   };
+
+  patches = [
+    # gcc-13 compatibility fix:
+    #   https://github.com/jpcima/string-machine/pull/36
+    (fetchpatch {
+      name = "gcc-13.patch";
+      url = "https://github.com/jpcima/string-machine/commit/e1f9c70da46e43beb2654b509bc824be5601a0a5.patch";
+      hash = "sha256-eS28wBuFjbx2tEb9gtVRZXfK0w2o1RCFTouNf8Adq+k=";
+    })
+  ];
 
   postPatch = ''
     patchShebangs ./dpf/utils/generate-ttl.sh


### PR DESCRIPTION
Without the change the build fails as
https://hydra.nixos.org/build/246390341:

    sources/ui/Color.h:4:5: error: 'uint8_t' does not name a type
        4 |     uint8_t r, g, b, a;
          |     ^~~~~~~
    sources/ui/Color.h:1:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
      +++ |+#include <cstdint>
        1 | #pragma once

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
