### PR TITLE
material-black-colors: init at 0-unstable-2020-12-17

### DIFF
--- a/pkgs/by-name/ma/material-black-colors/package.nix
+++ b/pkgs/by-name/ma/material-black-colors/package.nix
@@ -1,0 +1,66 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, colorVariants ? [] # default: install all icons
+}:
+
+let
+  pname = "material-black-colors";
+  colorVariantList = [
+    "MB-Blueberry-Suru-GLOW"
+    "MB-Cherry-Suru-GLOW"
+    "MB-Lime-Suru-GLOW"
+    "MB-Mango-Suru-GLOW"
+    "MB-Pistachio-Suru-GLOW"
+    "MB-Plum-Suru-GLOW"
+    "Material-Black-Blueberry-Numix-FLAT"
+    "Material-Black-Blueberry-Numix"
+    "Material-Black-Blueberry-Suru"
+    "Material-Black-Cherry-Numix-FLAT"
+    "Material-Black-Cherry-Numix"
+    "Material-Black-Cherry-Suru"
+    "Material-Black-Lime-Numix-FLAT"
+    "Material-Black-Lime-Numix"
+    "Material-Black-Lime-Suru"
+    "Material-Black-Mango-Numix-FLAT"
+    "Material-Black-Mango-Numix"
+    "Material-Black-Mango-Suru"
+    "Material-Black-Pistachio-Numix-FLAT"
+    "Material-Black-Pistachio-Numix"
+    "Material-Black-Pistachio-Suru"
+    "Material-Black-Plum-Numix-FLAT"
+    "Material-Black-Plum-Numix"
+    "Material-Black-Plum-Suru"
+  ];
+
+in
+lib.checkListOfEnum "${pname}: color variants" colorVariantList colorVariants
+
+stdenvNoCC.mkDerivation {
+  inherit pname;
+  version = "0-unstable-2020-12-17";
+
+  src = fetchFromGitHub {
+    owner = "rtlewis88";
+    repo = "rtl88-Themes";
+    rev = "3864d851aac7f4e76cf23717aee104de234aef74";
+    hash = "sha256-BUJMd6Ltq16/HqqDbB5VDGIRSzLivXxNYZPT9sd6oTI=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/icons
+    cp -r ${lib.concatStringsSep " " (if colorVariants != [] then colorVariants else colorVariantList)} $out/share/icons/
+    runHook postInstall
+  '';
+
+  dontFixup = true;
+
+  meta = with lib; {
+    description = "Material Black Colors icons";
+    homepage = "https://github.com/rtlewis88/rtl88-Themes/tree/material-black-COLORS";
+    maintainers = with maintainers; [ d3vil0p3r ];
+    platforms = platforms.all;
+    license = with licenses; [ gpl3Plus mit ];
+  };
+}


### PR DESCRIPTION
material-black-colors: init at unstable-2020-12-17

![image](https://github.com/NixOS/nixpkgs/assets/83867734/868e2ac2-fa5a-44e3-b99a-328cb44d64ed)

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
