### PR TITLE
storeBackup: 3.5 -> 3.5.2, apply patch for CVE-2020-7040

### DIFF
--- a/pkgs/tools/backup/store-backup/CVE-2020-7040.patch
+++ b/pkgs/tools/backup/store-backup/CVE-2020-7040.patch
@@ -1,0 +1,23 @@
+Index: storeBackup/lib/fileDir.pl
+===================================================================
+--- storeBackup.orig/lib/fileDir.pl
++++ storeBackup/lib/fileDir.pl
+@@ -21,7 +21,7 @@
+ 
+ 
+ use Digest::MD5 qw(md5_hex);
+-use Fcntl qw(O_RDWR O_CREAT);
++use Fcntl qw(O_RDWR O_CREAT O_WRONLY O_EXCL);
+ use Fcntl ':mode';
+ use POSIX;
+ use Cwd 'abs_path';
+@@ -482,7 +482,7 @@ sub checkLockFile
+ 		  '-str' => ["creating lock file <$lockFile>"]);
+ 
+     &::checkDelSymLink($lockFile, $prLog, 0x01);
+-    open(FILE, '>', $lockFile) or
++    sysopen(FILE, $lockFile, O_WRONLY | O_CREAT | O_EXCL) or
+ 	$prLog->print('-kind' => 'E',
+ 		      '-str' => ["cannot create lock file <$lockFile>"],
+ 		      '-exit' => 1);
+

--- a/pkgs/tools/backup/store-backup/default.nix
+++ b/pkgs/tools/backup/store-backup/default.nix
@@ -14,7 +14,7 @@ in
 
 stdenv.mkDerivation rec {
 
-  version = "3.5";
+  version = "3.5.2";
 
   pname = "store-backup";
 
@@ -25,8 +25,13 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://download.savannah.gnu.org/releases/storebackup/storeBackup-${version}.tar.bz2";
-    sha256 = "0y4gzssc93x6y93mjsxm5b5cdh68d7ffa43jf6np7s7c99xxxz78";
+    hash = "sha256-Ki1DT2zypFFiiMVd9Y8eSX7T+yr8moWMoALmAexjqWU=";
   };
+
+  patches = [
+    # https://www.openwall.com/lists/oss-security/2020/01/20/3
+    ./CVE-2020-7040.patch
+  ];
 
   installPhase = ''
     mkdir -p $out/scripts
@@ -48,7 +53,8 @@ stdenv.mkDerivation rec {
 
     PATH=$PATH:${dummyMount}/bin
 
-
+    export USER=test
+    export HOME=$(mktemp -d)
     { # simple sanity test, test backup/restore of simple store paths
 
       mkdir backup


### PR DESCRIPTION
## Description of changes

Changelog:
```
version 3.5.1
	storeBackup.pl
	- linkToRecent didn't work when used for the very first time
	  in a series
	- added option suppressInfo with key readCheckSums
	- changed the order of execution:
	  write backup -> sync -> write 'finished' -> write linkToRecent
	  -> delete old backups -> start postcommand

	storeBackupMergeIsolatedBackup.pl
	- added option --move

	storeBackupSearch.pl
	- option 'backupDir' didn't work (normally not needed)

	lib/fileDir.pl
	- more detailed error messages when copying of a file does
	  not succeed

	lib/checkParam2.pl
	- overwriting settings from config file via commandline didn't
	  work for options with parameters

	storeBackup.pl, storeBackupUpdateBackup.pl, linkToDirs.pl
	- added option --maxHardLinks

----------------------------
version 3.5.2
	storeBackup.pl
	- option --maxHardLinks was not configurable in the
	  configuration file
	- pipe buffering was changed to new needs since
	  about kernel 5.13 (relevant only if you backup devices)

	storeBackupRecover.pl
	- restoring of devices (eg. sda) didn't work because of
	  bug in option checkDevicesDir0 in storeBackup.pl when
	  using more than one directory level like "Devs/Sticks"

	storeBackupUpdateBackup.pl
	- added log file entry about number of WARNINGs and
	  ERRORs happend (like at storeBackup.pl)
```
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>storeBackup</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
