### PR TITLE
pythonPackages.oslo-log: Use a hook to run stestr tests

### DIFF
--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -213,6 +213,15 @@ in {
         };
       } ./setuptools-rust-hook.sh) {};
 
+  stestrCheckHook = callPackage ({ makePythonHook, stestr }:
+    makePythonHook {
+      name = "unittest-check-hook";
+      propagatedBuildInputs = [ stestr ];
+      substitutions = {
+        inherit pythonCheckInterpreter;
+      };
+    } ./stestr-check-hook.sh) {};
+
   unittestCheckHook = callPackage ({ makePythonHook }:
     makePythonHook {
       name = "unittest-check-hook";

--- a/pkgs/development/interpreters/python/hooks/stestr-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/stestr-check-hook.sh
@@ -1,0 +1,48 @@
+# Setup hook for stestr.
+echo "Sourcing stestr-check-hook"
+
+declare -ar disabledTests
+
+function _stestrComputeDisabledTestsString() {
+    regex=""
+    for test in "$@"; do
+        if [ -n "$regex" ]; then
+            regex+="|"
+        fi
+        regex+="^($( echo "$test" | sed -s 's/\./\\\./'))"
+    done
+    echo "$regex"
+}
+
+
+function stestrCheckPhase() {
+    echo "Executing stestrCheckPhase"
+    runHook preCheck
+
+    args=" -m stestr run"
+    if [ -n "$disabledTests" ]; then
+        args+=" -E '$(_stestrComputeDisabledTestsString $disabledTests)'"
+     fi
+
+    eval "@pythonCheckInterpreter@ $args"
+
+    runHook postCheck
+    echo "Finished executing stestrCheckPhase"
+}
+
+if [ -z "${dontUseStestrCheck-}" ] && [ -z "${installCheckPhase-}" ]; then
+    echo "Using stestrCheckPhase"
+    preDistPhases+=" stestrCheckPhase"
+
+    # It's almost always the case that setuptoolsCheckPhase should not be ran
+    # when the stestrCheckHook is being ran
+    if [ -z "${useSetuptoolsCheck-}" ]; then
+        dontUseSetuptoolsCheck=1
+
+        # Remove command if already injected into preDistPhases
+        if [[ "$preDistPhases" =~ "setuptoolsCheckPhase" ]]; then
+            echo "Removing setuptoolsCheckPhase"
+            preDistPhases=${preDistPhases/setuptoolsCheckPhase/}
+        fi
+    fi
+fi

--- a/pkgs/development/python-modules/cliff/tests.nix
+++ b/pkgs/development/python-modules/cliff/tests.nix
@@ -1,7 +1,7 @@
 { buildPythonPackage
 , cliff
 , docutils
-, stestr
+, stestrCheckHook
 , testscenarios
 }:
 
@@ -22,11 +22,7 @@ buildPythonPackage {
   nativeCheckInputs = [
     cliff
     docutils
-    stestr
+    stestrCheckHook
     testscenarios
   ];
-
-  checkPhase = ''
-    stestr run
-  '';
 }

--- a/pkgs/development/python-modules/debtcollector/tests.nix
+++ b/pkgs/development/python-modules/debtcollector/tests.nix
@@ -1,6 +1,6 @@
 { buildPythonPackage
 , debtcollector
-, stestr
+, stestrCheckHook
 }:
 
 buildPythonPackage {
@@ -19,10 +19,6 @@ buildPythonPackage {
 
   nativeCheckInputs = [
     debtcollector
-    stestr
+    stestrCheckHook
   ];
-
-  checkPhase = ''
-    stestr run
-  '';
 }

--- a/pkgs/development/python-modules/hacking/default.nix
+++ b/pkgs/development/python-modules/hacking/default.nix
@@ -3,7 +3,7 @@
 , fetchPypi
 , pbr
 , flake8
-, stestr
+, stestrCheckHook
 , ddt
 , testscenarios
 }:
@@ -34,15 +34,13 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     ddt
-    stestr
+    stestrCheckHook
     testscenarios
   ];
 
-  checkPhase = ''
+  preCheck = ''
     # tries to trigger flake8 and fails
     rm hacking/tests/test_doctest.py
-
-    stestr run
   '';
 
   pythonImportsCheck = [ "hacking" ];

--- a/pkgs/development/python-modules/keystoneauth1/default.nix
+++ b/pkgs/development/python-modules/keystoneauth1/default.nix
@@ -17,7 +17,7 @@
 , requests-mock
 , setuptools
 , six
-, stestr
+, stestrCheckHook
 , stevedore
 , testresources
 , testtools
@@ -63,17 +63,16 @@ buildPythonPackage rec {
     pycodestyle
     pyyaml
     requests-mock
-    stestr
+    stestrCheckHook
     testresources
     testtools
   ];
 
   # test_keystoneauth_betamax_fixture is incompatible with urllib3 2.0.0
   # https://bugs.launchpad.net/keystoneauth/+bug/2020112
-  checkPhase = ''
-    stestr run \
-      -E "keystoneauth1.tests.unit.test_betamax_fixture.TestBetamaxFixture.test_keystoneauth_betamax_fixture"
-  '';
+  disabledTests = [
+    "keystoneauth1.tests.unit.test_betamax_fixture.TestBetamaxFixture.test_keystoneauth_betamax_fixture"
+  ];
 
   pythonImportsCheck = [ "keystoneauth1" ];
 

--- a/pkgs/development/python-modules/openstacksdk/tests.nix
+++ b/pkgs/development/python-modules/openstacksdk/tests.nix
@@ -9,7 +9,7 @@
 , prometheus-client
 , requests-mock
 , stdenv
-, stestr
+, stestrCheckHook
 , testscenarios
 }:
 
