### PR TITLE
nmap-parse: init at 0-unstable-2022-09-26

### DIFF
--- a/pkgs/by-name/nm/nmap-parse/package.nix
+++ b/pkgs/by-name/nm/nmap-parse/package.nix
@@ -1,0 +1,48 @@
+{ lib
+, fetchFromGitHub
+, python3
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "nmap-parse";
+  version = "0-unstable-2022-09-26";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "jonny1102";
+    repo = "nmap-parse";
+    # https://github.com/jonny1102/nmap-parse/issues/12
+    rev = "ae270ac9ce05bfbe822dbbb29411adf562d40abf";
+    hash = "sha256-iaE4a5blbDPaKPRnR46+AfegXOEW88i+z/VIVGCepeM=";
+  };
+
+  propagatedBuildInputs = with python3.pkgs; [
+    beautifulsoup4
+    cmd2
+    colorama
+    ipy
+    tabulate
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm 755 "nmap-parse.py" "$out/bin/nmap-parse"
+
+    install -vd $out/${python3.sitePackages}/
+    cp -R modules $out/${python3.sitePackages}
+
+    runHook postInstall
+  '';
+
+  # Project has no tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Command line nmap XML parser";
+    homepage = "https://github.com/jonny1102/nmap-parse";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+    mainProgram = "nmap-parse";
+  };
+}


### PR DESCRIPTION
## Description of changes
Command line nmap XML parser

https://github.com/jonny1102/nmap-parse

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
