### PR TITLE
nixos/networking: add `networking.machineId`

### DIFF
--- a/nixos/modules/system/boot/stage-2-init.sh
+++ b/nixos/modules/system/boot/stage-2-init.sh
@@ -130,7 +130,9 @@ ln -sfn "$systemConfig" /run/booted-system
 # and systemd will immediately fill in the file when it starts, so just
 # creating it is enough. This `: >>` pattern avoids forking and avoids changing
 # the mtime if the file already exists.
-: >> /etc/machine-id
+if ! [ -e "/etc/machine-id" ]; then
+    : >> /etc/machine-id
+fi
 
 
 # No need to restore the stdout/stderr streams we never redirected and

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -609,6 +609,7 @@ in {
   netbox-upgrade = handleTest ./web-apps/netbox-upgrade.nix {};
   # TODO: put in networking.nix after the test becomes more complete
   networkingProxy = handleTest ./networking-proxy.nix {};
+  networkingMachineid = handleTest ./networking-machineid.nix {};
   nextcloud = handleTest ./nextcloud {};
   nexus = handleTest ./nexus.nix {};
   # TODO: Test nfsv3 + Kerberos

--- a/nixos/tests/networking-machineid.nix
+++ b/nixos/tests/networking-machineid.nix
@@ -1,0 +1,15 @@
+import ./make-test-python.nix ({ pkgs, lib, ...} : {
+  name = "networking-machineid";
+
+  meta.maintainers = [ pkgs.lib.maintainers.eyjhb ];
+
+  nodes.machine.networking.machineId = "7d3a942d3709b36857a06affc5019ba2";
+
+  testScript = { nodes, ... }:
+    ''
+      start_all()
+      machine.wait_for_unit("multi-user.target")
+      assert "${nodes.machine.networking.machineId}\n" == machine.succeed("cat /etc/machine-id")
+      assert "d086d05f\n" == machine.succeed("cat /etc/hostid | ${pkgs.xxd}/bin/xxd -p")
+    '';
+})


### PR DESCRIPTION
## Description of changes
Adds `networking.machineId`, which is very useful when running e.g. a impermanence setup, or generally for persisting the machine ID.
The machine ID is now also used to generate the host ID, if it is not already set.

I've also changed the zfs test to use `networking.machineId` instead of `machine.hostId`, and ran the test which works as expected.

Sorry for the ZFS maintainers this might request review for, this is not my intention.

@lilyinstarlight can you review this?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