@@ -30,35 +30,35 @@ buildPythonPackage {
     oslotest
     prometheus-client
     requests-mock
-    stestr
+    stestrCheckHook
     testscenarios
   ];
 
-  checkPhase = ''
-    stestr run -e <(echo "
-  '' + lib.optionalString stdenv.isAarch64 ''
-    openstack.tests.unit.cloud.test_baremetal_node.TestBaremetalNode.test_node_set_provision_state_with_retries
-    openstack.tests.unit.cloud.test_role_assignment.TestRoleAssignment.test_grant_role_user_domain_exists
-    openstack.tests.unit.cloud.test_volume_backups.TestVolumeBackups.test_delete_volume_backup_force
-    openstack.tests.unit.object_store.v1.test_proxy.TestTempURLBytesPathAndKey.test_set_account_temp_url_key_second
-    openstack.tests.unit.cloud.test_security_groups.TestSecurityGroups.test_delete_security_group_neutron_not_found
-  '' + ''
-    openstack.tests.unit.cloud.test_baremetal_node.TestBaremetalNode.test_wait_for_baremetal_node_lock_locked
-    openstack.tests.unit.cloud.test_baremetal_node.TestBaremetalNode.test_inspect_machine_inspect_failed
-    openstack.tests.unit.cloud.test_baremetal_node.TestBaremetalNode.test_inspect_machine_available_wait
-    openstack.tests.unit.cloud.test_baremetal_node.TestBaremetalNode.test_inspect_machine_wait
-    openstack.tests.unit.cloud.test_image.TestImage.test_create_image_task
-    openstack.tests.unit.image.v2.test_proxy.TestImageProxy.test_wait_for_task_error_396
-    openstack.tests.unit.image.v2.test_proxy.TestImageProxy.test_wait_for_task_wait
-    openstack.tests.unit.test_resource.TestWaitForStatus.test_status_fails
-    openstack.tests.unit.test_resource.TestWaitForStatus.test_status_fails_different_attribute
-    openstack.tests.unit.test_resource.TestWaitForStatus.test_status_match
-    openstack.tests.unit.test_resource.TestWaitForStatus.test_status_match_with_none
-    openstack.tests.unit.test_stats.TestStats.test_list_projects
-    openstack.tests.unit.test_stats.TestStats.test_projects
-    openstack.tests.unit.test_stats.TestStats.test_servers
-    openstack.tests.unit.test_stats.TestStats.test_servers_no_detail
-    openstack.tests.unit.test_stats.TestStats.test_timeout
-    ")
-  '';
+  disabledTests = (lib.optional stdenv.isAarch64 [
+    "openstack.tests.unit.cloud.test_baremetal_node.TestBaremetalNode.test_node_set_provision_state_with_retries"
+    "openstack.tests.unit.cloud.test_role_assignment.TestRoleAssignment.test_grant_role_user_domain_exists"
+    "openstack.tests.unit.cloud.test_volume_backups.TestVolumeBackups.test_delete_volume_backup_force"
+    "openstack.tests.unit.object_store.v1.test_proxy.TestTempURLBytesPathAndKey.test_set_account_temp_url_key_second"
+    "openstack.tests.unit.cloud.test_security_groups.TestSecurityGroups.test_delete_security_group_neutron_not_found"
+  ]) ++ [
+    "openstack.tests.unit.cloud.test_baremetal_node.TestBaremetalNode.test_wait_for_baremetal_node_lock_locked"
+    "openstack.tests.unit.cloud.test_baremetal_node.TestBaremetalNode.test_inspect_machine_inspect_failed"
+    "openstack.tests.unit.cloud.test_baremetal_node.TestBaremetalNode.test_inspect_machine_available_wait"
+    "openstack.tests.unit.cloud.test_baremetal_node.TestBaremetalNode.test_inspect_machine_wait"
+    "openstack.tests.unit.cloud.test_image.TestImage.test_create_image_task"
+    "openstack.tests.unit.image.v2.test_proxy.TestTask.test_wait_for_task_error_396"
+    "openstack.tests.unit.image.v2.test_proxy.TestTask.test_wait_for_task_wait"
+    "openstack.tests.unit.test_resource.TestWaitForStatus.test_callback"
+    "openstack.tests.unit.test_resource.TestWaitForStatus.test_callback_without_progress"
+    "openstack.tests.unit.test_resource.TestWaitForDelete.test_status"
+    "openstack.tests.unit.test_resource.TestWaitForStatus.test_status_fails"
+    "openstack.tests.unit.test_resource.TestWaitForStatus.test_status_fails_different_attribute"
+    "openstack.tests.unit.test_resource.TestWaitForStatus.test_status_match"
+    "openstack.tests.unit.test_resource.TestWaitForStatus.test_status_match_with_none"
+    "openstack.tests.unit.test_stats.TestStats.test_list_projects"
+    "openstack.tests.unit.test_stats.TestStats.test_projects"
+    "openstack.tests.unit.test_stats.TestStats.test_servers"
+    "openstack.tests.unit.test_stats.TestStats.test_servers_no_detail"
+    "openstack.tests.unit.test_stats.TestStats.test_timeout"
+  ];
 }

