### PR TITLE
openrocket: init at 23.09

### DIFF
--- a/pkgs/by-name/op/openrocket/package.nix
+++ b/pkgs/by-name/op/openrocket/package.nix
@@ -1,0 +1,71 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, ant
+, jdk17
+, makeWrapper
+}:
+
+let
+  jdk = jdk17; # Only java 17 is supported as of 23.09
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "openrocket";
+  version = "23.09";
+
+  src = fetchFromGitHub {
+    owner = "openrocket";
+    repo = "openrocket";
+    rev = "release-${finalAttrs.version}";
+    hash = "sha256-Dg/v72N9cDG9Ko5JIcZxGxh+ClRDgf5Jq5DvQyCiYOs=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    ant
+    jdk
+    makeWrapper
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    ant
+    runHook postBuild
+  '';
+
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+    ant unittest
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    sed -i "s|Icon=.*|Icon=openrocket|g" snap/gui/openrocket.desktop
+    install -Dm644 snap/gui/openrocket.desktop -t $out/share/applications
+    install -Dm644 snap/gui/openrocket.png -t $out/share/icons/hicolor/256x256/apps
+    install -Dm644 swing/build/jar/OpenRocket.jar -t $out/share/openrocket
+
+    makeWrapper ${jdk}/bin/java $out/bin/openrocket \
+        --add-flags "-jar $out/share/openrocket/OpenRocket.jar"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    changelog = "https://github.com/openrocket/openrocket/releases/tag/${finalAttrs.src.rev}";
+    description = "Model-rocketry aerodynamics and trajectory simulation software";
+    homepage = "openrocket.info";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "openrocket";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = jdk.meta.platforms;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode # source bundles dependencies as jars
+    ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/274805

This PR adds 1 package: `openrocket`

I won't worry about reproducibility until https://github.com/NixOS/nixpkgs/pull/278322 is merged. For now this is just for the package to exist.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
