### PR TITLE
lxc: fix aarch64 build failure

### DIFF
--- a/pkgs/os-specific/linux/lxc/default.nix
+++ b/pkgs/os-specific/linux/lxc/default.nix
@@ -45,7 +45,13 @@ stdenv.mkDerivation rec {
     systemd
   ];
 
-  patches = [ ./add-meson-options.patch ];
+  patches = [
+     # make build more nix compatible
+    ./add-meson-options.patch
+
+    # fix docbook2man version detection
+    ./docbook-hack.patch
+  ];
 
   mesonFlags = [
     "-Dinstall-init-files=false"

--- a/pkgs/os-specific/linux/lxc/docbook-hack.patch
+++ b/pkgs/os-specific/linux/lxc/docbook-hack.patch
@@ -1,0 +1,21 @@
+diff --git a/meson.build b/meson.build
+index d1527679e..360824994 100644
+--- a/meson.build
++++ b/meson.build
+@@ -320,15 +320,7 @@ docconf.set('LXC_USERNIC_CONF', lxc_user_network_conf)
+ docconf.set('LXC_USERNIC_DB', lxc_user_network_db)
+ docconf.set('PACKAGE_VERSION', version_data.get('LXC_VERSION'))
+ docconf.set('docdtd', '"-//OASIS//DTD DocBook XML" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd"')
+-sgml2man = find_program('docbook2X2man', 'docbook2x-man', 'db2x_docbook2man', 'docbook2man', 'docbook-to-man', required: false, version: '>=0.8')
+-if not sgml2man.found()
+-    sgml2man = find_program('docbook2man', required: false, version: '<0.8')
+-    if sgml2man.found()
+-        docconf.set('docdtd', '"-//Davenport//DTD DocBook V3.0//EN"')
+-    elif want_mans
+-        error('missing required docbook2x or docbook-utils dependency')
+-    endif
+-endif
++sgml2man = find_program('docbook2X2man', 'docbook2x-man', 'db2x_docbook2man', 'docbook2man', 'docbook-to-man', required: false)
+ 
+ ## Threads.
+ threads = dependency('threads')


### PR DESCRIPTION
## Description of changes

Starting with commit 1cf2d7357c61b9c9ca5c92cb0e810571edee948a lxc is failing on aarch64 only. For whatever reason, the version check done on docbook2man here is no longer registering as >=0.8.8

https://github.com/lxc/lxc/blob/3efa1c3037bff09d12e36727cd6fea2f97fc0a7c/meson.build#L323

This falls through to this line, which changes the behavior of the configured sgml header.

https://github.com/lxc/lxc/blob/3efa1c3037bff09d12e36727cd6fea2f97fc0a7c/meson.build#L327

Instead of figuring out /why/ this is the case, I'm just going to skip the check for lxc since we won't ever ship docbook2x < 0.8.



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
