### PR TITLE
material-icons: 3.0.1 -> 4.0.0 && cleanup

### DIFF
--- a/pkgs/data/fonts/material-icons/default.nix
+++ b/pkgs/data/fonts/material-icons/default.nix
@@ -11,6 +11,9 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-wX7UejIYUxXOnrH2WZYku9ljv4ZAlvgk8EEJJHOCCjE=";
   };
 
+  dontConfigure = true;
+  dontBuild = true;
+
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/data/fonts/material-icons/default.nix
+++ b/pkgs/data/fonts/material-icons/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenvNoCC, fetchFromGitHub }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "material-icons";
   version = "4.0.0";
 
@@ -33,4 +33,4 @@ stdenvNoCC.mkDerivation rec {
     platforms = platforms.all;
     maintainers = with maintainers; [ mpcsh ];
   };
-}
+})

--- a/pkgs/data/fonts/material-icons/default.nix
+++ b/pkgs/data/fonts/material-icons/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenvNoCC, fetchFromGitHub }:
+{ lib, stdenvNoCC, fetchFromGitHub, nix-update-script }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "material-icons";
@@ -7,7 +7,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "google";
     repo = "material-design-icons";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-wX7UejIYUxXOnrH2WZYku9ljv4ZAlvgk8EEJJHOCCjE=";
   };
 
@@ -25,6 +25,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "System status icons by Google, featuring material design";

--- a/pkgs/data/fonts/material-icons/default.nix
+++ b/pkgs/data/fonts/material-icons/default.nix
@@ -2,20 +2,23 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "material-icons";
-  version = "3.0.1";
+  version = "4.0.0";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "material-design-icons";
     rev = version;
-    hash = "sha256-4FphNJCsaLWzlVR4TmXnDBid0EVj39fkeoh5j1leBZ8=";
+    hash = "sha256-wX7UejIYUxXOnrH2WZYku9ljv4ZAlvgk8EEJJHOCCjE=";
   };
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/share/fonts/truetype
-    cp iconfont/*.ttf $out/share/fonts/truetype
+    cp font/*.ttf $out/share/fonts/truetype
+
+    mkdir -p $out/share/fonts/opentype
+    cp font/*.otf $out/share/fonts/opentype
 
     runHook postInstall
   '';


### PR DESCRIPTION
## Description of changes

material-icons: 3.0.1 -> 4.0.0
material-icons: skip unwanted phases
material-icons: rec -> finalAttrs
material-icons: add update script

Changelog: https://github.com/google/material-design-icons/releases

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
