### PR TITLE
libjpeg_turbo: add mingw support

### DIFF
--- a/pkgs/development/libraries/libjpeg-turbo/0001-Compile-transupp.c-as-part-of-the-library.patch
+++ b/pkgs/development/libraries/libjpeg-turbo/0001-Compile-transupp.c-as-part-of-the-library.patch
@@ -3,12 +3,9 @@ From: Las <las@protonmail.ch>
 Date: Sun, 3 Jan 2021 18:35:37 +0000
 Subject: [PATCH] Compile transupp.c as part of the library
 
-The exported symbols are made weak to not conflict with users
-of the library that already vendor this functionality.
 ---
  CMakeLists.txt |  4 ++--
- transupp.c     | 14 +++++++-------
- 2 files changed, 9 insertions(+), 9 deletions(-)
+ 1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index adb0ca45..46fc16dd 100644
@@ -32,73 +29,6 @@ index adb0ca45..46fc16dd 100644
    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
  
  include(cmakescripts/BuildPackages.cmake)
-diff --git a/transupp.c b/transupp.c
-index 34fbb371..c0ade5a9 100644
---- a/transupp.c
-+++ b/transupp.c
-@@ -1388,7 +1388,7 @@ jt_read_integer(const char **strptr, JDIMENSION *result)
-  * This code is loosely based on XParseGeometry from the X11 distribution.
-  */
- 
--GLOBAL(boolean)
-+GLOBAL(boolean) __attribute__((weak))
- jtransform_parse_crop_spec(jpeg_transform_info *info, const char *spec)
- {
-   info->crop = FALSE;
-@@ -1488,7 +1488,7 @@ trim_bottom_edge(jpeg_transform_info *info, JDIMENSION full_height)
-  * and transformation is not perfect.  Otherwise returns TRUE.
-  */
- 
--GLOBAL(boolean)
-+GLOBAL(boolean) __attribute__((weak))
- jtransform_request_workspace(j_decompress_ptr srcinfo,
-                              jpeg_transform_info *info)
- {
-@@ -2035,7 +2035,7 @@ adjust_exif_parameters(JOCTET *data, unsigned int length, JDIMENSION new_width,
-  * to jpeg_write_coefficients().
-  */
- 
--GLOBAL(jvirt_barray_ptr *)
-+GLOBAL(jvirt_barray_ptr *) __attribute__((weak))
- jtransform_adjust_parameters(j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
-                              jvirt_barray_ptr *src_coef_arrays,
-                              jpeg_transform_info *info)
-@@ -2154,7 +2154,7 @@ jtransform_adjust_parameters(j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
-  * Note that some transformations will modify the source data arrays!
-  */
- 
--GLOBAL(void)
-+GLOBAL(void) __attribute__((weak))
- jtransform_execute_transform(j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
-                              jvirt_barray_ptr *src_coef_arrays,
-                              jpeg_transform_info *info)
-@@ -2266,7 +2266,7 @@ jtransform_execute_transform(j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
-  *           (may use custom action then)
-  */
- 
--GLOBAL(boolean)
-+GLOBAL(boolean) __attribute__((weak))
- jtransform_perfect_transform(JDIMENSION image_width, JDIMENSION image_height,
-                              int MCU_width, int MCU_height,
-                              JXFORM_CODE transform)
-@@ -2305,7 +2305,7 @@ jtransform_perfect_transform(JDIMENSION image_width, JDIMENSION image_height,
-  * This must be called before jpeg_read_header() to have the desired effect.
-  */
- 
--GLOBAL(void)
-+GLOBAL(void) __attribute__((weak))
- jcopy_markers_setup(j_decompress_ptr srcinfo, JCOPY_OPTION option)
- {
- #ifdef SAVE_MARKERS_SUPPORTED
-@@ -2337,7 +2337,7 @@ jcopy_markers_setup(j_decompress_ptr srcinfo, JCOPY_OPTION option)
-  * JFIF APP0 or Adobe APP14 markers if selected.
-  */
- 
--GLOBAL(void)
-+GLOBAL(void) __attribute__((weak))
- jcopy_markers_execute(j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
-                       JCOPY_OPTION option)
- {
 -- 
 2.43.0
 

--- a/pkgs/development/libraries/libjpeg-turbo/0002-Make-exported-symbols-in-transupp.c-weak.patch
+++ b/pkgs/development/libraries/libjpeg-turbo/0002-Make-exported-symbols-in-transupp.c-weak.patch
@@ -1,0 +1,81 @@
+From 6442d11617f95d13e2a371bd3e01f5082a9c356d Mon Sep 17 00:00:00 2001
+From: Las <las@protonmail.ch>
+Date: Sun, 3 Jan 2021 18:35:37 +0000
+Subject: [PATCH] Make exported symbols in transupp.c weak
+
+The exported symbols are made weak to not conflict with users
+of the library that already vendor this functionality.
+---
+ transupp.c     | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/transupp.c b/transupp.c
+index 34fbb371..c0ade5a9 100644
+--- a/transupp.c
++++ b/transupp.c
+@@ -1388,7 +1388,7 @@ jt_read_integer(const char **strptr, JDIMENSION *result)
+  * This code is loosely based on XParseGeometry from the X11 distribution.
+  */
+ 
+-GLOBAL(boolean)
++GLOBAL(boolean) __attribute__((weak))
+ jtransform_parse_crop_spec(jpeg_transform_info *info, const char *spec)
+ {
+   info->crop = FALSE;
+@@ -1488,7 +1488,7 @@ trim_bottom_edge(jpeg_transform_info *info, JDIMENSION full_height)
+  * and transformation is not perfect.  Otherwise returns TRUE.
+  */
+ 
+-GLOBAL(boolean)
++GLOBAL(boolean) __attribute__((weak))
+ jtransform_request_workspace(j_decompress_ptr srcinfo,
+                              jpeg_transform_info *info)
+ {
+@@ -2035,7 +2035,7 @@ adjust_exif_parameters(JOCTET *data, unsigned int length, JDIMENSION new_width,
+  * to jpeg_write_coefficients().
+  */
+ 
+-GLOBAL(jvirt_barray_ptr *)
++GLOBAL(jvirt_barray_ptr *) __attribute__((weak))
+ jtransform_adjust_parameters(j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
+                              jvirt_barray_ptr *src_coef_arrays,
+                              jpeg_transform_info *info)
+@@ -2154,7 +2154,7 @@ jtransform_adjust_parameters(j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
+  * Note that some transformations will modify the source data arrays!
+  */
+ 
+-GLOBAL(void)
++GLOBAL(void) __attribute__((weak))
+ jtransform_execute_transform(j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
+                              jvirt_barray_ptr *src_coef_arrays,
+                              jpeg_transform_info *info)
+@@ -2266,7 +2266,7 @@ jtransform_execute_transform(j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
+  *           (may use custom action then)
+  */
+ 
+-GLOBAL(boolean)
++GLOBAL(boolean) __attribute__((weak))
+ jtransform_perfect_transform(JDIMENSION image_width, JDIMENSION image_height,
+                              int MCU_width, int MCU_height,
+                              JXFORM_CODE transform)
+@@ -2305,7 +2305,7 @@ jtransform_perfect_transform(JDIMENSION image_width, JDIMENSION image_height,
+  * This must be called before jpeg_read_header() to have the desired effect.
+  */
+ 
+-GLOBAL(void)
++GLOBAL(void) __attribute__((weak))
+ jcopy_markers_setup(j_decompress_ptr srcinfo, JCOPY_OPTION option)
+ {
+ #ifdef SAVE_MARKERS_SUPPORTED
+@@ -2337,7 +2337,7 @@ jcopy_markers_setup(j_decompress_ptr srcinfo, JCOPY_OPTION option)
+  * JFIF APP0 or Adobe APP14 markers if selected.
+  */
+ 
+-GLOBAL(void)
++GLOBAL(void) __attribute__((weak))
+ jcopy_markers_execute(j_decompress_ptr srcinfo, j_compress_ptr dstinfo,
+                       JCOPY_OPTION option)
+ {
+-- 
+2.43.0
+

--- a/pkgs/development/libraries/libjpeg-turbo/default.nix
+++ b/pkgs/development/libraries/libjpeg-turbo/default.nix
@@ -42,9 +42,13 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   # This is needed by freeimage
-  patches = [ ./0001-Compile-transupp.c-as-part-of-the-library.patch ]
-    ++ lib.optional stdenv.hostPlatform.isMinGW
-    ./mingw-boolean.patch;
+  patches = [
+    ./0001-Compile-transupp.c-as-part-of-the-library.patch
+  ] ++ lib.optionals (!stdenv.hostPlatform.isMinGW) [
+    ./0002-Make-exported-symbols-in-transupp.c-weak.patch
+  ] ++ lib.optionals stdenv.hostPlatform.isMinGW [
+    ./mingw-boolean.patch
+  ];
 
   outputs = [ "bin" "dev" "dev_private" "out" "man" "doc" ];
 


### PR DESCRIPTION
## Description of changes

See the commit message.

Supersedes #285604.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
