### PR TITLE
python311Packages.cryptodatahub: 0.10.1 -> 0.12.2

### DIFF
--- a/pkgs/development/python-modules/cryptodatahub/default.nix
+++ b/pkgs/development/python-modules/cryptodatahub/default.nix
@@ -1,35 +1,37 @@
 { lib
-, buildPythonPackage
-, fetchFromGitLab
-
-# build-system
-, setuptools
-
-# dependencies
 , asn1crypto
 , attrs
-, pathlib2
-, python-dateutil
-, six
-, urllib3
-
-# tests
 , beautifulsoup4
+, buildPythonPackage
+, fetchFromGitLab
+, pathlib2
 , pyfakefs
+, python-dateutil
+, pythonOlder
+, setuptools
+, six
 , unittestCheckHook
+, urllib3
 }:
 
 buildPythonPackage rec {
   pname = "cryptodatahub";
   version = "0.10.1";
-  format = "pyproject";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitLab {
     owner = "coroner";
     repo = "cryptodatahub";
-    rev = "v${version}";
+    rev = "refs/tags/v${version}";
     hash = "sha256-eLdK5gFrLnbIBB1NTeQzpdCLPdATVjzPn5LhhUsDuwo=";
   };
+
+  postPatch = ''
+    substituteInPlace requirements.txt  \
+      --replace-warn "attrs>=20.3.0,<22.0.1" "attrs>=20.3.0"
+  '';
 
   nativeBuildInputs = [
     setuptools
@@ -44,13 +46,16 @@ buildPythonPackage rec {
     urllib3
   ];
 
-  pythonImportsCheck = [ "cryptodatahub" ];
-
   nativeCheckInputs = [
     beautifulsoup4
     pyfakefs
     unittestCheckHook
   ];
+
+  pythonImportsCheck = [
+    "cryptodatahub"
+  ];
+
 
   preCheck = ''
     # failing tests
@@ -60,7 +65,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Repository of cryptography-related data";
     homepage = "https://gitlab.com/coroner/cryptodatahub";
-    changelog = "https://gitlab.com/coroner/cryptodatahub/-/blob/${src.rev}/CHANGELOG.rst";
+    changelog = "https://gitlab.com/coroner/cryptodatahub/-/blob/${version}/CHANGELOG.rst";
     license = licenses.mpl20;
     maintainers = with maintainers; [ ];
   };

--- a/pkgs/development/python-modules/cryptodatahub/default.nix
+++ b/pkgs/development/python-modules/cryptodatahub/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "cryptodatahub";
-  version = "0.10.1";
+  version = "0.12.2";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "coroner";
     repo = "cryptodatahub";
     rev = "refs/tags/v${version}";
-    hash = "sha256-eLdK5gFrLnbIBB1NTeQzpdCLPdATVjzPn5LhhUsDuwo=";
+    hash = "sha256-zVHHBQYcl26zTtXPAs/AgKOojKQORu08rpkfY0l1zjM=";
   };
 
   postPatch = ''
@@ -60,6 +60,8 @@ buildPythonPackage rec {
   preCheck = ''
     # failing tests
     rm test/updaters/test_common.py
+    # Tests require network access
+    rm test/common/test_utils.py
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/cryptolyzer/default.nix
+++ b/pkgs/development/python-modules/cryptolyzer/default.nix
@@ -1,19 +1,25 @@
 { lib
 , attrs
+, beautifulsoup4
 , buildPythonPackage
 , certvalidator
+, colorama
 , cryptoparser
+, dnspython
 , fetchPypi
+, pathlib2
+, pyfakefs
+, python-dateutil
 , pythonOlder
 , requests
-, six
+, setuptools
 , urllib3
 }:
 
 buildPythonPackage rec {
   pname = "cryptolyzer";
   version = "0.12.1";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -23,13 +29,28 @@ buildPythonPackage rec {
     hash = "sha256-1Ec57A5lCjy9FsA3vDmCyfOeHZaQz01FNiKyNV3eJfc=";
   };
 
+  postPatch = ''
+    substituteInPlace requirements.txt  \
+      --replace-warn "attrs>=20.3.0,<22.0.1" "attrs>=20.3.0" \
+      --replace-warn "bs4" "beautifulsoup4"
+  '';
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
   propagatedBuildInputs = [
-    certvalidator
     attrs
-    six
-    urllib3
+    beautifulsoup4
+    certvalidator
+    colorama
     cryptoparser
+    dnspython
+    pathlib2
+    pyfakefs
+    python-dateutil
     requests
+    urllib3
   ];
 
   # Tests require networking

--- a/pkgs/development/python-modules/cryptolyzer/default.nix
+++ b/pkgs/development/python-modules/cryptolyzer/default.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "cryptolyzer";
-  version = "0.12.1";
+  version = "0.12.2";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "CryptoLyzer";
     inherit version;
-    hash = "sha256-1Ec57A5lCjy9FsA3vDmCyfOeHZaQz01FNiKyNV3eJfc=";
+    hash = "sha256-UffFdQ+MiB8kPzqnmWdnGRwAAM9wJwpUDK2bPvPvH0c=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/cryptoparser/default.nix
+++ b/pkgs/development/python-modules/cryptoparser/default.nix
@@ -12,14 +12,19 @@
 
 buildPythonPackage rec {
   pname = "cryptoparser";
-  version = "0.12.1";
-  format = "pyproject";
+  version = "0.12.2";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "CryptoParser";
     inherit version;
-    hash = "sha256-Q05koDfVaVgiQYhULkwzl9uzUIumO8ZIGJPfxRBUsj0=";
+    hash = "sha256-SG7I/uOWZapjZ5zGW1HndGqaYc2k2aRWf3IWlartIJE=";
   };
+
+  postPatch = ''
+    substituteInPlace requirements.txt  \
+      --replace-warn "attrs>=20.3.0,<22.0.1" "attrs>=20.3.0"
+  '';
 
   nativeBuildInputs = [
     setuptools


### PR DESCRIPTION
Diff: https://gitlab.com/coroner/cryptodatahub/-/compare/refs/tags/v0.10.1...v0.12.2

Changelog: https://gitlab.com/coroner/cryptodatahub/-/blob/0.12.2/CHANGELOG.rst

## Description of changes
Fix build (https://hydra.nixos.org/build/247401227)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
