### PR TITLE
makeDesktopItem: Allow passing arguments to `writeTextFile`

### DIFF
--- a/pkgs/build-support/make-desktopitem/default.nix
+++ b/pkgs/build-support/make-desktopitem/default.nix
@@ -32,6 +32,9 @@ lib.makeOverridable ({ name # The name of the desktop file
 # not supported until version 1.5, which is not supported by our desktop-file-utils as of 2022-02-23
 # , singleMainWindow ? null
 , extraConfig ? {} # Additional values to be added literally to the final item, e.g. vendor extensions
+# Make the parameters sent to writeTextFile easily overridable, e.g. allow the .desktop file to be 
+# marked as executable
+, fileSettings ? {}
 }:
 let
   # There are multiple places in the FDO spec that make "boolean" values actually tristate,
@@ -115,4 +118,4 @@ writeTextFile {
   destination = "/share/applications/${name}.desktop";
   text = builtins.concatStringsSep "\n" content;
   checkPhase = ''${buildPackages.desktop-file-utils}/bin/desktop-file-validate "$target"'';
-})
+} // fileSettings)


### PR DESCRIPTION
## Description of changes
Use case; some desktop compositors (KDE(?), Cinnamon) require GUI program's .desktop files to be marked as executable files.
See https://github.com/NixOS/nixpkgs/issues/152059 and https://github.com/nix-community/home-manager/issues/4979.

__*CURRENTLY MARKED AS DRAFT SINCE I EXPECT THAT THIS IS NOT IDEAL AS-IS*__

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux (No idea how to "build" this - some packages found using it seem to work for me (not exhaustive list)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) 
  - This did not work, but neither did it on parent commit #286108... 
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
