### PR TITLE
esphome: fix compile issue, missing libstdc++.so.6

### DIFF
--- a/pkgs/tools/misc/esphome/default.nix
+++ b/pkgs/tools/misc/esphome/default.nix
@@ -6,6 +6,7 @@
 , platformio
 , esptool
 , git
+, stdenv
 }:
 
 let
@@ -80,6 +81,9 @@ python.pkgs.buildPythonApplication rec {
     "--prefix PATH : ${lib.makeBinPath [ platformio esptool git ]}"
     "--prefix PYTHONPATH : $PYTHONPATH" # will show better error messages
     "--set ESPHOME_USE_SUBPROCESS ''"
+    "--suffix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
+      stdenv.cc.cc.lib # libstdc++.so.6
+    ]}"
   ];
 
   nativeCheckInputs = with python3Packages; [


### PR DESCRIPTION
## Description of changes

Fixes this compile error when building firmware:

```console
Compiling /var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/api/api_connection.cpp.o
riscv32-esp-elf-g++: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory
Compiling /var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/api/api_frame_helper.cpp.o
riscv32-esp-elf-g++: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory
Compiling /var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/api/api_pb2.cpp.o
Compiling /var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/api/api_pb2_service.cpp.o
riscv32-esp-elf-g++: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory
riscv32-esp-elf-g++: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory
Compiling /var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/api/api_server.cpp.o
riscv32-esp-elf-g++: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory
Compiling /var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/api/list_entities.cpp.o
riscv32-esp-elf-g++: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory
Compiling /var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/api/proto.cpp.o
riscv32-esp-elf-g++: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory
Compiling /var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/api/subscribe_state.cpp.o
riscv32-esp-elf-g++: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory
Compiling /var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/api/user_services.cpp.o
riscv32-esp-elf-g++: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory
Compiling /var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/captive_portal/captive_portal.cpp.o
riscv32-esp-elf-g++: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory
Compiling /var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/esp32/core.cpp.o
riscv32-esp-elf-g++: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory
Compiling /var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/esp32/gpio.cpp.o
riscv32-esp-elf-g++: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory
Compiling /var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/esp32/preferences.cpp.o
riscv32-esp-elf-g++: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory
Compiling /var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/logger/logger.cpp.o
riscv32-esp-elf-g++: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory
Compiling /var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/md5/md5.cpp.o
riscv32-esp-elf-g++: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory
*** [/var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/api/api_connection.cpp.o] Error 127
*** [/var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/api/api_frame_helper.cpp.o] Error 127
*** [/var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/api/api_pb2.cpp.o] Error 127
*** [/var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/api/api_pb2_service.cpp.o] Error 127
*** [/var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/api/api_server.cpp.o] Error 127
*** [/var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/api/list_entities.cpp.o] Error 127
*** [/var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/api/proto.cpp.o] Error 127
*** [/var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/api/subscribe_state.cpp.o] Error 127
*** [/var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/api/user_services.cpp.o] Error 127
*** [/var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/captive_portal/captive_portal.cpp.o] Error 127
*** [/var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/esp32/core.cpp.o] Error 127
*** [/var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/esp32/gpio.cpp.o] Error 127
*** [/var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/esp32/preferences.cpp.o] Error 127
*** [/var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/logger/logger.cpp.o] Error 127
*** [/var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/md5/md5.cpp.o] Error 127
Compiling /var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/mdns/mdns_component.cpp.o
riscv32-esp-elf-g++: error while loading shared libraries: libstdc++.so.6: cannot open shared object file: No such file or directory
*** [/var/lib/esphome/.esphome/build/DEVICE_ID/.pioenvs/DEVICE_ID/src/esphome/components/mdns/mdns_component.cpp.o] Error 127
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
