### PR TITLE
nixos/archisteamfarm: allow bots.*.passwordFile to be null

### DIFF
--- a/nixos/modules/services/games/archisteamfarm.nix
+++ b/nixos/modules/services/games/archisteamfarm.nix
@@ -130,7 +130,10 @@ in
           passwordFile = lib.mkOption {
             type = with lib.types; nullOr path;
             default = null;
-            description = lib.mdDoc "Path to a file containing the password. The file must be readable by the `archisteamfarm` user/group.";
+            description = lib.mdDoc ''
+              Path to a file containing the password. The file must be readable by the `archisteamfarm` user/group.
+              Omit or set to null to provide the password a different way, such as through the web-ui.
+            '';
           };
           enabled = lib.mkOption {
             type = lib.types.bool;

--- a/nixos/modules/services/games/archisteamfarm.nix
+++ b/nixos/modules/services/games/archisteamfarm.nix
@@ -20,10 +20,11 @@ let
   mkBot = n: c:
     format.generate "${n}.json" (c.settings // {
       SteamLogin = if c.username == "" then n else c.username;
+      Enabled = c.enabled;
+    } // lib.optionalAttrs (c.passwordFile != null) {
       SteamPassword = c.passwordFile;
       # sets the password format to file (https://github.com/JustArchiNET/ArchiSteamFarm/wiki/Security#file)
       PasswordFormat = 4;
-      Enabled = c.enabled;
     });
 in
 {
@@ -127,7 +128,8 @@ in
             default = "";
           };
           passwordFile = lib.mkOption {
-            type = lib.types.path;
+            type = with lib.types; nullOr path;
+            default = null;
             description = lib.mdDoc "Path to a file containing the password. The file must be readable by the `archisteamfarm` user/group.";
           };
           enabled = lib.mkOption {


### PR DESCRIPTION
This adds support for alternate password specification methods, such as through the web-ui.

## Description of changes

Currently, the service for ArchiSteamFarm requires that the password for a bot account be provided via the contents of a file the user specifies. This method of providing the account password works, and is a good option for not putting the plaintext password in the configuration.

However, for users using the Web UI for managing ASF, there's another way of providing the password. When first activating the bot, the Web UI will ask the user for the password for the account. If the bot is configured to use "Login Keys" (enabled by default), it will then get a reusable "session" key from Valve's servers and save it for logging back in when needed in the future. With this solution, the plaintext password is never stored anywhere directly.

By changing the `paswordFile` config option to be nullable (and defaulted null), it allows the password to be omitted from the ASF configuration completely. This allows ASF to fallback to the above method for logging into the account.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Tested on NixOS (Unstable) by disabling the nixpkgs module and importing this one. I'm not sure how that fits with the checklist below, since it seems focused on packages, not services.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
