### PR TITLE
tlmi-auth: improve the derivation

### DIFF
--- a/pkgs/by-name/tl/tlmi-auth/package.nix
+++ b/pkgs/by-name/tl/tlmi-auth/package.nix
@@ -22,6 +22,9 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     pkg-config
+  ];
+
+  buildInputs = [
     openssl
   ];
 

--- a/pkgs/by-name/tl/tlmi-auth/package.nix
+++ b/pkgs/by-name/tl/tlmi-auth/package.nix
@@ -6,18 +6,15 @@
 , ninja
 , openssl
 }:
-let
-  name = "tlmi-auth";
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tlmi-auth";
   version = "1.0.1";
-in
-stdenv.mkDerivation {
-  pname = name;
-  version = version;
 
   src = fetchFromGitHub {
     owner = "lenovo";
-    repo = name;
-    rev = "v${version}";
+    repo = "tlmi-auth";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-/juXQrb3MsQ6FxmrAa7E1f0vIMu1397tZ1pzLfr56M4=";
   };
 
@@ -32,8 +29,8 @@ stdenv.mkDerivation {
     homepage = "https://github.com/lenovo/tlmi-auth";
     maintainers = with maintainers; [ snpschaaf ];
     description = "Utility for creating signature strings needed for thinklmi certificate based authentication";
-    mainProgram = name;
+    mainProgram = "tlmi-auth";
     license = licenses.gpl2;
     platforms = platforms.linux;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

- Improved overridability
- Enabled cross compilation

See the commit messages for more details and background.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
