### PR TITLE
python311Packages.es-client: 8.11.0 -> 8.12.3

### DIFF
--- a/pkgs/development/python-modules/es-client/default.nix
+++ b/pkgs/development/python-modules/es-client/default.nix
@@ -2,6 +2,7 @@
 , buildPythonPackage
 , certifi
 , click
+, ecs-logging
 , elastic-transport
 , elasticsearch8
 , fetchFromGitHub
@@ -19,8 +20,8 @@
 
 buildPythonPackage rec {
   pname = "es-client";
-  version = "8.11.0";
-  format = "pyproject";
+  version = "8.12.3";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -28,7 +29,7 @@ buildPythonPackage rec {
     owner = "untergeek";
     repo = "es_client";
     rev = "refs/tags/v${version}";
-    hash = "sha256-VsHpWe37/CZvGm3PqVq4mJCBA9juvOD9FLmDeW8OjiM=";
+    hash = "sha256-kskUPewMEp37OwLtopJFtbC8Nxa07qgImLejYyiUJao=";
   };
 
   pythonRelaxDeps = true;
@@ -41,6 +42,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     certifi
     click
+    ecs-logging
     elastic-transport
     elasticsearch8
     pyyaml
@@ -62,7 +64,11 @@ buildPythonPackage rec {
   disabledTests = [
     # Tests require network access
     "test_bad_version_raises"
+    "test_basic_operation"
+    "test_basic_operation"
     "test_client_info"
+    "test_logging_options_ecs"
+    "test_logging_options_json"
     "test_multiple_hosts_raises"
     "test_non_dict_passed"
     "test_skip_version_check"


### PR DESCRIPTION
Diff: https://github.com/untergeek/es_client/compare/refs/tags/v8.11.0...v8.12.3

Changelog: https://github.com/untergeek/es_client/releases/tag/v8.12.3

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
