### PR TITLE
python3Packages.lttng: init at 2.13.11

### DIFF
--- a/pkgs/development/python-modules/lttng/default.nix
+++ b/pkgs/development/python-modules/lttng/default.nix
@@ -20,6 +20,10 @@ toPythonModule (lttng-tools.overrideAttrs ({ nativeBuildInputs ? [ ], configureF
     "--disable-man-pages"
   ];
 
+  # Nix treats nativeBuildInputs specially for cross-compilation, but in this
+  # case, cross-compilation is accounted for explicitly. Using the variables
+  # ensures that the platform setup isn't messed with further. It also allows
+  # regular Python to be added in the future if it is ever needed.
   PYTHON = "${python.pythonOnBuildForHost}/bin/python";
   PYTHON_CONFIG = "${python.pythonOnBuildForHost}/bin/python-config";
 }))

--- a/pkgs/development/python-modules/lttng/default.nix
+++ b/pkgs/development/python-modules/lttng/default.nix
@@ -1,0 +1,25 @@
+{ toPythonModule
+, python
+, lttng-tools
+, swig2
+}:
+
+toPythonModule (lttng-tools.overrideAttrs ({ nativeBuildInputs ? [ ], configureFlags ? [ ], ... }: {
+  pname = "lttng";
+
+  nativeBuildInputs = nativeBuildInputs ++ [ swig2 ];
+
+  configureFlags = configureFlags ++ [
+    "--enable-python-bindings"
+    # "--disable-bin-lttng" # The Python bindings depend on liblttng-ctl, which is only built when the binary is enabled.
+    "--disable-bin-lttng-consumerd"
+    "--disable-bin-lttng-crash"
+    "--disable-bin-lttng-relayd"
+    "--disable-bin-lttng-sessiond"
+    # "--disable-extras" # The Python bindings are an extra.
+    "--disable-man-pages"
+  ];
+
+  PYTHON = "${python.pythonOnBuildForHost}/bin/python";
+  PYTHON_CONFIG = "${python.pythonOnBuildForHost}/bin/python-config";
+}))

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6695,6 +6695,8 @@ self: super: with self; {
 
   ltpycld2 = callPackage ../development/python-modules/ltpycld2 { };
 
+  lttng = callPackage ../development/python-modules/lttng { };
+
   luddite = callPackage ../development/python-modules/luddite { };
 
   luftdaten = callPackage ../development/python-modules/luftdaten { };


### PR DESCRIPTION
## Description of changes

This package contains Python bindings to `liblttng-ctl` from [LTTng‑tools](https://github.com/lttng/lttng-tools).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@bjornfor