### PR TITLE
dockerTools: add deprecation warning for dead code

### DIFF
--- a/pkgs/build-support/docker/default.nix
+++ b/pkgs/build-support/docker/default.nix
@@ -146,31 +146,40 @@ rec {
 
   # buildEnv creates symlinks to dirs, which is hard to edit inside the overlay VM
   mergeDrvs =
-    { derivations
-    , onlyDeps ? false
-    }:
-    runCommand "merge-drvs"
-      {
-        inherit derivations onlyDeps;
-      } ''
-      if [[ -n "$onlyDeps" ]]; then
-        echo $derivations > $out
-        exit 0
-      fi
+    let
+      warnMsg = "dockerTools.mergeDrvs is deprecated and will be removed after 24.05 due to lack of tests, "
+        + "documentation, being in the wrong place (its behaviour is not related to dockerTools), and "
+        + "having a misleading name. If you depend on this function, please visit "
+        + "https://github.com/NixOS/nixpkgs/issues/283952";
 
-      mkdir $out
-      for derivation in $derivations; do
-        echo "Merging $derivation..."
-        if [[ -d "$derivation" ]]; then
-          # If it's a directory, copy all of its contents into $out.
-          cp -drf --preserve=mode -f $derivation/* $out/
-        else
-          # Otherwise treat the derivation as a tarball and extract it
-          # into $out.
-          tar -C $out -xpf $drv || true
-        fi
-      done
-    '';
+      mergeDrvsFunc =
+        { derivations
+        , onlyDeps ? false
+        }:
+        runCommand "merge-drvs"
+          {
+            inherit derivations onlyDeps;
+          } ''
+          if [[ -n "$onlyDeps" ]]; then
+            echo $derivations > $out
+            exit 0
+          fi
+
+          mkdir $out
+          for derivation in $derivations; do
+            echo "Merging $derivation..."
+            if [[ -d "$derivation" ]]; then
+              # If it's a directory, copy all of its contents into $out.
+              cp -drf --preserve=mode -f $derivation/* $out/
+            else
+              # Otherwise treat the derivation as a tarball and extract it
+              # into $out.
+              tar -C $out -xpf $drv || true
+            fi
+          done
+        '';
+    in
+    lib.warn warnMsg mergeDrvsFunc;
 
   # Helper for setting up the base files for managing users and
   # groups, only if such files don't exist already. It is suitable for


### PR DESCRIPTION
## Description of changes

`dockerTools.mergeDrvs` hasn't been used since it was first introduced in commit 4a4561ce244c0cea1cb07fd02f176b11f094f570.

A [sourcegraph search](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/NixOS/nixpkgs%24+rev:4a4561ce244c0cea1cb07fd02f176b11f094f570+mergeDrvs&patternType=standard&sm=1) for `mergeDrvs` on that commit shows it wasn't used anywhere else when it was introduced, and to this day I haven't been able to find a single usage of `mergeDrvs` within Nixpkgs.

I also did a search of all public code on GitHub for `mergeDrvs` and couldn't find anyone using it for anything.

I understand why something like `mergeDrvs` would be created, but it makes some very specific assumptions about its usage, and if nobody has ever used it, it'd be best removed to reduce a little bit the maintenance overhead.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
