### PR TITLE
Update netsurf.browser and netsurf.lib*, fix on darwin

### DIFF
--- a/pkgs/applications/graphics/imv/default.nix
+++ b/pkgs/applications/graphics/imv/default.nix
@@ -16,7 +16,8 @@
 , libxkbcommon
 , libGLU
 , wayland
-, withBackends ? [ "freeimage" "libtiff" "libjpeg" "libpng" "librsvg" "libnsgif" "libheif" ]
+# "libnsgif" is disabled until https://todo.sr.ht/~exec64/imv/55 is solved
+, withBackends ? [ "freeimage" "libtiff" "libjpeg" "libpng" "librsvg" "libheif" ]
 , freeimage
 , libtiff
 , libjpeg_turbo

--- a/pkgs/applications/networking/browsers/netsurf/libcss.nix
+++ b/pkgs/applications/networking/browsers/netsurf/libcss.nix
@@ -10,11 +10,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "netsurf-libcss";
-  version = "0.9.1";
+  version = "0.9.2";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/libcss-${finalAttrs.version}-src.tar.gz";
-    hash = "sha256-0tzhbpM5Lo1qcglCDUfC1Wo4EXAaDoGnJPxUHGPTxtw=";
+    hash = "sha256-LfIVu+w01R1gwaBLAbLfTV0Y9RDx86evS4DN21ZxFU4=";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   env.NIX_CFLAGS_COMPILE = toString [
     "-Wno-error=implicit-fallthrough"
-    "-Wno-error=maybe-uninitialized"
+    "-Wno-error=${if stdenv.cc.isGNU then "maybe-uninitialized" else "uninitialized"}"
   ];
 
   meta = {

--- a/pkgs/applications/networking/browsers/netsurf/libdom.nix
+++ b/pkgs/applications/networking/browsers/netsurf/libdom.nix
@@ -11,11 +11,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "netsurf-libdom";
-  version = "0.4.1";
+  version = "0.4.2";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/libdom-${finalAttrs.version}-src.tar.gz";
-    hash = "sha256-mO4HJHHlXiCMmHjlFcQQrUYso2+HtK/L7K0CPzos70o=";
+    hash = "sha256-0F5FrxZUcBTCsKOuzzZw+hPUGfUFs/X8esihSR/DDzw=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/applications/networking/browsers/netsurf/libhubbub.nix
+++ b/pkgs/applications/networking/browsers/netsurf/libhubbub.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, gperf
 , perl
 , pkg-config
 , buildsystem
@@ -9,16 +10,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "netsurf-libhubbub";
-  version = "0.3.7";
+  version = "0.3.8";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/libhubbub-${finalAttrs.version}-src.tar.gz";
-    hash = "sha256-nnriU+bJBp51frmtTkhG84tNtSwMoBUURqn6Spd3NbY=";
+    hash = "sha256-isHm9fPUjAUUHVk5FxlTQpDFnNAp78JJ60/brBAs1aU=";
   };
 
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [
+    gperf
     perl
     buildsystem
     libparserutils

--- a/pkgs/applications/networking/browsers/netsurf/libnsbmp.nix
+++ b/pkgs/applications/networking/browsers/netsurf/libnsbmp.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "netsurf-libnsbmp";
-  version = "0.1.6";
+  version = "0.1.7";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/libnsbmp-${finalAttrs.version}-src.tar.gz";
-    hash = "sha256-ecSTZfhg7UUb/EEJ7d7I3j6bfOWjvgaVlr0qoZJ5Mk8=";
+    hash = "sha256-VAenaCoSK6qqWhW1BSkOLTffVME8Xt70sJ0SyGLYIpM=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/applications/networking/browsers/netsurf/libnsgif.nix
+++ b/pkgs/applications/networking/browsers/netsurf/libnsgif.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "netsurf-libnsgif";
-  version = "0.2.1";
+  version = "1.0.0";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/libnsgif-${finalAttrs.version}-src.tar.gz";
-    hash = "sha256-nq6lNM1wtTxar0UxeulXcBaFprSojb407Sb0+q6Hmks=";
+    hash = "sha256-YBTIQvYUVNL1oPgkPXqNe96bfaPM/cotNGx8CyxMBhs=";
   };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];

--- a/pkgs/applications/networking/browsers/netsurf/libnsutils.nix
+++ b/pkgs/applications/networking/browsers/netsurf/libnsutils.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "netsurf-libnsutils";
-  version = "0.1.0";
+  version = "0.1.1";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/libnsutils-${finalAttrs.version}-src.tar.gz";
-    hash = "sha256-eQxlFjRKvoL2KJ1lY5LpzOvkdbIMx+Hi2EMBE4X3rvA=";
+    hash = "sha256-VpS0Um5FjtAAQTzmAnWJy+EKJXp+zwZaAUIdxymd6pI=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/applications/networking/browsers/netsurf/libparserutils.nix
+++ b/pkgs/applications/networking/browsers/netsurf/libparserutils.nix
@@ -3,20 +3,22 @@
 , fetchurl
 , perl
 , buildsystem
