### PR TITLE
nixos/keepalived: support reload

### DIFF
--- a/nixos/modules/services/networking/keepalived/default.nix
+++ b/nixos/modules/services/networking/keepalived/default.nix
@@ -318,27 +318,32 @@ in
     };
 
     systemd.services.keepalived = let
-      finalConfigFile = if cfg.secretFile == null then keepalivedConf else "/run/keepalived/keepalived.conf";
+      finalConfigFile = "/run/keepalived/keepalived.conf";
+      populateSecrets =  ''
+        umask 077
+        ${pkgs.envsubst}/bin/envsubst -i "${keepalivedConf}" > ${finalConfigFile}
+      '';
     in {
       description = "Keepalive Daemon (LVS and VRRP)";
       after = [ "network.target" "network-online.target" "syslog.target" ];
       wants = [ "network-online.target" ];
+      reloadIfChanged = true;
+      restartTriggers = [ pkgs.keepalived cfg.snmp.enable ];
       serviceConfig = {
         Type = "forking";
         PIDFile = pidFile;
         KillMode = "process";
         RuntimeDirectory = "keepalived";
         EnvironmentFile = lib.optional (cfg.secretFile != null) cfg.secretFile;
-        ExecStartPre = lib.optional (cfg.secretFile != null)
-        (pkgs.writeShellScript "keepalived-pre-start" ''
-          umask 077
-          ${pkgs.envsubst}/bin/envsubst -i "${keepalivedConf}" > ${finalConfigFile}
-        '');
+        ExecStartPre = pkgs.writeShellScript "keepalived-pre-start" populateSecrets;
         ExecStart = "${pkgs.keepalived}/sbin/keepalived"
           + " -f ${finalConfigFile}"
           + " -p ${pidFile}"
           + optionalString cfg.snmp.enable " --snmp";
-        ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+        ExecReload = pkgs.writeShellScript "keepalived-reload" ''
+          ${populateSecrets}
+          ${pkgs.coreutils}/bin/kill -HUP $MAINPID
+        '';
         Restart = "always";
         RestartSec = "1s";
       };

--- a/nixos/tests/keepalived.nix
+++ b/nixos/tests/keepalived.nix
@@ -1,6 +1,6 @@
 import ./make-test-python.nix ({ pkgs, lib, ... }: {
   name = "keepalived";
-  maintainers = [ lib.maintainers.raitobezarius ];
+  meta.maintainers = [ lib.maintainers.raitobezarius ];
 
   nodes = {
     node1 = { pkgs, ... }: {

--- a/nixos/tests/keepalived.nix
+++ b/nixos/tests/keepalived.nix
@@ -39,5 +39,11 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     node2.wait_until_succeeds("ip addr show dev eth1 | grep -q 192.168.1.200")
     node1.fail("ip addr show dev eth1 | grep -q 192.168.1.200")
     node1.succeed("ping -c1 192.168.1.200")
+
+    with subtest("failover"):
+      node2.block()
+      node1.wait_until_succeeds("ip addr show dev eth1 | grep -q 192.168.1.200")
+      node2.unblock()
+      node1.wait_until_fails("ip addr show dev eth1 | grep -q 192.168.1.200")
   '';
 })

--- a/nixos/tests/keepalived.nix
+++ b/nixos/tests/keepalived.nix
@@ -56,8 +56,8 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     with subtest("reload config"):
       node1.fail("ip addr show dev eth1 | grep -q 192.168.1.201")
       node1.succeed("${reloadSystem}/bin/switch-to-configuration test >&2")
-      node1.fail("journalctl -u keepalived | grep -q -i stopped")
-      node1.succeed("journalctl -u keepalived | grep -q -i reloaded")
       node1.wait_until_succeeds("ip addr show dev eth1 | grep -q 192.168.1.201")
+      node1.fail("journalctl -u keepalived | grep -q Stopped")
+      node1.succeed("journalctl -u keepalived | grep -q Reloaded")
   '';
 })


### PR DESCRIPTION
## Description of changes

Add support for reloading keepalived on config change without having to restart.

Add tests for keepalived failover and config reload.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

cc @RaitoBezarius 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
