### PR TITLE
payloadsallthethings: init at 3.0-unstable-2024-01-21

### DIFF
--- a/pkgs/by-name/pa/payloadsallthethings/package.nix
+++ b/pkgs/by-name/pa/payloadsallthethings/package.nix
@@ -1,0 +1,33 @@
+{ lib
+, fetchFromGitHub
+, stdenvNoCC
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "payloadsallthethings";
+  version = "3.0-unstable-2024-01-21";
+
+  src = fetchFromGitHub {
+    owner = "swisskyrepo";
+    repo = "PayloadsAllTheThings";
+    rev = "97cfeee270395a838802fa1fcb8a4d5ffc6d6b48";
+    hash = "sha256-LRS60v0o5nPSLfGFH6P0Y5roN8Mk5/KyRF4SWTv/7Hw=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/payloadsallthethings
+    rm CONTRIBUTING.md mkdocs.yml custom.css
+    cp -a * $out/share/payloadsallthethings
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/swisskyrepo/PayloadsAllTheThings";
+    description = "A list of useful payloads and bypass for Web Application Security and Pentest/CTF";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ shard7 ];
+    platforms = lib.platforms.all;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+  };
+}


### PR DESCRIPTION
## Description of changes
PayloadsAllTheThings - A list of useful payloads and bypass for Web Application Security and Pentest/CTF.

See:
- https://github.com/swisskyrepo/PayloadsAllTheThings
- https://repology.org/project/payloadsallthethings/information

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
