### PR TITLE
Contrib/0/rfc169 proof/out

### DIFF
--- a/experimental.nix
+++ b/experimental.nix
@@ -1,46 +1,8 @@
 let
   nixpkgs = import ./. {};
-  inherit (nixpkgs) lib;
-
-  # TODO: Automate it.
-  BACKWARD = {
-    with_alsa = [ "alsaSupport" "withAlsa" ];
-  };
-  FORWARD = {
-    alsaSupport = "with_alsa";
-    withAlsa = "with_alsa";
-  };
-
-  victim = nixpkgs.cmus.override;
-
-  oldArgs = lib.functionArgs victim;
-
-  # Since we don't know what was the original deprecated name used by the
-  # package (if any, really), we have to extend original signature with all
-  # known deprecated names.
-  #
-  # Which means that if before it had "alsaSupport", now override can also be
-  # called with "withAlsa". And let's not bring what will happen if somebody
-  # provides both. Goal is to keep old code working, not preventing user from
-  # defying warnings and doing something stupid.
-  mkExtraArgs = name: value:
-    if lib.hasAttr name BACKWARD
-    then map (n: { name = n; value = value; }) (lib.getAttr name BACKWARD)
-    else [];
-
-  patch = builtins.listToAttrs (builtins.concatLists (lib.mapAttrsToList mkExtraArgs oldArgs));
-  newArgs = oldArgs // patch;
-
-  newFunctor = args':
-    let f = name: value:
-            let renamed = lib.getAttr name FORWARD;
-                warning = "Feature parameter '" + name + "' is deprecated in favor of '" + renamed + "'.";
-            in if lib.hasAttr name FORWARD && lib.hasAttr (lib.getAttr name FORWARD) BACKWARD
-            then lib.warn warning { name = renamed; inherit value; }
-            else { inherit name value; };
-        args = if builtins.isAttrs args' then builtins.listToAttrs (lib.mapAttrsToList f args') else args';
-    in victim args;
+  inherit (nixpkgs) cmus;
+  inherit (nixpkgs.lib) rfc0169Renamed;
 in {
-  cmus2 = newFunctor { with_alsa = false; };
-  cmus3 = newFunctor { alsaSupport = false; };
+  cmus2 = (rfc0169Renamed cmus.override) { with_alsa = false; };
+  cmus3 = (rfc0169Renamed cmus.override) { alsaSupport = false; };
 }

--- a/experimental.nix
+++ b/experimental.nix
@@ -1,0 +1,46 @@
+let
+  nixpkgs = import ./. {};
+  inherit (nixpkgs) lib;
+
+  # TODO: Automate it.
+  BACKWARD = {
+    with_alsa = [ "alsaSupport" "withAlsa" ];
+  };
+  FORWARD = {
+    alsaSupport = "with_alsa";
+    withAlsa = "with_alsa";
+  };
+
+  victim = nixpkgs.cmus.override;
+
+  oldArgs = lib.functionArgs victim;
+
+  # Since we don't know what was the original deprecated name used by the
+  # package (if any, really), we have to extend original signature with all
+  # known deprecated names.
+  #
+  # Which means that if before it had "alsaSupport", now override can also be
+  # called with "withAlsa". And let's not bring what will happen if somebody
+  # provides both. Goal is to keep old code working, not preventing user from
+  # defying warnings and doing something stupid.
+  mkExtraArgs = name: value:
+    if lib.hasAttr name BACKWARD
+    then map (n: { name = n; value = value; }) (lib.getAttr name BACKWARD)
+    else [];
+
+  patch = builtins.listToAttrs (builtins.concatLists (lib.mapAttrsToList mkExtraArgs oldArgs));
+  newArgs = oldArgs // patch;
+
+  newFunctor = args':
+    let f = name: value:
+            let renamed = lib.getAttr name FORWARD;
+                warning = "Feature parameter '" + name + "' is deprecated in favor of '" + renamed + "'.";
+            in if lib.hasAttr name FORWARD && lib.hasAttr (lib.getAttr name FORWARD) BACKWARD
+            then lib.warn warning { name = renamed; inherit value; }
+            else { inherit name value; };
+        args = if builtins.isAttrs args' then builtins.listToAttrs (lib.mapAttrsToList f args') else args';
+    in victim args;
+in {
+  cmus2 = newFunctor { with_alsa = false; };
+  cmus3 = newFunctor { alsaSupport = false; };
+}

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -7,7 +7,7 @@ let
     functionArgs isFunction mirrorFunctionArgs isAttrs setFunctionArgs
     optionalAttrs attrNames filter elemAt concatStringsSep sortOn take length
     filterAttrs optionalString flip pathIsDirectory head pipe isDerivation listToAttrs
-    mapAttrs seq flatten deepSeq warnIf isInOldestRelease extends
+    mapAttrs seq flatten deepSeq warnIf isInOldestRelease extends rfc0169Renamed
     ;
   inherit (lib.strings) levenshtein levenshteinAtMost;
 
@@ -107,7 +107,7 @@ rec {
     in
       if isAttrs result then
         result // {
-          override = overrideArgs;
+          override = rfc0169Renamed overrideArgs;
           overrideDerivation = fdrv: overrideResult (x: overrideDerivation x fdrv);
           ${if result ? overrideAttrs then "overrideAttrs" else null} = fdrv:
             overrideResult (x: x.overrideAttrs fdrv);
@@ -115,7 +115,7 @@ rec {
       else if isFunction result then
         # Transform the result into a functor while propagating its arguments
         setFunctionArgs result (functionArgs result) // {
-          override = overrideArgs;
+          override = rfc0169Renamed overrideArgs;
         }
       else result);
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -63,6 +63,7 @@ let
 
     # linux kernel configuration
     kernel = callLibs ./kernel.nix;
