### PR TITLE
dvtm-unstable: 2018-03-31 → unstable-2021-03-09

### DIFF
--- a/pkgs/tools/misc/dvtm/unstable.nix
+++ b/pkgs/tools/misc/dvtm/unstable.nix
@@ -1,13 +1,18 @@
-{callPackage, fetchFromGitHub, fetchpatch}:
+{ callPackage, fetchpatch, fetchzip }:
+
+let
+  rev = "7bcf43f8dbd5c4a67ec573a1248114caa75fa3c2";
+in
 callPackage ./dvtm.nix {
   pname = "dvtm-unstable";
-  version = "2018-03-31";
+  version = "unstable-2021-03-09";
 
-  src = fetchFromGitHub {
-    owner = "martanne";
-    repo = "dvtm";
-    rev = "311a8c0c28296f8f87fb63349e0f3254c7481e14";
-    sha256 = "0pyxjkaxh8n97kccnmd3p98vi9h8mcfy5lswzqiplsxmxxmlbpx2";
+  src = fetchzip {
+    urls = [
+      "https://github.com/martanne/dvtm/archive/${rev}.tar.gz"
+      "https://git.sr.ht/~martanne/dvtm/archive/${rev}.tar.gz"
+    ];
+    hash = "sha256-UtkNsW0mvLfbPSAIIZ1yvX9xzIDtiBeXCjhN2R8JhDc=";
   };
 
   patches = [
@@ -17,14 +22,6 @@ callPackage ./dvtm.nix {
       name = "use-self-pipe-fix-darwin";
       url = "https://github.com/martanne/dvtm/commit/1f1ed664d64603f3f1ce1388571227dc723901b2.patch";
       sha256 = "14j3kks7b1v6qq12442v1da3h7khp02rp0vi0qrz0rfgkg1zilpb";
-    })
-
-    # https://github.com/martanne/dvtm/pull/86
-    # Fix buffer corruption when title is updated
-    (fetchpatch {
-      name = "fix-buffer-corruption-on-title-update";
-      url = "https://github.com/martanne/dvtm/commit/be6c3f8f615daeab214d484e6fff22e19631a0d1.patch";
-      sha256 = "1wdrl3sg815lhs22fwbc4w5dn4ifpdgl7v1kqfnhg752av4im7h7";
     })
   ];
 }


### PR DESCRIPTION
• update to latest revision
• prepended "unstable-" to the version as suggested in the Nixpkgs docs 
• remove merged patch @ their Microsoft GitHub #86
• fetch from either Git forge mirror which reflects the documentation

  > You can always fetch the current code base from the Git repository
  > located at Github *or* SourceHut.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

@vrthra

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
