### PR TITLE
libsForQt5.quickflux: init at 1.1-unstable-2020-11-10

### DIFF
--- a/pkgs/development/libraries/quickflux/default.nix
+++ b/pkgs/development/libraries/quickflux/default.nix
@@ -1,0 +1,64 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, qtbase
+, qtquickcontrols2
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "quickflux";
+  version = "1.1-unstable-2020-11-10";
+
+  src = fetchFromGitHub {
+    owner = "benlau";
+    repo = "quickflux";
+    rev = "2a37acff0416c56cb349e5bc1b841b25ff1bb6f8";
+    hash = "sha256-c0W3Qj8kY6hMcMy/v5xhwJF9+muZjotmJqhbjqQVab0=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  postPatch = ''
+    # Don't hardcode static linking, let stdenv decide
+    # Use GNUInstallDirs
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'quickflux STATIC' 'quickflux' \
+      --replace-fail 'DESTINATION include' 'DESTINATION ''${CMAKE_INSTALL_INCLUDEDIR}'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    qtbase
+    qtquickcontrols2
+  ];
+
+  # Only a QML module
+  dontWrapQtApps = true;
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+  ];
+
+  preFixup = ''
+    # Has extra $out in includes list, breaks usage of module (complains about non-existent path in module includes)
+    substituteInPlace $out/lib/cmake/QuickFlux/QuickFluxTargets.cmake \
+      --replace "\''${_IMPORT_PREFIX}/include" '${placeholder "dev"}/include'
+  '';
+
+  meta = with lib; {
+    description = "A Flux implementation for QML";
+    homepage = "https://github.com/benlau/quickflux";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.unix;
+  };
+})

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -245,6 +245,8 @@ in (noExtraAttrs (kdeFrameworks // plasmaMobileGear // plasma5 // plasma5.thirdP
 
   quazip = callPackage ../development/libraries/quazip { };
 
+  quickflux = callPackage ../development/libraries/quickflux { };
+
   qscintilla = callPackage ../development/libraries/qscintilla { };
 
   qwt = callPackage ../development/libraries/qwt/default.nix { };


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[QuickFlux](https://github.com/benlau/quickflux) is a library, bringing Facebook's Flux application architecture framework to QML. It's required for building Lomiri's TELEports telegram client.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
