### PR TITLE
Disable compiler runtime-test for cmake when cross-compiling to None platform.

### DIFF
--- a/pkgs/build-support/lib/cmake.nix
+++ b/pkgs/build-support/lib/cmake.nix
@@ -20,11 +20,13 @@ let
       "-DCMAKE_HOST_SYSTEM_VERSION=${stdenv.buildPlatform.uname.release}"
     ] ++ optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
       "-DCMAKE_CROSSCOMPILING_EMULATOR=env"
+    ] ++ optionals (stdenv.hostPlatform.isNone) [
+      "-DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY"
     ] ++ optionals stdenv.hostPlatform.isStatic [
       "-DCMAKE_LINK_SEARCH_START_STATIC=ON"
     ]);
 
-  makeCMakeFlags = { cmakeFlags ? [], ... }: cmakeFlags ++ cmakeFlags';
+  makeCMakeFlags = { cmakeFlags ? [ ], ... }: cmakeFlags ++ cmakeFlags';
 
 in
 {


### PR DESCRIPTION
CMake implicitly runs a compiler test when it detects a new project. This normally compiles a minimal executable and runs it. In case of cross-compilation it still attempts to build an executable but not execute it. 

When cross-compiling to a None platform, this will fail for all CMake packages since executables cannot be built and the user is forced to override this manually through overlays.

This commit changes CMake's behavior when cross compiling to a None platform so that it compiles a static library as a test instead.

## Description of changes

Add [CMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY](https://cmake.org/cmake/help/latest/variable/CMAKE_TRY_COMPILE_TARGET_TYPE.html#variable:CMAKE_TRY_COMPILE_TARGET_TYPE) to cmakeFlags.

## Things done

Checked change with a large set of custom and builtin CMake libraries while cross-compiling to `arm-none-eabi` target
