### PR TITLE
cakelisp: 0.1.0 -> 0.3.0-unstable-2023-12-18

### DIFF
--- a/pkgs/development/compilers/cakelisp/default.nix
+++ b/pkgs/development/compilers/cakelisp/default.nix
@@ -1,13 +1,14 @@
-{ lib, stdenv, fetchgit, gcc }:
+{ lib, stdenv, fetchgit, fetchpatch, gcc, unstableGitUpdater }:
 
 stdenv.mkDerivation rec {
   pname = "cakelisp";
-  version = "0.1.0";
+  # using unstable as it's the only version that builds against gcc-13
+  version = "0.3.0-unstable-2023-12-18";
 
   src = fetchgit {
     url = "https://macoy.me/code/macoy/cakelisp";
-    rev = "v${version}";
-    sha256 = "sha256-r7Yg8+2U8qQTYRP3KFET7oBRCZHIZS6Y8TsfL1NR24g=";
+    rev = "866fa2806d3206cc9dd398f0e86640db5be42bd6";
+    hash = "sha256-vwMZUNy+updwk69ahA/D9LhO68eV6wH0Prq+o/i1Q/A=";
   };
 
   buildInputs = [ gcc ];
@@ -34,6 +35,10 @@ stdenv.mkDerivation rec {
     install -Dm755 bin/cakelisp -t $out/bin
     runHook postInstall
   '';
+
+  passthru.updateScript = unstableGitUpdater {
+    url = "https://macoy.me/code/macoy/cakelisp";
+  };
 
   meta = with lib; {
     description = "A performance-oriented Lisp-like language";


### PR DESCRIPTION
The main change is the fix against `gcc-13` build failure: https://hydra.nixos.org/build/247544946

    src/Utilities.hpp:84:46: error: 'uint32_t' has not been declared
       84 | void crc32(const void* data, size_t n_bytes, uint32_t* crc);
          |                                              ^~~~~~~~

Pulling unstable as latets release still does not build against `gcc-13`.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
