### PR TITLE
incus-unwrapped: 0.4.0 -> 0.5.1

### DIFF
--- a/pkgs/by-name/in/incus-unwrapped/package.nix
+++ b/pkgs/by-name/in/incus-unwrapped/package.nix
@@ -99,7 +99,7 @@ buildGoModule rec {
   meta = {
     description = "Powerful system container and virtual machine manager";
     homepage = "https://linuxcontainers.org/incus";
-    changelog = "https://github.com/lxc/incus/releases/tag/incus-${version}";
+    changelog = "https://github.com/lxc/incus/releases/tag/v${version}";
     license = lib.licenses.asl20;
     maintainers = lib.teams.lxc.members;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/in/incus-unwrapped/package.nix
+++ b/pkgs/by-name/in/incus-unwrapped/package.nix
@@ -1,7 +1,6 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
-, fetchpatch
 , acl
 , cowsql
 , hwdata
@@ -17,24 +16,16 @@
 
 buildGoModule rec {
   pname = "incus-unwrapped";
-  version = "0.4.0";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "lxc";
     repo = "incus";
     rev = "refs/tags/v${version}";
-    hash = "sha256-crWepf5j3Gd1lhya2DGIh/to7l+AnjKJPR+qUd9WOzw=";
+    hash = "sha256-GpCKfr07/JJz5YS/MuqRkanGfMgV9r+cCEDIuHTISKE=";
   };
 
-  vendorHash = "sha256-YfUvkN1qUS3FFKb1wysg40WcJA8fT9SGDChSdT+xnkc=";
-
-  patches = [
-    # remove with > 0.4.0
-    (fetchpatch {
-      url = "https://github.com/lxc/incus/commit/c0200b455a1468685d762649120ce7e2bb25adc9.patch";
-      hash = "sha256-4fiSv6GcsKpdLh3iNbw3AGuDzcw1EadUvxtSjxRjtTA=";
-    })
-  ];
+  vendorHash = "sha256-2ZJU7WshN4UIbJv55bFeo9qiAQ/wxu182mnz7pE60xA=";
 
   postPatch = ''
     substituteInPlace internal/usbid/load.go \

--- a/pkgs/by-name/in/incus-unwrapped/package.nix
+++ b/pkgs/by-name/in/incus-unwrapped/package.nix
@@ -16,13 +16,13 @@
 
 buildGoModule rec {
   pname = "incus-unwrapped";
-  version = "0.5.0";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "lxc";
     repo = "incus";
     rev = "refs/tags/v${version}";
-    hash = "sha256-GpCKfr07/JJz5YS/MuqRkanGfMgV9r+cCEDIuHTISKE=";
+    hash = "sha256-3eWkQT2P69ZfN62H9B4WLnmlUOGkpzRR0rctgchP+6A=";
   };
 
   vendorHash = "sha256-2ZJU7WshN4UIbJv55bFeo9qiAQ/wxu182mnz7pE60xA=";


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/lxc/incus/releases/tag/v0.5.0
Changelog: https://github.com/lxc/incus/releases/tag/v0.5.1


I have not bumped lxd-to-incus, since upstream merged this separate package into the main go.mod file. I have a refactor in the works that will collapse all the incus stuff into one package, but instead of waiting on that I will instead suggest we bump incus first.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
