### PR TITLE
Add `types.attrTag`

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -128,7 +128,7 @@ let
       canCleanSource pathIsGitRepo;
     inherit (self.modules) evalModules setDefaultModuleLocation
       unifyModuleSyntax applyModuleArgsIfFunction mergeModules
-      mergeModules' mergeOptionDecls evalOptionValue mergeDefinitions
+      mergeModules' mergeOptionDecls mergeDefinitions
       pushDownProperties dischargeProperties filterOverrides
       sortProperties fixupOptionType mkIf mkAssert mkMerge mkOverride
       mkOptionDefault mkDefault mkImageMediaOverride mkForce mkVMOverride
@@ -138,6 +138,7 @@ let
       mkMergedOptionModule mkChangedOptionModule
       mkAliasOptionModule mkDerivedConfig doRename
       mkAliasOptionModuleMD;
+    evalOptionValue = lib.warn "External use of `lib.evalOptionValue` is deprecated. If your use case isn't covered by non-deprecated functions, we'd like to know more and perhaps support your use case well, instead of providing access to these low level functions. In this case please open an issue in https://github.com/nixos/nixpkgs/issues/." self.modules.evalOptionValue;
     inherit (self.options) isOption mkEnableOption mkSinkUndeclaredOptions
       mergeDefaultOption mergeOneOption mergeEqualOption mergeUniqueOption
       getValues getFiles

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1307,7 +1307,6 @@ let
       inherit
         applyModuleArgsIfFunction
         dischargeProperties
-        evalOptionValue
         mergeModules
         mergeModules'
         pushDownProperties
@@ -1328,6 +1327,7 @@ private //
     defaultPriority
     doRename
     evalModules
+    evalOptionValue  # for use by lib.types
     filterOverrides
     filterOverrides'
     fixMergeModules

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -113,7 +113,7 @@ checkConfigError 'A definition for option .intStrings\.mergeError. is not of typ
 checkConfigError 'A definition for option .intStrings\.badTagError. is not of type .attribute-tagged union' config.intStrings.badTagError ./types-attrTag.nix
 checkConfigError 'A definition for option .intStrings\.badTagTypeError\.left. is not of type .signed integer.' config.intStrings.badTagTypeError.left ./types-attrTag.nix
 checkConfigError 'A definition for option .nested\.right\.left. is not of type .signed integer.' config.nested.right.left ./types-attrTag.nix
-checkConfigError 'In attrTag/attrTagWith, each tag value must be an option, but tag int was a bare type, not wrapped in mkOption.' config.opt.int ./types-attrTag-wrong-decl.nix
+checkConfigError 'In attrTag, each tag value must be an option, but tag int was a bare type, not wrapped in mkOption.' config.opt.int ./types-attrTag-wrong-decl.nix
 
 # types.pathInStore
 checkConfigOutput '".*/store/0lz9p8xhf89kb1c1kk6jxrzskaiygnlh-bash-5.2-p15.drv"' config.pathInStore.ok1 ./types.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -103,6 +103,17 @@ checkConfigError 'The option .sub.wrong2. does not exist. Definition values:' co
 checkConfigError '.*This can happen if you e.g. declared your options in .types.submodule.' config.sub ./error-mkOption-in-submodule-config.nix
 checkConfigError '.*A definition for option .bad. is not of type .non-empty .list of .submodule...\.' config.bad ./error-nonEmptyListOf-submodule.nix
 
