### PR TITLE
lomiri.lomiri-ui-toolkit: Fix compatibility with versioned QML import paths

### DIFF
--- a/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/2002-Nixpkgs-versioned-QML-path.patch.in
+++ b/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/2002-Nixpkgs-versioned-QML-path.patch.in
@@ -1,0 +1,29 @@
+From ca4c52a80532732243067eb00ec12b4ef84010a6 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Tue, 30 Jan 2024 19:46:09 +0100
+Subject: [PATCH] Nixpkgs versioned QML path
+
+---
+ src/LomiriToolkit/uctheme.cpp | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/LomiriToolkit/uctheme.cpp b/src/LomiriToolkit/uctheme.cpp
+index a10c89344..4b0653589 100644
+--- a/src/LomiriToolkit/uctheme.cpp
++++ b/src/LomiriToolkit/uctheme.cpp
+@@ -180,6 +180,12 @@ QStringList themeSearchPath()
+         pathList << QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation);
+     }
+
++    // append versioned QML import path from Nixpkgs
++    const QString nixpkgsQmlImportPath = QString::fromLocal8Bit(getenv("NIXPKGS_QT@qtVersion@_QML_IMPORT_PATH"));
++    if (!nixpkgsQmlImportPath.isEmpty()) {
++        pathList << nixpkgsQmlImportPath.split(':', QString::SkipEmptyParts);
++    }
++
+     // append QML import path(s); we must explicitly support env override here
+     const QString qml2ImportPath = QString::fromLocal8Bit(getenv("QML2_IMPORT_PATH"));
+     if (!qml2ImportPath.isEmpty()) {
+--
+2.42.0
+

--- a/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitLab
 , fetchpatch
 , gitUpdater
+, substituteAll
 , testers
 , dbus-test-runner
 , dpkg
@@ -74,6 +75,11 @@ stdenv.mkDerivation (finalAttrs: {
     })
 
     ./2001-Mark-problematic-tests.patch
+    (substituteAll {
+      src = ./2002-Nixpkgs-versioned-QML-path.patch.in;
+      name = "2002-Nixpkgs-versioned-QML-path.patch";
+      qtVersion = lib.versions.major qtbase.version;
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

LUITK uses `QML2_IMPORT_PATH` for finding themes, both additional ones & the default. If it can't find its default theme, most LUITK apps are displayed as solid-black.

Fix by adding the new (Qt-version-specific) variable added by https://github.com/NixOS/nixpkgs/pull/281486 to its list of considered envvars.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
