### PR TITLE
grip-search: fix build with GCC 13

### DIFF
--- a/pkgs/tools/text/grip-search/default.nix
+++ b/pkgs/tools/text/grip-search/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, boost, pkg-config, cmake, catch2 }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, boost, pkg-config, cmake, catch2 }:
 
 stdenv.mkDerivation rec {
   pname = "grip-search";
@@ -17,8 +17,17 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ boost ];
 
-  patchPhase = ''
-    substituteInPlace src/general/config.h --replace "CUSTOM-BUILD" "${version}"
+  patches = [
+    # Can be removed after this upstream PR gets merged: https://github.com/sc0ty/grip/pull/6
+    (fetchpatch {
+      name = "include-cstdint.patch";
+      url = "https://github.com/sc0ty/grip/commit/da37b3c805306ee4ea617ce3f1487b8ee9876e50.patch";
+      hash = "sha256-Xh++oDn5qn5NPgng7gfeCkO5FN9OmW+8fGhDLpAJfR8=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace src/general/config.h --replace-fail "CUSTOM-BUILD" "${version}"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
`grip-search` stopped building on GCC13 due to the standard `cstdint` header not getting transitively included through other standard headers anymore.

This change pulls in a patch from an open upstream PR [^1] that adds the necessary includes.

Since the current `substituteInPlace` patch that to the built-in version string was overriding the `patches` phase (preventing a simple declarative listing of patches to be applied), I moved it to the `postPatch` hook instead.

[^1]: https://github.com/sc0ty/grip/pull/6

Failing Hydra build: https://hydra.nixos.org/build/246246828
Hydra log: https://hydra.nixos.org/build/246246828/nixlog/1

Relevant log excerpt:
```
[ 25%] Building CXX object src/general/CMakeFiles/General.dir/file.cpp.o
In file included from /build/source/src/general/file.cpp:1:
/build/source/src/general/file.h:10:27: error: 'uint8_t' was not declared in this scope
   10 | void readFile(std::vector<uint8_t> &res, const char *fname,
      |                           ^~~~~~~
/build/source/src/general/file.h:8:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
    7 | #include "error.h"
  +++ |+#include <cstdint>
    8 | 
/build/source/src/general/file.h:10:34: error: template argument 1 is invalid
   10 | void readFile(std::vector<uint8_t> &res, const char *fname,
      |                                  ^
/build/source/src/general/file.h:10:34: error: template argument 2 is invalid
```

## Description of changes

- Pull in patch from upstream PR
- Move `CUSTOM-BUILD` replacement into `postPatch` hook
- Since `substituteInPlace  --replace` has been deprecated [^2], I switched the call to `--replace-fail` instead.

[^2]: https://github.com/NixOS/nixpkgs/issues/248565#issuecomment-1761740152

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
