### PR TITLE
python311Packages.starlette: 0.32.0.post1 -> 0.35.1; python311Packages.fastapi: 0.104.1 -> 0.109.0 

### DIFF
--- a/pkgs/development/python-modules/fastapi/default.nix
+++ b/pkgs/development/python-modules/fastapi/default.nix
@@ -38,8 +38,8 @@
 
 buildPythonPackage rec {
   pname = "fastapi";
-  version = "0.104.1";
-  format = "pyproject";
+  version = "0.109.0";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -47,7 +47,7 @@ buildPythonPackage rec {
     owner = "tiangolo";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-xTTFBc+fswLYUhKRkWP/eiYSbG3j1E7CASkEtHVNTlk=";
+    hash = "sha256-iZBc0tYGmhQuOL/pdthhBYYnZhe+wEttoinePNAIgEs=";
   };
 
   nativeBuildInputs = [
@@ -98,14 +98,9 @@ buildPythonPackage rec {
     # ignoring deprecation warnings to avoid test failure from
     # tests/test_tutorial/test_testing/test_tutorial001.py
     "-W ignore::DeprecationWarning"
-
-    # http code mismatches
-    "--deselect=tests/test_annotated.py::test_get"
   ];
 
   disabledTestPaths = [
-    # Disabled tests require orjson which requires rust nightly
-    "tests/test_default_response_class.py"
     # Don't test docs and examples
     "docs_src"
     # databases is incompatible with SQLAlchemy 2.0
@@ -113,30 +108,12 @@ buildPythonPackage rec {
     "tests/test_tutorial/test_sql_databases"
   ];
 
-  disabledTests = [
-    "test_get_custom_response"
-    # Failed: DID NOT RAISE <class 'starlette.websockets.WebSocketDisconnect'>
-    "test_websocket_invalid_data"
-    "test_websocket_no_credentials"
-    # TypeError: __init__() missing 1...starlette-releated
-    "test_head"
-    "test_options"
-    "test_trace"
-    # Unexpected number of warnings caught
-    "test_warn_duplicate_operation_id"
-    # assert state["except"] is True
-    "test_dependency_gets_exception"
-    # Fixtures drift
-    "test_openapi_schema_sub"
-    # 200 != 404
-    "test_flask"
-  ];
-
   pythonImportsCheck = [
     "fastapi"
   ];
 
   meta = with lib; {
+    changelog = "https://github.com/tiangolo/fastapi/releases/tag/${version}";
     description = "Web framework for building APIs";
     homepage = "https://github.com/tiangolo/fastapi";
     license = licenses.mit;

--- a/pkgs/development/python-modules/starlette/default.nix
+++ b/pkgs/development/python-modules/starlette/default.nix
@@ -20,6 +20,9 @@
 , pytestCheckHook
 , pythonOlder
 , trio
+
+# reverse dependencies
+, fastapi
 }:
 
 buildPythonPackage rec {
@@ -68,6 +71,10 @@ buildPythonPackage rec {
   pythonImportsCheck = [
     "starlette"
   ];
+
+  passthru.tests = {
+    inherit fastapi;
+  };
 
   meta = with lib; {
     changelog = "https://github.com/encode/starlette/releases/tag/${version}";

--- a/pkgs/development/python-modules/starlette/default.nix
+++ b/pkgs/development/python-modules/starlette/default.nix
@@ -1,18 +1,20 @@
 { lib
-, stdenv
 , buildPythonPackage
 , fetchFromGitHub
+
+# build-system
 , hatchling
 
-# runtime
-, ApplicationServices
+# dependencies
 , anyio
+, typing-extensions
+
+# optional dependencies
 , itsdangerous
 , jinja2
 , python-multipart
 , pyyaml
 , httpx
-, typing-extensions
 
 # tests
 , pytestCheckHook
@@ -22,16 +24,16 @@
 
 buildPythonPackage rec {
   pname = "starlette";
-  version = "0.32.0.post1";
-  format = "pyproject";
+  version = "0.35.1";
+  pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "encode";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-1twyN3fSlxwfDtyqaFFuCAVehLZ8vCV4voCT7CVSEbk=";
+    hash = "sha256-ynT1KowVJ1QdKLSOXYWVe5Q/PrYEWQDUbj395ebfk6Y=";
   };
 
   nativeBuildInputs = [
@@ -40,32 +42,27 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     anyio
+  ] ++ lib.optionals (pythonOlder "3.10") [
+    typing-extensions
+  ];
+
+  passthru.optional-dependencies.full = [
     itsdangerous
     jinja2
     python-multipart
     pyyaml
     httpx
-  ] ++ lib.optionals (pythonOlder "3.10") [
-    typing-extensions
-  ] ++ lib.optionals stdenv.isDarwin [
-    ApplicationServices
   ];
 
   nativeCheckInputs = [
     pytestCheckHook
     trio
     typing-extensions
-  ];
+  ] ++ lib.flatten (lib.attrValues passthru.optional-dependencies);
 
   pytestFlagsArray = [
     "-W" "ignore::DeprecationWarning"
     "-W" "ignore::trio.TrioDeprecationWarning"
-  ];
-
-  disabledTests = [
-    # asserts fail due to inclusion of br in Accept-Encoding
-    "test_websocket_headers"
-    "test_request_headers"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13846,9 +13846,7 @@ self: super: with self; {
 
   stanza = callPackage ../development/python-modules/stanza { };
 
-  starlette = callPackage ../development/python-modules/starlette {
-    inherit (pkgs.darwin.apple_sdk.frameworks) ApplicationServices;
-  };
+  starlette = callPackage ../development/python-modules/starlette { };
 
   starlette-wtf = callPackage ../development/python-modules/starlette-wtf { };
 


### PR DESCRIPTION
https://github.com/encode/starlette/releases/tag/0.33.0
https://github.com/encode/starlette/releases/tag/0.34.0
https://github.com/encode/starlette/releases/tag/0.35.0
https://github.com/encode/starlette/releases/tag/0.35.1

not updating starlette further to keep compat with fastapi

https://github.com/tiangolo/fastapi/releases/tag/0.105.0
https://github.com/tiangolo/fastapi/releases/tag/0.106.0
https://github.com/tiangolo/fastapi/releases/tag/0.107.0
https://github.com/tiangolo/fastapi/releases/tag/0.108.0
https://github.com/tiangolo/fastapi/releases/tag/0.109.0

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
