### PR TITLE
go-bare: init at 2021-04-06

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14990,6 +14990,12 @@
     githubId = 4201956;
     name = "pongo1231";
   };
+  poptart = {
+    email = "poptart@hosakacorp.net";
+    github = "terrorbyte";
+    githubId = 1601039;
+    name = "Cale Black";
+  };
   portothree = {
     name = "Gustavo Porto";
     email = "gus@p8s.co";

--- a/pkgs/by-name/go/go-bare/package.nix
+++ b/pkgs/by-name/go/go-bare/package.nix
@@ -1,0 +1,25 @@
+{ buildGoModule, fetchFromSourcehut, lib }:
+
+buildGoModule rec {
+  pname = "go-bare";
+  version = "0-unstable-2021-04-06";
+
+  src = fetchFromSourcehut {
+    owner = "~sircmpwn";
+    repo = "go-bare";
+    rev = "ab86bc2846d997bc8760fdb0d06d4a55e746b1db";
+    hash = "sha256-SKTYDKidB1Ia3Jg4EBg5rPAtqlXAa19RY5qieS82A34=";
+  };
+
+  vendorHash = "sha256-OhJb/q1XJ/U/AvCcCXw2Ll86UKlkHGuURHS5J6aXNTs=";
+
+  subPackages = [ "cmd/gen" ];
+
+  meta = with lib; {
+    description = "An implementation of the BARE message format for Go";
+    mainProgram = "gen";
+    homepage = "https://git.sr.ht/~sircmpwn/go-bare";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ poptart ];
+  };
+}


### PR DESCRIPTION
## Description of changes

An implementation of the [BARE](https://baremessages.org/) message format for Go. This package adds the [schema generator](https://git.sr.ht/~sircmpwn/go-bare/tree/master/item/cmd/gen/main.go) that is normally run with `go run git.sr.ht/~sircmpwn/go-bare/cmd/gen -p models schema.bare models/gen.go`.

One thing that I was unsure of is that the binary itself is named `gen` which is rather unclear. Would it be better to move that to something along the lines of `go-bare-gen` in the `installPhase` or is it preferred to keep the upstream name?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
