### PR TITLE
commandergenius: 2.3.3 -> 3.5.0

### DIFF
--- a/pkgs/games/commandergenius/default.nix
+++ b/pkgs/games/commandergenius/default.nix
@@ -1,19 +1,32 @@
-{ lib, stdenv, fetchFromGitLab, SDL2, SDL2_image, pkg-config
-, libvorbis, libGL, boost, cmake, zlib, curl, SDL2_mixer, python3
+{ lib
+, stdenv
+, fetchFromGitLab
+, SDL2
+, SDL2_image
+, pkg-config
+, libvorbis
+, libGL
+, boost
+, cmake
+, zlib
+, curl
+, SDL2_mixer
+, SDL2_ttf
+, python3
 }:
 
 stdenv.mkDerivation rec {
   pname = "commandergenius";
-  version = "2.3.3";
+  version = "3.5.0";
 
   src = fetchFromGitLab {
     owner = "Dringgstein";
     repo = "Commander-Genius";
     rev = "v${version}";
-    sha256 = "04nb23wwvc3yywz3cr6gvn02fa7psfs22ssg4wk12s08z1azvz3h";
+    hash = "sha256-w5DP7vkvWOs8qcHqoQaEWHnaBwUoi1I4gnE+Z3haHxE=";
   };
 
-  buildInputs = [ SDL2 SDL2_image SDL2_mixer libGL boost libvorbis zlib curl python3 ];
+  buildInputs = [ SDL2 SDL2_image SDL2_mixer SDL2_ttf libGL boost libvorbis zlib curl python3 ];
 
   preConfigure = ''
     export cmakeFlags="$cmakeFlags -DCMAKE_INSTALL_PREFIX=$out -DSHAREDIR=$out/share"


### PR DESCRIPTION
The currently packaged version of `Commander-Genius` stopped building with GCC 13, because GCC stopped transitively pulling in a couple of standard headers in various scenarios. Among these is `cstdint`, which declares a couple of standard integer types like `uint32_t`.

At the same time, the currently packaged version is rather old already, and these build issues have been resolved upstream in newer versions.

This change updates `Commander-Genius` to the most recent upstream release, fixing said build issues in the process as a side effect.

Failing Hydra build: https://hydra.nixos.org/build/246237074
Hydra log: https://hydra.nixos.org/build/246237074/nixlog/1

Relevant log excerpt:
```
[ 27%] Building CXX object src/engine/refkeen/kdreams/CMakeFiles/refkeen_kdreams.dir/id_ca.cpp.o
In file included from /build/source/GsKit/base/utils/FindFile.h:28,
                 from /build/source/src/engine/refkeen/kdreams/id_ca.cpp:21:
/build/source/GsKit/base/utils/Unicode.h:16:9: error: 'uint32_t' does not name a type
   16 | typedef uint32_t UnicodeChar;
      |         ^~~~~~~~
/build/source/GsKit/base/utils/Unicode.h:1:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
  +++ |+#include <cstdint>
    1 | /*
```

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
