### PR TITLE
xdg-utils: unstable-2022-11-06 -> 1.2.0, resholve

### DIFF
--- a/pkgs/tools/X11/xdg-utils/default.nix
+++ b/pkgs/tools/X11/xdg-utils/default.nix
@@ -1,9 +1,10 @@
-{ lib, stdenv, fetchFromGitLab, fetchFromGitHub, fetchpatch
-, file, libxslt, docbook_xml_dtd_412, docbook_xsl, xmlto
-, w3m, gnugrep, gnused, coreutils, xset, perlPackages
-, mimiSupport ? false, gawk
-, bash
-, glib
+{ lib, stdenv, fetchFromGitLab, fetchFromGitHub, fetchpatch, writeText
+# docs deps
+, libxslt, docbook_xml_dtd_412, docbook_xml_dtd_43, docbook_xsl, xmlto
+# runtime deps
+, resholve, bash, coreutils, dbus, file, gawk, gnugrep, gnused, jq, lockfileProgs, nettools, procmail, procps, xdg-user-dirs
+, perl, perlPackages
+, mimiSupport ? false
 , withXdgOpenUsePortalPatch ? true }:
 
 let
@@ -15,72 +16,249 @@ let
     sha256 = "15gw2nyrqmdsdin8gzxihpn77grhk9l97jp7s7pr7sl4n9ya2rpj";
   };
 