--- a/pkgs/development/python-modules/os-service-types/tests.nix
+++ b/pkgs/development/python-modules/os-service-types/tests.nix
@@ -3,7 +3,7 @@
 , os-service-types
 , oslotest
 , requests-mock
-, stestr
+, stestrCheckHook
 , testscenarios
 }:
 
@@ -26,11 +26,7 @@ buildPythonPackage {
     keystoneauth1
     oslotest
     requests-mock
-    stestr
+    stestrCheckHook
     testscenarios
   ];
-
-  checkPhase = ''
-    stestr run
-  '';
 }

--- a/pkgs/development/python-modules/osc-lib/default.nix
+++ b/pkgs/development/python-modules/osc-lib/default.nix
@@ -9,7 +9,7 @@
 , pbr
 , requests-mock
 , simplejson
-, stestr
+, stestrCheckHook
 }:
 
 buildPythonPackage rec {
@@ -41,18 +41,15 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     requests-mock
-    stestr
+    stestrCheckHook
   ];
 
-  checkPhase = ''
-    # tests parse cli output which slightly changed
-    stestr run -e <(echo "
-      osc_lib.tests.utils.test_tags.TestTagHelps.test_add_tag_filtering_option_to_parser
-      osc_lib.tests.utils.test_tags.TestTagHelps.test_add_tag_option_to_parser_for_create
-      osc_lib.tests.utils.test_tags.TestTagHelps.test_add_tag_option_to_parser_for_set
-      osc_lib.tests.utils.test_tags.TestTagHelps.test_add_tag_option_to_parser_for_unset
-    ")
-  '';
+  disabledTests = [
+    "osc_lib.tests.utils.test_tags.TestTagHelps.test_add_tag_filtering_option_to_parser"
+    "osc_lib.tests.utils.test_tags.TestTagHelps.test_add_tag_option_to_parser_for_create"
+    "osc_lib.tests.utils.test_tags.TestTagHelps.test_add_tag_option_to_parser_for_set"
+    "osc_lib.tests.utils.test_tags.TestTagHelps.test_add_tag_option_to_parser_for_unset"
+  ];
 
   pythonImportsCheck = [ "osc_lib" ];
 

--- a/pkgs/development/python-modules/oslo-concurrency/default.nix
+++ b/pkgs/development/python-modules/oslo-concurrency/default.nix
@@ -13,7 +13,7 @@
 , oslo-utils
 , oslotest
 , pbr
-, stestr
+, stestrCheckHook
 }:
 
 buildPythonPackage rec {
@@ -53,19 +53,13 @@ buildPythonPackage rec {
     eventlet
     fixtures
     oslotest
-    stestr
+    stestrCheckHook
   ];
 
-  checkPhase = ''
-    echo "nameserver 127.0.0.1" > resolv.conf
-    export NIX_REDIRECTS=/etc/protocols=${iana-etc}/etc/protocols:/etc/resolv.conf=$(realpath resolv.conf)
-    export LD_PRELOAD=${libredirect}/lib/libredirect.so
-
-    stestr run -e <(echo "
-    oslo_concurrency.tests.unit.test_lockutils_eventlet.TestInternalLock.test_fair_lock_with_spawn
-    oslo_concurrency.tests.unit.test_lockutils_eventlet.TestInternalLock.test_fair_lock_with_spawn_n
-    ")
-  '';
+  disabledTests = [
+    "oslo_concurrency.tests.unit.test_lockutils_eventlet.TestInternalLock.test_fair_lock_with_spawn"
+    "oslo_concurrency.tests.unit.test_lockutils_eventlet.TestInternalLock.test_fair_lock_with_spawn_n"
+  ];
 
   pythonImportsCheck = [ "oslo_concurrency" ];
 

--- a/pkgs/development/python-modules/oslo-config/tests.nix
+++ b/pkgs/development/python-modules/oslo-config/tests.nix
@@ -5,7 +5,7 @@
 , oslotest
 , requests-mock
 , sphinx
-, stestr
+, stestrCheckHook
 , testscenarios
 }:
 
@@ -30,11 +30,7 @@ pname = "oslo-config-tests";
     oslotest
     requests-mock
     sphinx
-    stestr
+    stestrCheckHook
     testscenarios
   ];
