### PR TITLE
arc_unpacker: apply AUR patch that fixes build on GCC 13

### DIFF
--- a/pkgs/tools/archivers/arc_unpacker/default.nix
+++ b/pkgs/tools/archivers/arc_unpacker/default.nix
@@ -31,6 +31,11 @@ stdenv.mkDerivation {
       url = "https://aur.archlinux.org/cgit/aur.git/plain/failing_tests.patch?h=arc_unpacker-git&id=bda1ad9f69e6802e703b2e6913d71a36d76cfef9";
       hash = "sha256-bClACsf/+SktyLAPtt7EcSqprkw8JVIi1ZLpcJcv9IE=";
     })
+    (fetchpatch {
+      name = "include_cstdint.patch";
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/include_cstdint.patch?h=arc_unpacker-git&id=8c5c5121b23813c7650db19cb617b409d8fdcc9f";
+      hash = "sha256-3BQ1v7s9enUK/js7Jqrqo2RdSRvGVd7hMcY4iL51SiE=";
+    })
   ];
 
   postPatch = ''
@@ -86,5 +91,8 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [ midchildan ];
     platforms = platforms.all;
     mainProgram = "arc_unpacker";
+
+    # unit test failures
+    broken = stdenv.isDarwin && stdenv.isAarch64;
   };
 }


### PR DESCRIPTION
`arc_unpacker` fails to build with GCC 13 because GCC stopped transitively including `cstdint` in a lot of scenarios. While the project is inactive (the repository has been archived on GitHub), the Arch Linux user repository already contains a patch that fixes this issue.

AUR patch: https://aur.archlinux.org/cgit/aur.git/plain/include_cstdint.patch?h=arc_unpacker-git
Failing Hydra build: https://hydra.nixos.org/build/246193581
Hydra log: https://hydra.nixos.org/build/246193581/nixlog/1

Relevant log excerpt:
```
[  0%] Building CXX object CMakeFiles/libau.dir/src/algo/crypt/aes.cc.o
In file included from /build/source/build/../src/algo/crypt/aes.h:20,
                 from /build/source/src/algo/crypt/aes.cc:18:
/build/source/build/../src/types.h:25:16: error: 'uint8_t' does not name a type
   25 |     using u8 = uint8_t;
      |                ^~~~~~~
/build/source/build/../src/types.h:22:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   21 | #include <vector>
  +++ |+#include <cstdint>
   22 | 
```

## Description of changes

Pulled in the AUR patch via `fetchpatch`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
