### PR TITLE
picard: set path for localedir build option

### DIFF
--- a/pkgs/applications/audio/picard/default.nix
+++ b/pkgs/applications/audio/picard/default.nix
@@ -60,7 +60,7 @@ pythonPackages.buildPythonApplication rec {
     pyyaml
   ];
 
-  setupPyGlobalFlags = [ "build" "--disable-autoupdate" ];
+  setupPyGlobalFlags = [ "build" "--disable-autoupdate" "--localedir=$out/share/locale" ];
 
   preCheck = ''
     export HOME=$(mktemp -d)


### PR DESCRIPTION
## Description of changes
All locales have already been installed, but without "localedir" build option picard will look at default "/usr/share/locale" path. For example, some debug info:
```
D: 19:20:42,618 i18n.setup_gettext:154: Trying locales: []
D: 19:20:42,618 i18n.set_locale_from_env:74: Setting locale from env: 'ru_RU.UTF-8'
D: 19:20:42,618 i18n.setup_gettext:171: Using locale: 'ru_RU.UTF-8'
D: 19:20:42,618 i18n._load_translation:118: Loading gettext translation for picard, localedir='/usr/share/locale', language='ru_RU.UTF-8'
D: 19:20:42,619 i18n._load_translation:121: [Errno 2] No translation file found for domain: 'picard'
D: 19:20:42,619 i18n._load_translation:118: Loading gettext translation for picard-attributes, localedir='/usr/share/locale', language='ru_RU.UTF-8'
D: 19:20:42,619 i18n._load_translation:121: [Errno 2] No translation file found for domain: 'picard-attributes'
D: 19:20:42,619 i18n._load_translation:118: Loading gettext translation for picard-constants, localedir='/usr/share/locale', language='ru_RU.UTF-8'
D: 19:20:42,619 i18n._load_translation:121: [Errno 2] No translation file found for domain: 'picard-constants'
D: 19:20:42,619 i18n._load_translation:118: Loading gettext translation for picard-countries, localedir='/usr/share/locale', language='ru_RU.UTF-8'
D: 19:20:42,619 i18n._load_translation:121: [Errno 2] No translation file found for domain: 'picard-countries'
```

with localedir:

```
D: 19:24:25,944 i18n.setup_gettext:154: Trying locales: []
D: 19:24:25,944 i18n.set_locale_from_env:74: Setting locale from env: 'ru_RU.UTF-8'
D: 19:24:25,944 i18n.setup_gettext:171: Using locale: 'ru_RU.UTF-8'
D: 19:24:25,945 i18n._load_translation:118: Loading gettext translation for picard, localedir='/nix/store/dr04dzy2lzgy76ilrjj1ij84y1b9ki88-picard-2.10/share/locale', language='ru_RU.UTF-8'
D: 19:24:25,946 i18n._load_translation:118: Loading gettext translation for picard-attributes, localedir='/nix/store/dr04dzy2lzgy76ilrjj1ij84y1b9ki88-picard-2.10/share/locale', language='ru_RU.UTF-8'
D: 19:24:25,947 i18n._load_translation:118: Loading gettext translation for picard-constants, localedir='/nix/store/dr04dzy2lzgy76ilrjj1ij84y1b9ki88-picard-2.10/share/locale', language='ru_RU.UTF-8'
D: 19:24:25,947 i18n._load_translation:118: Loading gettext translation for picard-countries, localedir='/nix/store/dr04dzy2lzgy76ilrjj1ij84y1b9k
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
