### PR TITLE
reth: init at 1.3.12

### DIFF
--- a/pkgs/by-name/re/reth/package.nix
+++ b/pkgs/by-name/re/reth/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "reth";
+  version = "1.3.12";
+
+  src = fetchFromGitHub {
+    owner = "paradigmxyz";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-59XUrMaXMiqSELQX8i7eK4Eo8YfGjPVZHT6q+rxoSPs=";
+  };
+
+  cargoHash = "sha256-FHQ+iPcjxwcY7uoZMXlm/lRoVA5E5wRg7qFgJe+VSEc=";
+
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+  ];
+
+  # Some tests fail due to I/O that is unfriendly with nix sandbox.
+  checkFlags = [
+    "--skip=builder::tests::block_number_node_config_test"
+    "--skip=builder::tests::launch_multiple_nodes"
+    "--skip=builder::tests::rpc_handles_none_without_http"
+    "--skip=cli::tests::override_trusted_setup_file"
+    "--skip=cli::tests::parse_env_filter_directives"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Modular Ethereum execution client in Rust by Paradigm";
+    homepage = "https://github.com/paradigmxyz/reth";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    mainProgram = "reth";
+    maintainers = with lib.maintainers; [ mitchmindtree ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
This commit adds `reth`, an Ethereum execution client by Paradigm written in Rust.

This package is adapted from the [nix-community/ethereum.nix package][1] with a version update, darwin support, and some slight modifications to better suit the nixpkgs conventions.

Closes #249233

[1]: https://github.com/nix-community/ethereum.nix/blob/main/packages/clients/execution/reth/default.nix

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

N/A

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
