### PR TITLE
public-transport-enabler: init at 20231217

### DIFF
--- a/pkgs/by-name/pu/public-transport-enabler/package.nix
+++ b/pkgs/by-name/pu/public-transport-enabler/package.nix
@@ -1,0 +1,104 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, gradle
+, perl
+, writeText
+}:
+
+let
+  pname = "public-transport-enabler";
+  version = "20231217";
+
+  src = fetchFromGitLab {
+    owner = "oeffi";
+    repo = "public-transport-enabler";
+    rev = "5f0f872b67183a87e1797df5b4b9bb05fe80237d";
+    hash = "sha256-8pUfg+rdTA0pTUWo3bAgNbtAGuBnWY2GJwbTlh03Rjo=";
+  };
+
+  # do not require android-specific deps
+  postPatch = ''
+    substituteInPlace build.gradle \
+      --replace \
+        "com.google.guava:guava:32.1.3-android" \
+        "com.google.guava:guava:32.1.3-jre"
+  '';
+
+  deps = stdenv.mkDerivation {
+    pname = "${pname}-deps";
+    inherit src version postPatch;
+    nativeBuildInputs = [ gradle perl ];
+
+    buildPhase = ''
+      export GRADLE_USER_HOME=$(mktemp -d);
+      gradle --no-daemon build -x test
+    '';
+
+    # perl code mavenizes pathes (com.squareup.okio/okio/1.13.0/a9283170b7305c8d92d25aff02a6ab7e45d06cbe/okio-1.13.0.jar -> com/squareup/okio/okio/1.13.0/okio-1.13.0.jar)
+    installPhase = ''
+      find $GRADLE_USER_HOME/caches/modules-2 -type f -regex '.*\.\(jar\|pom\)' \
+        | perl -pe 's#(.*/([^/]+)/([^/]+)/([^/]+)/[0-9a-f]{30,40}/([^/\s]+))$# ($x = $2) =~ tr|\.|/|; "install -Dm444 $1 \$out/$x/$3/$4/$5" #e' \
+        | sh
+    '';
+
+    dontStrip = true;
+
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = "sha256-Yiah8Exxup9tX3xd6hinrwb7aUdqvmafStQDkmhO0pM=";
+  };
+
+  # Point to our local deps repo
+  gradleInit = writeText "init.gradle" ''
+    settingsEvaluated { settings ->
+      settings.pluginManagement {
+        repositories {
+          clear()
+          maven { url '${deps}' }
+        }
+      }
+    }
+
+    gradle.projectsLoaded {
+      rootProject.allprojects {
+        repositories {
+          clear()
+          maven { url '${deps}' }
+        }
+      }
+    }
+  '';
+
+in stdenv.mkDerivation {
+  inherit pname version src postPatch;
+
+  nativeBuildInputs = [ gradle ];
+
+  buildPhase = ''
+    runHook preBuild
+    export GRADLE_USER_HOME=$(mktemp -d)
+
+    gradle --offline --no-daemon build -x test --init-script ${gradleInit}
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/java
+    cp build/libs/public-transport-enabler.jar $out/share/java
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Java library to get public transport data from various carriers";
+    homepage = "https://gitlab.com/oeffi/public-transport-enabler/";
+    sourceProvenance = with sourceTypes; [
+      fromSource
+      binaryBytecode   # deps
+    ];
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ gm6k ];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

Java library to get public transport data from various carriers.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).



---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
