### PR TITLE
Insomnium: 0.2.3-a init.

### DIFF
--- a/pkgs/development/web/insomnium/default.nix
+++ b/pkgs/development/web/insomnium/default.nix
@@ -1,0 +1,80 @@
+{ pkgs, stdenv, lib, makeDesktopItem, makeWrapper, fetchurl, appimageTools
+, undmg, ... }:
+let
+  pname = "insomnium";
+  version = "0.2.3-a";
+  appname = "Insomnium";
+  name = "${appname}.Core-${version}";
+  meta = with lib; {
+    description =
+      "Fast local API testing tool that is privacy-focused and 100% local";
+    homepage = "https://github.com/ArchGPT/insomnium";
+    license = licenses.mit;
+    maintainers = [ "nephalemsec" ];
+  };
+
+  filename =
+    if stdenv.isDarwin then "${name}.signed.dmg" else "${name}.AppImage";
+
+  src = pkgs.fetchurl {
+    url =
+      "https://github.com/ArchGPT/insomnium/releases/download/core%40${version}/${filename}";
+    sha256 = if stdenv.isDarwin then
+      "sha256-OlYfoNNBPSMYDVSIsANKW7yy1DPkYA4x0ALgyipS2d8="
+    else
+      "sha256-hFpAFxyoBtQPH+NPeQz9wjJSpyPm6yLfjXOQSomnoXE=";
+  };
+
+  icon = fetchurl {
+    url =
+      "https://raw.githubusercontent.com/ArchGPT/insomnium/main/packages/insomnia/src/icons/icon.png";
+    hash = "sha256-oz/x2kzMOHhoTut/G9SUdI+yXNbv/RT2Y1XN49PJslo=";
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "insomnium";
+    desktopName = "Insomnium";
+    comment = "Tiling window manager for macOS along the lines of xmonad.";
+    icon = "insomnium";
+    exec = "insomnium %u";
+    categories = [ "Office" ];
+    mimeTypes = [ "x-scheme-handler/insomnium" ];
+  };
+
+  darwin = stdenv.mkDerivation {
+    inherit desktopItem icon name src;
+
+    meta = meta // { platforms = [ "x86_64-darwin" "aarch64-darwin" ]; };
+
+    sourceRoot = "${appname}.app";
+
+    nativeBuildInputs = [ makeWrapper undmg ];
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/{Applications/${appname}.app,bin}
+      cp -R . $out/Applications/${appname}.app
+      makeWrapper $out/Applications/${appname}.app/Contents/MacOS/${appname} $out/bin/${pname}
+      runHook postInstall
+    '';
+  };
+
+  linux = pkgs.appimageTools.wrapType1 {
+    inherit name src;
+
+    meta = meta // { platforms = [ "x86_64-linux" ]; };
+
+    extraInstallCommands = ''
+      mv $out/bin/${name} $out/bin/${pname}
+
+      mkdir -p $out/share/applications $out/share/icons
+      install -D ${icon} $out/share/icons/hicolor/scalable/apps/${pname}.svg
+      cp -r ${desktopItem} $out/share/applications/${name}.desktop
+    '';
+
+    extraPkgs = pkgs: with pkgs; [ mesa ];
+  };
+
+in if stdenv.isDarwin then darwin else linux
+
+


### PR DESCRIPTION
## Description of changes

Insomnium is a fast local API testing tool that is privacy-focused and 100% local. For testing GraphQL, REST, WebSockets and gRPC. This is a fork of Kong/insomnia 

https://archgpt.dev/insomnium

- Themes work
- Custom themes work
- Plugins work
- All basic functionality works

![Pasted image](https://github.com/NixOS/nixpkgs/assets/87374160/18f646ae-6d4a-483f-aa91-709d90f3c823)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
