### PR TITLE
nixos/switch-to-configuration: correctly handle template instances with '.' in name

### DIFF
--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -579,7 +579,7 @@ while (my ($unit, $state) = each(%{$active_cur})) {
     my $new_base_unit_file = $new_unit_file;
 
     # Detect template instances.
-    if (!-e $cur_unit_file && !-e $new_unit_file && $unit =~ /^(.*)@[^\.]*\.(.*)$/msx) {
+    if (!-e $cur_unit_file && !-e $new_unit_file && $unit =~ /^(.*)@.*\.(.*)$/msx) {
       $base_unit = "$1\@.$2";
       $cur_base_unit_file = "/etc/systemd/system/$base_unit";
       $new_base_unit_file = "$toplevel/etc/systemd/system/$base_unit";
@@ -762,7 +762,7 @@ if ($action eq "dry-activate") {
         my $new_base_unit_file = $new_unit_file;
 
         # Detect template instances.
-        if (!-e $new_unit_file && $unit =~ /^(.*)@[^\.]*\.(.*)$/msx) {
+        if (!-e $new_unit_file && $unit =~ /^(.*)@.*\.(.*)$/msx) {
           $base_unit = "$1\@.$2";
           $new_base_unit_file = "$toplevel/etc/systemd/system/$base_unit";
         }
@@ -835,7 +835,7 @@ foreach (split(/\n/msx, read_file($restart_by_activation_file, err_mode => "quie
     my $new_base_unit_file = $new_unit_file;
 
     # Detect template instances.
-    if (!-e $new_unit_file && $unit =~ /^(.*)@[^\.]*\.(.*)$/msx) {
+    if (!-e $new_unit_file && $unit =~ /^(.*)@.*\.(.*)$/msx) {
       $base_unit = "$1\@.$2";
       $new_base_unit_file = "$toplevel/etc/systemd/system/$base_unit";
     }

--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -336,6 +336,10 @@ in {
             wantedBy = [ "multi-user.target" ];
             overrideStrategy = "asDropin";
           };
+          systemd.services."instantiated@three.with.dot" = {
+            wantedBy = [ "multi-user.target" ];
+            overrideStrategy = "asDropin";
+          };
         };
 
         unitWithTemplateModified.configuration = {
@@ -954,11 +958,11 @@ in {
         # Ensure templated units are restarted when the base unit changes
         switch_to_specialisation("${machine}", "unitWithTemplate")
         out = switch_to_specialisation("${machine}", "unitWithTemplateModified")
-        assert_contains(out, "stopping the following units: instantiated@one.service, instantiated@two.service\n")
+        assert_contains(out, "stopping the following units: instantiated@one.service, instantiated@three.with.dot.service, instantiated@two.service\n")
         assert_lacks(out, "NOT restarting the following changed units:")
         assert_lacks(out, "reloading the following units:")
         assert_lacks(out, "\nrestarting the following units:")
-        assert_contains(out, "\nstarting the following units: instantiated@one.service, instantiated@two.service\n")
+        assert_contains(out, "\nstarting the following units: instantiated@one.service, instantiated@three.with.dot.service, instantiated@two.service\n")
         assert_lacks(out, "the following new units were started:")
 
     with subtest("failing units"):

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/src/main.rs
@@ -1108,7 +1108,7 @@ won't take effect until you reboot the system.
 
     let current_active_units = get_active_units(&systemd)?;
 
-    let template_unit_re = Regex::new(r"^(.*)@[^\.]*\.(.*)$")
+    let template_unit_re = Regex::new(r"^(.*)@.*\.(.*)$")
         .context("Invalid regex for matching systemd template units")?;
     let unit_name_re = Regex::new(r"^(.*)\.[[:lower:]]*$")
         .context("Invalid regex for matching systemd unit names")?;


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR changes `switch-to-configuration.pl` and `switch-to-configuration-ng` to correctly handle templated service instances containing "." in their name (e.g. `my-service@a.b.c.service`). Prior to this change, these services were not started, restarted or stopped on configuration change.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
  - ) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
