### PR TITLE
Fix build error in rPackages.rhdf5 by adding missing include

### DIFF
--- a/pkgs/development/r-modules/patches/rhdf5.patch
+++ b/pkgs/development/r-modules/patches/rhdf5.patch
@@ -35,11 +35,12 @@ index b326444..5d58b4a 100644
    /* return value of lock attempt */
    PROTECT(Rval = allocVector(INTSXP, 1));
 diff --git a/src/h5testLock.h b/src/h5testLock.h
-index 2c1c5e4..660c747 100644
+index 2c1c5e4..25914ff 100644
 --- a/src/h5testLock.h
 +++ b/src/h5testLock.h
-@@ -1,5 +1,4 @@
+@@ -1,5 +1,5 @@
  #include <fcntl.h>
++#include <unistd.h>
  #include "myhdf5.h"
 -#include <H5private.h>
  


### PR DESCRIPTION
## Description of changes

Fixes the build error in rPackages.rhdf5 on aarch64-darwin by adding a missing include statement for "unistd.h". See #286190.
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
