### PR TITLE
sirius: 7.4.3 -> 7.5.2

### DIFF
--- a/pkgs/by-name/si/sirius/package.nix
+++ b/pkgs/by-name/si/sirius/package.nix
@@ -16,6 +16,7 @@
 , spfft
 , spla
 , costa
+, umpire
 , scalapack
 , boost
 , eigen
@@ -37,19 +38,14 @@ assert builtins.elem gpuBackend [ "none" "cuda" "rocm" ];
 
 stdenv.mkDerivation rec {
   pname = "SIRIUS";
-  version = "7.4.3";
+  version = "7.5.2";
 
   src = fetchFromGitHub {
     owner = "electronic-structure";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-s4rO+dePvtvn41wxCvbqgQGrEckWmfng7sPX2M8OPB0=";
+    hash = "sha256-DYie6ufgZNqg7ohlIed3Bo+sqLKHOxWXTwAkea2guLk=";
   };
-
-  postPatch = ''
-    substituteInPlace src/gpu/acc_blas_api.hpp \
-      --replace '#include <rocblas.h>' '#include <rocblas/rocblas.h>'
-  '';
 
   nativeBuildInputs = [
     cmake
@@ -63,6 +59,7 @@ stdenv.mkDerivation rec {
     gsl
     libxc
     hdf5
+    umpire
     spglib
     spfft
     spla
@@ -110,11 +107,12 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   # Can not run parallel checks generally as it requires exactly multiples of 4 MPI ranks
+  # Even cpu_serial tests had to be disabled as they require scalapack routines in the sandbox
+  # and run into the same problem as MPI tests
   checkPhase = ''
     runHook preCheck
 
     ctest --output-on-failure --label-exclude integration_test
-    ctest --output-on-failure -L cpu_serial
 
     runHook postCheck
   '';

--- a/pkgs/by-name/um/umpire/package.nix
+++ b/pkgs/by-name/um/umpire/package.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "umpire";
+  version = "2023.06.0";
+
+  src = fetchFromGitHub {
+    owner = "LLNL";
+    repo = "umpire";
+    rev = "v${version}";
+    hash = "sha256-gdwr0ACCfkrtlVROPhxM7zT7SaCo2Eg1etrPFN4JHaA=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    description = "Application-focused API for memory management on NUMA & GPU architectures";
+    homepage = "https://github.com/LLNL/Umpire";
+    maintainers = with maintainers; [ sheepforce ];
+    license = with licenses; [ mit ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Update to the latest sirius DFT planewave code: https://github.com/electronic-structure/SIRIUS/releases/tag/v7.5.2

Now requires umpire for building: https://github.com/LLNL/Umpire

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
