### PR TITLE
home-assistant-custom-components.emporia_vue: init at 0.8.3

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -4,6 +4,8 @@
 {
   adaptive_lighting = callPackage ./adaptive_lighting {};
 
+  emporia_vue = callPackage ./emporia_vue {};
+
   govee-lan = callPackage ./govee-lan {};
 
   gpio = callPackage ./gpio {};

--- a/pkgs/servers/home-assistant/custom-components/emporia_vue/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/emporia_vue/default.nix
@@ -1,0 +1,36 @@
+{ lib
+, fetchFromGitHub
+, buildHomeAssistantComponent
+, pyemvue
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "presto8";
+  domain = "emporia_vue";
+  version = "0.8.3";
+
+  src = fetchFromGitHub {
+    owner = "magico13";
+    repo = "ha-emporia-vue";
+    rev = "v${version}";
+    hash = "sha256-6NrRuBjpulT66pVUfW9ujULL5HSzfgyic1pKEBRupNA=";
+  };
+
+  propagatedBuildInputs = [
+    pyemvue
+  ];
+
+  postPatch = ''
+    substituteInPlace custom_components/emporia_vue/manifest.json --replace-fail 'pyemvue==0.17.1' 'pyemvue>=0.17.1'
+  '';
+
+  dontBuild = true;
+
+  meta = with lib; {
+    description = "Reads data from the Emporia Vue energy monitor into Home Assistant";
+    homepage = "https://github.com/magico13/ha-emporia-vue";
+    changelog = "https://github.com/magico13/ha-emporia-vue/releases/tag/v${version}";
+    maintainers = with maintainers; [ presto8 ];
+    license = licenses.mit;
+  };
+}


### PR DESCRIPTION
home-assistant-custom-components.emporia_vue: init at 0.8.3

## Description of changes

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] Tested with home-assistant and Emporia Vue hardware
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