-
-  checkPhase = ''
-    stestr run
-  '';
 }

--- a/pkgs/development/python-modules/oslo-context/default.nix
+++ b/pkgs/development/python-modules/oslo-context/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchPypi, debtcollector, oslotest, stestr, pbr }:
+{ lib, buildPythonPackage, fetchPypi, debtcollector, oslotest, stestrCheckHook, pbr }:
 
 buildPythonPackage rec {
   pname = "oslo.context";
@@ -22,12 +22,8 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     oslotest
-    stestr
+    stestrCheckHook
   ];
-
-  checkPhase = ''
-    stestr run
-  '';
 
   pythonImportsCheck = [ "oslo_context" ];
 

--- a/pkgs/development/python-modules/oslo-db/default.nix
+++ b/pkgs/development/python-modules/oslo-db/default.nix
@@ -13,7 +13,7 @@
 , setuptools
 , sqlalchemy
 , stevedore
-, stestr
+, stestrCheckHook
 , testresources
 , testscenarios
 }:
@@ -47,15 +47,11 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     oslo-context
     oslotest
-    stestr
+    stestrCheckHook
     psycopg2
     testresources
     testscenarios
   ];
-
-  checkPhase = ''
-    stestr run
-  '';
 
   pythonImportsCheck = [ "oslo_db" ];
 

