### PR TITLE
draft: treewide: dotnet reorg: dotnet-sdk -> dotnet

### DIFF
--- a/pkgs/applications/audio/famistudio/default.nix
+++ b/pkgs/applications/audio/famistudio/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchzip
 , autoPatchelfHook
-, dotnet-runtime
+, dotnet_6
 , ffmpeg
 , libglvnd
 , makeWrapper
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    dotnet-runtime
+    dotnet_6.runtime
     ffmpeg
     libglvnd
     openal
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/{bin,lib/famistudio}
     mv * $out/lib/famistudio
 
-    makeWrapper ${lib.getExe dotnet-runtime} $out/bin/famistudio \
+    makeWrapper ${lib.getExe dotnet_6.runtime} $out/bin/famistudio \
       --add-flags $out/lib/famistudio/FamiStudio.dll \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libglvnd ]} \
       --prefix PATH : ${lib.makeBinPath [ ffmpeg ]}

--- a/pkgs/applications/audio/galaxy-buds-client/default.nix
+++ b/pkgs/applications/audio/galaxy-buds-client/default.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, buildDotnetModule
+, dotnet_6
 , fetchFromGitHub
 , autoPatchelfHook
 , fontconfig
@@ -11,7 +11,7 @@
 , graphicsmagick
 }:
 
