### PR TITLE
turbo: golang code removal

### DIFF
--- a/pkgs/tools/misc/turbo/default.nix
+++ b/pkgs/tools/misc/turbo/default.nix
@@ -1,13 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, buildGo120Module
-, git
-, nodejs
-, capnproto
 , protobuf
-, protoc-gen-go
-, protoc-gen-go-grpc
 , rustPlatform
 , pkg-config
 , openssl
@@ -17,15 +11,13 @@
 , testers
 , turbo
 , nix-update-script
-, go
-, zlib
-, libiconv
-, Security
 , IOKit
 , CoreServices
 , CoreFoundation
+, capnproto
 }:
-let
+rustPlatform.buildRustPackage rec{
+  pname = "turbo";
   version = "1.11.3";
   src = fetchFromGitHub {
     owner = "vercel";
@@ -33,92 +25,6 @@ let
     rev = "v${version}";
     hash = "sha256-hjJXbGct9ZmriKdVjB7gwfmFsV1Tv57V7DfUMFZ8Xv0=";
   };
-
-  ffi = rustPlatform.buildRustPackage {
-    pname = "turbo-ffi";
-    inherit src version;
-    cargoBuildFlags = [ "--package" "turborepo-ffi" ];
-
-    cargoHash = "sha256-3eN8/nBARuaezlzPjAL0YPEPvNqm6jNQAREth8PgcSQ=";
-
-    RUSTC_BOOTSTRAP = 1;
-    nativeBuildInputs = [
-      pkg-config
-      extra-cmake-modules
-      protobuf
-    ];
-    buildInputs = [
-      openssl
-      fontconfig
-    ];
-
-    doCheck = false;
-
-    postInstall = ''
-      cp target/release-tmp/libturborepo_ffi.a $out/lib
-    '';
-  };
-
-
-  go-turbo = buildGo120Module {
-    inherit src version;
-    pname = "go-turbo";
-    modRoot = "cli";
-
-    proxyVendor = true;
-    vendorHash = "sha256-JHTg9Gcc0DVdltTGCUaOPSVxL0XVkwPJQm/LoKffU/o=";
-
-    nativeBuildInputs = [
-      git
-      nodejs
-      protobuf
-      protoc-gen-go
-      protoc-gen-go-grpc
-    ];
-
-    buildInputs = [zlib ] ++ lib.optionals stdenv.isDarwin [
-      Security
-      libiconv
-    ];
-
-    ldflags = [
-      "-s -w"
-      "-X main.version=${version}"
-      "-X main.commit=${src.rev}"
-      "-X main.date=1970-01-01-00:00:01"
-      "-X main.builtBy=goreleaser"
-    ];
-
-    preBuild = ''
-      make compile-protos
-      cp ${ffi}/lib/libturborepo_ffi.a ./internal/ffi/libturborepo_ffi_${go.GOOS}_${go.GOARCH}.a
-    '';
-
-    preCheck = ''
-      # Some tests try to run mkdir $HOME
-      HOME=$TMP
-
-      # Test_getTraversePath requires that source is a git repo
-      # pwd: /build/source/cli
-      pushd ..
-      git config --global init.defaultBranch main
-      git init
-      popd
-
-      # package_deps_hash_test.go:492: hash of child-dir/libA/pkgignorethisdir/file, got 67aed78ea231bdee3de45b6d47d8f32a0a792f6d want go-turbo>     package_deps_hash_test.go:499: found extra hashes in map[.gitignore:3237694bc3312ded18386964 a855074af7b066af some-dir/another-one:7e59c6a6ea9098c6d3beb00e753e2c54ea502311 some-dir/excluded-file:7e59 c6a6ea9098c6d3beb00e753e2c54ea502311 some-dir/other-file:7e59c6a6ea9098c6d3beb00e753e2c54ea502311 some-fil e:7e59c6a6ea9098c6d3beb00e753e2c54ea502311]
-      rm ./internal/hashing/package_deps_hash_test.go
-      rm ./internal/hashing/package_deps_hash_go_test.go
-      #  Error:          Not equal:
-      # expected: env.DetailedMap{All:env.EnvironmentVariableMap(nil), BySource:env.BySource{Explicit:env.EnvironmentVariableMap{}, Matching:env.EnvironmentVariableMap{}}}
-      #  actual  : env.DetailedMap{All:env.EnvironmentVariableMap{}, BySource:env.BySource{Explicit:env.EnvironmentVariableMap{}, Matching:env.EnvironmentVariableMap{}}}
-      rm ./internal/run/global_hash_test.go
-    '';
-
-  };
-in
-rustPlatform.buildRustPackage {
-  pname = "turbo";
-  inherit src version;
   cargoBuildFlags = [
     "--package"
     "turbo"
@@ -143,10 +49,6 @@ rustPlatform.buildRustPackage {
       CoreServices
       CoreFoundation
   ];
-
-  postInstall = ''
-    ln -s ${go-turbo}/bin/turbo $out/bin/go-turbo
-  '';
 
   # Browser tests time out with chromium and google-chrome
   doCheck = false;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14170,7 +14170,7 @@ with pkgs;
   tuptime = callPackage ../tools/system/tuptime { };
 
   turbo = callPackage ../tools/misc/turbo {
-    inherit (darwin.apple_sdk_11_0.frameworks) Security IOKit CoreServices CoreFoundation;
+    inherit (darwin.apple_sdk_11_0.frameworks) IOKit CoreServices CoreFoundation;
   };
 
   turses = callPackage ../applications/networking/instant-messengers/turses { };


### PR DESCRIPTION
## Description of changes

According to the [vercel blog](https://turbo.build/blog/turbo-1-11-0) they have finished the migration from golang to rust, so I believe we can remove that code now.

I've testing building with turbo and it seems to work well, whereas before it would error looking for the golang turbo command

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
