### PR TITLE
himalaya: 1.0.0-beta -> 1.0.0-beta.2

### DIFF
--- a/pkgs/applications/networking/mailreaders/himalaya/default.nix
+++ b/pkgs/applications/networking/mailreaders/himalaya/default.nix
@@ -8,47 +8,32 @@
 , installManPages ? stdenv.hostPlatform == stdenv.buildPlatform
 , notmuch
 , gpgme
-, withMaildir ? true
-, withImap ? true
-, withNotmuch ? false
-, withSendmail ? true
-, withSmtp ? true
-, withPgpCommands ? false
-, withPgpGpg ? false
-, withPgpNative ? false
+, buildNoDefaultFeatures ? false
+, buildFeatures ? []
 }:
 
 rustPlatform.buildRustPackage rec {
+  inherit buildNoDefaultFeatures buildFeatures;
+
   pname = "himalaya";
-  version = "1.0.0-beta";
+  version = "1.0.0-beta.2";
 
   src = fetchFromGitHub {
     owner = "soywod";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-39XYtxmo/12hkCS7zVIQi3UbLzaIKH1OwfdDB/ghU98=";
+    hash = "sha256-dLj/bEPz3SD1v54yXbtVdUJKQsyw0OJxmQh10ql+3iI=";
   };
 
-  cargoSha256 = "HIDmBPrcOcK2coTaD4v8ntIZrv2SwTa8vUTG8Ky4RhM=";
+  cargoSha256 = "0IYpuKq5amAcYtsDMzJGghbxkuldAulsgUmChTl2DIg=";
 
   nativeBuildInputs = [ ]
-    ++ lib.optional withPgpGpg pkg-config
+    ++ lib.optional (builtins.elem "pgp-gpg" buildFeatures) pkg-config
     ++ lib.optional (installManPages || installShellCompletions) installShellFiles;
 
   buildInputs = [ ]
-    ++ lib.optional withNotmuch notmuch
-    ++ lib.optional withPgpGpg gpgme;
-
-  buildNoDefaultFeatures = true;
-  buildFeatures = [ ]
-    ++ lib.optional withMaildir "maildir"
-    ++ lib.optional withImap "imap"
-    ++ lib.optional withNotmuch "notmuch"
-    ++ lib.optional withSmtp "smtp"
-    ++ lib.optional withSendmail "sendmail"
-    ++ lib.optional withPgpCommands "pgp-commands"
-    ++ lib.optional withPgpGpg "pgp-gpg"
-    ++ lib.optional withPgpNative "pgp-native";
+    ++ lib.optional (builtins.elem "notmuch" buildFeatures) notmuch
+    ++ lib.optional (builtins.elem "pgp-gpg" buildFeatures) gpgme;
 
   postInstall = lib.optionalString installManPages ''
     mkdir -p $out/man


### PR DESCRIPTION
## Description of changes

Release note: https://github.com/soywod/himalaya/releases/tag/v1.0.0-beta.2

Since a lot of cargo features have been introduced, `with{Feature}` nix inputs have been replaced by `buildNoDefaultFeatures` and `buildFeatures` (they are forwarded to `rustPlatform.buildRustPackage`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ X Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
