### PR TITLE
xsnip: init at unstable-2022-08-02

### DIFF
--- a/pkgs/by-name/xs/xsnip/makefile.diff
+++ b/pkgs/by-name/xs/xsnip/makefile.diff
@@ -1,0 +1,38 @@
+Various makefile improvements, notably the removal of the usage
+of pkg-config and the -g compiler flag. Swapped out -g for -O2.
+--- a/Makefile
++++ b/Makefile
+@@ -1,18 +1,14 @@
+-X11_CFLAGS != pkg-config --cflags x11
+-X11_LIBS != pkg-config --libs x11
+-
+-LIBPNG_CFLAGS != pkg-config --cflags libpng
+-LIBPNG_LIBS != pkg-config --libs libpng
+-
+-CC?=gcc
+-CFLAGS=-g ${X11_CFLAGS} ${LIBPNG_CFLAGS}
+-LIBS=${X11_LIBS} ${LIBPNG_LIBS}
+-DEPS=config.h 
++CC=cc
++CFLAGS=-O2
++LIBS=-lpng -lX11
++DEPS=config.h
+ OBJ=xsnip.o
+ 
+-prefix=/usr/local
+-exec_prefix=${prefix}
+-bindir=${exec_prefix}/bin
++ifeq (${OPAQUE},)
++	CFLAGS += -DOPAQUE=false
++else
++	CFLAGS += -DOPAQUE=true
++endif
+ 
+ %.o: %.c $(DEPS)
+ 	$(CC) -c -o $@ $< $(CFLAGS)
+@@ -21,4 +15,4 @@ xsnip: $(OBJ)
+ 	$(CC) -o $@ $^ $(LIBS)
+ 
+ install:
+-	cp xsnip $(bindir)
++	install -Dm755 xsnip ${DESTDIR}/bin/xsnip

--- a/pkgs/by-name/xs/xsnip/no-opaque.diff
+++ b/pkgs/by-name/xs/xsnip/no-opaque.diff
@@ -1,0 +1,13 @@
+Remove the definition of OPAQUE in config.h so we can set it
+through the compiler's command line.
+--- a/config.h
++++ b/config.h
+@@ -13,8 +13,4 @@
+ // Cursor image during selection
+ #define CURSOR XC_crosshair
+ 
+-// If your compositor is causing the overlay to behave strangely,
+-// set this option to true. (NOTE: this feature is still experimental)
+-#define OPAQUE false
+-
+ /* ------------------------- */

--- a/pkgs/by-name/xs/xsnip/package.nix
+++ b/pkgs/by-name/xs/xsnip/package.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeBinaryWrapper
+, libpng
+, libX11
+, xclip
+
+, opaqueMode ? true
+, saveDir ? "Pictures"
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xsnip";
+  version = "0-unstable-2022-08-02";
+
+  src = fetchFromGitHub {
+    owner = "ws-kj";
+    repo = "xsnip";
+    rev = "d477de3ed788d0d4fce9c6a30ab079035e8e3767";
+    hash = "sha256-d6CvAfG0cEVMzAzT/V91CACw4Yzp8PFuvChNnFZCEuI=";
+  };
+
+  buildInputs = [ libpng libX11 ];
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  patches = [
+    ./makefile.diff
+    ./no-opaque.diff
+  ];
+
+  buildFlags = lib.optional opaqueMode "OPAQUE=1";
+  installFlags = [ "DESTDIR=$(out)" ];
+
+  postPatch = ''
+    substituteInPlace config.h --replace-fail "Pictures" "${saveDir}"
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/xsnip \
+      --prefix PATH : "${lib.makeBinPath [ xclip ]}"
+  '';
+
+  meta = with lib; {
+    description = "Minimal screenshot utility for X";
+    homepage = "https://github.com/ws-kj/xsnip/";
+    license = licenses.gpl3Only;
+    platforms = platforms.unix;
+    mainProgram = "xsnip";
+    maintainers = with maintainers; [ jtbx ];
+  };
+})


### PR DESCRIPTION
## Description of changes

xsnip is a minimal screenshot utility for X that does the job.

https://github.com/ws-kj/xsnip

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
