### PR TITLE
prometheus-libvirt-exporter: init at 2.3.3 and add the prometheus module

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -52,6 +52,7 @@ let
     "keylight"
     "klipper"
     "knot"
+    "libvirt"
     "lnd"
     "mail"
     "mikrotik"

--- a/nixos/modules/services/monitoring/prometheus/exporters/libvirt.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/libvirt.nix
@@ -1,0 +1,29 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.prometheus.exporters.libvirt;
+in
+{
+  port = 9177;
+  extraOpts = {
+    libvirtUri = lib.mkOption {
+      type = lib.types.str;
+      default = "qemu:///system";
+      description = "Libvirt URI from which to extract metrics";
+    };
+  };
+  serviceOpts = {
+    serviceConfig = {
+      ExecStart = ''
+        ${lib.getExe pkgs.prometheus-libvirt-exporter} \
+        --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
+        --libvirt.uri ${cfg.libvirtUri} ${lib.concatStringsSep " " cfg.extraFlags}
+      '';
+    };
+  };
+}

--- a/pkgs/by-name/pr/prometheus-libvirt-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-libvirt-exporter/package.nix
@@ -1,8 +1,9 @@
-{ lib
-, buildGoModule
-, fetchFromGitHub
-, pkg-config
-, libvirt
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  pkg-config,
+  libvirt,
 }:
 
 buildGoModule rec {
@@ -18,17 +19,11 @@ buildGoModule rec {
 
   vendorHash = null;
 
-  ldflags = [
-    "-X=main.Version=${version}"
-  ];
+  ldflags = [ "-X=main.Version=${version}" ];
 
-  buildInputs = [
-    libvirt
-  ];
+  buildInputs = [ libvirt ];
 
-  nativeBuildInputs = [
-    pkg-config
-  ];
+  nativeBuildInputs = [ pkg-config ];
 
   meta = with lib; {
     description = "Prometheus metrics exporter for libvirt";

--- a/pkgs/by-name/pr/prometheus-libvirt-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-libvirt-exporter/package.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, pkg-config
+, libvirt
+}:
+
+buildGoModule rec {
+  pname = "prometheus-libvirt-exporter";
+  version = "2.3.3";
+
+  src = fetchFromGitHub {
+    owner = "Tinkoff";
+    repo = "libvirt-exporter";
+    rev = "refs/tags/${version}";
+    hash = "sha256-loh7fgeF1/OuTt2MQSkl/7VnX25idoF57+HtzV9L/ns=";
+  };
+
+  vendorHash = null;
+
+  ldflags = [
+    "-X=main.Version=${version}"
+  ];
+
+  buildInputs = [
+    libvirt
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  meta = with lib; {
+    description = "Prometheus metrics exporter for libvirt";
+    homepage = "https://github.com/Tinkoff/libvirt-exporter";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ farcaller ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This adds the [libvirt exporter](https://github.com/Tinkoff/libvirt-exporter) for prometheus and the relevant exporter module.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
