### PR TITLE
python3Packages.nanobind: init at 1.9.0

### DIFF
--- a/pkgs/development/python-modules/nanobind/default.nix
+++ b/pkgs/development/python-modules/nanobind/default.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  cmake,
+  eigen,
+  ninja,
+  scikit-build,
+  pytestCheckHook,
+  numpy,
+  scipy,
+  torch,
+  jax,
+  jaxlib,
+  tensorflow,
+  setuptools,
+}:
+buildPythonPackage rec {
+  pname = "nanobind";
+  version = "1.9.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "wjakob";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-6swDqw7sEYOawQbNWD8VfSQoi+9wjhOhOOwPPkahDas=";
+    fetchSubmodules = true;
+  };
+
+  disabled = pythonOlder "3.8";
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    scikit-build
+    setuptools
+  ];
+  buildInputs = [ eigen ];
+  dontUseCmakeBuildDir = true;
+
+  preCheck = ''
+    # build tests
+    make -j $NIX_BUILD_CORES
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    numpy
+    scipy
+    torch
+    tensorflow
+    jax
+    jaxlib
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/wjakob/nanobind";
+    changelog = "https://github.com/wjakob/nanobind/blob/${src.rev}/docs/changelog.rst";
+    description = "Tiny and efficient C++/Python bindings";
+    longDescription = ''
+      nanobind is a small binding library that exposes C++ types in Python and
+      vice versa. It is reminiscent of Boost.Python and pybind11 and uses
+      near-identical syntax. In contrast to these existing tools, nanobind is
+      more efficient: bindings compile in a shorter amount of time, produce
+      smaller binaries, and have better runtime performance.
+    '';
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ parras ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8329,6 +8329,8 @@ self: super: with self; {
 
   nampa = callPackage ../development/python-modules/nampa { };
 
+  nanobind = callPackage ../development/python-modules/nanobind { };
+
   nanoid = callPackage ../development/python-modules/nanoid { };
 
   nanoleaf = callPackage ../development/python-modules/nanoleaf { };


### PR DESCRIPTION
## Description of changes

nanobind is a small binding library that exposes C++ types in Python and vice versa. It is reminiscent of [Boost.Python](https://www.boost.org/doc/libs/1_64_0/libs/python/doc/html) and [pybind11](https://github.com/pybind/pybind11) and uses near-identical syntax. In contrast to these existing tools, nanobind is more efficient: bindings compile in a shorter amount of time, produce smaller binaries, and have better runtime performance.

https://github.com/wjakob/nanobind

Pinging the pybind11 maintainers @yuriaisaka @dotlambda
Pinging the nanobind/pybind11 author @wjakob 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (except tests depending on torch since cache.nixos.org does not provide a binary for torch and I did not have the patience to build it)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
