### PR TITLE
lomiri.lomiri-push-qml: init at 0-unstable-2022-09-15

### DIFF
--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -31,6 +31,7 @@ let
     #### QML / QML-related
     lomiri-action-api = callPackage ./qml/lomiri-action-api { };
     lomiri-notifications = callPackage ./qml/lomiri-notifications { };
+    lomiri-push-qml = callPackage ./qml/lomiri-push-qml { };
     lomiri-settings-components = callPackage ./qml/lomiri-settings-components { };
     lomiri-ui-extras = callPackage ./qml/lomiri-ui-extras { };
     lomiri-ui-toolkit = callPackage ./qml/lomiri-ui-toolkit { };

--- a/pkgs/desktops/lomiri/qml/lomiri-push-qml/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-push-qml/default.nix
@@ -1,0 +1,74 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, fetchpatch
+, cmake
+, lomiri-api
+, lomiri-indicator-network
+, pkg-config
+, qtbase
+, qtdeclarative
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri-push-qml";
+  version = "0-unstable-2022-09-15";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lomiri-push-qml";
+    rev = "6f87ee5cf92e2af0e0ce672835e71704e236b8c0";
+    hash = "sha256-ezLcQRJ7Sq/TVbeGJL3Vq2lzBe7StRRCrWXZs2CCUX8=";
+  };
+
+  patches = [
+    # Remove when https://gitlab.com/ubports/development/core/lomiri-push-qml/-/merge_requests/6 merged
+    (fetchpatch {
+      name = "0001-lomiri-push-qml-Stop-using-qt5_use_modules.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-push-qml/-/commit/a4268c98b9f50fdd52da69c173d377f78ea93104.patch";
+      hash = "sha256-OijTB5+I9/wabT7dX+DkvoEROKzAUIKhBZkkhqq5Oig=";
+    })
+  ];
+
+  postPatch = ''
+    # Queries QMake for QML install location, returns QtBase build path
+    substituteInPlace src/*/PushNotifications/CMakeLists.txt \
+      --replace-fail 'qmake -query QT_INSTALL_QML' 'echo ''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}' \
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qtdeclarative # qmlplugindump
+  ];
+
+  buildInputs = [
+    lomiri-api
+    lomiri-indicator-network
+    qtbase
+    qtdeclarative
+  ];
+
+  dontWrapQtApps = true;
+
+  cmakeFlags = [
+    # In case anything still depends on deprecated hints
+    (lib.cmakeBool "ENABLE_UBUNTU_COMPAT" true)
+  ];
+
+  preBuild = ''
+    # For qmlplugindump
+    export QT_PLUGIN_PATH=${lib.getBin qtbase}/${qtbase.qtPluginPrefix}
+  '';
+
+  meta = with lib; {
+    description = "Lomiri Push Notifications QML plugin";
+    homepage = "https://gitlab.com/ubports/development/core/lomiri-push-qml";
+    # License file indicates gpl3Only, but de87869c2cdb9819c2ca7c9eca9c5fb8b500a01f says it should be lgpl3Only
+    license = licenses.lgpl3Only;
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Working towards #99090.

[`lomiri-push-qml`](https://gitlab.com/ubports/development/core/lomiri-push-qml) is a QML plugin for using Lomiri's push notification API. It's required for building Lomiri's TELEports telegram client.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
