### PR TITLE
qt5.qtwebengine: fix plugin load path in propagated ALSA

### DIFF
--- a/pkgs/by-name/al/alsa-lib-with-plugins/package.nix
+++ b/pkgs/by-name/al/alsa-lib-with-plugins/package.nix
@@ -1,0 +1,52 @@
+{ lib
+, pkgs
+, alsa-lib
+, plugins ? [ pkgs.alsa-plugins ]
+, lndir
+, symlinkJoin
+, runCommand
+}:
+let
+  merged = symlinkJoin { name = "alsa-plugins-merged"; paths = plugins; };
+in
+runCommand "${alsa-lib.pname}-${alsa-lib.version}" {
+  meta = with lib; {
+    description = "wrapper to ease access to ALSA plugins";
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ gm6k ];
+  };
+  outputs = alsa-lib.outputs;
+} (
+    (
+      lib.concatMapStringsSep "\n" (
+        output: ''
+          mkdir ${builtins.placeholder output}
+          ${lndir}/bin/lndir ${lib.attrByPath [output] null alsa-lib} \
+            ${builtins.placeholder output}
+        ''
+      ) alsa-lib.outputs
+    ) + ''
+    cp -r ${merged}/lib/alsa-lib $out/lib
+    (
+      echo $out | wc -c
+      echo ${alsa-lib} | wc -c
+    ) | xargs echo | grep -q "^\(.*\) \1$" || (
+      echo cannot binary patch
+      exit 1
+    )
+    rm $out/lib/libasound.la
+    rm $out/lib/libasound.so.?.?.?
+    rm $dev/lib/pkgconfig/alsa.pc
+    rm $dev/nix-support/propagated-build-inputs
+    cp ${alsa-lib}/lib/libasound.la $out/lib
+    cp ${alsa-lib}/lib/libasound.so.?.?.? $out/lib
+    cp ${alsa-lib.dev}/lib/pkgconfig/alsa.pc $dev/lib/pkgconfig
+    cp ${alsa-lib.dev}/nix-support/propagated-build-inputs $dev/nix-support
+    sed -i \
+        $out/lib/libasound.la \
+        $out/lib/libasound.so.?.?.? \
+        $dev/lib/pkgconfig/alsa.pc \
+        $dev/nix-support/propagated-build-inputs \
+      -e "s@${alsa-lib}@$out@g"
+  ''
+)

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -11,7 +11,7 @@
 , fontconfig, freetype, harfbuzz, icu, dbus, libdrm
 , zlib, minizip, libjpeg, libpng, libtiff, libwebp, libopus
 , jsoncpp, protobuf, libvpx, srtp, snappy, nss, libevent
-, alsa-lib
+, alsa-lib-with-plugins
 , pulseaudio
 , libcap
 , pciutils
@@ -202,7 +202,7 @@ qtModule ({
     dbus zlib minizip snappy nss protobuf jsoncpp
 
     # Audio formats
-    alsa-lib
+    alsa-lib-with-plugins
     pulseaudio
 
     # Text rendering


### PR DESCRIPTION
## Description of changes

`qt5.qtwebengine` exports its `alsa-lib` dependency, which leads to the plugin load path bug (https://github.com/NixOS/nixpkgs/issues/6860) being exported to reverse dependencies. As a result, reverse dependencies may not be able to connect to MIDI (seen with `supercollider`).

This fixes it by using an `alsa-lib` wrapper fixing the plugin load path issue. To allow CI, this includes the commit from https://github.com/NixOS/nixpkgs/pull/277180 it depends on.

Fixes https://github.com/NixOS/nixpkgs/issues/284069
(changing `alsa-lib` in `supercollider` doesn't work because it still links to the one propagated by `qt5.qtwebengine`)

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).



---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
