### PR TITLE
tzdata: 2023d -> 2024a

### DIFF
--- a/pkgs/data/misc/tzdata/default.nix
+++ b/pkgs/data/misc/tzdata/default.nix
@@ -1,16 +1,16 @@
 { lib, stdenv, fetchurl, buildPackages }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tzdata";
   version = "2024a";
 
   srcs = [
     (fetchurl {
-      url = "https://data.iana.org/time-zones/releases/tzdata${version}.tar.gz";
+      url = "https://data.iana.org/time-zones/releases/tzdata${finalAttrs.version}.tar.gz";
       hash = "sha256-DQQ0RZrL0gWaeo2h8zBKhKhlkfbtacYkj/+lArbt/+M=";
     })
     (fetchurl {
-      url = "https://data.iana.org/time-zones/releases/tzcode${version}.tar.gz";
+      url = "https://data.iana.org/time-zones/releases/tzcode${finalAttrs.version}.tar.gz";
       hash = "sha256-gAcolK3/WkWPHRQ+FuTKHYsqEiycU5naSCy2jLpqH/g=";
     })
   ];
@@ -25,14 +25,14 @@ stdenv.mkDerivation rec {
   propagatedBuildOutputs = [ ];
 
   makeFlags = [
-    "TOPDIR=$(out)"
-    "TZDIR=$(out)/share/zoneinfo"
-    "BINDIR=$(bin)/bin"
-    "ZICDIR=$(bin)/bin"
+    "TOPDIR=${placeholder "out"}"
+    "TZDIR=${placeholder "out"}/share/zoneinfo"
+    "BINDIR=${placeholder "bin"}/bin"
+    "ZICDIR=${placeholder "bin"}/bin"
     "ETCDIR=$(TMPDIR)/etc"
     "TZDEFAULT=tzdefault-to-remove"
-    "LIBDIR=$(dev)/lib"
-    "MANDIR=$(man)/share/man"
+    "LIBDIR=${placeholder "dev"}/lib"
+    "MANDIR=${placeholder "man"}/share/man"
     "AWK=awk"
     "CFLAGS=-DHAVE_LINK=0"
     "CFLAGS+=-DZIC_BLOAT_DEFAULT=\\\"fat\\\""
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "http://www.iana.org/time-zones";
     description = "Database of current and historical time zones";
-    changelog = "https://github.com/eggert/tz/blob/${version}/NEWS";
+    changelog = "https://github.com/eggert/tz/blob/${finalAttrs.version}/NEWS";
     license = with licenses; [
       bsd3 # tzcode
       publicDomain # tzdata
@@ -78,4 +78,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     maintainers = with maintainers; [ ajs124 fpletz ];
   };
-}
+})

--- a/pkgs/data/misc/tzdata/default.nix
+++ b/pkgs/data/misc/tzdata/default.nix
@@ -2,16 +2,16 @@
 
 stdenv.mkDerivation rec {
   pname = "tzdata";
-  version = "2023d";
+  version = "2024a";
 
   srcs = [
     (fetchurl {
       url = "https://data.iana.org/time-zones/releases/tzdata${version}.tar.gz";
-      hash = "sha256-28ohlwsKi4wM7O7B17kfqQO+D27KWucytTKWciMqCPM=";
+      hash = "sha256-DQQ0RZrL0gWaeo2h8zBKhKhlkfbtacYkj/+lArbt/+M=";
     })
     (fetchurl {
       url = "https://data.iana.org/time-zones/releases/tzcode${version}.tar.gz";
-      hash = "sha256-6aX54RiIbS3pK2K7BVEKKMxsBY15HJO9a4TTKSw8Fh4=";
+      hash = "sha256-gAcolK3/WkWPHRQ+FuTKHYsqEiycU5naSCy2jLpqH/g=";
     })
   ];
 

--- a/pkgs/data/misc/tzdata/default.nix
+++ b/pkgs/data/misc/tzdata/default.nix
@@ -45,7 +45,9 @@ stdenv.mkDerivation (finalAttrs: {
     "CFLAGS+=-DRESERVE_STD_EXT_IDS"
   ];
 
-  doCheck = false; # needs more tools
+  doCheck = true;
+  # everything except for check_web, because that needs curl and wants to talk to https://validator.w3.org
+  checkTarget = "check_back check_character_set check_white_space check_links check_name_lengths check_now check_slashed_abbrs check_sorted check_tables check_ziguard check_zishrink check_tzs";
 
   installFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
     "zic=${buildPackages.tzdata.bin}/bin/zic"


### PR DESCRIPTION
## Description of changes
https://mm.icann.org/pipermail/tz-announce/2024-February/000081.html

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
