### PR TITLE
vegastrike: init at 0.8.0

### DIFF
--- a/pkgs/by-name/ve/vegastrike-utcs-data/package.nix
+++ b/pkgs/by-name/ve/vegastrike-utcs-data/package.nix
@@ -1,0 +1,34 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, vegastrike
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vegastrike-utcs-data";
+  inherit (vegastrike) version;
+
+  src = fetchFromGitHub {
+    owner = "vegastrike";
+    repo = "Assets-Production";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-XGDg3s8VAtJsO2HnbjA3Yt42euBFH79hIFfSh81jafk=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r $src $out
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Vega Strike - Upon The Coldest Sea - Assets";
+    homepage = "https://www.vega-strike.org";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ TheBrainScrambler ];
+    platforms = platforms.linux;
+    hydraPlatforms = [ ];
+  };
+})

--- a/pkgs/by-name/ve/vegastrike/package.nix
+++ b/pkgs/by-name/ve/vegastrike/package.nix
@@ -1,0 +1,96 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, makeWrapper
+# python311 causes trouble
+# https://github.com/vegastrike/Vega-Strike-Engine-Source/issues/777
+# Will be fixed in next release. There is alternatively a patch that fixes this
+# and allows to switch to latest python if needed
+, python310
+, libpng
+, libjpeg
+, expat
+, gtk3
+, glib
+, openal
+, libogg
+, libvorbis
+, SDL
+, boost
+, python310Packages
+, freeglut
+, vegastrike-utcs-data
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vegastrike";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "vegastrike";
+    repo = "Vega-Strike-Engine-Source";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-8NwXp7PDh8DL777LZcpyC2UmKFwzg1XKIGrL5hzKpbg=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+  ];
+
+  buildInputs = [
+    python310
+    libpng
+    libjpeg
+    expat
+    gtk3
+    glib
+    openal
+    libogg
+    libvorbis
+    SDL
+    boost
+    python310Packages.boost
+    freeglut
+    vegastrike-utcs-data
+  ];
+
+  # the bundled FindGTK3.cmake causes trouble, so we hack around it
+  cmakeFlags = [
+    "-DGTK3_GLIBCONFIG_INCLUDE_DIR=${glib.out}/lib/glib-2.0/include"
+  ];
+
+  sourceRoot = "${finalAttrs.src.name}/engine";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    # expose the unwrapped binaries because the engine can run other games,
+    # not only "Upon The Coldest Sea"
+    cp vegastrike-engine $out/bin
+    cp setup/vegasettings $out/bin
+
+    # upstream says the wrappers for "Upon The Coldest Sea" shall be named vs
+    # and vsettings
+    # https://github.com/vegastrike/Vega-Strike-Engine-Source/?tab=readme-ov-file#executable-name-changes
+    makeWrapper $out/bin/vegastrike-engine $out/bin/vs \
+      --add-flags '-d${vegastrike-utcs-data}'
+    makeWrapper $out/bin/vegasettings $out/bin/vsettings \
+      --add-flags '--target ${vegastrike-utcs-data}'
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A Space Flight Simulator that allows a player to explore, trade, and fight in the vast open space";
+    longDescription = ''
+      Vega Strike is a Space Flight Simulator that allows a player to explore, trade, and fight in the vast open space. You start in an old beat up cargo ship, with endless possibilities in front of you and just enough cash to scrape together a life. Yet danger lurks in the space beyond.
+    '';
+    homepage = "https://www.vega-strike.org";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ TheBrainScrambler ];
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Vega Strike is a Space Flight Simulator that allows a player to explore, trade, and fight in the vast open space. You start in an old beat up cargo ship, with endless possibilities in front of you and just enough cash to scrape together a life. Yet danger lurks in the space beyond.

https://www.vega-strike.org

I'm pushing this as a draft because I've not played it much and some things don't work very well. I get glitchy graphics at time, and when running `vsettings` and setting some values `vsettings` just crashes. I don't know if this is a NixOS problem or just an upstream problem waiting for 0.9.0 to be released. I'm just making this so that if someone else is interested in the game he doesn't have to redo everything I did here.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
