### PR TITLE
lib.fileset.gitTracked: Allow clones of shallow repositories

### DIFF
--- a/lib/fileset/internal.nix
+++ b/lib/fileset/internal.nix
@@ -5,6 +5,7 @@ let
     isAttrs
     isPath
     isString
+    nixVersion
     pathExists
     readDir
     split
@@ -17,6 +18,7 @@ let
     attrNames
     attrValues
     mapAttrs
+    optionalAttrs
     zipAttrsWith
     ;
 
@@ -56,6 +58,7 @@ let
     substring
     stringLength
     hasSuffix
+    versionAtLeast
     ;
 
   inherit (lib.trivial)
@@ -840,6 +843,10 @@ rec {
   # https://github.com/NixOS/nix/commit/55cefd41d63368d4286568e2956afd535cb44018
   _fetchGitSubmodulesMinver = "2.4";
 
+  # Support for `builtins.fetchGit` with `shallow = true` was introduced in 2.4
+  # https://github.com/NixOS/nix/commit/d1165d8791f559352ff6aa7348e1293b2873db1c
+  _fetchGitShallowMinver = "2.4";
+
   # Mirrors the contents of a Nix store path relative to a local path as a file set.
   # Some notes:
   # - The store path is read at evaluation time.
@@ -894,7 +901,17 @@ rec {
           # However a simpler alternative still would be [a builtins.gitLsFiles](https://github.com/NixOS/nix/issues/2944).
           fetchResult = fetchGit ({
             url = path;
-          } // extraFetchGitAttrs);
+          }
+          # In older Nix versions, repositories were always assumed to be deep clones, which made `fetchGit` fail for shallow clones
+          # For newer versions this was fixed, but the `shallow` flag is required.
+          # The only behavioral difference is that for shallow clones, `fetchGit` doesn't return a `revCount`,
+          # which we don't need here, so it's fine to always pass it.
+
+          # Unfortunately this means older Nix versions get a poor error message for shallow repositories, and there's no good way to improve that.
+          # Checking for `.git/shallow` doesn't seem worth it, especially since that's more of an implementation detail,
+          # and would also require more code to handle worktrees where `.git` is a file.
+          // optionalAttrs (versionAtLeast nixVersion _fetchGitShallowMinver) { shallow = true; }
+          // extraFetchGitAttrs);
         in
         # We can identify local working directories by checking for .git,
         # see https://git-scm.com/docs/gitrepository-layout#_description.

--- a/lib/fileset/tests.sh
+++ b/lib/fileset/tests.sh
@@ -1439,6 +1439,19 @@ if [[ -n "$fetchGitSupportsSubmodules" ]]; then
 fi
 rm -rf -- *
 
+# shallow = true is not supported on all Nix versions
+# and older versions don't support shallow clones at all
+if [[ "$(nix-instantiate --eval --expr "$prefixExpression (versionAtLeast builtins.nixVersion _fetchGitShallowMinver)")" == true ]]; then
+    createGitRepo full
+    # Extra commit such that there's a commit that won't be in the shallow clone
+    git -C full commit --allow-empty -q -m extra
+    git clone -q --depth 1 "file://${PWD}/full" shallow
+    cd shallow
+    checkGitTracked
+    cd ..
+    rm -rf -- *
+fi
+
 # Go through all stages of Git files
 # See https://www.git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository
 


### PR DESCRIPTION
## Description of changes
Allow `lib.fileset.gitTracked` on shallow repositories when using a Nix version that supports `shallow` in `builtins.fetchGit`.

I stumbled upon this issue when trying to use the `lib.fileset` library in a repository which builds the Nix expression in a GitHub Action. By default, GitHub actions clone a shallow repository, hence the Nix expression, which worked locally, failed in CI.

As far as I understand it, the only reason shallow clones are not the default in `builtins.fetchGit` is that [`revCount` can't be provided when cloning a shallow repository](https://github.com/NixOS/nix/commit/d1165d8791f559352ff6aa7348e1293b2873db1c). However, `revCount` isn't used or exposed by `lib.fileset`. Hence, allowing cloning shallow repositories makes `gitTracked` more general without any drawbacks.

Notice that not all supported Nix versions support cloning shallow Git repositories, hence this behavior should not be relied upon for backwards compatible code.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Sandboxing enabled in `nix.conf`
- [x] Tested, as applicable:
  - [x] run `nix-build lib/tests/release.nix`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