+# types.attrTag
+checkConfigOutput '^true$' config.okChecks ./types-attrTag.nix
+checkConfigError 'A definition for option .intStrings\.syntaxError. is not of type .attribute-tagged union of left, right' config.intStrings.syntaxError ./types-attrTag.nix
+checkConfigError 'A definition for option .intStrings\.syntaxError2. is not of type .attribute-tagged union of left, right' config.intStrings.syntaxError2 ./types-attrTag.nix
+checkConfigError 'A definition for option .intStrings\.syntaxError3. is not of type .attribute-tagged union of left, right' config.intStrings.syntaxError3 ./types-attrTag.nix
+checkConfigError 'A definition for option .intStrings\.syntaxError4. is not of type .attribute-tagged union of left, right' config.intStrings.syntaxError4 ./types-attrTag.nix
+checkConfigError 'A definition for option .intStrings\.mergeError. is not of type .attribute-tagged union of left, right' config.intStrings.mergeError ./types-attrTag.nix
+checkConfigError 'A definition for option .intStrings\.badTagError. is not of type .attribute-tagged union of left, right' config.intStrings.badTagError ./types-attrTag.nix
+checkConfigError 'A definition for option .intStrings\.badTagTypeError\.left. is not of type .signed integer.' config.intStrings.badTagTypeError.left ./types-attrTag.nix
+checkConfigError 'A definition for option .nested\.right\.left. is not of type .signed integer.' config.nested.right.left ./types-attrTag.nix
+
 # types.pathInStore
 checkConfigOutput '".*/store/0lz9p8xhf89kb1c1kk6jxrzskaiygnlh-bash-5.2-p15.drv"' config.pathInStore.ok1 ./types.nix
 checkConfigOutput '".*/store/0fb3ykw9r5hpayd05sr0cizwadzq1d8q-bash-5.2-p15"' config.pathInStore.ok2 ./types.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -105,12 +105,12 @@ checkConfigError '.*A definition for option .bad. is not of type .non-empty .lis
 
 # types.attrTag
 checkConfigOutput '^true$' config.okChecks ./types-attrTag.nix
-checkConfigError 'A definition for option .intStrings\.syntaxError. is not of type .attribute-tagged union of left, right' config.intStrings.syntaxError ./types-attrTag.nix
-checkConfigError 'A definition for option .intStrings\.syntaxError2. is not of type .attribute-tagged union of left, right' config.intStrings.syntaxError2 ./types-attrTag.nix
-checkConfigError 'A definition for option .intStrings\.syntaxError3. is not of type .attribute-tagged union of left, right' config.intStrings.syntaxError3 ./types-attrTag.nix
-checkConfigError 'A definition for option .intStrings\.syntaxError4. is not of type .attribute-tagged union of left, right' config.intStrings.syntaxError4 ./types-attrTag.nix
-checkConfigError 'A definition for option .intStrings\.mergeError. is not of type .attribute-tagged union of left, right' config.intStrings.mergeError ./types-attrTag.nix
-checkConfigError 'A definition for option .intStrings\.badTagError. is not of type .attribute-tagged union of left, right' config.intStrings.badTagError ./types-attrTag.nix
+checkConfigError 'A definition for option .intStrings\.syntaxError. is not of type .attribute-tagged union' config.intStrings.syntaxError ./types-attrTag.nix
+checkConfigError 'A definition for option .intStrings\.syntaxError2. is not of type .attribute-tagged union' config.intStrings.syntaxError2 ./types-attrTag.nix
+checkConfigError 'A definition for option .intStrings\.syntaxError3. is not of type .attribute-tagged union' config.intStrings.syntaxError3 ./types-attrTag.nix
+checkConfigError 'A definition for option .intStrings\.syntaxError4. is not of type .attribute-tagged union' config.intStrings.syntaxError4 ./types-attrTag.nix
+checkConfigError 'A definition for option .intStrings\.mergeError. is not of type .attribute-tagged union' config.intStrings.mergeError ./types-attrTag.nix
+checkConfigError 'A definition for option .intStrings\.badTagError. is not of type .attribute-tagged union' config.intStrings.badTagError ./types-attrTag.nix
 checkConfigError 'A definition for option .intStrings\.badTagTypeError\.left. is not of type .signed integer.' config.intStrings.badTagTypeError.left ./types-attrTag.nix
 checkConfigError 'A definition for option .nested\.right\.left. is not of type .signed integer.' config.nested.right.left ./types-attrTag.nix
 

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -113,6 +113,7 @@ checkConfigError 'A definition for option .intStrings\.mergeError. is not of typ
 checkConfigError 'A definition for option .intStrings\.badTagError. is not of type .attribute-tagged union' config.intStrings.badTagError ./types-attrTag.nix
 checkConfigError 'A definition for option .intStrings\.badTagTypeError\.left. is not of type .signed integer.' config.intStrings.badTagTypeError.left ./types-attrTag.nix
 checkConfigError 'A definition for option .nested\.right\.left. is not of type .signed integer.' config.nested.right.left ./types-attrTag.nix
