### PR TITLE
onnxruntime: 1.15.1 -> 1.16.3

### DIFF
--- a/pkgs/development/libraries/onnxruntime/default.nix
+++ b/pkgs/development/libraries/onnxruntime/default.nix
@@ -27,28 +27,28 @@ let
     owner = "HowardHinnant";
     repo = "date";
     rev = "v2.4.1";
-    sha256 = "sha256-BYL7wxsYRI45l8C3VwxYIIocn5TzJnBtU0UZ9pHwwZw=";
+    hash = "sha256-BYL7wxsYRI45l8C3VwxYIIocn5TzJnBtU0UZ9pHwwZw=";
   };
 
   eigen = fetchFromGitLab {
     owner = "libeigen";
     repo = "eigen";
-    rev = "d10b27fe37736d2944630ecd7557cefa95cf87c9";
-    sha256 = "sha256-Lmco0s9gIm9sIw7lCr5Iewye3RmrHEE4HLfyzRkQCm0=";
+    rev = "e7248b26a1ed53fa030c5c459f7ea095dfd276ac";
+    hash = "sha256-uQ1YYV3ojbMVfHdqjXRyUymRPjJZV3WHT36PTxPRius=";
   };
 
   mp11 = fetchFromGitHub {
     owner = "boostorg";
     repo = "mp11";
     rev = "boost-1.79.0";
-    sha256 = "sha256-ZxgPDLvpISrjpEHKpLGBowRKGfSwTf6TBfJD18yw+LM=";
+    hash = "sha256-ZxgPDLvpISrjpEHKpLGBowRKGfSwTf6TBfJD18yw+LM=";
   };
 
   safeint = fetchFromGitHub {
     owner = "dcleblanc";
     repo = "safeint";
     rev = "ff15c6ada150a5018c5ef2172401cb4529eac9c0";
-    sha256 = "sha256-PK1ce4C0uCR4TzLFg+elZdSk5DdPCRhhwT3LvEwWnPU=";
+    hash = "sha256-PK1ce4C0uCR4TzLFg+elZdSk5DdPCRhhwT3LvEwWnPU=";
   };
 
   pytorch_cpuinfo = fetchFromGitHub {
@@ -56,35 +56,38 @@ let
     repo = "cpuinfo";
     # There are no tags in the repository
     rev = "5916273f79a21551890fd3d56fc5375a78d1598d";
-    sha256 = "sha256-nXBnloVTuB+AVX59VDU/Wc+Dsx94o92YQuHp3jowx2A=";
+    hash = "sha256-nXBnloVTuB+AVX59VDU/Wc+Dsx94o92YQuHp3jowx2A=";
   };
 
   flatbuffers = fetchFromGitHub {
     owner = "google";
     repo = "flatbuffers";
     rev = "v1.12.0";
-    sha256 = "sha256-L1B5Y/c897Jg9fGwT2J3+vaXsZ+lfXnskp8Gto1p/Tg=";
+    hash = "sha256-L1B5Y/c897Jg9fGwT2J3+vaXsZ+lfXnskp8Gto1p/Tg=";
   };
 
   gtest' = gtest.overrideAttrs (oldAttrs: rec {
+    # TODO According to https://github.com/microsoft/onnxruntime/blob/v1.16.3/cmake/deps.txt#L20,
+    # we should be using revision 519beb0e52c842729b4b53731d27c0e0c32ab4a2 but v1.13.0 is the more recent
+    # that I (@GaetanLepage) managed to build using a simple override.
     version = "1.13.0";
     src = fetchFromGitHub {
       owner = "google";
       repo = "googletest";
-      rev = "v${version}";
+      rev = "refs/tags/v${version}";
       hash = "sha256-LVLEn+e7c8013pwiLzJiiIObyrlbBHYaioO/SWbItPQ=";
     };
     });
 in
 stdenv.mkDerivation rec {
   pname = "onnxruntime";
-  version = "1.15.1";
+  version = "1.16.3";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "onnxruntime";
-    rev = "v${version}";
-    sha256 = "sha256-SnHo2sVACc++fog7Tg6f2LK/Sv/EskFzN7RZS7D113s=";
+    rev = "refs/tags/v${version}";
+    sha256 = "sha256-bTW9Pc3rvH+c8VIlDDEtAXyA3sajVyY5Aqr6+SxaMF4=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
This is an attempt at fixing and updating `onnxruntime`. Unfortunately, some tests are failing:
```
onnxruntime> [----------] Global test environment tear-down
onnxruntime> [==========] 3790 tests from 269 test suites ran. (67205 ms total)
onnxruntime> [  PASSED  ] 3780 tests.
onnxruntime> [  FAILED  ] 10 tests, listed below:
onnxruntime> [  FAILED  ] TransposeOpTest.PermRankDoesNotMatchTensorRank
onnxruntime> [  FAILED  ] TfIdfVectorizerTest.Int32_TF_onlyBigrams_Skip0_Empty_Dim1Fail
onnxruntime> [  FAILED  ] TfIdfVectorizerTest.Int32_TF_onlyBigrams_Skip0_Empty_Dim2
onnxruntime> [  FAILED  ] TfIdfVectorizerTest.Int32_TF_onlyBigrams_Skip01_Empty_Dim2
onnxruntime> [  FAILED  ] ConvTest.Conv1D_Invalid_Input_Shape
onnxruntime> [  FAILED  ] ConvTest.Conv2D_Invalid_Input_Shape
onnxruntime> [  FAILED  ] InferenceSessionTests.TestStrictShapeInference
onnxruntime> [  FAILED  ] FunctionTest.AttrSaturateNan
onnxruntime> [  FAILED  ] GraphTransformationTests.GatherToSplitFusion
onnxruntime> [  FAILED  ] GraphTransformationTests.GatherToSplitFusion_NoSqueeze
```

I don't know if this is due to the fact that we use an outdated version of `googletest` compared to what they have upstream...

Changelog: https://github.com/microsoft/onnxruntime/releases/tag/v1.16.3

cc @jonringer  @puffnfresh @ck3d @cbourjau 

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
