### PR TITLE
phoc: 0.31.0 -> 0.35.0

### DIFF
--- a/nixos/modules/services/x11/desktop-managers/phosh.nix
+++ b/nixos/modules/services/x11/desktop-managers/phosh.nix
@@ -186,6 +186,21 @@ in
         UtmpIdentifier = "tty7";
         UtmpMode = "user";
       };
+      environment = {
+        # We are running without a display manager, so need to provide
+        # a value for XDG_CURRENT_DESKTOP.
+        #
+        # Among other things, this variable influences:
+        #  - visibility of desktop entries with "OnlyShowIn=Phosh;"
+        #    https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-1.5.html#key-onlyshowin
+        #  - the chosen xdg-desktop-portal configuration.
+        #    https://flatpak.github.io/xdg-desktop-portal/docs/portals.conf.html
+        XDG_CURRENT_DESKTOP = "Phosh:GNOME";
+        # pam_systemd uses these to identify the session in logind.
+        # https://www.freedesktop.org/software/systemd/man/latest/pam_systemd.html#desktop=
+        XDG_SESSION_DESKTOP = "phosh";
+        XDG_SESSION_TYPE = "wayland";
+      };
     };
 
     environment.systemPackages = [

--- a/pkgs/applications/misc/phoc/default.nix
+++ b/pkgs/applications/misc/phoc/default.nix
@@ -19,6 +19,7 @@
 , xorg
 , directoryListingUpdater
 , nixosTests
+, testers
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -72,6 +73,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests.phosh = nixosTests.phosh;
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+    };
     updateScript = directoryListingUpdater { };
   };
 

--- a/pkgs/applications/misc/phoc/default.nix
+++ b/pkgs/applications/misc/phoc/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
+, stdenvNoCC
 , fetchurl
-, fetchpatch
 , meson
 , ninja
 , pkg-config
@@ -21,25 +21,13 @@
 , nixosTests
 }:
 
-let
-  phocWlroots = wlroots.overrideAttrs (old: {
-    patches = (old.patches or []) ++ [
-      # Revert "layer-shell: error on 0 dimension without anchors"
-      # https://source.puri.sm/Librem5/phosh/-/issues/422
-      (fetchpatch {
-        name = "0001-Revert-layer-shell-error-on-0-dimension-without-anch.patch";
-        url = "https://gitlab.gnome.org/World/Phosh/phoc/-/raw/acb17171267ae0934f122af294d628ad68b09f88/subprojects/packagefiles/wlroots/0001-Revert-layer-shell-error-on-0-dimension-without-anch.patch";
-        hash = "sha256-uNJaYwkZImkzNUEqyLCggbXAoIRX5h2eJaGbSHj1B+o=";
-      })
-    ];
-  });
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "phoc";
   version = "0.31.0";
 
   src = fetchurl {
     # This tarball includes the meson wrapped subproject 'gmobile'.
-    url = "https://sources.phosh.mobi/releases/phoc/phoc-${version}.tar.xz";
+    url = with finalAttrs; "https://sources.phosh.mobi/releases/${pname}/${pname}-${version}.tar.xz";
     hash = "sha256-P7Bs9JMv6KNKo4d2ID0/Ba4+Nel6DMn8o4I7EDvY4vY=";
   };
 
@@ -61,11 +49,26 @@ in stdenv.mkDerivation rec {
     # For keybindings settings schemas
     gnome.mutter
     wayland
-    phocWlroots
+    finalAttrs.wlroots
     xorg.xcbutilwm
   ];
 
   mesonFlags = ["-Dembed-wlroots=disabled"];
+
+  # Patch wlroots to remove a check which crashes Phosh.
+  # This patch can be found within the phoc source tree.
+  wlroots = wlroots.overrideAttrs (old: {
+    patches = (old.patches or []) ++ [
+      (stdenvNoCC.mkDerivation {
+        name = "0001-Revert-layer-shell-error-on-0-dimension-without-anch.patch";
+        inherit (finalAttrs) src;
+        preferLocalBuild = true;
+        allowSubstitutes = false;
+        phases = "unpackPhase installPhase";
+        installPhase = "cp subprojects/packagefiles/wlroots/$name $out";
+      })
+    ];
+  });
 
   postPatch = ''
     chmod +x build-aux/post_install.py
