### PR TITLE
krita: wrap with plugins, krita-plugin-gmic init at 3.2.4.1

### DIFF
--- a/doc/packages/index.md
+++ b/doc/packages/index.md
@@ -14,6 +14,7 @@ fish.section.md
 fuse.section.md
 ibus.section.md
 kakoune.section.md
+krita.section.md
 linux.section.md
 locales.section.md
 etc-files.section.md

--- a/doc/packages/krita.section.md
+++ b/doc/packages/krita.section.md
@@ -1,0 +1,37 @@
+# Krita {#sec-krita}
+
+## Python plugins {#krita-python-plugins}
+
+"pykrita" plugins should be installed following
+[Krita's manual](https://docs.krita.org/en/user_manual/python_scripting/install_custom_python_plugin.html).
+This generally involves extracting the extension to `~/.local/share/krita/pykrita/`.
+
+## Binary plugins {#krita-binary-plugins}
+
+Binary plugins are Dynamically Linked Libraries to be loaded by Krita.
+
+_Note: You most likely won't need to deal with binary plugins,
+all known plugins are bundled and enabled by default._
+
+### Installing binary plugins {#krita-install-binary-plugins}
+
+You can choose what plugins are added to Krita by overriding the
+`binaryPlugins` attribute.
+
+If you want to add plugins instead of replacing, you can read the
+list of previous plugins via `pkgs.krita.binaryPlugins`:
+
+```nix
+(pkgs.krita.override (old: {
+    binaryPlugins = old.binaryPlugins ++ [ your-plugin ];
+}))
+```
+
+### Example structure of a binary plugin {#krita-binary-plugin-structure}
+
+```
+/nix/store/00000000000000000000000000000000-krita-plugin-example-1.2.3
+└── lib
+   └── kritaplugins
+      └── krita_example.so
+```

--- a/pkgs/applications/graphics/krita/generic.nix
+++ b/pkgs/applications/graphics/krita/generic.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, lib, stdenv, fetchpatch, makeWrapper, fetchurl, cmake, extra-cmake-modules
+{ mkDerivation, lib, stdenv, fetchpatch, fetchurl, cmake, extra-cmake-modules
 , karchive, kconfig, kwidgetsaddons, kcompletion, kcoreaddons
 , kguiaddons, ki18n, kitemmodels, kitemviews, kwindowsystem
 , kio, kcrash, breeze-icons
@@ -13,7 +13,7 @@
 }:
 
 mkDerivation rec {
-  pname = "krita";
+  pname = "krita-unwrapped";
   inherit version;
 
   src = fetchurl {
@@ -36,7 +36,7 @@ mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [ cmake extra-cmake-modules pkg-config python3Packages.sip makeWrapper ];
+  nativeBuildInputs = [ cmake extra-cmake-modules pkg-config python3Packages.sip ];
 
   buildInputs = [
     karchive kconfig kwidgetsaddons kcompletion kcoreaddons kguiaddons
@@ -72,14 +72,11 @@ mkDerivation rec {
     "-DBUILD_KRITA_QT_DESIGNER_PLUGINS=ON"
   ];
 
-  preInstall = ''
-    qtWrapperArgs+=(--prefix PYTHONPATH : "$PYTHONPATH")
-  '';
-
   meta = with lib; {
     description = "A free and open source painting application";
     homepage = "https://krita.org/";
     maintainers = with maintainers; [ abbradar sifmelcara nek0 ];
+    mainProgram = "krita";
     platforms = platforms.linux;
     license = licenses.gpl3Only;
   };

--- a/pkgs/applications/graphics/krita/wrapper.nix
+++ b/pkgs/applications/graphics/krita/wrapper.nix
@@ -1,0 +1,23 @@
+{ lib
+, libsForQt5
+, symlinkJoin
+, unwrapped ? libsForQt5.callPackage ./. { }
+, binaryPlugins ? [ ]
+}:
+
+symlinkJoin {
+  name = lib.replaceStrings [ "-unwrapped" ] [ "" ] unwrapped.name;
+  inherit (unwrapped) version buildInputs nativeBuildInputs meta;
+
+  paths = [ unwrapped ] ++ binaryPlugins;
+
+  postBuild = ''
+    wrapQtApp "$out/bin/krita" \
+      --prefix PYTHONPATH : "$PYTHONPATH" \
+      --set KRITA_PLUGIN_PATH "$out/lib/kritaplugins"
+  '';
+
+  passthru = {
+    inherit unwrapped binaryPlugins;
+  };
+}

--- a/pkgs/applications/graphics/krita/wrapper.nix
+++ b/pkgs/applications/graphics/krita/wrapper.nix
@@ -2,7 +2,11 @@
 , libsForQt5
 , symlinkJoin
 , unwrapped ? libsForQt5.callPackage ./. { }
-, binaryPlugins ? [ ]
+, krita-plugin-gmic
+, binaryPlugins ? [
+    # Default plugins provided by upstream appimage
+    krita-plugin-gmic
+  ]
 }:
 
 symlinkJoin {

--- a/pkgs/by-name/kr/krita-plugin-gmic/package.nix
+++ b/pkgs/by-name/kr/krita-plugin-gmic/package.nix
@@ -1,0 +1,51 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, extra-cmake-modules
+, fftw
+, krita
+, libsForQt5
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "krita-plugin-gmic";
+  version = "3.2.4.1";
+
+  src = fetchFromGitHub {
+    owner = "amyspark";
+    repo = "gmic";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-SYE8kGvN7iD5OqiEEZpB/eRle67PrB5DojMC79qAQtg=";
+  };
+  sourceRoot = "${finalAttrs.src.name}/gmic-qt";
+  dontWrapQtApps = true;
+
+  postPatch = ''
+    patchShebangs \
+      translations/filters/csv2ts.sh \
+      translations/lrelease.sh
+  '';
+
+  nativeBuildInputs = [ cmake extra-cmake-modules ];
+
+  buildInputs = [
+    fftw
+    krita.unwrapped
+    libsForQt5.kcoreaddons
+    libsForQt5.qttools
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "GMIC_QT_HOST" "krita-plugin")
+    # build krita's gmic instead of using the one from nixpkgs
+    (lib.cmakeBool "ENABLE_SYSTEM_GMIC" false)
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/amyspark/gmic";
+    description = "GMic plugin for Krita";
+    license = lib.licenses.cecill21;
+    maintainers = with maintainers; [ lelgenio ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32833,7 +32833,7 @@ with pkgs;
 
   krane = callPackage ../applications/networking/cluster/krane { };
 
-  krita = libsForQt5.callPackage ../applications/graphics/krita { };
+  krita = callPackage ../applications/graphics/krita/wrapper.nix { };
 
   ksuperkey = callPackage ../tools/X11/ksuperkey { };
 


### PR DESCRIPTION
## Description of changes

- Renamed `krita` to `krita-unwrapped`
- Created a wrapper `krita` to load plugins not included in `krita-unwrapped`
- Added the `krita-plugin-gmic` package, setting it as a default plugin

Fixes: #163645 

I decided on setting the wrapped version with gmic to be the true `krita` because it is included in the official Appimage.

<details><summary>I tried using gmic from nixpkgs, but it was incompatible.</summary>

```nix
(gmic.overrideAttrs {
  version = "3.2.4"; # The version required by the plugin
})
```

```sh
$ ./result/bin/krita
...
*** stack smashing detected ***: terminated
Magick: abort due to signal 6 (SIGABRT) "Abort"...
```

```
#0  0x00007f52634a402c __pthread_kill_implementation (libc.so.6 + 0x8d02c)
#1  0x00007f5263454e06 raise (libc.so.6 + 0x3de06)
#2  0x00007f526343d97f abort (libc.so.6 + 0x2697f)
#3  0x00007f51334ba437 MagickPanicSignalHandler (libGraphicsMagick.so.3 + 0xba437)
#4  0x00007f5263454eb0 __restore_rt (libc.so.6 + 0x3deb0)
#5  0x00007f52634a402c __pthread_kill_implementation (libc.so.6 + 0x8d02c)
#6  0x00007f5263454e06 raise (libc.so.6 + 0x3de06)
#7  0x00007f526343d8f5 abort (libc.so.6 + 0x268f5)
#8  0x00007f526343e7a1 __libc_message.cold (libc.so.6 + 0x277a1)
#9  0x00007f52635330c9 __fortify_fail (libc.so.6 + 0x11c0c9)
#10 0x00007f5263534374 __stack_chk_fail (libc.so.6 + 0x11d374)
#11 0x00007f5150354861 _ZN6GmicQt12FilterThread3runEv (krita_gmic_qt.so + 0x154861)
#12 0x00007f5263ae386c _ZN14QThreadPrivate5startEPv (libQt5Core.so.5 + 0xe386c)
#13 0x00007f52634a2333 start_thread (libc.so.6 + 0x8b333)
#14 0x00007f5263524efc __clone3 (libc.so.6 + 0x10defc)
```
</details> 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
---

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>krita</li>
    <li>krita-plugin-gmic</li>
    <li>krita-unwrapped</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc