### PR TITLE
python3Packages.stravalib: mark unbroken

### DIFF
--- a/pkgs/development/python-modules/stravalib/default.nix
+++ b/pkgs/development/python-modules/stravalib/default.nix
@@ -1,9 +1,9 @@
 { lib
 , arrow
 , buildPythonPackage
-, fetchPypi
+, fetchFromGitHub
 , pint
-, pydantic
+, pydantic_1 # use pydantic 2 on next release
 , pythonOlder
 , pytz
 , requests
@@ -19,10 +19,17 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.9";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-OEdMRg3KjUrXt/CgJgsUqa/sVFAE0JONNZg5MBKtxmY=";
+  src = fetchFromGitHub {
+    owner = "stravalib";
+    repo = "stravalib";
+    rev = "v${version}";
+    hash = "sha256-EQcLDU9id/DpUZKMI9prCJC9zEK1CuhOtSB4FAWLg/g=";
   };
+
+  postPatch = ''
+    # Remove on next release
+    sed -i 's/pydantic==1.10.9/pydantic/' pyproject.toml
+  '';
 
   nativeBuildInputs = [
     setuptools
@@ -32,7 +39,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     arrow
     pint
-    pydantic
+    pydantic_1
     pytz
     requests
     responses
@@ -50,8 +57,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/stravalib/stravalib";
     changelog = "https://github.com/stravalib/stravalib/releases/tag/v${version}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ ];
-    # Support for pydantic > 2, https://github.com/stravalib/stravalib/issues/379
-    broken = versionAtLeast pydantic.version "2";
+    maintainers = with maintainers; [ sikmir ];
   };
 }


### PR DESCRIPTION
## Description of changes

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
