### PR TITLE
grandorgue: 3.11.0 -> 3.14.0

### DIFF
--- a/pkgs/applications/audio/grandorgue/default.nix
+++ b/pkgs/applications/audio/grandorgue/default.nix
@@ -1,18 +1,34 @@
-{ lib, stdenv, fetchFromGitHub, cmake, pkg-config, fftwFloat, alsa-lib
-, zlib, wavpack, wxGTK32, udev, jackaudioSupport ? false, libjack2
-, imagemagick, libicns, makeWrapper, Cocoa
-, includeDemo ? true }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, fftwFloat
+, alsa-lib
+, zlib
+, wavpack
+, wxGTK32
+, udev
+, jackaudioSupport ? false
+, libjack2
+, imagemagick
+, libicns
+, yaml-cpp
+, makeWrapper
+, Cocoa
+, includeDemo ? true
+}:
 
 stdenv.mkDerivation rec {
   pname = "grandorgue";
-  version = "3.11.0";
+  version = "3.14.0";
 
   src = fetchFromGitHub {
     owner = "GrandOrgue";
     repo = pname;
     rev = version;
     fetchSubmodules = true;
-    sha256 = "sha256-l1KqER/vkNwgKLXIFUzHnYLw2ivGNP7hRiKhIOzn7pw=";
+    hash = "sha256-kPz11V2yNmBe80egNLYxh/m2B1nDca3C5sGbEnrkqnw=";
   };
 
   postPatch = ''
@@ -24,7 +40,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake pkg-config imagemagick libicns makeWrapper ];
 
-  buildInputs = [ fftwFloat zlib wavpack wxGTK32 ]
+  buildInputs = [ fftwFloat zlib wavpack wxGTK32 yaml-cpp ]
     ++ lib.optionals stdenv.isLinux [ alsa-lib udev ]
     ++ lib.optionals stdenv.isDarwin [ Cocoa ]
     ++ lib.optional jackaudioSupport libjack2;
@@ -53,5 +69,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.puzzlewolf ];
+    mainProgram = "GrandOrgue";
   };
 }


### PR DESCRIPTION
`grandorgue` failed to build because GCC 13 stopped transitively including some headers like `cstdint` in a lot of situations, leading to many references to types like `uint8_t` in old C++ code breaking unless the respective include statements were included directly in the referring code.

This build issue is already fixed upstream, and updating the package to the current release (3.14.0) fixes the build.

Failing Hydra build: https://hydra.nixos.org/build/247994558
Hydra log: https://hydra.nixos.org/build/247994558/nixlog/1

Relevant log excerpt:
```
[  6%] Building CXX object src/core/CMakeFiles/GrandOrgueCore.dir/archive/GOArchiveFile.cpp.o
In file included from /build/source/src/core/archive/GOArchiveFile.cpp:15:
/build/source/src/core/GOHash.h:16:3: error: 'uint8_t' does not name a type
   16 |   uint8_t hash[20];
      |   ^~~~~~~
/build/source/src/core/GOHash.h:14:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   13 | #include "contrib/sha1.h"
  +++ |+#include <cstdint>
   14 | 
```

## Description of changes

- Updated `grandorgue` to v. 3.14.0
- Added new dependency `yaml-cpp` to build inputs

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
