### PR TITLE
platformio-core: add missing dependency on aarch64-darwin

### DIFF
--- a/pkgs/development/embedded/platformio/core.nix
+++ b/pkgs/development/embedded/platformio/core.nix
@@ -72,7 +72,8 @@ with python3Packages; buildPythonApplication rec {
     uvicorn
     wsproto
     zeroconf
-
+  ] ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [
+    chardet
   ];
 
   preCheck = ''


### PR DESCRIPTION
## Description of changes

Add the `chardet` package as a dependency on `aarch64-darwin` platforms.

Before, package builds would fail on `aarch64-darwin` platforms due to `chardet` not being installed:
```
Checking runtime dependencies for platformio-6.1.11-py3-none-any.whl
  - chardet not installed
```

It seems that `chardet` was added as an upstream dependency on `aarch64-darwin` platforms:
https://github.com/platformio/platformio-core/commit/9170eee.

## Things done

The `chardet` package was added as a dependency on `aarch64-darwin` platforms.

With this change, all relevant package tests seem to pass:
```
============================= test session starts ==============================
platform darwin -- Python 3.11.7, pytest-7.4.3, pluggy-1.3.0
rootdir: /private/tmp/nix-build-platformio-6.1.11.drv-0/source
configfile: tox.ini
plugins: anyio-4.1.0
collected 125 items / 39 deselected / 86 selected

tests/test_examples.py s                                                 [  1%]
tests/commands/test_account_org_team.py ssssssssssssss                   [ 17%]
tests/commands/test_ci.py .                                              [ 18%]
tests/commands/test_init.py ...                                          [ 22%]
tests/commands/test_lib_complex.py .                                     [ 23%]
tests/commands/test_settings.py .                                        [ 24%]
tests/commands/pkg/test_exec.py .                                        [ 25%]
tests/misc/test_misc.py ..                                               [ 27%]
tests/package/test_manager.py ........                                   [ 37%]
tests/package/test_manifest.py ...........                               [ 50%]
tests/package/test_meta.py ..............                                [ 66%]
tests/package/test_pack.py ......                                        [ 73%]
tests/project/test_config.py ..............s......                       [ 97%]
tests/project/test_savedeps.py ..                                        [100%]

================ 70 passed, 16 skipped, 39 deselected in 1.43s =================
```

Basic testing has been done with the platformio CLI.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
