### PR TITLE
clairvoyant: 3.1.2 -> 3.1.3

### DIFF
--- a/pkgs/by-name/cl/clairvoyant/package.nix
+++ b/pkgs/by-name/cl/clairvoyant/package.nix
@@ -8,6 +8,8 @@
 , stdenv
 , vala
 , wrapGAppsHook4
+# Clairvoyant shows a non-dismissable banner recommending the use of the Flatpak version
+, hideUnsupportedVersionBanner ? false
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -33,6 +35,12 @@ stdenv.mkDerivation (finalAttrs: {
     gtk4
     libadwaita
   ];
+
+  preFixup = lib.optionalString hideUnsupportedVersionBanner ''
+    gappsWrapperArgs+=(
+      --set container true
+    )
+  '';
 
   meta = with lib; {
     changelog = "https://github.com/cassidyjames/clairvoyant/releases/tag/${finalAttrs.version}";

--- a/pkgs/by-name/cl/clairvoyant/package.nix
+++ b/pkgs/by-name/cl/clairvoyant/package.nix
@@ -7,16 +7,17 @@
 , pkg-config
 , stdenv
 , vala
+, wrapGAppsHook4
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "clairvoyant";
   version = "3.1.3";
 
   src = fetchFromGitHub {
     owner = "cassidyjames";
-    repo = pname;
-    rev = version;
+    repo = "clairvoyant";
+    rev = finalAttrs.version;
     hash = "sha256-eAcd8JJmcsz8dm049g5xsF6gPpNQ6ZvGGIhKAoMlPTU=";
   };
 
@@ -25,6 +26,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     vala
+    wrapGAppsHook4
   ];
 
   buildInputs = [
@@ -33,11 +35,11 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
+    changelog = "https://github.com/cassidyjames/clairvoyant/releases/tag/${finalAttrs.version}";
     description = "Ask questions and get psychic answers";
     homepage = "https://github.com/cassidyjames/clairvoyant";
-    changelog = "https://github.com/cassidyjames/clairvoyant/releases/tag/${version}";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ michaelgrahamevans ];
     mainProgram = "com.github.cassidyjames.clairvoyant";
+    maintainers = with maintainers; [ michaelgrahamevans ];
   };
-}
+})

--- a/pkgs/by-name/cl/clairvoyant/package.nix
+++ b/pkgs/by-name/cl/clairvoyant/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "clairvoyant";
-  version = "3.1.2";
+  version = "3.1.3";
 
   src = fetchFromGitHub {
     owner = "cassidyjames";
     repo = pname;
     rev = version;
-    hash = "sha256-q+yN3FAs1L+GzagOQRK5gw8ptBpHPqWOiCL6aaoWcJo=";
+    hash = "sha256-eAcd8JJmcsz8dm049g5xsF6gPpNQ6ZvGGIhKAoMlPTU=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

Supersedes https://github.com/NixOS/nixpkgs/pull/285165 and adds:

* `wrapGAppsHook4` to fix the app's icon not showing in the about window
* switch to the `finalAttrs` pattern
* an option to disable the "Unsupported version of this app" banner shown when not running as a Flatpak (disabled by default as I feel this is a valid and useful notice)

Upstream changes

* [Changelog](https://github.com/cassidyjames/clairvoyant/releases/tag/3.1.3)
* [Diff](https://github.com/cassidyjames/clairvoyant/compare/3.1.2...3.1.3)
 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