+    rfc_0169 = callLibs ./rfc_0169.nix;
 
     inherit (builtins) add addErrorContext attrNames concatLists
       deepSeq elem elemAt filter genericClosure genList getAttr
@@ -166,5 +167,6 @@ let
       nixType imap;
     inherit (self.versions)
       splitVersion;
+    inherit (self.rfc_0169) rfc0169Renamed;
   });
 in lib

--- a/lib/rfc0169.json
+++ b/lib/rfc0169.json
@@ -1,0 +1,6 @@
+{
+  "with_alsa": [
+    "alsaSupport",
+    "withAlsa"
+  ]
+}

--- a/lib/rfc_0169.nix
+++ b/lib/rfc_0169.nix
@@ -1,0 +1,40 @@
+{ lib }:
+let
+  inherit (lib) functionArgs isAttrs getAttr hasAttr mapAttrsToList warn;
+  # TODO: Automate it.
+  BACKWARD = {
+    with_alsa = [ "alsaSupport" "withAlsa" ];
+  };
+  FORWARD = {
+    alsaSupport = "with_alsa";
+    withAlsa = "with_alsa";
+  };
+  # Since we don't know what was the original deprecated name used by the
+  # package (if any, really), we have to extend original signature with all
+  # known deprecated names.
+  #
+  # Which means that if before it had "alsaSupport", now override can also be
+  # called with "withAlsa". And let's not bring what will happen if somebody
+  # provides both. Goal is to keep old code working, not preventing user from
+  # defying warnings and doing something stupid.
+  mkExtraArgs = name: value:
+    if hasAttr name BACKWARD
+    then map (n: { name = n; value = value; }) (getAttr name BACKWARD)
+    else [];
+  renamePair = name: value:
+    let renamed = lib.getAttr name FORWARD;
+        warning = "Feature parameter '" + name + "' is deprecated in favor of '" + renamed + "'.";
+    in if hasAttr name FORWARD && hasAttr (getAttr name FORWARD) BACKWARD
+    then warn warning { name = renamed; inherit value; }
+    else { inherit name value; };
+in {
+  rfc0169Renamed = functor:
+    let oldArgs = functionArgs functor;
+        patch = builtins.listToAttrs (builtins.concatLists (mapAttrsToList mkExtraArgs oldArgs));
+    in if patch == {}
+       then functor # nothing to do.
+       else args': functor (if isAttrs args' then builtins.listToAttrs (mapAttrsToList renamePair args') else args');
+}
+
+
+

--- a/lib/rfc_0169.nix
+++ b/lib/rfc_0169.nix
@@ -1,14 +1,10 @@
 { lib }:
 let
   inherit (lib) functionArgs isAttrs getAttr hasAttr mapAttrsToList warn;
-  # TODO: Automate it.
-  BACKWARD = {
-    with_alsa = [ "alsaSupport" "withAlsa" ];
-  };
-  FORWARD = {
-    alsaSupport = "with_alsa";
-    withAlsa = "with_alsa";
-  };
+
+  BACKWARD = builtins.fromJSON (builtins.readFile ./rfc0169.json);
+  FORWARD = builtins.listToAttrs (builtins.concatLists (mapAttrsToList (n: map (x: { name = x; value = n; })) BACKWARD));
+
   # Since we don't know what was the original deprecated name used by the
   # package (if any, really), we have to extend original signature with all
   # known deprecated names.

--- a/pkgs/applications/audio/cmus/default.nix
+++ b/pkgs/applications/audio/cmus/default.nix
@@ -1,7 +1,7 @@
 { config, lib, stdenv, fetchFromGitHub, fetchpatch, ncurses, pkg-config
 , libiconv, CoreAudio, AudioUnit, VideoToolbox
 
-, alsaSupport ? stdenv.isLinux, alsa-lib ? null
+, with_alsa ? stdenv.isLinux, alsa-lib ? null
 # simple fallback for everyone else
 , aoSupport ? !stdenv.isLinux, libao ? null
 , jackSupport ? false, libjack ? null
@@ -53,7 +53,7 @@ let
 
   opts = [
     # Audio output
-    (mkFlag alsaSupport       "CONFIG_ALSA=y"       alsa-lib)
+    (mkFlag with_alsa       "CONFIG_ALSA=y"       alsa-lib)
     (mkFlag aoSupport         "CONFIG_AO=y"         libao)
     (mkFlag jackSupport       "CONFIG_JACK=y"       libjack)
     (mkFlag samplerateSupport "CONFIG_SAMPLERATE=y" libsamplerate)


### PR DESCRIPTION
Supporting code for proposed [RFC0169](https://github.com/NixOS/rfcs/pull/169)

```
nix-repl> cmus.override { alsaSupport = false; }
trace: warning: Feature parameter 'alsaSupport' is deprecated in favor of 'with_alsa'.
«derivation /nix/store/jm87wmcnpibrxfzwz95i51zh2qdxxp32-cmus-2.10.0.drv»

nix-repl> cmus.override { with_alsa = false; }
«derivation /nix/store/jm87wmcnpibrxfzwz95i51zh2qdxxp32-cmus-2.10.0.drv»
```