@@ -84,4 +87,4 @@ in stdenv.mkDerivation rec {
     maintainers = with maintainers; [ masipcat tomfitzhenry zhaofengli ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/applications/misc/phoc/default.nix
+++ b/pkgs/applications/misc/phoc/default.nix
@@ -17,7 +17,7 @@
 , libxkbcommon
 , wlroots
 , xorg
-, gitUpdater
+, directoryListingUpdater
 , nixosTests
 }:
 
@@ -39,7 +39,7 @@ in stdenv.mkDerivation rec {
 
   src = fetchurl {
     # This tarball includes the meson wrapped subproject 'gmobile'.
-    url = "https://storage.puri.sm/releases/phoc/phoc-${version}.tar.xz";
+    url = "https://sources.phosh.mobi/releases/phoc/phoc-${version}.tar.xz";
     hash = "sha256-P7Bs9JMv6KNKo4d2ID0/Ba4+Nel6DMn8o4I7EDvY4vY=";
   };
 
@@ -74,10 +74,7 @@ in stdenv.mkDerivation rec {
 
   passthru = {
     tests.phosh = nixosTests.phosh;
-    updateScript = gitUpdater {
-      url = "https://gitlab.gnome.org/World/Phosh/phoc";
-      rev-prefix = "v";
-    };
+    updateScript = directoryListingUpdater { };
   };
 
   meta = with lib; {

--- a/pkgs/applications/misc/phoc/default.nix
+++ b/pkgs/applications/misc/phoc/default.nix
@@ -23,12 +23,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "phoc";
-  version = "0.31.0";
+  version = "0.35.0";
 
   src = fetchurl {
     # This tarball includes the meson wrapped subproject 'gmobile'.
     url = with finalAttrs; "https://sources.phosh.mobi/releases/${pname}/${pname}-${version}.tar.xz";
-    hash = "sha256-P7Bs9JMv6KNKo4d2ID0/Ba4+Nel6DMn8o4I7EDvY4vY=";
+    hash = "sha256-q2wyM0R7Mi/XuckNb6ZDkStaV9yJH1BgJ4cjqQc6EI4=";
   };
 
   nativeBuildInputs = [
@@ -69,11 +69,6 @@ stdenv.mkDerivation (finalAttrs: {
       })
     ];
   });
-
-  postPatch = ''
-    chmod +x build-aux/post_install.py
-    patchShebangs build-aux/post_install.py
-  '';
 
   passthru = {
     tests.phosh = nixosTests.phosh;

--- a/pkgs/applications/window-managers/phosh/default.nix
+++ b/pkgs/applications/window-managers/phosh/default.nix
@@ -6,7 +6,7 @@
 , ninja
 , pkg-config
 , python3
-, wrapGAppsHook
+, wrapGAppsHook4
 , libadwaita
 , libhandy
 , libxkbcommon
@@ -34,13 +34,13 @@
 , nixosTests
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "phosh";
   version = "0.35.0";
 
   src = fetchurl {
     # Release tarball which includes subprojects gvc and libcall-ui
-    url = "https://sources.phosh.mobi/releases/${pname}/${pname}-${version}.tar.xz";
+    url = with finalAttrs; "https://sources.phosh.mobi/releases/${pname}/${pname}-${version}.tar.xz";
     hash = "sha256-hfm89G9uxVc8j8rDOg1ytI+Pm9s9WQWazH3yLZdWSRg=";
   };
 
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     python3
-    wrapGAppsHook
+    wrapGAppsHook4
   ];
 
   buildInputs = [
@@ -90,7 +90,10 @@ stdenv.mkDerivation rec {
     "-Dsystemd=true"
     "-Dcompositor=${phoc}/bin/phoc"
     # https://github.com/NixOS/nixpkgs/issues/36468
+    # https://gitlab.gnome.org/World/Phosh/phosh/-/merge_requests/1363
     "-Dc_args=-I${glib.dev}/include/gio-unix-2.0"
+    # Save some time building if tests are disabled
+    "-Dtests=${lib.boolToString finalAttrs.finalPackage.doCheck}"
   ];
 
   checkPhase = ''
@@ -128,10 +131,10 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A pure Wayland shell prototype for GNOME on mobile devices";
     homepage = "https://gitlab.gnome.org/World/Phosh/phosh";
-    changelog = "https://gitlab.gnome.org/World/Phosh/phosh/-/blob/v${version}/debian/changelog";
+    changelog = "https://gitlab.gnome.org/World/Phosh/phosh/-/blob/v${finalAttrs.version}/debian/changelog";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ masipcat tomfitzhenry zhaofengli ];
     platforms = platforms.linux;
     mainProgram = "phosh-session";
   };
-}
+})

--- a/pkgs/applications/window-managers/phosh/default.nix
+++ b/pkgs/applications/window-managers/phosh/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
-, fetchFromGitLab
-, gitUpdater
+, fetchurl
+, directoryListingUpdater
 , meson
 , ninja
 , pkg-config
