### PR TITLE
mopidy-ytmusic: 0.3.8 -> 0.3.9

### DIFF
--- a/pkgs/applications/audio/mopidy/ytmusic.nix
+++ b/pkgs/applications/audio/mopidy/ytmusic.nix
@@ -1,31 +1,31 @@
 { lib
 , python3
-, fetchPypi
+, fetchFromGitHub
 , mopidy
 }:
 
 let
-  python = python3.override {
-    packageOverrides = self: super: {
-      ytmusicapi = super.ytmusicapi.overridePythonAttrs (old: rec {
-        version = "0.25.1";
-        src = fetchPypi {
-          inherit (old) pname;
-          inherit version;
-          hash = "sha256-uc/fgDetSYaCRzff0SzfbRhs3TaKrfE2h6roWkkj8yQ=";
-        };
-      });
-    };
-  };
+  python = python3;
 in python.pkgs.buildPythonApplication rec {
   pname = "mopidy-ytmusic";
-  version = "0.3.8";
+  version = "0.3.9";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit version;
-    pname = "mopidy_ytmusic";
-    sha256 = "6b4d8ff9c477dbdd30d0259a009494ebe104cad3f8b37241ae503e5bce4ec2e8";
+  src = fetchFromGitHub {
+    owner = "jmcdo29";
+    repo = "mopidy-ytmusic";
+    rev = "v${version}";
+    hash = "sha256-2o4fDtaIxRDvIiAGV/9qK/00BmYXasBUwW03fxFcDAU=";
   };
+
+  postPatch = ''
+    # only setup.py has up to date dependencies
+    rm pyproject.toml
+  '';
+
+  nativeBuildInputs = with python.pkgs; [
+    setuptools
+  ];
 
   propagatedBuildInputs = [
     (mopidy.override { pythonPackages = python.pkgs; })
@@ -39,9 +39,9 @@ in python.pkgs.buildPythonApplication rec {
   doCheck = false;
 
   meta = with lib; {
-    changelog = "https://github.com/OzymandiasTheGreat/mopidy-ytmusic/blob/v${version}/CHANGELOG.rst";
+    changelog = "https://github.com/jmcdo29/mopidy-ytmusic/releases/tag/${src.rev}";
     description = "Mopidy extension for playing music from YouTube Music";
-    homepage = "https://github.com/OzymandiasTheGreat/mopidy-ytmusic";
+    homepage = "https://github.com/jmcdo29/mopidy-ytmusic";
     license = licenses.asl20;
     maintainers = [ maintainers.nickhu ];
   };


### PR DESCRIPTION
## Description of changes
Just like the AUR and as suggested in https://github.com/OzymandiasTheGreat/mopidy-ytmusic/issues/71 we switch to a fork which uses a more recent version of ytmusicapi.

Diff: https://github.com/jmcdo29/mopidy-ytmusic/compare/v0.3.8...v0.3.9

Changelog: https://github.com/jmcdo29/mopidy-ytmusic/releases/tag/v0.3.9



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
