### PR TITLE
libsForQt5.rlottie-qml: init at 0-unstable-2021-05-03

### DIFF
--- a/pkgs/development/libraries/rlottie-qml/default.nix
+++ b/pkgs/development/libraries/rlottie-qml/default.nix
@@ -1,0 +1,73 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, fetchpatch
+, cmake
+, qtbase
+, qtdeclarative
+, qtmultimedia
+, quazip
+, rlottie
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "rlottie-qml";
+  version = "0-unstable-2021-05-03";
+
+  src = fetchFromGitLab {
+    owner = "mymike00";
+    repo = "rlottie-qml";
+    rev = "f9506889a284039888c7a43db37e155bb7b30c40";
+    hash = "sha256-e2/4e1GGFfJMwShy6qgnUVVRxjV4WfjQwcqs09RK194=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  patches = [
+    # Remove when https://gitlab.com/mymike00/rlottie-qml/-/merge_requests/1 merged
+    (fetchpatch {
+      name = "0001-rlottie-qml-Use-upstream-QuaZip-config-module.patch";
+      url = "https://gitlab.com/mymike00/rlottie-qml/-/commit/5656211dd8ae190795e343f47a3393fd3d8d25a4.patch";
+      hash = "sha256-t2NlYVU+D8hKd+AvBWPEavAhJKlk7Q3y2iAQSYtks5k=";
+    })
+  ];
+
+  postPatch = ''
+    # Fix QML install path
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'QT_IMPORTS_DIR "/lib/''${ARCH_TRIPLET}"' 'QT_IMPORTS_DIR "''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"' \
+      --replace-fail "\''${QT_IMPORTS_DIR}/\''${PLUGIN}" "\''${QT_IMPORTS_DIR}" \
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    rlottie
+    qtbase
+    qtdeclarative
+    qtmultimedia
+  ];
+
+  propagatedBuildInputs = [
+    # Config module requires this
+    quazip
+  ];
+
+  # Only a QML module
+  dontWrapQtApps = true;
+
+  meta = with lib; {
+    description = "Library for using rlottie via QML";
+    homepage = "https://gitlab.com/mymike00/rlottie-qml";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ OPNA2608 ];
+    platforms = platforms.all;
+  };
+})

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -255,6 +255,8 @@ in (noExtraAttrs (kdeFrameworks // plasmaMobileGear // plasma5 // plasma5.thirdP
 
   qzxing = callPackage ../development/libraries/qzxing { };
 
+  rlottie-qml = callPackage ../development/libraries/rlottie-qml { };
+
   soqt = callPackage ../development/libraries/soqt { };
 
   telepathy = callPackage ../development/libraries/telepathy/qt { };


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[rlottie-qml](https://gitlab.com/mymike00/rlottie-qml) allows the use of rLottie via QML. It's required for building Lomiri's TELEports telegram client.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
