### PR TITLE
element-desktop-nightly: added package

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -60,12 +60,6 @@
     See `./scripts/check-maintainer-github-handles.sh` for an example on how to work with this data.
 */
 {
-  willbou1 = {
-    name = "William Boulanger";
-    github = "willbou1";
-    email = "willbou2@gmail.com";
-    githubId = 6372967;
-  };
   _0b11stan = {
     name = "Tristan Auvinet Pinaudeau";
     email = "tristan@tic.sh";
@@ -20236,6 +20230,12 @@
     keys = [{
       fingerprint = "DA03 D6C6 3F58 E796 AD26  E99B 366A 2940 479A 06FC";
     }];
+  };
+  willbou1 = {
+    name = "William Boulanger";
+    github = "willbou1";
+    email = "willbou2@gmail.com";
+    githubId = 6372967;
   };
   willcohen = {
     github = "willcohen";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -60,6 +60,12 @@
     See `./scripts/check-maintainer-github-handles.sh` for an example on how to work with this data.
 */
 {
+  willbou1 = {
+    name = "William Boulanger";
+    github = "willbou1";
+    email = "willbou2@gmail.com";
+    githubId = 6372967;
+  };
   _0b11stan = {
     name = "Tristan Auvinet Pinaudeau";
     email = "tristan@tic.sh";

--- a/pkgs/applications/networking/instant-messengers/element-desktop-nightly/default.nix
+++ b/pkgs/applications/networking/instant-messengers/element-desktop-nightly/default.nix
@@ -1,0 +1,122 @@
+{ stdenv, fetchurl, dpkg, lib,
+alsaLib, atk, cairo, cups, curl, dbus, expat, fontconfig, freetype, gdk-pixbuf, glib, glibc, gnome2, gnome3, gtk3, libappindicator-gtk3, libdrm, libGL, libnotify, libpulseaudio, libsecret, libv4l, libxkbcommon, mesa, nspr, nss, pango, sqlcipher, systemd, wrapGAppsHook, xdg-utils, xorg, at-spi2-atk, libuuid, at-spi2-core }:
+
+################################################################################
+# Based on element-desktop-nightly package from AUR:
+# https://aur.archlinux.org/packages/element-desktop-nightly-bin
+################################################################################
+let
+    version = "2024012701";
+
+    rpath = lib.makeLibraryPath [
+        alsaLib
+        atk
+        at-spi2-atk
+        at-spi2-core
+        cairo
+        cups
+        curl
+        dbus
+        expat
+        fontconfig
+        freetype
+        glib
+        glibc
+        libdrm
+        libsecret
+        libuuid
+        mesa
+        sqlcipher
+
+        gnome2.GConf
+        gdk-pixbuf
+        gtk3
+        libappindicator-gtk3
+
+        gnome3.gnome-keyring
+
+        libnotify
+        libGL
+        libpulseaudio
+        nspr
+        nss
+        pango
+        stdenv.cc.cc
+        systemd
+        libv4l
+        xdg-utils
+
+        libxkbcommon
+        xorg.libxkbfile
+        xorg.libX11
+        xorg.libXcomposite
+        xorg.libXcursor
+        xorg.libXdamage
+        xorg.libXext
+        xorg.libXfixes
+        xorg.libXi
+        xorg.libXrandr
+        xorg.libXrender
+        xorg.libXtst
+        xorg.libXScrnSaver
+        xorg.libxcb
+    ] + ":${stdenv.cc.cc.lib}/lib64";
+
+    src = if stdenv.hostPlatform.system == "x86_64-linux" then
+        fetchurl {
+            url = "https://packages.element.io/debian/pool/main/e/element-nightly/element-nightly_${version}_amd64.deb";
+           sha256 = "1biv7w4dn6ymin8mwwzkkq01lzjmzf2qjip4k84ng14hmd1ss3lj"; 
+        }
+    else if stdenv.hostPlatform.system == "aarch64-linux" then
+        fetchurl {
+            url = "https://packages.element.io/debian/pool/main/e/element-nightly/element-nightly_${version}_arm64.deb";
+           sha256 = "1lb331kqrya5hsss505wv0iy2a0h24n3nji491w56k6c6ymwzim6"; 
+        }
+    else
+        throw "element-desktop-nightly is not supported on ${stdenv.hostPlatform.system}";
+
+in stdenv.mkDerivation {
+    pname = "element-desktop-nightly";
+    inherit version;
+    inherit src;
+    system = stdenv.hostPlatform.system;
+
+    buildInputs = [ dpkg ];
+    dontUnpack = true;
+
+    nativeBuildInputs = [
+        wrapGAppsHook
+        glib
+        xdg-utils
+    ];
+    
+    installPhase = ''
+        mkdir -p $out
+        dpkg -x $src $out
+
+        cp -av $out/usr/* $out
+        rm -rf $out/usr
+        
+        mkdir -p $out/bin
+        ln -s $out/opt/Element-Nightly/element-desktop-nightly $out/bin/element-desktop-nightly
+    '';
+
+    postFixup = ''
+        for file in $(find $out -type f \( -perm /0111 -o -name \*.so\* -or -name \*.node\* \) ); do
+            patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" "$file" || true
+            patchelf --set-rpath ${rpath}:$out/opt/Element-Nightly $file || true
+        done
+
+        # Fix the desktop link
+        substituteInPlace $out/share/applications/element-desktop-nightly.desktop \
+            --replace /opt $out/opt
+    '';
+
+    meta = with lib; {
+        description = "A feature-rich client for Matrix.org (nightly unstable build)";
+        homepage = "https://element.io";
+        license = licenses.asl20;
+        maintainers = teams.matrix.members;
+        mainProgram = "element-desktop-nightly";
+    };
+}

--- a/pkgs/applications/networking/instant-messengers/element-desktop-nightly/default.nix
+++ b/pkgs/applications/networking/instant-messengers/element-desktop-nightly/default.nix
@@ -116,7 +116,7 @@ in stdenv.mkDerivation {
         description = "A feature-rich client for Matrix.org (nightly unstable build)";
         homepage = "https://element.io";
         license = licenses.asl20;
-        maintainers = teams.matrix.members;
+        maintainers = maintainers.willbou1;
         mainProgram = "element-desktop-nightly";
     };
 }

--- a/pkgs/applications/networking/instant-messengers/element-desktop-nightly/default.nix
+++ b/pkgs/applications/networking/instant-messengers/element-desktop-nightly/default.nix
@@ -65,12 +65,12 @@ let
     src = if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchurl {
             url = "https://packages.element.io/debian/pool/main/e/element-nightly/element-nightly_${version}_amd64.deb";
-           sha256 = "1biv7w4dn6ymin8mwwzkkq01lzjmzf2qjip4k84ng14hmd1ss3lj"; 
+            sha256 = "1biv7w4dn6ymin8mwwzkkq01lzjmzf2qjip4k84ng14hmd1ss3lj";
         }
     else if stdenv.hostPlatform.system == "aarch64-linux" then
         fetchurl {
             url = "https://packages.element.io/debian/pool/main/e/element-nightly/element-nightly_${version}_arm64.deb";
-           sha256 = "1lb331kqrya5hsss505wv0iy2a0h24n3nji491w56k6c6ymwzim6"; 
+            sha256 = "1lb331kqrya5hsss505wv0iy2a0h24n3nji491w56k6c6ymwzim6";
         }
     else
         throw "element-desktop-nightly is not supported on ${stdenv.hostPlatform.system}";
@@ -89,14 +89,14 @@ in stdenv.mkDerivation {
         glib
         xdg-utils
     ];
-    
+
     installPhase = ''
         mkdir -p $out
         dpkg -x $src $out
 
         cp -av $out/usr/* $out
         rm -rf $out/usr
-        
+
         mkdir -p $out/bin
         ln -s $out/opt/Element-Nightly/element-desktop-nightly $out/bin/element-desktop-nightly
     '';


### PR DESCRIPTION
## Description of changes

Element-desktop-nightly is the nightly version of element-desktop. For example, the nightly version enabled me to finally use my IME on Wayland and the new Rust implementation of the cryptographic algorithms.
https://element.io

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md]
