### PR TITLE
fbjni: fix broken build due to missing `cstdint` include

### DIFF
--- a/pkgs/development/libraries/fbjni/default.nix
+++ b/pkgs/development/libraries/fbjni/default.nix
@@ -19,12 +19,20 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    # Upstram fix for builds on GCC 13. Should be removable with next release after 0.5.1
+    (fetchpatch {
+      name = "add-cstdint-include.patch";
+      url = "https://github.com/facebookincubator/fbjni/commit/59461eff6c7881d58e958287481e1f1cd99e08d3.patch";
+      hash = "sha256-r27C+ODTCZdd1tEz3cevnNNyZlrRhq1jOzwnIYlkglM=";
+    })
+
     # Part of https://github.com/facebookincubator/fbjni/pull/76
     # fix cmake file installation directory
     (fetchpatch {
       url = "https://github.com/facebookincubator/fbjni/commit/ab02e60b5da28647bfcc864b0bb1b9a90504cdb1.patch";
       sha256 = "sha256-/h6kosulRH/ZAU2u0zRSaNDK39jsnFt9TaSxyBllZqM=";
     })
+
     # install headers
     (fetchpatch {
       url = "https://github.com/facebookincubator/fbjni/commit/74e125caa9a815244f1e6bd08eaba57d015378b4.patch";


### PR DESCRIPTION
GCC 13 stopped transitively including `cstdint` in various scenarios, breaking the build of `fbjni`. This issue has already been resolved upstream but is currently only merged in `main` [^1] (there hasn't been a subsequent release yet).

This change pulls in the respective commit as a patch, fixing the build until a new version of `fbjni` is relased.

Failing Hydra build: https://hydra.nixos.org/build/247434300
Hydra build log: https://hydra.nixos.org/build/247434300/nixlog/1

Relevant log excerpt: 
```
[ 25%] Building CXX object CMakeFiles/fbjni.dir/cxx/fbjni/detail/utf8.cpp.o
In file included from /build/source/cxx/fbjni/detail/utf8.cpp:17:
/build/source/cxx/fbjni/detail/utf8.h:29:11: error: 'uint8_t' does not name a type
   29 |     const uint8_t* bytes,
      |           ^~~~~~~
/build/source/cxx/fbjni/detail/utf8.h:22:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   21 | #include <jni.h>
  +++ |+#include <cstdint>
   22 | 
```

[^1]: https://github.com/facebookincubator/fbjni/commit/59461eff6c7881d58e958287481e1f1cd99e08d3

## Description of changes

Added upstream patch introducing the missing `cstdint` include statement via `fetchpatch`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
