### PR TITLE
vllm: init at v0.3.1 with rocm support

### DIFF
--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -133,7 +133,7 @@ buildPythonPackage rec {
     changelog = "https://github.com/vllm-project/vllm/releases/tag/v${version}";
     homepage = "https://github.com/vllm-project/vllm";
     license = licenses.asl20;
-    maintainers = with maintainers; [ happysalada ];
+    maintainers = with maintainers; [ happysalada lach ];
     broken = !cudaSupport && !rocmSupport;
   };
 }

--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -1,0 +1,139 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+, which
+, ninja
+, packaging
+, setuptools
+, torch
+, wheel
+, psutil
+, ray
+, pandas
+, pyarrow
+, sentencepiece
+, numpy
+, transformers
+, xformers
+, fastapi
+, uvicorn
+, pydantic
+, aioprometheus
+, pynvml
+, cupy
+, writeShellScript
+
+, config
+
+, cudaSupport ? config.cudaSupport
+, cudaPackages ? {}
+
+, rocmSupport ? config.rocmSupport
+, rocmPackages ? {}
+, gpuTargets ? []
+}:
+
+buildPythonPackage rec {
+  pname = "vllm";
+  version = "0.3.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "vllm-project";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-hfd4ScU0mkZ7z4+w08BUA1K9bPXSiFThfiO+Ll2MTtg=";
+  };
+
+  # Otherwise it tries to enumerate host supported ROCM gfx archs, and that is not possible due to sandboxing.
+  PYTORCH_ROCM_ARCH = lib.optionalString rocmSupport (lib.strings.concatStringsSep ";" rocmPackages.clr.gpuTargets);
+
+  # xformers 0.0.23.post1 github release specifies its version as 0.0.24
+  #
+  # cupy-cuda12x is the same wheel as cupy, but built with cuda dependencies, we already have it set up
+  # like that in nixpkgs. Version upgrade is due to upstream shenanigans
+  # https://github.com/vllm-project/vllm/pull/2845/commits/34a0ad7f9bb7880c0daa2992d700df3e01e91363
+  #
+  # hipcc --version works badly on NixOS due to unresolved paths.
+  postPatch = ''
+    substituteInPlace requirements.txt \
+      --replace "xformers == 0.0.23.post1" "xformers == 0.0.24"
+    substituteInPlace requirements.txt \
+      --replace "cupy-cuda12x == 12.1.0" "cupy == 12.3.0"
+    substituteInPlace requirements-build.txt \
+      --replace "torch==2.1.2" "torch == 2.2.0"
+    substituteInPlace pyproject.toml \
+      --replace "torch == 2.1.2" "torch == 2.2.0"
+    substituteInPlace requirements.txt \
+      --replace "torch == 2.1.2" "torch == 2.2.0"
+  '' + lib.optionalString rocmSupport ''
+    substituteInPlace setup.py \
+      --replace "'hipcc', '--version'" "'${writeShellScript "hipcc-version-stub" "echo HIP version: 0.0"}'"
+  '';
+
+  preBuild = lib.optionalString cudaSupport ''
+    export CUDA_HOME=${cudaPackages.cuda_nvcc}
+  ''
+  + lib.optionalString rocmSupport ''
+    export ROCM_HOME=${rocmPackages.clr}
+    export PATH=$PATH:${rocmPackages.hipcc}
+  '';
+
+  nativeBuildInputs = [
+    ninja
+    packaging
+    setuptools
+    torch
+    wheel
+    which
+  ] ++ lib.optionals rocmSupport [
+    rocmPackages.hipcc
+  ];
+
+  buildInputs = (lib.optionals cudaSupport (with cudaPackages; [
+    cuda_cudart # cuda_runtime.h, -lcudart
+    cuda_cccl.dev # <thrust/*>
+    libcusparse.dev # cusparse.h
+    libcublas.dev # cublas_v2.h
+    libcusolver # cusolverDn.h
+  ])) ++ (lib.optionals rocmSupport (with rocmPackages; [
+    clr
+    rocthrust
+    rocprim
+    hipsparse
+    hipblas
+  ]));
+
+  propagatedBuildInputs = [
+    psutil
+    ray
+    pandas
+    pyarrow
+    sentencepiece
+    numpy
+    torch
+    transformers
+    xformers
+    fastapi
+    uvicorn
+    pydantic
+    aioprometheus
+  ] ++ uvicorn.optional-dependencies.standard
+    ++ aioprometheus.optional-dependencies.starlette
+    ++ lib.optionals cudaSupport [
+      pynvml
+      cupy
+    ];
+
+  pythonImportsCheck = [ "vllm" ];
+
+  meta = with lib; {
+    description = "A high-throughput and memory-efficient inference and serving engine for LLMs";
+    changelog = "https://github.com/vllm-project/vllm/releases/tag/v${version}";
+    homepage = "https://github.com/vllm-project/vllm";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ happysalada ];
+    broken = !cudaSupport && !rocmSupport;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16024,6 +16024,8 @@ self: super: with self; {
 
   viv-utils = callPackage ../development/python-modules/viv-utils { };
 
+  vllm = callPackage ../development/python-modules/vllm { };
+
   vmprof = callPackage ../development/python-modules/vmprof { };
 
   vncdo = callPackage ../development/python-modules/vncdo { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Depends on:

- [x] https://github.com/NixOS/nixpkgs/pull/258300 (VLLM uses newer versions of those libraries) - done in staging
- [x] https://github.com/psf/httpbin/issues/36 (As the needed for new werkzeug version is not released. VLLM doesn't depend directly on this, but httpbin is still in the dependency graph, and needs to be built.) - fix backported to staging
- [x] https://github.com/vllm-project/vllm/pull/2581 (Needed for proper sandbox support) - added patch
- [ ] https://github.com/NixOS/nixpkgs/pull/286720
- [ ] https://github.com/NixOS/nixpkgs/pull/286763

I am not very familiar with python packaging in nixos (Though, anything is better than requirements.txt)

Couple of changes were made to fix build due to conflicting dependencies:
- It now depends on torch instead of torch-bin, because plain torch dependency is propagated somewhere, together with duplicate openai-triton package
- xformers and openai-triton were also broken for me due to usage of different torch

I think the only working way here is to use `nixpkgs.config.torchSupport`/`nixpkgs.config.cudaSupport`, as overriding torch dependency doesn't work very well in this case.

It also builds with CUDA for me, though I haven't properly tested it in runtime

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