+checkConfigError 'In attrTag/attrTagWith, each tag value must be an option, but tag int was a bare type, not wrapped in mkOption.' config.opt.int ./types-attrTag-wrong-decl.nix
 
 # types.pathInStore
 checkConfigOutput '".*/store/0lz9p8xhf89kb1c1kk6jxrzskaiygnlh-bash-5.2-p15.drv"' config.pathInStore.ok1 ./types.nix

--- a/lib/tests/modules/docs.nix
+++ b/lib/tests/modules/docs.nix
@@ -1,0 +1,41 @@
+/*
+  A basic documentation generating module.
+  Declares and defines a `docs` option, suitable for making assertions about
+  the extraction "phase" of documentation generation.
+ */
+{ lib, options, ... }:
+
+let
+  inherit (lib)
+    head
+    length
+    mkOption
+    types
+  ;
+
+  traceListSeq = l: v: lib.foldl' (a: b: lib.traceSeq b a) v l;
+
+in
+
+{
+  options.docs = mkOption {
+    type = types.lazyAttrsOf types.raw;
+    description = ''
+      All options to be rendered, without any visibility filtering applied.
+    '';
+  };
+  config.docs =
+    lib.zipAttrsWith
+      (name: values:
+        if length values > 1 then
+          traceListSeq values
+          abort "Multiple options with the same name: ${name}"
+        else
+          assert length values == 1;
+          head values
+      )
+      (map
+        (opt: { ${opt.name} = opt; })
+        (lib.optionAttrSetToDocList options)
+      );
+}

--- a/lib/tests/modules/types-attrTag-wrong-decl.nix
+++ b/lib/tests/modules/types-attrTag-wrong-decl.nix
@@ -1,0 +1,14 @@
+{ lib, ... }:
+let
+  inherit (lib) types mkOption;
+in
+{
+  options = {
+    opt = mkOption {
+      type = types.attrTag {
+        int = types.int;
+      };
+      default = { int = 1; };
+    };
+  };
+}

--- a/lib/tests/modules/types-attrTag.nix
+++ b/lib/tests/modules/types-attrTag.nix
@@ -28,9 +28,24 @@ in
         }
       );
     };
+    submodules = mkOption {
+      type = types.attrsOf (
+        types.attrTag {
+          foo = types.submodule {
+            options = {
+              bar = mkOption {
+                type = types.int;
+              };
+            };
+          };
+          qux = types.str;
+        }
+      );
+    };
     okChecks = mkOption {};
   };
   imports = [
+    ./docs.nix
     {
       options.merged = mkOption {
         type = types.attrsOf (
@@ -59,6 +74,10 @@ in
       assert config.intStrings.numberOne.left == 1;
       assert config.merged.negative.nay == false;
       assert config.merged.positive.yay == 100;
+      # assert lib.foldl' (a: b: builtins.trace b a) true (lib.attrNames config.docs);
+      assert config.docs."submodules.<name>.foo.bar".type == "signed integer";
+      # It's not an option, so we can't render it as such. Something would be nice though.
+      assert ! (config.docs?"submodules.<name>.qux");
       true;
   };
 }

--- a/lib/tests/modules/types-attrTag.nix
+++ b/lib/tests/modules/types-attrTag.nix
@@ -98,12 +98,12 @@ in
     merged.extensi-foo.extensible = "foo";
     merged.extensi-bar.extensible = "bar";
     okChecks =
-      assert config.intStrings.hello.right == "hello world";
-      assert config.intStrings.numberOne.left == 1;
-      assert config.merged.negative.nay == false;
-      assert config.merged.positive.yay == 100;
-      assert config.merged.extensi-foo.extensible == "foo";
-      assert config.merged.extensi-bar.extensible == "bar";
+      assert config.intStrings.hello == { right = "hello world"; };
+      assert config.intStrings.numberOne == { left = 1; };
+      assert config.merged.negative == { nay = false; };
+      assert config.merged.positive == { yay = 100; };
+      assert config.merged.extensi-foo == { extensible = "foo"; };
+      assert config.merged.extensi-bar == { extensible = "bar"; };
       # assert lib.foldl' (a: b: builtins.trace b a) true (lib.attrNames config.docs);
       assert config.docs."submodules.<name>.foo.bar".type == "signed integer";
       assert config.docs."submodules.<name>.qux".type == "string";

--- a/lib/tests/modules/types-attrTag.nix
+++ b/lib/tests/modules/types-attrTag.nix
@@ -107,6 +107,7 @@ in
       # assert lib.foldl' (a: b: builtins.trace b a) true (lib.attrNames config.docs);
       assert config.docs."submodules.<name>.foo.bar".type == "signed integer";
       assert config.docs."submodules.<name>.qux".type == "string";
+      assert lib.length config.docs."merged.<name>.extensible".declarations == 2;
       true;
   };
 }

