### PR TITLE
mqtt2prometheus: init at 0.1.7, nixos/mqtt2prometheus: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -831,6 +831,7 @@
   ./services/monitoring/metricbeat.nix
   ./services/monitoring/mimir.nix
   ./services/monitoring/monit.nix
+  ./services/monitoring/mqtt2prometheus.nix
   ./services/monitoring/munin.nix
   ./services/monitoring/nagios.nix
   ./services/monitoring/netdata.nix

--- a/nixos/modules/services/monitoring/mqtt2prometheus.nix
+++ b/nixos/modules/services/monitoring/mqtt2prometheus.nix
@@ -1,0 +1,102 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.mqtt2prometheus;
+  settingsFormat = pkgs.formats.yaml { };
+in {
+  meta.maintainers = with lib.maintainers; [ lesuisse ];
+
+  options.services.mqtt2prometheus = {
+    enable = lib.mkEnableOption "MQTT to Prometheus gateway";
+
+    package = lib.mkPackageOption pkgs "mqtt2prometheus" { };
+
+    listenAddress = lib.mkOption {
+      default = "localhost";
+      example = "0.0.0.0";
+      type = lib.types.str;
+      description = lib.mdDoc ''
+        Listen address for the MQTT2Prometheus HTTP server used to expose metrics
+      '';
+    };
+
+    listenPort = lib.mkOption {
+      default = 9641;
+      type = lib.types.port;
+      description = lib.mdDoc ''
+        Port used by the MQTT2Prometheus HTTP server used to expose metrics
+      '';
+    };
+
+    logFormat = lib.mkOption {
+      default = "console";
+      type = lib.types.enum [ "console" "json" ];
+      description = lib.mdDoc ''
+        Desired log output format
+      '';
+    };
+
+    logLevel = lib.mkOption {
+      default = "info";
+      type = lib.types.enum [ "debug" "info" "warn" "error" ];
+      description = lib.mdDoc ''
+        Log level
+      '';
+    };
+
+    settings = lib.mkOption {
+      type = settingsFormat.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          mqtt.server = "tcp://127.0.0.1:1883";
+        }
+      '';
+      description = lib.mdDoc ''
+        Your {file}`config.yaml` as a Nix attribute set.
+        Check the [documentation](https://github.com/hikhvar/mqtt2prometheus#config-file)
+        for possible options.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.mqtt2prometheus = {
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      description = "MQTT to Prometheus gateway";
+      serviceConfig = let
+        configFile = settingsFormat.generate "config.yaml" cfg.settings;
+      in {
+        ExecStart = ''
+          ${cfg.package}/bin/mqtt2prometheus \
+            -config ${configFile} \
+            -listen-address ${lib.escapeShellArg cfg.listenAddress} \
+            -listen-port ${toString cfg.listenPort} \
+            -log-format ${cfg.logFormat} \
+            -log-level ${cfg.logLevel}
+        '';
+        DynamicUser = "yes";
+        PrivateUsers = "yes";
+        PrivateDevices = "yes";
+        ProtectClock = "yes";
+        ProtectControlGroups = "yes";
+        ProtectHome = "yes";
+        ProtectKernelLogs = "yes";
+        ProtectKernelModules = "yes";
+        ProtectKernelTunables = "yes";
+        ProtectHostname = "yes";
+        ProtectProc = "noaccess";
+        ProcSubset = "pid";
+        LockPersonality = "yes";
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
+        RestrictRealtime = "yes";
+        RestrictNamespaces = "yes";
+        MemoryDenyWriteExecute = "yes";
+        CapabilityBoundingSet = "";
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [ "@system-service" "~@privileged" ];
+        UMask = "0027";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -553,6 +553,7 @@ in {
   moosefs = handleTest ./moosefs.nix {};
   mpd = handleTest ./mpd.nix {};
   mpv = handleTest ./mpv.nix {};
+  mqtt2prometheus = handleTest ./mqtt2prometheus.nix {};
   mtp = handleTest ./mtp.nix {};
   multipass = handleTest ./multipass.nix {};
   mumble = handleTest ./mumble.nix {};

--- a/nixos/tests/mqtt2prometheus.nix
+++ b/nixos/tests/mqtt2prometheus.nix
@@ -1,0 +1,56 @@
+import ./make-test-python.nix ({ lib, ... }:
+
+let
+  mosquittoPort = 1883;
+  mqtt2PrometheusMetricsPort = 8080;
+in
+{
+  name = "mqtt2prometheus";
+  meta.maintainers = with lib.maintainers; [ lesuisse ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.mosquitto = {
+        enable = true;
+        listeners = [
+          {
+            address = "localhost";
+            port = mosquittoPort;
+            acl = [ "pattern readwrite #" ];
+            omitPasswordAuth = true;
+            settings.allow_anonymous = true;
+          }
+        ];
+      };
+      services.mqtt2prometheus = {
+        enable = true;
+        listenPort = mqtt2PrometheusMetricsPort;
+        settings = {
+          mqtt = {
+            server = "tcp://localhost:${toString mosquittoPort}";
+            topic_path = "test/+";
+          };
+          metrics = [
+            {
+              prom_name = "temperature";
+              mqtt_name = "temperature";
+              type = "gauge";
+            }
+          ];
+        };
+      };
+      environment.systemPackages = [
+        pkgs.mosquitto
+      ];
+    };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("mosquitto.service")
+    machine.wait_for_unit("mqtt2prometheus.service")
+    machine.wait_for_console_text("Connected to MQTT Broker")
+    machine.succeed("mosquitto_pub -h localhost -p ${toString mosquittoPort} -t test/foo -m '{\"temperature\":20}']")
+    machine.succeed("curl -sSfq http://localhost:${toString mqtt2PrometheusMetricsPort}/metrics | grep 'received_messages{status=\"success\",topic=\"test/foo\"} 1'")
+  '';
+})

--- a/pkgs/by-name/mq/mqtt2prometheus/package.nix
+++ b/pkgs/by-name/mq/mqtt2prometheus/package.nix
@@ -1,0 +1,42 @@
+{ fetchFromGitHub
+, buildGoModule
+, lib
+, testers
+, mqtt2prometheus
+}:
+buildGoModule rec {
+  pname = "mqtt2prometheus";
+  version = "0.1.7";
+
+  src = fetchFromGitHub {
+    owner = "hikhvar";
+    repo = "mqtt2prometheus";
+    rev = "v${version}";
+    hash = "sha256-D5AO6Qsz44ssmRu80PDiRjKSxkOUe4OSm+xtvyGkdUQ=";
+  };
+
+  vendorHash = "sha256-5P5J1HwlOFMaGj77k4jU8uJtm0XUIqdPT9abRcvHt2s=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+  ];
+
+  postInstall = ''
+    mv $out/bin/cmd $out/bin/mqtt2prometheus
+  '';
+
+  passthru = {
+    tests.version = testers.testVersion { package = mqtt2prometheus; };
+  };
+
+  meta = {
+    description = "MQTT to Prometheus gateway";
+    homepage = "https://github.com/hikhvar/mqtt2prometheus";
+    changelog = "https://github.com/hikhvar/mqtt2prometheus/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    mainProgram = "mqtt2prometheus";
+    maintainers = with lib.maintainers; [ lesuisse ];
+  };
+}

--- a/pkgs/by-name/mq/mqtt2prometheus/package.nix
+++ b/pkgs/by-name/mq/mqtt2prometheus/package.nix
@@ -3,6 +3,7 @@
 , lib
 , testers
 , mqtt2prometheus
+, nixosTests
 }:
 buildGoModule rec {
   pname = "mqtt2prometheus";
@@ -28,7 +29,10 @@ buildGoModule rec {
   '';
 
   passthru = {
-    tests.version = testers.testVersion { package = mqtt2prometheus; };
+    tests = {
+      version = testers.testVersion { package = mqtt2prometheus; };
+      inherit (nixosTests) mqtt2prometheus;
+    };
   };
 
   meta = {


### PR DESCRIPTION
## Description of changes

https://github.com/hikhvar/mqtt2prometheus

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
