### PR TITLE
glasskube: init at 0.0.4

### DIFF
--- a/pkgs/by-name/gl/glasskube/package.nix
+++ b/pkgs/by-name/gl/glasskube/package.nix
@@ -1,0 +1,47 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, nix-update-script
+, installShellFiles
+}:
+
+buildGoModule rec {
+  pname = "glasskube";
+  version = "0.0.4";
+
+  src = fetchFromGitHub {
+    owner = "glasskube";
+    repo = "glasskube";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-+5SinF85bU113C9B025DM83v8ApaXqLV4n1P9zZP3ns=";
+  };
+
+  vendorHash = "sha256-DBqO2EyB1TydsdK2GWJoFGGgTS+E62GogysPX4WtzYU=";
+
+  CGO_ENABLED = 0;
+
+  ldflags = [ "-s" "-w" "-X github.com/glasskube/glasskube/internal/config.Version=${version}" "-X github.com/glasskube/glasskube/internal/config.Commit=${src.rev}" ];
+
+  subPackages = [ "cmd/${pname}" "cmd/package-operator" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    # Completions
+    installShellCompletion --cmd glasskube \
+      --bash <($out/bin/glasskube completion bash) \
+      --fish <($out/bin/glasskube completion fish) \
+      --zsh <($out/bin/glasskube completion zsh)
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    description = "The missing Package Manager for Kubernetes featuring a GUI and a CLI";
+    homepage = "https://github.com/glasskube/glasskube";
+    changelog = "https://github.com/glasskube/glasskube/releases/tag/v${version}";
+    maintainers = with maintainers; [ jakuzure ];
+    license = licenses.asl20;
+    mainProgram = "glasskube";
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Package [glasskube](https://github.com/glasskube/glasskube) 

🧊 The missing Package Manager for Kubernetes 📦 Featuring a GUI and a CLI. Glasskube packages are dependency aware, GitOps ready and get automatic updates via a central public package repository. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
