### PR TITLE
mdp-toolkit: init at 3.6-unstable-2023-07-30

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12818,6 +12818,12 @@
     githubId = 2072185;
     name = "Marc Scholten";
   };
+  mq37 = {
+    email = "me@kopecky.io";
+    github = "MQ37";
+    githubId = 29043708;
+    name = "Jakub Kopecky";
+  };
   mrcjkb = {
     email = "marc@jakobi.dev";
     matrix = "@mrcjk:matrix.org";

--- a/pkgs/development/python-modules/mdp-toolkit/default.nix
+++ b/pkgs/development/python-modules/mdp-toolkit/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, future
+, joblib
+, numpy
+, pytest
+, pythonOlder
+, scikit-learn
+}:
+
+buildPythonPackage rec {
+  pname = "mdp-toolkit";
+  version = "3.6-unstable-2023-07-30";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "mdp-toolkit";
+    repo = "mdp-toolkit";
+    rev = "64f14eee8af55ecba32f884710d0e52ebbeb258b";
+    hash = "sha256-s6cPS6HM70tJUUAZMw6nhGyj64yNvQt+HilMENwdFHQ=";
+  };
+
+  postPatch = ''
+    # https://github.com/mdp-toolkit/mdp-toolkit/issues/92
+    substituteInPlace mdp/utils/routines.py \
+    --replace numx.typeDict numx.sctypeDict
+    substituteInPlace mdp/test/test_NormalizingRecursiveExpansionNode.py \
+    --replace py.test"" "pytest"
+    substituteInPlace mdp/test/test_RecursiveExpansionNode.py \
+    --replace py.test"" "pytest"
+  '';
+
+  propagatedBuildInputs = [
+    future
+    numpy
+  ];
+
+  nativeCheckInputs = [
+    joblib
+    pytest
+    scikit-learn
+  ];
+
+  pythonImportsCheck = [
+    "mdp"
+    "bimdp"
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    pytest --seed 7710873 mdp
+    pytest --seed 7710873 bimdp
+
+    runHook postCheck
+  '';
+
+  meta = with lib; {
+    description = "Library for building complex data processing software by combining widely used machine learning algorithms";
+    homepage = "https://mdp-toolkit.github.io/";
+    changelog = "https://github.com/mdp-toolkit/mdp-toolkit/blob/64f14eee8af55ecba32f884710d0e52ebbeb258b/CHANGES";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ mq37 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6946,6 +6946,7 @@ self: super: with self; {
   mdutils = callPackage ../development/python-modules/mdutils { };
 
   mdp = callPackage ../development/python-modules/mdp { };
+  mdp-toolkit = callPackage ../development/python-modules/mdp-toolkit { };
 
   measurement = callPackage ../development/python-modules/measurement { };
 


### PR DESCRIPTION
## Description of changes

This PR introduces new nixpkg python development package `mdp-toolkit` that uses newer version of `mdp-toolkit` python package. It is essentially the same as already existing nixpkg python package `python3*Packages.mdp` but instead of PyPi it uses git as a source. Reason behind this is that nixpkg `python3*Packages.mdp` seems to be broken and I could not use them on my NixOS because of the following python error while building:
```
       > ImportError while loading conftest '/build/MDP-3.6/mdp/test/conftest.py'.
       > mdp/__init__.py:133: in <module>
       >     utils.symeig = configuration.get_symeig(numx_linalg)
       > mdp/configuration.py:338: in get_symeig
       >     args = getargs(numx_linalg.eigh)[0]
       > /nix/store/qp5zys77biz7imbk6yy85q5pdv7qk84j-python3-3.11.6/lib/python3.11/inspect.py:1379: in getfullargspec
       >     raise TypeError('unsupported callable') from ex
       > E   TypeError: unsupported callabl
```

**I was not sure if changing the original nixpkg `mdp` source is desired so I created new one `mdp-toolkit` with name based on the git repo and not he PyPi package**

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
