### PR TITLE
googler: unbreak by incorporating a contributed patch

### DIFF
--- a/pkgs/applications/misc/googler/default.nix
+++ b/pkgs/applications/misc/googler/default.nix
@@ -1,15 +1,22 @@
-{ lib, stdenv, fetchFromGitHub, python, installShellFiles }:
+{ lib, stdenv, fetchFromGitHub, python, installShellFiles, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "googler";
-  version = "4.3.2";
+  version = "unstable-2024-01-05";
 
   src = fetchFromGitHub {
     owner = "jarun";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-PgWg396AQ15CAnfTXGDpSg1UXx7mNCtknEjJd/KV4MU=";
+    rev = "f55837974ae0566acd8125f59f5948be20e03b41";
+    sha256 = "sha256-kvN4i9faD82NL6e20tfIedjQsDburlLFYawQMZDmhCA=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/raffaelewylde/googler/commit/b974abc0903e7832b1d392cf26c46d04f6b36a63.patch";
+      sha256 = "sha256-Q2GUjADHu2hHUWdibPGf4kgj5z3G5RISXHP2DVRO32U=";
+    })
+  ];
 
   buildInputs = [ python ];
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

googler is a tool for searching Google from the command line. The version we currently have in nixpkgs, which is also the most recent official release, doesn't work any longer:

```
$ googler foo
/nix/store/s5ac4a3fi0zyn2g9maxz8q0pdd6q8ji3-googler-4.3.2/bin/googler:1611: DeprecationWarning: ssl.PROTOCOL_TLS is deprecated
  ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
No results.
If you believe this is a bug, please review https://git.io/googler-no-results before submitting a bug report.
```

This pull requests bumps the version to the latest commit in the official repository and furthermore incorporates a contributed patch in a fork.

It appears that googler is not maintained any more. But it was useful to me today, so I thought this PR wouldn't do any harm.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
