### PR TITLE
apparmor-utils: fix aa-remove-unknown read check

### DIFF
--- a/pkgs/os-specific/linux/apparmor/0001-aa-remove-unknown_empty-ruleset.patch
+++ b/pkgs/os-specific/linux/apparmor/0001-aa-remove-unknown_empty-ruleset.patch
@@ -1,0 +1,30 @@
+commit 166afaf144d6473464975438353257359dd51708
+Author: Andreas Wiese <andreas.wiese@kernkonzept.com>
+Date:   Thu Feb 1 11:35:02 2024 +0100
+
+    aa-remove-unknown: fix readability check
+    
+    This check is intended for ensuring that the profiles file can actually
+    be opened.  The *actual* check is performed by the shell, not the read
+    utility, which won't even be executed if the input redirection (and
+    hence the test) fails.
+    
+    If the test succeeds, though, using `read` here might actually
+    jeopardize the test result if there are no profiles loaded and the file
+    is empty.
+    
+    This commit fixes that case by simply using `true` instead of `read`.
+
+diff --git a/utils/aa-remove-unknown b/utils/aa-remove-unknown
+index 0e00d6a0..3351feef 100755
+--- a/utils/aa-remove-unknown
++++ b/utils/aa-remove-unknown
+@@ -63,7 +63,7 @@ fi
+ # We have to do this check because error checking awk's getline() below is
+ # tricky and, as is, results in an infinite loop when apparmorfs returns an
+ # error from open().
+-if ! IFS= read -r _ < "$PROFILES" ; then
++if ! true < "$PROFILES" ; then
+ 	echo "ERROR: Unable to read apparmorfs profiles file" 1>&2
+ 	exit 1
+ elif [ ! -w "$REMOVE" ] ; then

--- a/pkgs/os-specific/linux/apparmor/default.nix
+++ b/pkgs/os-specific/linux/apparmor/default.nix
@@ -56,7 +56,9 @@ let
       --replace "/usr/include/linux/capability.h" "${linuxHeaders}/include/linux/capability.h"
   '';
 
-  patches = lib.optionals stdenv.hostPlatform.isMusl [
+  patches = [
+    ./0001-aa-remove-unknown_empty-ruleset.patch
+  ] ++ lib.optionals stdenv.hostPlatform.isMusl [
     (fetchpatch {
       url = "https://git.alpinelinux.org/aports/plain/testing/apparmor/0003-Added-missing-typedef-definitions-on-parser.patch?id=74b8427cc21f04e32030d047ae92caa618105b53";
       name = "0003-Added-missing-typedef-definitions-on-parser.patch";


### PR DESCRIPTION
let aaru = "aa-remove-unknown"; in

aaru tests whether `/sys/kernel/security/apparmor/profiles` can be opened. Even though the file's permissions usually are 0444, open() still might return `EPERM`, as this is a virtual filesystem.  Thus, using `test -r` doesn't suffice for this check.

What aaru does to solve this is (approximately)

```sh
  if ! read … < /sys/kernel/security/apparmor/profiles; then
    echo "Meh";
  fi
```

In principal this works just fine.  When looking closer, it doesn't (which is the root cause of #273164).  Careful readers will notice that the actual access check (for `open()`) isn't actually related to the `read` invocation, but the shell's input redirection, which works totally fine:

If the file can't be opened, the shell will return an error and the test fails.  `read` won't even be invoked.  The culprit is, the `read` shell builtin might potentially jeopardize the *successful* test result (`open()` succeeding): When no profiles are loaded, the file will be empty and `read` will return 1 for `EOF`.

As the `if`'s command is only invoked after the actual test succeeded, `true` is the command of choice here.

I would prefer fixing this upstream, but I refuse to register an account there because GitLab.com wants me to validate an email address (sure), a phone number (why?) and a valid payment method ([redacted]).

This fixes #273164 (»Apparmor service fails to start after nixos-rebuild switch«).

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
