### PR TITLE
nixVersions.nix_2_20: init at 2.20.5; nixVersions.unstable: 2.19 -> 2.20

### DIFF
--- a/pkgs/tools/package-management/nix/common.nix
+++ b/pkgs/tools/package-management/nix/common.nix
@@ -15,6 +15,7 @@ let
   atLeast210 = lib.versionAtLeast version "2.10pre";
   atLeast213 = lib.versionAtLeast version "2.13pre";
   atLeast214 = lib.versionAtLeast version "2.14pre";
+  atLeast220 = lib.versionAtLeast version "2.20pre";
   atLeast221 = lib.versionAtLeast version "2.21pre";
   # Major.minor versions unaffected by CVE-2024-27297
   unaffectedByFodSandboxEscape = [
@@ -48,6 +49,7 @@ in
 , lib
 , libarchive
 , libcpuid
+, libgit2
 , libsodium
 , libxml2
 , libxslt
@@ -126,6 +128,8 @@ self = stdenv.mkDerivation {
     gtest
     libarchive
     lowdown
+  ] ++ lib.optionals atLeast220 [
+    libgit2
   ] ++ lib.optionals stdenv.isDarwin [
     Security
   ] ++ lib.optionals (stdenv.isx86_64) [

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -282,7 +282,7 @@ in lib.makeExtensible (self: ({
 
   stable = addFallbackPathsCheck self.nix_2_18;
 
-  unstable = self.nix_2_19;
+  unstable = self.nix_2_20;
 } // lib.optionalAttrs config.allowAliases {
   nix_2_4 = throw "nixVersions.nix_2_4 has been removed";
 

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -17,8 +17,19 @@ let
   boehmgc-nix_2_3 = boehmgc.override { enableLargeConfig = true; };
 
   boehmgc-nix = boehmgc-nix_2_3.overrideAttrs (drv: {
-    # Part of the GC solution in https://github.com/NixOS/nix/pull/4944
-    patches = (drv.patches or [ ]) ++ [ ./patches/boehmgc-coroutine-sp-fallback.patch ];
+    patches = (drv.patches or [ ]) ++ [
+      # Part of the GC solution in https://github.com/NixOS/nix/pull/4944
+      ./patches/boehmgc-coroutine-sp-fallback.patch
+
+      # Required since 2.20, and has always been a valid change
+      # Awaiting 8.2 patch release of https://github.com/ivmai/bdwgc/commit/d1d4194c010bff2dc9237223319792cae834501c
+      # or master release of https://github.com/ivmai/bdwgc/commit/86b3bf0c95b66f718c3cb3d35fd7387736c2a4d7
+      (fetchpatch {
+        name = "boehmgc-traceable_allocator-public.diff";
+        url = "https://github.com/NixOS/nix/raw/2.20.0/dep-patches/boehmgc-traceable_allocator-public.diff";
+        hash = "sha256-FLsHY/JS46neiSyyQkVpbHZEFvWSCzWrFQu1CC71sh4=";
+      })
+    ];
   });
 
   # old nix fails to build with newer aws-sdk-cpp and the patch doesn't apply

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -258,6 +258,11 @@ in lib.makeExtensible (self: ({
     ];
   };
 
+  nix_2_20 = common {
+    version = "2.20.5";
+    hash = "sha256-bfFe38BkoQws7om4gBtBWoNTLkt9piMXdLLoHYl+vBQ=";
+  };
+
   # The minimum Nix version supported by Nixpkgs
   # Note that some functionality *might* have been backported into this Nix version,
   # making this package an inaccurate representation of what features are available


### PR DESCRIPTION
## Description of changes

Fails to compile https://github.com/NixOS/nix/issues/9888

```
nix> In file included from include/boost/container/vector.hpp:27,
nix>                  from include/boost/container/small_vector.hpp:27,
nix>                  from src/libexpr/gc-small-vector.hh:3,
nix>                  from src/libexpr/eval.cc:21:
nix> include/boost/container/allocator_traits.hpp: In instantiation of 'struct boost::container::allocator_traits<traceable_allocator<void> >':
nix> include/boost/container/small_vector.hpp:122:7:   required from 'class boost::container::small_vector_allocator<nix::Value*, traceable_allocator<void>, void>'
nix> include/boost/container/allocator_traits.hpp:145:48:   required from 'struct boost::container::allocator_traits<boost::container::small_vector_allocator<nix::Value*, traceable_allocator<void>, void> >'
nix> include/boost/container/vector.hpp:802:88:   required from 'class boost::container::vector<nix::Value*, boost::container::small_vector_allocator<nix::Value*, traceable_allocator<void>,
void>, void>'
nix> include/boost/container/small_vector.hpp:341:7:   required from 'class boost::container::small_vector_base<nix::Value*, traceable_allocator<nix::Value*>, void>'
nix> include/boost/container/small_vector.hpp:531:7:   required from 'class boost::container::small_vector<nix::Value*, 4, traceable_allocator<nix::Value*>, void>'
nix> src/libexpr/eval.cc:1730:31:   required from here
nix> include/boost/container/allocator_traits.hpp:145:48: error: 'typedef void traceable_allocator<void>::value_type' is private within this context
nix> In file included from src/libexpr/value.hh:15,
nix>                  from src/libexpr/nixexpr.hh:7,
nix>                  from src/libexpr/attr-set.hh:4,
nix>                  from src/libexpr/eval.hh:4,
nix>                  from src/libexpr/eval.cc:1:
nix> /nix/store/7ikfgkswxfcqcxhpcz3bcpg98hv523y4-boehm-gc-8.2.4-dev/include/gc/gc_allocator.h:319:23: note: declared private here
nix>   319 |   typedef void        value_type;
nix>       |                       ^~~~~~~~~~
nix> include/boost/container/allocator_traits.hpp:210:13: error: 'typedef void traceable_allocator<void>::value_type' is private within this context
nix> /nix/store/7ikfgkswxfcqcxhpcz3bcpg98hv523y4-boehm-gc-8.2.4-dev/include/gc/gc_allocator.h:319:23: note: declared private here
nix>   319 |   typedef void        value_type;
nix>       |                       ^~~~~~~~~~
nix> include/boost/container/allocator_traits.hpp:215:16: error: 'typedef void traceable_allocator<void>::value_type' is private within this context
nix> /nix/store/7ikfgkswxfcqcxhpcz3bcpg98hv523y4-boehm-gc-8.2.4-dev/include/gc/gc_allocator.h:319:23: note: declared private here
nix>   319 |   typedef void        value_type;
nix>       |                       ^~~~~~~~~~
nix> include/boost/container/allocator_traits.hpp:215:16: error: 'typedef void traceable_allocator<void>::value_type' is private within this context
nix> /nix/store/7ikfgkswxfcqcxhpcz3bcpg98hv523y4-boehm-gc-8.2.4-dev/include/gc/gc_allocator.h:319:23: note: declared private here
nix>   319 |   typedef void        value_type;
nix>       |                       ^~~~~~~~~~
nix> include/boost/container/allocator_traits.hpp:219:13: error: 'typedef void traceable_allocator<void>::value_type' is private within this context
nix> /nix/store/7ikfgkswxfcqcxhpcz3bcpg98hv523y4-boehm-gc-8.2.4-dev/include/gc/gc_allocator.h:319:23: note: declared private here
nix>   319 |   typedef void        value_type;
nix>       |                       ^~~~~~~~~~
nix> include/boost/container/allocator_traits.hpp:223:16: error: 'typedef void traceable_allocator<void>::value_type' is private within this context
nix> /nix/store/7ikfgkswxfcqcxhpcz3bcpg98hv523y4-boehm-gc-8.2.4-dev/include/gc/gc_allocator.h:319:23: note: declared private here
nix>   319 |   typedef void        value_type;
nix>       |                       ^~~~~~~~~~
nix> include/boost/container/allocator_traits.hpp:228:16: error: 'typedef void traceable_allocator<void>::value_type' is private within this context
nix> /nix/store/7ikfgkswxfcqcxhpcz3bcpg98hv523y4-boehm-gc-8.2.4-dev/include/gc/gc_allocator.h:319:23: note: declared private here
nix>   319 |   typedef void        value_type;
nix>       |                       ^~~~~~~~~~
nix> include/boost/container/allocator_traits.hpp:233:16: error: 'typedef void traceable_allocator<void>::value_type' is private within this context
nix> /nix/store/7ikfgkswxfcqcxhpcz3bcpg98hv523y4-boehm-gc-8.2.4-dev/include/gc/gc_allocator.h:319:23: note: declared private here
nix>   319 |   typedef void        value_type;
nix>       |                       ^~~~~~~~~~
nix> In file included from include/boost/container/vector.hpp:27,
nix>                  from include/boost/container/small_vector.hpp:27,
nix>                  from src/libexpr/gc-small-vector.hh:3,
nix>                  from src/libexpr/primops.cc:7:
nix> include/boost/container/allocator_traits.hpp: In instantiation of 'struct boost::container::allocator_traits<traceable_allocator<void> >':
nix> include/boost/container/small_vector.hpp:122:7:   required from 'class boost::container::small_vector_allocator<nix::Value*, traceable_allocator<void>, void>'
nix> include/boost/container/allocator_traits.hpp:145:48:   required from 'struct boost::container::allocator_traits<boost::container::small_vector_allocator<nix::Value*, traceable_allocator<void>, void> >'
nix> include/boost/container/vector.hpp:802:88:   required from 'class boost::container::vector<nix::Value*, boost::container::small_vector_allocator<nix::Value*, traceable_allocator<void>,
void>, void>'
nix> include/boost/container/small_vector.hpp:341:7:   required from 'class boost::container::small_vector_base<nix::Value*, traceable_allocator<nix::Value*>, void>'
nix> include/boost/container/small_vector.hpp:531:7:   required from 'class boost::container::small_vector<nix::Value*, 128, traceable_allocator<nix::Value*>, void>'
nix> src/libexpr/primops.cc:2733:56:   required from here
nix> include/boost/container/allocator_traits.hpp:145:48: error: 'typedef void traceable_allocator<void>::value_type' is private within this context
nix> In file included from src/libexpr/value.hh:15,
nix>                  from src/libexpr/nixexpr.hh:7,
nix>                  from src/libexpr/attr-set.hh:4,
nix>                  from src/libexpr/eval.hh:4,
nix>                  from src/libexpr/eval-inline.hh:5,
nix>                  from src/libexpr/primops.cc:4:
nix> /nix/store/7ikfgkswxfcqcxhpcz3bcpg98hv523y4-boehm-gc-8.2.4-dev/include/gc/gc_allocator.h:319:23: note: declared private here
nix>   319 |   typedef void        value_type;
nix>       |                       ^~~~~~~~~~
nix> include/boost/container/allocator_traits.hpp:210:13: error: 'typedef void traceable_allocator<void>::value_type' is private within this context
nix> /nix/store/7ikfgkswxfcqcxhpcz3bcpg98hv523y4-boehm-gc-8.2.4-dev/include/gc/gc_allocator.h:319:23: note: declared private here
nix>   319 |   typedef void        value_type;
nix>       |                       ^~~~~~~~~~
nix> include/boost/container/allocator_traits.hpp:215:16: error: 'typedef void traceable_allocator<void>::value_type' is private within this context
nix> /nix/store/7ikfgkswxfcqcxhpcz3bcpg98hv523y4-boehm-gc-8.2.4-dev/include/gc/gc_allocator.h:319:23: note: declared private here
nix>   319 |   typedef void        value_type;
nix>       |                       ^~~~~~~~~~
nix> include/boost/container/allocator_traits.hpp:215:16: error: 'typedef void traceable_allocator<void>::value_type' is private within this context
nix> /nix/store/7ikfgkswxfcqcxhpcz3bcpg98hv523y4-boehm-gc-8.2.4-dev/include/gc/gc_allocator.h:319:23: note: declared private here
nix>   319 |   typedef void        value_type;
nix>       |                       ^~~~~~~~~~
nix> include/boost/container/allocator_traits.hpp:219:13: error: 'typedef void traceable_allocator<void>::value_type' is private within this context
nix> /nix/store/7ikfgkswxfcqcxhpcz3bcpg98hv523y4-boehm-gc-8.2.4-dev/include/gc/gc_allocator.h:319:23: note: declared private here
nix>   319 |   typedef void        value_type;
nix>       |                       ^~~~~~~~~~
nix> include/boost/container/allocator_traits.hpp:223:16: error: 'typedef void traceable_allocator<void>::value_type' is private within this context
nix> /nix/store/7ikfgkswxfcqcxhpcz3bcpg98hv523y4-boehm-gc-8.2.4-dev/include/gc/gc_allocator.h:319:23: note: declared private here
nix>   319 |   typedef void        value_type;
nix>       |                       ^~~~~~~~~~
nix> include/boost/container/allocator_traits.hpp:228:16: error: 'typedef void traceable_allocator<void>::value_type' is private within this context
nix> /nix/store/7ikfgkswxfcqcxhpcz3bcpg98hv523y4-boehm-gc-8.2.4-dev/include/gc/gc_allocator.h:319:23: note: declared private here
nix>   319 |   typedef void        value_type;
nix>       |                       ^~~~~~~~~~
nix> include/boost/container/allocator_traits.hpp:233:16: error: 'typedef void traceable_allocator<void>::value_type' is private within this context
nix> /nix/store/7ikfgkswxfcqcxhpcz3bcpg98hv523y4-boehm-gc-8.2.4-dev/include/gc/gc_allocator.h:319:23: note: declared private here
nix>   319 |   typedef void        value_type;
nix>       |                       ^~~~~~~~~~
nix> make: *** [mk/patterns.mk:2: src/libexpr/eval.o] Error 1
nix> make: *** Waiting for unfinished jobs....
nix> make: *** [mk/patterns.mk:2: src/libexpr/primops.o] Error 1
nix> rm src/nix/generated-doc/files/profiles.md
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
