### PR TITLE
linuxPackages.openafs: Patch for Linux kernel 6.7

### DIFF
--- a/pkgs/servers/openafs/1.8/module.nix
+++ b/pkgs/servers/openafs/1.8/module.nix
@@ -93,6 +93,21 @@ stdenv.mkDerivation {
       url = "https://git.openafs.org?p=openafs.git;a=patch;h=4f1d8104d17d2b4e95c7abaf5498db6b80aefa8f";
       hash = "sha256-XJpqbDB/LOuqZj3gPHlcLeGzAQCGvPH8ArgWf+sbBJU=";
     })
+    # Linux: Fix to use time_t instead of time64_t
+    (fetchpatch {
+      url = "https://git.openafs.org?p=openafs.git;a=patch;h=56763a199f92101c35d6b9b733302cb08fe0cdbe";
+      hash = "sha256-A2z+smBLQg6k+cHPpNr2s/SgoYuCOMNLcvm5LFRiqeM=";
+    })
+    # dir: Introduce struct DirEntryFlex
+    (fetchpatch {
+      url = "https://git.openafs.org?p=openafs.git;a=patch;h=fd527549c2d2b29a955f8c0427ac67c5d49ef38c";
+      hash = "sha256-jblsaJuTt3BsW5MG69ETcao/ZzSuh9aKRZyTIxZ7Ty4=";
+    })
+    # Linux 6.7: convert to inode a/mtime accessor funcs
+    (fetchpatch {
+      url = "https://git.openafs.org?p=openafs.git;a=patch;h=6edf9d350c6ffd9d5e51fb8106701c1bc2f6a4d9";
+      hash = "sha256-oQVyKzIcqzYDZHSut9Mw1t3kcEC5HGUX6eGlGJ9fZYo=";
+    })
   ];
 
   nativeBuildInputs = [ autoconf automake flex libtool_2 perl which bison ]


### PR DESCRIPTION
## Description of changes

Apply upstream patches from the `openafs-stable-1_8_x` branch to support Linux kernel 6.7.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
