### PR TITLE
aocd-example-parser: init at unstable-2023-12-17, python311Packages.aocd: refactor

### DIFF
--- a/pkgs/development/python-modules/aocd-example-parser/default.nix
+++ b/pkgs/development/python-modules/aocd-example-parser/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flit-core
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "aocd-example-parser";
+  version = "unstable-2023-12-17";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "wimglenn";
+    repo = "aocd-example-parser";
+    rev = "07330183f3e43401444fe17b08d72eb6168504e1";
+    hash = "sha256-iOxqzZj29aY/xyigir1KOU6GcBBvnlxEOBLHChEQjf4=";
+  };
+
+  nativeBuildInputs = [
+    flit-core
+  ];
+
+  # Circular dependency with aocd
+  # pythonImportsCheck = [
+  #   "aocd_example_parser"
+  # ];
+
+  meta = with lib; {
+    description = "Default implementation of an example parser plugin for advent-of-code-data";
+    homepage = "https://github.com/wimglenn/aocd-example-parser";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/aocd/default.nix
+++ b/pkgs/development/python-modules/aocd/default.nix
@@ -1,32 +1,33 @@
 { lib
 , stdenv
+, aocd-example-parser
+, beautifulsoup4
 , buildPythonPackage
 , fetchFromGitHub
-, requests
-, pytestCheckHook
-, tzlocal
-, pytest-mock
+, numpy
+, pebble
+, pook
 , pytest-freezegun
+, pytest-mock
 , pytest-raisin
 , pytest-socket
-, requests-mock
-, pook
-, numpy
-, rich
-, pebble
+, pytestCheckHook
 , python-dateutil
-, termcolor
-, beautifulsoup4
-, setuptools
 , pythonOlder
+, requests
+, requests-mock
+, rich
+, setuptools
+, termcolor
+, tzlocal
 }:
 
 buildPythonPackage rec {
   pname = "aocd";
   version = "2.0.1";
-  format = "pyproject";
+  pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "wimglenn";
@@ -35,15 +36,30 @@ buildPythonPackage rec {
     hash = "sha256-YZvcR97uHceloqwoP+azaBmj3GLusYNbItLIaeJ3QD0=";
   };
 
+  nativeBuildInputs = [
+    setuptools
+  ];
+
   propagatedBuildInputs = [
-    python-dateutil
-    requests
-    termcolor
+    aocd-example-parser
     beautifulsoup4
     pebble
-    tzlocal
-    setuptools
+    python-dateutil
+    requests
     rich # for example parser aoce. must either be here or checkInputs
+    termcolor
+    tzlocal
+  ];
+
+  nativeCheckInputs = [
+    numpy
+    pook
+    pytest-freezegun
+    pytest-mock
+    pytest-raisin
+    pytest-socket
+    pytestCheckHook
+    requests-mock
   ];
 
   # Too many failing tests
@@ -83,20 +99,6 @@ buildPythonPackage rec {
     "test_submit_puts_level1_by_default"
     "test_cannot_submit_same_bad_answer_twice"
     "test_submit_float_warns"
-  ];
-
-  nativeCheckInputs = [
-    pytestCheckHook
-    pytest-mock
-    pytest-freezegun
-    pytest-raisin
-    pytest-socket
-  ];
-
-  checkInputs = [
-    pook
-    numpy
-    requests-mock
   ];
 
   pythonImportsCheck = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -617,6 +617,8 @@ self: super: with self; {
 
   aocd = callPackage ../development/python-modules/aocd { };
 
+  aocd-example-parser = callPackage ../development/python-modules/aocd-example-parser { };
+
   apache-beam = callPackage ../development/python-modules/apache-beam { };
 
   apcaccess = callPackage ../development/python-modules/apcaccess { };


### PR DESCRIPTION
## Description of changes
Fix build (https://hydra.nixos.org/build/246504084)

Fixes https://github.com/NixOS/nixpkgs/issues/283807
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
