### PR TITLE
afterglow-cursors-recolored: init at 0-unstable-2023-10-04

### DIFF
--- a/pkgs/by-name/af/afterglow-cursors-recolored/package.nix
+++ b/pkgs/by-name/af/afterglow-cursors-recolored/package.nix
@@ -1,0 +1,126 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, themeVariants ? []
+, catppuccinColorVariants ? []
+, draculaColorVariants ? []
+, gruvboxColorVariants ? []
+, originalColorVariants ? []
+}:
+
+let
+  pname = "afterglow-cursors-recolored";
+
+  availableThemeVariants = [
+    "Catppuccin"
+    "Dracula"
+    "Gruvbox"
+    "Original"
+  ];
+
+  availableColorVariants = {
+    Catppuccin = [
+      "Blue"
+      "Flamingo"
+      "Green"
+      "Macchiato"
+      "Maroon"
+      "Mauve"
+      "Peach"
+      "Pink"
+      "Red"
+      "Rosewater"
+      "Sapphire"
+      "Sky"
+      "Teal"
+      "Yellow"
+    ];
+    Dracula = [
+      "Cyan"
+      "Green"
+      "Orange"
+      "Pink"
+      "Purple"
+      "Red"
+      "Teddy"
+      "Yellow"
+    ];
+    Gruvbox = [
+      "Aqua"
+      "Black"
+      "Blue"
+      "Gray"
+      "Green"
+      "Mojas84"
+      "Orange"
+      "Purple"
+      "White"
+    ];
+    Original = [
+      "Blue"
+      "Purple"
+      "joris"
+      "joris2"
+      "joris3"
+      "joris4"
+    ];
+  };
+in
+
+lib.checkListOfEnum "${pname}: theme variants" availableThemeVariants themeVariants
+lib.checkListOfEnum "${pname}: catppuccin color variants" availableColorVariants.Catppuccin catppuccinColorVariants
+lib.checkListOfEnum "${pname}: dracula color variants" availableColorVariants.Dracula draculaColorVariants
+lib.checkListOfEnum "${pname}: gruvbox color variants" availableColorVariants.Gruvbox  gruvboxColorVariants
+lib.checkListOfEnum "${pname}: original color variants" availableColorVariants.Original originalColorVariants
+
+stdenvNoCC.mkDerivation {
+  inherit pname;
+  version = "0-unstable-2023-10-04";
+
+  src = fetchFromGitHub {
+    owner = "TeddyBearKilla";
+    repo = "Afterglow-Cursors-Recolored";
+    rev = "940a5d30e52f8c827fa249d2bbcc4af889534888";
+    hash = "sha256-GR+d+jrbeIGpqal5krx83PxuQto2PQTO3unQ+jaJf6s=";
+  };
+
+  installPhase = let
+    dist = {
+      Catppuccin = "cat";
+      Dracula = "dracula";
+      Gruvbox = "gruvbox";
+    };
+    withAlternate = xs: xs': if xs != [ ] then xs else xs';
+    themeVariants' = withAlternate themeVariants availableThemeVariants;
+    colorVariants = {
+      Catppuccin =  withAlternate catppuccinColorVariants availableColorVariants.Catppuccin;
+      Dracula = withAlternate draculaColorVariants availableColorVariants.Dracula;
+      Gruvbox = withAlternate gruvboxColorVariants availableColorVariants.Gruvbox;
+      Original = withAlternate originalColorVariants availableColorVariants.Original;
+    };
+  in ''
+    runHook preInstall
+
+    mkdir -p $out/share/icons
+
+    ${
+      lib.concatMapStringsSep "\n" (theme:
+        lib.concatMapStringsSep "\n" (color: ''
+          ln -s \
+            "$src/colors/${theme}/${color}/dist-${lib.optionalString (theme != "Original") (dist.${theme} + "-")}${lib.toLower color}" \
+            "$out/share/icons/Afterglow-Recolored-${theme}-${color}"
+        '') colorVariants.${theme}
+      ) themeVariants'
+    }
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A recoloring of the Afterglow Cursors x-cursor theme";
+    homepage = "https://github.com/TeddyBearKilla/Afterglow-Cursors-Recolored";
+    maintainers = with maintainers; [ d3vil0p3r ];
+    platforms = platforms.all;
+    license = licenses.gpl3Plus;
+  };
+}


### PR DESCRIPTION
## Description of changes

afterglow-cursors-recolored: init at unstable-2023-10-04

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