-  perlPath = with perlPackages; makePerlPath [
-    NetDBus XMLTwig XMLParser X11Protocol
+  # Required by the common desktop detection code
+  commonDeps = [ dbus coreutils gnugrep gnused ];
+  # These are all faked because the current desktop is detected
+  # based on their presence, so we want them to be missing by default.
+  commonFakes = [
+    "explorer.exe"
+    "gnome-default-applications-properties"
+    "kde-config"
+    "xprop"
   ];
 
+  # This is still required to work around the eval trickery some scripts do
+  commonPrologue = "${writeText "xdg-utils-prologue" ''
+    export PATH=$PATH:${coreutils}/bin
+  ''}";
+
+  solutions = [
+    {
+      scripts = [ "bin/xdg-desktop-icon" ];
+      interpreter = "${bash}/bin/bash";
+      inputs = commonDeps ++ [ xdg-user-dirs ];
+      execer = [
+        "cannot:${xdg-user-dirs}/bin/xdg-user-dir"
+      ];
+      # These are desktop-specific, so we don't want xdg-utils to be able to
+      # call them when in a different setup.
+      fake.external = commonFakes ++ [
+        "gconftool-2"   # GNOME2
+      ];
+      keep."$KDE_SESSION_VERSION" = true;
+      prologue = commonPrologue;
+    }
+
+    {
+      scripts = [ "bin/xdg-desktop-menu" ];
+      interpreter = "${bash}/bin/bash";
+      inputs = commonDeps ++ [ gawk ];
+      fake.external = commonFakes;
+      keep."$KDE_SESSION_VERSION" = true;
+      prologue = commonPrologue;
+    }
+
+    {
+      scripts = [ "bin/xdg-email" ];
+      interpreter = "${bash}/bin/bash";
+      inputs = commonDeps ++ [ gawk "${placeholder "out"}/bin" ];
+      execer = [
+        "cannot:${placeholder "out"}/bin/xdg-mime"
+        "cannot:${placeholder "out"}/bin/xdg-open"
+      ];
+      # These are desktop-specific, so we don't want xdg-utils to be able to
+      # call them when in a different setup.
+      fake.external = commonFakes ++ [
+        "exo-open"           # XFCE
+        "gconftool-2"        # GNOME
+        "gdbus"              # Flatpak (calls xdg-portal)
+        "gio"                # GNOME (new)
+        "gnome-open"         # GNOME (very old)
+        "gvfs-open"          # GNOME (old)
+        "qtxdg-mat"          # LXQT
+        "xdg-email-hook.sh"  # user-defined hook that may be available ambiently
+      ];
+      fix."/bin/echo" = true;
+      keep = {
+        "$command" = true;
+        "$kreadconfig" = true;
+        "$THUNDERBIRD" = true;
+        "$utf8" = true;
+      };
+    }
+
+    {
+      scripts = [ "bin/xdg-icon-resource" ];
+      interpreter = "${bash}/bin/bash";
+      inputs = commonDeps;
+      fake.external = commonFakes;
+      keep."$KDE_SESSION_VERSION" = true;
+      prologue = commonPrologue;
+    }
+
+    {
+      scripts = [ "bin/xdg-mime" ];
+      interpreter = "${bash}/bin/bash";
+      inputs = commonDeps ++ [ file gawk ];
+      # These are desktop-specific, so we don't want xdg-utils to be able to
+      # call them when in a different setup.
+      fake.external = commonFakes ++ [
+        "gio"                # GNOME (new)
+        "gnomevfs-info"      # GNOME (very old)
+        "gvfs-info"          # GNOME (old)
+        "kde4-config"        # Plasma 4
+        "kfile"              # KDE 3
+        "kmimetypefinder"    # Plasma (generic)
+        "kmimetypefinder5"   # Plasma 5
+        "ktraderclient"      # KDE 3
+        "ktradertest"        # KDE 3
+        "mimetype"           # alternative tool for file, pulls in perl, avoid
+        "qtpaths"            # Plasma
+        "qtxdg-mat"          # LXQT
+      ];
+      fix."/usr/bin/file" = true;
+      keep = {
+        "$KDE_SESSION_VERSION" = true;
+        "$KTRADER" = true;
+      };
+      prologue = commonPrologue;
+    }
+
+    {
+      scripts = [ "bin/xdg-open" ];
+      interpreter = "${bash}/bin/bash";
+      inputs = commonDeps ++ [ nettools "${placeholder "out"}/bin" ];
+      execer = [
+        "cannot:${placeholder "out"}/bin/xdg-mime"
+      ];
+      # These are desktop-specific, so we don't want xdg-utils to be able to
+      # call them when in a different setup.
+      fake.external = commonFakes ++ [
+        "cygstart"            # Cygwin
+        "dde-open"            # Deepin
+        "enlightenment_open"  # Enlightenment
+        "exo-open"            # XFCE
+        "gdbus"               # Flatpak (calls xdg-portal)
+        "gio"                 # GNOME (new)
+        "gnome-open"          # GNOME (very old)
+        "gvfs-open"           # GNOME (old)
+        "kde-open"            # Plasma
+        "kfmclient"           # KDE3
+        "mate-open"           # MATE
+        "mimeopen"            # alternative tool for file, pulls in perl, avoid
+        "open"                # macOS
+        "pcmanfm"             # LXDE
+        "qtxdg-mat"           # LXQT
+        "run-mailcap"         # generic
+        "rundll32.exe"        # WSL
+        "wslpath"             # WSL
+      ];
+      fix."$printf" = [ "printf" ];
+      keep = {
+        "env:$command" = true;
+        "$browser" = true;
+        "$KDE_SESSION_VERSION" = true;
+      };
+    }
+
+    {
+      scripts = [ "bin/xdg-screensaver" ];
+      interpreter = "${bash}/bin/bash";
+      inputs = commonDeps ++ [ lockfileProgs nettools perl procmail procps ];
+      # These are desktop-specific, so we don't want xdg-utils to be able to
+      # call them when in a different setup.
+      fake.external = commonFakes ++ [
+        "dcop"                      # KDE3
+        "mate-screensaver-command"  # MATE
+        "xautolock"                 # Xautolock
+        "xscreensaver-command"      # Xscreensaver
+        "xset"                      # generic-ish X
+      ];
+      fix."$lockfile_command" = [ "lockfile" ];
+      keep = {
+        "$MV" = true;
+        "$XPROP" = true;
+      };
+      prologue = "${writeText "xdg-screensaver-prologue" ''
+        export PERL5LIB=${with perlPackages; makePerlPath [ NetDBus XMLTwig XMLParser X11Protocol ]}
+        export PATH=$PATH:${coreutils}/bin
+      ''}";
+    }
+
+    {
+      scripts = [ "bin/xdg-settings" ];
+      interpreter = "${bash}/bin/bash";
+      inputs = commonDeps ++ [ jq "${placeholder "out"}/bin" ];
+      execer = [
+        "cannot:${placeholder "out"}/bin/xdg-mime"
+      ];
+      # These are desktop-specific, so we don't want xdg-utils to be able to
+      # call them when in a different setup.
+      fake.external = commonFakes ++ [
+        "gconftool-2"    # GNOME
+        "kreadconfig"    # Plasma (generic)
+        "kreadconfig5"   # Plasma 5
+        "kreadconfig6"   # Plasma 6
+        "ktradertest"    # KDE3
+        "kwriteconfig"   # Plasma (generic)
+        "kwriteconfig5"  # Plasma 5
+        "kwriteconfig6"  # Plasma 6
+        "qtxdg-mat"      # LXQT
+      ];
+      keep = {
+        "$KDE_SESSION_VERSION" = true;
+        # get_browser_$handler
+        "$handler" = true;
+      };
+    }
+  ];
 in
 
 stdenv.mkDerivation rec {
   pname = "xdg-utils";
-  version = "unstable-2022-11-06";
+  version = "1.2.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "xdg";
     repo = "xdg-utils";
-    rev = "8ae02631a9806da11b34cd6b274af02d28aee5da";
-    sha256 = "sha256-WdnnAiPYbREny633FnBi5tD9hDuF8NCVVbUaAVIKTxM=";
+    rev = "v${version}";
+    hash = "sha256-rjNIO4B9jHsBmPaugWTMqTGNpjiw0MTEmf9/ds2Mud4=";
   };
 
