### PR TITLE
haskellPackages.taffybar: jailbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2837,6 +2837,10 @@ self: super: {
   # Too strict bounds on base
   kewar = doJailbreak super.kewar;
 
+  # Too strict bounds on scotty
+  # https://github.com/taffybar/taffybar/pull/572
+  taffybar = doJailbreak super.taffybar;
+
   # Too strict bounds on mtl, servant and servant-client
   unleash-client-haskell = doJailbreak super.unleash-client-haskell;
 


### PR DESCRIPTION
This PR is for merging into `haskell-updates` (#279413), cc @sternenseemann.
 
Adding a `doJailbreak` in case a Hackage revision of `taffybar.cabal` doesn't arrive in time for merging of the haskell-updates branch. Upstream PR is taffybar/taffybar#572.
