### PR TITLE
maintainers: Refine howto for adding a new maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -58,6 +58,10 @@
          nix-build lib/tests/maintainers.nix
 
     See `./scripts/check-maintainer-github-handles.sh` for an example on how to work with this data.
+
+    When adding a new maintainer, be aware of the current commit conventions
+    documented at [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#commit-conventions)
+    file located in the root of the Nixpkgs repo.
 */
 {
   _0b11stan = {


### PR DESCRIPTION
When adding a new maintainer, there is a good howto. That howto, however, is not complete. It misses to point out the correct git commit messate (as stated at https://github.com/NixOS/nixpkgs/pull/285242#issuecomment-1918797304).

This PR fixes that by adding another howto step.