### PR TITLE
[release-23.11] python3.pkgs.opentelemetry-instrumentation: 1.16.0 -> 0.43b0

### DIFF
--- a/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "opentelemetry-instrumentation";
-  version = "1.16.0";
+  version = "0.43b0";
   disabled = pythonOlder "3.7";
 
   # to avoid breakage, every package in opentelemetry-python-contrib must inherit this version, src, and meta
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "open-telemetry";
     repo = "opentelemetry-python-contrib";
     rev = "refs/tags/v${version}";
-    hash = "sha256-6tGQjPBej2zv5yJN0S46le3kyD7q3TELYyDmyxlp5Wo=";
+    hash = "sha256-fUyA3cPXAxO506usEWxOUX9xiapc8Ocnbx73LP6ghRE=";
   };
 
   sourceRoot = "${src.name}/opentelemetry-instrumentation";


### PR DESCRIPTION
Backport a commit from #282349 

---

This may seem like a downgrade, but actually it isn't: the library tags releases as 0.Xb0 with the title "1.22.0 / 0.43b0". Until 1.16 two tags were pushed, for 1.16 and 0.X. This isn't the case anymore, so 0.43b0 is far newer than 1.16. This has practical implications already since `opentelemetry-instrumentation-wsgi` doesn't build at all:

    Checking runtime dependencies for opentelemetry_instrumentation_wsgi-0.37b0-py3-none-any.whl
      - opentelemetry-semantic-conventions==0.37b0 not satisfied by version 0.42b0

Originally, this package was published via 0.X, but this was changed in 74303025237e4df97ba3597b089c1f1c596b9a71 which was a downgrade already. This looks like a bug in the automatic python updater and should be be skipped (or 1.x releases should be ignored).

ChangeLogs:
* https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.38b0
* https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.39b0
* https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.40b0
* https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.41b0
* https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.42b0
* https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/v0.43b0

(cherry picked from commit c913a0bc0da401762630277afe845ff2cf8289a3)

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
