### PR TITLE
docfd: init at 2.1.0

### DIFF
--- a/pkgs/by-name/do/docfd/package.nix
+++ b/pkgs/by-name/do/docfd/package.nix
@@ -1,0 +1,44 @@
+{ lib, ocamlPackages, fetchFromGitHub, python3, dune_3, makeWrapper, poppler_utils }:
+
+ocamlPackages.buildDunePackage rec {
+  pname = "docfd";
+  version = "2.1.0";
+
+  minimalOCamlVersion = "5.1";
+
+  src = fetchFromGitHub {
+    owner = "darrenldl";
+    repo = "docfd";
+    rev = version;
+    hash = "sha256-1DobGm6nI14951KNKEE0D3AF1TFsWQUEhe4L1PdWBDw=";
+  };
+
+  nativeBuildInputs = [ python3 dune_3 makeWrapper ];
+  buildInputs = [ poppler_utils ] ++
+    (with ocamlPackages; [ oseq spelll notty nottui lwd cmdliner domainslib digestif yojson eio_main containers-data timedesc ]);
+
+  postInstall = ''
+  # docfd needs pdftotext from popler_utils to allow pdf search
+  wrapProgram $out/bin/docfd --prefix PATH : "${lib.getBin poppler_utils}/bin/"
+  '';
+
+  meta = with lib; {
+    description = "TUI multiline fuzzy document finder";
+    longDescription = ''
+      Interactive grep, but word/token/phrase based rather than regex
+      and line based, so you can search across multiple lines (simlar to
+      Recoll but TUI).
+      Aims to provide a good UX via text editor and PDF viewer integration.
+      When opening a text file, Docfd opens file at first line of search
+      result. If PDF, then Docfd opens file at first page of the search
+      result and starts a text search of the most unique word of the matched
+      phrase within the same page.
+      Main intended use case: navigating directories of notes and PDFs.
+    '';
+    homepage = "https://github.com/darrenldl/docfd";
+    license = licenses.mit;
+    maintainers = with maintainers; [ chewblacka ];
+    platforms = platforms.all;
+    mainProgram = "docfd";
+  };
+}


### PR DESCRIPTION
## Description of changes
Docfd  - a TUI multiline fuzzy document finder. 
Init at 2.1.0
https://github.com/darrenldl/docfd

Closes https://github.com/NixOS/nixpkgs/issues/283503

Thanks to @vbgl for packaging timedesc required by this package.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
