### PR TITLE
gcc: amend __FILE__ mangling patch to only affect `-fmacro-prefix-map=`

### DIFF
--- a/pkgs/development/compilers/gcc/patches/12/mangle-NIX_STORE-in-__FILE__.patch
+++ b/pkgs/development/compilers/gcc/patches/12/mangle-NIX_STORE-in-__FILE__.patch
@@ -1,4 +1,4 @@
-From b10785c1be469319a09b10bc69db21159b0599ee Mon Sep 17 00:00:00 2001
+From 30908556fece379ffd7c0da96c774d8bd297e459 Mon Sep 17 00:00:00 2001
 From: Sergei Trofimovich <siarheit@google.com>
 Date: Fri, 22 Sep 2023 22:41:49 +0100
 Subject: [PATCH] gcc/file-prefix-map.cc: always mangle __FILE__ into invalid
@@ -14,9 +14,8 @@ Typical examples are `nix` -> `nlohmann_json` and `pipewire` ->
 
 For this reason we want to remove the occurrences of hashes in the
 expansion of `__FILE__`. `nuke-references` does it by replacing hashes
-by `eeeeee...` but those paths are also used for debug symbols. It is
-handy to be able to invert the transformation to go back to the original
-store path for debuginfod servers. The chosen solution is to make the
+by `eeeeee...`. It is handy to be able to invert the transformation to
+go back to the original store path. The chosen solution is to make the
 hash uppercase:
 - it does not trigger runtime references (except for all digit hashes,
   which are unlikely enough)
@@ -42,25 +41,27 @@ Tested as:
     ...
 
 Mangled successfully.
+
+To reverse the effect of the mangle use new `NIX_GCC_DONT_MANGLE_PREFIX_MAP`
+environment variable. It should not normally be needed.
 --- a/gcc/file-prefix-map.cc
 +++ b/gcc/file-prefix-map.cc
-@@ -60,6 +60,9 @@ add_prefix_map (file_prefix_map *&maps, const char *arg, const char *opt)
-   maps = map;
- }
- 
-+/* Forward declaration for a $NIX_STORE remap hack below. */
-+static file_prefix_map *macro_prefix_maps; /* -fmacro-prefix-map  */
-+
- /* Perform user-specified mapping of filename prefixes.  Return the
-    GC-allocated new name corresponding to FILENAME or FILENAME if no
+@@ -65,7 +65,7 @@ add_prefix_map (file_prefix_map *&maps, const char *arg, const char *opt)
     remapping was performed.  */
