### PR TITLE
stepmania: fix `aarch64-linux` build by using libpng from nixpkgs

### DIFF
--- a/pkgs/games/stepmania/default.nix
+++ b/pkgs/games/stepmania/default.nix
@@ -11,6 +11,7 @@
 , gtk2
 , libmad
 , libogg
+, libpng
 , libpulseaudio
 , libvorbis
 , udev
@@ -51,6 +52,7 @@ stdenv.mkDerivation {
     gtk2
     libmad
     libogg
+    libpng
     libpulseaudio
     libvorbis
     udev
@@ -59,6 +61,7 @@ stdenv.mkDerivation {
 
   cmakeFlags = [
     "-DWITH_SYSTEM_FFMPEG=1"
+    "-DWITH_SYSTEM_PNG=on"
     "-DGTK2_GDKCONFIG_INCLUDE_DIR=${gtk2.out}/lib/gtk-2.0/include"
     "-DGTK2_GLIBCONFIG_INCLUDE_DIR=${glib.out}/lib/glib-2.0/include"
   ];
@@ -79,8 +82,6 @@ stdenv.mkDerivation {
     platforms = platforms.linux;
     license = licenses.mit; # expat version
     maintainers = with maintainers; [ h7x4 ];
-    # never built on aarch64-linux since first introduction in nixpkgs
-    broken = stdenv.isLinux && stdenv.isAarch64;
     mainProgram = "stepmania";
   };
 }


### PR DESCRIPTION
Currently, the aarch64-linux build of Stepmania fails with libpng linkage errors:

> ld: ../extern/libpng.a(pngrtran.c.o): in function \`png_do_read_transformations':
> pngrtran.c:(.text+0x4118): undefined reference to \`png_riffle_palette_neon'
> ld: pngrtran.c:(.text+0x5188): undefined reference to \`png_do_expand_palette_rgba8_neon'
> ld: pngrtran.c:(.text+0x6268): undefined reference to \`png_do_expand_palette_rgb8_neon'
> ld: ../extern/libpng.a(pngrutil.c.o): in function \`png_read_filter_row':
> pngrutil.c:(.text+0x6734): undefined reference to \`png_init_filter_functions_neon'
> collect2: error: ld returned 1 exit status

Stepmania vendors many dependencies in source form in their code repository; it appears that the libpng build configured there seems to be either misconfigured or isn't building correctly under NixOS. I played around with a couple of NEON-related compile flags but couldn't get anything to stick.

A workaround that works seems to be building against the Nixpkgs libpng instead. It builds, launches, and (so far) plays correctly on my NixOS-based M1 Air and PC.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
