### PR TITLE
igv: use jdk17 instead of jdk11

### DIFF
--- a/pkgs/applications/science/biology/igv/default.nix
+++ b/pkgs/applications/science/biology/igv/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchzip, jdk11, wrapGAppsHook }:
+{ lib, stdenv, fetchzip, jdk17, testers, wrapGAppsHook, igv }:
 
 stdenv.mkDerivation rec {
   pname = "igv";
@@ -13,10 +13,10 @@ stdenv.mkDerivation rec {
     cp -Rv * $out/share/
 
     sed -i "s#prefix=.*#prefix=$out/share#g" $out/share/igv.sh
-    sed -i 's#java#${jdk11}/bin/java#g' $out/share/igv.sh
+    sed -i 's#java#${jdk17}/bin/java#g' $out/share/igv.sh
 
     sed -i "s#prefix=.*#prefix=$out/share#g" $out/share/igvtools
-    sed -i 's#java#${jdk11}/bin/java#g' $out/share/igvtools
+    sed -i 's#java#${jdk17}/bin/java#g' $out/share/igvtools
 
     ln -s $out/share/igv.sh $out/bin/igv
     ln -s $out/share/igvtools $out/bin/igvtools
@@ -25,6 +25,11 @@ stdenv.mkDerivation rec {
     chmod +x $out/bin/igvtools
   '';
   nativeBuildInputs = [ wrapGAppsHook ];
+
+  passthru.tests.version = testers.testVersion {
+    package = igv;
+  };
+
 
   meta = with lib; {
     homepage = "https://www.broadinstitute.org/igv/";


### PR DESCRIPTION
## Description of changes

This PR lets IGV use JDK17 not JDK11 which is not supported [anymore](https://igv.org/doc/desktop/#DownloadPage/). A test is added to catch this issue right away if it happens next time.

```bash
# JDK11:
Using system JDK.
Error occurred during initialization of boot layer
java.lang.module.FindException: Error reading module: /nix/store/q72xm63qbjhjfg289jgph4wxjjz4rqr6-igv-2.17.1/share/lib/igv.jar
Caused by: java.lang.module.InvalidModuleDescriptorException: Unsupported major.minor version 61.0
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
