### PR TITLE
compressFirmwareXz: rewrite

### DIFF
--- a/pkgs/build-support/kernel/compress-firmware-xz.nix
+++ b/pkgs/build-support/kernel/compress-firmware-xz.nix
@@ -1,24 +1,19 @@
-{ runCommand, lib }:
+{ runCommand, lib, python312 }:
 
 firmware:
 
 let
-  args = lib.optionalAttrs (firmware ? meta) { inherit (firmware) meta; };
+  extraArgs = lib.optionalAttrs (firmware ? meta) { inherit (firmware) meta; };
 in
 
-runCommand "${firmware.name}-xz" args ''
-  mkdir -p $out/lib
-  (cd ${firmware} && find lib/firmware -type d -print0) |
-      (cd $out && xargs -0 mkdir -v --)
-  (cd ${firmware} && find lib/firmware -type f -print0) |
-      (cd $out && xargs -0rtP "$NIX_BUILD_CORES" -n1 \
-          sh -c 'xz -9c -T1 -C crc32 --lzma2=dict=2MiB "${firmware}/$1" > "$1.xz"' --)
-  (cd ${firmware} && find lib/firmware -type l) | while read link; do
-      target="$(readlink "${firmware}/$link")"
-      if [ -f $target ]; then
-        ln -vs -- "''${target/^${firmware}/$out}.xz" "$out/$link.xz"
-      else
-        ln -vs -- "''${target/^${firmware}/$out}" "$out/$link"
-      fi
-  done
+runCommand "${firmware.name}-xz" ({
+  nativeBuildInputs = [ python312 ];
+  allowedRequisites = [];
+} // extraArgs) ''
+  python ${./compress-firmware.py} ${firmware}/lib/firmware $out/lib/firmware
+
+  if find $out -xtype l | grep .; then
+    echo "Found dead symlinks!"
+    exit 1
+  fi
 ''

--- a/pkgs/build-support/kernel/compress-firmware.py
+++ b/pkgs/build-support/kernel/compress-firmware.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+import argparse
+import lzma
+import multiprocessing
+import os
+import pathlib
+import shutil
+import typing
+
+
+def compress_one(source: pathlib.Path, destination: pathlib.Path):
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with source.open("rb") as src, lzma.open(
+        destination, "wb", check=lzma.CHECK_CRC32, preset=lzma.PRESET_EXTREME
+    ) as dst:
+        shutil.copyfileobj(src, dst)
+
+
+def compress_all(items: typing.Iterable[tuple[pathlib.Path, pathlib.Path]]):
+    cores = os.getenv("NIX_BUILD_CORES")
+    if cores is not None:
+        cores = int(cores)
+    multiprocessing.Pool(cores).starmap(compress_one, items, chunksize=16)
+
+
+def main(source: pathlib.Path, destination: pathlib.Path):
+    files_to_compress = {}
+
+    for path in source.rglob("*"):
+        if path.is_file() and not path.is_symlink():
+            out_path = destination / path.relative_to(source)
+            out_path = out_path.with_suffix(out_path.suffix + ".xz")
+            files_to_compress[path] = out_path
+
+    compress_all(files_to_compress.items())
+
+    for path in source.rglob("*"):
+        if path.is_symlink():
+            source_path = path.resolve()
+            if new_path := files_to_compress.get(source_path):
+                target_path = new_path
+                need_suffix = True
+            else:
+                target_path = destination / source_path.relative_to(source)
+                need_suffix = False
+
+            out_path = destination / path.relative_to(source)
+
+            if need_suffix:
+                out_path = out_path.with_suffix(out_path.suffix + ".xz")
+
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.symlink_to(target_path.relative_to(out_path.parent, walk_up=True))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("source", type=pathlib.Path, help="Source path")
+    parser.add_argument("destination", type=pathlib.Path, help="Destination path")
+    args = parser.parse_args()
+    source = args.source
+    destination = args.destination
+    main(source, destination)


### PR DESCRIPTION
## Description of changes

It does a whole bunch of non-trivial path wiggling that's hard to express cleanly in bash, so express it in Python/pathlib instead.

Python 3.12 for `pathlib.Path.relative_to(..., walk_up=True)`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
