### PR TITLE
xmage: 1.4.50V2 -> 1.4.51-dev_2024-01-20_14-01

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -355,6 +355,12 @@
     githubId = 13504599;
     name = "Adam Boseley";
   };
+  abueide = {
+    email = "andrea@abueide.com";
+    github = "abueide";
+    githubId = 19354425;
+    name = "Andrea Bueide";
+  };
   abuibrahim = {
     email = "ruslan@babayev.com";
     github = "abuibrahim";

--- a/pkgs/games/xmage/default.nix
+++ b/pkgs/games/xmage/default.nix
@@ -2,33 +2,35 @@
 , stdenv
 , fetchurl
 , jdk8
-, unzip
+, unzrip
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xmage";
-  version = "1.4.50V2";
+  version = "1.4.51-dev_2024-01-30_19-35";
 
   src = fetchurl {
-    url =
-      "https://github.com/magefree/mage/releases/download/xmage_${finalAttrs.version}/xmage_${finalAttrs.version}.zip";
-    sha256 = "sha256-t1peHYwCRy3wiIIwOD3nUyoxSOxbw6B/g++A1ofIbmg=";
+    url = "http://xmage.today/files/mage-full_${finalAttrs.version}.zip";
+    sha256 = "sha256-ogi0hd2FoulTnc3gg5cpLwr4Jln71YA0WBBZFOT6apg=";
   };
 
   preferLocalBuild = true;
 
   unpackPhase = ''
-    ${unzip}/bin/unzip $src
+    ${unzrip}/bin/unzrip $src
   '';
 
   installPhase = let
-    strVersion = lib.substring 0 6 finalAttrs.version;
+  # upstream maintainers forgot to update version, so manual override for now
+  # strVersion = lib.substring 0 6 finalAttrs.version;
+  strVersion = "1.4.50";
+
   in ''
     mkdir -p $out/bin
     cp -rv ./* $out
 
     cat << EOS > $out/bin/xmage
-    exec ${jdk8}/bin/java -Xms256m -Xmx512m -XX:MaxPermSize=384m -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -jar $out/mage-client/lib/mage-client-${strVersion}.jar
+    exec ${jdk8}/bin/java -Xms256m -Xmx1024m -XX:MaxPermSize=384m -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -jar $out/xmage/mage-client/lib/mage-client-${strVersion}.jar
     EOS
 
     chmod +x $out/bin/xmage

--- a/pkgs/games/xmage/default.nix
+++ b/pkgs/games/xmage/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Magic Another Game Engine";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.mit;
-    maintainers = with maintainers; [ matthiasbeyer ];
+    maintainers = with maintainers; [ matthiasbeyer abueide ];
     homepage = "http://xmage.de/";
   };
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
-  Update xmage to latest xmage.today release  
- Fix jar path by overriding version
- Fix unzipping issue with file path decoding error by switching to unzrip
- Update hash
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
