### PR TITLE
Revert "compressFirmwareXz: fix links to directories"

### DIFF
--- a/pkgs/build-support/kernel/compress-firmware-xz.nix
+++ b/pkgs/build-support/kernel/compress-firmware-xz.nix
@@ -15,10 +15,6 @@ runCommand "${firmware.name}-xz" args ''
           sh -c 'xz -9c -T1 -C crc32 --lzma2=dict=2MiB "${firmware}/$1" > "$1.xz"' --)
   (cd ${firmware} && find lib/firmware -type l) | while read link; do
       target="$(readlink "${firmware}/$link")"
-      if [ -f $target ]; then
-        ln -vs -- "''${target/^${firmware}/$out}.xz" "$out/$link.xz"
-      else
-        ln -vs -- "''${target/^${firmware}/$out}" "$out/$link"
-      fi
+      ln -vs -- "''${target/^${firmware}/$out}.xz" "$out/$link.xz"
   done
 ''


### PR DESCRIPTION
Reverts NixOS/nixpkgs#283110 as it breaks loading of certain firmware, including amdgpu ones.