### PR TITLE
yx: 1.0.0 -> 1.0.2

### DIFF
--- a/pkgs/tools/text/yx/default.nix
+++ b/pkgs/tools/text/yx/default.nix
@@ -1,4 +1,10 @@
-{ lib, stdenv, fetchFromGitLab, libyaml }:
+{ lib
+, stdenv
+, fetchFromGitLab
+, libyaml
+, testers
+, yx
+}:
 stdenv.mkDerivation rec {
   pname = "yx";
   version = "1.0.0";
@@ -19,6 +25,12 @@ stdenv.mkDerivation rec {
   buildInputs = [ libyaml ];
 
   doCheck = true;
+
+  passthru.tests.version = testers.testVersion {
+    package = yx;
+    command = "${meta.mainProgram} -v";
+    version = "v${yx.version}";
+  };
 
   meta = with lib; {
     description = "YAML Data Extraction Tool";

--- a/pkgs/tools/text/yx/default.nix
+++ b/pkgs/tools/text/yx/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitLab {
     owner = "tomalok";
-    repo = pname;
+    repo = "yx";
     rev = version;
     sha256 = "sha256-oY61V9xP0DwRooabzi0XtaFsQa2GwYbuvxfERXQtYcA=";
   };

--- a/pkgs/tools/text/yx/default.nix
+++ b/pkgs/tools/text/yx/default.nix
@@ -7,13 +7,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "yx";
-  version = "1.0.0";
+  version = "1.0.2";
 
   src = fetchFromGitLab {
     owner = "tomalok";
     repo = "yx";
     rev = version;
-    sha256 = "sha256-oY61V9xP0DwRooabzi0XtaFsQa2GwYbuvxfERXQtYcA=";
+    hash = "sha256-uuso+hsmdsB7VpIRKob8rfMaWvRMCBHvCFnYrHPC6iw=";
   };
 
   makeFlags = [


### PR DESCRIPTION
## Description of changes

* Add version test
* Don't misuse pname

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

```console
$ nix-build -A yx
/nix/store/7sw7mnlc4x4363l6cxzy44yxnqgpa0dc-yx-1.0.2

$ find /nix/store/7sw7mnlc4x4363l6cxzy44yxnqgpa0dc-yx-1.0.2 -type f
/nix/store/7sw7mnlc4x4363l6cxzy44yxnqgpa0dc-yx-1.0.2/bin/yx
/nix/store/7sw7mnlc4x4363l6cxzy44yxnqgpa0dc-yx-1.0.2/share/man/man1/yx.1.gz

$ /nix/store/7sw7mnlc4x4363l6cxzy44yxnqgpa0dc-yx-1.0.2/bin/yx -v
yx v1.0.2

$ nix-build --attr pkgs.yx.passthru.tests
this derivation will be built:
  /nix/store/z31zny12lfmqq17c59c17zxc268wf10h-yx-1.0.2-test-version.drv
building '/nix/store/z31zny12lfmqq17c59c17zxc268wf10h-yx-1.0.2-test-version.drv'...
yx v1.0.2
/nix/store/ww23n3w8d4yb2h9zwpzbi72a10w62pgj-yx-1.0.2-test-version
```

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
