### PR TITLE
frigate: backport security fixes from 0.13.0

### DIFF
--- a/pkgs/applications/video/frigate/CVE-2023-45670.patch
+++ b/pkgs/applications/video/frigate/CVE-2023-45670.patch
@@ -1,0 +1,182 @@
+diff --git a/frigate/http.py b/frigate/http.py
+index d3a059a7..b36bda57 100644
+--- a/frigate/http.py
++++ b/frigate/http.py
+@@ -61,6 +61,13 @@ def create_app(
+ ):
+     app = Flask(__name__)
+ 
++    @app.before_request
++    def check_csrf():
++        if request.method in ["GET", "HEAD", "OPTIONS", "TRACE"]:
++            pass
++        if "origin" in request.headers and "x-csrf-token" not in request.headers:
++            return jsonify({"success": False, "message": "Missing CSRF header"}), 401
++
+     @app.before_request
+     def _db_connect():
+         if database.is_closed():
+diff --git a/web/src/api/baseUrl.js b/web/src/api/baseUrl.js
+index 132f170c..1167789d 100644
+--- a/web/src/api/baseUrl.js
++++ b/web/src/api/baseUrl.js
+@@ -1,2 +1 @@
+-import { API_HOST } from '../env';
+-export const baseUrl = API_HOST || `${window.location.protocol}//${window.location.host}${window.baseUrl || '/'}`;
++export const baseUrl = `${window.location.protocol}//${window.location.host}${window.baseUrl || '/'}`;
+diff --git a/web/src/api/index.jsx b/web/src/api/index.jsx
+index 9f256dbb..9e4e63b4 100644
+--- a/web/src/api/index.jsx
++++ b/web/src/api/index.jsx
+@@ -5,6 +5,9 @@ import { WsProvider } from './ws';
+ import axios from 'axios';
+ 
+ axios.defaults.baseURL = `${baseUrl}api/`;
++axios.defaults.headers.common = {
++  'X-CSRF-TOKEN': 1,
++};
+ 
+ export function ApiProvider({ children, options }) {
+   return (
+diff --git a/web/src/components/CameraImage.jsx b/web/src/components/CameraImage.jsx
+index 98754e50..c747558c 100644
+--- a/web/src/components/CameraImage.jsx
++++ b/web/src/components/CameraImage.jsx
+@@ -53,7 +53,7 @@ export default function CameraImage({ camera, onload, searchParams = '', stretch
+     if (!config || scaledHeight === 0 || !canvasRef.current) {
+       return;
+     }
+-    img.src = `${apiHost}/api/${name}/latest.jpg?h=${scaledHeight}${searchParams ? `&${searchParams}` : ''}`;
++    img.src = `${apiHost}api/${name}/latest.jpg?h=${scaledHeight}${searchParams ? `&${searchParams}` : ''}`;
+   }, [apiHost, canvasRef, name, img, searchParams, scaledHeight, config]);
+ 
+   return (
+diff --git a/web/src/components/HistoryViewer/HistoryVideo.tsx b/web/src/components/HistoryViewer/HistoryVideo.tsx
+index 32ed7e6c..1544d1e1 100644
+--- a/web/src/components/HistoryViewer/HistoryVideo.tsx
++++ b/web/src/components/HistoryViewer/HistoryVideo.tsx
+@@ -57,10 +57,10 @@ export const HistoryVideo = ({
+     }
+ 
+     video.src({
+-      src: `${apiHost}/vod/event/${id}/master.m3u8`,
++      src: `${apiHost}vod/event/${id}/master.m3u8`,
+       type: 'application/vnd.apple.mpegurl',
+     });
+-    video.poster(`${apiHost}/api/events/${id}/snapshot.jpg`);
++    video.poster(`${apiHost}api/events/${id}/snapshot.jpg`);
+     if (videoIsPlaying) {
+       video.play();
+     }
+diff --git a/web/src/components/RecordingPlaylist.jsx b/web/src/components/RecordingPlaylist.jsx
+index 4d6f9384..a162aa34 100644
+--- a/web/src/components/RecordingPlaylist.jsx
++++ b/web/src/components/RecordingPlaylist.jsx
+@@ -153,7 +153,7 @@ export function EventCard({ camera, event }) {
+     <Link className="" href={`/recording/${camera}/${format(start, 'yyyy-MM-dd/HH/mm/ss')}`}>
+       <div className="flex flex-row mb-2">
+         <div className="w-28 mr-4">
+-          <img className="antialiased" loading="lazy" src={`${apiHost}/api/events/${event.id}/thumbnail.jpg`} />
++          <img className="antialiased" loading="lazy" src={`${apiHost}api/events/${event.id}/thumbnail.jpg`} />
+         </div>
+         <div className="flex flex-row w-full border-b">
+           <div className="w-full text-gray-700 font-semibold relative pt-0">
+diff --git a/web/src/routes/Camera.jsx b/web/src/routes/Camera.jsx
+index 7a50d530..63cbf130 100644
+--- a/web/src/routes/Camera.jsx
++++ b/web/src/routes/Camera.jsx
+@@ -197,7 +197,7 @@ export default function Camera({ camera }) {
+               key={objectType}
+               header={objectType}
+               href={`/events?cameras=${camera}&labels=${encodeURIComponent(objectType)}`}
+-              media={<img src={`${apiHost}/api/${camera}/${encodeURIComponent(objectType)}/thumbnail.jpg`} />}
++              media={<img src={`${apiHost}api/${camera}/${encodeURIComponent(objectType)}/thumbnail.jpg`} />}
+             />
+           ))}
+         </div>
+diff --git a/web/src/routes/CameraMap.jsx b/web/src/routes/CameraMap.jsx
+index ca77ec56..9f3124dc 100644
+--- a/web/src/routes/CameraMap.jsx
++++ b/web/src/routes/CameraMap.jsx
+@@ -226,7 +226,7 @@ ${Object.keys(objectMaskPoints)
+ 
+       <div className="space-y-4">
+         <div className="relative">
+-          <img ref={imageRef} src={`${apiHost}/api/${camera}/latest.jpg`} />
++          <img ref={imageRef} src={`${apiHost}api/${camera}/latest.jpg`} />
+           <EditableMask
+             onChange={handleUpdateEditable}
+             points={'subkey' in editing ? editing.set[editing.key][editing.subkey] : editing.set[editing.key]}
+diff --git a/web/src/routes/Config.jsx b/web/src/routes/Config.jsx
+index e043bbf2..c24a2860 100644
+--- a/web/src/routes/Config.jsx
++++ b/web/src/routes/Config.jsx
+@@ -71,7 +71,7 @@ export default function Config() {
+       format: true,
+       schemas: [
+         {
+-          uri: `${apiHost}/api/config/schema.json`,
++          uri: `${apiHost}api/config/schema.json`,
+           fileMatch: [String(modelUri)],
+         },
+       ],
+diff --git a/web/src/routes/Events.jsx b/web/src/routes/Events.jsx
+index ec50ca78..bec15c23 100644
+--- a/web/src/routes/Events.jsx
++++ b/web/src/routes/Events.jsx
+@@ -352,7 +352,7 @@ export default function Events({ path, ...props }) {
+               icon={Snapshot}
+               label="Download Snapshot"
+               value="snapshot"
+-              href={`${apiHost}/api/events/${downloadEvent.id}/snapshot.jpg?download=true`}
++              href={`${apiHost}api/events/${downloadEvent.id}/snapshot.jpg?download=true`}
+               download
+             />
+           )}
+@@ -361,7 +361,7 @@ export default function Events({ path, ...props }) {
+               icon={Clip}
+               label="Download Clip"
+               value="clip"
+-              href={`${apiHost}/api/events/${downloadEvent.id}/clip.mp4?download=true`}
++              href={`${apiHost}api/events/${downloadEvent.id}/clip.mp4?download=true`}
+               download
+             />
+           )}
+@@ -483,7 +483,7 @@ export default function Events({ path, ...props }) {
+                     <div
+                       className="relative rounded-l flex-initial min-w-[125px] h-[125px] bg-contain bg-no-repeat bg-center"
+                       style={{
+-                        'background-image': `url(${apiHost}/api/events/${event.id}/thumbnail.jpg)`,
++                        'background-image': `url(${apiHost}api/events/${event.id}/thumbnail.jpg)`,
+                       }}
+                     >
+                       <StarRecording
+@@ -595,8 +595,8 @@ export default function Events({ path, ...props }) {
+                                 className="flex-grow-0"
+                                 src={
+                                   event.has_snapshot
+-                                    ? `${apiHost}/api/events/${event.id}/snapshot.jpg`
+-                                    : `${apiHost}/api/events/${event.id}/thumbnail.jpg`
++                                    ? `${apiHost}api/events/${event.id}/snapshot.jpg`
++                                    : `${apiHost}api/events/${event.id}/thumbnail.jpg`
+                                 }
+                                 alt={`${event.label} at ${(event.top_score * 100).toFixed(0)}% confidence`}
+                               />
+diff --git a/web/vite.config.ts b/web/vite.config.ts
+index 6b02c932..0f57d920 100644
+--- a/web/vite.config.ts
++++ b/web/vite.config.ts
+@@ -9,6 +9,13 @@ export default defineConfig({
+   define: {
+     'import.meta.vitest': 'undefined',
+   },
++  server: {
++    proxy: {
++      '/api': {
++        target: 'http://localhost:5000'
++      }
++    }
++  },
+   plugins: [
+     preact(),
+     monacoEditorPlugin.default({

--- a/pkgs/applications/video/frigate/CVE-2023-45671.patch
+++ b/pkgs/applications/video/frigate/CVE-2023-45671.patch
@@ -1,0 +1,13 @@
+diff --git a/frigate/http.py b/frigate/http.py
+index d3a059a7..33519b7a 100644
+--- a/frigate/http.py
++++ b/frigate/http.py
+@@ -1119,7 +1119,7 @@ def recording_clip(camera_name, start_ts, end_ts):
+ 
+         if p.returncode != 0:
+             logger.error(p.stderr)
+-            return f"Could not create clip from recordings for {camera_name}.", 500
++            return "Could not create clip from recordings.", 500
+     else:
+         logger.debug(
+             f"Ignoring subsequent request for {path} as it already exists in the cache."

--- a/pkgs/applications/video/frigate/CVE-2023-45672.patch
+++ b/pkgs/applications/video/frigate/CVE-2023-45672.patch
@@ -1,0 +1,14 @@
+diff --git a/frigate/util.py b/frigate/util.py
+index a6fe4b29..510d5992 100755
+--- a/frigate/util.py
++++ b/frigate/util.py
+@@ -55,7 +55,8 @@ def load_config_with_no_duplicates(raw_config) -> dict:
+     """Get config ensuring duplicate keys are not allowed."""
+ 
+     # https://stackoverflow.com/a/71751051
+-    class PreserveDuplicatesLoader(yaml.loader.Loader):
++    # important to use SafeLoader here to avoid RCE
++    class PreserveDuplicatesLoader(yaml.loader.SafeLoader):
+         pass
+ 
+     def map_constructor(loader, node, deep=False):

--- a/pkgs/applications/video/frigate/default.nix
+++ b/pkgs/applications/video/frigate/default.nix
@@ -59,6 +59,15 @@ python.pkgs.buildPythonApplication rec {
       url = "https://github.com/blakeblackshear/frigate/commit/cb73d0cd392990448811c7212bc5f09be411fc69.patch";
       hash = "sha256-Spt7eRosmTN8zyJ2uVme5HPVy2TKgBtvbQ6tp6PaNac=";
     })
+
+    # https://github.com/blakeblackshear/frigate/security/advisories/GHSA-xq49-hv88-jr6h
+    ./CVE-2023-45670.patch
+
+    # https://github.com/blakeblackshear/frigate/security/advisories/GHSA-jjxc-m35j-p56f
+    ./CVE-2023-45671.patch
+
+    # https://github.com/blakeblackshear/frigate/security/advisories/GHSA-qp3h-4q62-p428
+    ./CVE-2023-45672.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
There is no security support for 0.12.1, and the newer commits did not apply cleanly, hence the manual backport.

The master branch will be updated to 0.13.0 shortly.`

https://github.com/blakeblackshear/frigate/security/advisories/GHSA-xq49-hv88-jr6h
https://github.com/blakeblackshear/frigate/security/advisories/GHSA-jjxc-m35j-p56f
https://github.com/blakeblackshear/frigate/security/advisories/GHSA-qp3h-4q62-p428

Fixes: CVE-2023-45670, CVE-2023-45671, CVE-2023-45672

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
