### PR TITLE
Make gnome-keyring PAM module components configurable

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -1,7 +1,7 @@
 # This module provides configuration for the PAM (Pluggable
 # Authentication Modules) system.
 
-{ config, lib, pkgs, ... }:
+{ config, options, lib, pkgs, ... }:
 
 with lib;
 
@@ -500,14 +500,17 @@ let
         '';
       };
 
-      gnomeKeyringComponents = lib.genAttrs ["ssh" "secrets" "pkcs11"] (name: mkOption {
+      gnomeKeyringComponents = lib.genAttrs ["ssh" "secrets" "pkcs11"] (name: mkOption ({
         default = true;
         type = types.bool;
         description = lib.mdDoc ''
           If enabled, the ${name} component will be enabled in the gnome-keyring-daemon
           started by pam_gnome_keyring.
         '';
-      });
+      } // (lib.optionalAttrs (name == "ssh") {
+        default = !config.programs.gnupg.agent.enableSSHSupport;
+        defaultText = lib.literalExpression "!config.programs.gnupg.agent.enableSSHSupport";
+      })));
 
       failDelay = {
         enable = mkOption {

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -94,7 +94,7 @@ let
 
   parentConfig = config;
 
-  pamOpts = { config, name, ... }: let cfg = config; in let config = parentConfig; in {
+  pamOpts = { config, options, name, ... }: let cfg = config; in let config = parentConfig; in {
 
     options = {
 
@@ -500,6 +500,15 @@ let
         '';
       };
 
+      gnomeKeyringComponents = lib.genAttrs ["ssh" "secrets" "pkcs11"] (name: mkOption {
+        default = true;
+        type = types.bool;
+        description = lib.mdDoc ''
+          If enabled, the ${name} component will be enabled in the gnome-keyring-daemon
+          started by pam_gnome_keyring.
+        '';
+      });
+
       failDelay = {
         enable = mkOption {
           type = types.bool;
@@ -624,6 +633,12 @@ let
           (map (rule: nameValuePair rule.name (removeAttrs rule [ "name" ])))
           listToAttrs
         ];
+        gnomeKeyringComponents = lib.filter
+          (component: cfg.gnomeKeyringComponents.${component})
+          (lib.attrNames options.gnomeKeyringComponents);
+        gnomeKeyringComponentsArgs = lib.optionals ((lib.length gnomeKeyringComponents) > 0) [
+          ("--components=" + (lib.concatStringsSep "," gnomeKeyringComponents))
+        ];
       in {
         account = autoOrderRules [
           { name = "ldap"; enable = use_ldap; control = "sufficient"; modulePath = "${pam_ldap}/lib/security/pam_ldap.so"; }
@@ -725,7 +740,7 @@ let
               { name = "kwallet5"; enable = cfg.enableKwallet; control = "optional"; modulePath = "${pkgs.plasma5Packages.kwallet-pam}/lib/security/pam_kwallet5.so"; settings = {
                 kwalletd = "${pkgs.plasma5Packages.kwallet.bin}/bin/kwalletd5";
               }; }
-              { name = "gnome_keyring"; enable = cfg.enableGnomeKeyring; control = "optional"; modulePath = "${pkgs.gnome.gnome-keyring}/lib/security/pam_gnome_keyring.so"; }
+              { name = "gnome_keyring"; enable = cfg.enableGnomeKeyring; control = "optional"; modulePath = "${pkgs.gnome.gnome-keyring}/lib/security/pam_gnome_keyring.so"; args = gnomeKeyringComponentsArgs; }
               { name = "gnupg"; enable = cfg.gnupg.enable; control = "optional"; modulePath = "${pkgs.pam_gnupg}/lib/security/pam_gnupg.so"; settings = {
                 store-only = cfg.gnupg.storeOnly;
               }; }
@@ -790,7 +805,7 @@ let
           { name = "krb5"; enable = config.security.pam.krb5.enable; control = "sufficient"; modulePath = "${pam_krb5}/lib/security/pam_krb5.so"; settings = {
             use_first_pass = true;
           }; }
-          { name = "gnome_keyring"; enable = cfg.enableGnomeKeyring; control = "optional"; modulePath = "${pkgs.gnome.gnome-keyring}/lib/security/pam_gnome_keyring.so"; settings = {
+          { name = "gnome_keyring"; enable = cfg.enableGnomeKeyring; control = "optional"; modulePath = "${pkgs.gnome.gnome-keyring}/lib/security/pam_gnome_keyring.so"; args = gnomeKeyringComponentsArgs; settings = {
             use_authtok = true;
           }; }
         ];
@@ -861,7 +876,7 @@ let
           { name = "kwallet5"; enable = cfg.enableKwallet; control = "optional"; modulePath = "${pkgs.plasma5Packages.kwallet-pam}/lib/security/pam_kwallet5.so"; settings = {
             kwalletd = "${pkgs.plasma5Packages.kwallet.bin}/bin/kwalletd5";
           }; }
-          { name = "gnome_keyring"; enable = cfg.enableGnomeKeyring; control = "optional"; modulePath = "${pkgs.gnome.gnome-keyring}/lib/security/pam_gnome_keyring.so"; settings = {
+          { name = "gnome_keyring"; enable = cfg.enableGnomeKeyring; control = "optional"; modulePath = "${pkgs.gnome.gnome-keyring}/lib/security/pam_gnome_keyring.so"; args = gnomeKeyringComponentsArgs; settings = {
             auto_start = true;
           }; }
           { name = "gnupg"; enable = cfg.gnupg.enable; control = "optional"; modulePath = "${pkgs.pam_gnupg}/lib/security/pam_gnupg.so"; settings = {

--- a/pkgs/desktops/gnome/core/gnome-keyring/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-keyring/default.nix
@@ -33,6 +33,12 @@ stdenv.mkDerivation rec {
     sha256 = "x/TQQMx2prf+Z+CO+RBpEcPIDUD8iMv8jiaEpMlG4+Y=";
   };
 
+  patches = [
+    # Make the components started via PAM module configurable
+    # https://gitlab.gnome.org/GNOME/gnome-keyring/-/merge_requests/40
+    ./pam-components-config.patch
+  ];
+
   nativeBuildInputs = [
     pkg-config
     gettext

--- a/pkgs/desktops/gnome/core/gnome-keyring/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-keyring/default.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation rec {
     # Make the components started via PAM module configurable
     # https://gitlab.gnome.org/GNOME/gnome-keyring/-/merge_requests/40
     ./pam-components-config.patch
+    ./fix-warnings.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome/core/gnome-keyring/fix-warnings.patch
+++ b/pkgs/desktops/gnome/core/gnome-keyring/fix-warnings.patch
@@ -1,0 +1,44 @@
+From 2bdd3748867d009702285d9876954e32923d155a Mon Sep 17 00:00:00 2001
+From: avitex <theavitex@gmail.com>
+Date: Sat, 27 Jan 2024 15:13:40 +1100
+Subject: [PATCH] Fix warnings
+
+- security_context_t usage replaced with char* due to type deprecation
+- handle seteuid and setegid results when reverting effective user
+---
+ pam/gkr-pam-module.c | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/pam/gkr-pam-module.c b/pam/gkr-pam-module.c
+index 7a6b735e..319007ac 100644
+--- a/pam/gkr-pam-module.c
++++ b/pam/gkr-pam-module.c
+@@ -319,7 +319,7 @@ cleanup_free_password (pam_handle_t *ph, void *data, int pam_end_status)
+    with default behaviour
+ */
+ static void setup_selinux_context(const char *command) {
+-	security_context_t fcon = NULL, newcon = NULL, execcon = NULL;
++	char *fcon = NULL, *newcon = NULL, *execcon = NULL;
+ 
+ 	if (is_selinux_enabled() != 1) return;
+ 
+@@ -388,10 +388,13 @@ setup_child (int inp[2],
+ 	close (outp[WRITE_END]);
+ 	close (errp[READ_END]);
+ 	close (errp[WRITE_END]);
+-	
++
+ 	/* We may be running effective as another user, revert that */
+-	seteuid (getuid ());
+-	setegid (getgid ());
++	if (seteuid (getuid ()) < 0 || setegid (getgid ()) < 0) {
++		syslog (GKR_LOG_ERR, "gkr-pam: couldn't revert effective user: %s",
++				strerror (errno));
++		exit (EXIT_FAILURE);
++	}
+ 	
+ 	/* Setup process credentials */
+ 	if (setgid (pwd->pw_gid) < 0 || setuid (pwd->pw_uid) < 0 ||
+-- 
+GitLab
+

--- a/pkgs/desktops/gnome/core/gnome-keyring/pam-components-config.patch
+++ b/pkgs/desktops/gnome/core/gnome-keyring/pam-components-config.patch
@@ -1,0 +1,213 @@
+From 821edabbcc783a8e9c26743279b4e0b4ce332128 Mon Sep 17 00:00:00 2001
+From: avitex <theavitex@gmail.com>
+Date: Fri, 26 Jan 2024 22:49:44 +1100
+Subject: [PATCH] Provide components option for configuring PAM daemon
+
+The PAM module exposes a new `components=<component,component>` argument
+which if provided is passed though to the daemon when started.
+
+The main drive behind this is to provide the ability to disable the SSH
+agent and subsequently the `SSH_AUTH_SOCK` env var when the daemon is
+started through the PAM module.
+---
+ pam/gkr-pam-module.c | 59 ++++++++++++++++++++++++++++++--------------
+ 1 file changed, 40 insertions(+), 19 deletions(-)
+
+diff --git a/pam/gkr-pam-module.c b/pam/gkr-pam-module.c
+index 319007ac..431ff203 100644
+--- a/pam/gkr-pam-module.c
++++ b/pam/gkr-pam-module.c
+@@ -348,18 +348,30 @@ setup_child (int inp[2],
+              int errp[2],
+              pam_handle_t *ph,
+              struct passwd *pwd,
+-             const char *argument)
++             bool is_user_login,
++             const char *components)
+ {
+ 	const char* display;
+ 	const char *runtime;
+ 	int i, ret;
+ 
+-	char *args[] = {
++	const char *args[] = {
+ 		GNOME_KEYRING_DAEMON,
+ 		"--daemonize",
+-		(char *)argument,
++		NULL,
++		NULL,
++		NULL,
+ 		NULL
+ 	};
++	const char **next_arg = args + 2;
++
++	if (is_user_login) {
++		*next_arg++ = "--login";
++	}
++	if (components != NULL) {
++		*next_arg++ = "--components";
++		*next_arg++ = components;
++	}
+ 
+ #ifdef WITH_SELINUX
+ 	setup_selinux_context(GNOME_KEYRING_DAEMON);
+@@ -425,7 +437,7 @@ setup_child (int inp[2],
+ 	}
+ 	
+ 	/* Now actually execute the process */
+-	execve (args[0], args, pam_getenvlist (ph));
++	execve (args[0], (char* const *) args, pam_getenvlist (ph));
+ 	syslog (GKR_LOG_ERR, "gkr-pam: couldn't run gnome-keyring-daemon: %s", 
+ 	        strerror (errno));
+ 	exit (EXIT_FAILURE);
+@@ -478,7 +490,8 @@ static int
+ start_daemon (pam_handle_t *ph,
+               struct passwd *pwd,
+               bool is_user_login,
+-              const char *password)
++              const char *password,
++              const char *components)
+ {
+ 	struct sigaction defsact, oldsact, ignpipe, oldpipe;
+ 	int inp[2] = { -1, -1 };
+@@ -527,8 +540,7 @@ start_daemon (pam_handle_t *ph,
+ 		
+ 	/* This is the child */
+ 	case 0:
+-		setup_child (inp, outp, errp, ph, pwd,
+-		             is_user_login ? "--login" : NULL);
++		setup_child (inp, outp, errp, ph, pwd, is_user_login, components);
+ 		/* Should never be reached */
+ 		break;
+ 		
+@@ -802,11 +814,12 @@ prompt_password (pam_handle_t *ph)
+ }
+ 
+ static uint 
+-parse_args (pam_handle_t *ph, int argc, const char **argv)
++parse_args (pam_handle_t *ph, int argc, const char **argv, const char **components)
+ {
+ 	uint args = 0;
+ 	const void *svc;
+ 	int only_if_len;
++	int components_len;
+ 	int i;
+ 
+ 	svc = NULL;
+@@ -814,6 +827,7 @@ parse_args (pam_handle_t *ph, int argc, const char **argv)
+ 		svc = NULL;
+ 
+ 	only_if_len = strlen ("only_if=");
++	components_len = strlen ("components=");
+ 
+ 	/* Parse the arguments */
+ 	for (i = 0; i < argc; i++) {
+@@ -825,6 +839,9 @@ parse_args (pam_handle_t *ph, int argc, const char **argv)
+ 			if (!evaluate_inlist (svc, value))
+ 				args |= ARG_IGNORE_SERVICE;
+ 
++		} else if (strncmp (argv[i], "components=", components_len) == 0) {
++			*components = argv[i] + components_len;
++
+ 		} else if (strcmp (argv[i], "use_authtok") == 0) {
+ 			args |= ARG_USE_AUTHTOK;
+ 
+@@ -853,13 +870,13 @@ stash_password_for_session (pam_handle_t *ph,
+ PAM_EXTERN int
+ pam_sm_authenticate (pam_handle_t *ph, int unused, int argc, const char **argv)
+ {
++	const char *user = NULL, *password = NULL, *components = NULL;
+ 	struct passwd *pwd;
+-	const char *user, *password;
+ 	int need_daemon = 0;
+ 	uint args;
+ 	int ret;
+ 	
+-	args = parse_args (ph, argc, argv);
++	args = parse_args (ph, argc, argv, &components);
+ 
+ 	if (args & ARG_IGNORE_SERVICE)
+ 		return PAM_SUCCESS;
+@@ -893,7 +910,7 @@ pam_sm_authenticate (pam_handle_t *ph, int unused, int argc, const char **argv)
+ 	if (ret != PAM_SUCCESS && need_daemon) {
+ 		if (args & ARG_AUTO_START) {
+ 			/* We pass password to the daemon when starting, thus it will immediately unlock keyring */
+-			ret = start_daemon (ph, pwd, true, password);
++			ret = start_daemon (ph, pwd, true, password, components);
+ 		} else {
+ 			ret = stash_password_for_session (ph, password);
+ 			syslog (GKR_LOG_INFO, "gkr-pam: stashed password to try later in open session");
+@@ -906,13 +923,13 @@ pam_sm_authenticate (pam_handle_t *ph, int unused, int argc, const char **argv)
+ PAM_EXTERN int
+ pam_sm_open_session (pam_handle_t *ph, int flags, int argc, const char **argv)
+ {
+-	const char *user = NULL, *password = NULL;
++	const char *user = NULL, *password = NULL, *components = NULL;
+ 	struct passwd *pwd;
+ 	int ret;
+ 	uint args;
+ 	int need_daemon = 0;
+ 
+-	args = parse_args (ph, argc, argv);
++	args = parse_args (ph, argc, argv, &components);
+ 
+ 	if (args & ARG_IGNORE_SERVICE)
+ 		return PAM_SUCCESS;
+@@ -946,7 +963,7 @@ pam_sm_open_session (pam_handle_t *ph, int flags, int argc, const char **argv)
+ 	if (args & ARG_AUTO_START || password) {
+ 		ret = unlock_keyring (ph, pwd, password, &need_daemon);
+ 		if (ret != PAM_SUCCESS && need_daemon && (args & ARG_AUTO_START))
+-			ret = start_daemon (ph, pwd, true, password);
++			ret = start_daemon (ph, pwd, true, password, components);
+ 	}
+ 
+ 	/* Destroy the stored authtok once it has been used */
+@@ -989,7 +1006,11 @@ pam_chauthtok_preliminary (pam_handle_t *ph, struct passwd *pwd)
+ }
+ 
+ static int
+-pam_chauthtok_update (pam_handle_t *ph, struct passwd *pwd, uint args)
++pam_chauthtok_update (
++	pam_handle_t *ph,
++	struct passwd *pwd,
++	uint args,
++	const char *components)
+ {
+ 	const char *password, *original;
+ 	int need_daemon = 0;
+@@ -1040,7 +1061,7 @@ pam_chauthtok_update (pam_handle_t *ph, struct passwd *pwd, uint args)
+ 		 *
+ 		 * Note that we don't pass in an unlock password, that happens below.
+ 		 */
+-		ret = start_daemon (ph, pwd, false, NULL);
++		ret = start_daemon (ph, pwd, false, NULL, components);
+ 		if (ret == PAM_SUCCESS) {
+ 			ret = change_keyring_password (ph, pwd, password, original, NULL);
+ 
+@@ -1071,12 +1092,12 @@ pam_sm_close_session (pam_handle_t *ph, int flags, int argc, const char **argv)
+ PAM_EXTERN int
+ pam_sm_chauthtok (pam_handle_t *ph, int flags, int argc, const char **argv)
+ {
+-	const char *user;
++	const char *user = NULL, *components = NULL;
+ 	struct passwd *pwd;
+ 	uint args;
+ 	int ret;
+ 	
+-	args = parse_args (ph, argc, argv);
++	args = parse_args (ph, argc, argv, &components);
+ 
+ 	if (args & ARG_IGNORE_SERVICE)
+ 		return PAM_SUCCESS;
+@@ -1098,7 +1119,7 @@ pam_sm_chauthtok (pam_handle_t *ph, int flags, int argc, const char **argv)
+ 	if (flags & PAM_PRELIM_CHECK) 
+ 		return pam_chauthtok_preliminary (ph, pwd);
+ 	else if (flags & PAM_UPDATE_AUTHTOK)
+-		return pam_chauthtok_update (ph, pwd, args);
++		return pam_chauthtok_update (ph, pwd, args, components);
+ 	else 
+ 		return PAM_IGNORE;
+ }
+-- 
+GitLab
+


### PR DESCRIPTION
This PR includes:

- New options for enabling/disabling gnome-keyring PAM module components:
  - `security.pam.services.<name>.gnomeKeyringComponents.ssh`
    - Defaults to `!programs.gnupg.agent.enableSSHSupport`
  - `security.pam.services.<name>.gnomeKeyringComponents.secrets`
  - `security.pam.services.<name>.gnomeKeyringComponents.pkcs11`
- Patch to make PAM components configurable via `--components` argument (patch submitted upstream https://gitlab.gnome.org/GNOME/gnome-keyring/-/merge_requests/40)
- Patch to fix gnome-keyring build due to warnings (patch submitted upstream https://gitlab.gnome.org/GNOME/gnome-keyring/-/merge_requests/64)

These changes help facilitate a fix for https://github.com/NixOS/nixpkgs/issues/101616, where the `ssh` component is started without any option to disable it, resulting in  the configuration of  `$SSH_AUTH_SOCK` for  `gpg-agent` getting overwritten by gnome-keyring. With these changes, one will be able to at the very least, set `gnomeKeyringComponents.ssh = false` to disable the `ssh` component.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
