### PR TITLE
diffuse: fix missing icons and use absolute path to macos bundle in the diffuse CLI wrapper for macos

### DIFF
--- a/pkgs/applications/misc/diffuse/default.nix
+++ b/pkgs/applications/misc/diffuse/default.nix
@@ -10,6 +10,7 @@
 , python3
 , atk
 , gtk3
+, hicolor-icon-theme
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -56,6 +57,10 @@ python3.pkgs.buildPythonApplication rec {
 
   # to avoid running gtk-update-icon-cache, update-desktop-database and glib-compile-schemas
   DESTDIR = "/";
+
+  makeWrapperArgs = [
+      "--prefix XDG_DATA_DIRS : ${hicolor-icon-theme}/share"
+  ];
 
   passthru = {
     updateScript = gitUpdater {

--- a/pkgs/applications/misc/diffuse/default.nix
+++ b/pkgs/applications/misc/diffuse/default.nix
@@ -48,7 +48,7 @@ python3.pkgs.buildPythonApplication rec {
 
   preConfigure = ''
     # app bundle for macos
-    substituteInPlace src/diffuse/meson.build data/icons/meson.build --replace "/Applications" "$out/Applications";
+    substituteInPlace src/diffuse/meson.build data/icons/meson.build src/diffuse/mac-os-app/diffuse-mac.in --replace-fail "/Applications" "$out/Applications";
   '';
 
   mesonFlags = [


### PR DESCRIPTION
## Description of changes

In the two most recent versions there were some icons in the toolbar missing.  I finally figured out that to fix this, it just needs `XDG_DATA_DIRS` set to `hicolor-icon-theme`.

Additionally, I fixed `diffuse` CLI wrapper to point to the absolute path. Originally it was looking for `/Applications/diffuse.app` which is not where Nix apps end up on MacOS. I wasn't using its app bundle personally at all (I have been using `diffuse_impl` script directly instead) but fixing the path to the bundle makes it possible to use `diffuse` script from terminal which results in a nicer icon in the Dock.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
