### PR TITLE
fetchgit: Support fetching signed tags over dumb http transport

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -166,7 +166,7 @@ checkout_hash(){
     clean_git fetch -t ${builder:+--progress} origin || return 1
 
     local object_type=$(git cat-file -t "$hash")
-    if [[ "$object_type" == "commit" ]]; then
+    if [[ "$object_type" == "commit" || "$object_type" == "tag" ]]; then
         clean_git checkout -b "$branchName" "$hash" || return 1
     elif [[ "$object_type" == "tree" ]]; then
         clean_git config user.email "nix-prefetch-git@localhost"

--- a/pkgs/build-support/fetchgit/tests.nix
+++ b/pkgs/build-support/fetchgit/tests.nix
@@ -72,4 +72,11 @@
     leaveDotGit = true;
     fetchSubmodules = true;
   };
+
+  dumb-http-signed-tag = testers.invalidateFetcherByDrvHash fetchgit {
+    name = "dumb-http-signed-tag-source";
+    url = "https://git.scottworley.com/pub/git/pinch";
+    rev = "v3.0.14";
+    sha256 = "sha256-bd0Lx75Gd1pcBJtwz5WGki7XoYSpqhinCT3a77wpY2c=";
+  };
 }


### PR DESCRIPTION
## Description of changes

Support fetching [annotated](https://git-scm.com/book/en/v2/Git-Basics-Tagging) (eg: signed) tags from dumb-http-transport git remotes.

Testing advice welcome!  It seems like these tests depend upon live internet services, which seems not-great!  Currently, it only depends upon github.com, which many other nixpkgs things also rely on, and github.com has pretty good capacity and availability.  But I don't immediately see a way to test this change against github.com because [github dropped support for dumb http fetching in 2011](https://github.blog/2011-03-09-git-dumb-http-transport-to-be-turned-off-in-90-days/).  I've included a test against my own humble home server here to demonstrate how this change corrects the defect, but my humble home server does not have the capacity and availability of github.com!  I'm wary of leaving this test case in, lest any unavailability of my humble home server cause spurious flaky test failures for others.  :(

Output of the test case failing without the fix:

    $ nix-build . -A tests.fetchgit.dumb-http-signed-tag
    this derivation will be built:
      /nix/store/by82f6l6xq9242r1v1gq6855i2y5mqhg-dumb-http-signed-tag-source-salted-mglyr7v5dxa5.drv
    building '/nix/store/by82f6l6xq9242r1v1gq6855i2y5mqhg-dumb-http-signed-tag-source-salted-mglyr7v5dxa5.drv'...
    exporting https://git.scottworley.com/pub/git/pinch (rev v3.0.14) into /nix/store/7886l42bijhly4k816zdnpy5gcp4h36d-dumb-http-signed-tag-source-salted-mglyr7v5dxa5
    Initialized empty Git repository in /nix/store/7886l42bijhly4k816zdnpy5gcp4h36d-dumb-http-signed-tag-source-salted-mglyr7v5dxa5/.git/
    fatal: dumb http transport does not support shallow capabilities
    fatal: dumb http transport does not support shallow capabilities
    From https://git.scottworley.com/pub/git/pinch
     * [new branch]      master     -> origin/master
     * [new tag]         1.0        -> 1.0
     ...
     * [new tag]         2.1.0      -> 2.1.0
     * [new tag]         2.1.1      -> 2.1.1
     * [new tag]         v3.0.0     -> v3.0.0
     * [new tag]         v3.0.1     -> v3.0.1
     * [new tag]         v3.0.10    -> v3.0.10
     * [new tag]         v3.0.11    -> v3.0.11
     * [new tag]         v3.0.12    -> v3.0.12
     * [new tag]         v3.0.13    -> v3.0.13
     * [new tag]         v3.0.14    -> v3.0.14
     * [new tag]         v3.0.2     -> v3.0.2
     ...
     * [new tag]         v3.0.9     -> v3.0.9
    Unrecognized git object type: tag
    Unable to checkout refs/tags/v3.0.14 from https://git.scottworley.com/pub/git/pinch.
    error: builder for '/nix/store/by82f6l6xq9242r1v1gq6855i2y5mqhg-dumb-http-signed-tag-source-salted-mglyr7v5dxa5.drv' failed with exit code 1;


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
