### PR TITLE
parsedmarc: fix and switch to OpenSearch

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -228,6 +228,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
   - The `erlang_node_short_name`, `erlang_node_name`, `port` and `options` configuration parameters are gone, and have been replaced with an `environment` parameter.
     Use the appropriate [environment variables](https://hexdocs.pm/livebook/readme.html#environment-variables) inside `environment` to configure the service instead.
 
+- The [`parsedmarc`](#module-services-parsedmarc) module has switched its default search engine from Elasticsearch to OpenSearch, since Elasticsearch is no longer open source. The `services.parsedmarc.provision.elasticsearch` option has been replaced by [`services.parsedmarc.provision.opensearch`](#opt-services.parsedmarc.provision.opensearch).
+
 ## Other Notable Changes {#sec-release-24.05-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/services/monitoring/parsedmarc.md
+++ b/nixos/modules/services/monitoring/parsedmarc.md
@@ -2,12 +2,12 @@
 [parsedmarc](https://domainaware.github.io/parsedmarc/) is a service
 which parses incoming [DMARC](https://dmarc.org/) reports and stores
 or sends them to a downstream service for further analysis. In
-combination with Elasticsearch, Grafana and the included Grafana
+combination with OpenSearch, Grafana and the included Grafana
 dashboard, it provides a handy overview of DMARC reports over time.
 
 ## Basic usage {#module-services-parsedmarc-basic-usage}
 A very minimal setup which reads incoming reports from an external
-email address and saves them to a local Elasticsearch instance looks
+email address and saves them to a local OpenSearch instance looks
 like this:
 
 ```nix
@@ -53,7 +53,7 @@ services.parsedmarc = {
 The reports can be visualized and summarized with parsedmarc's
 official Grafana dashboard. For all views to work, and for the data to
 be complete, GeoIP databases are also required. The following example
-shows a basic deployment where the provisioned Elasticsearch instance
+shows a basic deployment where the provisioned OpenSearch instance
 is automatically added as a Grafana datasource, and the dashboard is
 added to Grafana as well.
 
@@ -99,7 +99,7 @@ services.nginx = {
   recommendedOptimisation = true;
   recommendedGzipSettings = true;
   recommendedProxySettings = true;
-  upstreams.grafana.servers."unix:/${config.services.grafana.socket}" = {};
+  upstreams.grafana.servers."unix:/${config.services.grafana.settings.server.socket}" = {};
   virtualHosts.${url} = {
     root = config.services.grafana.staticRootPath;
     enableACME = true;

--- a/nixos/modules/services/monitoring/parsedmarc.nix
+++ b/nixos/modules/services/monitoring/parsedmarc.nix
@@ -305,7 +305,7 @@ in
               description = lib.mdDoc ''
                 The addresses to send outgoing mail to.
               '';
-              apply = x: if x == [] then null else lib.concatStringsSep "," x;
+              apply = x: if elem x [ [] null ] then null else lib.concatStringsSep "," x;
             };
           };
 

--- a/nixos/modules/services/search/opensearch.nix
+++ b/nixos/modules/services/search/opensearch.nix
@@ -37,7 +37,7 @@ in
           type = lib.types.str;
           default = "127.0.0.1";
           description = lib.mdDoc ''
-            Which port this service should listen on.
+            Which address this service should listen on.
           '';
         };
 

--- a/nixos/tests/parsedmarc/default.nix
+++ b/nixos/tests/parsedmarc/default.nix
@@ -92,27 +92,26 @@ in
 
       testScript = { nodes }:
         let
-          esPort = toString nodes.parsedmarc.config.services.elasticsearch.port;
-          valueObject = lib.optionalString (lib.versionAtLeast nodes.parsedmarc.config.services.elasticsearch.package.version "7") ".value";
+          osPort = toString nodes.parsedmarc.services.opensearch.settings."http.port";
         in ''
           parsedmarc.start()
           parsedmarc.wait_for_unit("postfix.service")
           parsedmarc.wait_for_unit("dovecot2.service")
           parsedmarc.wait_for_unit("parsedmarc.service")
           parsedmarc.wait_until_succeeds(
-              "curl -sS -f http://localhost:${esPort}"
+              "curl -sS -f http://localhost:${osPort}"
           )
 
           parsedmarc.fail(
-              "curl -sS -f http://localhost:${esPort}/_search?q=report_id:2940"
+              "curl -sS -f http://localhost:${osPort}/_search?q=report_id:2940"
               + " | tee /dev/console"
-              + " | jq -es 'if . == [] then null else .[] | .hits.total${valueObject} > 0 end'"
+              + " | jq -es 'if . == [] then null else .[] | .hits.total.value > 0 end'"
           )
           parsedmarc.succeed("send-email")
           parsedmarc.wait_until_succeeds(
-              "curl -sS -f http://localhost:${esPort}/_search?q=report_id:2940"
+              "curl -sS -f http://localhost:${osPort}/_search?q=report_id:2940"
               + " | tee /dev/console"
-              + " | jq -es 'if . == [] then null else .[] | .hits.total${valueObject} > 0 end'"
+              + " | jq -es 'if . == [] then null else .[] | .hits.total.value > 0 end'"
           )
         '';
     };
@@ -141,7 +140,7 @@ in
 
               networking.extraHosts = ''
                 127.0.0.1 ${parsedmarcDomain}
-                ${nodes.mail.config.networking.primaryIPAddress} ${mailDomain}
+                ${nodes.mail.networking.primaryIPAddress} ${mailDomain}
               '';
 
               services.parsedmarc = {
@@ -168,7 +167,7 @@ in
 
               networking.extraHosts = ''
                 127.0.0.1 ${mailDomain}
-                ${nodes.parsedmarc.config.networking.primaryIPAddress} ${parsedmarcDomain}
+                ${nodes.parsedmarc.networking.primaryIPAddress} ${parsedmarcDomain}
               '';
 
               services.dovecot2 = {
@@ -201,8 +200,7 @@ in
 
         testScript = { nodes }:
           let
-            esPort = toString nodes.parsedmarc.config.services.elasticsearch.port;
-            valueObject = lib.optionalString (lib.versionAtLeast nodes.parsedmarc.config.services.elasticsearch.package.version "7") ".value";
+            osPort = toString nodes.parsedmarc.services.opensearch.settings."http.port";
           in ''
             mail.start()
             mail.wait_for_unit("postfix.service")
@@ -211,19 +209,19 @@ in
             parsedmarc.start()
             parsedmarc.wait_for_unit("parsedmarc.service")
             parsedmarc.wait_until_succeeds(
-                "curl -sS -f http://localhost:${esPort}"
+                "curl -sS -f http://localhost:${osPort}"
             )
 
             parsedmarc.fail(
-                "curl -sS -f http://localhost:${esPort}/_search?q=report_id:2940"
+                "curl -sS -f http://localhost:${osPort}/_search?q=report_id:2940"
                 + " | tee /dev/console"
-                + " | jq -es 'if . == [] then null else .[] | .hits.total${valueObject} > 0 end'"
+                + " | jq -es 'if . == [] then null else .[] | .hits.total.value > 0 end'"
             )
             mail.succeed("send-email")
             parsedmarc.wait_until_succeeds(
-                "curl -sS -f http://localhost:${esPort}/_search?q=report_id:2940"
+                "curl -sS -f http://localhost:${osPort}/_search?q=report_id:2940"
                 + " | tee /dev/console"
-                + " | jq -es 'if . == [] then null else .[] | .hits.total${valueObject} > 0 end'"
+                + " | jq -es 'if . == [] then null else .[] | .hits.total.value > 0 end'"
             )
           '';
       };

--- a/pkgs/development/python-modules/parsedmarc/default.nix
+++ b/pkgs/development/python-modules/parsedmarc/default.nix
@@ -1,3 +1,24 @@
+{ pythonPackages }:
+let
+  packages = pythonPackages.overrideScope (final: prev: {
+    elasticsearch = prev.elasticsearch.overridePythonAttrs (oldAttrs: rec {
+      version = "7.13.1";
+      src = oldAttrs.src.override {
+        inherit version;
+        sha256 = "d6bcca0b2e5665d08e6fe6fadc2d4d321affd76ce483603078fc9d3ccd2bc0f9";
+      };
+    });
+    elasticsearch-dsl = prev.elasticsearch-dsl.overridePythonAttrs (oldAttrs: rec {
+      version = "7.4.0";
+      src = oldAttrs.src.override {
+        inherit version;
+        sha256 = "c4a7b93882918a413b63bed54018a1685d7410ffd8facbc860ee7fd57f214a6d";
+      };
+    });
+  });
+in
+packages.callPackage (
+
 { lib
 , azure-identity
 , azure-monitor-ingestion
@@ -49,12 +70,6 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-ibxSp1M85WngQKdjlRC4JvLxn0rEn9oVkid/V4iD6zY=";
   };
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace "elasticsearch<7.14.0" "elasticsearch" \
-      --replace "elasticsearch-dsl==7.4.0" "elasticsearch-dsl"
-  '';
 
   nativeBuildInputs = [
     hatchling
@@ -110,3 +125,5 @@ buildPythonPackage rec {
     mainProgram = "parsedmarc";
   };
 }
+
+) {}


### PR DESCRIPTION
## Description of changes

### Problems
**parsedmarc** has been broken for a while now, due to incompatible updates of the Elasticsearch python packages. This probably wasn't very obvious to anyone as the tests require `allowUnfree`, since Elasticsearch is no longer open source.

### Solutions
- Fix the broken python dependencies by pinning compatible ones
- Switch from Elasticsearch to OpenSearch

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
