### PR TITLE
bugdom: 1.3.3 -> 1.3.4

### DIFF
--- a/pkgs/games/bugdom/default.nix
+++ b/pkgs/games/bugdom/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "bugdom";
-  version = "1.3.3";
+  version = "1.3.4";
 
   src = fetchFromGitHub {
     owner = "jorio";
     repo = pname;
     rev = version;
-    hash = "sha256-oe7xxvoL82YF+EoIJDK6AfN3PmpqeGRlIsbaGx8xGeM=";
+    hash = "sha256-0c7v5tSqYuqtLOFl4sqD7+naJNqX/wlKHVntkZQGJ8A=";
     fetchSubmodules = true;
   };
 
@@ -51,8 +51,8 @@ stdenv.mkDerivation rec {
     mv Data $out/share/bugdom
     install -Dm755 {.,$out/bin}/Bugdom
     wrapProgram $out/bin/Bugdom --run "cd $out/share/bugdom"
-    install -Dm644 $src/packaging/bugdom.desktop $out/share/applications/bugdom.desktop
-    install -Dm644 $src/packaging/bugdom-desktopicon.png $out/share/pixmaps/bugdom-desktopicon.png
+    install -Dm644 $src/packaging/io.jor.bugdom.desktop $out/share/applications/io.jor.bugdom.desktop
+    install -Dm644 $src/packaging/io.jor.bugdom.png $out/share/pixmaps/io.jor.bugdom.png
   '') + ''
 
     runHook postInstall


### PR DESCRIPTION
`bugdom` failed to build on GCC 13 because GCC stopped transitively including `cstdint` in many scenarios and its external dependency `Pomme` didn't properly include `cstdint` in all of its headers.

Luckily, this issue has already been fixed by upstream `Pomme` and the fix has also been pulled into the latest `bugdom` release.

Failing Hydra build: https://hydra.nixos.org/build/246195951
Hydra log: https://hydra.nixos.org/build/246195951/nixlog/1

Relevant log excerpt:
```
[  2%] Building CXX object extern/Pomme/CMakeFiles/Pomme.dir/src/PommeDebug.cpp.o
In file included from /build/source/extern/Pomme/src/PommeDebug.cpp:1:
/build/source/extern/Pomme/src/PommeDebug.h:21:34: error: 'uint32_t' was not declared in this scope
   21 |         std::string FourCCString(uint32_t t, char filler = '?');
      |                                  ^~~~~~~~
/build/source/extern/Pomme/src/PommeDebug.h:7:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
    6 | #include <sstream>
  +++ |+#include <cstdint>
    7 | 
```

## Description of changes

Update Bugdom to v. 1.3.4

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
