### PR TITLE
lib.modules.doRename: Add condition parameter

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1256,7 +1256,7 @@ let
       (opt.highestPrio or defaultOverridePriority)
       (f opt.value);
 
-  doRename = { from, to, visible, warn, use, withPriority ? true }:
+  doRename = { from, to, visible, warn, use, withPriority ? true, condition ? true }:
     { config, options, ... }:
     let
       fromOpt = getAttrFromPath from options;
@@ -1272,7 +1272,7 @@ let
       } // optionalAttrs (toType != null) {
         type = toType;
       });
-      config = mkMerge [
+      config = mkIf condition (mkMerge [
         (optionalAttrs (options ? warnings) {
           warnings = optional (warn && fromOpt.isDefined)
             "The option `${showOption from}' defined in ${showFiles fromOpt.files} has been renamed to `${showOption to}'.";
@@ -1280,7 +1280,7 @@ let
         (if withPriority
           then mkAliasAndWrapDefsWithPriority (setAttrByPath to) fromOpt
           else mkAliasAndWrapDefinitions (setAttrByPath to) fromOpt)
-      ];
+      ]);
     };
 
   /* Use this function to import a JSON file as NixOS configuration.

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -465,6 +465,9 @@ checkConfigOutput '^1234$' config.c.d.e ./doRename-basic.nix
 checkConfigOutput '^"The option `a\.b. defined in `.*/doRename-warnings\.nix. has been renamed to `c\.d\.e.\."$' \
   config.result \
   ./doRename-warnings.nix
+checkConfigOutput "^true$" config.result ./doRename-condition.nix ./doRename-condition-enable.nix
+checkConfigOutput "^true$" config.result ./doRename-condition.nix ./doRename-condition-no-enable.nix
+checkConfigOutput "^true$" config.result ./doRename-condition.nix ./doRename-condition-migrated.nix
 
 # Anonymous modules get deduplicated by key
 checkConfigOutput '^"pear"$' config.once.raw ./merge-module-with-key.nix

--- a/lib/tests/modules/doRename-condition-enable.nix
+++ b/lib/tests/modules/doRename-condition-enable.nix
@@ -1,0 +1,10 @@
+{ config, lib, ... }:
+{
+  config = {
+    services.foo.enable = true;
+    services.foo.bar = "baz";
+    result =
+      assert config.services.foos == { "" = { bar = "baz"; }; };
+      true;
+  };
+}

--- a/lib/tests/modules/doRename-condition-migrated.nix
+++ b/lib/tests/modules/doRename-condition-migrated.nix
@@ -1,0 +1,10 @@
+{ config, lib, ... }:
+{
+  config = {
+    services.foos."".bar = "baz";
+    result =
+      assert config.services.foos == { "" = { bar = "baz"; }; };
+      assert config.services.foo.bar == "baz";
+      true;
+  };
+}

--- a/lib/tests/modules/doRename-condition-no-enable.nix
+++ b/lib/tests/modules/doRename-condition-no-enable.nix
@@ -1,0 +1,9 @@
+{ config, lib, options, ... }:
+{
+  config = {
+    result =
+      assert config.services.foos == { };
+      assert ! options.services.foo.bar.isDefined;
+      true;
+  };
+}

--- a/lib/tests/modules/doRename-condition.nix
+++ b/lib/tests/modules/doRename-condition.nix
@@ -1,0 +1,42 @@
+/*
+  Simulate a migration from a single-instance `services.foo` to a multi instance
+  `services.foos.<name>` module, where `name = ""` serves as the legacy /
+  compatibility instance.
+
+  - No instances must exist, unless one is defined in the multi-instance module,
+  or if the legacy enable option is set to true.
+  - The legacy instance options must be renamed to the new instance, if it exists.
+
+  The relevant scenarios are tested in separate files:
+  - ./doRename-condition-enable.nix
+  - ./doRename-condition-no-enable.nix
+ */
+{ config, lib, ... }:
+let
+  inherit (lib) mkOption mkEnableOption types doRename;
+in
+{
+  options = {
+    services.foo.enable = mkEnableOption "foo";
+    services.foos = mkOption {
+      type = types.attrsOf (types.submodule {
+        options = {
+          bar = mkOption { type = types.str; };
+        };
+      });
+      default = { };
+    };
+    result = mkOption {};
+  };
+  imports = [
+    (doRename {
+      from = [ "services" "foo" "bar" ];
+      to = [ "services" "foos" "" "bar" ];
+      visible = true;
+      warn = false;
+      use = x: x;
+      withPriority = true;
+      condition = config.services.foo.enable;
+    })
+  ];
+}


### PR DESCRIPTION

## Description of changes

This is to support single-to-multi service migrations, so that the `to` (e.g. `foos.""`) isn't defined unconditionally. See test cases.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
