### PR TITLE
make-startupitem: add `prependExtraArgs` and `appendExtraArgs`

### DIFF
--- a/pkgs/build-support/make-startupitem/default.nix
+++ b/pkgs/build-support/make-startupitem/default.nix
@@ -8,6 +8,8 @@
 , after ? null
 , condition ? null
 , phase ? "2"
+, prependExtraArgs ? []
+, appendExtraArgs ? []
 }:
 
 # the builder requires that
@@ -18,10 +20,17 @@ stdenv.mkDerivation {
   name = "autostart-${name}";
   priority = 5;
 
-  buildCommand = ''
+  buildCommand = let
+    escapeArgs = args: lib.escapeRegex (lib.escapeShellArgs args);
+    prependArgs = lib.optionalString (prependExtraArgs != []) "${escapeArgs prependExtraArgs} ";
+    appendArgs = lib.optionalString (appendExtraArgs != []) " ${escapeArgs appendExtraArgs}";
+  in ''
     mkdir -p $out/etc/xdg/autostart
     target=${name}.desktop
     cp ${package}/share/applications/${srcPrefix}${name}.desktop $target
+    ${lib.optionalString (prependExtraArgs != [] || appendExtraArgs != []) ''
+      sed -i -r "s/(Exec=)([^ ]*) (.*)/\1\2 ${prependArgs}\3${appendArgs}/" $target
+    ''}
     chmod +rw $target
     echo "X-KDE-autostart-phase=${phase}" >> $target
     ${lib.optionalString (after != null) ''echo "${after}" >> $target''}


### PR DESCRIPTION
## Description of changes

Adds `prependExtraArgs` & `appendExtraArgs` to `pkgs.makeAutostartItem`.
This is really useful some some apps, e.g. to make them start minimized & visible in the system tray.

Example usage:
```nix
pkgs.makeAutostartItem {
  name = "element-desktop";
  package = pkgs.element-desktop;
  prependExtraArgs = ["--hidden"];
  appendExtraArgs = ["--verbose"];
}
```

The resulting `.desktop` file will have the following `Exec` line:
```
Exec=element-desktop '--hidden' %u '--verbose'
```

It might be better to add the arguments before `%u` & other [field codes](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s07.html), but I couldn't figure out how to support all those variations with sed. Update: replaced `extraArgs` with separate `prependExtraArgs` & `appendExtraArgs`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
