### PR TITLE
services.gnome.gnome-settings-daemon:  allow disabling of arbitrary plugins

### DIFF
--- a/nixos/modules/services/desktops/gnome/gnome-settings-daemon.nix
+++ b/nixos/modules/services/desktops/gnome/gnome-settings-daemon.nix
@@ -8,6 +8,8 @@ let
 
   cfg = config.services.gnome.gnome-settings-daemon;
 
+  pkg = pkgs.gnome.gnome-settings-daemon.override { inherit (cfg) disabled-plugins; };
+
 in
 
 {
@@ -36,6 +38,36 @@ in
 
       enable = mkEnableOption (lib.mdDoc "GNOME Settings Daemon");
 
+      disabled-plugins = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = lib.mdDoc ''
+          Which of the gnome-settings-daemon plugins to disable.
+          Each of those plugins runs a user-level systemd service
+          called "org.gnome.SettingsDaemon.<x>".
+
+          As of Gnome 45, the plugins were:
+
+            a11y-settings,       GNOME accessibility (impacts keyboard shortcuts)
+            color,               GNOME color management (impacts night shift)
+            datetime,            GNOME date & time
+            power,               GNOME power management
+            housekeeping,        GNOME maintenance of expirable data
+            keyboard,            GNOME keyboard configuration
+            media-keys,          GNOME keyboard shortcuts
+            screensaver-proxy,   GNOME FreeDesktop screensaver
+            sharing,             GNOME file sharing
+            sound,               GNOME sound sample caching
+            usb-protection,      GNOME USB protection
+            xsettings,           GNOME XSettings
+            smartcard,           GNOME smartcard
+            wacom,               GNOME Wacom tablet support
+            print-notifications, GNOME printer notifications
+            rfkill,              GNOME RFKill support
+            wwan,                GNOME WWan support
+        '';
+      };
+
     };
 
   };
@@ -45,17 +77,11 @@ in
 
   config = mkIf cfg.enable {
 
-    environment.systemPackages = [
-      pkgs.gnome.gnome-settings-daemon
-    ];
+    environment.systemPackages = [ pkg ];
 
-    services.udev.packages = [
-      pkgs.gnome.gnome-settings-daemon
-    ];
+    services.udev.packages = [ pkg ];
 
-    systemd.packages = [
-      pkgs.gnome.gnome-settings-daemon
-    ];
+    systemd.packages = [ pkg ];
 
     systemd.user.targets."gnome-session-x11-services".wants = [
       "org.gnome.SettingsDaemon.XSettings.service"

--- a/pkgs/desktops/gnome/core/gnome-settings-daemon/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-settings-daemon/default.nix
@@ -36,6 +36,7 @@
 , tzdata
 , gcr_4
 , gnome-session-ctl
+, disabled-plugins ? []
 }:
 
 stdenv.mkDerivation rec {
@@ -54,6 +55,13 @@ stdenv.mkDerivation rec {
     (substituteAll {
       src = ./fix-paths.patch;
       inherit tzdata;
+    })
+
+    # HACK: We want to be able to disable arbitrary gnome-settings-daemon plugins,
+    # but Meson does not support this, so we need to convince it to anyway.
+    (substituteAll {
+      src = ./disabled-plugins.patch;
+      disabled = lib.concatStringsSep ", " (map (x: "'" + x + "'") disabled-plugins);
     })
   ];
 

--- a/pkgs/desktops/gnome/core/gnome-settings-daemon/disabled-plugins.patch
+++ b/pkgs/desktops/gnome/core/gnome-settings-daemon/disabled-plugins.patch
@@ -1,0 +1,11 @@
+--- a/plugins/meson.build
++++ b/plugins/meson.build
+@@ -18,6 +18,6 @@
+     ['wwan', 'Wwan', 'GNOME WWan support'],
+ ]
+
+-disabled_plugins = []
++disabled_plugins = [@disabled@]
+
+ if not enable_smartcard
+     disabled_plugins += ['smartcard']


### PR DESCRIPTION
In pursuit of minimising the Gnome desktop footprint one might be tempted to reduce the number of services that `gnome-settings-daemon` starts.

We can observe those by invoking `systemctl --all --user | grep SettingsDaemon`

This allows build-time subsetting of systemd services that are installed into the system by `gnome-settings-daemon` to handle its plugins.

Note that the set of plugin-induced systemd services that `gnome-system-daemon` injects is not controlled by its NixOS packaging and service definition -- instead it is a direct consequence _**exclusively**_ controlled by its build process.

## Description of changes

We patch the Meson build description in the `plugins` subdir to allow subsetting of the plugins.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
