### PR TITLE
buildGoModule: find build/test targets with `go list`

### DIFF
--- a/pkgs/applications/misc/darkman/default.nix
+++ b/pkgs/applications/misc/darkman/default.nix
@@ -30,6 +30,9 @@ buildGoModule rec {
     runHook postBuild
   '';
 
+  # No test target in Makefile.
+  doCheck = false;
+
   installPhase = ''
     runHook preInstall
     make PREFIX=$out install

--- a/pkgs/applications/networking/cloudflared/default.nix
+++ b/pkgs/applications/networking/cloudflared/default.nix
@@ -70,6 +70,9 @@ buildGoModule rec {
 
   doCheck = !stdenv.isDarwin;
 
+  # Test timed out after 10m0s
+  checkFlags = [ "-skip=^TestConcurrentUpdateAndRead$" ];
+
   passthru.tests.simple = callPackage ./tests.nix { inherit version; };
 
   meta = with lib; {

--- a/pkgs/applications/networking/cluster/argocd-autopilot/default.nix
+++ b/pkgs/applications/networking/cluster/argocd-autopilot/default.nix
@@ -30,6 +30,11 @@ buildGoModule rec {
 
   subPackages = [ "cmd" ];
 
+  checkFlags = [
+    # Tests asserts on installationManifestsURL which we set in ldflags.
+    "-skip=^Test_setBootstrapOptsDefaults/Basic$"
+  ];
+
   doInstallCheck = true;
   installCheckPhase = ''
     $out/bin/argocd-autopilot version | grep ${src.rev} > /dev/null

--- a/pkgs/applications/networking/cluster/argocd/default.nix
+++ b/pkgs/applications/networking/cluster/argocd/default.nix
@@ -36,6 +36,8 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
+  doCheck = false; # Too many tests are failing
+
   installPhase = ''
     runHook preInstall
     mkdir -p $out/bin

--- a/pkgs/applications/networking/cluster/arkade/default.nix
+++ b/pkgs/applications/networking/cluster/arkade/default.nix
@@ -41,6 +41,11 @@ buildGoModule rec {
     "-X github.com/alexellis/arkade/pkg.Version=${version}"
   ];
 
+  checkFlags = [
+    # Test needs network access
+    "-skip=^Test_DownloadKubens$"
+  ];
+
   postInstall = ''
     installShellCompletion --cmd arkade \
       --bash <($out/bin/arkade completion bash) \

--- a/pkgs/applications/networking/cluster/atlantis/default.nix
+++ b/pkgs/applications/networking/cluster/atlantis/default.nix
@@ -1,4 +1,8 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, git
+}:
 
 buildGoModule rec {
   pname = "atlantis";
@@ -18,6 +22,27 @@ buildGoModule rec {
   vendorHash = "sha256-W3bX5fAxFvI1zQCx8ioNIc/yeDAXChpxNPYyaghnxxE=";
 
   subPackages = [ "." ];
+
+  nativeCheckInputs = [
+    git
+  ];
+
+  checkFlags =
+    let
+      skippedTests = [
+        # Tests panic for unknown reason.
+        "TestPostWorkflowHookRunner_Run"
+        "TestPreWorkflowHookRunner_Run"
+        "TestNewServer"
+        "TestCommandRunnerVCSClientInitialized"
+        # Tests require Terraform, which is unfree.
+        "TestGitHubWorkflow"
+        "TestSimpleWorkflow_terraformLockFile"
+        "TestGitHubWorkflowWithPolicyCheck"
+        "TestDefaultProjectCommandBuilder_TerraformVersion"
+      ];
+    in
+    [ "-skip=^${lib.concatStringsSep "$|^" skippedTests}$" ];
 
   doInstallCheck = true;
   installCheckPhase = ''

--- a/pkgs/applications/networking/cluster/calico/default.nix
+++ b/pkgs/applications/networking/cluster/calico/default.nix
@@ -28,6 +28,8 @@ builtins.mapAttrs (pname: { doCheck ? true, mainProgram ? pname, subPackages }: 
   };
 }) {
   calico-apiserver = {
+    # integration tests require network
+    doCheck = false;
     mainProgram = "apiserver";
     subPackages = [
       "apiserver/cmd/..."
@@ -42,6 +44,8 @@ builtins.mapAttrs (pname: { doCheck ? true, mainProgram ? pname, subPackages }: 
     ];
   };
   calico-cni-plugin = {
+    # integration tests require network
+    doCheck = false;
     mainProgram = "calico";
     subPackages = [
       "cni-plugin/cmd/..."
@@ -64,16 +68,22 @@ builtins.mapAttrs (pname: { doCheck ? true, mainProgram ? pname, subPackages }: 
     ];
   };
   calico-typha = {
+    # integration tests require network
+    doCheck = false;
     subPackages = [
       "typha/cmd/..."
     ];
   };
   calicoctl = {
+    # integration tests require network
+    doCheck = false;
     subPackages = [
       "calicoctl/calicoctl"
     ];
   };
   confd-calico = {
+    # integration tests require network
+    doCheck = false;
     mainProgram = "confd";
     subPackages = [
       "confd"

--- a/pkgs/applications/networking/cluster/cloudfoundry-cli/default.nix
+++ b/pkgs/applications/networking/cluster/cloudfoundry-cli/default.nix
@@ -30,6 +30,28 @@ buildGoModule rec {
     "-X code.cloudfoundry.org/cli/version.binaryVersion=${version}"
   ];
 
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  checkFlags =
+    let
+      skippedTests = [
+        # Tests requiring network access.
+        "TestCloudcontroller"
+        "TestCommon"
+        "TestPlugin"
+        "TestPluginRepo"
+        # Tests assert on version, which we override in ldflags.
+        "TestCommands"
+        "TestConfig"
+        "TestVersion"
+        # Panic: sync: negative WaitGroup counter
+        "TestApplication"
+      ];
+    in
+    [ "-skip=^${lib.concatStringsSep "$|^" skippedTests}$" ];
+
   postInstall = ''
     mv "$out/bin/cli" "$out/bin/cf"
     installShellCompletion --bash $bashCompletionScript

--- a/pkgs/applications/networking/cluster/clusterctl/default.nix
+++ b/pkgs/applications/networking/cluster/clusterctl/default.nix
@@ -23,6 +23,22 @@ buildGoModule rec {
     "-X ${t}.gitVersion=v${version}"
   ];
 
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  excludedPackages = [
+    # Packages use envtest in their TestMain and panic when executed.
+    # Excluding these packages here so, as TestMain functions cannot
+    # be skipped on a per-package basis using '-skip' flag.
+    "util/patch"
+    "internal/controllers/clusterclass"
+    "controllers/remote"
+    "internal/util/ssa"
+    "internal/controllers/topology/cluster/structuredmerge"
+    "internal/controllers/topology/cluster"
+  ];
+
   postInstall = ''
     # errors attempting to write config to read-only $HOME
     export HOME=$TMPDIR

--- a/pkgs/applications/networking/cluster/cni/default.nix
+++ b/pkgs/applications/networking/cluster/cni/default.nix
@@ -19,6 +19,16 @@ buildGoModule rec {
 
   ldflags = [ "-s" "-w" ];
 
+  checkFlags =
+    let
+      skippedTests = [
+        # Tests require Go module proxy lookup.
+        "TestInvoke"
+        "TestLibcni"
+      ];
+    in
+    [ "-skip=^${lib.concatStringsSep "$|^" skippedTests}$" ];
+
   meta = with lib; {
     description = "Container Network Interface - networking for Linux containers";
     license = licenses.asl20;

--- a/pkgs/applications/networking/cluster/ktop/default.nix
+++ b/pkgs/applications/networking/cluster/ktop/default.nix
@@ -3,7 +3,6 @@
 buildGoModule rec {
   pname = "ktop";
   version = "0.3.5";
-  excludedPackages = [".ci"];
 
   src = fetchFromGitHub {
     owner = "vladimirvivien";
@@ -15,9 +14,7 @@ buildGoModule rec {
   vendorHash = "sha256-IiAMmHOq69WMT2B1q9ZV2fGDnLr7AbRm1P7ACSde2FE=";
   ldflags = [ "-s" "-w" "-X github.com/vladimirvivien/ktop/buildinfo.Version=v${version}" ];
 
-  postInstall = ''
-    rm $out/bin/hack
-  '';
+  subPackages = [ "." ];
 
   doCheck = false;
 

--- a/pkgs/applications/networking/cluster/velero/default.nix
+++ b/pkgs/applications/networking/cluster/velero/default.nix
@@ -13,7 +13,8 @@ buildGoModule rec {
   };
 
   ldflags = [
-    "-s" "-w"
+    "-s"
+    "-w"
     "-X github.com/vmware-tanzu/velero/pkg/buildinfo.Version=v${version}"
     "-X github.com/vmware-tanzu/velero/pkg/buildinfo.ImageRegistry=velero"
     "-X github.com/vmware-tanzu/velero/pkg/buildinfo.GitTreeState=clean"
@@ -22,7 +23,11 @@ buildGoModule rec {
 
   vendorHash = "sha256-Fu4T2VEW5s/KCdgJLk3bf0wIUhKULK6QuNEmL99MUCI=";
 
-  excludedPackages = [ "issue-template-gen" "release-tools" "v1" "velero-restic-restore-helper" ];
+  subPackages = [
+    "cmd/velero"
+    "cmd/velero-helper"
+    "cmd/velero-restore-helper"
+  ];
 
   doCheck = false; # Tests expect a running cluster see https://github.com/vmware-tanzu/velero/tree/main/test/e2e
   doInstallCheck = true;

--- a/pkgs/applications/networking/coreth/default.nix
+++ b/pkgs/applications/networking/coreth/default.nix
@@ -33,6 +33,16 @@ buildGoModule rec {
     "plugin"
   ];
 
+  checkFlags =
+    let
+      skippedTests = [
+        # Tests require additional dependencies not specified in go.mod.
+        "TestGolangBindings"
+        "TestGolangBindingsOverload"
+      ];
+    in
+    [ "-skip=^${lib.concatStringsSep "$|^" skippedTests}$" ];
+
   postInstall = "mv $out/bin/{plugin,evm}";
 
   meta = with lib; {

--- a/pkgs/applications/version-management/git-bug/default.nix
+++ b/pkgs/applications/version-management/git-bug/default.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
 
   doCheck = false;
 
-  excludedPackages = [ "doc" "misc" ];
+  subPackages = [ "." ];
 
   ldflags = [
     "-X github.com/MichaelMure/git-bug/commands.GitCommit=v${version}"

--- a/pkgs/by-name/at/athens/package.nix
+++ b/pkgs/by-name/at/athens/package.nix
@@ -2,6 +2,7 @@
 , fetchFromGitHub
 , buildGoModule
 , testers
+, git
 , athens
 }:
 buildGoModule rec {
@@ -21,6 +22,20 @@ buildGoModule rec {
   ldflags = [ "-s" "-w" "-X github.com/gomods/athens/pkg/build.version=${version}" ];
 
   subPackages = [ "cmd/proxy" ];
+
+  checkFlags =
+    let
+      skippedTests = [
+        # Tests requiring network access.
+        "TestModules"
+        "TestList"
+        "TestConcurrentLists"
+        "TestLatest"
+        "TestInfo"
+        "TestGoMod"
+      ];
+    in
+    [ "-skip=^${lib.concatStringsSep "$|^" skippedTests}$" ];
 
   postInstall = ''
     mv $out/bin/proxy $out/bin/athens

--- a/pkgs/by-name/cr/crc/package.nix
+++ b/pkgs/by-name/cr/crc/package.nix
@@ -53,6 +53,11 @@ buildGoModule rec {
     export HOME=$(mktemp -d)
   '';
 
+  checkFlags = [
+    # Assertions in the test fail.
+    "-skip=^TestCountPreflights$"
+  ];
+
   passthru.tests.version = testers.testVersion {
     package = crc;
     command = ''

--- a/pkgs/by-name/cr/crossplane-cli/package.nix
+++ b/pkgs/by-name/cr/crossplane-cli/package.nix
@@ -27,6 +27,10 @@ buildGoModule rec {
 
   subPackages = [ "cmd/crank" ];
 
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
   postInstall = ''
     mv $out/bin/crank $out/bin/crossplane
   '';

--- a/pkgs/desktops/deepin/go-package/deepin-pw-check/default.nix
+++ b/pkgs/desktops/deepin/go-package/deepin-pw-check/default.nix
@@ -52,6 +52,12 @@ buildGoModule rec {
     runHook postBuild
   '';
 
+  checkPhase = ''
+    runHook preCheck
+    make test
+    runHook postCheck
+  '';
+
   installPhase = ''
     runHook preInstall
     make install PREFIX="$out" PKG_FILE_DIR=$out/lib/pkgconfig PAM_MODULE_DIR=$out/etc/pam.d

--- a/pkgs/development/libraries/boringssl/default.nix
+++ b/pkgs/development/libraries/boringssl/default.nix
@@ -43,6 +43,10 @@ buildGoModule {
   # CMAKE_OSX_ARCHITECTURES is set to x86_64 by Nix, but it confuses boringssl on aarch64-linux.
   cmakeFlags = [ "-GNinja" ] ++ lib.optionals (stdenv.isLinux) [ "-DCMAKE_OSX_ARCHITECTURES=" ];
 
+  checkPhase = ''
+    ninjaCheckPhase
+  '';
+
   installPhase = ''
     mkdir -p $bin/bin $dev $out/lib
 

--- a/pkgs/development/tools/analysis/actionlint/default.nix
+++ b/pkgs/development/tools/analysis/actionlint/default.nix
@@ -34,6 +34,11 @@ buildGoModule rec {
 
   ldflags = [ "-s" "-w" "-X github.com/rhysd/actionlint.version=${version}" ];
 
+  checkFlags = [
+    # Test checks version output and assumes version is empty.
+    "-skip=^TestLinterFormatErrorMessageInSARIF$"
+  ];
+
   meta = with lib; {
     homepage = "https://rhysd.github.io/actionlint/";
     description = "Static checker for GitHub Actions workflow files";

--- a/pkgs/development/tools/cue/default.nix
+++ b/pkgs/development/tools/cue/default.nix
@@ -33,6 +33,9 @@ buildGoModule rec {
       --zsh <($out/bin/cue completion zsh)
   '';
 
+  # Tests asserts on development version, which we override in ldflags.
+  checkFlags = [ "-skip=^TestScript/version$" ];
+
   doInstallCheck = true;
   installCheckPhase = ''
     $out/bin/cue eval - <<<'a: "all good"' > /dev/null

--- a/pkgs/development/tools/dapr/cli/default.nix
+++ b/pkgs/development/tools/dapr/cli/default.nix
@@ -30,6 +30,15 @@ buildGoModule rec {
     "-X github.com/dapr/cli/pkg/standalone.gitversion=${version}"
   ];
 
+  checkFlags =
+    let
+      skippedTests = [
+        "TestValidateFilePaths"
+        "TestReadFile"
+      ];
+    in
+    [ "-skip=^${lib.concatStringsSep "$|^" skippedTests}" ];
+
   postInstall = ''
     mv $out/bin/cli $out/bin/dapr
 

--- a/pkgs/development/tools/database/atlas/default.nix
+++ b/pkgs/development/tools/database/atlas/default.nix
@@ -1,4 +1,11 @@
-{ lib, buildGoModule, fetchFromGitHub, installShellFiles, testers, atlas }:
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+, testers
+, git
+, atlas
+}:
 
 buildGoModule rec {
   pname = "atlas";
@@ -21,6 +28,8 @@ buildGoModule rec {
   ldflags = [ "-s" "-w" "-X ariga.io/atlas/cmd/atlas/internal/cmdapi.version=v${version}" ];
 
   subPackages = [ "." ];
+
+  nativeCheckInputs = [ git ];
 
   postInstall = ''
     installShellCompletion --cmd atlas \

--- a/pkgs/development/tools/delve/default.nix
+++ b/pkgs/development/tools/delve/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildGoModule, fetchFromGitHub, makeWrapper, stdenv }:
+{ lib, buildGoModule, fetchFromGitHub, makeWrapper, stdenv, lsof }:
 
 buildGoModule rec {
   pname = "delve";
@@ -18,6 +18,18 @@ buildGoModule rec {
   nativeBuildInputs = [ makeWrapper ];
 
   hardeningDisable = [ "fortify" ];
+
+  nativeCheckInputs = [ lsof ];
+
+  checkFlags =
+    let
+      skippedTests = [
+        # Tests fail with 'could not get the Go version for the moduledata extraction: no goversion found'
+        "TestDebugStripped"
+        "TestDebugStripped2"
+      ];
+    in
+    [ "-skip=^${lib.concatStringsSep "$|^" skippedTests}$" ];
 
   preCheck = ''
     XDG_CONFIG_HOME=$(mktemp -d)

--- a/pkgs/development/tools/devd/default.nix
+++ b/pkgs/development/tools/devd/default.nix
@@ -25,6 +25,9 @@ buildGoModule rec {
 
   ldflags = [ "-s" "-w" ];
 
+  # Test fails with 'Content-Length mismatch: got 11, want -1
+  checkFlags = [ "-skip=^TestServeFileWithContentEncoding$" ];
+
   meta = with lib; {
     description = "A local webserver for developers";
     homepage = "https://github.com/cortesi/devd";

--- a/pkgs/servers/dex/default.nix
+++ b/pkgs/servers/dex/default.nix
@@ -21,6 +21,16 @@ buildGoModule rec {
     "-w" "-s" "-X main.version=${src.rev}"
   ];
 
+  checkFlags =
+    let
+      skippedTests = [
+        # Tests require network access.
+        "TestOpen"
+        "TestGetGroups"
+      ];
+    in
+    [ "-skip=^${lib.concatStringsSep "$|^" skippedTests}" ];
+
   postInstall = ''
     mkdir -p $out/share
     cp -r $src/web $out/share/web

--- a/pkgs/servers/dns/coredns/default.nix
+++ b/pkgs/servers/dns/coredns/default.nix
@@ -66,6 +66,11 @@ in buildGoModule rec {
     sed -E -i 's/\blo\b/lo0/' plugin/bind/setup_test.go
   '';
 
+  checkFlags = [
+    # Tests fail with 'rcode is "REFUSED", expected "NOERROR"'
+    "-skip=^TestView$"
+  ];
+
   postInstall = ''
     installManPage man/*
   '';

--- a/pkgs/servers/monitoring/prometheus/alertmanager.nix
+++ b/pkgs/servers/monitoring/prometheus/alertmanager.nix
@@ -32,6 +32,11 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
+  checkFlags = [
+    # Expected nil, but got: &errors.errorString{s:"no private IP address found, and explicit IP not provided"}
+    "-skip=^TestFinalAdvertiseAddr$"
+  ];
+
   postInstall = ''
     $out/bin/amtool --completion-script-bash > amtool.bash
     installShellCompletion amtool.bash

--- a/pkgs/tools/admin/aliyun-cli/default.nix
+++ b/pkgs/tools/admin/aliyun-cli/default.nix
@@ -18,6 +18,19 @@ buildGoModule rec {
 
   ldflags = [ "-s" "-w" "-X github.com/aliyun/aliyun-cli/cli.Version=${version}" ];
 
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  checkFlags =
+    let
+      skippedTests = [
+        "Test_main" # Assertions in test fail
+        "Test" # TestSuite needs network access
+      ];
+    in
+    [ "-skip=^${lib.concatStringsSep "$|^" skippedTests}$" ];
+
   postInstall = ''
     mv $out/bin/main $out/bin/aliyun
   '';

--- a/pkgs/tools/admin/clair/default.nix
+++ b/pkgs/tools/admin/clair/default.nix
@@ -34,6 +34,10 @@ buildGoModule rec {
     "-X main.Version=${version}"
   ];
 
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
+
   postInstall = ''
     wrapProgram $out/bin/clair \
       --prefix PATH : "${lib.makeBinPath [ rpm xz ]}"

--- a/pkgs/tools/admin/copilot-cli/default.nix
+++ b/pkgs/tools/admin/copilot-cli/default.nix
@@ -25,6 +25,18 @@ buildGoModule rec {
 
   subPackages = [ "./cmd/copilot" ];
 
+  checkFlags =
+    let
+      skippedTests = [
+        # Tests executes docker.
+        "TestDockerCommand_CheckDockerEngineRunning"
+        "TestDockerCommand_GetPlatform"
+        # Tests require network access.
+        "TestWorkloadDeployer_UploadArtifacts"
+      ];
+    in
+    [ "-skip=^${lib.concatStringsSep "$|^" skippedTests}" ];
+
   postInstall = ''
     installShellCompletion --cmd copilot \
       --bash <($out/bin/copilot completion bash) \

--- a/pkgs/tools/networking/croc/default.nix
+++ b/pkgs/tools/networking/croc/default.nix
@@ -15,6 +15,17 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
+  # Test requires network access.
+  checkFlags =
+    let
+      skippedTests = [
+        # Tests require network access.
+        "TestPublicIP"
+        "TestLocalIP"
+      ];
+    in
+    [ "-skip=^${lib.concatStringsSep "$|^" skippedTests}$" ];
+
   passthru = {
     tests = {
       local-relay = callPackage ./test-local-relay.nix { };

--- a/pkgs/tools/networking/dd-agent/datadog-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-agent.nix
@@ -65,6 +65,7 @@ in buildGoModule rec {
     "log"
     "secrets"
     "zlib"
+    "kubeapiserver"
   ]
   ++ lib.optionals withSystemd [ "systemd" ]
   ++ extraTags;

--- a/pkgs/tools/security/browserpass/default.nix
+++ b/pkgs/tools/security/browserpass/default.nix
@@ -24,8 +24,6 @@ buildGoModule rec {
 
   vendorHash = "sha256-CjuH4ANP2bJDeA+o+1j+obbtk5/NVLet/OFS3Rms4r0=";
 
-  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
-
   postPatch = ''
     # Because this Makefile will be installed to be used by the user, patch
     # variables to be valid by default
@@ -45,7 +43,13 @@ buildGoModule rec {
     make browserpass
   '';
 
-  checkTarget = "test";
+  # doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  # Fails with 'fork/exec /build/go-build2422243092/b088/request.test: no such file or directory'
+  doCheck = false;
+
+  checkPhase = ''
+    make test
+  '';
 
   installPhase = ''
     make install

--- a/pkgs/tools/security/certstrap/default.nix
+++ b/pkgs/tools/security/certstrap/default.nix
@@ -20,6 +20,16 @@ buildGoModule rec {
 
   ldflags = [ "-X main.release=${version}" ];
 
+  checkFlags =
+    let
+      skippedTests = [
+        # Tests fail with 'x509: cannot verify signature: insecure algorithm SHA1-RSA'
+        "TestCertificateAuthority"
+        "TestCertificateVerify"
+      ];
+    in
+    [ "-skip=^${lib.concatStringsSep "$|^" skippedTests}$" ];
+
   meta = with lib; {
     description = "Tools to bootstrap CAs, certificate requests, and signed certificates";
     longDescription = ''

--- a/pkgs/tools/security/crowdsec/default.nix
+++ b/pkgs/tools/security/crowdsec/default.nix
@@ -33,6 +33,9 @@ buildGoModule rec {
 
   postBuild = "mv $GOPATH/bin/{crowdsec-cli,cscli}";
 
+  # Too many tests are failing.
+  doCheck = false;
+
   postInstall = ''
     mkdir -p $out/share/crowdsec
     cp -r ./config $out/share/crowdsec/


### PR DESCRIPTION
## Description of problem 

`buildGoModule` uses the internal `getGoDirs` function to find targets to build/test:

https://github.com/NixOS/nixpkgs/blob/b914a998ec98a873dcb05e3b33091f709acad1a4/pkgs/build-support/go/module.nix#L224-L232

#### No/not all relevant tests executed when `subPackage` is set

If the `subPackages` attribute is set, we will call `go test` on the specified subpackages.

This problematic as a common pattern in Go is to place the `main` packages of binaries in a `cmd` directory, often without test files. The most common pattern to test Go could is likely executing `go test ./...` in the module root directory to recursively tests all packages of the module. When we only test the `main` packages, we are likely missing many relevant tests for that binary.

#### Using `find` to find targets for Go does not respect Go conventions

When using `find` to discover packages to build, Go conventions will be ignored. Most Go commands will stop to recurse into submodules, and the dependency derivation will only contain the dependencies of the main module.

As a result, such packages must currently be explicitly excluded. In the following example, `vendored/toml` is a submodule:

https://github.com/NixOS/nixpkgs/blob/26f8f975be667287034b1d6db2e7eb3d8b3ac4b1/pkgs/by-name/gl/glauth/package.nix#L31-L33

#### Test performance

Right now we test each package in separate as we invoke the `go test` command for each package. This is slow and really bad for build time in cases where there are many packages but each package has only a few or no fast tests. While packages from different tests can run in parallel, tests within a package are executed sequentially by default. When we pass all the packages to the go command and just invoke it once, Go has the chance to parallelize test execution. 

## Description of changes

- Use `go list` to discover packages, both for builds and tests.
- For tests, we use a more sophisticated `go list` expression to identify the packages that our built targets actually depend on. This is an optimization over running tests for the full module which will save us some time when building a binary with only some local dependencies in a bigger Go module.


## Open TODOs

- [ ] Fix failing tests (~300-400). Mostly need to exclude tests with network etc.
- [x] Re-enable `excludedPackages`
- [x] Pass flags to `go list`
- [ ] Add documentation
- [ ] Migrate most packages from `excludedPackage` to `subPackages` (followup PR) and document that `subPackages` is prefered

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
