### PR TITLE
mate.atril: 1.26.1 -> 1.26.2

### DIFF
--- a/pkgs/desktops/mate/atril/default.nix
+++ b/pkgs/desktops/mate/atril/default.nix
@@ -6,6 +6,7 @@
 , gtk3
 , glib
 , libxml2
+, libarchive
 , libsecret
 , poppler
 , itstool
@@ -14,7 +15,7 @@
 , mate
 , wrapGAppsHook
 , enableEpub ? true
-, webkitgtk
+, webkitgtk_4_1
 , enableDjvu ? true
 , djvulibre
 , enablePostScript ? true
@@ -27,11 +28,11 @@
 
 stdenv.mkDerivation rec {
   pname = "atril";
-  version = "1.26.1";
+  version = "1.26.2";
 
   src = fetchurl {
     url = "https://pub.mate-desktop.org/releases/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "pTphOsuXAaGK1nG/WQJU0c6Da6CuG+LAvYlI/fa0kaQ=";
+    sha256 = "wwW51fVxP0Jiau4DggkTA0IrPXGlbd1lkyzNsjx86SY=";
   };
 
   nativeBuildInputs = [
@@ -44,6 +45,7 @@ stdenv.mkDerivation rec {
     gtk3
     glib
     itstool
+    libarchive
     libsecret
     libxml2
     poppler
@@ -53,7 +55,7 @@ stdenv.mkDerivation rec {
     texlive.bin.core # for synctex, used by the pdf back-end
   ]
   ++ lib.optionals enableDjvu [ djvulibre ]
-  ++ lib.optionals enableEpub [ webkitgtk ]
+  ++ lib.optionals enableEpub [ webkitgtk_4_1 ]
   ++ lib.optionals enablePostScript [ libspectre ]
   ++ lib.optionals enableXps [ libgxps ]
   ;


### PR DESCRIPTION
https://github.com/mate-desktop/atril/compare/v1.26.1...v1.26.2



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
