### PR TITLE
python3Packages.qemu: init at 0.6.1.0a1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4657,6 +4657,12 @@
     githubId = 30475873;
     name = "Andrei Hava";
   };
+  devplayer0 = {
+    email = "dev@nul.ie";
+    github = "devplayer0";
+    githubId = 1427254;
+    name = "Jack O'Sullivan";
+  };
   devusb = {
     email = "mhelton@devusb.us";
     github = "devusb";

--- a/pkgs/development/python-modules/qemu/default.nix
+++ b/pkgs/development/python-modules/qemu/default.nix
@@ -31,6 +31,6 @@ buildPythonPackage rec {
     homepage = "http://www.qemu.org/";
     description = "Python tooling used by the QEMU project to build, configure, and test QEMU";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ devplayer0 ];
+    maintainers = with maintainers; [ devplayer0 davhau ];
   };
 }

--- a/pkgs/development/python-modules/qemu/default.nix
+++ b/pkgs/development/python-modules/qemu/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, pkgs
+, buildPythonPackage
+, pythonOlder
+, fuseSupport ? false, fusepy
+, tuiSupport ? false, urwid, urwid-readline, pygments
+}:
+
+buildPythonPackage rec {
+  pname = "qemu";
+  version = "0.6.1.0a1";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.6";
+
+  src = pkgs.qemu.src;
+  prePatch = ''
+    cd python
+  '';
+
+  propagatedBuildInputs = [ ]
+    ++ lib.optionals fuseSupport [ fusepy ]
+    ++ lib.optionals tuiSupport [ urwid urwid-readline pygments ];
+
+  # Project requires avocado-framework for testing
+  doCheck = false;
+
+  pythonImportsCheck = [ "qemu" ];
+
+  meta = with lib; {
+    homepage = "http://www.qemu.org/";
+    description = "Python tooling used by the QEMU project to build, configure, and test QEMU";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ devplayer0 ];
+  };
+}

--- a/pkgs/development/python-modules/qemu/default.nix
+++ b/pkgs/development/python-modules/qemu/default.nix
@@ -1,31 +1,58 @@
 { lib
-, pkgs
 , buildPythonPackage
 , pythonOlder
+, qemu
+, setuptools
 , fuseSupport ? false, fusepy
 , tuiSupport ? false, urwid, urwid-readline, pygments
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "qemu";
   version = "0.6.1.0a1";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.6";
 
-  src = pkgs.qemu.src;
+  src = qemu.src;
+
   prePatch = ''
     cd python
   '';
+
+  # ensure the version matches qemu-xxx/python/VERSION
+  preConfigure = ''
+    if [ "$version" != "$(cat ./VERSION)" ]; then
+      echo "The nix package version attribute is not in sync with the QEMU source version" > /dev/stderr
+      echo "Please update the version attribute in the nix expression of python3Packages.qemu to '$version'" > /dev/stderr
+      exit 1
+    fi
+  '';
+
+  buildInputs = [
+    setuptools
+  ];
 
   propagatedBuildInputs = [ ]
     ++ lib.optionals fuseSupport [ fusepy ]
     ++ lib.optionals tuiSupport [ urwid urwid-readline pygments ];
 
-  # Project requires avocado-framework for testing
-  doCheck = false;
+  # Project requires avocado-framework for testing, therefore replacing check phase
+  checkPhase = ''
+    for bin in $out/bin/*; do
+      $bin --help
+    done
+  '';
 
   pythonImportsCheck = [ "qemu" ];
+
+  preFixup =
+    (lib.optionalString (! tuiSupport) ''
+      rm $out/bin/qmp-tui
+    '')
+    + (lib.optionalString (! fuseSupport) ''
+      rm $out/bin/qom-fuse
+    '');
 
   meta = with lib; {
     homepage = "http://www.qemu.org/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34760,7 +34760,12 @@ with pkgs;
     inherit (darwin) sigtool;
   };
 
-  qemu-python-utils = python3Packages.toPythonApplication python3Packages.qemu;
+  qemu-python-utils = python3Packages.toPythonApplication (
+    python3Packages.qemu.override {
+      fuseSupport = true;
+      tuiSupport = true;
+    }
+  );
 
   qemu-utils = qemu.override {
     toolsOnly = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34760,6 +34760,8 @@ with pkgs;
     inherit (darwin) sigtool;
   };
 
+  qemu-python-utils = python3Packages.toPythonApplication python3Packages.qemu;
+
   qemu-utils = qemu.override {
     toolsOnly = true;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2389,7 +2389,9 @@ self: super: with self; {
 
   cose = callPackage ../development/python-modules/cose { };
 
-  cot = callPackage ../development/python-modules/cot { };
+  cot = callPackage ../development/python-modules/cot {
+    qemu = pkgs.qemu;
+  };
 
   cov-core = callPackage ../development/python-modules/cov-core { };
 
@@ -5008,7 +5010,9 @@ self: super: with self; {
 
   guessit = callPackage ../development/python-modules/guessit { };
 
-  guestfs = callPackage ../development/python-modules/guestfs { };
+  guestfs = callPackage ../development/python-modules/guestfs {
+    qemu = pkgs.qemu;
+  };
 
   gudhi = callPackage ../development/python-modules/gudhi { };
 
@@ -12280,7 +12284,9 @@ self: super: with self; {
 
   qgrid = callPackage ../development/python-modules/qgrid { };
 
-  qemu = callPackage ../development/python-modules/qemu { };
+  qemu = callPackage ../development/python-modules/qemu {
+    qemu = pkgs.qemu;
+  };
 
   qiling = callPackage ../development/python-modules/qiling { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12280,6 +12280,8 @@ self: super: with self; {
 
   qgrid = callPackage ../development/python-modules/qgrid { };
 
+  qemu = callPackage ../development/python-modules/qemu { };
+
   qiling = callPackage ../development/python-modules/qiling { };
 
   qimage2ndarray = callPackage ../development/python-modules/qimage2ndarray { };


### PR DESCRIPTION
extends #171977 with fixes and improvements

- maintainers: add devplayer0
- python3Packages.qemu: init at 0.6.1.0a1
- python3Packages.qemu: add maintainer davhau
- qemu-python-utils: init at "0.6.1.0a1"
- python3Packages.qemu: fix shadowed qemu; improve expression

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
