### PR TITLE
check-by-name: Update pinned version

### DIFF
--- a/pkgs/test/nixpkgs-check-by-name/scripts/pinned-tool.json
+++ b/pkgs/test/nixpkgs-check-by-name/scripts/pinned-tool.json
@@ -1,4 +1,4 @@
 {
-  "rev": "842d9d80cfd4560648c785f8a4e6f3b096790e19",
-  "ci-path": "/nix/store/8habk3j25bs2a34zn5q5p17b9dl3fywg-nixpkgs-check-by-name"
+  "rev": "ae5c332cbb5827f6b1f02572496b141021de335f",
+  "ci-path": "/nix/store/ghfxriicygwcrxvm45r0cm9g0vshpw01-nixpkgs-check-by-name"
 }

--- a/pkgs/test/nixpkgs-check-by-name/scripts/run-local.sh
+++ b/pkgs/test/nixpkgs-check-by-name/scripts/run-local.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p jq -I nixpkgs=../../../..
+#!nix-shell -i bash -p jq
 
 set -o pipefail -o errexit -o nounset
 

--- a/pkgs/test/nixpkgs-check-by-name/scripts/update-pinned-tool.sh
+++ b/pkgs/test/nixpkgs-check-by-name/scripts/update-pinned-tool.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p jq -I nixpkgs=../../../..
+#!nix-shell -i bash -p jq
 
 set -o pipefail -o errexit -o nounset
 


### PR DESCRIPTION
## Description of changes

Makes the `pkgs/by-name` CI check use https://github.com/NixOS/nixpkgs/pull/283017 by updating the pinned tool using `update-pinned-tool.sh`.

Also includes https://github.com/NixOS/nixpkgs/pull/282226.

This work is sponsored by [Antithesis](https://antithesis.com/) and [Tweag](https://www.tweag.io/) :sparkles:

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
