### PR TITLE
linux: CONFIG_LED_TRIGGER_PHY=y

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -1023,6 +1023,9 @@ let
       # Bump the maximum number of CPUs to support systems like EC2 x1.*
       # instances and Xeon Phi.
       NR_CPUS = freeform "384";
+
+      # Enable LEDS to display link-state status of PHY devices (i.e. eth lan/wan interfaces)
+      LED_TRIGGER_PHY = whenAtLeast "4.10" yes;
     } // optionalAttrs (stdenv.hostPlatform.system == "armv7l-linux" || stdenv.hostPlatform.system == "aarch64-linux") {
       # Enables support for the Allwinner Display Engine 2.0
       SUN8I_DE2_CCU = yes;


### PR DESCRIPTION
## Motivation

There are many minipcs (i.e. [nanopi  r5c](https://www.friendlyelec.com/index.php?route=product/product&product_id=290), [nanopi r4s](https://www.friendlyelec.com/index.php?route=product/product&product_id=284)) that have LED indicators on the front panel labelled with the names
of ethernet PHY interfaces (i.e. LAN, WAN). However, with the default NixOS kernel build the LEDS are always off.

The LEDs can be turned-on manually by `echo 1 > /sys/class/leds/<led_name>/brightness`. But this is not a solution as the point of the LEDs is to display link state of respective PHY devices.

The [CONFIG_LED_TRIGGER_PHY](https://cateee.net/lkddb/web-lkddb/LED_TRIGGER_PHY.html) option enables LED tracking of PHY device link states.


## Comparion with other distributions.

As requested by respective [wiki](https://nixos.wiki/wiki/Linux_kernel#Requesting_a_change_in_the_default_nixos_kernel_configuration) this is to show which distro's compile their kernels with this option enabled:

1.  Arch: [enabled](https://github.com/archlinux/svntogit-packages/blob/b14ac92f4d7fcb63c544efaf809b2c9f681a2c7b/trunk/config#L3491)
2.  Debian: [enabled](https://salsa.debian.org/kernel-team/linux/blob/46d2e0c5d5a1bcfb363a10bdb04a8ffd23d2f54a/debian/config/config#L3753)
3. Fedora: [enabled](https://src.fedoraproject.org/rpms/kernel/blob/rawhide/f/kernel-x86_64-fedora.config#_3616)


I've tested the option by enabling it using kernelPatch (following some [prior art](https://alanpearce.eu/post/nixos-on-nanopi-r5s/)). It worked as expected:


```
  boot.kernelPatches = [
    {
      name = "status-leds.patch";
      patch = null;
      extraConfig = ''
        LED_TRIGGER_PHY y
      '';
      }
  ];
```

