### PR TITLE
bluez: 5.71 -> 5.72

### DIFF
--- a/pkgs/by-name/bl/bluez/package.nix
+++ b/pkgs/by-name/bl/bluez/package.nix
@@ -19,11 +19,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bluez";
-  version = "5.71";
+  version = "5.72";
 
   src = fetchurl {
     url = "mirror://kernel/linux/bluetooth/bluez-${finalAttrs.version}.tar.xz";
-    hash = "sha256-uCjUGMk87R9Vthb7VILPAVN0QL+zT72hpWTz7OlHNdg=";
+    hash = "sha256-SZ1/o0WplsG7ZQ9cZ0nh2SkRH6bs4L4OmGh/7mEkU24=";
   };
 
   buildInputs = [
@@ -42,6 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     docutils
     pkg-config
     python3.pkgs.wrapPython
+    python3.pkgs.pygments
   ];
 
   outputs = [ "out" "dev" "test" ];


### PR DESCRIPTION
Bump bluez to latest release.  I added `python3.pkgs.pygments` to native build inputs as it seems to be neccessary now for bluez to build.

Changelog of the bluez update: https://github.com/bluez/bluez/compare/5.71...5.72
