### PR TITLE
openscad-unstable: init at 2024-01-22

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14432,6 +14432,12 @@
     github = "pbsds";
     githubId = 140964;
   };
+  pca006132 = {
+    name = "pca006132";
+    email = "john.lck40@gmail.com";
+    github = "pca006132";
+    githubId = 12198657;
+  };
   pcarrier = {
     email = "pc@rrier.ca";
     github = "pcarrier";

--- a/pkgs/by-name/op/openscad-unstable/package.nix
+++ b/pkgs/by-name/op/openscad-unstable/package.nix
@@ -1,0 +1,159 @@
+{ lib
+, clangStdenv
+, llvmPackages
+, fetchFromGitHub
+, cmake
+, ninja
+, pkg-config
+, bison
+, boost
+, cairo
+, cgal_5
+, clipper2
+, double-conversion
+, eigen
+, flex
+, fontconfig
+, freetype
+, glib
+, glm
+, gmp
+, harfbuzz
+, hidapi
+, lib3mf
+, libGL
+, libGLU
+, libICE
+, libSM
+, libsForQt5
+, libspnav
+, libzip
+, mpfr
+, python3
+, tbb_2021_8
+, wayland
+, wayland-protocols
+}:
+let
+  # get cccl from source to avoid license issues
+  nvidia-cccl = clangStdenv.mkDerivation {
+    pname = "nvidia-cccl";
+    # note that v2.2.0 has some cmake issues
+    version = "2.2.0-unstable-2024-01-26";
+    src = fetchFromGitHub {
+      owner = "NVIDIA";
+      repo = "cccl";
+      fetchSubmodules = true;
+      rev = "0c9d03276206a5f59368e908e3d643610f9fddcd";
+      hash = "sha256-f11CNfa8jF9VbzvOoX1vT8zGIJL9cZ/VBpiklUn0YdU=";
+    };
+    nativeBuildInputs = [ cmake pkg-config ];
+    buildInputs = [ tbb_2021_8 ];
+    cmakeFlags = [
+      # only enable what we need
+      "-DCCCL_ENABLE_CUB=OFF"
+      "-DCCCL_ENABLE_LIBCUDACXX=ON"
+      "-DCCCL_ENABLE_THRUST=ON"
+      "-DCCCL_ENABLE_TESTING=OFF"
+      "-DCCCL_ENABLE_EXAMPLES=OFF"
+
+      "-DTHRUST_DEVICE_SYSTEM=TBB"
+      "-DTHRUST_HOST_SYSTEM=CPP"
+      "-DTHRUST_ENABLE_HEADER_TESTING=OFF"
+      "-DTHRUST_ENABLE_TESTING=OFF"
+      "-DTHRUST_ENABLE_EXAMPLES=OFF"
+
+      "-DLIBCUDACXX_ENABLE_CUDA=OFF"
+      "-DLIBCUDACXX_ENABLE_STATIC_LIBRARY=OFF"
+      "-DLIBCUDACXX_ENABLE_LIBCUDACXX_TESTS=OFF"
+    ];
+    meta = with lib; {
+      description = "CUDA C++ Core Libraries";
+      homepage = "https://github.com/NVIDIA/cccl";
+      license = licenses.asl20;
+      platforms = platforms.unix;
+    };
+  };
+in
+# clang consume much less RAM than GCC
+clangStdenv.mkDerivation rec {
+  pname = "openscad-unstable";
+  version = "2024-01-22";
+  src = fetchFromGitHub {
+    owner = "openscad";
+    repo = "openscad";
+    rev = "88d244aed3c40a76194ff537ed84bd65bc0e1aeb";
+    hash = "sha256-qkQNbYhmOxF14zm+eCcwe9asLOEciYBANefUb8+KNEI=";
+    fetchSubmodules = true;
+  };
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    ninja
+    bison
+    flex
+    python3
+    libsForQt5.qt5.wrapQtAppsHook
+    llvmPackages.bintools
+  ];
+  buildInputs = with libsForQt5; with qt5; [
+    # manifold dependencies
+    clipper2
+    glm
+    tbb_2021_8
+    nvidia-cccl
+
+    boost
+    cairo
+    cgal_5
+    double-conversion
+    eigen
+    fontconfig
+    freetype
+    glib
+    gmp
+    harfbuzz
+    hidapi
+    lib3mf
+    libspnav
+    libzip
+    mpfr
+    qscintilla
+    qtbase
+    qtmultimedia
+  ]
+  ++ lib.optionals clangStdenv.isLinux [ libICE libSM libGLU libGL wayland wayland-protocols qtwayland ]
+  ++ lib.optional clangStdenv.isDarwin qtmacextras
+  ;
+  cmakeFlags = [
+    "-DEXPERIMENTAL=ON" # enable experimental options
+    "-DSNAPSHOT=ON" # nightly icons
+    "-DUSE_BUILTIN_OPENCSG=ON" # bundled latest opencsg
+    "-DOPENSCAD_VERSION=\"${builtins.replaceStrings ["-"] ["."] version}\""
+    "-DCMAKE_UNITY_BUILD=ON" # faster build
+    "-DENABLE_TESTS=OFF" # tests do not work for now
+    # IPO
+    "-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld"
+    "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON"
+  ];
+  meta = with lib; {
+    description = "3D parametric model compiler (unstable)";
+    longDescription = ''
+      OpenSCAD is a software for creating solid 3D CAD objects. It is free
+      software and available for Linux/UNIX, MS Windows and macOS.
+
+      Unlike most free software for creating 3D models (such as the famous
+      application Blender) it does not focus on the artistic aspects of 3D
+      modelling but instead on the CAD aspects. Thus it might be the
+      application you are looking for when you are planning to create 3D models of
+      machine parts but pretty sure is not what you are looking for when you are more
+      interested in creating computer-animated movies.
+    '';
+    homepage = "https://openscad.org/";
+    # note that the *binary license* is gpl3 due to CGAL
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ pca006132 raskin ];
+    mainProgram = "openscad";
+  };
+}


### PR DESCRIPTION
## Description of changes

Add openscad-unstable package, which provides new experimental features on top of the old openscad package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

This is only tested on NixOS with wayland. Would be nice if someone can help me test on other environments, e.g. darwin.

Notify maintainers: @bjornfor @7c6f434c @gebner. Btw should I add maintainers for the stable openscad package to this openscad-unstable? The build system is completely changed.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
