### PR TITLE
idris2Packages.idris2Lsp: init at 2024-01-21

### DIFF
--- a/doc/languages-frameworks/idris2.section.md
+++ b/doc/languages-frameworks/idris2.section.md
@@ -2,7 +2,7 @@
 
 In addition to exposing the Idris2 compiler itself, Nixpkgs exposes an `idris2Packages.buildIdris` helper to make it a bit more ergonomic to build Idris2 executables or libraries.
 
-The `buildIdris` function takes a package set that defines at a minimum the `src` and `projectName` of the package to be built and any `idrisLibraries` required to build it. The `src` is the same source you're familiar with but the `projectName` must be the name of the `ipkg` file for the project (omitting the `.ipkg` extension). The `idrisLibraries` is a list of other library derivations created with `buildIdris`. You can optionally specify other derivation properties as needed but sensible defaults for `configurePhase`, `buildPhase`, and `installPhase` are provided.
+The `buildIdris` function takes an attribute set that defines at a minimum the `src` and `ipkgName` of the package to be built and any `idrisLibraries` required to build it. The `src` is the same source you're familiar with and the `ipkgName` must be the name of the `ipkg` file for the project (omitting the `.ipkg` extension). The `idrisLibraries` is a list of other library derivations created with `buildIdris`. You can optionally specify other derivation properties as needed but sensible defaults for `configurePhase`, `buildPhase`, and `installPhase` are provided.
 
 Importantly, `buildIdris` does not create a single derivation but rather an attribute set with two properties: `executable` and `library`. The `executable` property is a derivation and the `library` property is a function that will return a derivation for the library with or without source code included. Source code need not be included unless you are aiming to use IDE or LSP features that are able to jump to definitions within an editor.
 