@@ -36,16 +36,12 @@
 
 stdenv.mkDerivation rec {
   pname = "phosh";
-  version = "0.33.0";
+  version = "0.34.1";
 
-  src = fetchFromGitLab {
-    domain = "gitlab.gnome.org";
-    group = "World";
-    owner = "Phosh";
-    repo = pname;
-    rev = "v${version}";
-    fetchSubmodules = true; # including gvc and libcall-ui which are designated as subprojects
-    sha256 = "sha256-t+1MYfsz7KqsMvN8TyLIUrTLTQPWQQpOSk/ysxgE7kg=";
+  src = fetchurl {
+    # Release tarball which includes subprojects gvc and libcall-ui
+    url = "https://sources.phosh.mobi/releases/${pname}/${pname}-${version}.tar.xz";
+    hash = "sha256-nuPFhfnpLIHn1z3nQE7Lg3j75uIogWJatL4oGuoy1PE=";
   };
 
   nativeBuildInputs = [
@@ -126,9 +122,7 @@ stdenv.mkDerivation rec {
 
     tests.phosh = nixosTests.phosh;
 
-    updateScript = gitUpdater {
-      rev-prefix = "v";
-    };
+    updateScript = directoryListingUpdater { };
   };
 
   meta = with lib; {

--- a/pkgs/applications/window-managers/phosh/default.nix
+++ b/pkgs/applications/window-managers/phosh/default.nix
@@ -36,12 +36,12 @@
 
 stdenv.mkDerivation rec {
   pname = "phosh";
-  version = "0.34.1";
+  version = "0.35.0";
 
   src = fetchurl {
     # Release tarball which includes subprojects gvc and libcall-ui
     url = "https://sources.phosh.mobi/releases/${pname}/${pname}-${version}.tar.xz";
-    hash = "sha256-nuPFhfnpLIHn1z3nQE7Lg3j75uIogWJatL4oGuoy1PE=";
+    hash = "sha256-hfm89G9uxVc8j8rDOg1ytI+Pm9s9WQWazH3yLZdWSRg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/window-managers/phosh/default.nix
+++ b/pkgs/applications/window-managers/phosh/default.nix
@@ -113,18 +113,9 @@ stdenv.mkDerivation (finalAttrs: {
     )
   '';
 
-  postFixup = ''
-    mkdir -p $out/share/wayland-sessions
-    ln -s $out/share/applications/sm.puri.Phosh.desktop $out/share/wayland-sessions/
-  '';
-
   passthru = {
-    providedSessions = [
-      "sm.puri.Phosh"
-    ];
-
+    providedSessions = [ "phosh" ];
     tests.phosh = nixosTests.phosh;
-
     updateScript = directoryListingUpdater { };
   };
 

--- a/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
+++ b/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
@@ -14,16 +14,18 @@
 , phoc
 , phosh
 , wayland-protocols
+, json-glib
+, gsound
 }:
 
 stdenv.mkDerivation rec {
   pname = "phosh-mobile-settings";
-  version = "0.31.0";
+  version = "0.35.1";
 
   src = fetchurl {
     # This tarball includes the meson wrapped subproject 'gmobile'.
     url = "https://sources.phosh.mobi/releases/${pname}/${pname}-${version}.tar.xz";
-    hash = "sha256-5Qa6LSOLvZL0sFh2co9AqyS5ZTQQ+JRnPiHuMl1UgDI=";
+    hash = "sha256-Kg3efPs0knbJ9b0buIkgqIL1XplcZpGIi0hxJptG6UI=";
   };
 
   nativeBuildInputs = [
@@ -42,7 +44,15 @@ stdenv.mkDerivation rec {
     lm_sensors
     phoc
     wayland-protocols
+    json-glib
+    gsound
   ];
+
+  postPatch = ''
+    # There are no schemas to compile.
+    substituteInPlace meson.build \
+      --replace 'glib_compile_schemas: true' 'glib_compile_schemas: false'
+  '';
 
   postInstall = ''
     # this is optional, but without it phosh-mobile-settings won't know about lock screen plugins
@@ -50,7 +60,7 @@ stdenv.mkDerivation rec {
 
     # .desktop files marked `OnlyShowIn=Phosh;` aren't displayed even in our phosh, so remove that.
     # also make the Exec path absolute.
-    substituteInPlace "$out/share/applications/org.sigxcpu.MobileSettings.desktop" \
+    substituteInPlace "$out/share/applications/mobi.phosh.MobileSettings.desktop" \
       --replace 'OnlyShowIn=Phosh;' "" \
       --replace 'Exec=phosh-mobile-settings' "Exec=$out/bin/phosh-mobile-settings"
   '';

--- a/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
+++ b/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
-, fetchFromGitLab
-, gitUpdater
+, fetchurl
+, directoryListingUpdater
 , meson
 , ninja
 , pkg-config
@@ -18,14 +18,12 @@
 
 stdenv.mkDerivation rec {
   pname = "phosh-mobile-settings";
-  version = "0.23.1";
+  version = "0.31.0";
 
-  src = fetchFromGitLab {
-    domain = "gitlab.gnome.org";
-    owner = "guidog";
-    repo = "phosh-mobile-settings";
-    rev = "v${version}";
-    sha256 = "sha256-D605efn25Dl3Bj92DZiagcx+MMcRz0GRaWxplBRcZhA=";
+  src = fetchurl {
+    # This tarball includes the meson wrapped subproject 'gmobile'.
+    url = "https://sources.phosh.mobi/releases/${pname}/${pname}-${version}.tar.xz";
+    hash = "sha256-5Qa6LSOLvZL0sFh2co9AqyS5ZTQQ+JRnPiHuMl1UgDI=";
   };
 
   nativeBuildInputs = [
@@ -57,9 +55,7 @@ stdenv.mkDerivation rec {
       --replace 'Exec=phosh-mobile-settings' "Exec=$out/bin/phosh-mobile-settings"
   '';
 
-  passthru.updateScript = gitUpdater {
-    rev-prefix = "v";
-  };
+  passthru.updateScript = directoryListingUpdater { };
 
   meta = with lib; {
     description = "A settings app for mobile specific things";

--- a/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
+++ b/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.gnome.org/guidog/phosh-mobile-settings";
     changelog = "https://gitlab.gnome.org/guidog/phosh-mobile-settings/-/blob/v${version}/debian/changelog";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ colinsane ];
+    maintainers = with maintainers; [ rvl ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
+++ b/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
@@ -57,12 +57,6 @@ stdenv.mkDerivation rec {
   postInstall = ''
     # this is optional, but without it phosh-mobile-settings won't know about lock screen plugins
     ln -s '${phosh}/lib/phosh' "$out/lib/phosh"
-
-    # .desktop files marked `OnlyShowIn=Phosh;` aren't displayed even in our phosh, so remove that.
-    # also make the Exec path absolute.
-    substituteInPlace "$out/share/applications/mobi.phosh.MobileSettings.desktop" \
-      --replace 'OnlyShowIn=Phosh;' "" \
-      --replace 'Exec=phosh-mobile-settings' "Exec=$out/bin/phosh-mobile-settings"
   '';
 
   passthru.updateScript = directoryListingUpdater { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12040,7 +12040,7 @@ with pkgs;
   pfstools = libsForQt5.callPackage ../tools/graphics/pfstools { };
 
   phoc = callPackage ../applications/misc/phoc {
-    wlroots = wlroots_0_16;
+    wlroots = wlroots_0_17;
   };
 
   phockup = callPackage ../applications/misc/phockup { };


### PR DESCRIPTION
## Description of changes

The [Phosh 0.35.1 release](https://phosh.mobi/releases/rel-0.35.1/) contains:
- [`phoc` 0.35.0](https://gitlab.gnome.org/World/Phosh/phoc/-/releases/v0.35.0)
- [Phosh 0.35.0](https://gitlab.gnome.org/World/Phosh/phosh/-/releases/v0.35.0). That is PR #275037, but I also updated in this PR because it's impossible to test `phoc` without `phosh`.
- [phosh-mobile-settings 0.35.1](https://gitlab.gnome.org/World/Phosh/phosh-mobile-settings/-/releases/v0.35.1), because why not.
 
The Phosh/phoc release tarballs URL has changed from `storage.puri.sm` to `sources.phosh.mobi`. I have updated the source urls for the above three packages, so that auto-bot-updates should work from now on.

`phoc-0.35.0` now uses `wlroots-0.17.1`. Even so, it still needs to hack out the `height 0` error check in wlroots, otherwise Phosh will crash at startup. This patch needs to be updated, so I just grab it out of `phoc.src`, rather than using `fetchpatch`. I have also added the `wlroots` dependency as an attribute of `phoc`. This is better for cases when users need to override the `phoc` package.

cc @masipcat @tomfitzhenry @zhaofengli

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] darwin N/A
- Tested, as applicable:
  - [x] [`nixos/tests/phosh.nix`](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests) (x86_64-linux only)
  - [x] Added a `testers.testVersion` as `pkgs.phoc.tests.version`
  - [x] Tested on a pinephone, built with `--system aarch64-linux`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`.
- [x] Tested basic functionality of `./result/bin/phoc`. This is covered by `phoc.tests.version` and `phoc.tests.phosh`.
- [x] [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes) N/A
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
