### PR TITLE
celeste64: add package

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11200,6 +11200,12 @@
     githubId = 7910815;
     name = "Alex McGrath";
   };
+  lychee = {
+    email = "itslychee+nixpkgs@protonmail.com";
+    githubId = 82718618;
+    github = "itslychee";
+    name = "Lychee";
+  };
   lynty = {
     email = "ltdong93+nix@gmail.com";
     github = "Lynty";

--- a/pkgs/by-name/ce/celeste64/deps.nix
+++ b/pkgs/by-name/ce/celeste64/deps.nix
@@ -1,0 +1,11 @@
+{ fetchNuGet }: [
+  (fetchNuGet { pname = "FosterFramework"; version = "0.1.15-alpha"; sha256 = "0pzsdfbsfx28xfqljcwy100xhbs6wyx0z1d5qxgmv3l60di9xkll"; })
+  (fetchNuGet { pname = "Microsoft.AspNetCore.App.Runtime.linux-x64"; version = "8.0.1"; sha256 = "1gjz379y61ag9whi78qxx09bwkwcznkx2mzypgycibxk61g11da1"; })
+  (fetchNuGet { pname = "Microsoft.NET.ILLink.Tasks"; version = "8.0.1"; sha256 = "1drbgqdcvbpisjn8mqfgba1pwb6yri80qc4mfvyczqwrcsj5k2ja"; })
+  (fetchNuGet { pname = "Microsoft.NETCore.App.Runtime.linux-x64"; version = "8.0.1"; sha256 = "1g5b30f4l8a1zjjr3b8pk9mcqxkxqwa86362f84646xaj4iw3a4d"; })
+  (fetchNuGet { pname = "SharpGLTF.Core"; version = "1.0.0-alpha0031"; sha256 = "0ln78mkhbcxqvwnf944hbgg24vbsva2jpih6q3x82d3h7rl1pkh6"; })
+  (fetchNuGet { pname = "SharpGLTF.Runtime"; version = "1.0.0-alpha0031"; sha256 = "0lvb3asi3v0n718qf9y367km7qpkb9wci38y880nqvifpzllw0jg"; })
+  (fetchNuGet { pname = "Sledge.Formats"; version = "1.2.2"; sha256 = "1y0l66m9rym0p1y4ifjlmg3j9lsmhkvbh38frh40rpvf1axn2dyh"; })
+  (fetchNuGet { pname = "Sledge.Formats.Map"; version = "1.1.5"; sha256 = "1bww60hv9xcyxpvkzz5q3ybafdxxkw6knhv97phvpkw84pd0jil6"; })
+  (fetchNuGet { pname = "System.Numerics.Vectors"; version = "4.5.0"; sha256 = "1kzrj37yzawf1b19jq0253rcs8hsq1l2q8g69d7ipnhzb0h97m59"; })
+]

--- a/pkgs/by-name/ce/celeste64/package.nix
+++ b/pkgs/by-name/ce/celeste64/package.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  buildDotnetModule,
+  dotnetCorePackages,
+  fetchFromGitHub,
+  makeDesktopItem,
+  copyDesktopItems,
+  SDL2,
+  libGL,
+  mesa,
+  fmodex,
+  systemd,
+  libpulseaudio,
+  libselinux,
+  wayland,
+  libdecor,
+  xorg,
+  libxkbcommon,
+  libdrm,
+  withSELinux ? false,
+}:
+buildDotnetModule rec {
+  pname = "celeste64";
+  version = "0-unstable-2024-02-02";
+
+  src = fetchFromGitHub {
+    repo = "Celeste64";
+    owner = "ExOK";
+    rev = "e7130d376deed9ddf17a6631cf06d89d19a702c6";
+    hash = "sha256-KCCgjplAk+Nhjxk/p6Omt4GxN36kAgvg/OPbed2Ey+4=";
+  };
+  projectFile = "Celeste64.csproj";
+  dotnet-sdk = dotnetCorePackages.sdk_8_0;
+  dotnet-runtime = dotnetCorePackages.runtime_8_0;
+  nugetDeps = ./deps.nix;
+  strictDeps = true;
+  executables = [ "Celeste64" ];
+  nativeBuildInputs = [ copyDesktopItems ];
+  runtimeDeps =
+    [
+      libdecor
+      libGL
+      SDL2
+      fmodex
+      systemd
+      libpulseaudio
+      wayland
+      libdrm
+      libxkbcommon
+      xorg.libX11
+      xorg.libXfixes
+      xorg.libXext
+      xorg.libXcursor
+      xorg.libXi
+      xorg.libXrandr
+    ]
+    ++ lib.optionals withSELinux [ libselinux ];
+
+  postInstall = ''
+    export ICON_DIR=$out/share/icons/hicolor/256x256/apps
+    mkdir -p $ICON_DIR
+
+    cp -r $src/Content $out/lib/$pname/
+    cp $src/Content/Models/Sources/logo1.png $ICON_DIR/Celeste64.png
+  '';
+
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Celeste64";
+      exec = "Celeste64";
+      comment = meta.description;
+      desktopName = "Celeste64";
+      genericName = "Celeste64";
+      icon = "Celeste64";
+      categories = [ "Game" ];
+    })
+  ];
+
+  meta = {
+    license = with lib.licenses; [ unfree mit ];
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ lychee ];
+    mainProgram = "Celeste64";
+    homepage = "https://github.com/ExOK/Celeste64";
+    description = "Celeste 64: Fragments of the Mountain";
+    downloadPage = "https://maddymakesgamesinc.itch.io/celeste64";
+  };
+}


### PR DESCRIPTION
## Description of changes

Packages https://github.com/ExOK/Celeste64

> This is the source code and general information for Celeste 64: Fragments of the Mountain, a game made by the original Celeste developers in under 2 weeks for Celeste's 6th Anniversary. We haven't done a lot of 3D development so much of this is not very optimized, it's coded in libraries mostly intended for 2D games, and we put it all together very, very quickly. Consider this similar to a weekend jam game, so experiment and learn at your own risk!

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
