### PR TITLE
jmeter: Fix white screen on launching jmeter gui

### DIFF
--- a/pkgs/applications/networking/jmeter/default.nix
+++ b/pkgs/applications/networking/jmeter/default.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation rec {
 
     wrapProgram $out/bin/jmeter --set JAVA_HOME "${jre}"
     wrapProgram $out/bin/jmeter.sh --set JAVA_HOME "${jre}"
+    wrapProgram $out/bin/jmeter --set _JAVA_AWT_WM_NONREPARENTING=1
   '';
 
   doInstallCheck = false; #NoClassDefFoundError: org/apache/logging/log4j/Level for tests

--- a/pkgs/applications/networking/jmeter/default.nix
+++ b/pkgs/applications/networking/jmeter/default.nix
@@ -28,9 +28,11 @@ stdenv.mkDerivation rec {
         --prefix PATH : "${jre}/bin"
     done
 
-    wrapProgram $out/bin/jmeter --set JAVA_HOME "${jre}"
-    wrapProgram $out/bin/jmeter.sh --set JAVA_HOME "${jre}"
-    wrapProgram $out/bin/jmeter --set _JAVA_AWT_WM_NONREPARENTING=1
+    wrapProgram $out/bin/jmeter \
+      --set JAVA_HOME "${jre}" \
+      --set _JAVA_AWT_WM_NONREPARENTING=1
+    wrapProgram $out/bin/jmeter.sh \
+      --set JAVA_HOME "${jre}"
   '';
 
   doInstallCheck = false; #NoClassDefFoundError: org/apache/logging/log4j/Level for tests


### PR DESCRIPTION
## Description of changes
sets  _JAVA_AWT_WM_NONREPARENTING=1 for jmeter binary which fixes the issue on linux with openjdk
Issue reported in jmeter repo [link](https://github.com/apache/jmeter/issues/5977)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
