### PR TITLE
tetragon: init at 0.11.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6678,6 +6678,12 @@
     githubId = 293586;
     name = "Adam Gamble";
   };
+  gangaram = {
+    email = "Ganga.Ram@tii.ae";
+    github = "gangaram-tii";
+    githubId = 131853076;
+    name = "Ganga Ram";
+  };
   garaiza-93 = {
     email = "araizagustavo93@gmail.com";
     github = "garaiza-93";

--- a/pkgs/by-name/te/tetragon/package.nix
+++ b/pkgs/by-name/te/tetragon/package.nix
@@ -1,0 +1,65 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, go
+, llvm_16
+, clang_16
+, bash
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tetragon";
+  version = "0.11.0";
+
+  src = fetchFromGitHub {
+    owner = "cilium";
+    repo = "tetragon";
+    rev = "refs/tags/v${finalAttrs.version}";
+    sha256 = "sha256-KOR5MMRnhrlcMPqRjzjSJXvitiZQ8/tlxEnBiQG2x/Q=";
+  };  
+
+  buildInputs = [
+    clang_16
+    go
+    llvm_16
+    pkg-config
+  ];
+  buildPhase = ''
+    export HOME=$TMP
+    export LOCAL_CLANG=1
+    export LOCAL_CLANG_FORMAT=1
+    make tetragon
+    make tetragon-operator
+    make tetra
+    NIX_CFLAGS_COMPILE="-fno-stack-protector -Qunused-arguments" make tetragon-bpf
+  '';
+
+  postPatch = ''
+    substituteInPlace bpf/Makefile --replace '/bin/bash' '${bash}/bin/bash'
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib
+    mkdir -p $out/lib/tetragon
+    sed -i "s+/usr/local/+$out/+g" install/linux-tarball/usr/local/lib/tetragon/tetragon.conf.d/bpf-lib
+    cp -n -r install/linux-tarball/usr/local/lib/tetragon/tetragon.conf.d/ $out/lib/tetragon/
+    cp -n -r ./bpf/objs $out/lib/tetragon/bpf
+    mkdir -p $out/lib/tetragon/tetragon.tp.d/
+    install -m755 -D ./tetra $out/bin/tetra
+    install -m755 -D ./tetragon $out/bin/tetragon
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/cilium/tetragon";
+    description = "Real-time, eBPF-based Security Observability and Runtime Enforcement tool";
+    mainProgram = "tetragon";
+    maintainers = with maintainers; [ gangaram ];
+    platforms = platforms.linux;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    license = {
+      url = "https://github.com/cilium/tetragon/blob/main/LICENSE";
+    };
+  };
+})
+


### PR DESCRIPTION
## Description of changes
Tetragon: real-time, eBPF-based Security Observability and Runtime Enforcement tool.
See: 
https://github.com/cilium/tetragon

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
