### PR TITLE
hare: unstable-2023-11-27 -> 0-unstable-2024-02-01

### DIFF
--- a/pkgs/by-name/ha/harec/package.nix
+++ b/pkgs/by-name/ha/harec/package.nix
@@ -3,29 +3,33 @@
 , fetchFromSourcehut
 , qbe
 , fetchgit
+, unstableGitUpdater
 }:
 let
   # harec needs the dbgfile and dbgloc features implemented up to this commit.
-  # This can be dropped once 1.2 is released, for a possible release date see:
+  # This can be dropped once 1.2 is released. For a possible release date, see:
   # https://lists.sr.ht/~mpu/qbe/%3CZPkmHE9KLohoEohE%40cloudsdale.the-delta.net.eu.org%3E
   qbe' = qbe.overrideAttrs (_old: {
-    version = "1.1-unstable-2023-08-18";
+    version = "1.1-unstable-2024-01-12";
     src = fetchgit {
       url = "git://c9x.me/qbe.git";
-      rev = "36946a5142c40b733d25ea5ca469f7949ee03439";
-      hash = "sha256-bqxWFP3/aw7kRoD6ictbFcjzijktHvh4AgWAXBIODW8=";
+      rev = "85287081c4a25785dec1ec48c488a5879b3c37ac";
+      hash = "sha256-7bVbxUU/HXJXLtAxhoK0URmPtjGwMSZrPkx8WKl52Mg=";
     };
   });
+
+  platform = lib.toLower stdenv.hostPlatform.uname.system;
+  arch = stdenv.hostPlatform.uname.processor;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "harec";
-  version = "unstable-2023-11-29";
+  version = "0-unstable-2024-01-29";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "harec";
-    rev = "ec3193e3870436180b0f3df82b769adc57a1c099";
-    hash = "sha256-HXQIgFC4YVDJjo5xbyg1ea3jWYKLEwKkD1KFzWFz9UI= ";
+    rev = "f9e17e633845d8d38566b4ea32db0a29ac85d96e";
+    hash = "sha256-Xy9VOcDtbJUz3z6Vk8bqH41VbAFKtJ9fzPGEwVz8KQM=";
   };
 
   nativeBuildInputs = [
@@ -36,15 +40,26 @@ stdenv.mkDerivation (finalAttrs: {
     qbe'
   ];
 
+  makeFlags = [
+    "PREFIX=${builtins.placeholder "out"}"
+    "ARCH=${arch}"
+  ];
+
   strictDeps = true;
+
   enableParallelBuilding = true;
 
   doCheck = true;
+
+  postConfigure = ''
+    ln -s configs/${platform}.mk config.mk
+  '';
 
   passthru = {
     # We create this attribute so that the `hare` package can access the
     # overwritten `qbe`.
     qbeUnstable = qbe';
+    updateScript = unstableGitUpdater { };
   };
 
   meta = {
@@ -57,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
     # https://harelang.org/platforms/
     # UPDATE: https://github.com/hshq/harelang provides a MacOS port
     platforms = with lib.platforms;
-      lib.intersectLists (freebsd ++ linux) (aarch64 ++ x86_64 ++ riscv64);
+      lib.intersectLists (freebsd ++ openbsd ++ linux) (aarch64 ++ x86_64 ++ riscv64);
     badPlatforms = lib.platforms.darwin;
   };
 })

--- a/pkgs/development/hare-third-party/hare-ev/default.nix
+++ b/pkgs/development/hare-third-party/hare-ev/default.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation {
   pname = "hare-ev";
-  version = "unstable-2023-12-04";
+  version = "0-unstable-2024-01-04";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "hare-ev";
-    rev = "e3c3f7613c602672ac41a3e47c106a5bd27a2378";
-    hash = "sha256-TQsR2lXJfkPu53WpJy/K+Jruyfw8mCkEIE9DbFQoS+s=";
+    rev = "736ab9bb17257ee5eba3bc96f6650fc4a14608ea";
+    hash = "sha256-SXExwDZKlW/2XYzmJUhkLWj6NF/znrv3vY9V0mD5iFQ=";
   };
 
   nativeCheckInputs = [

--- a/pkgs/development/hare-third-party/hare-toml/default.nix
+++ b/pkgs/development/hare-third-party/hare-toml/default.nix
@@ -3,35 +3,19 @@
 , scdoc
 , lib
 , fetchFromGitea
-, fetchpatch
 , nix-update-script
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "hare-toml";
-  version = "0.1.0";
+  version = "0.1.0-unstable-2023-12-27";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "lunacb";
     repo = "hare-toml";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-JKK5CcDmAW7FH7AzFwgsr9i13eRSXDUokWfZix7f4yY=";
+    rev = "022d0a8d59e5518029f72724a46e6133b934774c";
+    hash = "sha256-DsVcbh1zn8GNKzzb+1o6bfgiVigrxHw/5Xm3uuUhRy0=";
   };
-
-  patches = [
-    # Remove `abort()` calls from never returning expressions.
-    (fetchpatch {
-      name = "remove-abort-from-never-returning-expressions.patch";
-      url = "https://codeberg.org/lunacb/hare-toml/commit/f26e7cdfdccd2e82c9fce7e9fca8644b825b40f1.patch";
-      hash = "sha256-DFbrxiaV4lQlFmMzo5GbMubIQ4hU3lXgsJqoyeFWf2g=";
-    })
-    # Fix make's install target to install the correct files
-    (fetchpatch {
-      name = "install-correct-files-with-install-target.patch";
-      url = "https://codeberg.org/lunacb/hare-toml/commit/b79021911fe7025a8f5ddd97deb2c4d18c67b25e.patch";
-      hash = "sha256-IL+faumX6BmdyePXTzsSGgUlgDBqOXXzShupVAa7jlQ=";
-    })
-  ];
 
   nativeBuildInputs = [
     scdoc


### PR DESCRIPTION
## Description of changes

- harec: unstable-2023-11-29 -> 0-unstable-2024-01-29
- hare: unstable-2023-11-27 -> 0-unstable-2024-02-01
- hareThirdParty.hare-ev: unstable-2023-12-04 -> 0-unstable-2024-01-04
- hareThirdParty.hare-toml: 0.1.0 -> 0.1.0-unstable-2023-12-27

With this update, we enable the new debugging features for Hare described on its
blog[0].

[0]: https://harelang.org/blog/2024-02-01-debugging-features/

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
