### PR TITLE
breeze-hacked-cursor-theme: init at unstable-2024-1-28

### DIFF
--- a/pkgs/by-name/br/breeze-hacked-cursor-theme/package.nix
+++ b/pkgs/by-name/br/breeze-hacked-cursor-theme/package.nix
@@ -1,0 +1,50 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, inkscape
+, xcursorgen
+, accentColor ? null
+, baseColor ? null
+, borderColor ? null
+, logoColor ? null
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "breeze-hacked-cursor-theme";
+  version = "unstable-2024-1-28";
+
+  src = fetchFromGitHub {
+    owner = "clayrisser";
+    repo = pname;
+    rev = "79dcc8925136ebe12612c6f124036c1aa816ebbe";
+    hash = "sha256-gm50qgHdbjDYMz/ksbDD8tMqY9AqJ23DKl4rPFNEDX8=";
+  };
+
+  postPatch = ''
+    patchShebangs build.sh recolor-cursor.sh
+    substituteInPlace Makefile \
+      --replace "~/.icons" "$out/share/icons"
+    ./recolor-cursor.sh \
+  '' + lib.optionalString (accentColor != null) ''
+    --accent-color "${accentColor}" \
+  '' + lib.optionalString (baseColor != null) ''
+    --base-color "${baseColor}" \
+  '' + lib.optionalString (borderColor != null) ''
+    --border-color "${borderColor}" \
+  '' + lib.optionalString (logoColor != null) ''
+    --logo-color "${logoColor}"
+  '';
+
+  nativeBuildInputs = [
+    inkscape
+    xcursorgen
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/clayrisser/breeze-hacked-cursor-theme";
+    description = "Breeze Hacked cursor theme";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ anomalocaris ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes
Adds [breeze-hacked-cursor-theme](https://github.com/clayrisser/breeze-hacked-cursor-theme).

It supports being recolored via a script in its repository, so I took the liberty of adding arguments that correspond to the script's options for convenience.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
