### PR TITLE
python311Packages.niworkflows: init at 1.10.0

### DIFF
--- a/pkgs/development/python-modules/nipreps-versions/default.nix
+++ b/pkgs/development/python-modules/nipreps-versions/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, flit-scm
+, packaging
+, setuptools-scm
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "nipreps-versions";
+  version = "1.0.4";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "nipreps";
+    repo = "version-schemes";
+    rev = "refs/tags/${version}";
+    hash = "sha256-B2wtLurzgk59kTooH51a2dewK7aEyA0dAm64Wp+tqhM=";
+  };
+
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeBuildInputs = [
+    flit-scm
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    packaging
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+  pythonImportsCheck = [ "nipreps_versions" ];
+
+  meta = with lib; {
+    description = "Setuptools_scm plugin for nipreps version schemes";
+    homepage = "https://github.com/nipreps/version-schemes";
+    changelog = "https://github.com/nipreps/version-schemes/blob/${src.rev}/CHANGES.md";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/niworkflows/default.nix
+++ b/pkgs/development/python-modules/niworkflows/default.nix
@@ -1,0 +1,101 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, hatch-vcs
+, hatchling
+, pytestCheckHook
+, attrs
+, importlib-resources
+, jinja2
+, looseversion
+, matplotlib
+, nibabel
+, nilearn
+, nipype
+, nitransforms
+, numpy
+, packaging
+, pandas
+, pybids
+, pyyaml
+, scikit-image
+, scipy
+, seaborn
+, svgutils
+, templateflow
+, traits
+, transforms3d
+}:
+
+buildPythonPackage rec {
+  pname = "niworkflows";
+  version = "1.10.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "nipreps";
+    repo = "niworkflows";
+    rev = "refs/tags/${version}";
+    hash = "sha256-wQPk9imDvomg+NTWk+VeW1TE2QlvMyi1YYVVaznhktU=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml --replace '"traits < 6.4"' '"traits"'
+  '';
+
+  nativeBuildInputs = [
+    hatch-vcs
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    attrs
+    importlib-resources
+    jinja2
+    looseversion
+    matplotlib
+    nibabel
+    nilearn
+    nipype
+    nitransforms
+    numpy
+    packaging
+    pandas
+    pybids
+    pyyaml
+    scikit-image
+    scipy
+    seaborn
+    svgutils
+    templateflow
+    traits
+    transforms3d
+  ];
+
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  nativeCheckInputs = [ pytestCheckHook ];
+  preCheck = ''export HOME=$(mktemp -d)'';
+  pytestFlagsArray = [ "niworkflows" ];
+  # try to download data:
+  disabledTests = [
+    "test_GenerateCifti"
+    "ROIsPlot"
+    "ROIsPlot2"
+    "test_SimpleShowMaskRPT"
+    "test_cifti_surfaces_plot"
+    "niworkflows.utils.misc.get_template_specs"
+    "niworkflows.interfaces.cifti._prepare_cifti"
+  ];
+  disabledTestPaths = [ "niworkflows/tests/test_registration.py" ];
+
+  pythonImportsCheck = [ "niworkflows" ];
+
+  meta = with lib; {
+    description = "Common workflows for MRI (anatomical, functional, diffusion, etc.)";
+    homepage = "https://github.com/nipreps/niworkflows";
+    changelog = "https://github.com/nipreps/niworkflows/blob/${src.rev}/CHANGES.rst";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/svgutils/default.nix
+++ b/pkgs/development/python-modules/svgutils/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, lxml
+, matplotlib
+, pytestCheckHook
+, nose
+}:
+
+buildPythonPackage rec {
+  pname = "svgutils";
+  version = "0.3.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "btel";
+    repo = "svg_utils";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-ITvZx+3HMbTyaRmCb7tR0LKqCxGjqDdV9/2taziUD0c=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  propagatedBuildInputs = [
+    lxml
+    matplotlib
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook nose ];
+
+  pythonImportsCheck = [ "svgutils" ];
+
+  meta = with lib; {
+    description = "Python tools to create and manipulate SVG files";
+    homepage = "https://github.com/btel/svg_utils";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/templateflow/default.nix
+++ b/pkgs/development/python-modules/templateflow/default.nix
@@ -1,0 +1,45 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+, pytestCheckHook
+, setuptools-scm
+, nipreps-versions
+, pybids
+, requests
+, tqdm
+}:
+
+buildPythonPackage rec {
+  pname = "templateflow";
+  version = "23.1.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "templateflow";
+    repo = "python-client";
+    rev = "refs/tags/${version}";
+    hash = "sha256-8AdXC1IFGfYZ5cvCAyBz0tD3zia+KBILX0tL9IcO2NA=";
+  };
+
+  nativeBuildInputs = [ setuptools-scm ];
+  propagatedBuildInputs = [
+    nipreps-versions
+    pybids
+    requests
+    tqdm
+  ];
+
+  doCheck = false;  # most tests try to download data
+  #pythonImportsCheck = [ "templateflow" ];  # touches $HOME/.cache, hence needs https://github.com/NixOS/nixpkgs/pull/120300
+
+  meta = with lib; {
+    homepage = "https://templateflow.org/python-client";
+    description = "Python API to query TemplateFlow via pyBIDS";
+    changelog = "https://github.com/templateflow/python-client/releases/tag/${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8377,6 +8377,8 @@ self: super: with self; {
 
   nitransforms = callPackage ../development/python-modules/nitransforms { };
 
+  niworkflows = callPackage ../development/python-modules/niworkflows { };
+
   nix-kernel = callPackage ../development/python-modules/nix-kernel {
     inherit (pkgs) nix;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14146,6 +14146,8 @@ self: super: with self; {
 
   tempita = callPackage ../development/python-modules/tempita { };
 
+  templateflow = callPackage ../development/python-modules/templateflow { };
+
   tempora = callPackage ../development/python-modules/tempora { };
 
   tenacity = callPackage ../development/python-modules/tenacity { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8363,6 +8363,8 @@ self: super: with self; {
 
   ninja = callPackage ../development/python-modules/ninja { inherit (pkgs) ninja; };
 
+  nipreps-versions = callPackage ../development/python-modules/nipreps-versions { };
+
   nipy = callPackage ../development/python-modules/nipy { };
 
   nipype = callPackage ../development/python-modules/nipype {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14002,6 +14002,8 @@ self: super: with self; {
 
   svgelements = callPackage ../development/python-modules/svgelements { };
 
+  svgutils = callPackage ../development/python-modules/svgutils { };
+
   svgwrite = callPackage ../development/python-modules/svgwrite { };
 
   sv-ttk = callPackage ../development/python-modules/sv-ttk { };


### PR DESCRIPTION
python311Packages.templateflow: init at 23.1.0
python311Packages.nipreps-version: init at 1.0.4
python311Packages.svgutils: init at 0.3.4


## Description of changes

Init `niworkflows`, a package for templating neuroimaging workflows using Jinja2 and Nipype, and its dependencies.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
