### PR TITLE
python311Packages.blosc2: 2.3.2 -> 2.5.1

### DIFF
--- a/pkgs/development/python-modules/blosc2/default.nix
+++ b/pkgs/development/python-modules/blosc2/default.nix
@@ -1,46 +1,34 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
-
-# build-system
 , cmake
 , cython_3
-, ninja
-, oldest-supported-numpy
-, scikit-build
-, setuptools
-, wheel
-
-# propagates
+, fetchFromGitHub
 , msgpack
 , ndindex
+, ninja
 , numpy
-, py-cpuinfo
-, rich
-
-# tests
+, oldest-supported-numpy
 , psutil
+, py-cpuinfo
 , pytestCheckHook
+, scikit-build
+, setuptools
 , torch
+, wheel
 }:
 
 buildPythonPackage rec {
   pname = "blosc2";
-  version = "2.3.2";
-  format = "pyproject";
+  version = "2.5.1";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Blosc";
     repo = "python-blosc2";
     rev = "refs/tags/v${version}";
     fetchSubmodules = true;
-    hash = "sha256-tRcyntJlmLPbqnX7nzdBQ/50uXy0fVLb2YGVOIwJjxU=";
+    hash = "sha256-72TBZ0EXMz8BeKJxjnG44//ICgdvoZG9gYC4gdq3+nA=";
   };
-
-  postPatch = ''
-    substituteInPlace requirements-runtime.txt \
-      --replace "pytest" ""
-  '';
 
   nativeBuildInputs = [
     cmake
@@ -59,13 +47,16 @@ buildPythonPackage rec {
     ndindex
     numpy
     py-cpuinfo
-    rich
   ];
 
   nativeCheckInputs = [
     psutil
     pytestCheckHook
     torch
+  ];
+
+  pythonImportsCheck = [
+    "blosc2"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
Diff: https://github.com/Blosc/python-blosc2/compare/refs/tags/v2.3.2...v2.5.1

Changelog: https://github.com/Blosc/python-blosc2/releases/tag/v2.5.1

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