--- a/pkgs/development/python-modules/oslo-i18n/default.nix
+++ b/pkgs/development/python-modules/oslo-i18n/default.nix
@@ -5,7 +5,7 @@
 , pbr
 , setuptools
 , testscenarios
-, stestr
+, stestrCheckHook
 }:
 
 buildPythonPackage rec {
@@ -32,20 +32,13 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     oslotest
-    stestr
+    stestrCheckHook
     testscenarios
   ];
 
-  checkPhase = ''
-    runHook preCheck
-
-    stestr run -e <(echo "
-    # test counts warnings which no longer matches in python 3.11
-    oslo_i18n.tests.test_message.MessageTestCase.test_translate_message_bad_translation
-    ")
-
-    runHook postCheck
-  '';
+  disabledTests = [
+    "oslo_i18n.tests.test_message.MessageTestCase.test_translate_message_bad_translation"
+  ];
 
   pythonImportsCheck = [ "oslo_i18n" ];
 

--- a/pkgs/development/python-modules/oslo-log/default.nix
+++ b/pkgs/development/python-modules/oslo-log/default.nix
@@ -11,7 +11,7 @@
 , pbr
 , pyinotify
 , python-dateutil
-, pytestCheckHook
+, stestrCheckHook
 , pythonOlder
 }:
 
@@ -42,7 +42,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     eventlet
     oslotest
-    pytestCheckHook
+    stestrCheckHook
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/oslo-serialization/default.nix
+++ b/pkgs/development/python-modules/oslo-serialization/default.nix
@@ -6,7 +6,7 @@
 , oslotest
 , pbr
 , pytz
-, stestr
+, stestrCheckHook
 }:
 
 buildPythonPackage rec {
@@ -30,11 +30,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ msgpack oslo-utils pytz ];
 
-  nativeCheckInputs = [ oslotest stestr ];
-
-  checkPhase = ''
-    stestr run
-  '';
+  nativeCheckInputs = [ oslotest stestrCheckHook ];
 
   pythonImportsCheck = [ "oslo_serialization" ];
 

--- a/pkgs/development/python-modules/oslo-utils/default.nix
+++ b/pkgs/development/python-modules/oslo-utils/default.nix
@@ -15,7 +15,7 @@
 , pyparsing
 , pytz
 , setuptools
-, stestr
+, stestrCheckHook
 , testscenarios
 , tzdata
 , pyyaml
@@ -62,17 +62,15 @@ buildPythonPackage rec {
     eventlet
     fixtures
     oslotest
-    stestr
+    stestrCheckHook
     testscenarios
     pyyaml
   ];
 
-  checkPhase = ''
+  preCheck = ''
     echo "nameserver 127.0.0.1" > resolv.conf
     export NIX_REDIRECTS=/etc/protocols=${iana-etc}/etc/protocols:/etc/resolv.conf=$(realpath resolv.conf)
     export LD_PRELOAD=${libredirect}/lib/libredirect.so
-
-    stestr run
   '';
 
   pythonImportsCheck = [ "oslo_utils" ];

