### PR TITLE
fritzing: 1.0.1 -> 1.0.2

### DIFF
--- a/pkgs/applications/science/electronics/fritzing/default.nix
+++ b/pkgs/applications/science/electronics/fritzing/default.nix
@@ -1,7 +1,6 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, fetchpatch
 , wrapQtAppsHook
 , qmake
 , pkg-config
@@ -15,6 +14,7 @@
 , libngspice
 , libgit2
 , quazip
+, clipper
 }:
 
 let
@@ -38,24 +38,16 @@ let
   };
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "fritzing";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
-    owner = pname;
+    owner = "fritzing";
     repo = "fritzing-app";
-    rev = "8f5f1373835050ce014299c78d91c24beea9b633";
-    hash = "sha256-jLVNzSh2KwXpi3begtp/53sdBmQQbCnKMCm2p770etg=";
+    rev = "dbdbe34c843677df721c7b3fc3e32c0f737e7e95";
+    hash = "sha256-Xi5sPU2RGkqh7T+EOvwxJJKKYDhJfccyEZ8LBBTb2s4=";
   };
-
-  patches = [
-    # Fix error caused by implicit call
-    (fetchpatch {
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/0003-ParseResult-operator-bool-in-explicit.patch?h=fritzing&id=b2c79b55f0a2811e80bb1136b1e021fbc56937c9";
-      hash = "sha256-9HdcNqLHEB0HQbF7AaTdUIJUbafwsRKPA+wfF4g8veU=";
-    })
-  ];
 
   nativeBuildInputs = [ qmake pkg-config qttools wrapQtAppsHook ];
   buildInputs = [
@@ -68,6 +60,7 @@ stdenv.mkDerivation rec {
     libgit2
     quazip
     libngspice
+    clipper
   ];
 
   postPatch = ''
@@ -81,13 +74,17 @@ stdenv.mkDerivation rec {
     substituteInPlace src/fapplication.cpp \
       --replace 'PartsChecker::getSha(dir.absolutePath());' '"${partsSha}";'
 
+    substituteInPlace phoenix.pro \
+      --replace "6.5.10" "${qtbase.version}"
+
     mkdir parts
     cp -a ${parts}/* parts/
   '';
 
   env.NIX_CFLAGS_COMPILE = lib.concatStringsSep " " [
-    "-I${lib.getDev quazip}/include/QuaZip-Qt${lib.versions.major qtbase.version}-${quazip.version}/quazip"
+    "-I${lib.getDev quazip}/include/QuaZip-Qt${lib.versions.major qtbase.version}-${quazip.version}"
     "-I${svgpp}/include"
+    "-I${clipper}/include/polyclipping"
   ];
   env.NIX_LDFLAGS = "-lquazip1-qt${lib.versions.major qtbase.version}";
 


### PR DESCRIPTION
## Description of changes

Following #264092.
Closes #275458.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
