### PR TITLE
cringify: 0.1.1 -> 0.2.0

### DIFF
--- a/pkgs/by-name/cr/cringify/package.nix
+++ b/pkgs/by-name/cr/cringify/package.nix
@@ -1,28 +1,35 @@
 { lib
 , rustPlatform
 , fetchFromGitHub
+, python3
+, testers
+, cringify
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "cringify";
-  version = "0.1.1";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "sansyrox";
     repo = "cringify";
-    rev = "dd753818f8dd4b343be9370d2c29a6be070ad791";
-    hash = "sha256-6hSgOk9DzDfGtZX1vt6AQsKSLdPdqy2Mz3UtK6d2AuA=";
+    rev = "857c2620ac9f1f53139d3a599e55679a75e77053";
+    hash = "sha256-U0tKYFRZToMALSeItn9yia7Dl7omETDTkuRlWJ8EZEo=";
   };
 
-  cargoHash = "sha256-w6lqPyUCaXZBQ1EmMyj0sVnEHugMD6JugIIK0rEa19Y=";
+  cargoHash = "sha256-OQXGn6m6VdSlxaCPRonjvEo/GOpsEiZkqL12UdoLu0Q=";
 
   postPatch = ''
-    # Upstream forgot to update the version value
-    substituteInPlace src/main.rs --replace '0.1.0' ${version}
+    # Upstream doesn't set the version string itself
+    substituteInPlace src/main.rs --replace '0.0.1' ${version}
   '';
+
+  nativeBuildInputs = [ python3 ];
 
   # No tests are present in the repository
   doCheck = false;
+
+  passthru.tests.version = testers.testVersion { package = cringify; };
 
   meta = {
     description = "Annoy your friends with the cringified text";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7285,8 +7285,6 @@ with pkgs;
 
   createrepo_c = callPackage ../tools/package-management/createrepo_c { };
 
-  cringify = callPackage ../tools/text/cringify { };
-
   cromfs = callPackage ../tools/archivers/cromfs { };
 
   cron = callPackage ../tools/system/cron { };


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/284017

This PR updates the version of the `cringify` package.

I added a test to check if the version-replacement went fine.

I also moved the package to `pkgs/by-name`

The package now requires `python3` to compile the library which is located in `$out/lib/libringify.so`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
