### PR TITLE
louvain-community: fix the build against `gcc-13`

### DIFF
--- a/pkgs/by-name/lo/louvain-community/package.nix
+++ b/pkgs/by-name/lo/louvain-community/package.nix
@@ -2,20 +2,23 @@
 , fetchFromGitHub
 , cmake
 , lib
+, unstableGitUpdater
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "louvain-community";
-  version = "unstable-2021-03-18";
+  version = "unstable-2024-01-30";
 
   src = fetchFromGitHub {
     owner = "meelgroup";
     repo = "louvain-community";
-    rev = "8cc5382d4844af127b1c1257373740d7e6b76f1e";
-    hash = "sha256-0i3wrDdOyleOPv5iVO1YzPfTPnIdljLabCvl3SYEQOs=";
+    rev = "681a711a530ded0b25af72ee4881d453a80ac8ac";
+    hash = "sha256-mp2gneTtm/PaCqz4JNOZgdKmFoV5ZRVwNYjHc4s2KuY=";
   };
 
   nativeBuildInputs = [ cmake ];
+
+  passthru.updateScript = unstableGitUpdater {};
 
   meta = with lib; {
     description = "Louvain Community Detection Library";


### PR DESCRIPTION
Without the change the build against `gcc-13` fails as: https://cache.nixos.org/log/xpqnf8kk3wxgqspxf2khipxlv0wf8i36-louvain-community-unstable-2021-03-18.drv

    /build/source/src/louvain_communities.cpp: At global scope:
    /build/source/src/louvain_communities.cpp:60:5: error: 'uint32_t' does not name a type
       60 |     uint32_t verbosity = 0;
          |     ^~~~~~~~
    /build/source/src/louvain_communities.cpp:44:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
       43 | #include "GitSHA1.h"
      +++ |+#include <cstdint>
       44 |

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