--- a/lib/tests/modules/types-attrTag.nix
+++ b/lib/tests/modules/types-attrTag.nix
@@ -59,6 +59,7 @@ in
           };
           qux = mkOption {
             type = types.str;
+            description = "A qux for when you don't want a foo";
           };
         }
       );
@@ -106,6 +107,14 @@ in
       assert config.merged.extensi-bar == { extensible = "bar"; };
       assert config.docs."submodules.<name>.foo.bar".type == "signed integer";
       assert config.docs."submodules.<name>.qux".type == "string";
+      assert config.docs."submodules.<name>.qux".declarations == [ __curPos.file ];
+      assert config.docs."submodules.<name>.qux".loc == [ "submodules" "<name>" "qux" ];
+      assert config.docs."submodules.<name>.qux".name == "submodules.<name>.qux";
+      assert config.docs."submodules.<name>.qux".description == "A qux for when you don't want a foo";
+      assert config.docs."submodules.<name>.qux".readOnly == false;
+      assert config.docs."submodules.<name>.qux".visible == true;
+      # Not available (yet?)
+      # assert config.docs."submodules.<name>.qux".declarationsWithPositions == [ ... ];
       assert lib.length config.docs."merged.<name>.extensible".declarations == 2;
       true;
   };

--- a/lib/tests/modules/types-attrTag.nix
+++ b/lib/tests/modules/types-attrTag.nix
@@ -39,6 +39,9 @@ in
           yay = mkOption {
             type = types.int;
           };
+          extensible = mkOption {
+            type = types.enum [ "foo" ];
+          };
         }
       );
     };
@@ -71,6 +74,9 @@ in
             nay = mkOption {
               type = types.bool;
             };
+            extensible = mkOption {
+              type = types.enum [ "bar" ];
+            };
           }
         );
       };
@@ -89,11 +95,15 @@ in
     nested.right.left = "not a number";
     merged.negative.nay = false;
     merged.positive.yay = 100;
+    merged.extensi-foo.extensible = "foo";
+    merged.extensi-bar.extensible = "bar";
     okChecks =
       assert config.intStrings.hello.right == "hello world";
       assert config.intStrings.numberOne.left == 1;
       assert config.merged.negative.nay == false;
       assert config.merged.positive.yay == 100;
+      assert config.merged.extensi-foo.extensible == "foo";
+      assert config.merged.extensi-bar.extensible == "bar";
       # assert lib.foldl' (a: b: builtins.trace b a) true (lib.attrNames config.docs);
       assert config.docs."submodules.<name>.foo.bar".type == "signed integer";
       assert config.docs."submodules.<name>.qux".type == "string";

--- a/lib/tests/modules/types-attrTag.nix
+++ b/lib/tests/modules/types-attrTag.nix
@@ -1,0 +1,64 @@
+{ lib, config, ... }:
+let
+  inherit (lib) mkOption types;
+  forceDeep = x: builtins.deepSeq x x;
+in
+{
+  options = {
+    intStrings = mkOption {
+      type = types.attrsOf
+        (types.attrTag {
+          left = types.int;
+          right = types.str;
+        });
+    };
+    nested = mkOption {
+      type = types.attrTag {
+        left = types.int;
+        right = types.attrTag {
+          left = types.int;
+          right = types.str;
+        };
+      };
+    };
+    merged = mkOption {
+      type = types.attrsOf (
+        types.attrTag {
+          yay = types.int;
+        }
+      );
+    };
+    okChecks = mkOption {};
+  };
+  imports = [
+    {
+      options.merged = mkOption {
+        type = types.attrsOf (
+          types.attrTag {
+            nay = types.bool;
+          }
+        );
+      };
+    }
+  ];
+  config = {
+    intStrings.syntaxError = 1;
+    intStrings.syntaxError2 = {};
+    intStrings.syntaxError3 = { a = true; b = true; };
+    intStrings.syntaxError4 = lib.mkMerge [ { a = true; } { b = true; } ];
+    intStrings.mergeError = lib.mkMerge [ { int = throw "do not eval"; } { string = throw "do not eval"; } ];
+    intStrings.badTagError.rite = throw "do not eval";
+    intStrings.badTagTypeError.left = "bad";
+    intStrings.numberOne.left = 1;
+    intStrings.hello.right = "hello world";
+    nested.right.left = "not a number";
+    merged.negative.nay = false;
+    merged.positive.yay = 100;
+    okChecks =
+      assert config.intStrings.hello.right == "hello world";
+      assert config.intStrings.numberOne.left == 1;
+      assert config.merged.negative.nay == false;
+      assert config.merged.positive.yay == 100;
+      true;
+  };
+}