--- a/pkgs/development/python-modules/oslotest/tests.nix
+++ b/pkgs/development/python-modules/oslotest/tests.nix
@@ -1,7 +1,7 @@
 { buildPythonPackage
 , oslo-config
 , oslotest
-, stestr
+, stestrCheckHook
 }:
 
 buildPythonPackage {
@@ -21,10 +21,6 @@ buildPythonPackage {
   nativeCheckInputs = [
     oslotest
     oslo-config
-    stestr
+    stestrCheckHook
   ];
-
-  checkPhase = ''
-    stestr run
-  '';
 }

--- a/pkgs/development/python-modules/pbr/tests.nix
+++ b/pkgs/development/python-modules/pbr/tests.nix
@@ -4,7 +4,7 @@
 , gnupg
 , pbr
 , sphinx
-, stestr
+, stestrCheckHook
 , testresources
 , testscenarios
 , virtualenv
@@ -33,18 +33,16 @@ buildPythonPackage {
     git
     gnupg
     sphinx
-    stestr
+    stestrCheckHook
     testresources
     testscenarios
     virtualenv
   ];
 
-  checkPhase = ''
-    stestr run -e <(echo "
-    pbr.tests.test_core.TestCore.test_console_script_develop
-    pbr.tests.test_core.TestCore.test_console_script_install
-    pbr.tests.test_wsgi.TestWsgiScripts.test_with_argument
-    pbr.tests.test_wsgi.TestWsgiScripts.test_wsgi_script_run
-    ")
-  '';
+  disabledTests = [
+    "pbr.tests.test_core.TestCore.test_console_script_develop"
+    "pbr.tests.test_core.TestCore.test_console_script_install"
+    "pbr.tests.test_wsgi.TestWsgiScripts.test_with_argument"
+    "pbr.tests.test_wsgi.TestWsgiScripts.test_wsgi_script_run"
+  ];
 }

--- a/pkgs/development/python-modules/python-cinderclient/default.nix
+++ b/pkgs/development/python-modules/python-cinderclient/default.nix
@@ -11,7 +11,7 @@
 , prettytable
 , requests-mock
 , simplejson
-, stestr
+, stestrCheckHook
 , stevedore
 }:
 
@@ -40,12 +40,8 @@ buildPythonPackage rec {
     ddt
     oslo-serialization
     requests-mock
-    stestr
+    stestrCheckHook
   ];
-
-  checkPhase = ''
-    stestr run
-  '';
 
   pythonImportsCheck = [ "cinderclient" ];
 

--- a/pkgs/development/python-modules/python-glanceclient/default.nix
+++ b/pkgs/development/python-modules/python-glanceclient/default.nix
@@ -12,10 +12,12 @@
 , wrapt
 , pyopenssl
 , pythonOlder
-, stestr
+, stestrCheckHook
 , testscenarios
 , ddt
 , requests-mock
+, libredirect
+, iana-etc
 }:
 
 buildPythonPackage rec {
@@ -48,18 +50,21 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    stestr
+    stestrCheckHook
     testscenarios
     ddt
     requests-mock
   ];
 
-  checkPhase = ''
-    stestr run
-  '';
-
   pythonImportsCheck = [
     "glanceclient"
+  ];
+
+  disabledTests = [
+    "glanceclient.tests.unit.test_ssl.TestHTTPSVerifyCert.test_v2_requests_valid_cert_verification"
+    "glanceclient.tests.unit.test_ssl.TestHTTPSVerifyCert.test_v2_requests_valid_cert_verification_no_compression"
+    "glanceclient.tests.unit.test_http.TestClient.test_http_chunked_response"
+    "glanceclient.tests.unit.test_http.TestClient.test_log_request_id_once"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/python-heatclient/default.nix
+++ b/pkgs/development/python-modules/python-heatclient/default.nix
@@ -15,7 +15,7 @@
 , pyyaml
 , requests
 , requests-mock
-, stestr
+, stestrCheckHook
 , testscenarios
 }:
 
@@ -47,17 +47,15 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    stestr
+    stestrCheckHook
     testscenarios
     requests-mock
   ];
 
-  checkPhase = ''
-    stestr run -e <(echo "
-      heatclient.tests.unit.test_common_http.HttpClientTest.test_get_system_ca_file
-      heatclient.tests.unit.test_deployment_utils.TempURLSignalTest.test_create_temp_url
-    ")
-  '';
+  disabledTests = [
+    "heatclient.tests.unit.test_common_http.HttpClientTest.test_get_system_ca_file"
+    "heatclient.tests.unit.test_deployment_utils.TempURLSignalTest.test_create_temp_url"
+  ];
 
   pythonImportsCheck = [
     "heatclient"

--- a/pkgs/development/python-modules/python-ironicclient/default.nix
+++ b/pkgs/development/python-modules/python-ironicclient/default.nix
@@ -13,7 +13,7 @@
 , pyyaml
 , requests
 , stevedore
-, stestr
+, stestrCheckHook
 , requests-mock
 , oslotest
 }:
@@ -44,14 +44,10 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    stestr
+    stestrCheckHook
     requests-mock
     oslotest
   ];
-
-  checkPhase = ''
-    stestr run
-  '';
 
   pythonImportsCheck = [ "ironicclient" ];
 

