### PR TITLE
{uid,nss,socket,resolv}_wrapper: fix meta description & homepage, add changelog

### DIFF
--- a/pkgs/development/libraries/nss_wrapper/default.nix
+++ b/pkgs/development/libraries/nss_wrapper/default.nix
@@ -17,5 +17,6 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     platforms = platforms.unix;
     broken = stdenv.isDarwin;
+    changelog = "https://git.samba.org/?p=nss_wrapper.git;a=blob;f=CHANGELOG;hb=HEAD";
   };
 }

--- a/pkgs/development/libraries/resolv_wrapper/default.nix
+++ b/pkgs/development/libraries/resolv_wrapper/default.nix
@@ -16,5 +16,6 @@ stdenv.mkDerivation rec {
     homepage = "https://git.samba.org/?p=resolv_wrapper.git;a=summary;";
     license = licenses.bsd3;
     platforms = platforms.linux;
+    changelog = "https://git.samba.org/?p=resolv_wrapper.git;a=blob;f=CHANGELOG;hb=HEAD";
   };
 }

--- a/pkgs/development/libraries/resolv_wrapper/default.nix
+++ b/pkgs/development/libraries/resolv_wrapper/default.nix
@@ -12,8 +12,8 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkg-config ];
 
   meta = with lib; {
-    description = "A wrapper for the user, group and hosts NSS API";
-    homepage = "https://git.samba.org/?p=uid_wrapper.git;a=summary;";
+    description = "A wrapper for DNS name resolving or DNS faking";
+    homepage = "https://git.samba.org/?p=resolv_wrapper.git;a=summary;";
     license = licenses.bsd3;
     platforms = platforms.linux;
   };

--- a/pkgs/development/libraries/socket_wrapper/default.nix
+++ b/pkgs/development/libraries/socket_wrapper/default.nix
@@ -16,5 +16,6 @@ stdenv.mkDerivation rec {
     homepage = "https://git.samba.org/?p=socket_wrapper.git;a=summary;";
     license = licenses.bsd3;
     platforms = platforms.all;
+    changelog = "https://git.samba.org/?p=socket_wrapper.git;a=blob;f=CHANGELOG;hb=HEAD";
   };
 }

--- a/pkgs/development/libraries/uid_wrapper/default.nix
+++ b/pkgs/development/libraries/uid_wrapper/default.nix
@@ -16,6 +16,6 @@ stdenv.mkDerivation rec {
     homepage = "https://git.samba.org/?p=uid_wrapper.git;a=summary;";
     license = licenses.bsd3;
     platforms = platforms.all;
-    changelog = "https://git.samba.org/?p=uid_wrapper.git;a=blob;f=CHANGELOG;hb=HEAD";
+    changelog = "https://git.samba.org/?p=uid_wrapper.git;a=blob;f=CHANGELOG;hb=refs/tags/uid_wrapper-${version}";
   };
 }

--- a/pkgs/development/libraries/uid_wrapper/default.nix
+++ b/pkgs/development/libraries/uid_wrapper/default.nix
@@ -16,5 +16,6 @@ stdenv.mkDerivation rec {
     homepage = "https://git.samba.org/?p=uid_wrapper.git;a=summary;";
     license = licenses.bsd3;
     platforms = platforms.all;
+    changelog = "https://git.samba.org/?p=uid_wrapper.git;a=blob;f=CHANGELOG;hb=HEAD";
   };
 }

--- a/pkgs/development/libraries/uid_wrapper/default.nix
+++ b/pkgs/development/libraries/uid_wrapper/default.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake pkg-config ];
 
   meta = with lib; {
-    description = "A wrapper for the user, group and hosts NSS API";
+    description = "A testing tool to fake privilege separation";
     homepage = "https://git.samba.org/?p=uid_wrapper.git;a=summary;";
     license = licenses.bsd3;
     platforms = platforms.all;


### PR DESCRIPTION
Description and homepage where seemingly copied over from uid_wrapper by mistake.
Also, add meta.changelog to all of the packaged samba wrappers.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
