### PR TITLE
snicat: init at 0.0.1

### DIFF
--- a/pkgs/by-name/sn/snicat/deps.nix
+++ b/pkgs/by-name/sn/snicat/deps.nix
@@ -1,0 +1,12 @@
+[
+  {
+    goPackagePath = "github.com/therootcompany/sclient";
+    fetch = {
+      type = "FromGitHub";
+      owner = "therootcompany";
+      repo = "sclient";
+      rev = "v1.5.0";
+      sha256 = "sha256-NAFTOx2sm92K+d746Z5UpB1HGsJI6cJgmh+YTyVkJ0w=";
+    };
+  }
+]

--- a/pkgs/by-name/sn/snicat/package.nix
+++ b/pkgs/by-name/sn/snicat/package.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, buildGoPackage
+, fetchFromGitHub
+}:
+buildGoPackage rec {
+  pname = "snicat";
+  version = "0.0.1";
+
+  src = fetchFromGitHub {
+    owner = "CTFd";
+    repo = "snicat";
+    rev = version;
+    hash = "sha256-fFlTBOz127le2Y7F9KKhbcldcyFEpAU5QiJ4VCAPs9Y=";
+  };
+
+  patchPhase = ''
+    runHook prePatch
+
+    substituteInPlace snicat.go \
+      --replace-warn "v0.0.0" "v${version}"
+
+    runHook postPatch
+  '';
+
+  goPackagePath = "github.com/CTFd/snicat";
+
+  goDeps = ./deps.nix;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm555 go/bin/snicat $out/bin/sc
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "TLS & SNI aware netcat";
+    homepage = "https://github.com/CTFd/snicat";
+    license = licenses.asl20;
+    mainProgram = "sc";
+    maintainers = with maintainers; [ felixalbrigtsen ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Added snicat(`sc`), the TLS/SNI aware netcat, which is useful for general service debugging and CTF challenges, as an alternative to `openssl s_client`.
There was no lock file or go.mod, so I added `./deps.nix` that includes the only dependency at the currently latest release rev.
The binary is renamed to match the documentation.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
