### PR TITLE
haskell-modules: Add revision argument to callHackageDirect

### DIFF
--- a/pkgs/development/haskell-modules/make-package-set.nix
+++ b/pkgs/development/haskell-modules/make-package-set.nix
@@ -199,12 +199,16 @@ in package-set { inherit pkgs lib callPackage; } self // {
     # for any version that has been released on hackage as opposed to only
     # versions released before whatever version of all-cabal-hashes you happen
     # to be currently using.
-    callHackageDirect = {pkg, ver, sha256}:
+    callHackageDirect = {pkg, ver, sha256, rev ? { revision = null; sha256 = null; }}: args:
       let pkgver = "${pkg}-${ver}";
-      in self.callCabal2nix pkg (pkgs.fetchzip {
-           url = "mirror://hackage/${pkgver}/${pkgver}.tar.gz";
-           inherit sha256;
-         });
+          firstRevision = self.callCabal2nix pkg (pkgs.fetchzip {
+            url = "mirror://hackage/${pkgver}/${pkgver}.tar.gz";
+            inherit sha256;
+          }) args;
+      in overrideCabal (orig: {
+        revision = rev.revision;
+        editedCabalFile = rev.sha256;
+      }) firstRevision;
 
     # Creates a Haskell package from a source package by calling cabal2nix on the source.
     callCabal2nixWithOptions = name: src: extraCabal2nixOptions: args:
@@ -635,7 +639,7 @@ in package-set { inherit pkgs lib callPackage; } self // {
 
       Type: drv -> drv
     */
-    forceLlvmCodegenBackend = haskellLib.overrideCabal (drv: {
+    forceLlvmCodegenBackend = overrideCabal (drv: {
       configureFlags = drv.configureFlags or [ ] ++ [ "--ghc-option=-fllvm" ];
       buildTools = drv.buildTools or [ ] ++ [ self.llvmPackages.llvm ];
     });


### PR DESCRIPTION
Previously, callHackageDirect was only able to fetch the first revision of a package.

Resolves #134747

## Description of changes

Tested with a random package which needs a revision. Fails without revision argument:

```
nix-build -E - <<EOE
with import ./default.nix {};
haskellPackages.callHackageDirect {
  pkg = "hopfli";
  ver = "0.2.2.1";
  sha256 = "sha256-tW96rAmt0SyWXEfm6GdzCFQVS8JigA4ID2rkd9u9pMg=";
} {}
EOE

[...]
Error: Setup: Encountered missing or private dependencies:
QuickCheck >=2.6 && <2.11, hspec >=1.7.2.1 && <2.5

error: builder for '/nix/store/sm9p7bd4kdqpq4yyc2fb24fy8f5q6yrh-hopfli-0.2.2.1.drv' failed with exit code 1
```

Succeeds with revision argument:

```
nix-build -E - <<EOE
with import ./default.nix {};
haskellPackages.callHackageDirect {
  pkg = "hopfli";
  ver = "0.2.2.1";
  sha256 = "sha256-tW96rAmt0SyWXEfm6GdzCFQVS8JigA4ID2rkd9u9pMg=";
  rev = { revision = "1"; sha256 = "116jns5im51sb9xiwpx308wz3pr67335633anrf8f704pz8vwjka"; };
} {}
EOE

/nix/store/7hfbgajzlbxjpffc858glcq7j37ygl9g-hopfli-0.2.2.1
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
