### PR TITLE
darwin.apple_sdk.frameworks.CoreFoundation: drop hook

### DIFF
--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -113,9 +113,8 @@ stdenv.mkDerivation (finalAttrs: {
     ${lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (stdenv.hostPlatform.emulator buildPackages)} ${lib.getDev gdk-pixbuf}/bin/gdk-pixbuf-query-loaders
   '';
 
-  # librsvg only links Foundation, but it also requiers libobjc. The Framework.tbd in the 11.0 SDK
-  # reexports libobjc, but the one in the 10.12 SDK does not, so link it manually.
-  env = lib.optionalAttrs (stdenv.isDarwin && stdenv.isx86_64) {
+  # librsvg only links Foundation, but it also requiers libobjc.
+  env = lib.optionalAttrs stdenv.isDarwin {
     NIX_LDFLAGS = "-lobjc";
   };
 

--- a/pkgs/os-specific/darwin/apple-sdk-11.0/apple_sdk.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/apple_sdk.nix
@@ -214,10 +214,6 @@ in rec {
 
     # Overrides for framework derivations.
     overrides = super: {
-      CoreFoundation = lib.overrideDerivation super.CoreFoundation (drv: {
-        setupHook = ./cf-setup-hook.sh;
-      });
-
       # This framework doesn't exist in newer SDKs (somewhere around 10.13), but
       # there are references to it in nixpkgs.
       QuickTime = throw "QuickTime framework not available";

--- a/pkgs/os-specific/darwin/apple-sdk-11.0/cf-setup-hook.sh
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/cf-setup-hook.sh
@@ -1,6 +1,0 @@
-forceLinkCoreFoundationFramework() {
-  NIX_CFLAGS_COMPILE="-F@out@/Library/Frameworks${NIX_CFLAGS_COMPILE:+ }${NIX_CFLAGS_COMPILE-}"
-  NIX_LDFLAGS+=" @out@/Library/Frameworks/CoreFoundation.framework/CoreFoundation.tbd"
-}
-
-preConfigureHooks+=(forceLinkCoreFoundationFramework)

--- a/pkgs/os-specific/darwin/apple-sdk/cf-setup-hook.sh
+++ b/pkgs/os-specific/darwin/apple-sdk/cf-setup-hook.sh
@@ -1,9 +1,0 @@
-linkSystemCoreFoundationFramework() {
-  NIX_CFLAGS_COMPILE="-F@out@/Library/Frameworks${NIX_CFLAGS_COMPILE:+ }${NIX_CFLAGS_COMPILE-}"
-  # gross! many symbols (such as _OBJC_CLASS_$_NSArray) are defined in system CF, but not
-  # in the opensource release
-  # if the package needs private headers, we assume they also want to link with system CF
-  NIX_LDFLAGS+=" @out@/Library/Frameworks/CoreFoundation.framework/CoreFoundation.tbd"
-}
-
-preConfigureHooks+=(linkSystemCoreFoundationFramework)

--- a/pkgs/os-specific/darwin/apple-sdk/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/default.nix
@@ -276,10 +276,6 @@ in rec {
       extraTBDFiles = [ "Versions/A/Frameworks/HTMLRendering.framework/Versions/A/HTMLRendering.tbd" ];
     });
 
-    CoreFoundation = lib.overrideDerivation super.CoreFoundation (drv: {
-      setupHook = ./cf-setup-hook.sh;
-    });
-
     CoreMedia = lib.overrideDerivation super.CoreMedia (drv: {
       __propagatedImpureHostDeps = drv.__propagatedImpureHostDeps or [] ++ [
         "/System/Library/Frameworks/CoreImage.framework"

--- a/pkgs/tools/backup/bacula/default.nix
+++ b/pkgs/tools/backup/bacula/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, sqlite, postgresql, zlib, acl, ncurses, openssl, readline
-, CoreFoundation, IOKit
+, gettext, CoreFoundation, IOKit, Kerberos
 }:
 
 stdenv.mkDerivation rec {
@@ -19,8 +19,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ postgresql sqlite zlib ncurses openssl readline ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      gettext # bacula requires CoreFoundation, but its `configure` script will only link it when it detects libintl.
       CoreFoundation
       IOKit
+      Kerberos
     ]
     # acl relies on attr, which I can't get to build on darwin
     ++ lib.optional (!stdenv.isDarwin) acl;
@@ -31,7 +33,13 @@ stdenv.mkDerivation rec {
     "--with-logdir=/var/log/bacula"
     "--with-working-dir=/var/lib/bacula"
     "--mandir=\${out}/share/man"
-  ] ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "ac_cv_func_setpgrp_void=yes";
+  ] ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "ac_cv_func_setpgrp_void=yes"
+    ++ lib.optionals stdenv.isDarwin [
+      # bacula’s `configure` script fails to detect CoreFoundation correctly,
+      # but these symbols are available in the nixpkgs CoreFoundation framework.
+      "gt_cv_func_CFLocaleCopyCurrent=yes"
+      "gt_cv_func_CFPreferencesCopyAppValue=yes"
+  ];
 
   installFlags = [
     "logdir=\${out}/logdir"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6611,7 +6611,7 @@ with pkgs;
   };
 
   bacula = callPackage ../tools/backup/bacula {
-    inherit (darwin.apple_sdk.frameworks) CoreFoundation IOKit;
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation IOKit Kerberos;
   };
 
   bacon = callPackage ../development/tools/bacon {

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -201,26 +201,8 @@ impure-cmds // appleSourcePackages // chooseLibs // {
 
   CoreSymbolication = callPackage ../os-specific/darwin/CoreSymbolication { };
 
-  # TODO: Remove the CF hook if a solution to the crashes is not found.
-  CF =
-    # CF used to refer to the open source version of CoreFoundation from the Swift
-    # project. As of macOS 14, the rpath-based approach allowing packages to choose
-    # which version to use no longer seems to work reliably. Sometimes they works,
-    # but sometimes they crash with the error (in the system crash logs):
-    # CF objects must have a non-zero isa.
-    # See https://developer.apple.com/forums/thread/739355 for more on that error.
-    #
-    # In this branch, we only have a single "CoreFoundation" to choose from.
-    # To be compatible with the existing convention, we define
-    # CoreFoundation with the setup hook, and CF as the same package but
-    # with the setup hook removed.
-    #
-    # This may seem unimportant, but without it packages (e.g., bacula) will
-    # fail with linker errors referring ___CFConstantStringClassReference.
-    # It's not clear to me why some packages need this extra setup.
-    lib.overrideDerivation apple_sdk.frameworks.CoreFoundation (drv: {
-      setupHook = null;
-    });
+  # TODO: Move stdenv to use apple_sdk.frameworks.CoreFoundation and deprecate darwin.CF.
+  CF = apple_sdk.frameworks.CoreFoundation;
 
   # Formerly the CF attribute. Use this is you need the open source release.
   swift-corelibs-foundation = callPackage ../os-specific/darwin/swift-corelibs/corefoundation.nix { };


### PR DESCRIPTION
## Description of changes

As of https://github.com/NixOS/nixpkgs/pull/265102, x86_64-darwin no longer uses the open-source CF release. Since there is no longer a need to switch between implementations, and the hook causes problems with cross-compilation (see https://github.com/NixOS/nixpkgs/issues/278348), drop the hook and make both darwin.CF an alias for darwin.apple_sdk.frameworks.CoreFoundation.

Thank you to @szlend for his work on #284288 and @r-burns for identifying the issue in #278348.

Testing was done by confirming the following packages built on aarch64- and x86_64-darwin:

* bacula (requires patches in commit)
* pkgsCross.muslpi.aws-sdk-cpp
* wine64Packages.unstable

I am targeting this for backporting to fix the cross-compilation issue in 23.11. Since the hook is already not present by default, this change will only affect packages that explicitly use the CoreFoundation framework as a build input.

Fixes #278348
Closes #284288

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
