### PR TITLE
2048-qt: init at 0.1.7

### DIFF
--- a/pkgs/by-name/_2/_2048-qt/package.nix
+++ b/pkgs/by-name/_2/_2048-qt/package.nix
@@ -1,0 +1,52 @@
+{ cmake
+, fetchFromGitHub
+, hicolor-icon-theme
+, lib
+, libsForQt5
+, stdenv
+}:
+
+stdenv.mkDerivation rec {
+  pname = "2048-qt";
+  version = "0.1.7";
+  src = fetchFromGitHub {
+    owner = "OpenOrphanage";
+    repo = "2048-Qt";
+    rev = "v${version}";
+    hash = "sha256-Un1A5kSFKXtA3Z1YJwG2g6EgT3lB7mI5c44PpdmPRls=";
+  };
+
+  buildInputs = with libsForQt5.qt5; [
+    hicolor-icon-theme
+    qtquickcontrols2
+    qttools
+    qtbase
+  ];
+
+  nativeBuildInputs = with libsForQt5.qt5; [
+    qmake
+    wrapQtAppsHook
+  ];
+
+  preConfigure = ''
+    sed -i 's|/opt/$${TARGET}/bin|'"`echo $out`"'/bin|' deployment.pri
+  '';
+
+  postInstall = ''
+    install -D -m644 res/icons/16x16/apps/${pname}.png "$out/share/icons/hicolor/16x16/apps/${pname}.png"
+    install -D -m644 res/icons/32x32/apps/${pname}.png "$out/share/icons/hicolor/32x32/apps/${pname}.png"
+    install -D -m644 res/icons/48x48/apps/${pname}.png "$out/share/icons/hicolor/48x48/apps/${pname}.png"
+    install -D -m644 res/icons/256x256/apps/${pname}.png "$out/share/icons/hicolor/256x256/apps/${pname}.png"
+    install -D -m644 res/icons/scalable/apps/${pname}.svg "$out/share/icons/hicolor/scalable/apps/${pname}.svg"
+    install -D -m644 res/${pname}.desktop "$out/share/applications/${pname}.desktop"
+    install -D -m644 res/man/${pname}.6 "$out/share/man/man6/${pname}.6"
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/OpenOrphanage/2048-Qt";
+    description = "The 2048 number game implemented in Qt";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with lib.maintainers; [ raspher ];
+  };
+}


### PR DESCRIPTION
## Description of changes
Adds 2048-qt game

**It's a fork**. As main developer was not active for a long time i've created a fork. I found it much easier to fork and merge the PR from the original repository, which fixes some bugs, than patching. (those PR's required small corrections and manual testing)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