@@ -10,7 +10,7 @@ A simple example of a fully packaged library would be the [`LSP-lib`](https://gi
 ```nix
 { fetchFromGitHub, idris2Packages }:
 let lspLibPkg = idris2Packages.buildIdris {
-  projectName = "lsp-lib";
+  ipkgName = "lsp-lib";
   src = fetchFromGitHub {
    owner = "idris-community";
    repo = "LSP-lib";
@@ -31,7 +31,7 @@ A slightly more involved example of a fully packaged executable would be the [`i
 # Assuming the previous example lives in `lsp-lib.nix`:
 let lspLib = callPackage ./lsp-lib.nix { };
     lspPkg = idris2Packages.buildIdris {
-      projectName = "idris2-lsp";
+      ipkgName = "idris2-lsp";
       src = fetchFromGitHub {
          owner = "idris-community";
          repo = "idris2-lsp";

--- a/pkgs/development/compilers/idris2/build-idris.nix
+++ b/pkgs/development/compilers/idris2/build-idris.nix
@@ -1,9 +1,9 @@
-{ stdenv, lib, idris2
+{ stdenv, lib, idris2, makeWrapper
 }:
 # Usage: let
 #          pkg = idris2Packages.buildIdris {
 #            src = ...;
-#            projectName = "my-pkg";
+#            ipkgName = "my-pkg";
 #            idrisLibraries = [ ];
 #          };
 #        in {
@@ -12,62 +12,75 @@
 #        }
 #
 { src
-, projectName
+, ipkgName
+, version ? "unversioned"
 , idrisLibraries # Other libraries built with buildIdris
 , ... }@attrs:
 
 let
-  ipkgName = projectName + ".ipkg";
+  ipkgFileName = ipkgName + ".ipkg";
   idrName = "idris2-${idris2.version}";
   libSuffix = "lib/${idrName}";
   libDirs =
-    lib.makeSearchPath libSuffix idrisLibraries;
-  drvAttrs = builtins.removeAttrs attrs [ "idrisLibraries" ];
+    (lib.makeSearchPath libSuffix idrisLibraries) +
+    ":${idris2}/${idrName}";
+  supportDir = "${idris2}/${idrName}/lib";
+  drvAttrs = builtins.removeAttrs attrs [
+    "ipkgName"
+    "idrisLibraries"
+  ];
 
-  sharedAttrs = {
-    name = projectName;
+  sharedAttrs = drvAttrs // {
+    pname = ipkgName;
+    inherit version;
     src = src;
-    nativeBuildInputs = [ idris2 ];
+    nativeBuildInputs = [ idris2 makeWrapper ] ++ attrs.nativeBuildInputs or [];
+    buildInputs = idrisLibraries ++ attrs.buildInputs or [];
 
     IDRIS2_PACKAGE_PATH = libDirs;
 
-    configurePhase = ''
-      runHook preConfigure
-      runHook postConfigure
-    '';
-
     buildPhase = ''
       runHook preBuild
-      idris2 --build ${ipkgName}
+      idris2 --build ${ipkgFileName}
       runHook postBuild
     '';
   };
 
 in {
-  executable = stdenv.mkDerivation (lib.attrsets.mergeAttrsList [
-    sharedAttrs
-    { installPhase = ''
-        runHook preInstall
-        mkdir -p $out/bin
-        mv build/exec/* $out/bin
-        runHook postInstall
-      '';
-    }
-    drvAttrs
-  ]);
+  executable = stdenv.mkDerivation (sharedAttrs // {
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/bin
+      scheme_app="$(find ./build/exec -name '*_app')"
+      if [ "$scheme_app" = ''' ]; then
+        mv -- build/exec/* $out/bin/
+        chmod +x $out/bin/*
+        # ^ remove after Idris2 0.8.0 is released. will be superfluous:
+        # https://github.com/idris-lang/Idris2/pull/3189
+      else
+        cd build/exec/*_app
+        rm -f ./libidris2_support.so
+        for file in *.so; do
+          bin_name="''${file%.so}"
+          mv -- "$file" "$out/bin/$bin_name"
+          wrapProgram "$out/bin/$bin_name" \
+            --prefix LD_LIBRARY_PATH : ${supportDir} \
+            --prefix DYLD_LIBRARY_PATH : ${supportDir}
+        done
+      fi
+      runHook postInstall
+    '';
+  });
+
   library = { withSource ? false }:
     let installCmd = if withSource then "--install-with-src" else "--install";
-    in stdenv.mkDerivation (lib.attrsets.mergeAttrsList [
-      sharedAttrs
-      {
-        installPhase = ''
-          runHook preInstall
-          mkdir -p $out/${libSuffix}
-          export IDRIS2_PREFIX=$out/lib
-          idris2 ${installCmd} ${ipkgName}
-          runHook postInstall
-        '';
-      }
-      drvAttrs
-    ]);
+    in stdenv.mkDerivation (sharedAttrs // {
+      installPhase = ''
+        runHook preInstall
+        mkdir -p $out/${libSuffix}
+        export IDRIS2_PREFIX=$out/lib
+        idris2 ${installCmd} ${ipkgFileName}
+        runHook postInstall
+      '';
+    });
 }

--- a/pkgs/development/compilers/idris2/default.nix
+++ b/pkgs/development/compilers/idris2/default.nix
@@ -5,12 +5,13 @@
 let
 in {
   idris2 = callPackage ./idris2.nix { };
+  idris2Lsp = callPackage ./idris2-lsp.nix { };
 
   buildIdris = callPackage ./build-idris.nix { };
 
   idris2Api = (idris2Packages.buildIdris {
-    inherit (idris2Packages.idris2) src;
-    projectName = "idris2api";
+    inherit (idris2Packages.idris2) src version;
+    ipkgName = "idris2api";
     idrisLibraries = [ ];
     preBuild = ''
       export IDRIS2_PREFIX=$out/lib

--- a/pkgs/development/compilers/idris2/idris2-lsp.nix
+++ b/pkgs/development/compilers/idris2/idris2-lsp.nix
@@ -1,0 +1,44 @@
+{ fetchFromGitHub, idris2Packages, makeWrapper }:
+
+let
+  globalLibraries = let
+    idrName = "idris2-${idris2Packages.idris2.version}";
+    libSuffix = "lib/${idrName}";
+  in [
+    "\\$HOME/.nix-profile/lib/${idrName}"
+    "/run/current-system/sw/lib/${idrName}"
+    "${idris2Packages.idris2}/${idrName}"
+  ];
+  globalLibrariesPath = builtins.concatStringsSep ":" globalLibraries;
+
+  idris2Api = idris2Packages.idris2Api { };
+  lspLib = (idris2Packages.buildIdris {
+    ipkgName = "lsp-lib";
+    version = "2024-01-21";
+    src = fetchFromGitHub {
+     owner = "idris-community";
+     repo = "LSP-lib";
+     rev = "03851daae0c0274a02d94663d8f53143a94640da";
+     hash = "sha256-ICW9oOOP70hXneJFYInuPY68SZTDw10dSxSPTW4WwWM=";
+    };
+    idrisLibraries = [ ];
+  }).library { };
+
+  lspPkg = idris2Packages.buildIdris {
+    ipkgName = "idris2-lsp";
+    version = "2024-01-21";
+    src = fetchFromGitHub {
+       owner = "idris-community";
+       repo = "idris2-lsp";
+       rev = "a77ef2d563418925aa274fa29f06880dde43f4ec";
+       hash = "sha256-zjfVfkpiQS9AdmTfq0hYRSelJq5Caa9VGTuFLtSvl5o=";
+    };
+    idrisLibraries = [idris2Api lspLib];
+
+    buildInputs = [makeWrapper];
+    postInstall = ''
+      wrapProgram $out/bin/idris2-lsp \
+        --suffix IDRIS2_PACKAGE_PATH ':' "${globalLibrariesPath}"
+    '';
+  };
+in lspPkg.executable


### PR DESCRIPTION
## Description of changes

In short:
1. Make some tweaks to `buildIdris` to better support executable builds (like the LSP server) and hopefully create a more ergonomic interface all around (more details below).
2. Introduce `idris2Packages.idris2Lsp`, an LSP server for Idris 2 that is well maintained by the Idris community.

As of the changes in this PR, the `buildIdris` found here and the one found in the Idris 2 repository are almost identical. The big remaining difference is that I was able to rework the upstream repository's `Idris2` to build the support files (a shared library) as a separate derivation and use that in `buildIdris` to clean up linker paths a bit. I will be able to port that change (long requested in [code comments](https://github.com/NixOS/nixpkgs/blob/854f4671883250e456dc1553c783ac9741a0e9a4/pkgs/development/compilers/idris2/idris2.nix#L75)) once Idris2 v0.8.0 is released. In order to make the changes I made I also modified the Makefile (post release of v0.7.0).

### `buildIdris` changes
Since there has not been a release of Nixpkgs since I introduced `buildIdris`, I made some breaking changes to adapt to lessons learned while packaging the LSP server.

1. I renamed the `projectName` input attribute to `ipkgName`. This was always used to locate the `*.ipkg` file that should be used to build an Idris 2 project, but the name didn't used to imply that purpose. This even bit me once when I accidentally used different capitalization in `projectName` than was found in the `*.ipkg` file name.
2. I switched the input name (now `ipkgName`) from being directly applied to the `name` of the derivation to instead apply to the derivation's `pname`, making it much easier to apply a `version` to a derivation.
3. I previously merged the input attributes with the derivation at the end. I thought this would make it easiest to override `buildIdris` attributes. That ended up being inconvenient because it is useful to have `buildIdris` add to e.g. `buildInputs` for the derivation so we don't want to blow those additions away at the end. Now input attributes have the standard and executable or library attributes merged into them instead of the other way around.
4. The `library` output is basically unchanged but the `executable` output now supports nuanced distinctions of executables produced by the NodeJS vs. Scheme backends of the compiler. This is immediately useful in building the LSP server executable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
