### PR TITLE
oterm: 0.1.18 -> 0.1.21; fix build; python311Packages.rich-pixels: fix version string

### DIFF
--- a/pkgs/by-name/ot/oterm/package.nix
+++ b/pkgs/by-name/ot/oterm/package.nix
@@ -5,14 +5,19 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "oterm";
-  version = "0.1.18";
+  version = "0.1.21";
   pyproject = true;
   src = fetchFromGitHub {
     owner = "ggozad";
     repo = "oterm";
     rev = "refs/tags/${version}";
-    hash = "sha256-hog0oEiZMxM3lM3xFZ+c15OTOwGXZ97FmG4PpyA94Ys=";
+    hash = "sha256-S6v7VDIGPu6UDbDe0H3LWF6IN0Z6ENmiCDxz+GuCibI=";
   };
+
+  pythonRelaxDeps = [
+    "pillow"
+  ];
+
   propagatedBuildInputs = with python3Packages; [
     textual
     typer
@@ -23,8 +28,18 @@ python3Packages.buildPythonApplication rec {
     pyperclip
     packaging
     rich-pixels
+    pillow
+    aiohttp
   ];
-  nativeBuildInputs = with python3Packages; [ poetry-core ];
+
+  nativeBuildInputs = with python3Packages; [
+    poetry-core
+    pythonRelaxDepsHook
+  ];
+
+  pythonImportsCheck = [
+    "oterm"
+  ];
 
   # Tests require a HTTP connection to ollama
   doCheck = false;

--- a/pkgs/development/python-modules/rich-pixels/default.nix
+++ b/pkgs/development/python-modules/rich-pixels/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , poetry-core
 , pytestCheckHook
 , syrupy
@@ -20,6 +21,14 @@ buildPythonPackage rec {
     rev = version;
     hash = "sha256-fbpnHEfBPWLSYhgETqKbdmmzt7Lu/4oKgetjgNvv04c=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "fix-version.patch";
+      url = "https://github.com/darrenburns/rich-pixels/commit/ff1cc3fef789321831f29e9bf282ae6b337eddb2.patch";
+      hash = "sha256-58ZHBNg1RCuOfuE034qF1SbAgoiWMNlSG3c5pCSLUyI=";
+    })
+  ];
 
   nativeBuildInputs = [
     poetry-core


### PR DESCRIPTION
## Description of changes

Diff: https://github.com/ggozad/oterm/compare/refs/tags/0.1.18...0.1.21

Changelog: https://github.com/ggozad/oterm/releases/tag/0.1.21

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