-  patches = lib.optionals withXdgOpenUsePortalPatch [
+  patches = [
+    # Backport typo fix
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/xdg/xdg-utils/-/commit/af2fe0d1dcbcd982d84ddf2bbd174afe90976ed9.patch";
+      hash = "sha256-HhQk06wWkyWjSxjXet+sADKf1irswKxDA8WuOknZKRs=";
+    })
+    # Backport docs rendering fixes
+    # See: https://gitlab.freedesktop.org/xdg/xdg-utils/-/merge_requests/106
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/xdg/xdg-utils/-/commit/403a720ad18920030418a7c3d1f2caba9ce3892d.patch";
+      hash = "sha256-XxFUeyXENHCy+wplIJ5OzoU5oyA4v1bz/9qMXp1ZwsE=";
+    })
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/xdg/xdg-utils/-/commit/a137f2ba87620402aca21b14fb1d79517782dd29.patch";
+      hash = "sha256-XFUAWn4uOyzgLdvupBxsO7wm6VDSzYj1SGZEM+9ouec=";
+    })
+  ] ++ lib.optionals withXdgOpenUsePortalPatch [
     # Allow forcing the use of XDG portals using NIXOS_XDG_OPEN_USE_PORTAL environment variable.
     # Upstream PR: https://github.com/freedesktop/xdg-utils/pull/12
     ./allow-forcing-portal-use.patch
-    # Allow opening files when using portal with xdg-open.
-    # Upstream PR: https://gitlab.freedesktop.org/xdg/xdg-utils/-/merge_requests/65
-    (fetchpatch {
-      name = "support-openfile-with-portal.patch";
-      url = "https://gitlab.freedesktop.org/xdg/xdg-utils/-/commit/5cd8c38f58d9db03240f4bc67267fe3853b66ec7.diff";
-      hash = "sha256-snkhxwGF9hpqEh5NGG8xixTi/ydAk5apXRtgYrVgNY8=";
-    })
   ];
 
   # just needed when built from git
-  nativeBuildInputs = [ libxslt docbook_xml_dtd_412 docbook_xsl xmlto w3m ];
+  nativeBuildInputs = [ libxslt docbook_xml_dtd_412 docbook_xml_dtd_43 docbook_xsl xmlto ];
 
   # explicitly provide a runtime shell so patchShebangs is consistent across build platforms
   buildInputs = [ bash ];
 
   postInstall = lib.optionalString mimiSupport ''
     cp ${mimisrc}/xdg-open $out/bin/xdg-open
-  '' + ''
-    sed  '2s#.#\
-    sed()   { ${gnused}/bin/sed     "$@"; }\
-    grep()  { ${gnugrep}/bin/grep   "$@"; }\
-    egrep() { ${gnugrep}/bin/egrep  "$@"; }\
-    file()  { ${file}/bin/file      "$@"; }\
-    awk()   { ${gawk}/bin/awk       "$@"; }\
-    xset()  { ${xset}/bin/xset      "$@"; }\
-    perl()  { PERL5LIB=${perlPath} ${perlPackages.perl}/bin/perl "$@"; }\
-    mimetype() { ${perlPackages.FileMimeInfo}/bin/mimetype "$@"; }\
-    PATH=$PATH:'$out'/bin:${coreutils}/bin\
-    &#' -i "$out"/bin/*
-
-    substituteInPlace $out/bin/xdg-open \
-      --replace "/usr/bin/printf" "${coreutils}/bin/printf" \
-      --replace "gdbus" "${glib}/bin/gdbus" \
-      --replace "mimeopen" "${perlPackages.FileMimeInfo}/bin/mimeopen"
-
-    substituteInPlace $out/bin/xdg-mime \
-      --replace "/usr/bin/file" "${file}/bin/file"
-
-    substituteInPlace $out/bin/xdg-email \
-      --replace "/bin/echo" "${coreutils}/bin/echo" \
-      --replace "gdbus" "${glib}/bin/gdbus"
-
-    sed 's|\bwhich\b|type -P|g' -i "$out"/bin/*
   '';
+
+  preFixup = lib.concatStringsSep "\n" (map (resholve.phraseSolution "xdg-utils-resholved") solutions);
 
   meta = with lib; {
     homepage = "https://www.freedesktop.org/wiki/Software/xdg-utils/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36541,9 +36541,7 @@ with pkgs;
 
   xdg-user-dirs = callPackage ../tools/X11/xdg-user-dirs { };
 
-  xdg-utils = callPackage ../tools/X11/xdg-utils {
-    w3m = buildPackages.w3m-batch;
-  };
+  xdg-utils = callPackage ../tools/X11/xdg-utils {};
 
   xdgmenumaker = callPackage ../applications/misc/xdgmenumaker { };
 


### PR DESCRIPTION
## Description of changes

Upstream is a giant pile of bash goop. Apply resholve to keep the goop somewhat manageable (it's still not really).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