--- a/pkgs/development/python-modules/python-jenkins/default.nix
+++ b/pkgs/development/python-modules/python-jenkins/default.nix
@@ -11,7 +11,7 @@
 , testscenarios
 , requests
 , requests-mock
-, stestr
+, stestrCheckHook
 , multiprocess
 , pythonRelaxDepsHook
 }:
@@ -45,13 +45,13 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
-  nativeCheckInputs = [ stestr testscenarios requests-mock multiprocess ];
-  checkPhase = ''
+  nativeCheckInputs = [ stestrCheckHook testscenarios requests-mock multiprocess ];
+  disabledTests = [
     # Skip tests that fail due to setuptools>=66.0.0 rejecting PEP 440
     # non-conforming versions. See
     # https://github.com/pypa/setuptools/issues/2497 for details.
-    stestr run -E "tests.test_plugins.(PluginsTestScenarios.test_plugin_version_comparison|PluginsTestScenarios.test_plugin_version_object_comparison|PluginsTest.test_plugin_equal|PluginsTest.test_plugin_not_equal)"
-  '';
+    "tests.test_plugins.(PluginsTestScenarios.test_plugin_version_comparison|PluginsTestScenarios.test_plugin_version_object_comparison|PluginsTest.test_plugin_equal|PluginsTest.test_plugin_not_equal)"
+  ];
 
   meta = with lib; {
     description = "Python bindings for the remote Jenkins API";

--- a/pkgs/development/python-modules/python-keystoneclient/default.nix
+++ b/pkgs/development/python-modules/python-keystoneclient/default.nix
@@ -8,7 +8,7 @@
 , pbr
 , pythonOlder
 , requests-mock
-, stestr
+, stestrCheckHook
 , testresources
 , testscenarios
 }:
@@ -35,14 +35,10 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     openssl
     requests-mock
-    stestr
+    stestrCheckHook
     testresources
     testscenarios
   ];
