### PR TITLE
zulu21: 21.0.0 -> 21.0.2

### DIFF
--- a/pkgs/development/compilers/zulu/21.nix
+++ b/pkgs/development/compilers/zulu/21.nix
@@ -8,35 +8,35 @@ callPackage ./common.nix ({
   # Note that the latest build may differ by platform
   dists = {
     x86_64-linux = {
-      zuluVersion = "21.28.85";
-      jdkVersion = "21.0.0";
+      zuluVersion = "21.32.17";
+      jdkVersion = "21.0.2";
       hash =
-        if enableJavaFX then "sha256-ew/tgSdkrPdk1CTguk9nyl30w7se+YZYqyqOTaeketk="
-        else "sha256-DA6t+9xHp8pkrqtRucBh9xtuTSXS2HZ0US6bY4fp46Y=";
+        if enableJavaFX then "sha256-CEM2lMjyZLWS1tBcS1tBTUxBwAyzW3vrpRWFVVSFVGY="
+        else "sha256-Wtcw++5rtJv/8QvznoQ5LnKNiRA9NHSn5d7w/RNLMAo=";
     };
 
     aarch64-linux = {
-      zuluVersion = "21.28.85";
-      jdkVersion = "21.0.0";
+      zuluVersion = "21.32.17";
+      jdkVersion = "21.0.2";
       hash =
         if enableJavaFX then throw "JavaFX is not available for aarch64-linux"
-        else "sha256-H7ZLgDbF1GPYq1mvBr9bawBoEeYBLjsOtrzPV/HFWDU=";
+        else "sha256-zn3xr11EqfRVYXxLiJFEP74+Syacd32Lgu1m93Fnz+A=";
     };
 
     x86_64-darwin = {
-      zuluVersion = "21.28.85";
-      jdkVersion = "21.0.0";
+      zuluVersion = "21.32.17";
+      jdkVersion = "21.0.2";
       hash =
-        if enableJavaFX then "sha256-QrgEpLaNGc2aNFF38z2ckUTCpweKnuALYLOWATZFJPA="
-        else "sha256-ljm4fbWG0MifepiSrkf0IeRCxkuXuuvf8xeI++IyZb0=";
+        if enableJavaFX then "sha256-CbEKa9Z/ItFqVM4BqsWXyRf5ejQZXPK8OqkULr9Cpqk="
+        else "sha256-Otj+KI61fZdcJ4auRToDaqRuR6sqw9gVOOuuKlTTwCU=";
     };
 
     aarch64-darwin = {
-      zuluVersion = "21.28.85";
-      jdkVersion = "21.0.0";
+      zuluVersion = "21.32.17";
+      jdkVersion = "21.0.2";
       hash =
-        if enableJavaFX then "sha256-PUVB/R1K1dLTi1FsOYIvcI76M6EYYeMG1Bm+oMno//Y="
-        else "sha256-KnqZo+omPb2NMqZ9Hm42O6iyXGRcgm9eFnoCu6+v8fo=";
+        if enableJavaFX then "sha256-PK+cafgQsnK6acuQxun4IUiyYHQJsBfUawwfGV8OCfQ="
+        else "sha256-6CYFFt6LYGYUIqcl8d8sNu+Ij2+zU5NWawDnMl2z0E4=";
     };
   };
 } // builtins.removeAttrs args [ "callPackage" ])


### PR DESCRIPTION
## Description of changes

Only `zulu21.override { enableJavaFX = true; }` doesn't build on `x86_64-linux`, but that doesn't seem to be a regression. It doesn't seem to be easily solvable either...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
