### PR TITLE
Add appres to the path for xscreensaver to fix broken screensavers

### DIFF
--- a/pkgs/by-name/xs/xscreensaver/package.nix
+++ b/pkgs/by-name/xs/xscreensaver/package.nix
@@ -22,6 +22,7 @@
 , makeWrapper
 , pam
 , perlPackages
+, xorg
 , pkg-config
 , systemd
 , forceInstallAllHacks ? true
@@ -102,7 +103,7 @@ stdenv.mkDerivation (finalAttrs: {
     for bin in $out/bin/*; do
       wrapProgram "$bin" \
         --prefix PATH : "$out/libexec/xscreensaver" \
-        --prefix PATH : "${lib.makeBinPath [ coreutils perlPackages.perl ]}" \
+        --prefix PATH : "${lib.makeBinPath [ coreutils perlPackages.perl xorg.appres ]}" \
         --prefix PERL5LIB ':' $PERL5LIB
     done
   ''


### PR DESCRIPTION

## Description of changes

Fixes the `xscreensaver-text` based screensavers, namely:

- Apple ][
- Flip Text
- Font Glide
- GL Text
- Nose Guy
- Phosphor
- Split-Flap
- Star Wars
- Windup Robot
- XMatrix

Symptom of breakage was these screensavers showing the following text rather than various system information:
```
Can't exec "appres": No such file or directory at /nix/store/cm6kipfjrgj17pwdj5si39njzfrrvw8k-xscreensaver-6.08/libexec/xscreensaver/xscreensaver-text line 139.
Use of uninitialized value $body in substitution (s///) at /nix/store/cm6kipfjrgj17pwdj5si39njzfrrvw8k-xscreensaver-6.08/libexec/xscreensaver/xscreensaver-text line 161.
Use of uninitialized value $body in substitution (s///) at /nix/store/cm6kipfjrgj17pwdj5si39njzfrrvw8k-xscreensaver-6.08/libexec/xscreensaver/xscreensaver-text line 162.
Use of uninitialized value $body in pattern match (m//) at /nix/store/cm6kipfjrgj17pwdj5si39njzfrrvw8k-xscreensaver-6.08/libexec/xscreensaver/xscreensaver-text line 164.
Use of uninitialized value $body in pattern match (m//) at /nix/store/cm6kipfjrgj17pwdj5si39njzfrrvw8k-xscreensaver-6.08/libexec/xscreensaver/xscreensaver-text line 168.
Use of uninitialized value $body in pattern match (m//) at /nix/store/cm6kipfjrgj17pwdj5si39njzfrrvw8k-xscreensaver-6.08/libexec/xscreensaver/xscreensaver-text line 171.
Use of uninitialized value $body in pattern match (m//) at /nix/store/cm6kipfjrgj17pwdj5si39njzfrrvw8k-xscreensaver-6.08/libexec/xscreensaver/xscreensaver-text line 174.
Use of uninitialized value $body in pattern match (m//) at /nix/store/cm6kipfjrgj17pwdj5si39njzfrrvw8k-xscreensaver-6.08/libexec/xscreensaver/xscreensaver-text line 177.
```
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
