### PR TITLE
colobot: 0.2.0-alpha -> 0.2.1-alpha

### DIFF
--- a/pkgs/games/colobot/default.nix
+++ b/pkgs/games/colobot/default.nix
@@ -9,13 +9,13 @@ stdenv.mkDerivation rec {
   pname = "colobot";
   # Maybe require an update to package colobot-data as well
   # in file data.nix next to this one
-  version = "0.2.0-alpha";
+  version = "0.2.1-alpha";
 
   src = fetchFromGitHub {
     owner = "colobot";
     repo = pname;
     rev = "colobot-gold-${version}";
-    sha256 = "sha256-Nu7NyicNIk5yza9sXfd4KbGdB65guVuGREd6rwRU3lU=";
+    hash = "sha256-3iea2+5xCT0//NAjMHrynZKSoiOSgLTNMUQkRhXuXg8=";
   };
 
   nativeBuildInputs = [ cmake xmlstarlet doxygen python3 ];


### PR DESCRIPTION
`colobot` 0.2.0 stopped building with GCC 13, as GCC stopped transitively including standard header files like `cstdint` in various scenarios. Luckily, these issues were already solved upstream, and simply upgrading colobot to v. 0.2.1-alpha fixes the Nixpkgs build on current GCC versions.

Failing Hydra build: https://hydra.nixos.org/build/246302318/nixlog/1
Hydra log: https://hydra.nixos.org/build/246302318/nixlog/1

Relevant log excerpt:
```
[ 11%] Building CXX object src/CMakeFiles/colobotbase.dir/common/restext.cpp.o
In file included from /build/source/src/CBot/CBot.h:26,
                 from /build/source/src/common/restext.cpp:23:
/build/source/src/CBot/CBotFileUtils.h:93:38: error: 'uint32_t' has not been declared
   93 | bool WriteUInt32(std::ostream &ostr, uint32_t i);
      |                                      ^~~~~~~~
/build/source/src/CBot/CBotFileUtils.h:101:37: error: 'uint32_t' has not been declared
  101 | bool ReadUInt32(std::istream &istr, uint32_t &i);
      |                                     ^~~~~~~~
```

## Description of changes

Update `colobot` from v. 0.2.0-alpha to 0.2.1-alpha.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
