### PR TITLE
openmpi: split dev into separate output, reduce closure size

### DIFF
--- a/nixos/tests/slurm.nix
+++ b/nixos/tests/slurm.nix
@@ -45,7 +45,7 @@ let
       '';
     in pkgs.runCommand "mpitest" {} ''
       mkdir -p $out/bin
-      ${pkgs.openmpi}/bin/mpicc ${mpitestC} -o $out/bin/mpitest
+      ${lib.getDev pkgs.mpi}/bin/mpicc ${mpitestC} -o $out/bin/mpitest
     '';
 in {
   name = "slurm";

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -168,7 +168,7 @@ stdenv.mkDerivation {
 
   preConfigure = lib.optionalString useMpi ''
     cat << EOF >> user-config.jam
-    using mpi : ${mpi}/bin/mpiCC ;
+    using mpi : ${lib.getDev mpi}/bin/mpiCC ;
     EOF
   ''
   # On darwin we need to add the `$out/lib` to the libraries' rpath explicitly,

--- a/pkgs/development/libraries/netcdf/default.nix
+++ b/pkgs/development/libraries/netcdf/default.nix
@@ -59,7 +59,7 @@ in stdenv.mkDerivation rec {
       "--disable-dap-remote-tests"
       "--with-plugin-dir=${placeholder "out"}/lib/hdf5-plugins"
   ]
-  ++ (lib.optionals mpiSupport [ "--enable-parallel-tests" "CC=${mpi}/bin/mpicc" ]);
+  ++ (lib.optionals mpiSupport [ "--enable-parallel-tests" "CC=${lib.getDev mpi}/bin/mpicc" ]);
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/openmpi/default.nix
+++ b/pkgs/development/libraries/openmpi/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchurl, gfortran, perl, libnl
+{ lib, stdenv, fetchurl, removeReferencesTo, gfortran, perl, libnl
 , rdma-core, zlib, numactl, libevent, hwloc, targetPackages, symlinkJoin
-, libpsm2, libfabric, pmix, ucx, ucc
+, libpsm2, libfabric, pmix, ucx, ucc, makeWrapper
 , config
 # Enable CUDA support
 , cudaSupport ? config.cudaSupport, cudaPackages
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     find -name "Makefile.in" -exec sed -i "s/\`date\`/$ts/" \{} \;
   '';
 
-  outputs = [ "out" "man" ];
+  outputs = [ "out" "man" "dev" ];
 
   buildInputs = [ zlib ]
     ++ lib.optionals stdenv.isLinux [ libnl numactl pmix ucx ucc ]
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional (stdenv.isLinux || stdenv.isFreeBSD) rdma-core
     ++ lib.optionals fabricSupport [ libpsm2 libfabric ];
 
-  nativeBuildInputs = [ perl ]
+  nativeBuildInputs = [ perl removeReferencesTo makeWrapper ]
     ++ lib.optionals cudaSupport [ cudaPackages.cuda_nvcc ]
     ++ lib.optionals fortranSupport [ gfortran ];
 
@@ -71,24 +71,51 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     find $out/lib/ -name "*.la" -exec rm -f \{} \;
+
+    for f in mpi shmem osh; do
+      for i in f77 f90 CC c++ cxx cc fort; do
+        moveToOutput "bin/$f$i" "''${!outputDev}"
+        echo "move $fi$i"
+        moveToOutput "share/openmpi/$f$i-wrapper-data.txt" "''${!outputDev}"
+      done
+    done
+
+    for i in ortecc orte-info ompi_info oshmem_info opal_wrapper; do
+      moveToOutput "bin/$i" "''${!outputDev}"
+    done
+
+    moveToOutput "share/openmpi/ortecc-wrapper-data.txt" "''${!outputDev}"
    '';
 
   postFixup = ''
+    remove-references-to -t $dev $(readlink -f $out/lib/libopen-pal${stdenv.hostPlatform.extensions.sharedLibrary})
+    remove-references-to -t $man $(readlink -f $out/lib/libopen-pal${stdenv.hostPlatform.extensions.sharedLibrary})
+
+    # The path to the wrapper is hard coded in libopen-pal.so, which we just cleared.
+    wrapProgram $dev/bin/opal_wrapper \
+      --set OPAL_INCLUDEDIR $dev/include \
+      --set OPAL_PKGDATADIR $dev/share/openmpi
+
     # default compilers should be indentical to the
     # compilers at build time
 
+    echo "$dev/share/openmpi/mpicc-wrapper-data.txt"
     sed -i 's:compiler=.*:compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc:' \
-      $out/share/openmpi/mpicc-wrapper-data.txt
+      $dev/share/openmpi/mpicc-wrapper-data.txt
 
+    echo "$dev/share/openmpi/ortecc-wrapper-data.txt"
     sed -i 's:compiler=.*:compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc:' \
-       $out/share/openmpi/ortecc-wrapper-data.txt
+       $dev/share/openmpi/ortecc-wrapper-data.txt
 
+    echo "$dev/share/openmpi/mpic++-wrapper-data.txt"
     sed -i 's:compiler=.*:compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}c++:' \
-       $out/share/openmpi/mpic++-wrapper-data.txt
+       $dev/share/openmpi/mpic++-wrapper-data.txt
   '' + lib.optionalString fortranSupport ''
 
+    echo "$dev/share/openmpi/mpifort-wrapper-data.txt"
     sed -i 's:compiler=.*:compiler=${gfortran}/bin/${gfortran.targetPrefix}gfortran:'  \
-       $out/share/openmpi/mpifort-wrapper-data.txt
+       $dev/share/openmpi/mpifort-wrapper-data.txt
+
   '';
 
   doCheck = true;

--- a/pkgs/development/libraries/science/chemistry/libvdwxc/default.nix
+++ b/pkgs/development/libraries/science/chemistry/libvdwxc/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
     export PATH=$PATH:${mpi}/bin
     configureFlagsArray+=(
-      --with-mpi=${mpi}
+      --with-mpi=${lib.getDev mpi}
       CC=mpicc
       FC=mpif90
       MPICC=mpicc

--- a/pkgs/development/libraries/science/math/scalapack/default.nix
+++ b/pkgs/development/libraries/science/math/scalapack/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
       -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=OFF
       -DLAPACK_LIBRARIES="-llapack"
       -DBLAS_LIBRARIES="-lblas"
-      -DCMAKE_Fortran_COMPILER=${mpi}/bin/mpif90
+      -DCMAKE_Fortran_COMPILER=${lib.getDev mpi}/bin/mpif90
       ${lib.optionalString passthru.isILP64 ''
         -DCMAKE_Fortran_FLAGS="-fdefault-integer-8"
         -DCMAKE_C_FLAGS="-DInt=long"

--- a/pkgs/development/python-modules/gpaw/default.nix
+++ b/pkgs/development/python-modules/gpaw/default.nix
@@ -29,8 +29,8 @@ let
     text = ''
       # Compiler
       compiler = 'gcc'
-      mpicompiler = '${mpi}/bin/mpicc'
-      mpilinker = '${mpi}/bin/mpicc'
+      mpicompiler = '${lib.getDev mpi}/bin/mpicc'
+      mpilinker = '${lib.getDev mpi}/bin/mpicc'
 
       # BLAS
       libraries += ['blas']

--- a/pkgs/development/python-modules/h5py/default.nix
+++ b/pkgs/development/python-modules/h5py/default.nix
@@ -47,7 +47,7 @@ in buildPythonPackage rec {
     ${lib.optionalString mpiSupport "export OMPI_MCA_rmaps_base_oversubscribe=yes"}
   '';
 
-  preBuild = lib.optionalString mpiSupport "export CC=${mpi}/bin/mpicc";
+  preBuild = lib.optionalString mpiSupport "export CC=${lib.getDev mpi}/bin/mpicc";
 
   nativeBuildInputs = [
     cython

--- a/pkgs/development/python-modules/mpi4py/default.nix
+++ b/pkgs/development/python-modules/mpi4py/default.nix
@@ -38,8 +38,6 @@ buildPythonPackage rec {
     # work as expected
   '';
 
-  setupPyBuildFlags = ["--mpicc=${mpi}/bin/mpicc"];
-
   nativeBuildInputs = [ mpi ];
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/tools/misc/hdf5/default.nix
+++ b/pkgs/tools/misc/hdf5/default.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional cppSupport "-DHDF5_BUILD_CPP_LIB=ON"
     ++ lib.optional fortranSupport "-DHDF5_BUILD_FORTRAN=ON"
     ++ lib.optional szipSupport "-DHDF5_ENABLE_SZIP_SUPPORT=ON"
-    ++ lib.optionals mpiSupport [ "-DHDF5_ENABLE_PARALLEL=ON" "CC=${mpi}/bin/mpicc" ]
+    ++ lib.optionals mpiSupport [ "-DHDF5_ENABLE_PARALLEL=ON" ]
     ++ lib.optional enableShared "-DBUILD_SHARED_LIBS=ON"
     ++ lib.optional javaSupport "-DHDF5_BUILD_JAVA=ON"
     ++ lib.optional usev110Api "-DDEFAULT_API_VERSION=v110"


### PR DESCRIPTION
## Description of changes
Follow up PR to https://github.com/NixOS/nixpkgs/pull/282034

This PR disentangles the dev outputs that rely on the whole compiler tool chain from the parts that are needed at runime.
Note that all build time related binaries, such as the compiler wrappers (e.g. mpicc) are now in the dev output.
For most packages this has little impact on the build process. One now needs to use, for example 
`"${lib.getDev mpi}/bin/mpicc"`, when referring to the full path compiler wrapper.
I did not run nixpkgs-review in full, but have checked (and fixed) numeros packages that directly depend on `mpi`.

Note, that the splitting the dev output requires some (not so nice) patching, since paths to "$dev" are hardcoded
into the libraries for multiple reasons. However, the savings in closure size are dramatic (before/after):

```
/nix/store/yqarhqaf0jcb1j67ql59f1w0dn1bp9b2-openmpi-4.1.6         10.3M  726.0M
/nix/store/m8fdzvnj5kwmp5k195125wnk8c0gzx74-openmpi-4.1.6          9.3M  176.8M
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
