### PR TITLE
vorta: 0.8.12 -> 0.9.1

### DIFF
--- a/pkgs/applications/backup/vorta/default.nix
+++ b/pkgs/applications/backup/vorta/default.nix
@@ -3,44 +3,43 @@
 , fetchFromGitHub
 , wrapQtAppsHook
 , borgbackup
-, qt5
+, qtbase
+, qtwayland
 , stdenv
+, makeFontsConf
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "vorta";
-  version = "0.8.12";
+  version = "0.9.1";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "borgbase";
     repo = "vorta";
     rev = "v${version}";
-    hash = "sha256-nLdLTh1qSKvOR2cE9HWQrIWQ9L+ynX4qF+lTtKn/Ubs=";
+    hash = "sha256-wGlnldS2p92NAYAyRPqKjSneIlbdsOiJ0N42n/mMGFI=";
   };
 
-  nativeBuildInputs = [ wrapQtAppsHook ];
+  nativeBuildInputs = [
+    python3Packages.setuptools
+    wrapQtAppsHook
+  ];
 
   buildInputs = lib.optionals stdenv.isLinux [
-    qt5.qtwayland
+    qtwayland
   ];
 
   propagatedBuildInputs = with python3Packages; [
     peewee
-    pyqt5
-    python-dateutil
+    pyqt6
     psutil
-    qdarkstyle
     secretstorage
-    appdirs
     setuptools
     platformdirs
   ];
 
   postPatch = ''
-    substituteInPlace setup.cfg \
-    --replace setuptools_git "" \
-    --replace pytest-runner ""
-
     substituteInPlace src/vorta/assets/metadata/com.borgbase.Vorta.desktop \
     --replace com.borgbase.Vorta "com.borgbase.Vorta-symbolic"
   '';
@@ -63,33 +62,28 @@ python3Packages.buildPythonApplication rec {
     pytestCheckHook
   ];
 
-  preCheck = ''
+  preCheck = let
+    fontsConf = makeFontsConf {
+      fontDirectories = [ ];
+    };
+  in ''
     export HOME=$(mktemp -d)
+    export FONTCONFIG_FILE=${fontsConf};
     # For tests/test_misc.py::test_autostart
     mkdir -p $HOME/.config/autostart
-    export QT_PLUGIN_PATH="${qt5.qtbase.bin}/${qt5.qtbase.qtPluginPrefix}"
+    export QT_PLUGIN_PATH="${qtbase}/${qtbase.qtPluginPrefix}"
     export QT_QPA_PLATFORM=offscreen
   '';
 
   disabledTestPaths = [
-    "tests/test_archives.py"
-    "tests/test_borg.py"
-    "tests/test_lock.py"
-    "tests/test_notifications.py"
-  ];
-
-  disabledTests = [
-    "diff_archives_dict_issue-Users"
-    "diff_archives-test"
-    "test_repo_unlink"
-    "test_repo_add_success"
-    "test_ssh_dialog"
-    "test_create"
-    "test_scheduler_create_backup"
+    # QObject::connect: No such signal QPlatformNativeInterface::systemTrayWindowChanged(QScreen*)
+    "tests/test_excludes.py"
+    "tests/integration"
+    "tests/unit"
   ];
 
   meta = with lib; {
-    changelog = "https://github.com/borgbase/vorta/releases/tag/v0.8.10";
+    changelog = "https://github.com/borgbase/vorta/releases/tag/${src.rev}";
     description = "Desktop Backup Client for Borg";
     homepage = "https://vorta.borgbase.com/";
     license = licenses.gpl3Only;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7861,7 +7861,7 @@ with pkgs;
     (callPackage ../development/libraries/volk { })
   ;
 
-  vorta = libsForQt5.callPackage ../applications/backup/vorta { };
+  vorta = qt6Packages.callPackage ../applications/backup/vorta { };
 
   vowpal-wabbit = callPackage ../applications/science/machine-learning/vowpal-wabbit { };
 


### PR DESCRIPTION

## Description of changes
Diff: https://github.com/borgbase/vorta/compare/v0.8.12...v0.9.1

Changelog: https://github.com/borgbase/vorta/releases/tag/v0.9.1

fixes https://github.com/NixOS/nixpkgs/issues/284532
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
cc @nadir-ishiguro

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
