### PR TITLE
kotlin-interactive-shell: init at 0.5.2

### DIFF
--- a/pkgs/by-name/ko/kotlin-interactive-shell/package.nix
+++ b/pkgs/by-name/ko/kotlin-interactive-shell/package.nix
@@ -11,7 +11,7 @@ maven.buildMavenPackage rec {
     hash = "sha256-3DTyo7rPswpEVzFkcprT6FD+ITGJ+qCXFKXEGoCK+oE=";
   };
 
-  mvnHash = "sha256-MPMGj6lWl38oczBHpOny3eLuBVG0h0VqN4DNdaJY2ps";
+  mvnHash = "sha256-m1o0m0foqJhEzWjC9behBeld5HT08WClcZN2xc3fZrI=";
   mvnParameters = "-DskipTests compile";
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/by-name/ko/kotlin-interactive-shell/package.nix
+++ b/pkgs/by-name/ko/kotlin-interactive-shell/package.nix
@@ -1,0 +1,45 @@
+{ lib, maven, fetchFromGitHub, makeWrapper, jre }:
+
+maven.buildMavenPackage rec {
+  pname = "kotlin-interactive-shell";
+  version = "0.5.2";
+
+  src = fetchFromGitHub {
+    owner = "Kotlin";
+    repo = "kotlin-interactive-shell";
+    rev = "v${version}";
+    hash = "sha256-3DTyo7rPswpEVzFkcprT6FD+ITGJ+qCXFKXEGoCK+oE=";
+  };
+
+  mvnHash = "sha256-MPMGj6lWl38oczBHpOny3eLuBVG0h0VqN4DNdaJY2ps";
+  mvnParameters = "-DskipTests compile";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib}
+    cp lib/ki-shell.jar $out/lib/ki-shell.jar
+    makeWrapper ${lib.getExe jre} $out/bin/ki \
+      --add-flags "-jar $out/lib/ki-shell.jar"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Kotlin Language Interactive Shell";
+    longDescription = ''
+      The shell is an extensible implementation of Kotlin REPL with a rich set of features including:
+      - Syntax highlight
+      - Type inference command
+      - Downloading dependencies in runtime using Maven coordinates
+      - List declared symbols
+    '';
+    homepage = "https://github.com/Kotlin/kotlin-interactive-shell";
+    license = licenses.asl20;
+    maintainers = [ maintainers.starsep ];
+    platforms = jre.meta.platforms;
+    mainProgram = "ki";
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Kotlin Language Interactive Shell (ki)
https://github.com/Kotlin/kotlin-interactive-shell
Closes #284536

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
