### PR TITLE
abduco: add bug/feature patches, add mirror

### DIFF
--- a/pkgs/tools/misc/abduco/default.nix
+++ b/pkgs/tools/misc/abduco/default.nix
@@ -24,6 +24,14 @@ stdenv.mkDerivation rec {
       url = "https://github.com/martanne/abduco/commit/0e9a00312ac9777edcb169122144762e3611287b.patch";
       sha256 = "sha256-4NkIflbRkUpS5XTM/fxBaELpvlZ4S5lecRa8jk0XC9g=";
     })
+
+    # “fix bug where attaching to dead session won't give underlying exit code”
+    # https://github.com/martanne/abduco/pull/45
+    (fetchpatch {
+      name = "exit-code-when-attaching-to-dead-session";
+      url = "https://github.com/martanne/abduco/commit/972ca8ab949ee342569dbd66b47cc4a17b28247b.patch";
+      sha256 = "sha256-8hios0iKYDOmt6Bi5NNM9elTflGudnG2xgPF1pSkHI0=";
+    })
   ];
 
   meta = with lib; {

--- a/pkgs/tools/misc/abduco/default.nix
+++ b/pkgs/tools/misc/abduco/default.nix
@@ -1,14 +1,18 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, writeText, conf ? null }:
+{ lib, stdenv, fetchpatch, fetchzip, writeText, conf ? null }:
 
-stdenv.mkDerivation rec {
+let
+  rev = "8c32909a159aaa9484c82b71f05b7a73321eb491";
+in
+stdenv.mkDerivation {
   pname = "abduco";
-  version = "2020-04-30";
+  version = "unstable-2020-04-30";
 
-  src = fetchFromGitHub {
-    owner = "martanne";
-    repo = "abduco";
-    rev = "8c32909a159aaa9484c82b71f05b7a73321eb491";
-    sha256 = "0a3p8xljhpk7zh203s75248blfir15smgw5jmszwbmdpy4mqzd53";
+  src = fetchzip {
+    urls = [
+      "https://github.com/martanne/abduco/archive/${rev}.tar.gz"
+      "https://git.sr.ht/~martanne/abduco/archive/${rev}.tar.gz"
+    ];
+    hash = "sha256-o7SPK/G31cW/rrLwV3UJOTq6EBHl6AEE/GdeKGlHdyg=";
   };
 
   preBuild = lib.optionalString (conf != null)

--- a/pkgs/tools/misc/abduco/default.nix
+++ b/pkgs/tools/misc/abduco/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, writeText, conf ? null }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, writeText, conf ? null }:
 
 stdenv.mkDerivation rec {
   pname = "abduco";
@@ -16,6 +16,15 @@ stdenv.mkDerivation rec {
 
   installFlags = [ "install-completion" ];
   CFLAGS = lib.optionalString stdenv.isDarwin "-D_DARWIN_C_SOURCE";
+
+  patches = [
+    # https://github.com/martanne/abduco/pull/22
+    (fetchpatch {
+      name = "use-XDG-directory-scheme-by-default";
+      url = "https://github.com/martanne/abduco/commit/0e9a00312ac9777edcb169122144762e3611287b.patch";
+      sha256 = "sha256-4NkIflbRkUpS5XTM/fxBaELpvlZ4S5lecRa8jk0XC9g=";
+    })
+  ];
 
   meta = with lib; {
     homepage = "http://brain-dump.org/projects/abduco";

--- a/pkgs/tools/misc/abduco/default.nix
+++ b/pkgs/tools/misc/abduco/default.nix
@@ -32,6 +32,15 @@ stdenv.mkDerivation rec {
       url = "https://github.com/martanne/abduco/commit/972ca8ab949ee342569dbd66b47cc4a17b28247b.patch";
       sha256 = "sha256-8hios0iKYDOmt6Bi5NNM9elTflGudnG2xgPF1pSkHI0=";
     })
+
+    # “report pixel sizes to child processes that use ioctl(0, TIOCGWINSZ, ...)”
+    # used for kitty & other terminals that display images
+    # https://github.com/martanne/abduco/pull/62
+    (fetchpatch {
+      name = "report-pixel-sizes-to-child-processes";
+      url = "https://github.com/martanne/abduco/commit/a1e222308119b3251f00b42e1ddff74a385d4249.patch";
+      sha256 = "sha256-eiF0A4IqJrrvXxjBYtltuVNpxQDv/iQPO+K7Y8hWBGg=";
+    })
   ];
 
   meta = with lib; {


### PR DESCRIPTION
This eliminates clutter in the user’s $HOME directory

https://github.com/martanne/abduco/pull/22

Exit codes not reported on dead sessions

https://github.com/martanne/abduco/pull/45

Send down pixels for window sizing so terminal emulators like kitty can use it display images

https://github.com/martanne/abduco/pull/62

Project owner explicitly states code is available on _both_ GitHub & SourceHut, so a mirror was added--this also adds resilience.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
