### PR TITLE
nixos/wrapper: pass trusted argv[0] to the privileged executable

### DIFF
--- a/nixos/modules/security/wrappers/wrapper.c
+++ b/nixos/modules/security/wrappers/wrapper.c
@@ -170,15 +170,6 @@ static int make_caps_ambient(const char *self_path) {
     "MALLOC_ARENA_TEST\0"
 
 int main(int argc, char **argv) {
-    ASSERT(argc >= 1);
-
-    // argv[0] goes into a lot of places, to a far greater degree than other elements
-    // of argv. glibc has had buffer overflows relating to argv[0], eg CVE-2023-6246.
-    // Since we expect the wrappers to be invoked from either $PATH or /run/wrappers/bin,
-    // there should be no reason to pass any particularly large values here, so we can
-    // be strict for strictness' sake.
-    ASSERT(strlen(argv[0]) < 512);
-
     int debug = getenv(wrapper_debug) != NULL;
 
     // Drop insecure environment variables explicitly
@@ -209,10 +200,22 @@ int main(int argc, char **argv) {
         return 1;
     }
 
+    char *replacement_argv[2] = {SOURCE_PROG, NULL};
+    char *old_argv0;
+    // Replace untrusted or missing argv[0] by the wrapped program path.
+    // This mitigates vulnerabilities caused by incorrect handling in privileged code.
+    if (argv[0]) {
+        old_argv0 = argv[0];
+        argv[0] = SOURCE_PROG;
+    } else {
+        old_argv0 = "«nullptr»";
+        argv = replacement_argv;
+    }
+
     execve(SOURCE_PROG, argv, environ);
-    
+
     fprintf(stderr, "%s: cannot run `%s': %s\n",
-        argv[0], SOURCE_PROG, strerror(errno));
+        old_argv0, SOURCE_PROG, strerror(errno));
 
     return 1;
 }


### PR DESCRIPTION
This mitigates CVE-2023-6246 for executables acquiring privileges through the wrapper. By far most potential sources of untrusted argv[0] in a privileged process should be covered by that.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
