### PR TITLE
lfe: 2.1.1 -> 2.1.3

### DIFF
--- a/pkgs/development/interpreters/lfe/2.1.nix
+++ b/pkgs/development/interpreters/lfe/2.1.nix
@@ -1,7 +1,7 @@
 { fetchpatch, mkDerivation }:
 
 mkDerivation {
-  version = "2.1.1";
-  sha256 = "sha256-HUOVBzUaU0ixIfPPctwR2TPijxJjcFY3dJ8Z7Ot2bpE=";
-  maximumOTPVersion = "25";
+  version = "2.1.3";
+  hash = "sha256-HUOVBzUaU0ixIfPPctwR2TPijxJjcFY3dJ8Z7Ot2bpE=";
+  maximumOTPVersion = "26";
 }

--- a/pkgs/development/interpreters/lfe/generic-builder.nix
+++ b/pkgs/development/interpreters/lfe/generic-builder.nix
@@ -3,9 +3,10 @@
 { baseName ? "lfe"
 , version
 , maximumOTPVersion
-, sha256 ? null
+, sha256 ? ""
+, hash ? ""
 , rev ? version
-, src ? fetchFromGitHub { inherit rev sha256; owner = "lfe"; repo = "lfe"; }
+, src ? fetchFromGitHub { inherit hash rev sha256; owner = "lfe"; repo = "lfe"; }
 , patches ? []
 }:
 

--- a/pkgs/development/interpreters/lfe/generic-builder.nix
+++ b/pkgs/development/interpreters/lfe/generic-builder.nix
@@ -5,7 +5,7 @@
 , maximumOTPVersion
 , sha256 ? null
 , rev ? version
-, src ? fetchFromGitHub { inherit rev sha256; owner = "rvirding"; repo = "lfe"; }
+, src ? fetchFromGitHub { inherit rev sha256; owner = "lfe"; repo = "lfe"; }
 , patches ? []
 }:
 


### PR DESCRIPTION
## Description of changes

* Update `lfe` (and `lfe_2_1`) from 2.1.1 to [2.1.3](https://github.com/lfe/lfe/releases/tag/v2.1.3)
* Update `beam.beamLib.callLFE`
    * Update `src` to set `owner = "lfe"` as upstream was moved a while ago
    * Support `sha256` xor `hash` (like `fetchFromGitHub`)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
