### PR TITLE
libjpeg_turbo: 2.1.5.1 -> 3.0.2

### DIFF
--- a/pkgs/development/libraries/libjpeg-turbo/0001-Compile-transupp.c-as-part-of-the-library.patch
+++ b/pkgs/development/libraries/libjpeg-turbo/0001-Compile-transupp.c-as-part-of-the-library.patch
@@ -1,4 +1,4 @@
-From 4a0584f7c05641143151ebdc1be1163bebf9d35d Mon Sep 17 00:00:00 2001
+From 6442d11617f95d13e2a371bd3e01f5082a9c356d Mon Sep 17 00:00:00 2001
 From: Las <las@protonmail.ch>
 Date: Sun, 3 Jan 2021 18:35:37 +0000
 Subject: [PATCH] Compile transupp.c as part of the library
@@ -11,19 +11,19 @@ of the library that already vendor this functionality.
  2 files changed, 9 insertions(+), 9 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 0ca6f98..a9a0fae 100644
+index adb0ca45..46fc16dd 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -533,7 +533,7 @@ set(JPEG_SOURCES jcapimin.c jcapistd.c jccoefct.c jccolor.c jcdctmgr.c jchuff.c
-   jdatasrc.c jdcoefct.c jdcolor.c jddctmgr.c jdhuff.c jdicc.c jdinput.c
-   jdmainct.c jdmarker.c jdmaster.c jdmerge.c jdphuff.c jdpostct.c jdsample.c
-   jdtrans.c jerror.c jfdctflt.c jfdctfst.c jfdctint.c jidctflt.c jidctfst.c
--  jidctint.c jidctred.c jquant1.c jquant2.c jutils.c jmemmgr.c jmemnobs.c)
-+  jidctint.c jidctred.c jquant1.c jquant2.c jutils.c jmemmgr.c jmemnobs.c transupp.c)
+@@ -581,7 +581,7 @@ set(JPEG_SOURCES ${JPEG12_SOURCES} jcapimin.c jchuff.c jcicc.c jcinit.c
+   jclhuff.c jcmarker.c jcmaster.c jcomapi.c jcparam.c jcphuff.c jctrans.c
+   jdapimin.c jdatadst.c jdatasrc.c jdhuff.c jdicc.c jdinput.c jdlhuff.c
+   jdmarker.c jdmaster.c jdphuff.c jdtrans.c jerror.c jfdctflt.c jmemmgr.c
+-  jmemnobs.c jpeg_nbits.c)
++  jmemnobs.c jpeg_nbits.c transupp.c)
  
  if(WITH_ARITH_ENC OR WITH_ARITH_DEC)
    set(JPEG_SOURCES ${JPEG_SOURCES} jaricom.c)
