### PR TITLE
nixos/tests/kernel-rust: test against 6.7 and testing (6.8rc1)

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -451,7 +451,7 @@ in {
   kerberos = handleTest ./kerberos/default.nix {};
   kernel-generic = handleTest ./kernel-generic.nix {};
   kernel-latest-ath-user-regd = handleTest ./kernel-latest-ath-user-regd.nix {};
-  kernel-rust = runTestOn ["x86_64-linux"] ./kernel-rust.nix;
+  kernel-rust = handleTestOn ["x86_64-linux"] ./kernel-rust.nix {};
   keter = handleTest ./keter.nix {};
   kexec = handleTest ./kexec.nix {};
   keycloak = discoverTests (import ./keycloak.nix);

--- a/nixos/tests/kernel-rust.nix
+++ b/nixos/tests/kernel-rust.nix
@@ -1,30 +1,43 @@
-{ pkgs, ... }: {
-  name = "kernel-rust";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ blitz ];
-  };
+{ system ? builtins.currentSystem
+, config ? { }
+, pkgs ? import ../.. { inherit system config; }
+}:
 
-  nodes.machine = { config, pkgs, ... }:
-    {
-      boot.kernelPackages = pkgs.linuxPackages_testing;
+let
+  inherit (pkgs.lib) const filterAttrs mapAttrs;
 
-      boot.extraModulePackages = [
-        config.boot.kernelPackages.rust-out-of-tree-module
-      ];
-
-      boot.kernelPatches = [
-        {
-          name = "Rust Support";
-          patch = null;
-          features = {
-            rust = true;
-          };
-        }
-      ];
+  kernelRustTest = kernelPackages: import ./make-test-python.nix ({ lib, ... }: {
+    name = "kernel-rust";
+    meta.maintainers = with lib.maintainers; [ blitz ma27 ];
+    nodes.machine = { config, ... }: {
+      boot = {
+        inherit kernelPackages;
+        extraModulePackages = [ config.boot.kernelPackages.rust-out-of-tree-module ];
+        kernelPatches = [
+          {
+            name = "Rust Support";
+            patch = null;
+            features = {
+              rust = true;
+            };
+          }
+        ];
+      };
     };
+    testScript = ''
+      machine.wait_for_unit("default.target")
+      machine.succeed("modprobe rust_out_of_tree")
+    '';
+  });
 
-  testScript = ''
-    machine.wait_for_unit("default.target")
-    machine.succeed("modprobe rust_out_of_tree")
-  '';
-}
+  kernels = {
+    inherit (pkgs.linuxKernel.packages) linux_testing;
+  }
+  // filterAttrs
+    (const (x: let
+      inherit (builtins.tryEval (
+        x.rust-out-of-tree-module or null != null
+      )) success value;
+    in success && value))
+    pkgs.linuxKernel.vanillaPackages;
+in mapAttrs (const kernelRustTest) kernels


### PR DESCRIPTION

## Description of changes
In #283893 we realized that not only 6.7, but also testing is affected. And with more stable kernels following, we'll probably want to test against all of them whether Rust support is working fine. As long as it's not the default at least, then we should probably move this to `kernel-generic`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
