### PR TITLE
stylelint: init at 16.2.0

### DIFF
--- a/pkgs/by-name/st/stylelint/extensions/default.nix
+++ b/pkgs/by-name/st/stylelint/extensions/default.nix
@@ -1,0 +1,6 @@
+{ pkgs }: {
+  stylelint-config-standard =
+    pkgs.callPackage ./stylelint-config-standard/package.nix { };
+  stylelint-config-clean-order =
+    pkgs.callPackage ./stylelint-config-clean-order/package.nix { };
+}

--- a/pkgs/by-name/st/stylelint/extensions/stylelint-config-clean-order/package.nix
+++ b/pkgs/by-name/st/stylelint/extensions/stylelint-config-clean-order/package.nix
@@ -1,0 +1,25 @@
+{ lib, buildNpmPackage, fetchFromGitHub }:
+buildNpmPackage rec {
+  pname = "stylelint-config-clean-order";
+  version = "5.4.0";
+
+  src = fetchFromGitHub {
+    owner = "kutsan";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-I8fBJFSS74FyA77IYWfTWlgEVwLMsHekmMOCaJcbH4E=";
+  };
+
+  dontNpmBuild = true;
+  npmDepsHash = "sha256-b3lxKp+mK3wZUrks3nzcNjW/MNZTS3VH+eyJYsEK2hc=";
+  npmFlags = [ "--legacy-peer-deps" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/kutsan/stylelint-config-clean-order";
+    description = "A clean and complete config for stylelint-order";
+    license = licenses.mit;
+    maintainers = with maintainers; [ eownerdead ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/by-name/st/stylelint/extensions/stylelint-config-standard/package.nix
+++ b/pkgs/by-name/st/stylelint/extensions/stylelint-config-standard/package.nix
@@ -1,0 +1,25 @@
+{ lib, buildNpmPackage, fetchFromGitHub }:
+buildNpmPackage rec {
+  pname = "stylelint-config-standard";
+  version = "36.0.0";
+
+  src = fetchFromGitHub {
+    owner = "stylelint";
+    repo = pname;
+    rev = version;
+    hash = "sha256-5uW11/LXfjII1IKTYazcdL/GqxCvJpp6Jq7cOFn45JI=";
+  };
+
+  dontNpmBuild = true;
+  npmDepsHash = "sha256-jLDLDSG0HjKmSj5cTee4LF1aJnqJqpKX+WI9J1/6vHo=";
+  npmFlags = [ "--legacy-peer-deps" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/stylelint/stylelint-config-standard";
+    description = "The standard shareable config for Stylelint";
+    license = licenses.mit;
+    maintainers = with maintainers; [ eownerdead ];
+    platforms = platforms.all;
+  };
+}
+

--- a/pkgs/by-name/st/stylelint/package.nix
+++ b/pkgs/by-name/st/stylelint/package.nix
@@ -1,0 +1,48 @@
+{ lib
+, pkgs
+, writeShellScriptBin
+, makeWrapper
+, buildNpmPackage
+, fetchFromGitHub
+}:
+let
+  env = f:
+    writeShellScriptBin "stylelint" ''
+      export NODE_PATH="$NODE_PATH:${
+        lib.makeSearchPath "lib/node_modules"
+        ([ stylelint ] ++ (f stylelint.extensions))
+      }"
+
+      exec ${stylelint}/bin/stylelint "$@"
+    '';
+
+  stylelint = buildNpmPackage rec {
+    pname = "stylelint";
+    version = "16.2.0";
+
+    src = fetchFromGitHub {
+      owner = "stylelint";
+      repo = pname;
+      rev = version;
+      hash = "sha256-l7+Pd+H/JOKK/sIt0FwDU69t/dWUNhI+JnkBk9MSTtg=";
+    };
+
+    npmDepsHash = "sha256-F4XSp6s4VHZdHAeGfY/XHK6+PSpNi3ZMzFKRK6eQ+Uw=";
+
+    meta = with lib; {
+      homepage = "https://stylelint.io/";
+      description =
+        "A mighty CSS linter that helps you avoid errors and enforce conventions";
+      license = licenses.mit;
+      maintainers = with maintainers; [ eownerdead ];
+      mainProgram = "stylelint";
+      platforms = platforms.all;
+    };
+
+    passthru = {
+      extensions = import ./extensions { inherit pkgs; };
+      withExtensions = env;
+    };
+  };
+in
+stylelint

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19914,7 +19914,7 @@ with pkgs;
 
   strace-analyzer = callPackage ../development/tools/misc/strace-analyzer { };
 
-  stylelint = callPackage ../development/tools/analysis/stylelint { };
+  stylelintExtensions = stylelint.extensions;
 
   stylua = callPackage ../development/tools/stylua { };
 


### PR DESCRIPTION
## Description of changes

Already, there is stylelint as a dependency of coc-stylelint.
nixpkgs-review fails with `nixpkgs_review.errors.NixpkgsReviewError: Failed to list packages: nix-env failed with exit code -9`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
