### PR TITLE
ocamlPackages.timedesc: init at 2.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/timedesc/default.nix
+++ b/pkgs/development/ocaml-modules/timedesc/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, fetchurl
+, buildDunePackage
+, angstrom
+, ptime
+, seq
+, timedesc-tzdb
+, timedesc-tzlocal
+}:
+
+buildDunePackage rec {
+  pname = "timedesc";
+  version = "2.0.0";
+
+  src = fetchurl {
+    url = "https://github.com/daypack-dev/timere/releases/download/timedesc-${version}/timedesc-${version}.tar.gz";
+    hash = "sha256-NnnQpWOE1mt/F5lkWRPdDwpqXCUlcNi+Z5GE6YQQLK8=";
+  };
+
+  sourceRoot = ".";
+
+  propagatedBuildInputs = [
+    angstrom
+    ptime
+    seq
+    timedesc-tzdb
+    timedesc-tzlocal
+  ];
+
+  meta = {
+    description = "OCaml date time handling library";
+    homepage = "https://github.com/daypack-dev/timere";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/timedesc/tzdb.nix
+++ b/pkgs/development/ocaml-modules/timedesc/tzdb.nix
@@ -1,0 +1,15 @@
+{ lib
+, buildDunePackage
+, timedesc
+}:
+
+buildDunePackage {
+  pname = "timedesc-tzdb";
+
+  inherit (timedesc) version src sourceRoot;
+
+  meta = timedesc.meta // {
+    description = "Virtual library for Timedesc time zone database backends";
+  };
+}
+

--- a/pkgs/development/ocaml-modules/timedesc/tzlocal.nix
+++ b/pkgs/development/ocaml-modules/timedesc/tzlocal.nix
@@ -1,0 +1,16 @@
+{ lib
+, buildDunePackage
+, timedesc
+}:
+
+buildDunePackage {
+  pname = "timedesc-tzlocal";
+
+  inherit (timedesc) version src sourceRoot;
+
+  minimalOCamlVersion = "4.08";
+
+  meta = timedesc.meta // {
+    description = "Virtual library for Timedesc local time zone detection backends";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1757,6 +1757,10 @@ let
 
     timed = callPackage ../development/ocaml-modules/timed { };
 
+    timedesc = callPackage ../development/ocaml-modules/timedesc { };
+    timedesc-tzdb = callPackage ../development/ocaml-modules/timedesc/tzdb.nix { };
+    timedesc-tzlocal = callPackage ../development/ocaml-modules/timedesc/tzlocal.nix { };
+
     tiny_httpd = callPackage ../development/ocaml-modules/tiny_httpd { };
 
     tls = callPackage ../development/ocaml-modules/tls { };


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
