### PR TITLE
Fix clang resources in castxml to resolve missing standard header

### DIFF
--- a/pkgs/development/tools/castxml/default.nix
+++ b/pkgs/development/tools/castxml/default.nix
@@ -8,12 +8,14 @@
 , withManual ? true
 , withHTML ? true
 , llvmPackages
+, clang
 , python3
 }:
 
 let
   inherit (llvmPackages) libclang llvm;
   inherit (python3.pkgs) sphinx;
+  clangVersion = lib.getVersion clang;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "castxml";
@@ -45,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DCLANG_RESOURCE_DIR=${libclang.dev}/"
+    "-DCLANG_RESOURCE_DIR=${clang.cc.lib}/lib/clang/${clangVersion}"
     "-DSPHINX_HTML=${if withHTML then "ON" else "OFF"}"
     "-DSPHINX_MAN=${if withManual then "ON" else "OFF"}"
   ];


### PR DESCRIPTION
## Description of changes

(Reopened #284290 since I've renamed the branch)

A while I ago I needed to build a modified derivation of ITK to enable the python binding. Unfortunately, I encountered this particular type of error:

```
/nix/store/lw5b7x8wndk7sdis78r2f8fy12ldmpwc-glibc-2.37-45-dev/include/wchar.h:35:10: fatal error: 'stddef.h' file not found
#include <stddef.h>
```

It appears that the issue is related to castxml. Upon further
examination, I managed to develop a minimal reproducible example:

```nix
with import <nixpkgs> {}; 
stdenv.mkDerivation rec {
        name = "example";
        buildInputs = [pkgs.castxml pkgs.gcc];
        unpackPhase = ''
                echo "#include <wchar.h>" > example.cc
                '';
        buildPhase = ''
                castxml --castxml-cc-gnu gcc example.cc
                '';
        installPhase = ''
                mkdir $out
                touch $out/success.txt
                '';
}
```

I was able to resolve this issue by overriding castxml:

```nix
with import <nixpkgs> {}; 
let
   custom_castxml = pkgs.castxml.overrideAttrs(prev: let
           clang = pkgs.clang;
           clangVersion = lib.getVersion clang;
    in {
            cmakeFlags = prev.cmakeFlags ++ [
                    "-DCLANG_RESOURCE_DIR=${clang.cc.lib}/lib/clang/${clangVersion}"
            ];
     });
in stdenv.mkDerivation rec {
        name = "example";
        buildInputs = [custom_castxml pkgs.gcc];
        unpackPhase = ''
                echo "#include <wchar.h>" > example.cc
                '';
        buildPhase = ''
                castxml --castxml-cc-gnu gcc example.cc
                '';
        installPhase = ''
                mkdir $out
                touch $out/success.txt
                '';
}
```

I thought it would be beneficial to share this fix with the upstream nixpkgs version.

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
