### PR TITLE
Revert "python311Packages.markupsafe: 2.1.3 -> 2.1.5"

### DIFF
--- a/pkgs/development/python-modules/markupsafe/default.nix
+++ b/pkgs/development/python-modules/markupsafe/default.nix
@@ -1,54 +1,28 @@
 { lib
 , buildPythonPackage
-, fetchPypi
 , pythonOlder
-
-# build-system
-, setuptools
-
-# tests
+, fetchPypi
 , pytestCheckHook
-
-# reverse dependencies
-, jinja2
-, mkdocs
-, quart
-, werkzeug
 }:
 
 buildPythonPackage rec {
   pname = "markupsafe";
-  version = "2.1.5";
-  pyproject = true;
+  version = "2.1.3";
+  format = "setuptools";
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     pname = "MarkupSafe";
     inherit version;
-    hash = "sha256-0oPTeokLpMGuc/+t+ARkNcdue8Ike7tjwAvRpwnGVEs=";
+    hash = "sha256-r1mO0y1q6G8bdHuCeDlYsaSrj2F7Bv5oeVx/Amq73K0=";
   };
-
-  nativeBuildInputs = [
-    setuptools
-  ];
 
   nativeCheckInputs = [
     pytestCheckHook
   ];
 
-  pythonImportsCheck = [
-    "markupsafe"
-  ];
-
-  passthru.tests = {
-    inherit
-      jinja2
-      mkdocs
-      quart
-      werkzeug
-    ;
-  };
+  pythonImportsCheck = [ "markupsafe" ];
 
   meta = with lib; {
     changelog = "https://markupsafe.palletsprojects.com/en/${versions.majorMinor version}.x/changes/#version-${replaceStrings [ "." ] [ "-" ] version}";


### PR DESCRIPTION
Reverts NixOS/nixpkgs#285928

Causes a darwin-stdenv rebuild, I missed that.