### PR TITLE
octopus: add mpi and libvdwxc support

### DIFF
--- a/pkgs/applications/science/chemistry/octopus/default.nix
+++ b/pkgs/applications/science/chemistry/octopus/default.nix
@@ -1,5 +1,23 @@
-{ lib, stdenv, fetchFromGitLab, gfortran, which, perl, procps
-, libyaml, libxc, fftw, blas, lapack, gsl, netcdf, arpack, autoreconfHook
+{ lib
+, stdenv
+, fetchFromGitLab
+, gfortran
+, which
+, perl
+, procps
+, libvdwxc
+, libyaml
+, libxc
+, fftw
+, blas
+, lapack
+, gsl
+, netcdf
+, arpack
+, autoreconfHook
+, scalapack
+, mpi
+, enableMpi ? true
 , python3
 , enableFma ? stdenv.hostPlatform.fmaSupport
 , enableFma4 ? stdenv.hostPlatform.fma4Support
@@ -38,8 +56,12 @@ stdenv.mkDerivation rec {
     fftw
     netcdf
     arpack
+    libvdwxc
     (python3.withPackages (ps: [ ps.pyyaml ]))
-  ];
+  ] ++ lib.optional enableMpi scalapack;
+
+  propagatedBuildInputs = lib.optional enableMpi mpi;
+  propagatedUserEnvPkgs = lib.optional enableMpi mpi;
 
   configureFlags = with lib; [
     "--with-yaml-prefix=${lib.getDev libyaml}"
@@ -48,12 +70,22 @@ stdenv.mkDerivation rec {
     "--with-fftw-prefix=${lib.getDev fftw}"
     "--with-gsl-prefix=${lib.getDev gsl}"
     "--with-libxc-prefix=${lib.getDev libxc}"
+    "--with-libvdwxc"
     "--enable-openmp"
-  ] ++ optional enableFma "--enable-fma3"
-    ++ optional enableFma4 "--enable-fma4"
-    ++ optional enableAvx "--enable-avx"
-    ++ optional enableAvx512 "--enable-avx512";
+  ]
+  ++ optional enableFma "--enable-fma3"
+  ++ optional enableFma4 "--enable-fma4"
+  ++ optional enableAvx "--enable-avx"
+  ++ optional enableAvx512 "--enable-avx512"
+  ++ optionals enableMpi [
+    "--enable-mpi"
+    "--with-scalapack=-lscalapack"
+    "CC=mpicc"
+    "FC=mpif90"
+  ];
 
+
+  nativeCheckInputs = lib.optional.enableMpi mpi;
   doCheck = false;
   checkTarget = "check-short";
 
@@ -66,6 +98,8 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
+
+  passthru = lib.attrsets.optionalAttrs enableMpi { inherit mpi; };
 
   meta = with lib; {
     description = "Real-space time dependent density-functional theory code";


### PR DESCRIPTION
## Description of changes

Adds MPI and libvdwxc support for the Octopus DFT code.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
