### PR TITLE
libgudev: fix build on musl

### DIFF
--- a/pkgs/development/libraries/libgudev/default.nix
+++ b/pkgs/development/libraries/libgudev/default.nix
@@ -9,7 +9,6 @@
 , gnome
 , vala
 , gobject-introspection
-, fetchpatch
 , glibcLocales
 , umockdev
 }:
@@ -24,6 +23,18 @@ stdenv.mkDerivation (finalAttrs: {
     url = "mirror://gnome/sources/libgudev/${lib.versions.majorMinor finalAttrs.version}/libgudev-${finalAttrs.version}.tar.xz";
     hash = "sha256-YSZqsa/J1z28YKiyr3PpnS/f9H2ZVE0IV2Dk+mZ7XdE=";
   };
+
+  patches = [
+    # Conditionally disable one test that requires a locale implementation
+    # https://gitlab.gnome.org/GNOME/libgudev/-/merge_requests/31
+    ./tests-skip-double-test-on-stub-locale-impls.patch
+  ];
+
+  postPatch = ''
+    # The relative location of LD_PRELOAD works for Glibc but not for other loaders (e.g. pkgsMusl)
+    substituteInPlace tests/meson.build \
+      --replace "LD_PRELOAD=libumockdev-preload.so.0" "LD_PRELOAD=${lib.getLib umockdev}/lib/libumockdev-preload.so.0"
+  '';
 
   strictDeps = true;
 

--- a/pkgs/development/libraries/libgudev/tests-skip-double-test-on-stub-locale-impls.patch
+++ b/pkgs/development/libraries/libgudev/tests-skip-double-test-on-stub-locale-impls.patch
@@ -1,0 +1,41 @@
+From ad8b10870ee2092268f87144d8e5ab7db2011139 Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Tue, 30 Jan 2024 20:47:21 +0100
+Subject: [PATCH] tests: Skip double test on stub locale impls
+
+On musl, setlocale() with an unknown locale name will succeed, but
+treat the requested locale as if it were C.UTF-8.  Therefore, to
+properly check whether the locale is supported, we need to actually
+verify whether it works the way we expect when deciding whether to
+skip the test.
+---
+ tests/test-double.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/tests/test-double.c b/tests/test-double.c
+index 91e77c9..e9d9232 100644
+--- a/tests/test-double.c
++++ b/tests/test-double.c
+@@ -39,8 +39,6 @@ fixture_teardown (Fixture *f, G_GNUC_UNUSED const void *data)
+ static void
+ test_double (Fixture *f, G_GNUC_UNUSED const void *data)
+ {
+-	g_assert_cmpstr (nl_langinfo(RADIXCHAR), ==, ",");
+-
+ 	umockdev_testbed_add_device (f->testbed, "platform", "dev1", NULL,
+ 				     "in_accel_scale", "0.0000098", NULL,
+ 				     "ID_MODEL", "KoolGadget", "SCALE", "0.0000098", NULL);
+@@ -73,6 +71,10 @@ int main(int argc, char **argv)
+ 	if (setlocale (LC_NUMERIC, "fr_FR.UTF-8") == NULL)
+ 		return GNU_SKIP_RETURNCODE;
+ 
++	/* Skip if locale doesn't work how we expect. */
++	if (strcmp (nl_langinfo(RADIXCHAR), ","))
++		return GNU_SKIP_RETURNCODE;
++
+ 	g_test_init (&argc, &argv, NULL);
+ 
+ 	g_test_add ("/gudev/double", Fixture, NULL,
+-- 
+GitLab
+


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
