### PR TITLE
cling, xeus-cling: vendor llvm

### DIFF
--- a/pkgs/applications/editors/jupyter-kernels/xeus-cling/xeus-cling.nix
+++ b/pkgs/applications/editors/jupyter-kernels/xeus-cling/xeus-cling.nix
@@ -1,11 +1,8 @@
 { lib
-, callPackage
 , clangStdenv
 , cmake
 , fetchFromGitHub
-, gcc
-, git
-, llvmPackages_9
+, fetchpatch
 # Libraries
 , argparse
 , cling
@@ -52,6 +49,11 @@ clangStdenv.mkDerivation rec {
   patches = [
     ./0001-Fix-bug-in-extract_filename.patch
     ./0002-Don-t-pass-extra-includes-configure-this-with-flags.patch
+    (fetchpatch {
+      name = "0002-Use-llvm-from-cling.patch";
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/0002-Use-llvm-from-cling.patch?h=xeus-cling&id=294d0aa6648c0f8a95fd0435c993130627059934";
+      hash = "sha256-z3KUYMEc4RqLwzbb4hC9qBRBYsB1jtLIRt8fWb3zj5k=";
+    })
   ];
 
   nativeBuildInputs = [ cmake ];
@@ -60,7 +62,6 @@ clangStdenv.mkDerivation rec {
     cling.unwrapped
     cppzmq
     libuuid
-    llvmPackages_9.llvm
     ncurses
     openssl
     pugixml

--- a/pkgs/development/interpreters/cling/no-clang-cpp.patch
+++ b/pkgs/development/interpreters/cling/no-clang-cpp.patch
@@ -1,7 +1,7 @@
-diff --git a/tools/driver/CMakeLists.txt b/tools/driver/CMakeLists.txt
+diff --git a/tools/clang/tools/driver/CMakeLists.txt b/tools/clang/tools/driver/CMakeLists.txt
 index 590d708d83..340ae529d4 100644
---- a/tools/driver/CMakeLists.txt
-+++ b/tools/driver/CMakeLists.txt
+--- a/tools/clang/tools/driver/CMakeLists.txt
++++ b/tools/clang/tools/driver/CMakeLists.txt
 @@ -63,7 +63,7 @@ endif()
  add_dependencies(clang clang-resource-headers)
 


### PR DESCRIPTION
## Description of changes

This PR attempts to build Cling with root's LLVM fork, as the packages involved are the last blockers for the removal of LLVM 8-11 in Nixpkgs (see #283954). The refactor basically follows https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=cling.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
