### PR TITLE
nixos/sysupdate: allow lists in sysupdate config

### DIFF
--- a/nixos/modules/system/boot/systemd/sysupdate.nix
+++ b/nixos/modules/system/boot/systemd/sysupdate.nix
@@ -3,7 +3,7 @@
 let
   cfg = config.systemd.sysupdate;
 
-  format = pkgs.formats.ini { };
+  format = pkgs.formats.ini { listToValue = toString; };
 
   definitionsDirectory = utils.systemdUtils.lib.definitions
     "sysupdate.d"
@@ -79,7 +79,7 @@ in
           Source = {
             Type = "url-file";
             Path = "https://download.example.com/";
-            MatchPattern = "nixos_@v.efi.xz";
+            MatchPattern = [ "nixos_@v+@l-@d.efi" "nixos_@v+@l.efi" "nixos_@v.efi" ];
           };
 
           Target = {

--- a/nixos/tests/systemd-sysupdate.nix
+++ b/nixos/tests/systemd-sysupdate.nix
@@ -23,8 +23,8 @@ in
             mkdir -p $out
             cd $out
 
-            echo "nixos" > nixos_1.efi
-            sha256sum nixos_1.efi > SHA256SUMS
+            echo "nixos" > nixos_1.txt
+            sha256sum nixos_1.txt > SHA256SUMS
 
             export GNUPGHOME="$(mktemp -d)"
             cp -R ${gpgKeyring}/* $GNUPGHOME
@@ -39,15 +39,15 @@ in
       systemd.sysupdate = {
         enable = true;
         transfers = {
-          "uki" = {
+          "text-file" = {
             Source = {
               Type = "url-file";
               Path = "http://server/";
-              MatchPattern = "nixos_@v.efi";
+              MatchPattern = "nixos_@v.txt";
             };
             Target = {
-              Path = "/boot/EFI/Linux";
-              MatchPattern = "nixos_@v.efi";
+              Path = "/";
+              MatchPattern = [ "nixos_@v.txt" ];
             };
           };
         };
@@ -61,6 +61,6 @@ in
     server.wait_for_unit("nginx.service")
 
     target.succeed("systemctl start systemd-sysupdate")
-    assert "nixos" in target.wait_until_succeeds("cat /boot/EFI/Linux/nixos_1.efi", timeout=5)
+    assert "nixos" in target.wait_until_succeeds("cat /nixos_1.txt", timeout=5)
   '';
 }


### PR DESCRIPTION
## Description of changes

Lists are convenient to have in sysupdate configuration when using multiple `MatchPattern` under `Target` when the target can have multiple filenames. This use-case is helpful for BootLoaderSpec bootcounting where the target file on disk can have multiple filenames, and in order for sysupdate to properly ensure only N number of instances of this target exist at one time, we need to have multiple match patterns.

Also in this PR is a fix for the broken systemd-sysupdate test

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