-buildDotnetModule rec {
+dotnet_6.buildDotnetModule rec {
   pname = "galaxy-buds-client";
   version = "4.5.4";
 

--- a/pkgs/applications/audio/openutau/default.nix
+++ b/pkgs/applications/audio/openutau/default.nix
@@ -1,8 +1,7 @@
 { lib
 , stdenv
-, buildDotnetModule
 , fetchFromGitHub
-, dotnetCorePackages
+, dotnet_7
 , dbus
 , fontconfig
 , libICE
@@ -11,7 +10,7 @@
 , portaudio
 }:
 
-buildDotnetModule rec {
+dotnet_7.buildDotnetModule rec {
   pname = "OpenUtau";
   version = "0.1.327";
 
@@ -21,9 +20,6 @@ buildDotnetModule rec {
     rev = "build/${version}";
     hash = "sha256-Bss32Fk4yBEFqaIxT2dfdvWXz09sO6akiitDQBXoSvY=";
   };
-
-  dotnet-sdk = dotnetCorePackages.sdk_7_0;
-  dotnet-runtime = dotnetCorePackages.runtime_7_0;
 
   projectFile = "OpenUtau.sln";
   nugetDeps = ./deps.nix;

--- a/pkgs/applications/audio/tone/default.nix
+++ b/pkgs/applications/audio/tone/default.nix
@@ -1,6 +1,6 @@
-{ lib, fetchFromGitHub, buildDotnetModule, ffmpeg-full, dotnetCorePackages }:
+{ lib, fetchFromGitHub, ffmpeg-full, dotnet_6 }:
 
-buildDotnetModule rec {
+dotnet_6.buildDotnetModule rec {
   pname = "tone";
   version = "0.1.5";
 
@@ -19,7 +19,6 @@ buildDotnetModule rec {
     "-p:PublishSingleFile=false"
   ];
 
-  dotnet-sdk = dotnetCorePackages.sdk_6_0;
   runtimeDeps = [ ffmpeg-full ];
 
   meta = with lib; {

--- a/pkgs/applications/blockchains/btcpayserver/default.nix
+++ b/pkgs/applications/blockchains/btcpayserver/default.nix
@@ -1,10 +1,9 @@
 { lib
-, buildDotnetModule
 , fetchFromGitHub
-, dotnetCorePackages
+, dotnet_8
 , altcoinSupport ? false }:
 
-buildDotnetModule rec {
+dotnet_8.buildDotnetModule rec {
   pname = "btcpayserver";
   version = "1.12.5";
 
@@ -18,8 +17,7 @@ buildDotnetModule rec {
   projectFile = "BTCPayServer/BTCPayServer.csproj";
   nugetDeps = ./deps.nix;
 
-  dotnet-sdk = dotnetCorePackages.sdk_8_0;
-  dotnet-runtime = dotnetCorePackages.aspnetcore_8_0;
+  dotnet-runtime = dotnet_8.aspnetcore;
 
   buildType = if altcoinSupport then "Altcoins-Release" else "Release";
 

--- a/pkgs/applications/blockchains/nbxplorer/default.nix
+++ b/pkgs/applications/blockchains/nbxplorer/default.nix
@@ -1,10 +1,9 @@
 { lib
-, buildDotnetModule
 , fetchFromGitHub
-, dotnetCorePackages
+, dotnet_8
 }:
 
-buildDotnetModule rec {
+dotnet_8.buildDotnetModule rec {
   pname = "nbxplorer";
   version = "2.5.0";
 
@@ -18,8 +17,7 @@ buildDotnetModule rec {
   projectFile = "NBXplorer/NBXplorer.csproj";
   nugetDeps = ./deps.nix;
 
-  dotnet-sdk = dotnetCorePackages.sdk_8_0;
-  dotnet-runtime = dotnetCorePackages.aspnetcore_8_0;
+  dotnet-runtime = dotnet_8.aspnetcore;
 
   # macOS has a case-insensitive filesystem, so these two can be the same file
   postFixup = ''

--- a/pkgs/applications/blockchains/wasabibackend/default.nix
+++ b/pkgs/applications/blockchains/wasabibackend/default.nix
@@ -2,13 +2,12 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  buildDotnetModule,
-  dotnetCorePackages,
+  dotnet_7,
   autoPatchelfHook,
   zlib,
   openssl,
 }:
-buildDotnetModule rec {
+dotnet_7.buildDotnetModule rec {
   pname = "wasabibackend";
   version = "2.0.2.1";
 
@@ -22,8 +21,7 @@ buildDotnetModule rec {
   projectFile = "WalletWasabi.Backend/WalletWasabi.Backend.csproj";
   nugetDeps = ./deps.nix;
 
-  dotnet-sdk = dotnetCorePackages.sdk_7_0;
-  dotnet-runtime = dotnetCorePackages.aspnetcore_7_0;
+  dotnet-runtime = dotnet_7.aspnetcore;
 
   nativeBuildInputs = [autoPatchelfHook];
   buildInputs = [stdenv.cc.cc.lib zlib];

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -7,7 +7,7 @@
 , zlib
 , python3
 , lldb
-, dotnet-sdk_7
+, dotnet_7
 , maven
 , openssl
 , expat
@@ -202,7 +202,7 @@ rec {
 
           for dir in lib/ReSharperHost/linux-*; do
             rm -rf $dir/dotnet
-            ln -s ${dotnet-sdk_7} $dir/dotnet
+            ln -s ${dotnet_7.sdk} $dir/dotnet
           done
         )
       '';

--- a/pkgs/applications/finance/denaro/default.nix
+++ b/pkgs/applications/finance/denaro/default.nix
@@ -1,7 +1,6 @@
 { lib
-, buildDotnetModule
 , fetchFromGitHub
-, dotnetCorePackages
+, dotnet_8
 , gtk4
 , libadwaita
 , pkg-config
@@ -12,7 +11,7 @@
 , blueprint-compiler
 }:
 
-buildDotnetModule rec {
+dotnet_8.buildDotnetModule rec {
   pname = "denaro";
   version = "2024.2.0";
 
@@ -22,9 +21,6 @@ buildDotnetModule rec {
     rev = version;
     hash = "sha256-fEhwup8SiYvKH2FtzruEFsj8axG5g3YJ917aqc8dn/8=";
   };
-
-  dotnet-sdk = dotnetCorePackages.sdk_8_0;
-  dotnet-runtime = dotnetCorePackages.runtime_8_0;
 
   projectFile = "NickvisionMoney.GNOME/NickvisionMoney.GNOME.csproj";
   nugetDeps = ./deps.nix;

--- a/pkgs/applications/graphics/pinta/default.nix
+++ b/pkgs/applications/graphics/pinta/default.nix
@@ -1,6 +1,5 @@
 { lib
-, buildDotnetModule
-, dotnetCorePackages
+, dotnet_7
 , fetchFromGitHub
 , glibcLocales
 , gtk3
@@ -8,7 +7,7 @@
 , wrapGAppsHook
 }:
 
-buildDotnetModule rec {
+dotnet_7.buildDotnetModule rec {
   pname = "Pinta";
   version = "2.1.1";
 
@@ -16,9 +15,6 @@ buildDotnetModule rec {
     intltool
     wrapGAppsHook
   ];
-
-  dotnet-sdk = dotnetCorePackages.sdk_7_0;
-  dotnet-runtime = dotnetCorePackages.runtime_7_0;
 
   runtimeDeps = [ gtk3 ];
   buildInputs = runtimeDeps;

--- a/pkgs/applications/misc/ArchiSteamFarm/default.nix
+++ b/pkgs/applications/misc/ArchiSteamFarm/default.nix
@@ -1,14 +1,13 @@
 { lib
-, buildDotnetModule
 , fetchFromGitHub
-, dotnetCorePackages
+, dotnet_8
 , libkrb5
 , zlib
 , openssl
 , callPackage
 }:
 
-buildDotnetModule rec {
+dotnet_8.buildDotnetModule rec {
   pname = "ArchiSteamFarm";
   # nixpkgs-update: no auto update
   version = "5.5.3.4";
@@ -20,8 +19,7 @@ buildDotnetModule rec {
     hash = "sha256-9ISEIKrAK6UTDM3TPizBRMU+wfiinhnaWmS5CkXpkYo=";
   };
 
-  dotnet-runtime = dotnetCorePackages.aspnetcore_8_0;
-  dotnet-sdk = dotnetCorePackages.sdk_8_0;
+  dotnet-runtime = dotnet_8.aspnetcore;
 
   nugetDeps = ./deps.nix;
 

--- a/pkgs/applications/misc/avalonia-ilspy/default.nix
+++ b/pkgs/applications/misc/avalonia-ilspy/default.nix
@@ -1,8 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, buildDotnetModule
-, dotnetCorePackages
+, dotnet_6
 , libX11
 , libICE
 , libSM
@@ -21,7 +20,7 @@
 , autoSignDarwinBinariesHook
 }:
 
-buildDotnetModule rec {
+dotnet_6.buildDotnetModule rec {
   pname = "avalonia-ilspy";
   version = "7.2-rc";
 
@@ -75,9 +74,6 @@ buildDotnetModule rec {
     mkdir -p $out/Applications/ILSpy.app/Contents/MacOS
     ln -s $out/bin/ILSpy $out/Applications/ILSpy.app/Contents/MacOS/ILSpy
   '';
-
-  dotnet-sdk = dotnetCorePackages.sdk_6_0;
-  dotnet-runtime = dotnetCorePackages.runtime_6_0;
 
   projectFile = "ILSpy/ILSpy.csproj";
   nugetDeps = ./deps.nix;

--- a/pkgs/applications/science/logic/dafny/default.nix
+++ b/pkgs/applications/science/logic/dafny/default.nix
@@ -1,12 +1,12 @@
 { lib
-, buildDotnetModule
+, dotnet_6
 , fetchFromGitHub
 , writeScript
 , jdk11
 , z3
 }:
 
-buildDotnetModule rec {
+dotnet_6.buildDotnetModule rec {
   pname = "Dafny";
   version = "4.4.0";
 

--- a/pkgs/applications/science/logic/formula/default.nix
+++ b/pkgs/applications/science/logic/formula/default.nix
@@ -1,6 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, buildDotnetModule, dotnetCorePackages, unstableGitUpdater }:
+{ lib, stdenv, fetchFromGitHub, dotnet_6, unstableGitUpdater }:
 
-buildDotnetModule rec {
+dotnet_6.buildDotnetModule rec {
   pname = "formula-dotnet";
   version = "2.0";
 
@@ -17,7 +17,7 @@ buildDotnetModule rec {
   postFixup = if stdenv.isLinux then ''
     mv $out/bin/CommandLine $out/bin/formula
   '' else lib.optionalString stdenv.isDarwin ''
-    makeWrapper ${dotnetCorePackages.runtime_6_0}/bin/dotnet $out/bin/formula \
+    makeWrapper ${dotnet_6.runtime}/bin/dotnet $out/bin/formula \
       --add-flags "$out/lib/formula-dotnet/CommandLine.dll" \
       --prefix DYLD_LIBRARY_PATH : $out/lib/formula-dotnet/runtimes/macos/native
   '';

--- a/pkgs/applications/version-management/git-credential-manager/default.nix
+++ b/pkgs/applications/version-management/git-credential-manager/default.nix
@@ -1,7 +1,6 @@
 { lib
 , fetchFromGitHub
-, buildDotnetModule
-, dotnetCorePackages
+, dotnet_7
 , libX11
 , libICE
 , libSM
@@ -18,7 +17,7 @@
 }:
 
 assert withLibsecretSupport -> withGuiSupport;
-buildDotnetModule rec {
+dotnet_7.buildDotnetModule rec {
   pname = "git-credential-manager";
   version = "2.4.1";
 
@@ -31,8 +30,6 @@ buildDotnetModule rec {
 
   projectFile = "src/shared/Git-Credential-Manager/Git-Credential-Manager.csproj";
   nugetDeps = ./deps.nix;
-  dotnet-sdk = dotnetCorePackages.sdk_7_0;
-  dotnet-runtime = dotnetCorePackages.runtime_7_0;
   dotnetInstallFlags = [ "--framework" "net7.0" ];
   executables = [ "git-credential-manager" ];
 

--- a/pkgs/build-support/dotnet/build-dotnet-global-tool/default.nix
+++ b/pkgs/build-support/dotnet/build-dotnet-global-tool/default.nix
@@ -1,4 +1,4 @@
-{ buildDotnetModule, emptyDirectory, mkNugetDeps, dotnet-sdk }:
+{ emptyDirectory, mkNugetDeps, dotnet }:
 
 { pname
 , version
@@ -12,11 +12,11 @@
   # a default of `pname` instead of null, to avoid auto-wrapping everything
 , executables ? pname
   # The dotnet runtime to use, dotnet tools need a full SDK to function
-, dotnet-runtime ? dotnet-sdk
+, dotnet-runtime ? dotnet.runtime
 , ...
 } @ args:
 
-buildDotnetModule (args // {
+dotnet.buildDotnetModule (args // {
   inherit pname version dotnet-runtime executables;
 
   src = emptyDirectory;

--- a/pkgs/build-support/dotnet/build-dotnet-module/default.nix
+++ b/pkgs/build-support/dotnet/build-dotnet-module/default.nix
@@ -6,10 +6,10 @@
 , linkFarmFromDrvs
 , symlinkJoin
 , makeWrapper
+, dotnet
 , dotnetCorePackages
 , mkNugetSource
 , mkNugetDeps
-, nuget-to-nix
 , cacert
 , coreutils
 , runtimeShellPackage
@@ -81,9 +81,9 @@
   # Whether to explicitly enable UseAppHost when building. This is redundant if useDotnetFromEnv is enabledz
 , useAppHost ? true
   # The dotnet SDK to use.
-, dotnet-sdk ? dotnetCorePackages.sdk_6_0
+, dotnet-sdk ? dotnet.sdk
   # The dotnet runtime to use.
-, dotnet-runtime ? dotnetCorePackages.runtime_6_0
+, dotnet-runtime ? dotnet.runtime
   # The dotnet SDK to run tests against. This can differentiate from the SDK compiled against.
 , dotnet-test-sdk ? dotnet-sdk
 , ...
@@ -208,7 +208,7 @@ stdenvNoCC.mkDerivation (args // {
       writeShellScript "fetch-${pname}-deps" ''
         set -euo pipefail
 
-        export PATH="${lib.makeBinPath [ coreutils runtimeShellPackage dotnet-sdk (nuget-to-nix.override { inherit dotnet-sdk; }) ]}"
+        export PATH="${lib.makeBinPath [ coreutils runtimeShellPackage dotnet-sdk (dotnetCorePackages.nuget-to-nix.override { inherit dotnet-sdk; }) ]}"
 
         for arg in "$@"; do
             case "$arg" in

--- a/pkgs/build-support/dotnet/nuget-to-nix/default.nix
+++ b/pkgs/build-support/dotnet/nuget-to-nix/default.nix
@@ -9,7 +9,7 @@
 , curl
 , gnugrep
 , gawk
-, dotnet-sdk
+, dotnet
 }:
 
 runCommandLocal "nuget-to-nix" {
@@ -25,7 +25,7 @@ runCommandLocal "nuget-to-nix" {
       curl
       gnugrep
       gawk
-      dotnet-sdk
+      dotnet.sdk
     ];
   };
 

--- a/pkgs/build-support/writers/scripts.nix
+++ b/pkgs/build-support/writers/scripts.nix
@@ -421,7 +421,7 @@ rec {
     writePyPy3 "/bin/${name}";
 
 
-  makeFSharpWriter = { dotnet-sdk ? pkgs.dotnet-sdk, fsi-flags ? "", libraries ? _: [] }: nameOrPath:
+  makeFSharpWriter = { dotnet-sdk ? pkgs.dotnet_8.sdk, fsi-flags ? "", libraries ? _: [] }: nameOrPath:
   let
     fname = last (builtins.split "/" nameOrPath);
     path = if strings.hasSuffix ".fsx" nameOrPath then nameOrPath else "${nameOrPath}.fsx";

--- a/pkgs/by-name/bo/boogie/package.nix
+++ b/pkgs/by-name/bo/boogie/package.nix
@@ -1,6 +1,6 @@
-{ lib, buildDotnetModule, fetchFromGitHub, z3 }:
+{ lib, dotnet_6, fetchFromGitHub, z3 }:
 
-buildDotnetModule rec {
+dotnet_6.buildDotnetModule rec {
   pname = "Boogie";
   version = "3.1.1";
 
@@ -54,4 +54,3 @@ buildDotnetModule rec {
     platforms = with platforms; (linux ++ darwin);
   };
 }
-

--- a/pkgs/by-name/ca/cavalier/package.nix
+++ b/pkgs/by-name/ca/cavalier/package.nix
@@ -1,6 +1,5 @@
 { lib
-, buildDotnetModule
-, dotnetCorePackages
+, dotnet_8
 , fetchFromGitHub
 , pkg-config
 , blueprint-compiler
@@ -13,7 +12,7 @@
 , cava
 }:
 
-buildDotnetModule rec {
+dotnet_8.buildDotnetModule rec {
   pname = "cavalier";
   version = "2024.1.0";
 
@@ -23,9 +22,6 @@ buildDotnetModule rec {
     rev = "refs/tags/${version}";
     hash = "sha256-SFhEKtYrlnkbLMnxU4Uf4jnFsw0MJHstgZgLLnGC2d8=";
   };
-
-  dotnet-sdk = dotnetCorePackages.sdk_8_0;
-  dotnet-runtime = dotnetCorePackages.runtime_8_0;
 
   projectFile = "NickvisionCavalier.GNOME/NickvisionCavalier.GNOME.csproj";
   nugetDeps = ./deps.nix;

--- a/pkgs/by-name/ce/celeste64/package.nix
+++ b/pkgs/by-name/ce/celeste64/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
-  buildDotnetModule,
-  dotnetCorePackages,
+  dotnet_8,
   fetchFromGitHub,
   makeDesktopItem,
   copyDesktopItems,
@@ -19,7 +18,7 @@
   withSELinux ? false,
 }:
 
-buildDotnetModule rec {
+dotnet_8.buildDotnetModule rec {
   pname = "celeste64";
   version = "1.1.1";
 
@@ -30,8 +29,6 @@ buildDotnetModule rec {
     hash = "sha256-XRAjDYIqYaQYCWNNT7UuLDKDBgq3vqxtCzay7pGICtA=";
   };
   projectFile = "Celeste64.csproj";
-  dotnet-sdk = dotnetCorePackages.sdk_8_0;
-  dotnet-runtime = dotnetCorePackages.runtime_8_0;
   nugetDeps = ./deps.nix;
   strictDeps = true;
   executables = [ "Celeste64" ];

--- a/pkgs/by-name/cs/csharpier/package.nix
+++ b/pkgs/by-name/cs/csharpier/package.nix
@@ -1,6 +1,6 @@
-{ buildDotnetGlobalTool, lib }:
+{ dotnet_6, lib }:
 
-buildDotnetGlobalTool {
+dotnet_6.buildDotnetGlobalTool {
   pname = "csharpier";
   version = "0.27.2";
   executables = "dotnet-csharpier";

--- a/pkgs/by-name/cs/csharprepl/package.nix
+++ b/pkgs/by-name/cs/csharprepl/package.nix
@@ -1,12 +1,9 @@
-{ buildDotnetGlobalTool, dotnetCorePackages, lib }:
+{ buildDotnetGlobalTool, dotnet_8, lib }:
 
-buildDotnetGlobalTool {
+dotnet_8.buildDotnetGlobalTool {
   pname = "csharprepl";
   nugetName = "CSharpRepl";
   version = "0.6.6";
-
-  dotnet-sdk = dotnetCorePackages.sdk_8_0;
-  dotnet-runtime = dotnetCorePackages.runtime_8_0;
 
   nugetSha256 = "sha256-VkZGnfD8p6oAJ7i9tlfwJfmKfZBHJU7Wdq+K4YjPoRs=";
 

--- a/pkgs/by-name/dy/dyalog/package.nix
+++ b/pkgs/by-name/dy/dyalog/package.nix
@@ -16,7 +16,7 @@
 , glib
 , ncurses5
 
-, dotnet-sdk_6
+, dotnet_6
 , dotnetSupport ? false
 
 , alsa-lib
@@ -61,7 +61,7 @@ let
   ]
   ++ lib.optionals dotnetSupport [
     # needs to be set to run .NET Bridge
-    "--set DOTNET_ROOT ${dotnet-sdk_6}"
+    "--set DOTNET_ROOT ${dotnet_6.sdk}"
     # .NET Bridge files are runtime dependencies, but cannot be patchelf'd
     "--prefix LD_LIBRARY_PATH : ${dyalogHome}"
   ]

--- a/pkgs/by-name/fa/fantomas/package.nix
+++ b/pkgs/by-name/fa/fantomas/package.nix
@@ -1,6 +1,6 @@
-{ buildDotnetGlobalTool, lib }:
+{ dotnet_6, lib }:
 
-buildDotnetGlobalTool {
+dotnet_6.buildDotnetGlobalTool {
   pname = "fantomas";
   version = "6.2.3";
 

--- a/pkgs/by-name/li/libation/package.nix
+++ b/pkgs/by-name/li/libation/package.nix
@@ -1,8 +1,7 @@
 { lib
 , stdenv
-, buildDotnetModule
 , fetchFromGitHub
-, dotnetCorePackages
+, dotnet_8
 , wrapGAppsHook
 
 , libX11
@@ -17,7 +16,7 @@
 , gtk3
 }:
 
-buildDotnetModule rec {
+dotnet_8.buildDotnetModule rec {
   pname = "libation";
   version = "11.3.1";
 
@@ -29,9 +28,6 @@ buildDotnetModule rec {
   };
 
   sourceRoot = "${src.name}/Source";
-
-  dotnet-sdk = dotnetCorePackages.sdk_8_0;
-  dotnet-runtime = dotnetCorePackages.runtime_8_0;
 
   nugetDeps = ./deps.nix;
 

--- a/pkgs/by-name/lu/lubelogger/package.nix
+++ b/pkgs/by-name/lu/lubelogger/package.nix
@@ -1,10 +1,10 @@
 { lib
 , buildDotnetModule
-, dotnetCorePackages
+, dotnet_8
 , fetchFromGitHub
 }:
 
-buildDotnetModule rec {
+dotnet_8.buildDotnetModule rec {
   pname = "lubelogger";
   version = "1.2.5";
 
@@ -18,8 +18,7 @@ buildDotnetModule rec {
   projectFile = "CarCareTracker.sln";
   nugetDeps = ./deps.nix; # File generated with `nix-build -A package.passthru.fetch-deps`.
 
-  dotnet-sdk = dotnetCorePackages.sdk_8_0;
-  dotnet-runtime = dotnetCorePackages.aspnetcore_8_0;
+  dotnet-runtime = dotnet_8.aspnetcore;
 
   makeWrapperArgs = [
     "--set DOTNET_CONTENTROOT ${placeholder "out"}/lib/lubelogger"

--- a/pkgs/by-name/na/naps2/package.nix
+++ b/pkgs/by-name/na/naps2/package.nix
@@ -1,6 +1,6 @@
 { lib
-, buildDotnetModule
-, dotnetCorePackages
+, dotnet_8
+, dotnet_6
 , fetchFromGitHub
 , gtk3
 , gdk-pixbuf
@@ -9,7 +9,10 @@
 , libnotify
 }:
 
-buildDotnetModule rec {
+let
+  dotnet = dotnet_8.withExtraSDKs [ dotnet_6.sdk ];
+
+in dotnet.buildDotnetModule rec {
   pname = "naps2";
   version = "7.3.0";
 
@@ -25,8 +28,6 @@ buildDotnetModule rec {
 
   executables = [ "naps2" ];
 
-  dotnet-sdk = with dotnetCorePackages; combinePackages [ sdk_6_0 sdk_8_0 ];
-  dotnet-runtime = dotnetCorePackages.runtime_8_0;
   selfContainedBuild = true;
   runtimeDeps = [
     gtk3

--- a/pkgs/by-name/pa/parabolic/package.nix
+++ b/pkgs/by-name/pa/parabolic/package.nix
@@ -1,7 +1,6 @@
 { lib
-, buildDotnetModule
 , fetchFromGitHub
-, dotnetCorePackages
+, dotnet_8
 , gtk4
 , libadwaita
 , pkg-config
@@ -14,7 +13,7 @@
 , ffmpeg
 }:
 
-buildDotnetModule rec {
+dotnet_8.buildDotnetModule rec {
   pname = "parabolic";
   version = "2023.12.0";
 
@@ -26,8 +25,6 @@ buildDotnetModule rec {
     fetchSubmodules = true;
   };
 
-  dotnet-sdk = dotnetCorePackages.sdk_8_0;
-  dotnet-runtime = dotnetCorePackages.runtime_8_0;
   pythonEnv = python3.withPackages(ps: with ps; [ yt-dlp ]);
 
   projectFile = "NickvisionTubeConverter.GNOME/NickvisionTubeConverter.GNOME.csproj";

--- a/pkgs/by-name/pu/pupdate/package.nix
+++ b/pkgs/by-name/pu/pupdate/package.nix
@@ -2,7 +2,7 @@
 , stdenv
 , lib
 , fetchFromGitHub
-, buildDotnetModule
+, dotnet_6
 , dotnetCorePackages
 , openssl
 , zlib
@@ -10,7 +10,7 @@
 , nix-update-script
 }:
 
-buildDotnetModule rec {
+dotnet_6.buildDotnetModule rec {
   pname = "pupdate";
   version = "3.2.1";
 
@@ -45,9 +45,6 @@ buildDotnetModule rec {
   dotnetFlags = [
     "-p:PackageRuntime=${dotnetCorePackages.systemToDotnetRid stdenv.hostPlatform.system}"
   ];
-
-  dotnet-sdk = dotnetCorePackages.sdk_6_0;
-  dotnet-runtime = dotnetCorePackages.runtime_6_0;
 
   passthru = {
     updateScript = nix-update-script { };

--- a/pkgs/by-name/ro/roslyn-ls/package.nix
+++ b/pkgs/by-name/ro/roslyn-ls/package.nix
@@ -1,15 +1,16 @@
-{ lib, fetchFromGitHub, buildDotnetModule, dotnetCorePackages, stdenvNoCC, testers, roslyn-ls, jq }:
+{ lib, fetchFromGitHub, buildDotnetModule, dotnet_8, dotnet_7, dotnet_6, dotnetCorePackages, stdenvNoCC, testers, roslyn-ls, jq }:
 let
   pname = "roslyn-ls";
   # see https://github.com/dotnet/roslyn/blob/main/eng/targets/TargetFrameworks.props
-  dotnet-sdk = with dotnetCorePackages; combinePackages [ sdk_6_0 sdk_7_0 sdk_8_0 ];
+  dotnet = dotnet_8.withExtraSDKs [ dotnet_6.sdk dotnet_7.sdk ];
   # need sdk on runtime as well
-  dotnet-runtime = dotnetCorePackages.sdk_8_0;
 
   project = "Microsoft.CodeAnalysis.LanguageServer";
 in
-buildDotnetModule rec {
-  inherit pname dotnet-sdk dotnet-runtime;
+dotnet.buildDotnetModule rec {
+  inherit pname;
+
+  dotnet-runtime = dotnet_8.sdk;
 
   vsVersion = "2.17.7";
   src = fetchFromGitHub {

--- a/pkgs/by-name/ry/ryujinx/package.nix
+++ b/pkgs/by-name/ry/ryujinx/package.nix
@@ -1,6 +1,5 @@
 { lib
-, buildDotnetModule
-, dotnetCorePackages
+, dotnet_8
 , fetchFromGitHub
 , libX11
 , libgdiplus
@@ -23,7 +22,7 @@
 , SDL2_mixer
 }:
 
-buildDotnetModule rec {
+dotnet_8.buildDotnetModule rec {
   pname = "ryujinx";
   version = "1.1.1217"; # Based off of the official github actions builds: https://github.com/Ryujinx/Ryujinx/actions/workflows/release.yml
 
@@ -33,9 +32,6 @@ buildDotnetModule rec {
     rev = "bc4d99a0786dbcbfde62d3bdeb98ed3d12c94852";
     sha256 = "00qvwhl18f09lgs94b66kzxyf0pbhwdkcyrsc7vjyv5dl88f5120";
   };
-
-  dotnet-sdk = dotnetCorePackages.sdk_8_0;
-  dotnet-runtime = dotnetCorePackages.runtime_8_0;
 
   nugetDeps = ./deps.nix;
 

--- a/pkgs/by-name/to/torrentstream/package.nix
+++ b/pkgs/by-name/to/torrentstream/package.nix
@@ -1,11 +1,10 @@
 { lib
-, buildDotnetModule
 , fetchFromGitHub
-, dotnetCorePackages
+, dotnet_7
 , fetchpatch
 }:
 
-buildDotnetModule rec {
+dotnet_7.buildDotnetModule rec {
   pname = "torrentstream";
   version = "1.0.1.6";
 
@@ -20,8 +19,7 @@ buildDotnetModule rec {
 
   projectFile = "TorrentStream.sln";
   nugetDeps = ./deps.nix;
-  dotnet-sdk = dotnetCorePackages.sdk_7_0;
-  dotnet-runtime = dotnetCorePackages.aspnetcore_7_0;
+  dotnet-runtime = dotnet_7.aspnetcore;
   executables = [ "TorrentStream" ];
 
   patches = [

--- a/pkgs/development/compilers/dotnet/9/default.nix
+++ b/pkgs/development/compilers/dotnet/9/default.nix
@@ -5,5 +5,5 @@
   releaseInfoFile = ./release-info.json;
   allowPrerelease = true;
   depsFile = ./deps.nix;
-  bootstrapSdk = dotnetCorePackages.sdk_9_0;
+  bootstrapSdk = dotnetCorePackages.dotnet_9-bin.sdk;
 }

--- a/pkgs/development/compilers/dotnet/combine-packages.nix
+++ b/pkgs/development/compilers/dotnet/combine-packages.nix
@@ -9,8 +9,9 @@ let cli = builtins.head dotnetPackages;
 in
 assert lib.assertMsg ((builtins.length dotnetPackages) > 0)
     ''You must include at least one package, e.g
-      `with dotnetCorePackages; combinePackages [
-          sdk_6_0 aspnetcore_7_0
+      `combinePackages [
+          dotnet_6.sdk
+          dotnet_7.sdk
        ];`'' ;
   buildEnv {
     name = "dotnet-core-combined";

--- a/pkgs/development/compilers/dotnet/default.nix
+++ b/pkgs/development/compilers/dotnet/default.nix
@@ -14,13 +14,6 @@ let
     buildNetSdk = attrs: buildDotnet (attrs // { type = "sdk"; });
   };
 
-  ## Files in versions/ are generated automatically by update.sh ##
-  dotnet_6_0 = import ./versions/6.0.nix buildAttrs;
-  dotnet_7_0 = import ./versions/7.0.nix buildAttrs;
-  dotnet_8_0 = import ./versions/8.0.nix buildAttrs;
-  dotnet_8_0_102 = import ./versions/8.0.102.nix buildAttrs;
-  dotnet_9_0 = import ./versions/9.0.nix buildAttrs;
-
   runtimeIdentifierMap = {
     "x86_64-linux" = "linux-x64";
     "aarch64-linux" = "linux-arm64";
@@ -32,19 +25,37 @@ let
 
   # Convert a "stdenv.hostPlatform.system" to a dotnet RID
   systemToDotnetRid = system: runtimeIdentifierMap.${system} or (throw "unsupported platform ${system}");
+
+  pkgs = rec {
+    inherit systemToDotnetRid;
+
+    combinePackages = attrs: callPackage (import ./combine-packages.nix attrs) {};
+
+    ## Files in versions/ are generated automatically by update.sh ##
+    dotnet_6-bin = import ./versions/6.0.nix buildAttrs;
+    dotnet_7-bin = import ./versions/7.0.nix buildAttrs;
+    dotnet_8-bin = import ./versions/8.0.nix buildAttrs;
+    dotnet_8_0_102-bin = import ./versions/8.0.102.nix buildAttrs;
+    dotnet_9-bin = import ./versions/9.0.nix buildAttrs;
+
+    dotnet_8 = recurseIntoAttrs (callPackage ./8 { bootstrapSdk = dotnet_8_0_102-bin.sdk; });
+    dotnet_9 = recurseIntoAttrs (callPackage ./9 {});
+  };
+
 in
-{
-  inherit systemToDotnetRid;
-
-  combinePackages = attrs: callPackage (import ./combine-packages.nix attrs) {};
-
-  dotnet_8 = recurseIntoAttrs (callPackage ./8 { bootstrapSdk = dotnet_8_0_102.sdk_8_0; });
-  dotnet_9 = recurseIntoAttrs (callPackage ./9 {});
-} // lib.optionalAttrs config.allowAliases {
-  # EOL
-  sdk_2_1 = throw "Dotnet SDK 2.1 is EOL, please use 6.0 (LTS) or 7.0 (Current)";
-  sdk_2_2 = throw "Dotnet SDK 2.2 is EOL, please use 6.0 (LTS) or 7.0 (Current)";
-  sdk_3_0 = throw "Dotnet SDK 3.0 is EOL, please use 6.0 (LTS) or 7.0 (Current)";
-  sdk_3_1 = throw "Dotnet SDK 3.1 is EOL, please use 6.0 (LTS) or 7.0 (Current)";
-  sdk_5_0 = throw "Dotnet SDK 5.0 is EOL, please use 6.0 (LTS) or 7.0 (Current)";
-} // dotnet_6_0 // dotnet_7_0 // dotnet_8_0 // dotnet_9_0
+  pkgs // lib.optionalAttrs config.allowAliases (with pkgs; {
+    sdk_2_1 = throw "Dotnet SDK 2.1 is EOL";
+    sdk_2_2 = throw "Dotnet SDK 2.2 is EOL";
+    sdk_3_0 = throw "Dotnet SDK 3.0 is EOL";
+    sdk_3_1 = throw "Dotnet SDK 3.1 is EOL";
+    sdk_5_0 = throw "Dotnet SDK 5.0 is EOL";
+    aspnetcore_6_0 = dotnet_6-bin.aspnetcore;
+    aspnetcore_7_0 = dotnet_7-bin.aspnetcore;
+    aspnetcore_8_0 = dotnet_8-bin.aspnetcore;
+    runtime_6_0 = dotnet_6-bin.runtime;
+    runtime_7_0 = dotnet_7-bin.runtime;
+    runtime_8_0 = dotnet_8-bin.runtime;
+    sdk_6_0 = dotnet_6-bin.sdk;
+    sdk_7_0 = dotnet_7-bin.sdk;
+    sdk_8_0 = dotnet_8-bin.sdk;
+  })

--- a/pkgs/development/compilers/dotnet/update.sh
+++ b/pkgs/development/compilers/dotnet/update.sh
@@ -339,7 +339,6 @@ Examples:
     major_minor=$(sed 's/^\([0-9]*\.[0-9]*\).*$/\1/' <<< "$sem_version")
     content=$(curl -sL https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/"$major_minor"/releases.json)
     major_minor_patch=$([ "$patch_specified" == true ] && echo "$sem_version" || jq -r '."latest-sdk"' <<< "$content")
-    major_minor_underscore=${major_minor/./_}
 
     sdk_version=$major_minor_patch
     release_content=$(release "$content" "$sdk_version")
@@ -353,7 +352,7 @@ Examples:
             buildAspNetCore = { ... }: {}; \
             buildNetRuntime = { ... }: {}; \
             buildNetSdk = { version, ... }: version; \
-            }).sdk_${major_minor_underscore}" | jq -r)
+            }).sdk" | jq -r)
 
         if [[ "$current_version" == "$sdk_version" ]]; then
             echo "Nothing to update."
@@ -382,17 +381,17 @@ Examples:
 
 # v$channel_version ($support_phase)
 {
-  aspnetcore_$major_minor_underscore = buildAspNetCore {
+  aspnetcore = buildAspNetCore {
     version = \"${aspnetcore_version}\";
     $aspnetcore_sources
   };
 
-  runtime_$major_minor_underscore = buildNetRuntime {
+  runtime = buildNetRuntime {
     version = \"${runtime_version}\";
     $runtime_sources
   };
 
-  sdk_$major_minor_underscore = buildNetSdk {
+  sdk = buildNetSdk {
     version = \"${sdk_version}\";
     $sdk_sources
     packages = { fetchNuGet }: [

--- a/pkgs/development/compilers/dotnet/versions/6.0.nix
+++ b/pkgs/development/compilers/dotnet/versions/6.0.nix
@@ -2,7 +2,7 @@
 
 # v6.0 (active)
 {
-  aspnetcore_6_0 = buildAspNetCore {
+  aspnetcore = buildAspNetCore {
     version = "6.0.27";
     srcs = {
       x86_64-linux = {
@@ -24,7 +24,7 @@
     };
   };
 
-  runtime_6_0 = buildNetRuntime {
+  runtime = buildNetRuntime {
     version = "6.0.27";
     srcs = {
       x86_64-linux = {
@@ -46,7 +46,7 @@
     };
   };
 
-  sdk_6_0 = buildNetSdk {
+  sdk = buildNetSdk {
     version = "6.0.419";
     srcs = {
       x86_64-linux = {

--- a/pkgs/development/compilers/dotnet/versions/7.0.nix
+++ b/pkgs/development/compilers/dotnet/versions/7.0.nix
@@ -2,7 +2,7 @@
 
 # v7.0 (maintenance)
 {
-  aspnetcore_7_0 = buildAspNetCore {
+  aspnetcore = buildAspNetCore {
     version = "7.0.16";
     srcs = {
       x86_64-linux = {
@@ -24,7 +24,7 @@
     };
   };
 
-  runtime_7_0 = buildNetRuntime {
+  runtime = buildNetRuntime {
     version = "7.0.16";
     srcs = {
       x86_64-linux = {
@@ -46,7 +46,7 @@
     };
   };
 
-  sdk_7_0 = buildNetSdk {
+  sdk = buildNetSdk {
     version = "7.0.406";
     srcs = {
       x86_64-linux = {

--- a/pkgs/development/compilers/dotnet/versions/8.0.102.nix
+++ b/pkgs/development/compilers/dotnet/versions/8.0.102.nix
@@ -2,7 +2,7 @@
 
 # v8.0 (active)
 {
-  aspnetcore_8_0 = buildAspNetCore {
+  aspnetcore = buildAspNetCore {
     version = "8.0.2";
     srcs = {
       x86_64-linux = {
@@ -24,7 +24,7 @@
     };
   };
 
-  runtime_8_0 = buildNetRuntime {
+  runtime = buildNetRuntime {
     version = "8.0.2";
     srcs = {
       x86_64-linux = {
@@ -46,7 +46,7 @@
     };
   };
 
-  sdk_8_0 = buildNetSdk {
+  sdk = buildNetSdk {
     version = "8.0.102";
     srcs = {
       x86_64-linux = {

--- a/pkgs/development/compilers/dotnet/versions/8.0.nix
+++ b/pkgs/development/compilers/dotnet/versions/8.0.nix
@@ -2,7 +2,7 @@
 
 # v8.0 (active)
 {
-  aspnetcore_8_0 = buildAspNetCore {
+  aspnetcore = buildAspNetCore {
     version = "8.0.2";
     srcs = {
       x86_64-linux = {
@@ -24,7 +24,7 @@
     };
   };
 
-  runtime_8_0 = buildNetRuntime {
+  runtime = buildNetRuntime {
     version = "8.0.2";
     srcs = {
       x86_64-linux = {
@@ -46,7 +46,7 @@
     };
   };
 
-  sdk_8_0 = buildNetSdk {
+  sdk = buildNetSdk {
     version = "8.0.201";
     srcs = {
       x86_64-linux = {

--- a/pkgs/development/compilers/dotnet/versions/9.0.nix
+++ b/pkgs/development/compilers/dotnet/versions/9.0.nix
@@ -2,7 +2,7 @@
 
 # v9.0 (preview)
 {
-  aspnetcore_9_0 = buildAspNetCore {
+  aspnetcore = buildAspNetCore {
     version = "9.0.0-preview.1.24081.5";
     srcs = {
       x86_64-linux = {
@@ -24,7 +24,7 @@
     };
   };
 
-  runtime_9_0 = buildNetRuntime {
+  runtime = buildNetRuntime {
     version = "9.0.0-preview.1.24080.9";
     srcs = {
       x86_64-linux = {
@@ -46,7 +46,7 @@
     };
   };
 
-  sdk_9_0 = buildNetSdk {
+  sdk = buildNetSdk {
     version = "9.0.100-preview.1.24101.2";
     srcs = {
       x86_64-linux = {

--- a/pkgs/development/compilers/inklecate/default.nix
+++ b/pkgs/development/compilers/inklecate/default.nix
@@ -1,12 +1,11 @@
 { lib
 , stdenv
 , autoPatchelfHook
-, buildDotnetModule
-, dotnetCorePackages
+, dotnet_6
 , fetchFromGitHub
 }:
 
-buildDotnetModule rec {
+dotnet_6.buildDotnetModule rec {
   pname = "inklecate";
   version = "1.1.1";
 
@@ -23,9 +22,6 @@ buildDotnetModule rec {
   projectFile = "inklecate/inklecate.csproj";
   nugetDeps = ./deps.nix;
   executables = [ "inklecate" ];
-
-  dotnet-sdk = dotnetCorePackages.sdk_6_0;
-  dotnet-runtime = dotnetCorePackages.runtime_6_0;
 
   meta = with lib; {
     description = "Compiler for ink, inkle's scripting language";

--- a/pkgs/development/compilers/roslyn/default.nix
+++ b/pkgs/development/compilers/roslyn/default.nix
@@ -1,12 +1,11 @@
 { lib
 , fetchFromGitHub
 , mono
-, buildDotnetModule
-, dotnetCorePackages
+, dotnet_6
 , unzip
 }:
 
-buildDotnetModule rec {
+dotnet_6.buildDotnetModule rec {
   pname = "roslyn";
   version = "4.2.0";
 
@@ -16,8 +15,6 @@ buildDotnetModule rec {
     rev = "v${version}";
     hash = "sha256-4iXabFp0LqJ8TXOrqeD+oTAocg6ZTIfijfX3s3fMJuI=";
   };
-
-  dotnet-sdk = dotnetCorePackages.sdk_6_0;
 
   projectFile = [ "src/NuGet/Microsoft.Net.Compilers.Toolset/Microsoft.Net.Compilers.Toolset.Package.csproj" ];
 

--- a/pkgs/development/python-modules/clr-loader/default.nix
+++ b/pkgs/development/python-modules/clr-loader/default.nix
@@ -2,11 +2,10 @@
 , fetchPypi
 , buildPythonPackage
 , pytestCheckHook
-, dotnetCorePackages
+, dotnet_6
 , setuptools
 , setuptools-scm
 , wheel
-, buildDotnetModule
 , cffi
 }:
 
@@ -21,7 +20,7 @@ let
 
   # This buildDotnetModule is used only to get nuget sources, the actual
   # build is done in `buildPythonPackage` below.
-  dotnet-build = buildDotnetModule {
+  dotnet-build = dotnet_6.buildDotnetModule {
     inherit pname version src;
     projectFile = [ "netfx_loader/ClrLoader.csproj" "example/example.csproj" ];
     nugetDeps = ./deps.nix;
@@ -36,7 +35,7 @@ buildPythonPackage {
     setuptools
     setuptools-scm
     wheel
-    dotnetCorePackages.sdk_6_0
+    dotnet_6.sdk
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pythonnet/default.nix
+++ b/pkgs/development/python-modules/pythonnet/default.nix
@@ -4,8 +4,7 @@
 , pytestCheckHook
 , pycparser
 , psutil
-, dotnet-sdk
-, buildDotnetModule
+, dotnet_6
 , clr-loader
 , setuptools
 }:
@@ -21,7 +20,7 @@ let
 
   # This buildDotnetModule is used only to get nuget sources, the actual
   # build is done in `buildPythonPackage` below.
-  dotnet-build = buildDotnetModule {
+  dotnet-build = dotnet_6.buildDotnetModule {
     inherit pname version src;
     nugetDeps = ./deps.nix;
   };
@@ -38,7 +37,7 @@ buildPythonPackage {
 
   nativeBuildInputs = [
     setuptools
-    dotnet-sdk
+    dotnet_6.sdk
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/tools/azure-functions-core-tools/default.nix
+++ b/pkgs/development/tools/azure-functions-core-tools/default.nix
@@ -2,9 +2,8 @@
   stdenv,
   callPackage,
   fetchFromGitHub,
-  buildDotnetModule,
   buildGoModule,
-  dotnetCorePackages,
+  dotnet_6,
 }:
 let
   version = "4.0.5455";
@@ -21,11 +20,11 @@ let
     vendorHash = null;
   };
 in
-buildDotnetModule rec {
+dotnet_6.buildDotnetModule rec {
   pname = "azure-functions-core-tools";
   inherit src version;
 
-  dotnet-runtime = dotnetCorePackages.sdk_6_0;
+  dotnet-runtime = dotnet_6.sdk;
   nugetDeps = ./deps.nix;
   useDotnetFromEnv = true;
   executables = [ "func" ];

--- a/pkgs/development/tools/build-managers/msbuild/default.nix
+++ b/pkgs/development/tools/build-managers/msbuild/default.nix
@@ -1,8 +1,8 @@
-{ lib, stdenv, fetchurl, fetchpatch, makeWrapper, glibcLocales, mono, nuget, unzip, dotnetCorePackages, writeText, roslyn }:
+{ lib, stdenv, fetchurl, fetchpatch, makeWrapper, glibcLocales, mono, nuget, unzip, dotnet_6, writeText, roslyn }:
 
 let
 
-  dotnet-sdk = dotnetCorePackages.sdk_6_0;
+  dotnet-sdk = dotnet_6.sdk;
 
   xplat = fetchurl {
     url = "https://github.com/mono/msbuild/releases/download/v16.9.0/mono_msbuild_6.12.0.137.zip";

--- a/pkgs/development/tools/continuous-integration/github-runner/default.nix
+++ b/pkgs/development/tools/continuous-integration/github-runner/default.nix
@@ -1,6 +1,6 @@
 { autoPatchelfHook
 , autoSignDarwinBinariesHook
-, buildDotnetModule
+, dotnet_6
 , dotnetCorePackages
 , fetchFromGitHub
 , fetchpatch
@@ -21,7 +21,7 @@
 # Node.js runtimes supported by upstream
 assert builtins.all (x: builtins.elem x [ "node20" ]) nodeRuntimes;
 
-buildDotnetModule rec {
+dotnet_6.buildDotnetModule rec {
   pname = "github-runner";
   version = "2.314.1";
 
@@ -121,9 +121,6 @@ buildDotnetModule rec {
   ];
 
   buildInputs = [ stdenv.cc.cc.lib ];
-
-  dotnet-sdk = dotnetCorePackages.sdk_6_0;
-  dotnet-runtime = dotnetCorePackages.runtime_6_0;
 
   dotnetFlags = [ "-p:PackageRuntime=${dotnetCorePackages.systemToDotnetRid stdenv.hostPlatform.system}" ];
 
@@ -236,7 +233,7 @@ buildDotnetModule rec {
   '' + lib.optionalString stdenv.isLinux ''
     substituteInPlace $out/lib/github-runner/config.sh \
       --replace 'command -v ldd' 'command -v ${glibc.bin}/bin/ldd' \
-      --replace 'ldd ./bin' '${glibc.bin}/bin/ldd ${dotnet-runtime}/shared/Microsoft.NETCore.App/${dotnet-runtime.version}/' \
+      --replace 'ldd ./bin' '${glibc.bin}/bin/ldd ${dotnet_6.runtime}/shared/Microsoft.NETCore.App/${dotnet_6.runtime.version}/' \
       --replace '/sbin/ldconfig' '${glibc.bin}/bin/ldconfig'
   '' + ''
     # Remove uneeded copy for run-helper template

--- a/pkgs/development/tools/fable/default.nix
+++ b/pkgs/development/tools/fable/default.nix
@@ -1,6 +1,6 @@
-{ buildDotnetGlobalTool, lib }:
+{ dotnet_6, lib }:
 
-buildDotnetGlobalTool {
+dotnet_6.buildDotnetGlobalTool {
   pname = "fable";
   version = "4.13.0";
 

--- a/pkgs/development/tools/fsautocomplete/default.nix
+++ b/pkgs/development/tools/fsautocomplete/default.nix
@@ -1,6 +1,9 @@
-{ lib, buildDotnetModule, fetchFromGitHub, dotnetCorePackages }:
+{ lib, fetchFromGitHub, dotnet_7, dotnet_6 }:
 
-buildDotnetModule rec {
+let
+  dotnet = dotnet_7.withExtraSDKs [ dotnet_6.sdk ];
+
+in dotnet.buildDotnetModule rec {
   pname = "fsautocomplete";
   version = "0.69.0";
 
@@ -20,8 +23,7 @@ buildDotnetModule rec {
       --replace TargetFrameworks TargetFramework \
   '';
 
-  dotnet-sdk = with dotnetCorePackages; combinePackages [ sdk_6_0 sdk_7_0 ];
-  dotnet-runtime = dotnetCorePackages.sdk_7_0;
+  dotnet-runtime = dotnet_7.sdk;
 
   projectFile = "src/FsAutoComplete/FsAutoComplete.fsproj";
   executables = [ "fsautocomplete" ];

--- a/pkgs/development/tools/godot/3/mono/default.nix
+++ b/pkgs/development/tools/godot/3/mono/default.nix
@@ -3,7 +3,7 @@
 , mkNugetDeps
 , mkNugetSource
 , mono
-, dotnet-sdk
+, dotnet_6
 , writeText
 }:
 
@@ -12,7 +12,7 @@ godot3.overrideAttrs (self: base: {
 
   godotBuildDescription = "mono build";
 
-  nativeBuildInputs = base.nativeBuildInputs ++ [ mono dotnet-sdk ];
+  nativeBuildInputs = base.nativeBuildInputs ++ [ mono dotnet_6.sdk ];
 
   glue = callPackage ./glue.nix {};
 

--- a/pkgs/development/tools/ilspycmd/default.nix
+++ b/pkgs/development/tools/ilspycmd/default.nix
@@ -1,13 +1,12 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, buildDotnetModule
-, dotnetCorePackages
+, dotnet_6
 , powershell
 , autoSignDarwinBinariesHook
 , glibcLocales
 }:
-buildDotnetModule rec {
+dotnet_6.buildDotnetModule rec {
   pname = "ilspycmd";
   version = "8.0";
 
@@ -25,9 +24,6 @@ buildDotnetModule rec {
   # https://github.com/NixOS/nixpkgs/issues/38991
   # bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
   env.LOCALE_ARCHIVE = lib.optionalString stdenv.hostPlatform.isLinux "${glibcLocales}/lib/locale/locale-archive";
-
-  dotnet-sdk = dotnetCorePackages.sdk_6_0;
-  dotnet-runtime = dotnetCorePackages.runtime_6_0;
 
   projectFile = "ICSharpCode.ILSpyCmd/ICSharpCode.ILSpyCmd.csproj";
   nugetDeps = ./deps.nix;

--- a/pkgs/development/tools/language-servers/csharp-ls/default.nix
+++ b/pkgs/development/tools/language-servers/csharp-ls/default.nix
@@ -1,19 +1,13 @@
 { lib
-, buildDotnetGlobalTool
-, dotnetCorePackages
+, dotnet_8
 }:
-let
-  inherit (dotnetCorePackages) sdk_8_0;
-in
-
-buildDotnetGlobalTool rec {
+dotnet_8.buildDotnetGlobalTool rec {
   pname = "csharp-ls";
   version = "0.11.0";
 
   nugetSha256 = "sha256-zB8uJqlf8kL8jh3WNsPQF7EJpONqi23co3O/iBzfEoU=";
 
-  dotnet-sdk = sdk_8_0;
-  dotnet-runtime = sdk_8_0;
+  dotnet-runtime = dotnet_8.sdk;
 
   meta = with lib; {
     description = "Roslyn-based LSP language server for C#";

--- a/pkgs/development/tools/marksman/default.nix
+++ b/pkgs/development/tools/marksman/default.nix
@@ -1,12 +1,11 @@
 { lib
 , fetchFromGitHub
-, buildDotnetModule
-, dotnetCorePackages
+, dotnet_8
 , marksman
 , testers
 }:
 
-buildDotnetModule rec {
+dotnet_8.buildDotnetModule rec {
   pname = "marksman";
   version = "2023-12-09";
 
@@ -24,9 +23,6 @@ buildDotnetModule rec {
   testProjectFile = "Tests/Tests.fsproj";
 
   nugetDeps = ./deps.nix;
-
-  dotnet-sdk = dotnetCorePackages.sdk_8_0;
-  dotnet-runtime = dotnetCorePackages.runtime_8_0;
 
   postInstall = ''
     install -m 644 -D -t "$out/share/doc/${pname}" LICENSE
@@ -53,7 +49,6 @@ buildDotnetModule rec {
     homepage = "https://github.com/artempyanykh/marksman";
     license = licenses.mit;
     maintainers = with maintainers; [ stasjok plusgut ];
-    platforms = dotnet-sdk.meta.platforms;
     mainProgram = "marksman";
   };
 }

--- a/pkgs/development/tools/misc/netcoredbg/default.nix
+++ b/pkgs/development/tools/misc/netcoredbg/default.nix
@@ -1,4 +1,4 @@
-{ lib, clangStdenv, stdenv, cmake, autoPatchelfHook, fetchFromGitHub, dotnetCorePackages, buildDotnetModule, netcoredbg, testers }:
+{ lib, clangStdenv, stdenv, cmake, autoPatchelfHook, fetchFromGitHub, dotnet_6, dotnet_7, netcoredbg, testers }:
 let
   pname = "netcoredbg";
   build = "1018";
@@ -14,8 +14,6 @@ let
     sha256 = "sha256-n7ySUTB4XOXxeeVomySdZIYepdp0PNNGW9pU/2wwVGM=";
   };
 
-  dotnet-sdk = dotnetCorePackages.sdk_7_0;
-
   src = fetchFromGitHub {
     owner = "Samsung";
     repo = pname;
@@ -26,7 +24,7 @@ let
   unmanaged = clangStdenv.mkDerivation {
     inherit src pname version;
 
-    nativeBuildInputs = [ cmake dotnet-sdk ];
+    nativeBuildInputs = [ cmake dotnet_7.sdk ];
 
     hardeningDisable = [ "strictoverflow" ];
 
@@ -36,13 +34,15 @@ let
 
     cmakeFlags = [
       "-DCORECLR_DIR=${coreclr-src}/src/coreclr"
-      "-DDOTNET_DIR=${dotnet-sdk}"
+      "-DDOTNET_DIR=${dotnet_7.sdk}"
       "-DBUILD_MANAGED=0"
     ];
   };
 
-  managed = buildDotnetModule {
-    inherit pname version src dotnet-sdk;
+  managed = dotnet_7.buildDotnetModule {
+    inherit pname version src;
+
+    dotnet-runtime = dotnet_6.runtime;
 
     projectFile = "src/managed/ManagedPart.csproj";
     nugetDeps = ./deps.nix;

--- a/pkgs/games/BeatSaberModManager/default.nix
+++ b/pkgs/games/BeatSaberModManager/default.nix
@@ -1,13 +1,11 @@
 {
   lib,
-  dotnet-sdk,
   stdenv,
   substituteAll,
 
-  buildDotnetModule,
+  dotnet_7,
+  dotnet_6,
   fetchFromGitHub,
-
-  dotnetCorePackages,
 
   libX11,
   libICE,
@@ -16,8 +14,10 @@
 
   xdg-utils,
 }:
+let
+  dotnet = dotnet_7.withExtraSDKs [ dotnet_6.sdk ];
 
-buildDotnetModule rec {
+in dotnet.buildDotnetModule rec {
   pname = "BeatSaberModManager";
   version = "0.0.5";
 
@@ -28,13 +28,6 @@ buildDotnetModule rec {
     sha256 = "sha256-HHWC+MAwJ+AMCuBzSuR7FbW3k+wLri0B9J1DftyfNEU=";
     fetchSubmodules = true; # It vendors BSIPA-Linux
   };
-
-  dotnet-sdk = with dotnetCorePackages; combinePackages [
-    sdk_7_0
-    sdk_6_0
-  ];
-
-  dotnet-runtime = dotnetCorePackages.runtime_7_0;
 
   projectFile = [ "BeatSaberModManager/BeatSaberModManager.csproj" ];
 

--- a/pkgs/games/openra/build-engine.nix
+++ b/pkgs/games/openra/build-engine.nix
@@ -1,10 +1,10 @@
-{ lib, buildDotnetModule, dotnetCorePackages
+{ lib, dotnet_6
 , fetchFromGitHub
 , SDL2, freetype, openal, lua51Packages
 }:
 engine:
 
-buildDotnetModule rec {
+dotnet_6.buildDotnetModule rec {
   pname = "openra-${engine.build}";
   inherit (engine) version;
 
@@ -16,9 +16,6 @@ buildDotnetModule rec {
   };
 
   nugetDeps = engine.deps;
-
-  dotnet-sdk = dotnetCorePackages.sdk_6_0;
-  dotnet-runtime = dotnetCorePackages.runtime_6_0;
 
   useAppHost = false;
 
@@ -67,7 +64,7 @@ buildDotnetModule rec {
     # Create Nix wrappers to the application scripts which setup the needed environment
     for bin in $(find $out/.bin-unwrapped -type f); do
       makeWrapper "$bin" "$out/bin/$(basename "$bin")" \
-        --prefix "PATH" : "${lib.makeBinPath [ dotnet-runtime ]}"
+        --prefix "PATH" : "${lib.makeBinPath [ dotnet_6.runtime ]}"
     done
   '';
 

--- a/pkgs/games/osu-lazer/default.nix
+++ b/pkgs/games/osu-lazer/default.nix
@@ -1,8 +1,7 @@
 { lib
 , stdenvNoCC
-, buildDotnetModule
+, dotnet_8
 , fetchFromGitHub
-, dotnetCorePackages
 , makeDesktopItem
 , copyDesktopItems
 , ffmpeg
@@ -15,7 +14,7 @@
 , udev
 }:
 
-buildDotnetModule rec {
+dotnet_8.buildDotnetModule rec {
   pname = "osu-lazer";
   version = "2024.302.1";
 
@@ -28,9 +27,6 @@ buildDotnetModule rec {
 
   projectFile = "osu.Desktop/osu.Desktop.csproj";
   nugetDeps = ./deps.nix;
-
-  dotnet-sdk = dotnetCorePackages.sdk_8_0;
-  dotnet-runtime = dotnetCorePackages.runtime_8_0;
 
   nativeBuildInputs = [ copyDesktopItems ];
 

--- a/pkgs/games/space-station-14-launcher/space-station-14-launcher.nix
+++ b/pkgs/games/space-station-14-launcher/space-station-14-launcher.nix
@@ -1,6 +1,6 @@
 { lib
-, buildDotnetModule
-, dotnetCorePackages
+, dotnet_6
+, dotnet_8
 , fetchFromGitHub
 , wrapGAppsHook
 , iconConvTools
@@ -34,7 +34,10 @@ let
   version = "0.25.1";
   pname = "space-station-14-launcher";
 in
-buildDotnetModule rec {
+let
+  dotnet = dotnet_8.withExtraSDKs [ dotnet_6.sdk ];
+
+in dotnet.buildDotnetModule rec {
   inherit pname;
 
   # Workaround to prevent buildDotnetModule from overriding assembly versions.
@@ -62,10 +65,6 @@ buildDotnetModule rec {
     inherit version; # Workaround so update script works.
     updateScript = ./update.sh;
   };
-
-  # SDK 6.0 required for Robust.LoaderApi
-  dotnet-sdk = with dotnetCorePackages; combinePackages [ sdk_8_0 sdk_6_0 ];
-  dotnet-runtime = dotnetCorePackages.runtime_8_0;
 
   dotnetFlags = [
     "-p:FullRelease=true"

--- a/pkgs/games/vintagestory/default.nix
+++ b/pkgs/games/vintagestory/default.nix
@@ -15,7 +15,7 @@
 , libglvnd
 , pipewire
 , libpulseaudio
-, dotnet-runtime_7
+, dotnet_7
 }:
 
 stdenv.mkDerivation rec {
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper copyDesktopItems ];
 
-  buildInputs = [ dotnet-runtime_7 ];
+  buildInputs = [ dotnet_7.runtime ];
 
   runtimeLibs = lib.makeLibraryPath ([
     gtk2
@@ -69,10 +69,10 @@ stdenv.mkDerivation rec {
   '';
 
   preFixup = ''
-    makeWrapper ${dotnet-runtime_7}/bin/dotnet $out/bin/vintagestory \
+    makeWrapper ${dotnet_7.runtime}/bin/dotnet $out/bin/vintagestory \
       --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
       --add-flags $out/share/vintagestory/Vintagestory.dll
-    makeWrapper ${dotnet-runtime_7}/bin/dotnet $out/bin/vintagestory-server \
+    makeWrapper ${dotnet_7.runtime}/bin/dotnet $out/bin/vintagestory-server \
       --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
       --add-flags $out/share/vintagestory/VintagestoryServer.dll
   '' + ''

--- a/pkgs/games/xivlauncher/default.nix
+++ b/pkgs/games/xivlauncher/default.nix
@@ -1,11 +1,11 @@
-{ lib, buildDotnetModule, fetchFromGitHub, dotnetCorePackages, SDL2, libsecret, glib, gnutls, aria2, steam, gst_all_1
+{ lib, fetchFromGitHub, dotnet_6, SDL2, libsecret, glib, gnutls, aria2, steam, gst_all_1
 , copyDesktopItems, makeDesktopItem, makeWrapper
 , useSteamRun ? true }:
 
 let
   rev = "1.0.7";
 in
-  buildDotnetModule rec {
+  dotnet_6.buildDotnetModule rec {
     pname = "XIVLauncher";
     version = rev;
 

--- a/pkgs/servers/bililiverecorder/default.nix
+++ b/pkgs/servers/bililiverecorder/default.nix
@@ -2,15 +2,16 @@
 , stdenv
 , fetchzip
 , makeWrapper
+, dotnet_6
 , dotnetCorePackages
 }:
 
 let
   pname = "bililiverecorder";
 
-  dotnet = with dotnetCorePackages; combinePackages [
-    runtime_6_0
-    aspnetcore_6_0
+  dotnet = with dotnet_6; dotnetCorePackages.combinePackages [
+    runtime
+    aspnetcore
   ];
 
   version = "2.10.1";

--- a/pkgs/servers/jackett/default.nix
+++ b/pkgs/servers/jackett/default.nix
@@ -1,13 +1,12 @@
 { lib
 , stdenv
-, buildDotnetModule
 , fetchFromGitHub
-, dotnetCorePackages
+, dotnet_6
 , openssl
 , mono
 }:
 
-buildDotnetModule rec {
+dotnet_6.buildDotnetModule rec {
   pname = "jackett";
   version = "0.21.1915";
 
@@ -21,7 +20,7 @@ buildDotnetModule rec {
   projectFile = "src/Jackett.Server/Jackett.Server.csproj";
   nugetDeps = ./deps.nix;
 
-  dotnet-runtime = dotnetCorePackages.aspnetcore_6_0;
+  dotnet-runtime = dotnet_6.aspnetcore;
 
   dotnetInstallFlags = [ "-p:TargetFramework=net6.0" ];
 

--- a/pkgs/servers/jellyfin/default.nix
+++ b/pkgs/servers/jellyfin/default.nix
@@ -3,8 +3,7 @@
 , fetchurl
 , nixosTests
 , stdenv
-, dotnetCorePackages
-, buildDotnetModule
+, dotnet_6
 , ffmpeg
 , fontconfig
 , freetype
@@ -12,7 +11,7 @@
 , sqlite
 }:
 
-buildDotnetModule rec {
+dotnet_6.buildDotnetModule rec {
   pname = "jellyfin";
   version = "10.8.13"; # ensure that jellyfin-web has matching version
 
@@ -40,8 +39,7 @@ buildDotnetModule rec {
     fontconfig
     freetype
   ];
-  dotnet-sdk = dotnetCorePackages.sdk_6_0;
-  dotnet-runtime = dotnetCorePackages.aspnetcore_6_0;
+  dotnet-runtime = dotnet_6.aspnetcore;
   dotnetBuildFlags = [ "--no-self-contained" ];
 
   preInstall = ''

--- a/pkgs/servers/lidarr/default.nix
+++ b/pkgs/servers/lidarr/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, mono, libmediainfo, sqlite, curl, chromaprint, makeWrapper, icu, dotnet-runtime, openssl, nixosTests }:
+{ lib, stdenv, fetchurl, mono, libmediainfo, sqlite, curl, chromaprint, makeWrapper, icu, dotnet_6, openssl, nixosTests }:
 
 let
   os = if stdenv.isDarwin then "osx" else "linux";
@@ -28,7 +28,7 @@ in stdenv.mkDerivation rec {
 
     mkdir -p $out/{bin,share/${pname}-${version}}
     cp -r * $out/share/${pname}-${version}/.
-    makeWrapper "${dotnet-runtime}/bin/dotnet" $out/bin/Lidarr \
+    makeWrapper "${dotnet_6.runtime}/bin/dotnet" $out/bin/Lidarr \
       --add-flags "$out/share/${pname}-${version}/Lidarr.dll" \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
         curl sqlite libmediainfo icu  openssl ]}

--- a/pkgs/servers/nosql/eventstore/default.nix
+++ b/pkgs/servers/nosql/eventstore/default.nix
@@ -1,8 +1,7 @@
 { lib
 , git
-, dotnetCorePackages
+, dotnet_6
 , glibcLocales
-, buildDotnetModule
 , fetchFromGitHub
 , bintools
 , stdenv
@@ -12,7 +11,7 @@ let
   mainProgram = "EventStore.ClusterNode";
 in
 
-buildDotnetModule rec {
+dotnet_6.buildDotnetModule rec {
   pname = "EventStore";
   version = "23.6.0";
 
@@ -27,8 +26,7 @@ buildDotnetModule rec {
   # Fixes application reporting 0.0.0.0 as its version.
   MINVERVERSIONOVERRIDE = version;
 
-  dotnet-sdk = dotnetCorePackages.sdk_6_0;
-  dotnet-runtime = dotnetCorePackages.aspnetcore_6_0;
+  dotnet-runtime = dotnet_6.aspnetcore;
 
   nativeBuildInputs = [ git glibcLocales bintools ];
 

--- a/pkgs/servers/prowlarr/default.nix
+++ b/pkgs/servers/prowlarr/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, mono, libmediainfo, sqlite, curl, makeWrapper, icu, dotnet-runtime, openssl, nixosTests, zlib }:
+{ lib, stdenv, fetchurl, mono, libmediainfo, sqlite, curl, makeWrapper, icu, dotnet_6, openssl, nixosTests, zlib }:
 
 let
   pname = "prowlarr";
@@ -44,7 +44,7 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/{bin,share/${pname}-${version}}
     cp -r * $out/share/${pname}-${version}/.
 
-    makeWrapper "${dotnet-runtime}/bin/dotnet" $out/bin/Prowlarr \
+    makeWrapper "${dotnet_6.runtime}/bin/dotnet" $out/bin/Prowlarr \
       --add-flags "$out/share/${pname}-${version}/Prowlarr.dll" \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
         curl sqlite libmediainfo mono openssl icu zlib ]}

--- a/pkgs/servers/radarr/default.nix
+++ b/pkgs/servers/radarr/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, mono, libmediainfo, sqlite, curl, makeWrapper, icu, dotnet-runtime, openssl, nixosTests, zlib }:
+{ lib, stdenv, fetchurl, mono, libmediainfo, sqlite, curl, makeWrapper, icu, dotnet_6, openssl, nixosTests, zlib }:
 
 let
   os = if stdenv.isDarwin then "osx" else "linux";
@@ -33,7 +33,7 @@ in stdenv.mkDerivation rec {
     mkdir -p $out/{bin,share/${pname}-${version}}
     cp -r * $out/share/${pname}-${version}/.
 
-    makeWrapper "${dotnet-runtime}/bin/dotnet" $out/bin/Radarr \
+    makeWrapper "${dotnet_6.runtime}/bin/dotnet" $out/bin/Radarr \
       --add-flags "$out/share/${pname}-${version}/Radarr.dll" \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
         curl sqlite libmediainfo mono openssl icu zlib ]}

--- a/pkgs/servers/readarr/default.nix
+++ b/pkgs/servers/readarr/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, libmediainfo, sqlite, curl, makeWrapper, icu, dotnet-runtime, openssl, nixosTests }:
+{ lib, stdenv, fetchurl, libmediainfo, sqlite, curl, makeWrapper, icu, dotnet_6, openssl, nixosTests }:
 
 let
   os = if stdenv.isDarwin then "osx" else "linux";
@@ -28,7 +28,7 @@ in stdenv.mkDerivation rec {
 
     mkdir -p $out/{bin,share/${pname}-${version}}
     cp -r * $out/share/${pname}-${version}/.
-    makeWrapper "${dotnet-runtime}/bin/dotnet" $out/bin/Readarr \
+    makeWrapper "${dotnet_6.runtime}/bin/dotnet" $out/bin/Readarr \
       --add-flags "$out/share/${pname}-${version}/Readarr.dll" \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ curl sqlite libmediainfo icu openssl ]}
 
@@ -51,4 +51,3 @@ in stdenv.mkDerivation rec {
     platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
   };
 }
-

--- a/pkgs/servers/sonarr/default.nix
+++ b/pkgs/servers/sonarr/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, dotnet-runtime, icu, ffmpeg, openssl, sqlite, curl, makeWrapper, nixosTests }:
+{ lib, stdenv, fetchurl, dotnet_6, icu, ffmpeg, openssl, sqlite, curl, makeWrapper, nixosTests }:
 
 let
   os = if stdenv.isDarwin then "osx" else "linux";
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/{bin,share/sonarr-${version}}
     cp -r * $out/share/sonarr-${version}/.
 
-    makeWrapper "${dotnet-runtime}/bin/dotnet" $out/bin/NzbDrone \
+    makeWrapper "${dotnet_6.runtime}/bin/dotnet" $out/bin/NzbDrone \
       --add-flags "$out/share/sonarr-${version}/Sonarr.dll" \
       --prefix PATH : ${lib.makeBinPath [ ffmpeg ]} \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ curl sqlite openssl icu ]}

--- a/pkgs/servers/web-apps/kavita/default.nix
+++ b/pkgs/servers/web-apps/kavita/default.nix
@@ -1,9 +1,8 @@
 { lib
 , stdenvNoCC
 , fetchFromGitHub
-, buildDotnetModule
 , buildNpmPackage
-, dotnetCorePackages
+, dotnet_6
 , nixosTests
 , substituteAll
 }:
@@ -19,7 +18,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-jNhiwyz6iVSLlvMNjI689TwQYuEvTJ+QaPvvDQ4UOwc=";
   };
 
-  backend = buildDotnetModule {
+  backend = dotnet_6.buildDotnetModule {
     pname = "kavita-backend";
     inherit (finalAttrs) version src;
 
@@ -35,8 +34,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     projectFile = "API/API.csproj";
     nugetDeps = ./nuget-deps.nix;
-    dotnet-sdk = dotnetCorePackages.sdk_6_0;
-    dotnet-runtime = dotnetCorePackages.aspnetcore_6_0;
+    dotnet-runtime = dotnet_6.aspnetcore;
   };
 
   frontend =  buildNpmPackage {

--- a/pkgs/servers/web-apps/slskd/default.nix
+++ b/pkgs/servers/web-apps/slskd/default.nix
@@ -1,8 +1,7 @@
 { lib
 , buildNpmPackage
 , fetchFromGitHub
-, dotnetCorePackages
-, buildDotnetModule
+, dotnet_7
 , mono
 , nodejs_18
 }:
@@ -38,13 +37,12 @@ let
     '';
   };
 
-in buildDotnetModule {
+in dotnet_7.buildDotnetModule {
   inherit pname version src meta;
 
   runtimeDeps = [ mono ];
 
-  dotnet-sdk = dotnetCorePackages.sdk_7_0;
-  dotnet-runtime = dotnetCorePackages.aspnetcore_7_0;
+  dotnet-runtime = dotnet_7.aspnetcore;
 
   projectFile = "slskd.sln";
 

--- a/pkgs/test/dotnet/project-references/default.nix
+++ b/pkgs/test/dotnet/project-references/default.nix
@@ -3,8 +3,7 @@
 # https://nixos.org/manual/nixpkgs/unstable/index.html#packaging-a-dotnet-application
 
 { lib
-, dotnet-sdk
-, buildDotnetModule
+, dotnet_6
 , runCommand
 }:
 
@@ -13,9 +12,9 @@ let
 
   # Specify the TargetFramework via an environment variable so that we don't
   # have to update the .csproj files when updating dotnet-sdk
-  TargetFramework = "net${lib.versions.majorMinor (lib.getVersion dotnet-sdk)}";
+  TargetFramework = "net${lib.versions.majorMinor (lib.getVersion dotnet_6.sdk)}";
 
-  library = buildDotnetModule {
+  library = dotnet_6.buildDotnetModule {
     name = "project-references-test-library";
     src = ./library;
     inherit nugetDeps TargetFramework;
@@ -23,7 +22,7 @@ let
     packNupkg = true;
   };
 
-  application = buildDotnetModule {
+  application = dotnet_6.buildDotnetModule {
     name = "project-references-test-application";
     src = ./application;
     inherit nugetDeps TargetFramework;

--- a/pkgs/tools/X11/opentabletdriver/default.nix
+++ b/pkgs/tools/X11/opentabletdriver/default.nix
@@ -1,5 +1,5 @@
 { lib
-, buildDotnetModule
+, dotnet_6
 , fetchFromGitHub
 , gtk3
 , libX11
@@ -16,7 +16,7 @@
 , coreutils
 }:
 
-buildDotnetModule rec {
+dotnet_6.buildDotnetModule rec {
   pname = "OpenTabletDriver";
   version = "0.6.4.0";
 

--- a/pkgs/tools/admin/pbm/default.nix
+++ b/pkgs/tools/admin/pbm/default.nix
@@ -1,6 +1,6 @@
-{ buildDotnetGlobalTool, lib }:
+{ dotnet_6, lib }:
 
-buildDotnetGlobalTool {
+dotnet_6.buildDotnetGlobalTool {
   pname = "pbm";
   version = "1.3.2";
 

--- a/pkgs/tools/backup/discordchatexporter-cli/default.nix
+++ b/pkgs/tools/backup/discordchatexporter-cli/default.nix
@@ -1,12 +1,11 @@
 { lib
-, buildDotnetModule
-, dotnetCorePackages
+, dotnet_7
 , fetchFromGitHub
 , testers
 , discordchatexporter-cli
 }:
 
-buildDotnetModule rec {
+dotnet_7.buildDotnetModule rec {
   pname = "discordchatexporter-cli";
   version = "2.41.2";
 
@@ -19,8 +18,6 @@ buildDotnetModule rec {
 
   projectFile = "DiscordChatExporter.Cli/DiscordChatExporter.Cli.csproj";
   nugetDeps = ./deps.nix;
-  dotnet-sdk = dotnetCorePackages.sdk_7_0;
-  dotnet-runtime = dotnetCorePackages.runtime_7_0;
 
   postFixup = ''
     ln -s $out/bin/DiscordChatExporter.Cli $out/bin/discordchatexporter-cli

--- a/pkgs/tools/games/opentracker/default.nix
+++ b/pkgs/tools/games/opentracker/default.nix
@@ -1,11 +1,10 @@
 {
   lib,
   stdenv,
-  buildDotnetModule,
   fetchFromGitHub,
   autoPatchelfHook,
   wrapGAppsHook,
-  dotnetCorePackages,
+  dotnet_6,
   fontconfig,
   gtk3,
   libunwind,
@@ -13,7 +12,7 @@
   xinput,
   xorg,
 }:
-buildDotnetModule rec {
+dotnet_6.buildDotnetModule rec {
   pname = "opentracker";
   version = "1.8.5";
 
@@ -25,8 +24,6 @@ buildDotnetModule rec {
   };
 
   patches = [./remove-project.patch];
-
-  dotnet-runtime = dotnetCorePackages.runtime_6_0;
 
   nugetDeps = ./deps.nix;
 

--- a/pkgs/tools/games/ps3-disc-dumper/default.nix
+++ b/pkgs/tools/games/ps3-disc-dumper/default.nix
@@ -1,11 +1,11 @@
 { lib
-, buildDotnetModule
+, dotnet_6
 , fetchFromGitHub
 , zlib
 , openssl
 }:
 
-buildDotnetModule rec {
+dotnet_6.buildDotnetModule rec {
   pname = "ps3-disc-dumper";
   version = "3.2.3";
 

--- a/pkgs/tools/games/scarab/default.nix
+++ b/pkgs/tools/games/scarab/default.nix
@@ -1,5 +1,5 @@
 { lib
-, buildDotnetModule
+, dotnet_6
 , fetchFromGitHub
 , glibc
 , zlib
@@ -14,7 +14,7 @@
 , makeDesktopItem
 }:
 
-buildDotnetModule rec {
+dotnet_6.buildDotnetModule rec {
   pname = "scarab";
   version = "2.5.0.0";
 

--- a/pkgs/tools/misc/depotdownloader/default.nix
+++ b/pkgs/tools/misc/depotdownloader/default.nix
@@ -1,9 +1,9 @@
 { lib
-, buildDotnetModule
+, dotnet_6
 , fetchFromGitHub
 }:
 
-buildDotnetModule rec {
+dotnet_6.buildDotnetModule rec {
   pname = "depotdownloader";
   version = "2.5.0";
 

--- a/pkgs/tools/misc/pre-commit/default.nix
+++ b/pkgs/tools/misc/pre-commit/default.nix
@@ -4,7 +4,7 @@
 , libiconv
 , cargo
 , coursier
-, dotnet-sdk
+, dotnet_6
 , git
 , glibcLocales
 , go
@@ -48,7 +48,7 @@ buildPythonApplication rec {
   nativeCheckInputs = [
     cargo
     coursier
-    dotnet-sdk
+    dotnet_6.sdk
     git
     glibcLocales
     go
@@ -90,7 +90,7 @@ buildPythonApplication rec {
            VIRTUALENV_NO_DOWNLOAD=1 PRE_COMMIT_NO_CONCURRENCY=1 LANG=en_US.UTF-8
 
     # Resolve `.NET location: Not found` errors for dotnet tests
-    export DOTNET_ROOT="${dotnet-sdk}"
+    export DOTNET_ROOT="${dotnet_6.sdk}"
 
     export HOME=$(mktemp -d)
 

--- a/pkgs/tools/networking/mqttmultimeter/default.nix
+++ b/pkgs/tools/networking/mqttmultimeter/default.nix
@@ -1,9 +1,7 @@
 { lib
 , stdenv
-, dotnetCorePackages
-, dotnet-runtime_6
-, dotnet-runtime_7
-, buildDotnetModule
+, dotnet_6
+, dotnet_7
 , fetchFromGitHub
 , autoPatchelfHook
 , fontconfig
@@ -19,18 +17,13 @@
 let
   version = "1.7.0.211";
 
-  sdk =
+  dotnetPackages =
     if lib.versionAtLeast (lib.versions.majorMinor version) "1.7"
-    then dotnetCorePackages.sdk_7_0
-    else dotnetCorePackages.sdk_6_0;
-
-  runtime =
-    if lib.versionAtLeast (lib.versions.majorMinor version) "1.7"
-    then dotnet-runtime_7
-    else dotnet-runtime_6;
+    then dotnet_7
+    else dotnet_6;
 
 in
-buildDotnetModule rec {
+dotnetPackages.buildDotnetModule rec {
   pname = "mqttmultimeter";
   inherit version;
 
@@ -45,8 +38,6 @@ buildDotnetModule rec {
 
   projectFile = [ "mqttMultimeter.sln" ];
   nugetDeps = ./deps.nix;
-  dotnet-sdk = sdk;
-  dotnet-runtime = runtime;
   executables = [ "mqttMultimeter" ];
 
   nativeBuildInputs = [

--- a/pkgs/tools/security/certdump/default.nix
+++ b/pkgs/tools/security/certdump/default.nix
@@ -1,11 +1,10 @@
 { lib
-, buildDotnetModule
 , fetchFromGitHub
-, dotnetCorePackages
+, dotnet_7
 , callPackage
 }:
 
-buildDotnetModule rec {
+dotnet_7.buildDotnetModule rec {
   pname = "certdump";
   version = "unstable-2023-07-12";
 
@@ -23,8 +22,7 @@ buildDotnetModule rec {
   executables = [ "CertDump" ];
   xBuildFiles = [ "CertDump/CertDump.csproj" ];
 
-  dotnet-runtime = dotnetCorePackages.aspnetcore_7_0;
-  dotnet-sdk = dotnetCorePackages.sdk_7_0;
+  dotnet-runtime = dotnet_7.aspnetcore;
 
   dotnetFlags = [
     "-property:ImportByWildcardBeforeSolution=false"

--- a/pkgs/tools/security/networkminer/default.nix
+++ b/pkgs/tools/security/networkminer/default.nix
@@ -1,12 +1,12 @@
 { lib
-, buildDotnetModule
+, dotnet_6
 , fetchurl
 , unzip
 , dos2unix
 , msbuild
 , mono
 }:
-buildDotnetModule rec {
+dotnet_6.buildDotnetModule rec {
   pname = "networkminer";
   version = "2.8";
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1352,4 +1352,19 @@ mapAliases ({
     purple-facebook
     ;
 
+  dotnet-sdk_6 = dotnetCorePackages.sdk_6_0;
+  dotnet-sdk_7 = dotnetCorePackages.sdk_7_0;
+  dotnet-sdk_8 = dotnetCorePackages.sdk_8_0;
+
+  dotnet-runtime_6 = dotnetCorePackages.runtime_6_0;
+  dotnet-runtime_7 = dotnetCorePackages.runtime_7_0;
+  dotnet-runtime_8 = dotnetCorePackages.runtime_8_0;
+
+  dotnet-aspnetcore_6 = dotnetCorePackages.aspnetcore_6_0; dotnet-aspnetcore_7 = dotnetCorePackages.aspnetcore_7_0;
+  dotnet-aspnetcore_8 = dotnetCorePackages.aspnetcore_8_0;
+
+  dotnet-sdk = dotnetCorePackages.sdk_6_0;
+  dotnet-runtime = dotnetCorePackages.runtime_6_0;
+  dotnet-aspnetcore = dotnetCorePackages.aspnetcore_6_0;
+
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -921,12 +921,22 @@ with pkgs;
 
   dotnetCorePackages = recurseIntoAttrs (callPackage ../development/compilers/dotnet {});
 
-  buildDotnetModule = callPackage ../build-support/dotnet/build-dotnet-module { };
-  nuget-to-nix = callPackage ../build-support/dotnet/nuget-to-nix { };
+  inherit (dotnetCorePackages)
+    dotnet_6-bin
+    dotnet_7-bin
+    dotnet_8-bin
+    dotnet_9-bin
+    dotnet_6
+    dotnet_7
+    dotnet_8
+    dotnet_9;
+
+  buildDotnetModule = callPackage ../build-support/dotnet/build-dotnet-module { dotnet = dotnet_6; };
+  nuget-to-nix = callPackage ../build-support/dotnet/nuget-to-nix { dotnet = dotnet_6; };
   mkNugetSource = callPackage ../build-support/dotnet/make-nuget-source { };
   mkNugetDeps = callPackage ../build-support/dotnet/make-nuget-deps { };
 
-  buildDotnetGlobalTool = callPackage ../build-support/dotnet/build-dotnet-global-tool { };
+  buildDotnetGlobalTool = callPackage ../build-support/dotnet/build-dotnet-global-tool { dotnet = dotnet_6; };
 
   fsautocomplete = callPackage ../development/tools/fsautocomplete { };
 
@@ -3227,7 +3237,7 @@ with pkgs;
 
   aptly = callPackage ../tools/misc/aptly { };
 
-  ArchiSteamFarm = callPackage ../applications/misc/ArchiSteamFarm { };
+  ArchiSteamFarm = callPackage ../applications/misc/ArchiSteamFarm { dotnet_8 = dotnet_8-bin; };
 
   archivebox = callPackage ../applications/misc/archivebox { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -921,22 +921,6 @@ with pkgs;
 
   dotnetCorePackages = recurseIntoAttrs (callPackage ../development/compilers/dotnet {});
 
-  dotnet-sdk_6 = dotnetCorePackages.sdk_6_0;
-  dotnet-sdk_7 = dotnetCorePackages.sdk_7_0;
-  dotnet-sdk_8 = dotnetCorePackages.sdk_8_0;
-
-  dotnet-runtime_6 = dotnetCorePackages.runtime_6_0;
-  dotnet-runtime_7 = dotnetCorePackages.runtime_7_0;
-  dotnet-runtime_8 = dotnetCorePackages.runtime_8_0;
-
-  dotnet-aspnetcore_6 = dotnetCorePackages.aspnetcore_6_0;
-  dotnet-aspnetcore_7 = dotnetCorePackages.aspnetcore_7_0;
-  dotnet-aspnetcore_8 = dotnetCorePackages.aspnetcore_8_0;
-
-  dotnet-sdk = dotnetCorePackages.sdk_6_0;
-  dotnet-runtime = dotnetCorePackages.runtime_6_0;
-  dotnet-aspnetcore = dotnetCorePackages.aspnetcore_6_0;
-
   buildDotnetModule = callPackage ../build-support/dotnet/build-dotnet-module { };
   nuget-to-nix = callPackage ../build-support/dotnet/nuget-to-nix { };
   mkNugetSource = callPackage ../build-support/dotnet/make-nuget-source { };

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -2,7 +2,6 @@
 , lib
 , pkgs
 , buildDotnetPackage
-, buildDotnetModule
 , fetchurl
 , fetchFromGitHub
 , fetchNuGet


### PR DESCRIPTION
## Description of changes

FYI @NixOS/dotnet 

This is an early draft of some potential package renames that @mdarocha and I discussed on a thread on #190129.

- There is no default version of dotnet (was 6 before).  I'm not sure if this is a good idea.  How many places that used e.g. `dotnet-sdk` would have been portable to other versions?

- There is no top-level `dotnet-runtime` / `dotnet-sdk`.  These may still be useful in some cases?

- Specifying aspnetcore as runtime is still awkward.  Maybe this should be a dedicated flag on `buildDotnetModule` or something like `buildAspnetcoreModule`? 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