-
-  checkPhase = ''
-    stestr run
-  '';
 
   pythonImportsCheck = [
     "keystoneclient"

--- a/pkgs/development/python-modules/python-manilaclient/tests.nix
+++ b/pkgs/development/python-modules/python-manilaclient/tests.nix
@@ -1,6 +1,6 @@
 { buildPythonPackage
 , python-manilaclient
-, stestr
+, stestrCheckHook
 , ddt
 , tempest
 , mock
@@ -17,14 +17,10 @@ buildPythonPackage {
 
   nativeCheckInputs = [
     python-manilaclient
-    stestr
+    stestrCheckHook
     ddt
     tempest
     mock
     python-openstackclient
   ];
-
-  checkPhase = ''
-    stestr run
-  '';
 }

--- a/pkgs/development/python-modules/python-novaclient/default.nix
+++ b/pkgs/development/python-modules/python-novaclient/default.nix
@@ -11,7 +11,7 @@
 , prettytable
 , pythonOlder
 , requests-mock
-, stestr
+, stestrCheckHook
 , testscenarios
 }:
 
@@ -40,16 +40,14 @@ buildPythonPackage rec {
     ddt
     openssl
     requests-mock
-    stestr
+    stestrCheckHook
     testscenarios
   ];
 
-  checkPhase = ''
-    stestr run -e <(echo "
-    novaclient.tests.unit.test_shell.ShellTest.test_osprofiler
-    novaclient.tests.unit.test_shell.ShellTestKeystoneV3.test_osprofiler
-    ")
-  '';
+  disabledTests = [
+    "novaclient.tests.unit.test_shell.ShellTest.test_osprofiler"
+    "novaclient.tests.unit.test_shell.ShellTestKeystoneV3.test_osprofiler"
+  ];
 
   pythonImportsCheck = [ "novaclient" ];
 

--- a/pkgs/development/python-modules/python-openstackclient/default.nix
+++ b/pkgs/development/python-modules/python-openstackclient/default.nix
@@ -11,7 +11,7 @@
 , python-novaclient
 , requests-mock
 , sphinx
-, stestr
+, stestrCheckHook
 }:
 
 buildPythonPackage rec {
@@ -45,13 +45,9 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     ddt
-    stestr
+    stestrCheckHook
     requests-mock
   ];
-
-  checkPhase = ''
-    stestr run
-  '';
 
   pythonImportsCheck = [ "openstackclient" ];
 

--- a/pkgs/development/python-modules/python-swiftclient/default.nix
+++ b/pkgs/development/python-modules/python-swiftclient/default.nix
@@ -7,7 +7,7 @@
 , pbr
 , python-keystoneclient
 , pythonOlder
-, stestr
+, stestrCheckHook
 }:
 
 buildPythonPackage rec {
@@ -41,17 +41,13 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     mock
     openstacksdk
-    stestr
+    stestrCheckHook
   ];
 
   postInstall = ''
     installShellCompletion --cmd swift \
       --bash tools/swift.bash_completion
     installManPage doc/manpages/*
-  '';
-
-  checkPhase = ''
-    stestr run
   '';
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/subunit2sql/default.nix
+++ b/pkgs/development/python-modules/subunit2sql/default.nix
@@ -6,7 +6,7 @@
 , oslo-db
 , pbr
 , python-dateutil
-, stestr
+, stestrCheckHook
 , testresources
 , testscenarios
 }:
@@ -30,24 +30,24 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     mock
     oslo-concurrency
-    stestr
+    stestrCheckHook
     testresources
     testscenarios
   ];
 
-  checkPhase = ''
+  preCheck = ''
     export PATH=$out/bin:$PATH
     export HOME=$TMPDIR
-
-    stestr run -e <(echo "
-    subunit2sql.tests.db.test_api.TestDatabaseAPI.test_get_failing_test_ids_from_runs_by_key_value
-    subunit2sql.tests.db.test_api.TestDatabaseAPI.test_get_id_from_test_id
-    subunit2sql.tests.db.test_api.TestDatabaseAPI.test_get_test_run_dict_by_run_meta_key_value
-    subunit2sql.tests.migrations.test_migrations.TestWalkMigrations.test_sqlite_opportunistically
-    subunit2sql.tests.test_shell.TestMain.test_main
-    subunit2sql.tests.test_shell.TestMain.test_main_with_targets
-    ")
   '';
+
+  disabledTests = [
+    "subunit2sql.tests.db.test_api.TestDatabaseAPI.test_get_failing_test_ids_from_runs_by_key_value"
+    "subunit2sql.tests.db.test_api.TestDatabaseAPI.test_get_id_from_test_id"
+    "subunit2sql.tests.db.test_api.TestDatabaseAPI.test_get_test_run_dict_by_run_meta_key_value"
+    "subunit2sql.tests.migrations.test_migrations.TestWalkMigrations.test_sqlite_opportunistically"
+    "subunit2sql.tests.test_shell.TestMain.test_main"
+    "subunit2sql.tests.test_shell.TestMain.test_main_with_targets"
+  ];
 
   pythonImportsCheck = [ "subunit2sql" ];
 

--- a/pkgs/development/python-modules/swift/default.nix
+++ b/pkgs/development/python-modules/swift/default.nix
@@ -17,7 +17,7 @@
 , requests
 , setuptools
 , six
-, stestr
+, stestrCheckHook
 , swiftclient
 , xattr
 }:
@@ -63,21 +63,19 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     boto3
     mock
-    stestr
+    stestrCheckHook
     swiftclient
   ];
 
   # a lot of tests currently fail while establishing a connection
   doCheck = false;
 
-  checkPhase = ''
+  preCheck = ''
     echo "nameserver 127.0.0.1" > resolv.conf
     export NIX_REDIRECTS=/etc/protocols=${iana-etc}/etc/protocols:/etc/resolv.conf=$(realpath resolv.conf)
     export LD_PRELOAD=${libredirect}/lib/libredirect.so
 
     export SWIFT_TEST_CONFIG_FILE=test/sample.conf
-
-    stestr run
   '';
 
   pythonImportsCheck = [ "swift" ];


### PR DESCRIPTION
## Description of changes

Add a hook to run stestr tests in python packages and make oslo-log use it instead of running it via checkPhase.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
