### PR TITLE
fbpanel: 6.1 -> 7.0

### DIFF
--- a/pkgs/applications/window-managers/fbpanel/default.nix
+++ b/pkgs/applications/window-managers/fbpanel/default.nix
@@ -1,30 +1,51 @@
-{ lib, stdenv, fetchurl, pkg-config
-, libX11, libXmu, libXpm, gtk2, libpng, libjpeg, libtiff, librsvg, gdk-pixbuf, gdk-pixbuf-xlib
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, libX11
+, libXmu
+, libXpm
+, gtk2
+, libpng
+, libjpeg
+, libtiff
+, librsvg
+, gdk-pixbuf
+, gdk-pixbuf-xlib
+, pypy2
 }:
 
 stdenv.mkDerivation rec {
   pname = "fbpanel";
-  version = "6.1";
-  src = fetchurl {
-    url = "mirror://sourceforge/fbpanel/${pname}-${version}.tbz2";
-    sha256 = "e14542cc81ea06e64dd4708546f5fd3f5e01884c3e4617885c7ef22af8cf3965";
+  version = "7.0";
+  src = fetchFromGitHub {
+    owner = "aanatoly";
+    repo = "fbpanel";
+    rev = "478754b687e2b48b111507ea22e8e2a001be5199";
+    hash = "sha256-+KcVcrh1aV6kjLGyiDnRHXSzJfelXWrhJS0DitG4yPA=";
   };
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs =
-    [ libX11 libXmu libXpm gtk2 libpng libjpeg libtiff librsvg gdk-pixbuf gdk-pixbuf-xlib.dev ];
+  nativeBuildInputs = [ pkg-config pypy2 ];
+  buildInputs = [
+    libX11
+    libXmu
+    libXpm
+    gtk2
+    libpng
+    libjpeg
+    libtiff
+    librsvg
+    gdk-pixbuf
+    gdk-pixbuf-xlib.dev
+  ];
 
-  preConfigure = "patchShebangs .";
-
-  postConfigure = ''
-    substituteInPlace config.mk \
-      --replace "CFLAGSX =" "CFLAGSX = -I${gdk-pixbuf-xlib.dev}/include/gdk-pixbuf-2.0"
+  preConfigure = ''
+    sed -re '1i#!${pypy2}/bin/pypy' -i configure .config/*.py
+    sed -re 's/\<out\>/outputredirect/g' -i .config/rules.mk
+    sed -i 's/struct\ \_plugin_instance \*stam\;//' panel/plugin.h
   '';
 
-  # Workaround build failure on -fno-common toolchains like upstream
-  # gcc-10. Otherwise build fails as:
-  #   ld: plugin.o:(.bss+0x0): multiple definition of `stam'; panel.o:(.bss+0x20): first defined here
-  env.NIX_CFLAGS_COMPILE = "-fcommon";
-  NIX_LDFLAGS="-lX11";
+  makeFlags = ["V=1"];
+  NIX_CFLAGS_COMPILE = ["-Wno-error" "-I${gdk-pixbuf-xlib.dev}/include/gdk-pixbuf-2.0"];
 
   meta = with lib; {
     description = "A stand-alone panel";
@@ -34,9 +55,4 @@ stdenv.mkDerivation rec {
     mainProgram = "fbpanel";
   };
 
-  passthru = {
-    updateInfo = {
-      downloadPage = "fbpanel.sourceforge.net";
-    };
-  };
 }


### PR DESCRIPTION
Fixes: #176966

Will probably self-merge once CI passes.

## Description of changes

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
