### PR TITLE
llvm14: add patch to clear GOTOffsetMap

### DIFF
--- a/pkgs/development/compilers/llvm/14/llvm/clear-got-offset-map.patch
+++ b/pkgs/development/compilers/llvm/14/llvm/clear-got-offset-map.patch
@@ -1,0 +1,28 @@
+From 2e1b838a889f9793d4bcd5dbfe10db9796b77143 Mon Sep 17 00:00:00 2001
+From: Graham Markall <gmarkall@nvidia.com>
+Date: Mon, 3 Apr 2023 11:15:36 -0700
+Subject: [PATCH] [RuntimeDyld] RuntimeDyldELF: Clear GOTOffsetMap when
+ resetting GOT section.
+
+When the GOT section ID is reset, the GOTOffsetMap must also be cleared,
+otherwise spurious matches can be located when handling GOT relocations
+in subsequently-linked objects.
+
+Fixes Issue #61402 - see https://github.com/llvm/llvm-project/issues/61402.
+
+Reviewed By: lhames
+
+Differential Revision: https://reviews.llvm.org/D146938
+---
+ llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- /lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp	2024-01-31 16:02:37.006152749 +0000
++++ /lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp	2024-01-31 16:02:59.924392986 +0000
+@@ -2345,6 +2345,7 @@
+     }
+   }
+ 
++  GOTOffsetMap.clear();
+   GOTSectionID = 0;
+   CurrentGOTIndex = 0;

--- a/pkgs/development/compilers/llvm/14/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/14/llvm/default.nix
@@ -87,6 +87,7 @@ in stdenv.mkDerivation (rec {
 
   patches = [
     ./gnu-install-dirs.patch
+    ./clear-got-offset-map.patch
 
     # Fix musl build.
     (fetchpatch {


### PR DESCRIPTION
Adapted from a patch in condaforge. This fixes segfaults in downstream consumers of numba.

## Description of changes

I see segfaults in some numba dependenices for aarch64. E.g.:

```python
import numpy as np
import umap

u = umap.UMAP()
u.fit_transform(np.random.rand(100, 10))
```

which have been fixed in conda with the following patch:

* https://github.com/conda-forge/llvmdev-feedstock/pull/209/files
* https://github.com/numba/numba/issues/8994

I have verified that with this patch the segfault no longer happens.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
