### PR TITLE
obs-webkitgtk: init at unstable-2023-11-10

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -78,6 +78,8 @@
 
   obs-websocket = qt6Packages.callPackage ./obs-websocket.nix { }; # Websocket 4.x compatibility for OBS Studio 28+
 
+  obs-webkitgtk = callPackage ./obs-webkitgtk.nix { };
+
   wlrobs = callPackage ./wlrobs.nix { };
 
   waveform = callPackage ./waveform { };

--- a/pkgs/applications/video/obs-studio/plugins/obs-webkitgtk.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-webkitgtk.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "fzwoch";
     repo = "obs-webkitgtk";
-    rev = version;
+    rev = "ddf230852c3c338e69b248bdf453a0630f1298a7";
     hash = "sha256-DU2w9dRgqWniTE76KTAtFdxIN82VKa/CS6ZdfNcTMto=";
   };
 

--- a/pkgs/applications/video/obs-studio/plugins/obs-webkitgtk.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-webkitgtk.nix
@@ -13,7 +13,7 @@
 
 stdenv.mkDerivation rec {
   pname = "obs-webkitgtk";
-  version = "ddf230852c3c338e69b248bdf453a0630f1298a7";
+  version = "unstable-2023-11-10";
 
   src = fetchFromGitHub {
     owner = "fzwoch";

--- a/pkgs/applications/video/obs-studio/plugins/obs-webkitgtk.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-webkitgtk.nix
@@ -1,0 +1,51 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, obs-studio
+, webkitgtk
+, glib-networking
+, meson
+, cmake
+, pkg-config
+, ninja
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "obs-webkitgtk";
+  version = "ddf230852c3c338e69b248bdf453a0630f1298a7";
+
+  src = fetchFromGitHub {
+    owner = "fzwoch";
+    repo = "obs-webkitgtk";
+    rev = version;
+    hash = "sha256-DU2w9dRgqWniTE76KTAtFdxIN82VKa/CS6ZdfNcTMto=";
+  };
+
+  buildInputs = [
+    obs-studio
+    webkitgtk
+    glib-networking
+  ];
+
+  nativeBuildInputs = [
+    meson
+    cmake
+    pkg-config
+    ninja
+    wrapGAppsHook
+  ];
+
+  postPatch = ''
+    substituteInPlace ./obs-webkitgtk.c \
+      --replace 'g_file_read_link("/proc/self/exe", NULL)' "g_strdup(\"$out/lib/obs-plugins\")"
+  '';
+
+  meta = with lib; {
+    description = "Yet another OBS Studio browser source";
+    homepage = "https://github.com/fzwoch/obs-webkitgtk";
+    maintainers = with maintainers; [ j-hui ];
+    license = licenses.gpl2Only;
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add `obs-webkitgtk` plugin, which is an alternative "Browser" source to the default `obs-browser` plugin (based on CEF).

To test this, I built OBS with this plugin using the following derivation:

```nix
{ pkgs ? import ../nixpkgs/default.nix {} }:
(pkgs.wrapOBS {
  plugins = [
    pkgs.obs-studio-plugins.obs-webkitgtk
  ];
})
```

Ran `nix-build` and `./results/bin/obs` to test.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
