### PR TITLE
gpt4all-chat: init at 2.6.2

### DIFF
--- a/pkgs/by-name/gp/gpt4all-chat/package.nix
+++ b/pkgs/by-name/gp/gpt4all-chat/package.nix
@@ -1,0 +1,72 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, qt6
+, fmt
+, shaderc
+, vulkan-headers
+, wayland
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gpt4all-chat";
+  version = "2.6.2";
+
+  src = fetchFromGitHub {
+    fetchSubmodules = true;
+    hash = "sha256-BQE4UQEOOUAh0uGwQf7Q9D30s+aoGFyyMH6EI/WVIkc=";
+    owner = "nomic-ai";
+    repo = "gpt4all";
+    rev = "v${finalAttrs.version}";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/gpt4all-chat";
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace 'set(CMAKE_INSTALL_PREFIX ''${CMAKE_BINARY_DIR}/install)' ""
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    fmt
+    qt6.qtwayland
+    qt6.qtquicktimeline
+    qt6.qtsvg
+    qt6.qthttpserver
+    qt6.qtwebengine
+    qt6.qt5compat
+    shaderc
+    vulkan-headers
+    wayland
+  ];
+
+  cmakeFlags = [
+    "-DKOMPUTE_OPT_USE_BUILT_IN_VULKAN_HEADER=OFF"
+    "-DKOMPUTE_OPT_DISABLE_VULKAN_VERSION_CHECK=ON"
+    "-DKOMPUTE_OPT_USE_BUILT_IN_FMT=OFF"
+  ];
+
+  postInstall = ''
+    rm -rf $out/include
+    rm -rf $out/lib/*.a
+    mv $out/bin/chat $out/bin/${finalAttrs.meta.mainProgram}
+    install -m 444 -D $src/gpt4all-chat/flatpak-manifest/io.gpt4all.gpt4all.desktop $out/share/applications/io.gpt4all.gpt4all.desktop
+    install -m 444 -D $src/gpt4all-chat/icons/logo.svg $out/share/icons/hicolor/scalable/apps/io.gpt4all.gpt4all.svg
+    substituteInPlace $out/share/applications/io.gpt4all.gpt4all.desktop \
+      --replace 'Exec=chat' 'Exec=${finalAttrs.meta.mainProgram}'
+  '';
+
+  meta = {
+    description = "A free-to-use, locally running, privacy-aware chatbot. No GPU or internet required";
+    homepage = "https://github.com/nomic-ai/gpt4all-chat";
+    license = lib.licenses.mit;
+    mainProgram = "gpt4all-chat";
+    maintainers = with lib.maintainers; [ drupol polygon ];
+  };
+})


### PR DESCRIPTION
Source: https://github.com/nomic-ai/gpt4all

Disclaimer: NIH, shamelessly stolen from @polygon's flake at https://github.com/polygon/gpt4all-nix, all the props to him/her! @polygon if you want to claim commit authorship, feel free to amend this PR and do the necessary changes, I'm totally OK with that.

Fix #259798

Tested locally successfully:

![image](https://github.com/NixOS/nixpkgs/assets/252042/52b08bb1-7392-4432-a664-1bb4a32d427b)

![image](https://github.com/NixOS/nixpkgs/assets/252042/8c2a39dd-ab33-48d4-9add-418e75c34ff8)

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
