### PR TITLE
[23.11] backport GraalVM reference fix

### DIFF
--- a/pkgs/by-name/cl/cljfmt/package.nix
+++ b/pkgs/by-name/cl/cljfmt/package.nix
@@ -1,7 +1,5 @@
 { lib
 , buildGraalvmNativeImage
-, graalvmCEPackages
-, removeReferencesTo
 , fetchurl
 , nix-update-script
 , testers
@@ -17,10 +15,6 @@ buildGraalvmNativeImage rec {
     sha256 = "sha256-vEldQ7qV375mHMn3OUdn0FaPd+f/v9g+C+PuzbSTWtk=";
   };
 
-  graalvmDrv = graalvmCEPackages.graalvm-ce;
-
-  nativeBuildInputs = [ removeReferencesTo ];
-
   extraNativeImageBuildArgs = [
     "-H:+ReportExceptionStackTraces"
     "-H:Log=registerResource:"
@@ -29,10 +23,6 @@ buildGraalvmNativeImage rec {
     "--report-unsupported-elements-at-runtime"
     "--no-fallback"
   ];
-
-  postInstall = ''
-    remove-references-to -t ${graalvmDrv} $out/bin/${pname}
-  '';
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/cl/cljfmt/package.nix
+++ b/pkgs/by-name/cl/cljfmt/package.nix
@@ -1,5 +1,7 @@
 { lib
 , buildGraalvmNativeImage
+, graalvmCEPackages
+, removeReferencesTo
 , fetchurl
 , nix-update-script
 , testers
@@ -15,6 +17,10 @@ buildGraalvmNativeImage rec {
     sha256 = "sha256-vEldQ7qV375mHMn3OUdn0FaPd+f/v9g+C+PuzbSTWtk=";
   };
 
+  graalvmDrv = graalvmCEPackages.graalvm-ce;
+
+  nativeBuildInputs = [ removeReferencesTo ];
+
   extraNativeImageBuildArgs = [
     "-H:+ReportExceptionStackTraces"
     "-H:Log=registerResource:"
@@ -23,6 +29,10 @@ buildGraalvmNativeImage rec {
     "--report-unsupported-elements-at-runtime"
     "--no-fallback"
   ];
+
+  postInstall = ''
+    remove-references-to -t ${graalvmDrv} $out/bin/${pname}
+  '';
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/development/interpreters/babashka/default.nix
+++ b/pkgs/development/interpreters/babashka/default.nix
@@ -1,7 +1,6 @@
 { lib
 , buildGraalvmNativeImage
 , graalvmCEPackages
-, removeReferencesTo
 , fetchurl
 , writeScript
 , installShellFiles
@@ -21,7 +20,7 @@ let
 
     executable = "bb";
 
-    nativeBuildInputs = [ removeReferencesTo installShellFiles ];
+    nativeBuildInputs = [ installShellFiles ];
 
     extraNativeImageBuildArgs = [
       "-H:+ReportExceptionStackTraces"
@@ -39,11 +38,7 @@ let
       $out/bin/bb '(prn "bépo àê")' | fgrep 'bépo àê'
     '';
 
-    # As of v1.2.174, this will remove references to ${graalvmDrv}/conf/chronology,
-    # not sure the implications of this but this file is not available in
-    # graalvm-ce anyway.
     postInstall = ''
-      remove-references-to -t ${graalvmDrv} $out/bin/${executable}
       installShellCompletion --cmd bb --bash ${./completions/bb.bash}
       installShellCompletion --cmd bb --zsh ${./completions/bb.zsh}
       installShellCompletion --cmd bb --fish ${./completions/bb.fish}

--- a/pkgs/development/tools/jet/default.nix
+++ b/pkgs/development/tools/jet/default.nix
@@ -1,7 +1,5 @@
 { lib
 , buildGraalvmNativeImage
-, graalvmCEPackages
-, removeReferencesTo
 , fetchurl
 , testers
 , jet
@@ -16,20 +14,12 @@ buildGraalvmNativeImage rec {
     sha256 = "sha256-250/1DBNCXlU1b4jjLUUOXI+uSbOyPXtBN1JJRpdmFc=";
   };
 
-  graalvmDrv = graalvmCEPackages.graalvm-ce;
-
-  nativeBuildInputs = [ removeReferencesTo ];
-
   extraNativeImageBuildArgs = [
     "-H:+ReportExceptionStackTraces"
     "-H:Log=registerResource:"
     "--no-fallback"
     "--no-server"
   ];
-
-  postInstall = ''
-    remove-references-to -t ${graalvmDrv} $out/bin/${pname}
-  '';
 
   passthru.tests.version = testers.testVersion {
     inherit version;

--- a/pkgs/development/tools/jet/default.nix
+++ b/pkgs/development/tools/jet/default.nix
@@ -3,6 +3,8 @@
 , graalvmCEPackages
 , removeReferencesTo
 , fetchurl
+, testers
+, jet
 }:
 
 buildGraalvmNativeImage rec {
@@ -28,6 +30,12 @@ buildGraalvmNativeImage rec {
   postInstall = ''
     remove-references-to -t ${graalvmDrv} $out/bin/${pname}
   '';
+
+  passthru.tests.version = testers.testVersion {
+    inherit version;
+    package = jet;
+    command = "jet --version";
+  };
 
   meta = with lib; {
     description = "CLI to transform between JSON, EDN, YAML and Transit, powered with a minimal query language";

--- a/pkgs/development/tools/jet/default.nix
+++ b/pkgs/development/tools/jet/default.nix
@@ -1,4 +1,9 @@
-{ lib, buildGraalvmNativeImage, fetchurl }:
+{ lib
+, buildGraalvmNativeImage
+, graalvmCEPackages
+, removeReferencesTo
+, fetchurl
+}:
 
 buildGraalvmNativeImage rec {
   pname = "jet";
@@ -9,12 +14,20 @@ buildGraalvmNativeImage rec {
     sha256 = "sha256-250/1DBNCXlU1b4jjLUUOXI+uSbOyPXtBN1JJRpdmFc=";
   };
 
+  graalvmDrv = graalvmCEPackages.graalvm-ce;
+
+  nativeBuildInputs = [ removeReferencesTo ];
+
   extraNativeImageBuildArgs = [
     "-H:+ReportExceptionStackTraces"
     "-H:Log=registerResource:"
     "--no-fallback"
     "--no-server"
   ];
+
+  postInstall = ''
+    remove-references-to -t ${graalvmDrv} $out/bin/${pname}
+  '';
 
   meta = with lib; {
     description = "CLI to transform between JSON, EDN, YAML and Transit, powered with a minimal query language";

--- a/pkgs/development/tools/misc/clojure-lsp/default.nix
+++ b/pkgs/development/tools/misc/clojure-lsp/default.nix
@@ -1,4 +1,14 @@
-{ lib, stdenv, buildGraalvmNativeImage, babashka, fetchurl, fetchFromGitHub, clojure, writeScript }:
+{ lib
+, stdenv
+, buildGraalvmNativeImage
+, graalvmCEPackages
+, removeReferencesTo
+, babashka
+, fetchurl
+, fetchFromGitHub
+, clojure
+, writeScript
+}:
 
 buildGraalvmNativeImage rec {
   pname = "clojure-lsp";
@@ -16,10 +26,18 @@ buildGraalvmNativeImage rec {
     sha256 = "c301821ac6914999a44f5c1cd371d46b248fe9a2e31d43a666d0bc2656cfdd78";
   };
 
+  graalvmDrv = graalvmCEPackages.graalvm-ce;
+
+  nativeBuildInputs = [ removeReferencesTo ];
+
   extraNativeImageBuildArgs = [
     "--no-fallback"
     "--native-image-info"
   ];
+
+  postInstall = ''
+    remove-references-to -t ${graalvmDrv} $out/bin/${pname}
+  '';
 
   doCheck = true;
   checkPhase = ''

--- a/pkgs/development/tools/misc/clojure-lsp/default.nix
+++ b/pkgs/development/tools/misc/clojure-lsp/default.nix
@@ -8,6 +8,8 @@
 , fetchFromGitHub
 , clojure
 , writeScript
+, testers
+, clojure-lsp
 }:
 
 buildGraalvmNativeImage rec {
@@ -46,11 +48,17 @@ buildGraalvmNativeImage rec {
     export HOME="$(mktemp -d)"
     ./${pname} --version | fgrep -q '${version}'
   ''
-    # TODO: fix classpath issue per https://github.com/NixOS/nixpkgs/pull/153770
-    #${babashka}/bin/bb integration-test ./${pname}
+  # TODO: fix classpath issue per https://github.com/NixOS/nixpkgs/pull/153770
+  #${babashka}/bin/bb integration-test ./${pname}
   + ''
     runHook postCheck
   '';
+
+  passthru.tests.version = testers.testVersion {
+    inherit version;
+    package = clojure-lsp;
+    command = "clojure-lsp --version";
+  };
 
   passthru.updateScript = writeScript "update-clojure-lsp" ''
     #!/usr/bin/env nix-shell

--- a/pkgs/development/tools/misc/clojure-lsp/default.nix
+++ b/pkgs/development/tools/misc/clojure-lsp/default.nix
@@ -1,8 +1,6 @@
 { lib
 , stdenv
 , buildGraalvmNativeImage
-, graalvmCEPackages
-, removeReferencesTo
 , babashka
 , fetchurl
 , fetchFromGitHub
@@ -28,18 +26,10 @@ buildGraalvmNativeImage rec {
     sha256 = "c301821ac6914999a44f5c1cd371d46b248fe9a2e31d43a666d0bc2656cfdd78";
   };
 
-  graalvmDrv = graalvmCEPackages.graalvm-ce;
-
-  nativeBuildInputs = [ removeReferencesTo ];
-
   extraNativeImageBuildArgs = [
     "--no-fallback"
     "--native-image-info"
   ];
-
-  postInstall = ''
-    remove-references-to -t ${graalvmDrv} $out/bin/${pname}
-  '';
 
   doCheck = true;
   checkPhase = ''

--- a/pkgs/development/tools/zprint/default.nix
+++ b/pkgs/development/tools/zprint/default.nix
@@ -1,7 +1,5 @@
 { lib
 , buildGraalvmNativeImage
-, graalvmCEPackages
-, removeReferencesTo
 , fetchurl
 , testers
 , zprint
@@ -16,10 +14,6 @@ buildGraalvmNativeImage rec {
     sha256 = "sha256-o0yoW45a5r+sTGvjEqr5VZgQKm72qsPH/kbLTbMTgEM=";
   };
 
-  graalvmDrv = graalvmCEPackages.graalvm-ce;
-
-  nativeBuildInputs = [ removeReferencesTo ];
-
   extraNativeImageBuildArgs = [
     "--no-server"
     "-H:EnableURLProtocols=https,http"
@@ -28,10 +22,6 @@ buildGraalvmNativeImage rec {
     "--initialize-at-build-time"
     "--no-fallback"
   ];
-
-  postInstall = ''
-    remove-references-to -t ${graalvmDrv} $out/bin/${pname}
-  '';
 
   passthru.tests.version = testers.testVersion {
     inherit version;

--- a/pkgs/development/tools/zprint/default.nix
+++ b/pkgs/development/tools/zprint/default.nix
@@ -1,4 +1,9 @@
-{ lib, buildGraalvmNativeImage, fetchurl }:
+{ lib
+, buildGraalvmNativeImage
+, graalvmCEPackages
+, removeReferencesTo
+, fetchurl
+}:
 
 buildGraalvmNativeImage rec {
   pname = "zprint";
@@ -9,6 +14,10 @@ buildGraalvmNativeImage rec {
     sha256 = "sha256-o0yoW45a5r+sTGvjEqr5VZgQKm72qsPH/kbLTbMTgEM=";
   };
 
+  graalvmDrv = graalvmCEPackages.graalvm-ce;
+
+  nativeBuildInputs = [ removeReferencesTo ];
+
   extraNativeImageBuildArgs = [
     "--no-server"
     "-H:EnableURLProtocols=https,http"
@@ -17,6 +26,10 @@ buildGraalvmNativeImage rec {
     "--initialize-at-build-time"
     "--no-fallback"
   ];
+
+  postInstall = ''
+    remove-references-to -t ${graalvmDrv} $out/bin/${pname}
+  '';
 
   meta = with lib; {
     description = "Clojure/EDN source code formatter and pretty printer";

--- a/pkgs/development/tools/zprint/default.nix
+++ b/pkgs/development/tools/zprint/default.nix
@@ -3,6 +3,8 @@
 , graalvmCEPackages
 , removeReferencesTo
 , fetchurl
+, testers
+, zprint
 }:
 
 buildGraalvmNativeImage rec {
@@ -30,6 +32,12 @@ buildGraalvmNativeImage rec {
   postInstall = ''
     remove-references-to -t ${graalvmDrv} $out/bin/${pname}
   '';
+
+  passthru.tests.version = testers.testVersion {
+    inherit version;
+    package = zprint;
+    command = "zprint --version";
+  };
 
   meta = with lib; {
     description = "Clojure/EDN source code formatter and pretty printer";


### PR DESCRIPTION
## Description of changes

PR to backport https://github.com/NixOS/nixpkgs/pull/269479 to 23.11 release.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
