### PR TITLE
nixos/ttyd: add `entrypoint` and `writable` option

### DIFF
--- a/nixos/modules/services/web-servers/ttyd.nix
+++ b/nixos/modules/services/web-servers/ttyd.nix
@@ -1,10 +1,16 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
 
   cfg = config.services.ttyd;
+
+  inherit (lib)
+    optionals
+    types
+    concatLists
+    mapAttrsToList
+    mkOption
+    ;
 
   # Command line arguments for the ttyd daemon
   args = [ "--port" (toString cfg.port) ]
@@ -31,39 +37,39 @@ in
 
   options = {
     services.ttyd = {
-      enable = mkEnableOption (lib.mdDoc "ttyd daemon");
+      enable = lib.mkEnableOption ("ttyd daemon");
 
       port = mkOption {
         type = types.port;
         default = 7681;
-        description = lib.mdDoc "Port to listen on (use 0 for random port)";
+        description = "Port to listen on (use 0 for random port)";
       };
 
       socket = mkOption {
         type = types.nullOr types.path;
         default = null;
         example = "/var/run/ttyd.sock";
-        description = lib.mdDoc "UNIX domain socket path to bind.";
+        description = "UNIX domain socket path to bind.";
       };
 
       interface = mkOption {
         type = types.nullOr types.str;
         default = null;
         example = "eth0";
-        description = lib.mdDoc "Network interface to bind.";
+        description = "Network interface to bind.";
       };
 
       username = mkOption {
         type = types.nullOr types.str;
         default = null;
-        description = lib.mdDoc "Username for basic authentication.";
+        description = "Username for basic authentication.";
       };
 
       passwordFile = mkOption {
         type = types.nullOr types.path;
         default = null;
         apply = value: if value == null then null else toString value;
-        description = lib.mdDoc ''
+        description = ''
           File containing the password to use for basic authentication.
           For insecurely putting the password in the globally readable store use
           `pkgs.writeText "ttydpw" "MyPassword"`.
@@ -73,26 +79,26 @@ in
       signal = mkOption {
         type = types.ints.u8;
         default = 1;
-        description = lib.mdDoc "Signal to send to the command on session close.";
+        description = "Signal to send to the command on session close.";
       };
 
       writeable = mkOption {
         type = types.nullOr types.bool;
         default = null; # null causes an eval error, forcing the user to consider attack surface
         example = true;
-        description = lib.mdDoc "Allow clients to write to the TTY.";
+        description = "Allow clients to write to the TTY.";
       };
 
       clientOptions = mkOption {
         type = types.attrsOf types.str;
         default = {};
-        example = literalExpression ''
+        example = lib.literalExpression ''
           {
             fontSize = "16";
             fontFamily = "Fira Code";
           }
         '';
-        description = lib.mdDoc ''
+        description = ''
           Attribute set of client options for xtermjs.
           <https://xtermjs.org/docs/api/terminal/interfaces/iterminaloptions/>
         '';
@@ -101,50 +107,50 @@ in
       terminalType = mkOption {
         type = types.str;
         default = "xterm-256color";
-        description = lib.mdDoc "Terminal type to report.";
+        description = "Terminal type to report.";
       };
 
       checkOrigin = mkOption {
         type = types.bool;
         default = false;
-        description = lib.mdDoc "Whether to allow a websocket connection from a different origin.";
+        description = "Whether to allow a websocket connection from a different origin.";
       };
 
       maxClients = mkOption {
         type = types.int;
         default = 0;
-        description = lib.mdDoc "Maximum clients to support (0, no limit)";
+        description = "Maximum clients to support (0, no limit)";
       };
 
       indexFile = mkOption {
         type = types.nullOr types.path;
         default = null;
-        description = lib.mdDoc "Custom index.html path";
+        description = "Custom index.html path";
       };
 
       enableIPv6 = mkOption {
         type = types.bool;
         default = false;
-        description = lib.mdDoc "Whether or not to enable IPv6 support.";
+        description = "Whether or not to enable IPv6 support.";
       };
 
       enableSSL = mkOption {
         type = types.bool;
         default = false;
-        description = lib.mdDoc "Whether or not to enable SSL (https) support.";
+        description = "Whether or not to enable SSL (https) support.";
       };
 
       certFile = mkOption {
         type = types.nullOr types.path;
         default = null;
-        description = lib.mdDoc "SSL certificate file path.";
+        description = "SSL certificate file path.";
       };
 
       keyFile = mkOption {
         type = types.nullOr types.path;
         default = null;
         apply = value: if value == null then null else toString value;
-        description = lib.mdDoc ''
+        description = ''
           SSL key file path.
           For insecurely putting the keyFile in the globally readable store use
           `pkgs.writeText "ttydKeyFile" "SSLKEY"`.
@@ -154,20 +160,20 @@ in
       caFile = mkOption {
         type = types.nullOr types.path;
         default = null;
-        description = lib.mdDoc "SSL CA file path for client certificate verification.";
+        description = "SSL CA file path for client certificate verification.";
       };
 
       logLevel = mkOption {
         type = types.int;
         default = 7;
-        description = lib.mdDoc "Set log level.";
+        description = "Set log level.";
       };
     };
   };
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     assertions =
       [ { assertion = cfg.enableSSL
@@ -196,7 +202,7 @@ in
       script = if cfg.passwordFile != null then ''
         PASSWORD=$(cat "$CREDENTIALS_DIRECTORY/TTYD_PASSWORD_FILE")
         ${pkgs.ttyd}/bin/ttyd ${lib.escapeShellArgs args} \
-          --credential ${escapeShellArg cfg.username}:"$PASSWORD" \
+          --credential ${lib.escapeShellArg cfg.username}:"$PASSWORD" \
           ${pkgs.shadow}/bin/login
       ''
       else ''

--- a/nixos/tests/web-servers/ttyd.nix
+++ b/nixos/tests/web-servers/ttyd.nix
@@ -5,8 +5,7 @@ import ../make-test-python.nix ({ lib, pkgs, ... }: {
   nodes.readonly = { pkgs, ... }: {
     services.ttyd = {
       enable = true;
-      username = "foo";
-      passwordFile = pkgs.writeText "password" "bar";
+      entrypoint = [ (lib.getExe pkgs.htop) ];
       writeable = false;
     };
   };

--- a/nixos/tests/web-servers/ttyd.nix
+++ b/nixos/tests/web-servers/ttyd.nix
@@ -2,18 +2,29 @@ import ../make-test-python.nix ({ lib, pkgs, ... }: {
   name = "ttyd";
   meta.maintainers = with lib.maintainers; [ stunkymonkey ];
 
-  nodes.machine = { pkgs, ... }: {
+  nodes.readonly = { pkgs, ... }: {
     services.ttyd = {
       enable = true;
       username = "foo";
       passwordFile = pkgs.writeText "password" "bar";
+      writeable = false;
+    };
+  };
+
+  nodes.writeable = { pkgs, ... }: {
+    services.ttyd = {
+      enable = true;
+      username = "foo";
+      passwordFile = pkgs.writeText "password" "bar";
+      writeable = true;
     };
   };
 
   testScript = ''
-    machine.wait_for_unit("ttyd.service")
-    machine.wait_for_open_port(7681)
-    response = machine.succeed("curl -vvv -u foo:bar -s -H 'Host: ttyd' http://127.0.0.1:7681/")
-    assert '<title>ttyd - Terminal</title>' in response, "Page didn't load successfully"
+    for machine in [readonly, writeable]:
+      machine.wait_for_unit("ttyd.service")
+      machine.wait_for_open_port(7681)
+      response = machine.succeed("curl -vvv -u foo:bar -s -H 'Host: ttyd' http://127.0.0.1:7681/")
+      assert '<title>ttyd - Terminal</title>' in response, "Page didn't load successfully"
   '';
 })


### PR DESCRIPTION
## Description of changes

superseeds and closes #268504


* Adds the option to set `--writable` via `services.ttyd.writeable = true` (closes #268501)
* Adds the option to use a different entrypoint than `login`, making `writeable = false` an actual usecase (https://github.com/NixOS/nixpkgs/pull/268504#issuecomment-1829985843)
* will eval error if `services.ttyd.writeable` is unset
* Removes `with lib;`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
