### PR TITLE
tcptrace: init at 6.6.7

### DIFF
--- a/pkgs/by-name/tc/tcptrace/fix-owners.patch
+++ b/pkgs/by-name/tc/tcptrace/fix-owners.patch
@@ -1,0 +1,16 @@
+Index: tcptrace-6.6.1/Makefile.in
+===================================================================
+--- tcptrace-6.6.1.orig/Makefile.in
+--- tcptrace-6.6.1/Makefile.in
+@@ -286,9 +286,9 @@
+ # just a quick installation rule
+ INSTALL = ./install-sh -c
+ install: tcptrace install-man
+-	$(INSTALL) -m 755 -o bin -g bin tcptrace ${BINDIR}/tcptrace
++	$(INSTALL) -m 755 tcptrace ${BINDIR}/tcptrace
+ install-man: 
+-	$(INSTALL) -m 444 -o bin -g bin tcptrace.man $(MANDIR)/man1/tcptrace.1
++	$(INSTALL) -m 444 tcptrace.man $(MANDIR)/man1/tcptrace.1
+ 
+ 
+ 

--- a/pkgs/by-name/tc/tcptrace/package.nix
+++ b/pkgs/by-name/tc/tcptrace/package.nix
@@ -1,0 +1,54 @@
+{
+  stdenv,
+  fetchurl,
+  lib,
+  libpcap,
+}:
+stdenv.mkDerivation (final: {
+  name = "tcptrace";
+  version = "6.6.7";
+
+  srcs = [
+    (fetchurl {
+      # Home page was down on 2024-02-01, so use Debian mirror as fallback.
+      urls = [
+        "http://www.tcptrace.org/download/tcptrace-${final.version}.tar.gz"
+        "mirror://debian/pool/main/t/tcptrace/tcptrace_${final.version}.orig.tar.gz"
+      ];
+      hash = "sha256-YzgKQFGTPKCJeUdqnfxvlZMIvJ9g1FJVIC44jrVpEL0=";
+    })
+    (fetchurl {
+      url = "mirror://debian/pool/main/t/tcptrace/tcptrace_6.6.7-6.debian.tar.xz";
+      hash = "sha256-8rkwzdXcDOc3kACvrlyTQsnSw6AJgy6xA0YrECu63gY=";
+    })
+  ];
+  sourceRoot = "tcptrace-${final.version}";
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  setOutputFlags = false;
+
+  patches = [ ./fix-owners.patch ];
+  prePatch = ''
+    patches_deb=(../debian/patches/bug*)
+    patches+=" ''${patches_deb[*]}"
+  '';
+
+  buildInputs = [ libpcap ];
+  makeFlags = [
+    "BINDIR=${placeholder "out"}/bin"
+    "MANDIR=${placeholder "man"}/share/man"
+  ];
+
+  meta = {
+    description = "Tool for analysis of TCP dump files";
+    homepage = "http://www.tcptrace.org/";
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ lib.maintainers.gmacon ];
+    mainProgram = "tcptrace";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[tcptrace](http://tcptrace.org/) ([Wayback Machine](https://web.archive.org/web/20230929062820/http://tcptrace.org/) is a tool for analysis of TCP dump files. It handles the TCP reassembly step so that you can focus on the application layer.

(The home page is down right now, but the name is still registered and points to an IP address owed by Ohio University. The author of tcptrace, Shawn Ostermann, is on the faculty there, so I suspect the server fell over and he just hasn't noticed yet.)

I picked up WIP from #56160 and I think I've addressed the comments there. @Twey, if you are still interested in being listed as a maintainer of this package, please let me know and I'll be happy to add you back to the list.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
