### PR TITLE
apfs-fuse: unstable-2023-01-04 -> unstable-2023-03-12; cleanup pname, version, mainProgram

### DIFF
--- a/pkgs/tools/filesystems/apfs-fuse/default.nix
+++ b/pkgs/tools/filesystems/apfs-fuse/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "apfs-fuse";
-  version = "unstable-2023-01-04";
+  version = "unstable-2023-03-12";
 
   src = fetchFromGitHub {
     owner  = "sgan81";
     repo   = "apfs-fuse";
-    rev    = "1f041d7af5df5423832e54e9f358fd9234773fcc";
-    hash = "sha256-EmhCvIwyVJvib/ZHzCsULh8bOjhzKRu47LojX+L40qQ=";
+    rev    = "66b86bd525e8cb90f9012543be89b1f092b75cf3";
+    hash = "sha256-uYAlqnQp0K880XEWuH1548DUA3ii53+hfsuh/T3Vwzg=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/tools/filesystems/apfs-fuse/default.nix
+++ b/pkgs/tools/filesystems/apfs-fuse/default.nix
@@ -1,8 +1,8 @@
 { lib, stdenv, fetchFromGitHub, fuse, fuse3, bzip2, zlib, attr, cmake }:
 
 stdenv.mkDerivation {
-  pname = "apfs-fuse-unstable";
-  version = "2023-01-04";
+  pname = "apfs-fuse";
+  version = "unstable-2023-01-04";
 
   src = fetchFromGitHub {
     owner  = "sgan81";
@@ -37,8 +37,8 @@ stdenv.mkDerivation {
     homepage    = "https://github.com/sgan81/apfs-fuse";
     description = "FUSE driver for APFS (Apple File System)";
     license     = licenses.gpl2Plus;
+    mainProgram = "apfs-fuse";
     maintainers = with maintainers; [ ealasu ];
     platforms   = platforms.unix;
   };
-
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
