### PR TITLE
Improve arm none eabi generated binary size

### DIFF
--- a/pkgs/development/compilers/gcc/common/extra-target-flags.nix
+++ b/pkgs/development/compilers/gcc/common/extra-target-flags.nix
@@ -8,26 +8,33 @@ in
   # For non-cross builds these flags are currently assigned in builder.sh.
   # It would be good to consolidate the generation of makeFlags
   # ({C,CXX,LD}FLAGS_FOR_{BUILD,TARGET}, etc...) at some point.
-  EXTRA_FLAGS_FOR_TARGET = let
+  EXTRA_FLAGS_FOR_TARGET =
+    let
+      commonFlags = "-O2";
+      nanoFlags = "-Os -fdata-sections -ffunction-sections -fno-exceptions";
       mkFlags = dep: langD: lib.optionals (targetPlatform != hostPlatform && dep != null && !langD) ([
-        "-O2 -idirafter ${lib.getDev dep}${dep.incdir or "/include"}"
+        (if targetPlatform.isNone && targetPlatform.libc == "newlib-nano" then nanoFlags else commonFlags)
+        "-idirafter ${lib.getDev dep}${dep.incdir or "/include"}"
       ] ++ lib.optionals (! withoutTargetLibc) [
         "-B${lib.getLib dep}${dep.libdir or "/lib"}"
       ]);
-    in mkFlags libcCross langD
-       ++ lib.optionals (!withoutTargetLibc) (mkFlags (threadsCross.package or null) langD)
-    ;
+    in
+    mkFlags libcCross langD
+    ++ lib.optionals (!withoutTargetLibc) (mkFlags (threadsCross.package or null) langD)
+  ;
 
-  EXTRA_LDFLAGS_FOR_TARGET = let
+  EXTRA_LDFLAGS_FOR_TARGET =
+    let
       mkFlags = dep: lib.optionals (targetPlatform != hostPlatform && dep != null) ([
         "-Wl,-L${lib.getLib dep}${dep.libdir or "/lib"}"
       ] ++ (if withoutTargetLibc then [
-          "-B${lib.getLib dep}${dep.libdir or "/lib"}"
-        ] else [
-          "-Wl,-rpath,${lib.getLib dep}${dep.libdir or "/lib"}"
-          "-Wl,-rpath-link,${lib.getLib dep}${dep.libdir or "/lib"}"
+        "-B${lib.getLib dep}${dep.libdir or "/lib"}"
+      ] else [
+        "-Wl,-rpath,${lib.getLib dep}${dep.libdir or "/lib"}"
+        "-Wl,-rpath-link,${lib.getLib dep}${dep.libdir or "/lib"}"
       ]));
-    in mkFlags libcCross
-       ++ lib.optionals (!withoutTargetLibc) (mkFlags (threadsCross.package or null))
-    ;
+    in
+    mkFlags libcCross
+    ++ lib.optionals (!withoutTargetLibc) (mkFlags (threadsCross.package or null))
+  ;
 }

--- a/pkgs/development/misc/newlib/default.nix
+++ b/pkgs/development/misc/newlib/default.nix
@@ -88,6 +88,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   dontDisableStatic = true;
 
+  preBuild = lib.optionalString nanoizeNewlib (
+    let
+      flags = "-Os -fdata-sections -ffunction-sections";
+    in ''
+    makeFlagsArray+=(CFLAGS="${flags}" CXXFLAGS="${flags}")
+    ''
+  );
+
   # apply necessary nano changes from https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/manifest/copy_nano_libraries.sh?rev=4c50be6ccb9c4205a5262a3925317073&hash=1375A7B0A1CD0DB9B9EB0D2B574ADF66
   postInstall = lib.optionalString nanoizeNewlib ''
     mkdir -p $out${finalAttrs.passthru.incdir}/newlib-nano


### PR DESCRIPTION
## Description of changes

  Decrease the size of arm-none-eabi when using newlib-nano as libc.
    
  Newlib-nano is used to decrease the produced binary size as much as
  possible.
  
  As such, it is usually built with `-Os`
  along with `-fdata-sections` and `-ffunction-sections` flags to allow
  better discarding using `-Wl,--gc-sections`.
  
  `libstdc++` in this case should also be built with the same flags and with
  disabled exceptions in order to reduce its binary size considerably.
  
  The above match the behavior of the upstream GNU Arm Embedded toolchain.

## Testing done

Compiled a large firmware project for cortex-m4 and compared with upstream GNU Arm Embedded toolchain. Was getting ~350kb for nixpkgs toolchain vs ~266kb with upstream. After the changes I get ~266kb with nixpkgs toolchain.