### PR TITLE
nixos/qemu: Support System Management Mode

### DIFF
--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -132,6 +132,9 @@ To solve this, you can run `fdisk -l $image` and generate `dd if=$image of=$imag
 , # Whether to output have EFIVARS available in $out/efi-vars.fd and use it during disk creation
   touchEFIVars ? false
 
+, # Whether to enforce SMM in QEMU for EFI variables manipulation - this can break authenticated variables manipulation such as bootloader installation.
+  systemManagementModeEnforcement ? false
+
 , # OVMF firmware derivation
   OVMF ? pkgs.OVMF.fd
 
@@ -536,6 +539,11 @@ let format' = format; in let
         concatStringsSep " " (lib.optional useEFIBoot "-drive if=pflash,format=raw,unit=0,readonly=on,file=${efiFirmware}"
         ++ lib.optionals touchEFIVars [
           "-drive if=pflash,format=raw,unit=1,file=$efiVars"
+        ]
+        ++ lib.optionals systemManagementModeEnforcement [
+          "-machine type=q35,accel=kvm,smm=on"
+          # Ensure we require EFI firmware to go through SMM to touch secureboot variables (once setup is done)
+          "-global driver=cfi.pflash01,property=secure,value=on"
         ]
       );
       inherit memSize;

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -278,6 +278,7 @@ let
   # a boot partition and root partition.
   systemImage = import ../../lib/make-disk-image.nix {
     inherit pkgs config lib;
+    inherit (cfg.efi) systemManagementModeEnforcement;
     additionalPaths = [ regInfo ];
     format = "qcow2";
     onlyNixStore = false;
@@ -865,13 +866,15 @@ in
       OVMF = mkOption {
         type = types.package;
         default = (pkgs.OVMF.override {
+          systemManagementModeSupport = cfg.efi.systemManagementModeEnforcement;
           secureBoot = cfg.useSecureBoot;
         }).fd;
         defaultText = ''(pkgs.OVMF.override {
+          systemManagementModeSupport = cfg.efi.systemManagementModeEnforcement;
           secureBoot = cfg.useSecureBoot;
         }).fd'';
         description =
-        lib.mdDoc "OVMF firmware package, defaults to OVMF configured with secure boot if needed.";
+        lib.mdDoc "OVMF firmware package, defaults to OVMF configured with secure boot and system management mode if needed.";
       };
 
       firmware = mkOption {
@@ -892,6 +895,18 @@ in
           lib.mdDoc ''
             Platform-specific flash binary for EFI variables, implementation-dependent to the EFI firmware.
             Defaults to OVMF.
+          '';
+        };
+
+      systemManagementModeEnforcement = mkOption {
+        type = types.bool;
+        default = false;
+        description =
+          lib.mdDoc ''
+            Enable system management mode enforcement for QEMU which prevent the OS from arbitrary accessing the UEFI variables memory.
+            It enforces to use the SMM API to perform any changes, useful in SecureBoot contexts.
+
+            WARNING: OVMF implementation seems broken.
           '';
       };
     };
@@ -1012,6 +1027,20 @@ in
         ];
 
     warnings =
+      optional (cfg.efi.systemManagementModeEnforcement)
+        ''
+          You have enabled ${opt.efi.systemManagementModeEnforcement} = true.
+
+          This will enable system management mode for QEMU (cfi.pflash01, secure=on)
+          and if you're using the default OVMF image, it will build a SMM-enabled firmware
+          for UEFI.
+
+          This will lock down UEFI authenticated variables to ensure an actually secure
+          SecureBoot for example.
+
+          WARNING: currently, SMM seems to be broken and will cause boot failures and silent hung tasks.
+        ''
+      ++
       optional (
         cfg.writableStore &&
         cfg.useNixStoreImage &&
@@ -1152,6 +1181,12 @@ in
       (mkIf cfg.useEFIBoot [
         "-drive if=pflash,format=raw,unit=0,readonly=on,file=${cfg.efi.firmware}"
         "-drive if=pflash,format=raw,unit=1,readonly=off,file=$NIX_EFI_VARS"
+      ])
+      (mkIf cfg.efi.systemManagementModeEnforcement [
+        # SMM requires Q35 machine.
+        "-machine type=q35,accel=kvm,smm=on"
+        # Enforce SMM usage for authenticated variables in UEFI
+        "-global driver=cfi.pflash01,property=secure,value=on"
       ])
       (mkIf (cfg.bios != null) [
         "-bios ${cfg.bios}/bios.bin"

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -6,6 +6,7 @@
 , httpSupport ? false
 , tpmSupport ? false
 , tlsSupport ? false
+, systemManagementModeSupport ? false
 , debug ? false
 # Usually, this option is broken, do not use it except if you know what you are
 # doing.
@@ -54,6 +55,7 @@ edk2.mkDerivation projectDscPath (finalAttrs: {
     ++ lib.optionals debug [ "-D DEBUG_ON_SERIAL_PORT=TRUE" ]
     ++ lib.optionals sourceDebug [ "-D SOURCE_DEBUG_ENABLE=TRUE" ]
     ++ lib.optionals secureBoot [ "-D SECURE_BOOT_ENABLE=TRUE" ]
+    ++ lib.optionals systemManagementModeSupport [ "-D SMM_REQUIRE" ]
     ++ lib.optionals csmSupport [ "-D CSM_ENABLE" ]
     ++ lib.optionals fdSize2MB ["-D FD_SIZE_2MB"]
     ++ lib.optionals fdSize4MB ["-D FD_SIZE_4MB"]

--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -1,7 +1,7 @@
 { stdenv, nixosTests, lib, edk2, util-linux, nasm, acpica-tools, llvmPackages
 , csmSupport ? false, seabios
 , fdSize2MB ? csmSupport
-, fdSize4MB ? false
+, fdSize4MB ? secureBoot
 , secureBoot ? false
 , httpSupport ? false
 , tpmSupport ? false


### PR DESCRIPTION
## Description of changes

new take on #207043

Mostly a rebase, and adding a test for it as well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
