### PR TITLE
[23.11] python311Packages.jq: 1.5.0 -> 1.6.0, clean up, skip failing test

### DIFF
--- a/pkgs/development/python-modules/jq/default.nix
+++ b/pkgs/development/python-modules/jq/default.nix
@@ -2,15 +2,15 @@
 , buildPythonPackage
 , cython
 , fetchFromGitHub
-, fetchpatch
 , jq
+, oniguruma
 , pytestCheckHook
 , pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "jq";
-  version = "1.5.0";
+  version = "1.6.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -19,18 +19,10 @@ buildPythonPackage rec {
     owner = "mwilliamson";
     repo = "jq.py";
     rev = "refs/tags/${version}";
-    hash = "sha256-mITk5y2AdUc9kZ/WrsnHxS1GRRmO4FDbPRgTtV2gIXI=";
+    hash = "sha256-c6tJI/mPlBGIYTk5ObIQ1CUTq73HouQ2quMZVWG8FFg=";
   };
 
-  patches = [
-    # Removes vendoring
-    ./jq-py-setup.patch
-    (fetchpatch {
-      url = "https://github.com/mwilliamson/jq.py/commit/805705dde4beb9db9a1743663d415198fb02eb1a.patch";
-      includes = [ "tests/*" ];
-      hash = "sha256-AgdpwmtOTeJ4nSbM6IknKaIVqqtWkpxTTtblXjlbWeA=";
-    })
-  ];
+  env.JQPY_USE_SYSTEM_LIBS = 1;
 
   nativeBuildInputs = [
     cython
@@ -38,6 +30,7 @@ buildPythonPackage rec {
 
   buildInputs = [
     jq
+    oniguruma
   ];
 
   preBuild = ''
@@ -46,6 +39,11 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
+  ];
+
+  disabledTests = [
+    # intentional behavior change in jq 1.7.1 not reflected upstream
+    "test_given_json_text_then_strings_containing_null_characters_are_preserved"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
## Description of changes
fixes https://github.com/NixOS/nixpkgs/issues/285051
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
