### PR TITLE
gnome-extensions-cli: 0.9.5 -> 0.10.0

### DIFF
--- a/pkgs/desktops/gnome/misc/gnome-extensions-cli/default.nix
+++ b/pkgs/desktops/gnome/misc/gnome-extensions-cli/default.nix
@@ -3,24 +3,24 @@
 , buildPythonApplication
 , poetry-core
 , colorama
-, more-itertools
 , packaging
 , pydantic
 , requests
 , pygobject3
+, tqdm
 , gobject-introspection
 , wrapGAppsNoGuiHook
 }:
 
 buildPythonApplication rec {
   pname = "gnome-extensions-cli";
-  version = "0.9.5";
+  version = "0.10.1";
   format = "pyproject";
 
   src = fetchPypi {
     pname = "gnome_extensions_cli";
     inherit version;
-    hash = "sha256-4eRVmG5lqK8ql9WpvXsf18znOt7kDSnpQnLfy73doy4=";
+    hash = "sha256-yAoo3NjNtTZSHmbLKzW2X7Cy2smLNp8/9vo+OPGxlVY=";
   };
 
   nativeBuildInputs = [
@@ -31,11 +31,11 @@ buildPythonApplication rec {
 
   propagatedBuildInputs = [
     colorama
-    more-itertools
     packaging
     pydantic
     requests
     pygobject3
+    tqdm
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
The `gnome-extensions-cli` uses other packaged Python dependencies and failing to build because the packaged versions of `more-itertools` and `pydantic` are newer than what the project's dependency constraints allow for.

Upgrading the package to the newest version fixes the build.

Failing Hydra build: https://hydra.nixos.org/build/247490403
Hydra log: https://hydra.nixos.org/build/247490403/nixlog/1

Relevant log excerpt:
```
Successfully built gnome_extensions_cli-0.9.5-py3-none-any.whl
Finished creating a wheel...
Finished executing pypaBuildPhase
Running phase: pythonRuntimeDepsCheckHook
Executing pythonRuntimeDepsCheck
Checking runtime dependencies for gnome_extensions_cli-0.9.5-py3-none-any.whl
  - more-itertools<10.0.0,>=9.0.0 not satisfied by version 10.1.0
  - pydantic<2.0.0,>=1.10.4 not satisfied by version 2.5.2
```

## Description of changes

- Udpated `gnome-extensions-cli` to v. 0.10.0
- Added new dependency `tqdm` to build inputs.
- Removed `more-itertools` from build inputs, as it isn't referenced anymore by the new version.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
