### PR TITLE
airbuddy, aldente: unpack with 7zz

### DIFF
--- a/pkgs/os-specific/darwin/airbuddy/default.nix
+++ b/pkgs/os-specific/darwin/airbuddy/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenvNoCC
 , fetchurl
-, undmg
+, _7zz
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -19,18 +19,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   dontBuild = true;
   dontFixup = true;
 
-  nativeBuildInputs = [ undmg ];
+  nativeBuildInputs = [ _7zz ];
 
-  # AirBuddy.dmg is not HFS formatted, default unpackPhase fails
-  # https://discourse.nixos.org/t/help-with-error-only-hfs-file-systems-are-supported-on-ventura
+  # AirBuddy.dmg is APFS formatted, unpack with 7zz
   unpackCmd = ''
-    mnt=$(mktemp -d)
+    runHook preUnpack
 
-    /usr/bin/hdiutil attach -nobrowse -readonly $src -mountpoint $mnt
+    7zz x $src
 
-    shopt -s extglob
-    DEST="$PWD"
-    (cd "$mnt"; cp -a !(Applications) "$DEST/")
+    runHook postUnpack
   '';
 
   sourceRoot = "AirBuddy.app";

--- a/pkgs/os-specific/darwin/aldente/default.nix
+++ b/pkgs/os-specific/darwin/aldente/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenvNoCC
 , fetchurl
-, undmg
+, _7zz
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -16,24 +16,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   dontBuild = true;
   dontFixup = true;
 
-  nativeBuildInputs = [ undmg ];
+  nativeBuildInputs = [ _7zz ];
 
-  # AlDente.dmg is not HFS formatted, default unpackPhase fails
-  # https://discourse.nixos.org/t/help-with-error-only-hfs-file-systems-are-supported-on-ventura
+  # AlDente.dmg is APFS formatted, unpack with 7zz
   unpackCmd = ''
-    if ! [[ "$curSrc" =~ \.dmg$ ]]; then return 1; fi
-    mnt=$(mktemp -d -t ci-XXXXXXXXXX)
+    runHook preUnpack
 
-    function finish {
-      /usr/bin/hdiutil detach $mnt -force
-    }
-    trap finish EXIT
+    7zz x $src
 
-    /usr/bin/hdiutil attach -nobrowse -readonly $src -mountpoint $mnt
-
-    shopt -s extglob
-    DEST="$PWD"
-    (cd "$mnt"; cp -a !(Applications) "$DEST/")
+    runHook postUnpack
   '';
 
   sourceRoot = "AlDente.app";


### PR DESCRIPTION
## Description of changes

Calling `/usr/bin/hdiutil` is too scary!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
