### PR TITLE
ocamlPackages.lablgtk3: 3.1.3 → 3.1.4

### DIFF
--- a/pkgs/development/ocaml-modules/lablgtk3/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk3/default.nix
@@ -1,19 +1,17 @@
-{ lib, fetchFromGitHub, pkg-config, buildDunePackage, dune-configurator
+{ lib, fetchurl, pkg-config, buildDunePackage, dune-configurator
 , gtk3, cairo2
 , camlp-streams
 }:
 
 buildDunePackage rec {
-  version = "3.1.3";
+  version = "3.1.4";
   pname = "lablgtk3";
 
   minimalOCamlVersion = "4.05";
 
-  src = fetchFromGitHub {
-    owner = "garrigue";
-    repo = "lablgtk";
-    rev = version;
-    sha256 = "sha256-1kXJP+tKudP3qfosTgZAQueNK46H9aLevEj6wxPKDWY=";
+  src = fetchurl {
+    url = "https://github.com/garrigue/lablgtk/releases/download/${version}/lablgtk3-${version}.tbz";
+    hash = "sha256-bxEVMzfnaH5yHVxAmifNYOy8GnSivLLgSE/9+1yxBI4=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/ocaml-modules/lablgtk3/rsvg2.nix
+++ b/pkgs/development/ocaml-modules/lablgtk3/rsvg2.nix
@@ -1,0 +1,20 @@
+{ buildDunePackage
+, dune-configurator
+, lablgtk3
+, librsvg
+, pkg-config
+}:
+
+buildDunePackage rec {
+  pname = "lablgtk3-rsvg2";
+
+  inherit (lablgtk3) version src;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ lablgtk3 librsvg ];
+
+  meta = lablgtk3.meta // {
+    description = "OCaml interface to Gnome rsvg2 library";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -910,6 +910,8 @@ let
 
     lablgtk3-gtkspell3 = callPackage ../development/ocaml-modules/lablgtk3/gtkspell3.nix { };
 
+    lablgtk3-rsvg2 = callPackage ../development/ocaml-modules/lablgtk3/rsvg2.nix { };
+
     lablgtk3-sourceview3 = callPackage ../development/ocaml-modules/lablgtk3/sourceview3.nix { };
 
     labltk = callPackage ../development/ocaml-modules/labltk {


### PR DESCRIPTION
## Description of changes

https://raw.githubusercontent.com/garrigue/lablgtk/3.1.4/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
