### PR TITLE
fix: microsoft-edge: msedge-sandbox hardened kernel

### DIFF
--- a/pkgs/applications/networking/browsers/microsoft-edge/browser.nix
+++ b/pkgs/applications/networking/browsers/microsoft-edge/browser.nix
@@ -143,6 +143,8 @@ stdenv.mkDerivation rec {
     rm -rf $out/share/doc
     rm -rf $out/opt/microsoft/${shortName}/cron
 
+    chmod 4755 $out/opt/microsoft/msedge/msedge-sandbox
+
     for icon in '16' '24' '32' '48' '64' '128' '256'
     do
       ${ "icon_source=$out/opt/microsoft/${shortName}/product_logo_\${icon}${iconSuffix}.png" }

--- a/pkgs/applications/networking/browsers/microsoft-edge/browser.nix
+++ b/pkgs/applications/networking/browsers/microsoft-edge/browser.nix
@@ -99,6 +99,7 @@ stdenv.mkDerivation rec {
       ];
     };
   in ''
+    ls -al opt/microsoft/msedge/msedge-sandbox
     chmod 4755 opt/microsoft/msedge/msedge-sandbox
 
     patchelf \

--- a/pkgs/applications/networking/browsers/microsoft-edge/browser.nix
+++ b/pkgs/applications/networking/browsers/microsoft-edge/browser.nix
@@ -99,6 +99,8 @@ stdenv.mkDerivation rec {
       ];
     };
   in ''
+    chmod 4755 opt/microsoft/msedge/msedge-sandbox
+
     patchelf \
       --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
       --set-rpath "${libPath.msedge}" \
@@ -142,8 +144,6 @@ stdenv.mkDerivation rec {
 
     rm -rf $out/share/doc
     rm -rf $out/opt/microsoft/${shortName}/cron
-
-    chmod 4755 $out/opt/microsoft/msedge/msedge-sandbox
 
     for icon in '16' '24' '32' '48' '64' '128' '256'
     do


### PR DESCRIPTION
## Description of changes

Give msedge-sandbox correct permissions in the nix store for the microsoft-edge package

Error:
<code>[138912:138912:0129/220258.693964:FATAL:setuid_sandbox_host.cc(158)] The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /nix/store/fv50g3b07d4r4v4si427c4xfkq2rbva9-microsoft-edge-stable-120.0.2210.77/opt/microsoft/msedge/msedge-sandbox is owned by root and has mode 4755.
[0129/220258.695679:ERROR:process_memory_range.cc(75)] read out of range
Trace/breakpoint trap (core dumped)</code>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
