### PR TITLE
maintainers: add `koppor`

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10001,6 +10001,12 @@
     githubId = 264372;
     name = "Jan van den Berg";
   };
+  koppor = {
+    email = "kopp.dev@gmail.com";
+    github = "koppor";
+    githubId = 1366654;
+    name = "Oliver Kopp";
+  };
   koral = {
     email = "koral@mailoo.org";
     github = "k0ral";


### PR DESCRIPTION
This adds @koppor to maintainers - as requested at https://github.com/NixOS/nixpkgs/pull/284708#discussion_r1470328996