### PR TITLE
pipewire: 1.0.1 -> 1.0.2, big cleanup

### DIFF
--- a/pkgs/development/libraries/pipewire/default.nix
+++ b/pkgs/development/libraries/pipewire/default.nix
@@ -1,8 +1,6 @@
 { stdenv
 , lib
-, buildPackages
 , fetchFromGitLab
-, fetchpatch
 , python3
 , meson
 , ninja
@@ -28,7 +26,6 @@
 , readline # meson can't find <7 as those versions don't have a .pc file
 , lilv
 , makeFontsConf
-, callPackage
 , nixosTests
 , withValgrind ? lib.meta.availableOn stdenv.hostPlatform valgrind
 , valgrind
@@ -76,155 +73,141 @@
 # Bluetooth codec only makes sense if general bluetooth enabled
 assert ldacbtSupport -> bluezSupport;
 
-let
-  mesonEnableFeature = b: if b then "enabled" else "disabled";
+stdenv.mkDerivation(finalAttrs: {
+  pname = "pipewire";
+  version = "1.0.2";
 
-  self = stdenv.mkDerivation rec {
-    pname = "pipewire";
-    version = "1.0.1";
+  outputs = [
+    "out"
+    "jack"
+    "dev"
+    "doc"
+    "man"
+    "installedTests"
+  ];
 
-    outputs = [
-      "out"
-      "jack"
-      "dev"
-      "doc"
-      "man"
-      "installedTests"
-    ];
-
-    src = fetchFromGitLab {
-      domain = "gitlab.freedesktop.org";
-      owner = "pipewire";
-      repo = "pipewire";
-      rev = version;
-      sha256 = "sha256-rvf0sZRgDDLcqroLg7hcMUqXD/4JT+3lBRX6/m+3Ry8=";
-    };
-
-    patches = [
-      # Load libjack from a known location
-      ./0060-libjack-path.patch
-      # Move installed tests into their own output.
-      ./0070-installed-tests-path.patch
-
-      # Remove for release post 1.0.1:
-      (fetchpatch {
-        # https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/1750
-        name = "pipewire-spa-libcamera-use-cameraconfiguration-orientation-pr1750.patch";
-        url = "https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/1750.patch ";
-        hash = "sha256-Ugg913KZDKELnYLwpDEgYh92YPxccw61l6kAJulBbIA=";
-      })
-    ];
-
-    strictDeps = true;
-    nativeBuildInputs = [
-      docutils
-      doxygen
-      graphviz
-      meson
-      ninja
-      pkg-config
-      python3
-      glib
-    ];
-
-    buildInputs = [
-      alsa-lib
-      dbus
-      glib
-      libjack2
-      libusb1
-      libselinux
-      libsndfile
-      lilv
-      ncurses
-      readline
-      udev
-      vulkan-headers
-      vulkan-loader
-      tinycompress
-    ] ++ (if enableSystemd then [ systemd ] else [ eudev ])
-    ++ (if lib.meta.availableOn stdenv.hostPlatform webrtc-audio-processing_1 then [ webrtc-audio-processing_1 ] else [ webrtc-audio-processing ])
-    ++ lib.optionals gstreamerSupport [ gst_all_1.gst-plugins-base gst_all_1.gstreamer ]
-    ++ lib.optionals libcameraSupport [ libcamera libdrm ]
-    ++ lib.optional ffmpegSupport ffmpeg
-    ++ lib.optionals bluezSupport [ bluez libfreeaptx liblc3 sbc fdk_aac libopus ]
-    ++ lib.optional ldacbtSupport ldacbt
-    ++ lib.optional nativeModemManagerSupport modemmanager
-    ++ lib.optional pulseTunnelSupport libpulseaudio
-    ++ lib.optional zeroconfSupport avahi
-    ++ lib.optional raopSupport openssl
-    ++ lib.optional rocSupport roc-toolkit
-    ++ lib.optionals x11Support [ libcanberra xorg.libX11 xorg.libXfixes ]
-    ++ lib.optional mysofaSupport libmysofa
-    ++ lib.optional ffadoSupport ffado;
-
-    # Valgrind binary is required for running one optional test.
-    nativeCheckInputs = lib.optional withValgrind valgrind;
-
-    mesonFlags = [
-      "-Ddocs=enabled"
-      "-Dudevrulesdir=lib/udev/rules.d"
-      "-Dinstalled_tests=enabled"
-      "-Dinstalled_test_prefix=${placeholder "installedTests"}"
-      "-Dlibjack-path=${placeholder "jack"}/lib"
-      "-Dlibcamera=${mesonEnableFeature libcameraSupport}"
-      "-Dlibffado=${mesonEnableFeature ffadoSupport}"
-      "-Droc=${mesonEnableFeature rocSupport}"
-      "-Dlibpulse=${mesonEnableFeature pulseTunnelSupport}"
-      "-Davahi=${mesonEnableFeature zeroconfSupport}"
-      "-Dgstreamer=${mesonEnableFeature gstreamerSupport}"
-      "-Dsystemd-system-service=${mesonEnableFeature enableSystemd}"
-      "-Dudev=${mesonEnableFeature (!enableSystemd)}"
-      "-Dffmpeg=${mesonEnableFeature ffmpegSupport}"
-      "-Dbluez5=${mesonEnableFeature bluezSupport}"
-      "-Dbluez5-backend-hsp-native=${mesonEnableFeature nativeHspSupport}"
-      "-Dbluez5-backend-hfp-native=${mesonEnableFeature nativeHfpSupport}"
-      "-Dbluez5-backend-native-mm=${mesonEnableFeature nativeModemManagerSupport}"
-      "-Dbluez5-backend-ofono=${mesonEnableFeature ofonoSupport}"
-      "-Dbluez5-backend-hsphfpd=${mesonEnableFeature hsphfpdSupport}"
-      # source code is not easily obtainable
-      "-Dbluez5-codec-lc3plus=disabled"
-      "-Dbluez5-codec-lc3=${mesonEnableFeature bluezSupport}"
-      "-Dbluez5-codec-ldac=${mesonEnableFeature ldacbtSupport}"
-      "-Dsysconfdir=/etc"
-      "-Draop=${mesonEnableFeature raopSupport}"
-      "-Dsession-managers="
-      "-Dvulkan=enabled"
-      "-Dx11=${mesonEnableFeature x11Support}"
-      "-Dx11-xfixes=${mesonEnableFeature x11Support}"
-      "-Dlibcanberra=${mesonEnableFeature x11Support}"
-      "-Dlibmysofa=${mesonEnableFeature mysofaSupport}"
-      "-Dsdl2=disabled" # required only to build examples, causes dependency loop
-      "-Drlimits-install=false" # installs to /etc, we won't use this anyway
-      "-Dcompress-offload=enabled"
-      "-Dman=enabled"
-    ];
-
-    # Fontconfig error: Cannot load default config file
-    FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
-
-    doCheck = true;
-
-    postUnpack = ''
-      patchShebangs source/doc/*.py
-      patchShebangs source/doc/input-filter-h.sh
-    '';
-
-    postInstall = ''
-      moveToOutput "bin/pw-jack" "$jack"
-    '';
-
-    passthru.tests.installed-tests = nixosTests.installed-tests.pipewire;
-
-    meta = with lib; {
-      description = "Server and user space API to deal with multimedia pipelines";
-      changelog = "https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/${version}";
-      homepage = "https://pipewire.org/";
-      license = licenses.mit;
-      platforms = platforms.linux;
-      maintainers = with maintainers; [ kranzes k900 ];
-    };
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "pipewire";
+    repo = "pipewire";
+    rev = finalAttrs.version;
+    sha256 = "sha256-+D9+IvKDrsEdhJd9bRsWg6vwvbEomOxN/5XgTHQimQI=";
   };
 
-in
-self
+  patches = [
+    # Load libjack from a known location
+    ./0060-libjack-path.patch
+    # Move installed tests into their own output.
+    ./0070-installed-tests-path.patch
+  ];
+
+  strictDeps = true;
+  nativeBuildInputs = [
+    docutils
+    doxygen
+    graphviz
+    meson
+    ninja
+    pkg-config
+    python3
+    glib
+  ];
+
+  buildInputs = [
+    alsa-lib
+    dbus
+    glib
+    libjack2
+    libusb1
+    libselinux
+    libsndfile
+    lilv
+    ncurses
+    readline
+    udev
+    vulkan-headers
+    vulkan-loader
+    tinycompress
+  ] ++ (if enableSystemd then [ systemd ] else [ eudev ])
+  ++ (if lib.meta.availableOn stdenv.hostPlatform webrtc-audio-processing_1 then [ webrtc-audio-processing_1 ] else [ webrtc-audio-processing ])
+  ++ lib.optionals gstreamerSupport [ gst_all_1.gst-plugins-base gst_all_1.gstreamer ]
+  ++ lib.optionals libcameraSupport [ libcamera libdrm ]
+  ++ lib.optional ffmpegSupport ffmpeg
+  ++ lib.optionals bluezSupport [ bluez libfreeaptx liblc3 sbc fdk_aac libopus ]
+  ++ lib.optional ldacbtSupport ldacbt
+  ++ lib.optional nativeModemManagerSupport modemmanager
+  ++ lib.optional pulseTunnelSupport libpulseaudio
+  ++ lib.optional zeroconfSupport avahi
+  ++ lib.optional raopSupport openssl
+  ++ lib.optional rocSupport roc-toolkit
+  ++ lib.optionals x11Support [ libcanberra xorg.libX11 xorg.libXfixes ]
+  ++ lib.optional mysofaSupport libmysofa
+  ++ lib.optional ffadoSupport ffado;
+
+  # Valgrind binary is required for running one optional test.
+  nativeCheckInputs = lib.optional withValgrind valgrind;
+
+  mesonFlags = [
+    (lib.mesonEnable "docs" true)
+    (lib.mesonOption "udevrulesdir" "lib/udev/rules.d")
+    (lib.mesonEnable "installed_tests" true)
+    (lib.mesonOption "installed_test_prefix" (placeholder "installedTests"))
+    (lib.mesonOption "libjack-path" "${placeholder "jack"}/lib")
+    (lib.mesonEnable "libcamera" libcameraSupport)
+    (lib.mesonEnable "libffado" ffadoSupport)
+    (lib.mesonEnable "roc" rocSupport)
+    (lib.mesonEnable "libpulse" pulseTunnelSupport)
+    (lib.mesonEnable "avahi" zeroconfSupport)
+    (lib.mesonEnable "gstreamer" gstreamerSupport)
+    (lib.mesonEnable "systemd-system-service" enableSystemd)
+    (lib.mesonEnable "udev" (!enableSystemd))
+    (lib.mesonEnable "ffmpeg" ffmpegSupport)
+    (lib.mesonEnable "bluez5" bluezSupport)
+    (lib.mesonEnable "bluez5-backend-hsp-native" nativeHspSupport)
+    (lib.mesonEnable "bluez5-backend-hfp-native" nativeHfpSupport)
+    (lib.mesonEnable "bluez5-backend-native-mm" nativeModemManagerSupport)
+    (lib.mesonEnable "bluez5-backend-ofono" ofonoSupport)
+    (lib.mesonEnable "bluez5-backend-hsphfpd" hsphfpdSupport)
+    # source code is not easily obtainable
+    (lib.mesonEnable "bluez5-codec-lc3plus" false)
+    (lib.mesonEnable "bluez5-codec-lc3" bluezSupport)
+    (lib.mesonEnable "bluez5-codec-ldac" ldacbtSupport)
+    (lib.mesonOption "sysconfdir" "/etc")
+    (lib.mesonEnable "raop" raopSupport)
+    (lib.mesonOption "session-managers" "")
+    (lib.mesonEnable "vulkan" true)
+    (lib.mesonEnable "x11" x11Support)
+    (lib.mesonEnable "x11-xfixes" x11Support)
+    (lib.mesonEnable "libcanberra" x11Support)
+    (lib.mesonEnable "libmysofa" mysofaSupport)
+    (lib.mesonEnable "sdl2" false) # required only to build examples, causes dependency loop
+    (lib.mesonBool "rlimits-install" false) # installs to /etc, we won't use this anyway
+    (lib.mesonEnable "compress-offload" true)
+    (lib.mesonEnable "man" true)
+  ];
+
+  # Fontconfig error: Cannot load default config file
+  FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
+
+  doCheck = true;
+
+  postUnpack = ''
+    patchShebangs source/doc/*.py
+    patchShebangs source/doc/input-filter-h.sh
+  '';
+
+  postInstall = ''
+    moveToOutput "bin/pw-jack" "$jack"
+  '';
+
+  passthru.tests.installed-tests = nixosTests.installed-tests.pipewire;
+
+  meta = with lib; {
+    description = "Server and user space API to deal with multimedia pipelines";
+    changelog = "https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/${version}";
+    homepage = "https://pipewire.org/";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ kranzes k900 ];
+  };
+})


### PR DESCRIPTION
Diff: https://gitlab.freedesktop.org/pipewire/pipewire/-/compare/1.0.1...1.0.2

Changelog: https://gitlab.freedesktop.org/pipewire/pipewire/-/releases/24.05pre-git

## Description of changes

- switched to lib.meson* helpers
- removed unnecessary recursion
- finalAttrs instead of rec
- removed unused args

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