-@@ -1489,7 +1489,7 @@ install(EXPORT ${CMAKE_PROJECT_NAME}Targets
+@@ -1803,7 +1803,7 @@ install(EXPORT ${CMAKE_PROJECT_NAME}Targets
  
  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/jconfig.h
    ${CMAKE_CURRENT_SOURCE_DIR}/jerror.h ${CMAKE_CURRENT_SOURCE_DIR}/jmorecfg.h
@@ -33,10 +33,10 @@ index 0ca6f98..a9a0fae 100644
  
  include(cmakescripts/BuildPackages.cmake)
 diff --git a/transupp.c b/transupp.c
-index 6e86077..2da49a7 100644
+index 34fbb371..c0ade5a9 100644
 --- a/transupp.c
 +++ b/transupp.c
-@@ -1386,7 +1386,7 @@ jt_read_integer(const char **strptr, JDIMENSION *result)
+@@ -1388,7 +1388,7 @@ jt_read_integer(const char **strptr, JDIMENSION *result)
   * This code is loosely based on XParseGeometry from the X11 distribution.
   */
  
@@ -45,7 +45,7 @@ index 6e86077..2da49a7 100644
  jtransform_parse_crop_spec(jpeg_transform_info *info, const char *spec)
  {
    info->crop = FALSE;
-@@ -1486,7 +1486,7 @@ trim_bottom_edge(jpeg_transform_info *info, JDIMENSION full_height)
+@@ -1488,7 +1488,7 @@ trim_bottom_edge(jpeg_transform_info *info, JDIMENSION full_height)
   * and transformation is not perfect.  Otherwise returns TRUE.
   */
  
@@ -54,7 +54,7 @@ index 6e86077..2da49a7 100644
  jtransform_request_workspace(j_decompress_ptr srcinfo,
                               jpeg_transform_info *info)
  {
-@@ -2033,7 +2033,7 @@ adjust_exif_parameters(JOCTET *data, unsigned int length, JDIMENSION new_width,
+@@ -2035,7 +2035,7 @@ adjust_exif_parameters(JOCTET *data, unsigned int length, JDIMENSION new_width,
   * to jpeg_write_coefficients().
   */
  
@@ -63,7 +63,7 @@ index 6e86077..2da49a7 100644
  jtransform_adjust_parameters(j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
                               jvirt_barray_ptr *src_coef_arrays,
                               jpeg_transform_info *info)
-@@ -2152,7 +2152,7 @@ jtransform_adjust_parameters(j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
+@@ -2154,7 +2154,7 @@ jtransform_adjust_parameters(j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
   * Note that some transformations will modify the source data arrays!
   */
  
@@ -72,7 +72,7 @@ index 6e86077..2da49a7 100644
  jtransform_execute_transform(j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
                               jvirt_barray_ptr *src_coef_arrays,
                               jpeg_transform_info *info)
-@@ -2264,7 +2264,7 @@ jtransform_execute_transform(j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
+@@ -2266,7 +2266,7 @@ jtransform_execute_transform(j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
   *           (may use custom action then)
   */
  
@@ -81,7 +81,7 @@ index 6e86077..2da49a7 100644
  jtransform_perfect_transform(JDIMENSION image_width, JDIMENSION image_height,
                               int MCU_width, int MCU_height,
                               JXFORM_CODE transform)
-@@ -2303,7 +2303,7 @@ jtransform_perfect_transform(JDIMENSION image_width, JDIMENSION image_height,
+@@ -2305,7 +2305,7 @@ jtransform_perfect_transform(JDIMENSION image_width, JDIMENSION image_height,
   * This must be called before jpeg_read_header() to have the desired effect.
   */
  
@@ -90,7 +90,7 @@ index 6e86077..2da49a7 100644
  jcopy_markers_setup(j_decompress_ptr srcinfo, JCOPY_OPTION option)
  {
  #ifdef SAVE_MARKERS_SUPPORTED
-@@ -2331,7 +2331,7 @@ jcopy_markers_setup(j_decompress_ptr srcinfo, JCOPY_OPTION option)
+@@ -2337,7 +2337,7 @@ jcopy_markers_setup(j_decompress_ptr srcinfo, JCOPY_OPTION option)
   * JFIF APP0 or Adobe APP14 markers if selected.
   */
  
@@ -100,5 +100,5 @@ index 6e86077..2da49a7 100644
                        JCOPY_OPTION option)
  {
 -- 
-2.29.2
+2.43.0
 

--- a/pkgs/development/libraries/libjpeg-turbo/default.nix
+++ b/pkgs/development/libraries/libjpeg-turbo/default.nix
@@ -32,13 +32,13 @@ assert !(enableJpeg7 && enableJpeg8);  # pick only one or none, not both
 stdenv.mkDerivation (finalAttrs: {
 
   pname = "libjpeg-turbo";
-  version = "2.1.5.1";
+  version = "3.0.2";
 
   src = fetchFromGitHub {
     owner = "libjpeg-turbo";
     repo = "libjpeg-turbo";
     rev = finalAttrs.version;
-    sha256 = "sha256-96SBBZp+/4WkXLvHKSPItNi5WuzdVccI/ZcbJOFjYYk=";
+    hash = "sha256-xHjd0WHN50b75wdWPHUwfmJGsiWKmj+zA59UwakIo74=";
   };
 
   # This is needed by freeimage


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/pull/248969.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
