### PR TITLE
inflow: init at 1.0.1

### DIFF
--- a/pkgs/by-name/in/inflow/package.nix
+++ b/pkgs/by-name/in/inflow/package.nix
@@ -1,0 +1,76 @@
+{ lib, stdenv, fetchFromGitHub, runCommand, inflow, diffutils }:
+
+stdenv.mkDerivation rec {
+  pname = "inflow";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "stephen-huan";
+    repo = "inflow";
+    rev = "v${version}";
+    sha256 = "sha256-xKUqkrPwITai8g6U1NiNieAip/AzISgFfFtvR30hLNk=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    $CXX -Wall -Wpedantic -Wextra -O3 -o inflow inflow.cpp
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 inflow -t $out/bin
+
+    runHook postInstall
+  '';
+
+  passthru.tests = {
+    reflowWithLineLength = runCommand "${pname}-test"
+      {
+        nativeBuildInputs = [ inflow ];
+        buildInputs = [ diffutils ];
+      } ''
+      cat <<EOF > input.txt
+      xxxxx xxx xxx xxxx xxxxxxxxx xx x xxxxxxxxx x xxxx xxxx xxxxxxx xxxxxxxx xxx
+      xxxxxxxxx xxxxxxxx xx xx xxxxx xxxxx xxxx xx x xxxx xx xxxxxxxx xxxxxxxx xxxx
+      xxx xxxx xxxx xxx xxxxxxxxxxxxxxxxxxx xxxxxxxxxxxxx xxx xxxxx xx xxxx x xxxx
+      xxxxxxxx xxxx xxxx xx xxxxx xxxx xxxxx xxxx xxxxxxxxx xxx xxxxxxxxxxx xxxxxx
+      xxx xxxxxxxxx xxxx xxxx xx x xx xxxx xxx xxxx xx xxx xxx xxxxxxxxxxx xxxx xxxxx
+      x xxxxx xxxxxxx xxxxxxx xx xx xxxxxx xx xxxxx
+      EOF
+
+      inflow 72 < input.txt > actual.txt
+
+      cat <<EOF > expected.txt
+      xxxxx xxx xxx xxxx xxxxxxxxx xx x xxxxxxxxx x xxxx xxxx xxxxxxx
+      xxxxxxxx xxx xxxxxxxxx xxxxxxxx xx xx xxxxx xxxxx xxxx xx x xxxx
+      xx xxxxxxxx xxxxxxxx xxxx xxx xxxx xxxx xxx xxxxxxxxxxxxxxxxxxx
+      xxxxxxxxxxxxx xxx xxxxx xx xxxx x xxxx xxxxxxxx xxxx xxxx xx xxxxx
+      xxxx xxxxx xxxx xxxxxxxxx xxx xxxxxxxxxxx xxxxxx xxx xxxxxxxxx
+      xxxx xxxx xx x xx xxxx xxx xxxx xx xxx xxx xxxxxxxxxxx xxxx xxxxx
+      x xxxxx xxxxxxx xxxxxxx xx xx xxxxxx xx xxxxx
+      EOF
+
+      if ! cmp --silent expected.txt actual.txt
+      then
+        echo "Error: actual.txt and expected.txt are different"
+        diff actual.txt expected.txt
+        exit 1
+      fi
+
+      touch $out
+    '';
+  };
+
+  meta = with lib; {
+    description = "Variance-optimal paragraph formatter";
+    homepage = "https://github.com/stephen-huan/inflow";
+    license = licenses.unlicense;
+    mainProgram = "inflow";
+    maintainers = with maintainers; [ fbrs ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

Add [`inflow`](https://github.com/stephen-huan/inflow) (see also this [blog post](https://cgdct.moe/blog/far/)) a paragraph formatter, created and maintained by @stephen-huan 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