--- a/lib/tests/modules/types-attrTag.nix
+++ b/lib/tests/modules/types-attrTag.nix
@@ -8,37 +8,55 @@ in
     intStrings = mkOption {
       type = types.attrsOf
         (types.attrTag {
-          left = types.int;
-          right = types.str;
+          left = mkOption {
+            type = types.int;
+          };
+          right = mkOption {
+            type = types.str;
+          };
         });
     };
     nested = mkOption {
       type = types.attrTag {
-        left = types.int;
-        right = types.attrTag {
-          left = types.int;
-          right = types.str;
+        left = mkOption {
+          type = types.int;
+        };
+        right = mkOption {
+          type = types.attrTag {
+            left = mkOption {
+              type = types.int;
+            };
+            right = mkOption {
+              type = types.str;
+            };
+          };
         };
       };
     };
     merged = mkOption {
       type = types.attrsOf (
         types.attrTag {
-          yay = types.int;
+          yay = mkOption {
+            type = types.int;
+          };
         }
       );
     };
     submodules = mkOption {
       type = types.attrsOf (
         types.attrTag {
-          foo = types.submodule {
-            options = {
-              bar = mkOption {
-                type = types.int;
+          foo = mkOption {
+            type = types.submodule {
+              options = {
+                bar = mkOption {
+                  type = types.int;
+                };
               };
             };
           };
-          qux = types.str;
+          qux = mkOption {
+            type = types.str;
+          };
         }
       );
     };
@@ -50,7 +68,9 @@ in
       options.merged = mkOption {
         type = types.attrsOf (
           types.attrTag {
-            nay = types.bool;
+            nay = mkOption {
+              type = types.bool;
+            };
           }
         );
       };
@@ -76,8 +96,7 @@ in
       assert config.merged.positive.yay == 100;
       # assert lib.foldl' (a: b: builtins.trace b a) true (lib.attrNames config.docs);
       assert config.docs."submodules.<name>.foo.bar".type == "signed integer";
-      # It's not an option, so we can't render it as such. Something would be nice though.
-      assert ! (config.docs?"submodules.<name>.qux");
+      assert config.docs."submodules.<name>.qux".type == "string";
       true;
   };
 }

--- a/lib/tests/modules/types-attrTag.nix
+++ b/lib/tests/modules/types-attrTag.nix
@@ -104,7 +104,6 @@ in
       assert config.merged.positive == { yay = 100; };
       assert config.merged.extensi-foo == { extensible = "foo"; };
       assert config.merged.extensi-bar == { extensible = "bar"; };
-      # assert lib.foldl' (a: b: builtins.trace b a) true (lib.attrNames config.docs);
       assert config.docs."submodules.<name>.foo.bar".type == "signed integer";
       assert config.docs."submodules.<name>.qux".type == "string";
       assert lib.length config.docs."merged.<name>.extensible".declarations == 2;

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -662,15 +662,6 @@ rec {
                 };
             })
             tags;
