### PR TITLE
python311Packages.approvaltests: 10.2.0 -> 10.3.0

### DIFF
--- a/pkgs/development/python-modules/approvaltests/default.nix
+++ b/pkgs/development/python-modules/approvaltests/default.nix
@@ -19,16 +19,16 @@
 
 buildPythonPackage rec {
   pname = "approvaltests";
-  version = "10.2.0";
+  version = "10.3.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "approvals";
     repo = "ApprovalTests.Python";
     rev = "refs/tags/v${version}";
-    hash = "sha256-2NaqqgrHXJovoVExvbr0s86eRbcxy+DUrsdRH/vak3E=";
+    hash = "sha256-1f0iTwLREF20Khkd4/xEfxXINJIpc4LfszsvCblS/yM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/robotframework-seleniumlibrary/default.nix
+++ b/pkgs/development/python-modules/robotframework-seleniumlibrary/default.nix
@@ -41,24 +41,9 @@ buildPythonPackage rec {
     robotstatuschecker
   ];
 
-  disabledTestPaths = [
-    # https://github.com/robotframework/SeleniumLibrary/issues/1804
-    "utest/test/keywords/test_webdrivercache.py"
-  ];
-
-  disabledTests = [
-    "test_create_opera_executable_path_not_set"
-    "test_create_opera_executable_path_set"
-    "test_create_opera_with_options"
-    "test_create_opera_with_service_log_path_real_path"
-    "test_get_executable_path"
-    "test_get_ff_profile_instance_FirefoxProfile"
-    "test_has_options"
-    "test_importer"
-    "test_log_file_with_index_exist"
-    "test_opera"
-    "test_single_method"
-  ];
+  preCheck = ''
+    mkdir utest/output_dir
+  '';
 
   meta = with lib; {
     changelog = "https://github.com/robotframework/SeleniumLibrary/blob/${src.rev}/docs/SeleniumLibrary-${version}.rst";


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/approvals/ApprovalTests.Python/compare/refs/tags/v10.2.0...v10.3.0

Changelog: https://github.com/approvals/ApprovalTests.Python/releases/tag/v10.3.0



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
