### PR TITLE
crossfire-server: fix build due to missing `cstdint` include

### DIFF
--- a/pkgs/games/crossfire/add-cstdint-include-to-crossfire-server.patch
+++ b/pkgs/games/crossfire/add-cstdint-include-to-crossfire-server.patch
@@ -1,0 +1,13 @@
+diff --git a/include/Treasures.h b/include/Treasures.h
+index 614078f..a00b4f6 100644
+--- a/include/Treasures.h
++++ b/include/Treasures.h
+@@ -13,6 +13,8 @@
+ #ifndef TREASURES_H
+ #define TREASURES_H
+ 
++#include <cstdint>
++
+ #include "AssetsCollection.h"
+ 
+ extern "C" {

--- a/pkgs/games/crossfire/crossfire-server.nix
+++ b/pkgs/games/crossfire/crossfire-server.nix
@@ -27,6 +27,10 @@ stdenv.mkDerivation rec {
     rev = "r${rev}";
   };
 
+  patches = [
+    ./add-cstdint-include-to-crossfire-server.patch
+  ];
+
   nativeBuildInputs = [ autoconf automake libtool flex perl check pkg-config python39 ];
   hardeningDisable = [ "format" ];
 


### PR DESCRIPTION
GCC 13 stopped including `cstdint` (and other headers) transitively in most scenarios, causing build failures in programs that relied on that behavior.

This change adds a missing `cstdint` include via patch to the `crossfire-server` source, fixing such a build failure.

Failing Hydra build: https://hydra.nixos.org/build/247498362
Hydra log: https://hydra.nixos.org/build/247498362/nixlog/1

Relevant log excerpt:
```
  CXX      assets/Treasures.o
In file included from ../include/Treasures.h:19,
                 from assets/Treasures.cpp:13:
../include/treasure.h:70:5: error: 'uint8_t' does not name a type
   70 |     uint8_t chance;                       /**< Percent chance for this item */
      |     ^~~~~~~
../include/treasure.h:1:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
  +++ |+#include <cstdint>
    1 | /**
```


## Description of changes

Added a patch that introduces the missing `#include <cstdio>` statement.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