-        substSubModules = m:
-          attrTag
-            (mapAttrs
-              (n: opt:
-                opt // {
-                  type = (opt.type or types.unspecified).substSubModules m;
-                }
-              )
-              tags);
         check = v: isAttrs v && length (attrNames v) == 1 && tags?${head (attrNames v)};
         merge = loc: defs:
           let

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -623,7 +623,11 @@ rec {
       mkOptionType {
         name = "attrTag";
         description = "attribute-tagged union of ${choicesStr}";
-        getSubModules = null;
+        getSubOptions = prefix:
+          mapAttrs
+            (tagName: tagType:
+              tagType.getSubOptions (prefix ++ [ tagName ]))
+            tags;
         substSubModules = m: attrTagWith { tags = mapAttrs (n: v: v.substSubModules m) tags; };
         check = v: isAttrs v && length (attrNames v) == 1 && tags?${head (attrNames v)};
         merge = loc: defs:

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -15,6 +15,7 @@ let
     isList
     isString
     isStorePath
+    throwIf
     toDerivation
     toList
     ;
@@ -627,7 +628,13 @@ rec {
           mapAttrs
             (n: opt:
               builtins.addErrorContext "while checking that attrTag tag ${lib.strings.escapeNixIdentifier n} is an option with a type${inAttrPosSuffix args.tags n}" (
-                assert opt._type == "option";
+                throwIf (opt._type or null != "option")
+                  "In attrTag/attrTagWith, each tag value must be an option, but tag ${lib.strings.escapeNixIdentifier n} ${
+                    if opt?_type then
+                      if opt._type == "option-type"
+                      then "was a bare type, not wrapped in mkOption."
+                      else "was of type ${lib.strings.escapeNixString opt._type}."
+                    else "was not."}"
                 opt // {
                   declarations = opt.declarations or (
                     let pos = builtins.unsafeGetAttrPos n args.tags;

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -658,7 +658,6 @@ rec {
               "${lib.showOption prefix}" =
                 tagOption // {
                   loc = prefix ++ [ tagName ];
-                  definitions = [];
                 };
             })
             tags;

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -707,7 +707,7 @@ rec {
                     // {
                       # mergeOptionDecls is not idempotent in these attrs:
                       declarations = a.tags.${tagName}.declarations ++ bOpt.declarations;
-                      declarationPositions = a.tags.${tagName}.declarations ++ bOpt.declarations;
+                      declarationPositions = a.tags.${tagName}.declarationPositions ++ bOpt.declarationPositions;
                     }
                   )
                   (builtins.intersectAttrs a.tags b.tags);

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -644,7 +644,8 @@ rec {
       in
       mkOptionType {
         name = "attrTag";
-        description = "attribute-tagged union of ${choicesStr}";
+        description = "attribute-tagged union";
+        descriptionClass = "noun";
         getSubOptions = prefix:
           mapAttrs
             (tagName: tagOption: {

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -157,7 +157,7 @@ rec {
       # If it doesn't, this should be {}
       # This may be used when a value is required for `mkIf false`. This allows the extra laziness in e.g. `lazyAttrsOf`.
       emptyValue ? {}
-    , # Return a flat list of sub-options.  Used to generate
+    , # Return a flat attrset of sub-options.  Used to generate
       # documentation.
       getSubOptions ? prefix: {}
     , # List of modules if any, or null if none.

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -288,6 +288,16 @@ A union of types is a type such that a value is valid when it is valid for at le
 
 If some values are instances of more than one of the types, it is not possible to distinguish which type they are meant to be instances of. If that's needed, consider using a [sum type](#sec-option-types-sums).
 
+`types.either` *`t1 t2`*
+
+:   Type *`t1`* or type *`t2`*, e.g. `with types; either int str`.
+    Multiple definitions cannot be merged.
+
+`types.oneOf` \[ *`t1 t2`* ... \]
+
+:   Type *`t1`* or type *`t2`* and so forth, e.g.
+    `with types; oneOf [ int str bool ]`. Multiple definitions cannot be
+    merged.
 
 
 ## Sum types {#sec-option-types-sums}
@@ -364,17 +374,6 @@ Composed types are types that take a type as parameter. `listOf
     This is one possible representation of what may be called a _tagged union_ or _sum type_.
     `attrTag` can be thought of as an extension of *`enum`* where the permissible items
     are attribute names, and each item is paired with a value of a specific type.
-
-`types.either` *`t1 t2`*
-
-:   Type *`t1`* or type *`t2`*, e.g. `with types; either int str`.
-    Multiple definitions cannot be merged.
-
-`types.oneOf` \[ *`t1 t2`* ... \]
-
-:   Type *`t1`* or type *`t2`* and so forth, e.g.
-    `with types; oneOf [ int str bool ]`. Multiple definitions cannot be
-    merged.
 
 `types.coercedTo` *`from f to`*
 

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -334,6 +334,16 @@ Composed types are types that take a type as parameter. `listOf
     the line `The option <option path> is defined multiple times.` and before
     a list of definition locations.
 
+`types.attrTag` *`{ attr1 = t1; attr2 = t2; ... }`*
+
+:   An attribute set containing one attribute, whose name must be picked from
+    the attribute set (`attr1`, etc) and whose value must be of the accompanying
+    type.
+
+    This is one possible representation of what may be called a _tagged union_ or _sum type_.
+    `attrTag` can be thought of as an extension of *`enum`* where the permissible items
+    are attribute names, and each item is paired with a value of a specific type.
+
 `types.either` *`t1 t2`*
 
 :   Type *`t1`* or type *`t2`*, e.g. `with types; either int str`.

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -307,7 +307,11 @@ Nix does not have a built-in syntax for this pairing of a label and a type or va
 
 If the built-in Nix value types provide enough distinction, you simplify your syntax with a [union type](#sec-option-types-unions) instead.
 
+`types.attrTag` *`{ attr1 = t1; attr2 = t2; ... }`*
 
+:   An attribute set containing one attribute, whose name must be picked from
+    the attribute set (`attr1`, etc) and whose value must be of the accompanying
+    type.
 
 
 ## Composed types {#sec-option-types-composed}
@@ -364,16 +368,6 @@ Composed types are types that take a type as parameter. `listOf
 :   Ensures that type *`t`* cannot be merged. Prints the message *`m`*, after
     the line `The option <option path> is defined multiple times.` and before
     a list of definition locations.
-
-`types.attrTag` *`{ attr1 = t1; attr2 = t2; ... }`*
-
-:   An attribute set containing one attribute, whose name must be picked from
-    the attribute set (`attr1`, etc) and whose value must be of the accompanying
-    type.
-
-    This is one possible representation of what may be called a _tagged union_ or _sum type_.
-    `attrTag` can be thought of as an extension of *`enum`* where the permissible items
-    are attribute names, and each item is paired with a value of a specific type.
 
 `types.coercedTo` *`from f to`*
 

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -42,6 +42,9 @@ merging is handled.
 :   One element of the list *`l`*, e.g. `types.enum [ "left" "right" ]`.
     Multiple definitions cannot be merged.
 
+    If you want to pair these values with more information, possibly of
+    distinct types, consider using a [sum type](#sec-option-types-sums).
+
 `types.anything`
 
 :   A type that accepts any value and recursively merges attribute sets
@@ -278,6 +281,24 @@ Submodules are detailed in [Submodule](#section-option-types-submodule).
     user to affect all submodules in an `attrsOf submodule` at once. This is
     more convenient and discoverable than expecting the module user to
     type-merge with the `attrsOf submodule` option.
+
+## Union types {#sec-option-types-unions}
+
+A union of types is a type such that a value is valid when it is valid for at least one of those types.
+
+If some values are instances of more than one of the types, it is not possible to distinguish which type they are meant to be instances of. If that's needed, consider using a [sum type](#sec-option-types-sums).
+
+
+
+## Sum types {#sec-option-types-sums}
+
+A sum type can be thought of, conceptually, as a *`types.enum`* where each valid item is paired with a type, through some value syntax.
+Nix does not have a built-in syntax for this pairing of a label and a type or value, so sum types may be represented in multiple ways.
+
+If the built-in Nix value types provide enough distinction, you simplify your syntax with a [union type](#sec-option-types-unions) instead.
+
+
+
 
 ## Composed types {#sec-option-types-composed}
 

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -299,6 +299,11 @@ If some values are instances of more than one of the types, it is not possible t
     `with types; oneOf [ int str bool ]`. Multiple definitions cannot be
     merged.
 
+`types.nullOr` *`t`*
+
+:   `null` or type *`t`*. Multiple definitions are merged according to
+    type *`t`*.
+
 
 ## Sum types {#sec-option-types-sums}
 
@@ -352,11 +357,6 @@ Composed types are types that take a type as parameter. `listOf
     type of `foo.attr` was `lazyAttrsOf (nullOr int)`, `null` would be
     returned instead for the same `mkIf false` definition.
     :::
-
-`types.nullOr` *`t`*
-
-:   `null` or type *`t`*. Multiple definitions are merged according to
-    type *`t`*.
 
 `types.uniq` *`t`*
 

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -318,6 +318,30 @@ If the built-in Nix value types provide enough distinction, you simplify your sy
     the attribute set (`attr1`, etc) and whose value must be of the accompanying
     type.
 
+    This type appears in the documentation as _attribute-tagged union_.
+
+    Example:
+
+    ```nix
+    types.attrTag {
+      bounce = mkOption {
+        description = "Send back a packet explaining why it wasn't forwarded.";
+        type = submodule {
+          options.errorMessage = mkOption { … };
+        };
+      };
+      forward = mkOption {
+        description = "Forward the packet.";
+        type = submodule {
+          options.destination = mkOption { … };
+        };
+      };
+      ignore = mkOption {
+        description = "Drop the packet without sending anything back.";
+        type = submodule {};
+      };
+    }
+    ```
 
 ## Composed types {#sec-option-types-composed}
 

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -307,16 +307,15 @@ If some values are instances of more than one of the types, it is not possible t
 
 ## Sum types {#sec-option-types-sums}
 
-A sum type can be thought of, conceptually, as a *`types.enum`* where each valid item is paired with a type, through some value syntax.
+A sum type can be thought of, conceptually, as a *`types.enum`* where each valid item is paired with at least a type, through some value syntax.
 Nix does not have a built-in syntax for this pairing of a label and a type or value, so sum types may be represented in multiple ways.
 
-If the built-in Nix value types provide enough distinction, you simplify your syntax with a [union type](#sec-option-types-unions) instead.
+If the you're interested in can be distinguished without a label, you may simplify your value syntax with a [union type](#sec-option-types-unions) instead.
 
-`types.attrTag` *`{ attr1 = t1; attr2 = t2; ... }`*
+`types.attrTag` *`{ attr1 = option1; attr2 = option2; ... }`*
 
 :   An attribute set containing one attribute, whose name must be picked from
-    the attribute set (`attr1`, etc) and whose value must be of the accompanying
-    type.
+    the attribute set (`attr1`, etc) and whose value consists of definitions that are valid for the corresponding option (`option1`, etc).
 
     This type appears in the documentation as _attribute-tagged union_.
 

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -323,22 +323,40 @@ If the built-in Nix value types provide enough distinction, you simplify your sy
     Example:
 
     ```nix
-    types.attrTag {
-      bounce = mkOption {
-        description = "Send back a packet explaining why it wasn't forwarded.";
-        type = submodule {
-          options.errorMessage = mkOption { … };
-        };
+    { lib, ... }:
+    let inherit (lib) type mkOption;
+    in {
+      options.toyRouter.rules = mkOption {
+        description = ''
+          Rules for a fictional packet routing service.
+        '';
+        type = types.attrsOf (
+          types.attrTag {
+            bounce = mkOption {
+              description = "Send back a packet explaining why it wasn't forwarded.";
+              type = types.submodule {
+                options.errorMessage = mkOption { … };
+              };
+            };
+            forward = mkOption {
+              description = "Forward the packet.";
+              type = types.submodule {
+                options.destination = mkOption { … };
+              };
+            };
+            ignore = types.mkOption {
+              description = "Drop the packet without sending anything back.";
+              type = types.submodule {};
+            };
+          });
       };
-      forward = mkOption {
-        description = "Forward the packet.";
-        type = submodule {
-          options.destination = mkOption { … };
+      config.toyRouter.rules = {
+        http = {
+          bounce = {
+            errorMessage = "Unencrypted HTTP is banned. You must always use https://.";
+          };
         };
-      };
-      ignore = mkOption {
-        description = "Drop the packet without sending anything back.";
-        type = submodule {};
+        ssh = { drop = {}; };
       };
     }
     ```


### PR DESCRIPTION
## Description of changes

The purpose of `attrTag` is to describe values that are already structured with this exact syntax, in RFC 42 settings.

It can also be used as an alternative to other sum type representations that aren't merged yet (edit: in some cases). This may or may not be nice, but that's irrelevant because `attrTag` is needed for a specific purpose anyway, as mentioned.
My goal here is only to introduce _mechanism_, not _policy_. For instance, if we want to pick a favorite sum type representation, or formulate some other kinds of recommendations, that can be done separately, later, when we have practical experience with multiple sum types.

I've updated the docs to lay out the new concept and how it relates to the existing "union-like" types.

Other sum type in development (not suitable for my use case as mentioned)
- #254790

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