-@@ -76,7 +79,31 @@ remap_filename (file_prefix_map *maps, const char *filename)
+ 
+ static const char *
+-remap_filename (file_prefix_map *maps, const char *filename)
++remap_filename (file_prefix_map *maps, const char *filename, bool mangle_nix_store = false)
+ {
+   file_prefix_map *map;
+   char *s;
+@@ -76,7 +76,31 @@ remap_filename (file_prefix_map *maps, const char *filename)
      if (filename_ncmp (filename, map->old_prefix, map->old_len) == 0)
        break;
    if (!map)
 -    return filename;
 +    {
-+      if (maps == macro_prefix_maps)
++      if (mangle_nix_store && getenv("NIX_GCC_DONT_MANGLE_PREFIX_MAP") == NULL)
 +	{
 +	  /* Remap the 32 characters after $NIX_STORE/ to uppercase
 +	  *
@@ -76,7 +77,7 @@ Mangled successfully.
 +	    {
 +	       s = (char *) ggc_alloc_atomic (name_len + 1);
 +	       memcpy(s, name, name_len + 1);
-+	       for (int i = nix_store_len + 1; i < nix_store_len + 1 + 32; i++) {
++	       for (size_t i = nix_store_len + 1; i < nix_store_len + 1 + 32; i++) {
 +		 s[i] = TOUPPER(s[i]);
 +	       }
 +	       return s;
@@ -87,11 +88,12 @@ Mangled successfully.
    name = filename + map->old_len;
    name_len = strlen (name) + 1;
  
-@@ -90,7 +117,6 @@ remap_filename (file_prefix_map *maps, const char *filename)
-    ignore it in DW_AT_producer (dwarf2out.cc).  */
+@@ -129,7 +153,7 @@ add_profile_prefix_map (const char *arg)
+ const char *
+ remap_macro_filename (const char *filename)
+ {
+-  return remap_filename (macro_prefix_maps, filename);
++  return remap_filename (macro_prefix_maps, filename, true);
+ }
  
- /* Linked lists of file_prefix_map structures.  */
--static file_prefix_map *macro_prefix_maps; /* -fmacro-prefix-map  */
- static file_prefix_map *debug_prefix_maps; /* -fdebug-prefix-map  */
- static file_prefix_map *profile_prefix_maps; /* -fprofile-prefix-map  */
- 
+ /* Remap using -fdebug-prefix-map.  Return the GC-allocated new name

--- a/pkgs/development/compilers/gcc/patches/13/mangle-NIX_STORE-in-__FILE__.patch
+++ b/pkgs/development/compilers/gcc/patches/13/mangle-NIX_STORE-in-__FILE__.patch
@@ -1,4 +1,4 @@
-From b10785c1be469319a09b10bc69db21159b0599ee Mon Sep 17 00:00:00 2001
+From e160a8cd4a704f4b7724df02b62394f677cc4198 Mon Sep 17 00:00:00 2001
 From: Sergei Trofimovich <siarheit@google.com>
 Date: Fri, 22 Sep 2023 22:41:49 +0100
 Subject: [PATCH] gcc/file-prefix-map.cc: always mangle __FILE__ into invalid
@@ -14,9 +14,8 @@ Typical examples are `nix` -> `nlohmann_json` and `pipewire` ->
 
 For this reason we want to remove the occurrences of hashes in the
 expansion of `__FILE__`. `nuke-references` does it by replacing hashes
-by `eeeeee...` but those paths are also used for debug symbols. It is
-handy to be able to invert the transformation to go back to the original
-store path for debuginfod servers. The chosen solution is to make the
+by `eeeeee...`. It is handy to be able to invert the transformation to
+go back to the original store path. The chosen solution is to make the
 hash uppercase:
 - it does not trigger runtime references (except for all digit hashes,
   which are unlikely enough)
@@ -42,23 +41,25 @@ Tested as:
     ...
 
 Mangled successfully.
+
+To reverse the effect of the mangle use new `NIX_GCC_DONT_MANGLE_PREFIX_MAP`
+environment variable. It should not normally be needed.
 --- a/gcc/file-prefix-map.cc
 +++ b/gcc/file-prefix-map.cc
-@@ -69,6 +69,9 @@ add_prefix_map (file_prefix_map *&maps, const char *arg, const char *opt)
-   maps = map;
- }
- 
-+/* Forward declaration for a $NIX_STORE remap hack below. */
-+static file_prefix_map *macro_prefix_maps; /* -fmacro-prefix-map  */
-+
- /* Perform user-specified mapping of filename prefixes.  Return the
-    GC-allocated new name corresponding to FILENAME or FILENAME if no
+@@ -74,7 +74,7 @@ add_prefix_map (file_prefix_map *&maps, const char *arg, const char *opt)
     remapping was performed.  */
-@@ -102,6 +105,30 @@ remap_filename (file_prefix_map *maps, const char *filename)
+ 
+ static const char *
+-remap_filename (file_prefix_map *maps, const char *filename)
++remap_filename (file_prefix_map *maps, const char *filename, bool mangle_nix_store = false)
+ {
+   file_prefix_map *map;
+   char *s;
+@@ -102,6 +102,30 @@ remap_filename (file_prefix_map *maps, const char *filename)
        break;
    if (!map)
      {
-+      if (maps == macro_prefix_maps)
++      if (mangle_nix_store && getenv("NIX_GCC_DONT_MANGLE_PREFIX_MAP") == NULL)
 +	{
 +	  /* Remap all fo $NIX_STORE/.{32} paths to uppercase
 +	   *
@@ -74,7 +75,7 @@ Mangled successfully.
 +	     {
 +		s = (char *) ggc_alloc_atomic (name_len + 1);
 +		memcpy(s, name, name_len + 1);
-+		for (int i = nix_store_len + 1; i < nix_store_len + 1 + 32; i++) {
++		for (size_t i = nix_store_len + 1; i < nix_store_len + 1 + 32; i++) {
 +		  s[i] = TOUPPER(s[i]);
 +		}
 +		if (realname != filename)
@@ -85,11 +86,12 @@ Mangled successfully.
        if (realname != filename)
  	free (const_cast <char *> (realname));
        return filename;
-@@ -124,7 +151,6 @@ remap_filename (file_prefix_map *maps, const char *filename)
-    ignore it in DW_AT_producer (gen_command_line_string in opts.cc).  */
+@@ -163,7 +187,7 @@ add_profile_prefix_map (const char *arg)
+ const char *
+ remap_macro_filename (const char *filename)
+ {
+-  return remap_filename (macro_prefix_maps, filename);
++  return remap_filename (macro_prefix_maps, filename, true);
+ }
  
- /* Linked lists of file_prefix_map structures.  */
--static file_prefix_map *macro_prefix_maps; /* -fmacro-prefix-map  */
- static file_prefix_map *debug_prefix_maps; /* -fdebug-prefix-map  */
- static file_prefix_map *profile_prefix_maps; /* -fprofile-prefix-map  */
- 
+ /* Remap using -fdebug-prefix-map.  Return the GC-allocated new name


### PR DESCRIPTION
THe initial intent of the change was to only affect `-fmacro-prefix-map=` option.

Due to the bug of `if (maps == macro_prefix_maps)` condition of initial setting all three of:

    static file_prefix_map *macro_prefix_maps; /* -fmacro-prefix-map  */
    static file_prefix_map *debug_prefix_maps; /* -fdebug-prefix-map  */
    static file_prefix_map *profile_prefix_maps; /* -fprofile-prefix-map  */

matches the comparison and applied the mangling (as long as on options were passed into those before).

As a result not only (intended) `__FILE__` embedding happened in `.data` section, but also (unintended) debugging symbols (`-fdebug-prefix-map`) and profiling data (`-fprofile-prefix-map`) were broken by mangling.

The patch update fixes it by explicitly passing a boolean that controls the mangling in a single call site relevant to `-fmacro-prefix-map`.

While at it fixed `int / size_t` mismatch that caused build failure on upcoming `gcc-14`.

Tested as:

- `nix` still has no `nlohmann_json` retention
- `gdb` can now resolve `stdc++` debugging symbols in templates
- `--coverage` has working source file paths

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