+, iconv
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "netsurf-libparserutils";
-  version = "0.2.4";
+  version = "0.2.5";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/libparserutils-${finalAttrs.version}-src.tar.gz";
-    hash = "sha256-MiuuYbMMzt4+MFv26uJBSSBkl3W8X/HRtogBKjxJR9g=";
+    hash = "sha256-MX7VxxjxeSe1chl0uuXeMsP9bQVdsTGtMbQxKgMu0Tk=";
   };
 
   buildInputs = [
     perl
     buildsystem
+    iconv
   ];
 
   makeFlags = [

--- a/pkgs/applications/networking/browsers/netsurf/libsvgtiny.nix
+++ b/pkgs/applications/networking/browsers/netsurf/libsvgtiny.nix
@@ -12,11 +12,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "netsurf-libsvgtiny";
-  version = "0.1.7";
+  version = "0.1.8";
 
   src = fetchurl {
     url = "http://download.netsurf-browser.org/libs/releases/libsvgtiny-${finalAttrs.version}-src.tar.gz";
-    hash = "sha256-LA3PlS8c2ILD6VQB75RZ8W27U8XT5FEjObL563add4E=";
+    hash = "sha256-w1cifwLoP7KnaxK5ARkaCCIp2x8Ac2Lo8xx1RRDCoBw=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

Updates netsurf.browser from 3.10 to 3.11, and similar updates for all corresponding libraries(see commit messages).

- [changelog](https://download.netsurf-browser.org/netsurf/releases/ChangeLog.txt) for NetSurf/browser and various libs
- [changelog](https://www.netsurf-browser.org/projects/libcss/#changes-0.9.2) for libcss

These include a few minor but potentially breaking changes, like deprecating TLS 1.0 / 1.1.

Adds compile flags in browser.nix to allow building on darwin and with clang in general.

The build system is already updated in #277664.
Supersedes #277662 and #277669.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Remaining / TODO:
- [x] Test with uilib=framebuffer
  - Seems to work fine on NixOS, build fails on darwin
- [x] Test with uilib=gtk2
  - Builds fine, shows websites fine, but seems to be missing some UI icons (e.g. back button)
  - [ ] Fix missing resources
- [x] Test with uilib=sixel
  - Works fine on NixOS, but SDL_sixel is broken on darwin
- [ ] Enable tests in testPhase
- [ ] Enable/fix "Export to PDF" with libharu
- [x] Look into broken gimpPlugins, imv and toppler

---

Result of `nixpkgs-review` run on aarch64-darwin [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages marked as broken and skipped:</summary>
  <ul>
    <li>gimpPlugins.exposureBlend</li>
    <li>gimpPlugins.resynthesizer</li>
  </ul>
</details>
<details>
  <summary>2 packages failed to build:</summary>
  <ul>
    <li>gimpPlugins.bimp</li>
    <li>gimpPlugins.gap</li>
  </ul>
</details>
<details>
  <summary>21 packages built:</summary>
  <ul>
    <li>gegl</li>
    <li>gegl.dev</li>
    <li>gegl.devdoc</li>
    <li>gimp</li>
    <li>gimp.dev</li>
    <li>gimpPlugins.farbfeld</li>
    <li>gimpPlugins.fourier</li>
    <li>gimpPlugins.gmic</li>
    <li>gimpPlugins.lightning</li>
    <li>gimpPlugins.lqrPlugin</li>
    <li>gimpPlugins.texturize</li>
    <li>gimpPlugins.waveletSharpen</li>
    <li>netsurf.browser</li>
    <li>netsurf.libcss</li>
    <li>netsurf.libdom</li>
    <li>netsurf.libhubbub</li>
    <li>netsurf.libnsbmp</li>
    <li>netsurf.libnsgif</li>
    <li>netsurf.libnsutils</li>
    <li>netsurf.libparserutils</li>
    <li>netsurf.libsvgtiny</li>
  </ul>
</details>

<hr>

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>2 packages marked as broken and skipped:</summary>
  <ul>
    <li>gimpPlugins.exposureBlend</li>
    <li>gimpPlugins.resynthesizer</li>
  </ul>
</details>
<details>
  <summary>3 packages failed to build:</summary>
  <ul>
    <li>imv</li>
    <li>imv.man</li>
    <li>toppler</li>
  </ul>
</details>
<details>
  <summary>27 packages built:</summary>
  <ul>
    <li>gegl</li>
    <li>gegl.dev</li>
    <li>gegl.devdoc</li>
    <li>gimp</li>
    <li>gimp-with-plugins</li>
    <li>gimp.dev</li>
    <li>gimpPlugins.bimp</li>
    <li>gimpPlugins.farbfeld</li>
    <li>gimpPlugins.fourier</li>
    <li>gimpPlugins.gap</li>
    <li>gimpPlugins.gimplensfun</li>
    <li>gimpPlugins.gmic</li>
    <li>gimpPlugins.lightning</li>
    <li>gimpPlugins.lqrPlugin</li>
    <li>gimpPlugins.texturize</li>
    <li>gimpPlugins.waveletSharpen</li>
    <li>gnome-photos</li>
    <li>gnome-photos.installedTests</li>
    <li>netsurf.browser</li>
    <li>netsurf.libcss</li>
    <li>netsurf.libdom</li>
    <li>netsurf.libhubbub</li>
    <li>netsurf.libnsbmp</li>
    <li>netsurf.libnsgif</li>
    <li>netsurf.libnsutils</li>
    <li>netsurf.libparserutils</li>
    <li>netsurf.libsvgtiny</li>
  </ul>
</details>

<hr>

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
