### PR TITLE
Bump all* JDK packages

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1787,6 +1787,12 @@
     githubId = 816777;
     name = "Ashley Gillman";
   };
+  ashgoldofficial = {
+    email = "ashley.goldwater@gmail.com";
+    github = "ASHGOLDOFFICIAL";
+    githubId = 104313094;
+    name = "Andrey Shaat";
+  };
   ashkitten = {
     email = "ashlea@protonmail.com";
     github = "ashkitten";

--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -285,7 +285,7 @@ in
             KERNEL=="nvidia_uvm", RUN+="${pkgs.runtimeShell} -c 'mknod -m 666 /dev/nvidia-uvm-tools c $$(grep nvidia-uvm /proc/devices | cut -d \  -f 1) 1'"
           '';
           hardware.opengl = {
-            extraPackages = [ nvidia_x11.out ];
+            extraPackages = [ nvidia_x11.out nvidia_x11.settings.libXNVCtrl ];
             extraPackages32 = [ nvidia_x11.lib32 ];
           };
           environment.systemPackages = [ nvidia_x11.bin ];

--- a/nixos/modules/services/video/frigate.nix
+++ b/nixos/modules/services/video/frigate.nix
@@ -427,10 +427,6 @@ in
         PrivateTmp = true;
         CacheDirectory = "frigate";
         CacheDirectoryMode = "0750";
-
-        BindPaths = [
-          "/migrations:${cfg.package}/share/frigate/migrations:ro"
-        ];
       };
     };
   };

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -1,11 +1,11 @@
 {
   stable = {
     chromedriver = {
-      hash_darwin = "sha256-DX0J3xeOK4Dy4BAjbrbu1rnIkmF8nlmy9tMaQhLsFcU=";
+      hash_darwin = "sha256-1gi+hWrVL+mBB8pHMXnX/8kzRCQqGuut/+wO/9yBABs=";
       hash_darwin_aarch64 =
-        "sha256-hRJeaeQS30srO5M1Gi43VYR/KrjNAhH0XozkEzvcbA0=";
-      hash_linux = "sha256-CcBQhIsK7mL7VNJCs6ynhrQeXPuB793DysyV1nj90mM=";
-      version = "125.0.6422.76";
+        "sha256-skYFjXBvv+2u/K770Dd3uxFYFer6GGx/EgWfAgzE9pI=";
+      hash_linux = "sha256-67rXlDJeDSpcpEhNQq0rVS2bSWPy3GXVnTo6dwKAnZU=";
+      version = "125.0.6422.78";
     };
     deps = {
       gn = {

--- a/pkgs/applications/networking/browsers/chromium/upstream-info.nix
+++ b/pkgs/applications/networking/browsers/chromium/upstream-info.nix
@@ -15,8 +15,8 @@
         version = "2024-04-10";
       };
     };
-    hash = "sha256-m7WeRloS6tGH2AwhkNicpqThUQmS+9w2xFS2dbmu1vw=";
-    version = "125.0.6422.76";
+    hash = "sha256-EA8TzemtndFb8qAp4XWNjwWmNRz/P4Keh3k1Cn9qLEU=";
+    version = "125.0.6422.112";
   };
   ungoogled-chromium = {
     deps = {

--- a/pkgs/applications/networking/cluster/helm/default.nix
+++ b/pkgs/applications/networking/cluster/helm/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "kubernetes-helm";
-  version = "3.15.0";
+  version = "3.15.1";
 
   src = fetchFromGitHub {
     owner = "helm";
     repo = "helm";
     rev = "v${version}";
-    sha256 = "sha256-0YBpxXM/+mU0y1lf/h3xFbF5nfbjk6D9qT10IMR9XUY=";
+    sha256 = "sha256-DTHohUkL4ophYeXSZ/acle6Ruum9IIHxnu7gvPOOaYY=";
   };
   vendorHash = "sha256-VPahAeeRz3fk1475dlCofiLVAKXMhpvspENmQmlPyPM=";
 

--- a/pkgs/applications/networking/cluster/kubebuilder/default.nix
+++ b/pkgs/applications/networking/cluster/kubebuilder/default.nix
@@ -12,13 +12,13 @@
 
 buildGoModule rec {
   pname = "kubebuilder";
-  version = "3.15.0";
+  version = "3.15.1";
 
   src = fetchFromGitHub {
     owner = "kubernetes-sigs";
     repo = "kubebuilder";
     rev = "v${version}";
-    hash = "sha256-YaISsW+USP9M4Mblluo+SXSwGspiTiiPFA3VvLmhqaQ=";
+    hash = "sha256-Fc9EzzOULRfzQENHd/7aXWqLeoPjNsseqpZETNGvV6U=";
   };
 
   vendorHash = "sha256-g9QjalRLc2NUsyd7Do1PWw9oD9ATuJGMRaqSaC6AcD0=";

--- a/pkgs/applications/networking/cluster/kubecolor/default.nix
+++ b/pkgs/applications/networking/cluster/kubecolor/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "kubecolor";
-  version = "0.3.2";
+  version = "0.3.3";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-9fL1zuhQ1B8QpJXcGVxg8mqIQoM5ZhwuE000rDcrrw0=";
+    sha256 = "sha256-VGpyYc6YmRr58OSRQvWTo4f8ku8L1/gn0ilbQSotO2k=";
   };
 
   vendorHash = "sha256-Gzz+mCEMQCcLwTiGMB8/nXk7HDAEGkEapC/VOyXrn/Q=";

--- a/pkgs/applications/networking/flexget/default.nix
+++ b/pkgs/applications/networking/flexget/default.nix
@@ -6,7 +6,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "flexget";
-  version = "3.11.33";
+  version = "3.11.34";
   pyproject = true;
 
   # Fetch from GitHub in order to use `requirements.in`
@@ -14,7 +14,7 @@ python3.pkgs.buildPythonApplication rec {
     owner = "Flexget";
     repo = "Flexget";
     rev = "refs/tags/v${version}";
-    hash = "sha256-kgTlz3cUztIUKKqmUpUpEwu5qyjE0fCarG/EKJ1PoPc=";
+    hash = "sha256-g5TmjR3N/21JgXoRy56PN5A+Jbow2DFaAu0ammLtPxw=";
   };
 
   postPatch = ''

--- a/pkgs/applications/networking/instant-messengers/signalbackup-tools/default.nix
+++ b/pkgs/applications/networking/instant-messengers/signalbackup-tools/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "signalbackup-tools";
-  version = "20240514";
+  version = "20240521";
 
   src = fetchFromGitHub {
     owner = "bepaald";
     repo = pname;
     rev = version;
-    hash = "sha256-3coP4Bia/a2xbeHQBUq2rXPEPzWEX9hJX1kb1wh60FA=";
+    hash = "sha256-aNiOqY1qRdPQl02Pr+A9OQgh0zHJnk8XaxdapQ/TwmE=";
   };
 
   postPatch = ''

--- a/pkgs/applications/networking/instant-messengers/twitch-tui/default.nix
+++ b/pkgs/applications/networking/instant-messengers/twitch-tui/default.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "twitch-tui";
-  version = "2.6.9";
+  version = "2.6.10";
 
   src = fetchFromGitHub {
     owner = "Xithrius";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-c5wDneX7p3kOhARaDISHFdPpo4Bs1KbRdShp2cjI6wQ=";
+    hash = "sha256-RJ/+yXbCS8DkdvblBYlxE4sStpTQcGQZXWAApdL7/2o=";
   };
 
-  cargoHash = "sha256-4kz8s5cQDSPZEyHB7+A5q+PrvSr/jAyjfLw+uhThFxQ=";
+  cargoHash = "sha256-lI0HR0iNA2C0kf+oBLxxjcOhsf70wCo3tKPMAC76EZM=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/applications/networking/protonmail-bridge/default.nix
+++ b/pkgs/applications/networking/protonmail-bridge/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "protonmail-bridge";
-  version = "3.11.0";
+  version = "3.11.1";
 
   src = fetchFromGitHub {
     owner = "ProtonMail";
     repo = "proton-bridge";
     rev = "v${version}";
-    hash = "sha256-V2PevO9jhtKMrFVlviKPwcApP4ZTRbCLVoPx0gGNosU=";
+    hash = "sha256-PM162vj1Q336fM5z6KoBgtujz9UgESIxUW3Lw8AEYTw=";
   };
 
   vendorHash = "sha256-qi6ME74pJH/wgDh0xp/Rsc9hPd3v3L/M8pBQJzNieK8=";

--- a/pkgs/applications/networking/sync/wdt/default.nix
+++ b/pkgs/applications/networking/sync/wdt/default.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation {
   pname = "wdt";
-  version = "1.27.1612021-unstable-2024-02-05";
+  version = "1.27.1612021-unstable-2024-05-21";
 
   src = fetchFromGitHub {
     owner = "facebook";
     repo = "wdt";
-    rev = "d94b2d5df6f1c803f9f3b8ed9247b752fa853865";
-    sha256 = "sha256-9TeJbZZq9uQ6KaEBFGDyIGcXgxi2y1aj55vxv5dAIzw=";
+    rev = "6263fee3bebc8bb0012e095723170f70b99ff67d";
+    sha256 = "sha256-CxwRfjPkR7d+Poe+8+TbBGcsK90EwupCyLqUkxUlITs=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/applications/version-management/gfold/default.nix
+++ b/pkgs/applications/version-management/gfold/default.nix
@@ -11,7 +11,7 @@
 
 let
   pname = "gfold";
-  version = "4.4.1";
+  version = "4.5.0";
 in
 rustPlatform.buildRustPackage {
   inherit pname version;
@@ -20,10 +20,10 @@ rustPlatform.buildRustPackage {
     owner = "nickgerace";
     repo = pname;
     rev = version;
-    sha256 = "sha256-KKuWPitm7oD2mXPSu2rbOyzwJ9JJ23LBQIIkkPHm1w4=";
+    sha256 = "sha256-7wTU+yVp/GO1H1MbgZKO0OwqSC2jbHO0lU8aa0tHLTY=";
   };
 
-  cargoHash = "sha256-wDUOYK9e0i600UnJ0w0FPI2GhTa/QTq/2+ICiDWrmEU=";
+  cargoHash = "sha256-idzw5dfCCvujvYr7DG0oOzQUIcbACtiIZLoA4MEClzY=";
 
   buildInputs = lib.optionals stdenv.isDarwin [
     libiconv

--- a/pkgs/applications/version-management/git-machete/default.nix
+++ b/pkgs/applications/version-management/git-machete/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonApplication rec {
   pname = "git-machete";
-  version = "3.25.2";
+  version = "3.25.3";
 
   src = fetchFromGitHub {
     owner = "virtuslab";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-uTbDrSR2Aqeq73PI0dghCkOQS7QPFb/I9Yrl3wIH9ZQ=";
+    hash = "sha256-2XWQK0dXJeQJsB2FUsLoOA4SIoterb1WGXqYi1JHPQY=";
   };
 
   nativeBuildInputs = [ installShellFiles ];

--- a/pkgs/by-name/db/dbeaver-bin/package.nix
+++ b/pkgs/by-name/db/dbeaver-bin/package.nix
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       };
       hash = selectSystem {
         x86_64-linux = "sha256-q6VIr55hXn47kZrE2i6McEOfp2FBOvwB0CcUnRHFMZs=";
-        aarch64-linux = "sha256-CQg2+p1P+Bg1uFM1PMTWtweS0TNElXTP7tI7D5WxixM=";
+        aarch64-linux = "sha256-Xn3X1C31UALBAsZIGyMWdp0HNhJEm5N+7Go7nMs8W64=";
       };
     in
     fetchurl {

--- a/pkgs/by-name/db/dbeaver-bin/package.nix
+++ b/pkgs/by-name/db/dbeaver-bin/package.nix
@@ -61,6 +61,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = with lib; {
     homepage = "https://dbeaver.io/";
     description = "Universal SQL Client for developers, DBA and analysts. Supports MySQL, PostgreSQL, MariaDB, SQLite, and more";

--- a/pkgs/by-name/db/dbeaver-bin/update.sh
+++ b/pkgs/by-name/db/dbeaver-bin/update.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p curl jq
+
+latestVersion=$(curl "https://api.github.com/repos/dbeaver/dbeaver/tags" | jq -r '.[0].name')
+currentVersion=$(nix-instantiate --eval -E "with import ./. {}; dbeaver-bin.version" | tr -d '"')
+
+echo "latest  version: $latestVersion"
+echo "current version: $currentVersion"
+
+if [[ "$latestVersion" == "$currentVersion" ]]; then
+    echo "package is up-to-date"
+    exit 0
+fi
+
+for i in \
+    "x86_64-linux linux.gtk.x86_64-nojdk.tar.gz" \
+    "aarch64-linux linux.gtk.aarch64-nojdk.tar.gz"
+do
+    set -- $i
+    prefetch=$(nix-prefetch-url "https://github.com/dbeaver/dbeaver/releases/download/$latestVersion/dbeaver-ce-$latestVersion-$2")
+    hash=$(nix-hash --type sha256 --to-sri $prefetch)
+
+    update-source-version dbeaver-bin 0 "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" --system=$1
+    update-source-version dbeaver-bin $latestVersion $hash --system=$1
+done

--- a/pkgs/by-name/ff/ff2mpv-rust/package.nix
+++ b/pkgs/by-name/ff/ff2mpv-rust/package.nix
@@ -23,16 +23,16 @@ in
 
 rustPlatform.buildRustPackage rec {
   pname = "ff2mpv-rust";
-  version = "1.1.4";
+  version = "1.1.5";
 
   src = fetchFromGitHub {
     owner = "ryze312";
     repo = "ff2mpv-rust";
     rev = version;
-    hash = "sha256-lQ1VRz/1HYZ3Il/LNNL+Jr6zFvGyxw9rUuzCCA1DZYo=";
+    hash = "sha256-hAhHfNiHzrzACrijpVkzpXqrqGYKI3HIJZtUuTrRIcQ=";
   };
 
-  cargoHash = "sha256-cbueToB7zDHV4k9K8RusHjnMR0ElXsPEfuqHYli25nc=";
+  cargoHash = "sha256-EKmysiq1NTv1aQ1DZGS8bziY4lRr+KssBgXa8MO76Ac=";
 
   postInstall = ''
     $out/bin/ff2mpv-rust manifest > manifest.json

--- a/pkgs/by-name/ko/kor/package.nix
+++ b/pkgs/by-name/ko/kor/package.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "kor";
-  version = "0.4.0";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "yonahd";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-OZSec1S583jVGqSET0y4WhKxWf9CyLKuhEwu39Zg9vE=";
+    hash = "sha256-4l19/vIvcgt7g3o6IWGHhIsXurAy6Ts4fJjs8OMZalk=";
   };
 
-  vendorHash = "sha256-4XcmaW4H+IgZZx3PuG0aimqSG1eUnRtcbebKXuencnQ=";
+  vendorHash = "sha256-NPmsXS7P+pCF97N8x3nQhCRoHJLMO5plNtcUqxxexVE=";
 
   preCheck = ''
     HOME=$(mktemp -d)

--- a/pkgs/by-name/li/libui-ng/package.nix
+++ b/pkgs/by-name/li/libui-ng/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libui-ng";
-  version = "4.1-unstable-2024-05-03";
+  version = "4.1-unstable-2024-05-19";
 
   src = fetchFromGitHub {
     owner = "libui-ng";
     repo = "libui-ng";
-    rev = "56f1ad65f0f32bb1eb67a268cca4658fbe4567c1";
-    hash = "sha256-wo4iS/a1ErdipFDPYKvaGpO/JGtk6eU/qMLC4eUoHnA=";
+    rev = "49b04c4cf8ae4d3e38e389f446ef75170eb62762";
+    hash = "sha256-W9LnUBUKwx1x3+BEeUanisBGR2Q4dnbcMM5k8mCondM=";
   };
 
   postPatch = lib.optionalString (stdenv.isDarwin && stdenv.isx86_64) ''

--- a/pkgs/by-name/li/licensure/package.nix
+++ b/pkgs/by-name/li/licensure/package.nix
@@ -8,16 +8,16 @@
 }:
 rustPlatform.buildRustPackage rec {
   pname = "licensure";
-  version = "0.3.2";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "chasinglogic";
     repo = "licensure";
     rev = version;
-    hash = "sha256-rOD2H9TEoZ8JCjlg6feNQiAjvroVGqrlOkDHNZKXDoE=";
+    hash = "sha256-y72+k3AaR6iT99JJpGs6WZAEyG6CrOZHLqKRj19gLs0=";
   };
 
-  cargoHash = "sha256-ku0SI14pZmbhzE7RnK5kJY6tSMjRVKEMssC9e0Hq6hc=";
+  cargoHash = "sha256-75UNzC+8qjm0A82N63i8YY92wCNQccrS3kIqDlR8pkc=";
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl git gitls ];
 

--- a/pkgs/by-name/no/normcap/package.nix
+++ b/pkgs/by-name/no/normcap/package.nix
@@ -25,7 +25,7 @@ in
 
 ps.buildPythonApplication rec {
   pname = "normcap";
-  version = "0.5.7";
+  version = "0.5.8";
   format = "pyproject";
 
   disabled = ps.pythonOlder "3.9";
@@ -34,7 +34,7 @@ ps.buildPythonApplication rec {
     owner = "dynobo";
     repo = "normcap";
     rev = "refs/tags/v${version}";
-    hash = "sha256-JeecX7rxM3T2WqGFwANI5+HQFWCLLA8ESHy8mEKYUmc=";
+    hash = "sha256-iMlW8oEt4OSipJaQ2XzBZeBVqiZP/C1sM0f5LYjv7/A=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/pa/patch2pr/package.nix
+++ b/pkgs/by-name/pa/patch2pr/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "patch2pr";
-  version = "0.24.0";
+  version = "0.25.0";
 
   src = fetchFromGitHub {
     owner = "bluekeyes";
     repo = "patch2pr";
     rev = "v${version}";
-    hash = "sha256-ot/PECNRuhJUYX1woektKC6VEV+rLKiSnCVCLIRhSUo=";
+    hash = "sha256-mS7Yz1RPeA/pms3gGQ1oEjtzH9miIOWlf6YrrIoJk94=";
   };
 
-  vendorHash = "sha256-K2qYfS0A1gOo2n3pBy00oLbd1/q/p5N8RoId+OP1Jmw=";
+  vendorHash = "sha256-XJC4rJI+adqiyFfiuyTbrAoWDiTThz7vjDZQrchDEiA=";
 
   ldflags = [
     "-X main.version=${version}"

--- a/pkgs/by-name/ph/phpdocumentor/package.nix
+++ b/pkgs/by-name/ph/phpdocumentor/package.nix
@@ -6,16 +6,16 @@
 
 php.buildComposerProject (finalAttrs: {
   pname = "phpdocumentor";
-  version = "3.4.3";
+  version = "3.5.0";
 
   src = fetchFromGitHub {
     owner = "phpDocumentor";
     repo = "phpDocumentor";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-NCBCwQ8im6ttFuQBaG+bzmtinf+rqNnbogcK8r60dCM=";
+    hash = "sha256-//erxY9ryJne/HZLB1l4SwF3EsQ1vmgSe4pZ5xSieIU=";
   };
 
-  vendorHash = "sha256-/TJ/CahmOWcRBlAsJDzWcfhlDd+ypRapruFT0Dvlb1w=";
+  vendorHash = "sha256-VNlAzWueF7ZXBpr9RrJghMPrAUof7f1DCh1osFIwFfs=";
 
   # Needed because of the unbound version constraint on phpdocumentor/json-path
   composerStrictValidation = false;

--- a/pkgs/data/themes/nordic/default.nix
+++ b/pkgs/data/themes/nordic/default.nix
@@ -10,70 +10,70 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "nordic";
-  version = "2.2.0-unstable-2024-02-20";
+  version = "2.2.0-unstable-2024-05-24";
 
   srcs = [
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "58d5a8e10ae068b98a63e6de2791e289f417842d";
-      hash = "sha256-Z3e7DoakK6f+UMBr78gZ+NJPb5vuJCfDgPRYywFDYeg=";
+      rev = "2f6b72b7b6d7112bb147a5adeca307631dd698cb";
+      hash = "sha256-4GNEJTAS6EAPYyaNOZS1lGu67nobGmMOHoq8I5WaPcA=";
       name = "Nordic";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "cb7d95bd5438728f30f361a888dfb33b7f6ad28c";
-      hash = "sha256-ZWGmDiXjEt0UuALyw7cjTYgdw9kdJJKc0vkclbZkBvo=";
+      rev = "d92b503cdabb4cf263de4c3fd9afba889c65aad1";
+      hash = "sha256-foCWcKNdk9S1MijJOuw8jFV4gnDSNWmTjgSCU9GefzE=";
       name = "Nordic-standard-buttons";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "37b86a30ad3e048f87a689f2813aa28644035fa8";
-      hash = "sha256-+O8+30H6humVQTwgFL3uQkeo5gPYrokpAKbT56PX6YQ=";
+      rev = "b76c48252c9dc6171cccf63c0c412b9afe7fa89c";
+      hash = "sha256-q/duyEin377J1cxD5+uXlEbPN/S27ht2es/02wKoiEY=";
       name = "Nordic-darker";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "926b215d14394ff043f2d2969e730759af7acd86";
-      hash = "sha256-yR0DfmUW1rr38Zbwtr7TUYL6z8vTNyoj0vEhphbZieU=";
+      rev = "b8b16b451bf5fcfada98a92682a6ff97d93fc36f";
+      hash = "sha256-959P2xdpCLhNRedoakMiHXzj+H4SWX1Lb9w6yYRzGds=";
       name = "Nordic-darker-standard-buttons";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "1ae59d40ba8342fc14f3a55a2fb37446a8d10880";
-      hash = "sha256-tFIXPP5Ohw8atNIqvMtB7sLka+/tw+aSbjMdzKfI9r0=";
+      rev = "c45681eca7fce4c129063a0aae727d42b570fcfd";
+      hash = "sha256-8a4pMkyGt+WIVXLSsLKbxCP9i4RdZKX5lvwZB+BemSY=";
       name = "Nordic-bluish-accent";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = pname;
-      rev = "aaaa5dab0517f182a85a75d457da70d22e577b26";
-      hash = "sha256-J/nti2jxQ0VfTbp5WfrE0CN6Pvfg1edplL6/QPKUBzc=";
+      rev = "b07b6450ff2389f88ef5ad980a1ead47071b1d63";
+      hash = "sha256-+o46apK051UH6GbG/ugSgxI212MWEnYaVlDK9rWqPMU=";
       name = "Nordic-bluish-accent-standard-buttons";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = "${pname}-polar";
-      rev = "733d5ea57c6ecd8209ec0a928029e28b3f54f83d";
-      hash = "sha256-y3ge0DF0SdKFjH+mZdHDpK3YG7Ng3rN0y0Er2WBC6Sc=";
+      rev = "bc3e7554ab8e8d94e978691054b1b062696eb688";
+      hash = "sha256-tJX/oTEp/9pmzrINBWrnhS9n8JR40T1C0A4LhRLWU9A=";
       name = "Nordic-Polar";
     })
 
     (fetchFromGitHub {
       owner = "EliverLara";
       repo = "${pname}-polar";
-      rev = "667dfe4f6e8157f30a4e0ea5dc1d17438520d6cf";
-      hash = "sha256-p7bY1r8Ik+jsIyjR75UFHw8XuiGz5LmT09txBLyZpx4=";
+      rev = "26b44080c2dbd1a9b576a24d1b14ae01b98519d0";
+      hash = "sha256-5gGiBL7ZKFSPZtnikfrdvrWKG9RkIHdPyWdHYnmSTvg=";
       name = "Nordic-Polar-standard-buttons";
     })
   ];

--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -9,6 +9,7 @@
 , hddtemp
 , libgda
 , libgtop
+, libhandy
 , liquidctl
 , lm_sensors
 , netcat-gnu
@@ -47,9 +48,9 @@ super: lib.trivial.pipe super [
 
   (patchExtension "ddterm@amezin.github.com" (old: {
     nativeBuildInputs = [ gobject-introspection wrapGAppsHook3 ];
-    buildInputs = [ vte ];
+    buildInputs = [ vte libhandy gjs ];
     postFixup = ''
-      substituteInPlace "$out/share/gnome-shell/extensions/ddterm@amezin.github.com/bin/com.github.amezin.ddterm" --replace "gjs" "${gjs}/bin/gjs"
+      patchShebangs "$out/share/gnome-shell/extensions/ddterm@amezin.github.com/bin/com.github.amezin.ddterm"
       wrapGApp "$out/share/gnome-shell/extensions/ddterm@amezin.github.com/bin/com.github.amezin.ddterm"
     '';
   }))

--- a/pkgs/desktops/pantheon/apps/elementary-calculator/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-calculator/default.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-calculator";
-  version = "2.0.3";
+  version = "8.0.0";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = "calculator";
     rev = version;
-    sha256 = "sha256-VPxCW2lVA/nS2aJsjLgkuEM9wnAzyEr864XY8tfLQAY=";
+    sha256 = "sha256-QEs83hSv9Kupj2p/OTnuPZsC8tdm+IqgpeObBVrPRas=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk15-darwin.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk15-darwin.nix
@@ -4,8 +4,8 @@ let
   sources = lib.importJSON ./sources.json;
 in
 {
-  jdk-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk15.mac.jdk.hotspot; };
-  jre-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk15.mac.jre.hotspot; };
-  jdk-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk15.mac.jdk.openj9; };
-  jre-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk15.mac.jre.openj9; };
+  jdk-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk15.mac.jdk.hotspot; knownVulnerabilities = [ "Support ended" ]; };
+  jre-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk15.mac.jre.hotspot; knownVulnerabilities = [ "Support ended" ]; };
+  jdk-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk15.mac.jdk.openj9; knownVulnerabilities = [ "Support ended" ]; };
+  jre-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk15.mac.jre.openj9; knownVulnerabilities = [ "Support ended" ]; };
 }

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk15-linux.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk15-linux.nix
@@ -5,8 +5,8 @@ let
   sources = lib.importJSON ./sources.json;
 in
 {
-  jdk-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk15.${variant}.jdk.hotspot; };
-  jre-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk15.${variant}.jre.hotspot; };
-  jdk-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk15.${variant}.jdk.openj9; };
-  jre-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk15.${variant}.jre.openj9; };
+  jdk-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk15.${variant}.jdk.hotspot; knownVulnerabilities = [ "Support ended" ]; };
+  jre-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk15.${variant}.jre.hotspot; knownVulnerabilities = [ "Support ended" ]; };
+  jdk-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk15.${variant}.jdk.openj9; knownVulnerabilities = [ "Support ended" ]; };
+  jre-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk15.${variant}.jre.openj9; knownVulnerabilities = [ "Support ended" ]; };
 }

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk16-darwin.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk16-darwin.nix
@@ -4,8 +4,8 @@ let
   sources = lib.importJSON ./sources.json;
 in
 {
-  jdk-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk16.mac.jdk.hotspot; };
-  jre-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk16.mac.jre.hotspot; };
-  jdk-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk16.mac.jdk.openj9; };
-  jre-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk16.mac.jre.openj9; };
+  jdk-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk16.mac.jdk.hotspot; knownVulnerabilities = [ "Support ended" ]; };
+  jre-hotspot = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk16.mac.jre.hotspot; knownVulnerabilities = [ "Support ended" ]; };
+  jdk-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk16.mac.jdk.openj9; knownVulnerabilities = [ "Support ended" ]; };
+  jre-openj9 = import ./jdk-darwin-base.nix { sourcePerArch = sources.openjdk16.mac.jre.openj9; knownVulnerabilities = [ "Support ended" ]; };
 }

--- a/pkgs/development/compilers/adoptopenjdk-bin/jdk16-linux.nix
+++ b/pkgs/development/compilers/adoptopenjdk-bin/jdk16-linux.nix
@@ -5,8 +5,8 @@ let
   sources = lib.importJSON ./sources.json;
 in
 {
-  jdk-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk16.${variant}.jdk.hotspot; };
-  jre-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk16.${variant}.jre.hotspot; };
-  jdk-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk16.${variant}.jdk.openj9; };
-  jre-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk16.${variant}.jre.openj9; };
+  jdk-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk16.${variant}.jdk.hotspot; knownVulnerabilities = [ "Support ended" ]; };
+  jre-hotspot = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk16.${variant}.jre.hotspot; knownVulnerabilities = [ "Support ended" ]; };
+  jdk-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk16.${variant}.jdk.openj9; knownVulnerabilities = [ "Support ended" ]; };
+  jre-openj9 = import ./jdk-linux-base.nix { sourcePerArch = sources.openjdk16.${variant}.jre.openj9; knownVulnerabilities = [ "Support ended" ]; };
 }

--- a/pkgs/development/compilers/corretto/11.nix
+++ b/pkgs/development/compilers/corretto/11.nix
@@ -1,5 +1,4 @@
-{ corretto11
-, fetchFromGitHub
+{ fetchFromGitHub
 , gradle_7
 , jdk11
 , lib

--- a/pkgs/development/compilers/corretto/11.nix
+++ b/pkgs/development/compilers/corretto/11.nix
@@ -10,7 +10,7 @@
 }:
 
 let
-  corretto = import ./mk-corretto.nix {
+  corretto = import ./mk-corretto.nix rec {
     inherit lib stdenv rsync runCommand testers;
     jdk = jdk11;
     gradle = gradle_7;
@@ -20,12 +20,12 @@ let
       # Corretto, too.
       "--disable-warnings-as-errors"
     ];
-    version = "11.0.20.9.1";
+    version = "11.0.23.9.1";
     src = fetchFromGitHub {
       owner = "corretto";
       repo = "corretto-11";
-      rev = "b880bdc8397ec3dd6b7cd4b837ce846c9e902783";
-      sha256 = "sha256-IomJHQn0ZgqsBZ5BrRqVrEOhTq7wjLiIKMQlz53JxsU=";
+      rev = version;
+      sha256 = "sha256-GG2Fq30Gex47iicfC2qvckfRvYt3lvSqCXP3XDwEO34=";
     };
   };
 in

--- a/pkgs/development/compilers/corretto/17.nix
+++ b/pkgs/development/compilers/corretto/17.nix
@@ -1,5 +1,6 @@
 { corretto17
 , fetchFromGitHub
+, fetchurl
 , gradle_7
 , jdk17
 , lib
@@ -10,17 +11,25 @@
 }:
 
 let
-  corretto = import ./mk-corretto.nix {
+  corretto = import ./mk-corretto.nix rec {
     inherit lib stdenv rsync runCommand testers;
     jdk = jdk17;
     gradle = gradle_7;
-    version = "17.0.8.8.1";
+    version = "17.0.11.9.1";
     src = fetchFromGitHub {
       owner = "corretto";
       repo = "corretto-17";
-      rev = "9a3cc984f76cb5f90598bdb43215bad20e0f7319";
-      sha256 = "sha256-/VuB3ocD5VvDqCU7BoTG+fQ0aKvK1TejegRYmswInqQ=";
+      rev = version;
+      sha256 = "sha256-aaZItc0MmPaWAJO5ZxS2pBs2RnaK2W0xMkuX8awqvpM=";
     };
   };
 in
-corretto
+corretto.overrideAttrs (final: prev: {
+  # HACK: Removes the FixNullPtrCast patch, as it fails to apply. Need to figure out what causes it to fail to apply.
+  patches = lib.remove
+    (fetchurl {
+      url = "https://git.alpinelinux.org/aports/plain/community/openjdk17/FixNullPtrCast.patch?id=41e78a067953e0b13d062d632bae6c4f8028d91c";
+      sha256 = "sha256-LzmSew51+DyqqGyyMw2fbXeBluCiCYsS1nCjt9hX6zo=";
+    })
+    prev.patches;
+})

--- a/pkgs/development/compilers/corretto/17.nix
+++ b/pkgs/development/compilers/corretto/17.nix
@@ -1,5 +1,4 @@
-{ corretto17
-, fetchFromGitHub
+{ fetchFromGitHub
 , fetchurl
 , gradle_7
 , jdk17

--- a/pkgs/development/compilers/corretto/19.nix
+++ b/pkgs/development/compilers/corretto/19.nix
@@ -10,7 +10,7 @@
 }:
 
 let
-  corretto = import ./mk-corretto.nix {
+  corretto = import ./mk-corretto.nix rec {
     inherit lib stdenv rsync runCommand testers;
     jdk = jdk19;
     gradle = gradle_7;
@@ -18,7 +18,7 @@ let
     src = fetchFromGitHub {
       owner = "corretto";
       repo = "corretto-19";
-      rev = "72f064a1d716272bd17d4e425d4a264b2c2c7d36";
+      rev = version;
       sha256 = "sha256-mEj/MIbdXU0+fF5RhqjPuSeyclstesGaXB0e48YlKuw=";
     };
   };

--- a/pkgs/development/compilers/corretto/19.nix
+++ b/pkgs/development/compilers/corretto/19.nix
@@ -1,5 +1,4 @@
-{ corretto19
-, fetchFromGitHub
+{ fetchFromGitHub
 , gradle_7
 , jdk19
 , lib

--- a/pkgs/development/compilers/corretto/21.nix
+++ b/pkgs/development/compilers/corretto/21.nix
@@ -10,7 +10,7 @@
 }:
 
 let
-  corretto = import ./mk-corretto.nix {
+  corretto = import ./mk-corretto.nix rec {
     inherit lib stdenv rsync runCommand testers;
     jdk = jdk21;
     gradle = gradle_7;
@@ -18,7 +18,7 @@ let
     src = fetchFromGitHub {
       owner = "corretto";
       repo = "corretto-21";
-      rev = "97b366227b4dc8f5a89bbedea88b0b18c9e21886";
+      rev = version;
       sha256 = "sha256-V8UDyukDCQVTWUg4IpSKoY0qnnQ5fePbm3rxcw06Vr0=";
     };
   };

--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -2,8 +2,8 @@
 , stdenv
 , fetchFromGitHub
 , jetbrains
-, openjdk17
-, openjdk17-bootstrap
+, openjdk21
+, openjdk21-bootstrap
 , git
 , autoconf
 , unzip
@@ -37,16 +37,16 @@ let
   }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   cpu = stdenv.hostPlatform.parsed.cpu.name;
 in
-openjdk17.overrideAttrs (oldAttrs: rec {
+openjdk21.overrideAttrs (oldAttrs: rec {
   pname = "jetbrains-jdk" + lib.optionalString withJcef "-jcef";
-  javaVersion = "17.0.8";
-  build = "1000.8";
+  javaVersion = "21.0.2";
+  build = "375.1";
   # To get the new tag:
   # git clone https://github.com/jetbrains/jetbrainsruntime
   # cd jetbrainsruntime
   # git reset --hard [revision]
   # git log --simplify-by-decoration --decorate=short --pretty=short | grep "jbr-" --color=never | cut -d "(" -f2 | cut -d ")" -f1 | awk '{print $2}' | sort -t "-" -k 2 -g | tail -n 1 | tr -d ","
-  openjdkTag = "jbr-17.0.7+7";
+  openjdkTag = "jbr-21.0.2+13";
   version = "${javaVersion}-b${build}";
 
   src = fetchFromGitHub {
@@ -56,9 +56,9 @@ openjdk17.overrideAttrs (oldAttrs: rec {
     hash = "sha256-PXS8wRF37D9vzeC4CvmB3szFMbt+NRqhQqtPZcbeAO8=";
   };
 
-  BOOT_JDK = openjdk17-bootstrap.home;
+  BOOT_JDK = openjdk21-bootstrap.home;
   # run `git log -1 --pretty=%ct` in jdk repo for new value on update
-  SOURCE_DATE_EPOCH = 1691119859;
+  SOURCE_DATE_EPOCH = 1708120903;
 
   patches = [ ];
 
@@ -144,7 +144,7 @@ openjdk17.overrideAttrs (oldAttrs: rec {
       your own risk.
     '';
     homepage = "https://confluence.jetbrains.com/display/JBR/JetBrains+Runtime";
-    inherit (openjdk17.meta) license platforms mainProgram;
+    inherit (openjdk21.meta) license platforms mainProgram;
     maintainers = with maintainers; [ edwtjo ];
 
     broken = stdenv.isDarwin;

--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -2,8 +2,8 @@
 , stdenv
 , fetchFromGitHub
 , jetbrains
-, openjdk21
-, openjdk21-bootstrap
+, openjdk17
+, openjdk17-bootstrap
 , git
 , autoconf
 , unzip
@@ -37,28 +37,28 @@ let
   }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
   cpu = stdenv.hostPlatform.parsed.cpu.name;
 in
-openjdk21.overrideAttrs (oldAttrs: rec {
+openjdk17.overrideAttrs (oldAttrs: rec {
   pname = "jetbrains-jdk" + lib.optionalString withJcef "-jcef";
-  javaVersion = "21.0.2";
-  build = "375.1";
+  javaVersion = "17.0.11";
+  build = "1207.24";
   # To get the new tag:
   # git clone https://github.com/jetbrains/jetbrainsruntime
   # cd jetbrainsruntime
   # git reset --hard [revision]
   # git log --simplify-by-decoration --decorate=short --pretty=short | grep "jbr-" --color=never | cut -d "(" -f2 | cut -d ")" -f1 | awk '{print $2}' | sort -t "-" -k 2 -g | tail -n 1 | tr -d ","
-  openjdkTag = "jbr-21.0.2+13";
+  openjdkTag = "jbr-17.0.8+7";
   version = "${javaVersion}-b${build}";
 
   src = fetchFromGitHub {
     owner = "JetBrains";
     repo = "JetBrainsRuntime";
     rev = "jb${version}";
-    hash = "sha256-PXS8wRF37D9vzeC4CvmB3szFMbt+NRqhQqtPZcbeAO8=";
+    hash = "";
   };
 
-  BOOT_JDK = openjdk21-bootstrap.home;
+  BOOT_JDK = openjdk17-bootstrap.home;
   # run `git log -1 --pretty=%ct` in jdk repo for new value on update
-  SOURCE_DATE_EPOCH = 1708120903;
+  SOURCE_DATE_EPOCH = 1715809405;
 
   patches = [ ];
 
@@ -144,7 +144,7 @@ openjdk21.overrideAttrs (oldAttrs: rec {
       your own risk.
     '';
     homepage = "https://confluence.jetbrains.com/display/JBR/JetBrains+Runtime";
-    inherit (openjdk21.meta) license platforms mainProgram;
+    inherit (openjdk17.meta) license platforms mainProgram;
     maintainers = with maintainers; [ edwtjo ];
 
     broken = stdenv.isDarwin;

--- a/pkgs/development/compilers/openjdk/11.nix
+++ b/pkgs/development/compilers/openjdk/11.nix
@@ -11,8 +11,8 @@
 let
   major = "11";
   minor = "0";
-  update = "19";
-  build = "7";
+  update = "23";
+  build = "9";
 
   # when building a headless jdk, also bootstrap it with a headless jdk
   openjdk-bootstrap = openjdk11-bootstrap.override { gtkSupport = !headless; };
@@ -25,7 +25,7 @@ let
       owner = "openjdk";
       repo = "jdk${major}u";
       rev = "jdk-${version}";
-      sha256 = "sha256-mp8toB1dWcwOtMqNFd7UwRg8pLJckovqD/LD5p9zUoA=";
+      sha256 = "sha256-6y6wge8ZuSKBpb5QNihvAlD4Pv/0d3AQCPOkxUm/sJk=";
     };
 
     nativeBuildInputs = [ pkg-config autoconf unzip ];

--- a/pkgs/development/compilers/openjdk/17.nix
+++ b/pkgs/development/compilers/openjdk/17.nix
@@ -11,8 +11,8 @@
 let
   version = {
     feature = "17";
-    interim = ".0.7";
-    build = "7";
+    interim = ".0.11";
+    build = "9";
   };
 
   # when building a headless jdk, also bootstrap it with a headless jdk
@@ -26,7 +26,7 @@ let
       owner = "openjdk";
       repo = "jdk${version.feature}u";
       rev = "jdk-${version.feature}${version.interim}+${version.build}";
-      sha256 = "sha256-S6QOB4Tbi+K1yjvvywTfvwFI2eX8AiqIx5c3zfxcskc=";
+      sha256 = "sha256-aO4iSc9MklW/4q9U86WEfiiWnlq6iZSbxzq2fbsqd0A=";
     };
 
     nativeBuildInputs = [ pkg-config autoconf unzip ];

--- a/pkgs/development/compilers/openjdk/21.nix
+++ b/pkgs/development/compilers/openjdk/21.nix
@@ -14,8 +14,8 @@
 let
   version = {
     feature = "21";
-    interim = "";
-    build = "35";
+    interim = ".0.3";
+    build = "9";
   };
 
   # when building a headless jdk, also bootstrap it with a headless jdk
@@ -29,7 +29,7 @@ let
       owner = "openjdk";
       repo = "jdk${version.feature}u";
       rev = "jdk-${version.feature}${version.interim}+${version.build}";
-      hash = "sha256-fA8nRWBuTL87S8mwapmNfCPPQoI2aKHjbHJ6PDN3khs=";
+      hash = "sha256-zRN16lrc5gtDlTVIQJRRx103w/VbRkatCLeEc9AXWPE=";
     };
 
     nativeBuildInputs = [ pkg-config autoconf unzip ensureNewerSourcesForZipFilesHook ];

--- a/pkgs/development/compilers/openjdk/8.nix
+++ b/pkgs/development/compilers/openjdk/8.nix
@@ -20,7 +20,7 @@ let
     powerpc64le-linux = "ppc64le";
   }.${stdenv.system} or (throw "Unsupported platform ${stdenv.system}");
 
-  update = "362";
+  update = "412";
   build = "ga";
 
   # when building a headless jdk, also bootstrap it with a headless jdk
@@ -34,7 +34,7 @@ let
       owner = "openjdk";
       repo = "jdk8u";
       rev = "jdk${version}";
-      sha256 = "sha256-C5dQwfIIpIrLeO3JWERyFCQHUSgG8gARuc3qXAeLkJ4=";
+      sha256 = "sha256-o+H5n5p6JG1giJj9OADgMbQPaoKMzLMFquKH536SHhM=";
     };
     outputs = [ "out" "jre" ];
 

--- a/pkgs/development/compilers/openjdk/meta.nix
+++ b/pkgs/development/compilers/openjdk/meta.nix
@@ -2,7 +2,7 @@ lib: version: with lib; {
   homepage = "https://openjdk.java.net/";
   license = licenses.gpl2Only;
   description = "The open-source Java Development Kit";
-  maintainers = with maintainers; [ edwtjo ];
+  maintainers = with maintainers; [ edwtjo infinidoge ];
   platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" "armv7l-linux" "armv6l-linux" "powerpc64le-linux" ];
   mainProgram = "java";
   knownVulnerabilities = optionals (builtins.elem (versions.major version) [ "12" "13" "14" "15" "16" "18" "19" "20" ]) [

--- a/pkgs/development/compilers/openjdk/meta.nix
+++ b/pkgs/development/compilers/openjdk/meta.nix
@@ -5,7 +5,7 @@ lib: version: with lib; {
   maintainers = with maintainers; [ edwtjo ];
   platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" "armv7l-linux" "armv6l-linux" "powerpc64le-linux" ];
   mainProgram = "java";
-  knownVulnerabilities = optionals (builtins.elem (versions.major version) [ "12" "13" "14" "15" "16" "18" ]) [
+  knownVulnerabilities = optionals (builtins.elem (versions.major version) [ "12" "13" "14" "15" "16" "18" "19" "20" ]) [
     "This OpenJDK version has reached its end of life."
   ];
 }

--- a/pkgs/development/compilers/openjdk/openjfx/11.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/11.nix
@@ -7,7 +7,7 @@
 
 let
   major = "11";
-  update = ".0.18";
+  update = ".0.20";
   build = "1";
   repover = "${major}${update}+${build}";
   gradle_ = (gradle_7.override {
@@ -31,7 +31,7 @@ let
       owner = "openjdk";
       repo = "jfx${major}u";
       rev = repover;
-      sha256 = "sha256-46DjIzcBHkmp5vnhYnLu78CG72bIBRM4A6mgk2OLOko=";
+      sha256 = "sha256-BbBP2DiPZTSn1SBYMCgyiNdF9GD+NqR6YjeVNOQHHn4=";
     };
 
     buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4-headless ];

--- a/pkgs/development/compilers/openjdk/openjfx/17.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/17.nix
@@ -7,8 +7,8 @@
 
 let
   major = "17";
-  update = ".0.6";
-  build = "+3";
+  update = ".0.11";
+  build = "-ga";
   repover = "${major}${update}${build}";
   gradle_ = (gradle_7.override {
     java = openjdk17_headless;
@@ -31,7 +31,7 @@ let
       owner = "openjdk";
       repo = "jfx${major}u";
       rev = repover;
-      sha256 = "sha256-9VfXk2EfMebMyVKPohPRP2QXRFf8XemUtfY0JtBCHyw=";
+      sha256 = "sha256-WV8NHlYlt7buGbirLSorLnS2TnyBD17zUquFfwSL3xE=";
     };
 
     buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4-headless ];

--- a/pkgs/development/compilers/openjdk/openjfx/19.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/19.nix
@@ -141,5 +141,8 @@ in makePackage {
     description = "The next-generation Java client toolkit";
     maintainers = with maintainers; [ abbradar ];
     platforms = platforms.unix;
+    knownVulnerabilities = [
+      "This OpenJFX version has reached its end of life."
+    ];
   };
 }

--- a/pkgs/development/compilers/openjdk/openjfx/20.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/20.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, writeText, openjdk17_headless
-, openjdk19_headless, gradle_7, pkg-config, perl, cmake, gperf, gtk2, gtk3, libXtst
+, openjdk20_headless, gradle_7, pkg-config, perl, cmake, gperf, gtk2, gtk3, libXtst
 , libXxf86vm, glib, alsa-lib, ffmpeg_4, python3, ruby, fetchurl, runCommand
 , withMedia ? true
 , withWebKit ? false
@@ -49,7 +49,7 @@ let
 
     config = writeText "gradle.properties" (''
       CONF = Release
-      JDK_HOME = ${openjdk19_headless.home}
+      JDK_HOME = ${openjdk20_headless.home}
     '' + args.gradleProperties or "");
 
     buildPhase = ''
@@ -111,14 +111,14 @@ in makePackage {
 
   postFixup = ''
     # Remove references to bootstrap.
-    export openjdkOutPath='${openjdk19_headless.outPath}'
+    export openjdkOutPath='${openjdk20_headless.outPath}'
     find "$out" -name \*.so | while read lib; do
       new_refs="$(patchelf --print-rpath "$lib" | perl -pe 's,:?\Q$ENV{openjdkOutPath}\E[^:]*,,')"
       patchelf --set-rpath "$new_refs" "$lib"
     done
   '';
 
-  disallowedReferences = [ openjdk17_headless openjdk19_headless ];
+  disallowedReferences = [ openjdk17_headless openjdk20_headless ];
 
   passthru.deps = deps;
 

--- a/pkgs/development/compilers/openjdk/openjfx/20.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/20.nix
@@ -128,5 +128,8 @@ in makePackage {
     description = "The next-generation Java client toolkit";
     maintainers = with maintainers; [ abbradar ];
     platforms = platforms.unix;
+    knownVulnerabilities = [
+      "This OpenJFX version has reached its end of life."
+    ];
   };
 }

--- a/pkgs/development/compilers/openjdk/openjfx/21.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/21.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, writeText, openjdk17_headless
-, openjdk19_headless, gradle_7, pkg-config, perl, cmake, gperf, gtk2, gtk3, libXtst
+, openjdk21_headless, gradle_7, pkg-config, perl, cmake, gperf, gtk2, gtk3, libXtst
 , libXxf86vm, glib, alsa-lib, ffmpeg_4, python3, ruby, fetchurl, runCommand
 , withMedia ? true
 , withWebKit ? false
@@ -49,7 +49,7 @@ let
 
     config = writeText "gradle.properties" (''
       CONF = Release
-      JDK_HOME = ${openjdk19_headless.home}
+      JDK_HOME = ${openjdk21_headless.home}
     '' + args.gradleProperties or "");
 
     buildPhase = ''
@@ -111,14 +111,14 @@ in makePackage {
 
   postFixup = ''
     # Remove references to bootstrap.
-    export openjdkOutPath='${openjdk19_headless.outPath}'
+    export openjdkOutPath='${openjdk21_headless.outPath}'
     find "$out" -name \*.so | while read lib; do
       new_refs="$(patchelf --print-rpath "$lib" | perl -pe 's,:?\Q$ENV{openjdkOutPath}\E[^:]*,,')"
       patchelf --set-rpath "$new_refs" "$lib"
     done
   '';
 
-  disallowedReferences = [ openjdk17_headless openjdk19_headless ];
+  disallowedReferences = [ openjdk17_headless openjdk21_headless ];
 
   passthru.deps = deps;
 

--- a/pkgs/development/compilers/openjdk/openjfx/21.nix
+++ b/pkgs/development/compilers/openjdk/openjfx/21.nix
@@ -7,7 +7,7 @@
 
 let
   major = "21";
-  update = "";
+  update = ".0.3";
   build = "-ga";
   repover = "${major}${update}${build}";
   gradle_ = (gradle_7.override {
@@ -30,9 +30,9 @@ let
 
     src = fetchFromGitHub {
       owner = "openjdk";
-      repo = "jfx";
+      repo = "jfx21u";
       rev = repover;
-      hash = "sha256-deNAGfnA6gwcAa64l0AWdkX+vJd3ZOfIgAifSl+/m+s=";
+      hash = "sha256-7z0GIbkQwG9mXY9dssaicqaKpMo3FkNEpyAvkswoQQ4=";
     };
 
     buildInputs = [ gtk2 gtk3 libXtst libXxf86vm glib alsa-lib ffmpeg_4 ];

--- a/pkgs/development/compilers/semeru-bin/generate-sources.py
+++ b/pkgs/development/compilers/semeru-bin/generate-sources.py
@@ -9,7 +9,7 @@ import sys
 feature_versions = (8, 11, 16, 17)
 oses = ("mac", "linux")
 types = ("jre", "jdk")
-impls = ("openj9")
+impls = ("openj9",)
 
 arch_to_nixos = {
     "x64": ("x86_64",),

--- a/pkgs/development/compilers/semeru-bin/generate-sources.py
+++ b/pkgs/development/compilers/semeru-bin/generate-sources.py
@@ -6,7 +6,7 @@ import re
 import requests
 import sys
 
-feature_versions = (8, 11, 16, 17)
+feature_versions = (8, 11, 16, 17, 21)
 oses = ("mac", "linux")
 types = ("jre", "jdk")
 impls = ("openj9",)

--- a/pkgs/development/compilers/semeru-bin/jdk-darwin.nix
+++ b/pkgs/development/compilers/semeru-bin/jdk-darwin.nix
@@ -13,4 +13,6 @@ in
   jre-16 = common { sourcePerArch = sources.jre.openjdk16; };
   jdk-17 = common { sourcePerArch = sources.jdk.openjdk17; };
   jre-17 = common { sourcePerArch = sources.jre.openjdk17; };
+  jdk-21 = common { sourcePerArch = sources.jdk.openjdk21; };
+  jre-21 = common { sourcePerArch = sources.jre.openjdk21; };
 }

--- a/pkgs/development/compilers/semeru-bin/jdk-darwin.nix
+++ b/pkgs/development/compilers/semeru-bin/jdk-darwin.nix
@@ -3,14 +3,16 @@
 let
   sources = (lib.importJSON ./sources.json).openj9.mac;
   common = opts: callPackage (import ./jdk-darwin-base.nix opts) {};
+
+  EOL = [ "This JDK/JRE version has reached End of Life." ];
 in
 {
   jdk-8 = common { sourcePerArch = sources.jdk.openjdk8; };
   jre-8 = common { sourcePerArch = sources.jre.openjdk8; };
   jdk-11 = common { sourcePerArch = sources.jdk.openjdk11; };
   jre-11 = common { sourcePerArch = sources.jre.openjdk11; };
-  jdk-16 = common { sourcePerArch = sources.jdk.openjdk16; };
-  jre-16 = common { sourcePerArch = sources.jre.openjdk16; };
+  jdk-16 = common { sourcePerArch = sources.jdk.openjdk16; knownVulnerabilities = EOL; };
+  jre-16 = common { sourcePerArch = sources.jre.openjdk16; knownVulnerabilities = EOL; };
   jdk-17 = common { sourcePerArch = sources.jdk.openjdk17; };
   jre-17 = common { sourcePerArch = sources.jre.openjdk17; };
   jdk-21 = common { sourcePerArch = sources.jdk.openjdk21; };

--- a/pkgs/development/compilers/semeru-bin/jdk-linux.nix
+++ b/pkgs/development/compilers/semeru-bin/jdk-linux.nix
@@ -3,14 +3,16 @@
 let
   sources = (lib.importJSON ./sources.json).openj9.linux;
   common = opts: callPackage (import ./jdk-linux-base.nix opts) {};
+
+  EOL = [ "This JDK/JRE version has reached End of Life." ];
 in
 {
   jdk-8 = common { sourcePerArch = sources.jdk.openjdk8; };
   jre-8 = common { sourcePerArch = sources.jre.openjdk8; };
   jdk-11 = common { sourcePerArch = sources.jdk.openjdk11; };
   jre-11 = common { sourcePerArch = sources.jre.openjdk11; };
-  jdk-16 = common { sourcePerArch = sources.jdk.openjdk16; };
-  jre-16 = common { sourcePerArch = sources.jre.openjdk16; };
+  jdk-16 = common { sourcePerArch = sources.jdk.openjdk16; knownVulnerabilities = EOL; };
+  jre-16 = common { sourcePerArch = sources.jre.openjdk16; knownVulnerabilities = EOL; };
   jdk-17 = common { sourcePerArch = sources.jdk.openjdk17; };
   jre-17 = common { sourcePerArch = sources.jre.openjdk17; };
   jdk-21 = common { sourcePerArch = sources.jdk.openjdk21; };

--- a/pkgs/development/compilers/semeru-bin/jdk-linux.nix
+++ b/pkgs/development/compilers/semeru-bin/jdk-linux.nix
@@ -13,4 +13,6 @@ in
   jre-16 = common { sourcePerArch = sources.jre.openjdk16; };
   jdk-17 = common { sourcePerArch = sources.jdk.openjdk17; };
   jre-17 = common { sourcePerArch = sources.jre.openjdk17; };
+  jdk-21 = common { sourcePerArch = sources.jdk.openjdk21; };
+  jre-21 = common { sourcePerArch = sources.jre.openjdk21; };
 }

--- a/pkgs/development/compilers/semeru-bin/sources.json
+++ b/pkgs/development/compilers/semeru-bin/sources.json
@@ -50,6 +50,22 @@
             "version": "17.0.9"
           }
         },
+        "openjdk21": {
+          "aarch64": {
+            "build": "13",
+            "sha256": "6404c5fe4a71049d4f80429720b7d3f3e3b0ebea8067b823a6bfb24b9fe69797",
+            "url": "https://github.com/ibmruntimes/semeru21-binaries/releases/download/jdk-21.0.2%2B13_openj9-0.43.0/ibm-semeru-open-jdk_aarch64_linux_21.0.2_13_openj9-0.43.0.tar.gz",
+            "version": "21.0.2"
+          },
+          "packageType": "jdk",
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "13",
+            "sha256": "7a7a186a7a48537519917331ec91d9180b961dcc7ea0f627a23fa369edab6f16",
+            "url": "https://github.com/ibmruntimes/semeru21-binaries/releases/download/jdk-21.0.2%2B13_openj9-0.43.0/ibm-semeru-open-jdk_x64_linux_21.0.2_13_openj9-0.43.0.tar.gz",
+            "version": "21.0.2"
+          }
+        },
         "openjdk8": {
           "aarch64": {
             "build": "06",
@@ -116,6 +132,22 @@
             "version": "17.0.9"
           }
         },
+        "openjdk21": {
+          "aarch64": {
+            "build": "13",
+            "sha256": "d89507e6d05132106122894b76e2e466521be047c928faf3d47827b3343c3631",
+            "url": "https://github.com/ibmruntimes/semeru21-binaries/releases/download/jdk-21.0.2%2B13_openj9-0.43.0/ibm-semeru-open-jre_aarch64_linux_21.0.2_13_openj9-0.43.0.tar.gz",
+            "version": "21.0.2"
+          },
+          "packageType": "jre",
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "13",
+            "sha256": "ce5a4caf90072fcac02301af6f7771f051cf89a6e63f2ff33325c13ac1fbff56",
+            "url": "https://github.com/ibmruntimes/semeru21-binaries/releases/download/jdk-21.0.2%2B13_openj9-0.43.0/ibm-semeru-open-jre_x64_linux_21.0.2_13_openj9-0.43.0.tar.gz",
+            "version": "21.0.2"
+          }
+        },
         "openjdk8": {
           "aarch64": {
             "build": "06",
@@ -178,6 +210,22 @@
             "version": "17.0.9"
           }
         },
+        "openjdk21": {
+          "aarch64": {
+            "build": "13",
+            "sha256": "78d3e37d57f7b1ab37bba82a65a0d575939cbb06c10e0ddc6a3a1c5576d185d3",
+            "url": "https://github.com/ibmruntimes/semeru21-binaries/releases/download/jdk-21.0.2%2B13_openj9-0.43.0/ibm-semeru-open-jdk_aarch64_mac_21.0.2_13_openj9-0.43.0.tar.gz",
+            "version": "21.0.2"
+          },
+          "packageType": "jdk",
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "13",
+            "sha256": "d4918284a06a921dcadeec700d2a22c7e3d9bf09f28b30423563daecececb8f4",
+            "url": "https://github.com/ibmruntimes/semeru21-binaries/releases/download/jdk-21.0.2%2B13_openj9-0.43.0/ibm-semeru-open-jdk_x64_mac_21.0.2_13_openj9-0.43.0.tar.gz",
+            "version": "21.0.2"
+          }
+        },
         "openjdk8": {
           "packageType": "jdk",
           "vmType": "openj9",
@@ -230,6 +278,22 @@
             "sha256": "f5781de29132c04f54341349e99954ec3cfbdbc65fdebdd00feff47c68793299",
             "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.9%2B9_openj9-0.41.0/ibm-semeru-open-jre_x64_mac_17.0.9_9_openj9-0.41.0.tar.gz",
             "version": "17.0.9"
+          }
+        },
+        "openjdk21": {
+          "aarch64": {
+            "build": "13",
+            "sha256": "69cfdbc1289fc0de58777df56603737f8d1ebf844c3358ea837ca7f6aac03c6e",
+            "url": "https://github.com/ibmruntimes/semeru21-binaries/releases/download/jdk-21.0.2%2B13_openj9-0.43.0/ibm-semeru-open-jre_aarch64_mac_21.0.2_13_openj9-0.43.0.tar.gz",
+            "version": "21.0.2"
+          },
+          "packageType": "jre",
+          "vmType": "openj9",
+          "x86_64": {
+            "build": "13",
+            "sha256": "30372f404fabef92f96d35b979ff9f316361840533a28fa21f0505f1fde8d134",
+            "url": "https://github.com/ibmruntimes/semeru21-binaries/releases/download/jdk-21.0.2%2B13_openj9-0.43.0/ibm-semeru-open-jre_x64_mac_21.0.2_13_openj9-0.43.0.tar.gz",
+            "version": "21.0.2"
           }
         },
         "openjdk8": {

--- a/pkgs/development/compilers/semeru-bin/sources.json
+++ b/pkgs/development/compilers/semeru-bin/sources.json
@@ -4,18 +4,18 @@
       "jdk": {
         "openjdk11": {
           "aarch64": {
-            "build": "8",
-            "sha256": "488739171f84e3949df6ccb1c40eaf1b73541748b123d88780329648d6b383d0",
-            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.16%2B8_openj9-0.33.0/ibm-semeru-open-jdk_aarch64_linux_11.0.16_8_openj9-0.33.0.tar.gz",
-            "version": "11.0.16"
+            "build": "7",
+            "sha256": "8462e525d9fb3ac0d1a3915f859175450da58958a1257cb37fe9cbde57c03eb8",
+            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.22%2B7_openj9-0.43.0/ibm-semeru-open-jdk_aarch64_linux_11.0.22_7_openj9-0.43.0.tar.gz",
+            "version": "11.0.22"
           },
           "packageType": "jdk",
           "vmType": "openj9",
           "x86_64": {
-            "build": "8",
-            "sha256": "eeca01d4e245a001d01663c5c20a8d50ef3d572b47a9b3689a5154f2a37bf005",
-            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.16%2B8_openj9-0.33.0/ibm-semeru-open-jdk_x64_linux_11.0.16_8_openj9-0.33.0.tar.gz",
-            "version": "11.0.16"
+            "build": "7",
+            "sha256": "8407088440c18273f0b3ada109b2a0283045c7cad0390156dbb1b8ce620d5c12",
+            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.22%2B7_openj9-0.43.0/ibm-semeru-open-jdk_x64_linux_11.0.22_7_openj9-0.43.0.tar.gz",
+            "version": "11.0.22"
           }
         },
         "openjdk16": {
@@ -36,52 +36,52 @@
         },
         "openjdk17": {
           "aarch64": {
-            "build": "8",
-            "sha256": "18d291411ee4a956018b4dcefe436971e73694128782617f1b44beca991956c5",
-            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.4%2B8_openj9-0.33.0/ibm-semeru-open-jdk_aarch64_linux_17.0.4_8_openj9-0.33.0.tar.gz",
-            "version": "17.0.4"
+            "build": "9",
+            "sha256": "cfdff21ce44ae6af494cba75c1f323bef83a982f2c11944988bab2125f85b906",
+            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.9%2B9_openj9-0.41.0/ibm-semeru-open-jdk_aarch64_linux_17.0.9_9_openj9-0.41.0.tar.gz",
+            "version": "17.0.9"
           },
           "packageType": "jdk",
           "vmType": "openj9",
           "x86_64": {
-            "build": "8",
-            "sha256": "78ae15d9e01fce3a473f4d6a90c331fb766211b950931088c2a85590f178ad39",
-            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.4%2B8_openj9-0.33.0/ibm-semeru-open-jdk_x64_linux_17.0.4_8_openj9-0.33.0.tar.gz",
-            "version": "17.0.4"
+            "build": "9",
+            "sha256": "9b945e58f024108a20eb907015cca4a452332b7644e8dd8e051149a3ec62e3a3",
+            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.9%2B9_openj9-0.41.0/ibm-semeru-open-jdk_x64_linux_17.0.9_9_openj9-0.41.0.tar.gz",
+            "version": "17.0.9"
           }
         },
         "openjdk8": {
           "aarch64": {
-            "build": "01",
-            "sha256": "6b89e648899709459b7c7dbe0a5b1ea480a88da84c6163f01255d638dbdd051b",
-            "url": "https://github.com/ibmruntimes/semeru8-binaries/releases/download/8u345-b01_openj9-0.33.0/ibm-semeru-open-jdk_aarch64_linux_8u345b01_openj9-0.33.0.tar.gz",
-            "version": "8.0.345"
+            "build": "06",
+            "sha256": "eee642d945d249f9aa2bba0b788a7d79d4989a32205b18e6bb075b50e77d700a",
+            "url": "https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk8u402-b06_openj9-0.43.0/ibm-semeru-open-jdk_aarch64_linux_8u402b06_openj9-0.43.0.tar.gz",
+            "version": "8.0.402"
           },
           "packageType": "jdk",
           "vmType": "openj9",
           "x86_64": {
-            "build": "01",
-            "sha256": "82c8232a5cb420246457d65a5014602feb8b288079cdae896e22a2eb6e390b58",
-            "url": "https://github.com/ibmruntimes/semeru8-binaries/releases/download/8u345-b01_openj9-0.33.0/ibm-semeru-open-jdk_x64_linux_8u345b01_openj9-0.33.0.tar.gz",
-            "version": "8.0.345"
+            "build": "06",
+            "sha256": "6e5f623ca42d1f37e769a44b26641a6b0382145f5eb8d9c3ff980e6ebcd7ac2e",
+            "url": "https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk8u402-b06_openj9-0.43.0/ibm-semeru-open-jdk_x64_linux_8u402b06_openj9-0.43.0.tar.gz",
+            "version": "8.0.402"
           }
         }
       },
       "jre": {
         "openjdk11": {
           "aarch64": {
-            "build": "8",
-            "sha256": "49dc05a3e9f3f99c5f8fa466261aa3e33a753694c67cabfa7d3f682e5a2e3685",
-            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.16%2B8_openj9-0.33.0/ibm-semeru-open-jre_aarch64_linux_11.0.16_8_openj9-0.33.0.tar.gz",
-            "version": "11.0.16"
+            "build": "7",
+            "sha256": "cf723eca95f805d5ba0dfc33aa798ccd9f2a1984d2dc72c0b2fed5df804e8edf",
+            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.22%2B7_openj9-0.43.0/ibm-semeru-open-jre_aarch64_linux_11.0.22_7_openj9-0.43.0.tar.gz",
+            "version": "11.0.22"
           },
           "packageType": "jre",
           "vmType": "openj9",
           "x86_64": {
-            "build": "8",
-            "sha256": "ba09711193b8b8664478f3f949b5320232f65c1bdf61f32a885d84de73c02767",
-            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.16%2B8_openj9-0.33.0/ibm-semeru-open-jre_x64_linux_11.0.16_8_openj9-0.33.0.tar.gz",
-            "version": "11.0.16"
+            "build": "7",
+            "sha256": "c0677152632c8da8b840b9b4475046318b25dcb3e15096f5f7fd6a49952afd6a",
+            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.22%2B7_openj9-0.43.0/ibm-semeru-open-jre_x64_linux_11.0.22_7_openj9-0.43.0.tar.gz",
+            "version": "11.0.22"
           }
         },
         "openjdk16": {
@@ -102,34 +102,34 @@
         },
         "openjdk17": {
           "aarch64": {
-            "build": "8",
-            "sha256": "6c40c1e0d7ee0509c44465e9f26dd970904137a95fd751e6447b1d6a9ef5092a",
-            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.4%2B8_openj9-0.33.0/ibm-semeru-open-jre_aarch64_linux_17.0.4_8_openj9-0.33.0.tar.gz",
-            "version": "17.0.4"
+            "build": "9",
+            "sha256": "9760aa27a5790a8c20a702ff5f036535f3df51d3fb291bb5254b5ae76e096bad",
+            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.9%2B9_openj9-0.41.0/ibm-semeru-open-jre_aarch64_linux_17.0.9_9_openj9-0.41.0.tar.gz",
+            "version": "17.0.9"
           },
           "packageType": "jre",
           "vmType": "openj9",
           "x86_64": {
-            "build": "8",
-            "sha256": "b2c176f8aa8cc7138d4c22ce9298d8f49597e1d8e3fdd33125898e5ee0182c93",
-            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.4%2B8_openj9-0.33.0/ibm-semeru-open-jre_x64_linux_17.0.4_8_openj9-0.33.0.tar.gz",
-            "version": "17.0.4"
+            "build": "9",
+            "sha256": "1caf409f33f7738efe37742197525b5ae6244d6383b2017e7b8e925dc0b6a329",
+            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.9%2B9_openj9-0.41.0/ibm-semeru-open-jre_x64_linux_17.0.9_9_openj9-0.41.0.tar.gz",
+            "version": "17.0.9"
           }
         },
         "openjdk8": {
           "aarch64": {
-            "build": "01",
-            "sha256": "03caff41622e84a6e7fa66a225414a9b6eefb38dd215f830cae0bc4bbfc55b5c",
-            "url": "https://github.com/ibmruntimes/semeru8-binaries/releases/download/8u345-b01_openj9-0.33.0/ibm-semeru-open-jre_aarch64_linux_8u345b01_openj9-0.33.0.tar.gz",
-            "version": "8.0.345"
+            "build": "06",
+            "sha256": "4921671d26754483f096007cfb537922f1b190ca471aaebda6eccdefe91f7fb0",
+            "url": "https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk8u402-b06_openj9-0.43.0/ibm-semeru-open-jre_aarch64_linux_8u402b06_openj9-0.43.0.tar.gz",
+            "version": "8.0.402"
           },
           "packageType": "jre",
           "vmType": "openj9",
           "x86_64": {
-            "build": "01",
-            "sha256": "0d4fe62716b9da2ccce324b5b46d57e8d47e5dfb5d128f87e16135ee9bc36cdc",
-            "url": "https://github.com/ibmruntimes/semeru8-binaries/releases/download/8u345-b01_openj9-0.33.0/ibm-semeru-open-jre_x64_linux_8u345b01_openj9-0.33.0.tar.gz",
-            "version": "8.0.345"
+            "build": "06",
+            "sha256": "6f2e0e977f833ad9b2d85e97e568aa57c658eea3f096a1544d72e70f94e55f73",
+            "url": "https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk8u402-b06_openj9-0.43.0/ibm-semeru-open-jre_x64_linux_8u402b06_openj9-0.43.0.tar.gz",
+            "version": "8.0.402"
           }
         }
       }
@@ -138,18 +138,18 @@
       "jdk": {
         "openjdk11": {
           "aarch64": {
-            "build": "8",
-            "sha256": "9881b292142a129f6f5c6b21608b090f8f94625052b4f7d0ce5bd982c054ca2e",
-            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.16%2B8_openj9-0.33.0/ibm-semeru-open-jdk_aarch64_mac_11.0.16_8_openj9-0.33.0.tar.gz",
-            "version": "11.0.16"
+            "build": "7",
+            "sha256": "b5039b79a601c07dcba819f29e111871662218d042d2ee2b246b6beaccf09342",
+            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.22%2B7_openj9-0.43.0/ibm-semeru-open-jdk_aarch64_mac_11.0.22_7_openj9-0.43.0.tar.gz",
+            "version": "11.0.22"
           },
           "packageType": "jdk",
           "vmType": "openj9",
           "x86_64": {
-            "build": "8",
-            "sha256": "8638735d2cae3efff212f898728685380355bb0a298076e9e46244d0bf3d4a64",
-            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.16%2B8_openj9-0.33.0/ibm-semeru-open-jdk_x64_mac_11.0.16_8_openj9-0.33.0.tar.gz",
-            "version": "11.0.16"
+            "build": "7",
+            "sha256": "16dbe2be761ae7c48a1338398c6cad748014137e59509aa2b84223049d385bbc",
+            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.22%2B7_openj9-0.43.0/ibm-semeru-open-jdk_x64_mac_11.0.22_7_openj9-0.43.0.tar.gz",
+            "version": "11.0.22"
           }
         },
         "openjdk16": {
@@ -164,46 +164,46 @@
         },
         "openjdk17": {
           "aarch64": {
-            "build": "8",
-            "sha256": "bf22628b54115dff9939b94751531544ab735b7cbbc8d6ddfe83d1b04df3a532",
-            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.4%2B8_openj9-0.33.0/ibm-semeru-open-jdk_aarch64_mac_17.0.4_8_openj9-0.33.0.tar.gz",
-            "version": "17.0.4"
+            "build": "9",
+            "sha256": "5fed15250cb613a4024f2b2e75ccb54e6526ffa5ff78d955a6e2a11ae330f003",
+            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.9%2B9_openj9-0.41.0/ibm-semeru-open-jdk_aarch64_mac_17.0.9_9_openj9-0.41.0.tar.gz",
+            "version": "17.0.9"
           },
           "packageType": "jdk",
           "vmType": "openj9",
           "x86_64": {
-            "build": "8",
-            "sha256": "a935f20564e347a9292955c04eb57e51efdb1853ae7f0b4fe759b22c9fe248be",
-            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.4%2B8_openj9-0.33.0/ibm-semeru-open-jdk_x64_mac_17.0.4_8_openj9-0.33.0.tar.gz",
-            "version": "17.0.4"
+            "build": "9",
+            "sha256": "585f48be83935a44ef980249aaab024119d4ea6ef0937a2cd2d97d0c77cda1c2",
+            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.9%2B9_openj9-0.41.0/ibm-semeru-open-jdk_x64_mac_17.0.9_9_openj9-0.41.0.tar.gz",
+            "version": "17.0.9"
           }
         },
         "openjdk8": {
           "packageType": "jdk",
           "vmType": "openj9",
           "x86_64": {
-            "build": "01",
-            "sha256": "c69086950c006b17484a70ef7bc85e92d121be15e69e282e1446fd238d42b6b4",
-            "url": "https://github.com/ibmruntimes/semeru8-binaries/releases/download/8u345-b01_openj9-0.33.0/ibm-semeru-open-jdk_x64_mac_8u345b01_openj9-0.33.0.tar.gz",
-            "version": "8.0.345"
+            "build": "06",
+            "sha256": "e30b49c934aab3d40bf844dae8cae6cfe6f9436f87c3b24d02680313a794ad05",
+            "url": "https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk8u402-b06_openj9-0.43.0/ibm-semeru-open-jdk_x64_mac_8u402b06_openj9-0.43.0.tar.gz",
+            "version": "8.0.402"
           }
         }
       },
       "jre": {
         "openjdk11": {
           "aarch64": {
-            "build": "8",
-            "sha256": "39802020896476342dc11486e3cbdf10f6311c172abeb4a1e2931b472da4417e",
-            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.16%2B8_openj9-0.33.0/ibm-semeru-open-jre_aarch64_mac_11.0.16_8_openj9-0.33.0.tar.gz",
-            "version": "11.0.16"
+            "build": "7",
+            "sha256": "8002fe1c531144d1748d0d1d352b14bcd9fcf3bffdd9af45e87f449f28d64585",
+            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.22%2B7_openj9-0.43.0/ibm-semeru-open-jre_aarch64_mac_11.0.22_7_openj9-0.43.0.tar.gz",
+            "version": "11.0.22"
           },
           "packageType": "jre",
           "vmType": "openj9",
           "x86_64": {
-            "build": "8",
-            "sha256": "92f87a3c2fb5fe60d3d51020ff95b9c234b2ae2677b79aebbe749dda717c9cdd",
-            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.16%2B8_openj9-0.33.0/ibm-semeru-open-jre_x64_mac_11.0.16_8_openj9-0.33.0.tar.gz",
-            "version": "11.0.16"
+            "build": "7",
+            "sha256": "7b3261229ff3e44dcdc2bccbc15e2a3e8ffdb64df3f25a28825a362c8c6c63b0",
+            "url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.22%2B7_openj9-0.43.0/ibm-semeru-open-jre_x64_mac_11.0.22_7_openj9-0.43.0.tar.gz",
+            "version": "11.0.22"
           }
         },
         "openjdk16": {
@@ -218,28 +218,28 @@
         },
         "openjdk17": {
           "aarch64": {
-            "build": "8",
-            "sha256": "4057c94cd46b814cc5a4d683d5f0b95dbd0b9e13e8c2e11155561ad0d8bec85b",
-            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.4%2B8_openj9-0.33.0/ibm-semeru-open-jre_aarch64_mac_17.0.4_8_openj9-0.33.0.tar.gz",
-            "version": "17.0.4"
+            "build": "9",
+            "sha256": "fbd093ab7218c916aa4f49ac851635020dd1c8a98a98158fc44a6565e3d182ed",
+            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.9%2B9_openj9-0.41.0/ibm-semeru-open-jre_aarch64_mac_17.0.9_9_openj9-0.41.0.tar.gz",
+            "version": "17.0.9"
           },
           "packageType": "jre",
           "vmType": "openj9",
           "x86_64": {
-            "build": "8",
-            "sha256": "8e957d2eb47eaca64516ac669272c6e5186155ed8ee4d6a77e0d4b7811cd7bb6",
-            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.4%2B8_openj9-0.33.0/ibm-semeru-open-jre_x64_mac_17.0.4_8_openj9-0.33.0.tar.gz",
-            "version": "17.0.4"
+            "build": "9",
+            "sha256": "f5781de29132c04f54341349e99954ec3cfbdbc65fdebdd00feff47c68793299",
+            "url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.9%2B9_openj9-0.41.0/ibm-semeru-open-jre_x64_mac_17.0.9_9_openj9-0.41.0.tar.gz",
+            "version": "17.0.9"
           }
         },
         "openjdk8": {
           "packageType": "jre",
           "vmType": "openj9",
           "x86_64": {
-            "build": "01",
-            "sha256": "019e08dea8fbd54517dacbeac791d85717902800dd8bba77fbca1dfc6b0abd9e",
-            "url": "https://github.com/ibmruntimes/semeru8-binaries/releases/download/8u345-b01_openj9-0.33.0/ibm-semeru-open-jre_x64_mac_8u345b01_openj9-0.33.0.tar.gz",
-            "version": "8.0.345"
+            "build": "06",
+            "sha256": "50039cbce2377658de7a5a57b24db4dc4d1fcd7b46f84badd24a5dc835d1ab6a",
+            "url": "https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk8u402-b06_openj9-0.43.0/ibm-semeru-open-jre_x64_mac_8u402b06_openj9-0.43.0.tar.gz",
+            "version": "8.0.402"
           }
         }
       }

--- a/pkgs/development/compilers/temurin-bin/generate-sources.py
+++ b/pkgs/development/compilers/temurin-bin/generate-sources.py
@@ -6,7 +6,7 @@ import re
 import requests
 import sys
 
-feature_versions = (8, 11, 16, 17, 18, 19, 20, 21)
+feature_versions = (8, 11, 16, 17, 18, 19, 20, 21, 22)
 oses = ("mac", "linux", "alpine-linux")
 types = ("jre", "jdk")
 impls = ("hotspot",)

--- a/pkgs/development/compilers/temurin-bin/generate-sources.py
+++ b/pkgs/development/compilers/temurin-bin/generate-sources.py
@@ -9,7 +9,7 @@ import sys
 feature_versions = (8, 11, 16, 17, 18, 19, 20, 21)
 oses = ("mac", "linux", "alpine-linux")
 types = ("jre", "jdk")
-impls = ("hotspot")
+impls = ("hotspot",)
 
 arch_to_nixos = {
     "x64": ("x86_64",),

--- a/pkgs/development/compilers/temurin-bin/jdk-darwin-base.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-darwin-base.nix
@@ -1,11 +1,12 @@
 { name-prefix ? "temurin"
 , brand-name ? "Eclipse Temurin"
 , sourcePerArch
-, knownVulnerabilities ? []
+, knownVulnerabilities ? [ ]
 }:
 
 { swingSupport ? true # not used for now
-, lib, stdenv
+, lib
+, stdenv
 , fetchurl
 , setJavaClassPath
 }:
@@ -17,7 +18,8 @@ let
     (arch: builtins.elem arch validCpuTypes)
     (builtins.attrNames sourcePerArch);
   result = stdenv.mkDerivation {
-    pname = if sourcePerArch.packageType == "jdk"
+    pname =
+      if sourcePerArch.packageType == "jdk"
       then "${name-prefix}-bin"
       else "${name-prefix}-${sourcePerArch.packageType}-bin";
     version =
@@ -66,10 +68,11 @@ let
       license = licenses.gpl2Classpath;
       sourceProvenance = with sourceTypes; [ binaryNativeCode binaryBytecode ];
       description = "${brand-name}, prebuilt OpenJDK binary";
-      platforms = builtins.map (arch: arch + "-darwin") providedCpuTypes;  # some inherit jre.meta.platforms
+      platforms = builtins.map (arch: arch + "-darwin") providedCpuTypes; # some inherit jre.meta.platforms
       maintainers = with maintainers; [ taku0 ];
       inherit knownVulnerabilities;
       mainProgram = "java";
     };
   };
-in result
+in
+result

--- a/pkgs/development/compilers/temurin-bin/jdk-darwin.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-darwin.nix
@@ -3,25 +3,27 @@
 let
   sources = (lib.importJSON ./sources.json).hotspot.mac;
   common = opts: callPackage (import ./jdk-darwin-base.nix opts) {};
+
+  EOL = [ "This JDK version has reached End of Life." ];
 in
 {
   jdk-8 = common { sourcePerArch = sources.jdk.openjdk8; };
   jre-8 = common { sourcePerArch = sources.jre.openjdk8; };
   jdk-11 = common { sourcePerArch = sources.jdk.openjdk11; };
   jre-11 = common { sourcePerArch = sources.jre.openjdk11; };
-  jdk-16 = common { sourcePerArch = sources.jdk.openjdk16; };
+  jdk-16 = common { sourcePerArch = sources.jdk.openjdk16; knownVulnerabilities = EOL; };
 
   jdk-17 = common { sourcePerArch = sources.jdk.openjdk17; };
   jre-17 = common { sourcePerArch = sources.jre.openjdk17; };
 
-  jdk-18 = common { sourcePerArch = sources.jdk.openjdk18; };
-  jre-18 = common { sourcePerArch = sources.jre.openjdk18; };
+  jdk-18 = common { sourcePerArch = sources.jdk.openjdk18; knownVulnerabilities = EOL; };
+  jre-18 = common { sourcePerArch = sources.jre.openjdk18; knownVulnerabilities = EOL; };
 
-  jdk-19 = common { sourcePerArch = sources.jdk.openjdk19; };
-  jre-19 = common { sourcePerArch = sources.jre.openjdk19; };
+  jdk-19 = common { sourcePerArch = sources.jdk.openjdk19; knownVulnerabilities = EOL; };
+  jre-19 = common { sourcePerArch = sources.jre.openjdk19; knownVulnerabilities = EOL; };
 
-  jdk-20 = common { sourcePerArch = sources.jdk.openjdk20; };
-  jre-20 = common { sourcePerArch = sources.jre.openjdk20; };
+  jdk-20 = common { sourcePerArch = sources.jdk.openjdk20; knownVulnerabilities = EOL; };
+  jre-20 = common { sourcePerArch = sources.jre.openjdk20; knownVulnerabilities = EOL; };
 
   jdk-21 = common { sourcePerArch = sources.jdk.openjdk21; };
   jre-21 = common { sourcePerArch = sources.jre.openjdk21; };

--- a/pkgs/development/compilers/temurin-bin/jdk-darwin.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-darwin.nix
@@ -2,15 +2,17 @@
 
 let
   sources = (lib.importJSON ./sources.json).hotspot.mac;
-  common = opts: callPackage (import ./jdk-darwin-base.nix opts) {};
+  common = opts: callPackage (import ./jdk-darwin-base.nix opts) { };
 
   EOL = [ "This JDK version has reached End of Life." ];
 in
 {
   jdk-8 = common { sourcePerArch = sources.jdk.openjdk8; };
   jre-8 = common { sourcePerArch = sources.jre.openjdk8; };
+
   jdk-11 = common { sourcePerArch = sources.jdk.openjdk11; };
   jre-11 = common { sourcePerArch = sources.jre.openjdk11; };
+
   jdk-16 = common { sourcePerArch = sources.jdk.openjdk16; knownVulnerabilities = EOL; };
 
   jdk-17 = common { sourcePerArch = sources.jdk.openjdk17; };

--- a/pkgs/development/compilers/temurin-bin/jdk-darwin.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-darwin.nix
@@ -25,4 +25,7 @@ in
 
   jdk-21 = common { sourcePerArch = sources.jdk.openjdk21; };
   jre-21 = common { sourcePerArch = sources.jre.openjdk21; };
+
+  jdk-22 = common { sourcePerArch = sources.jdk.openjdk22; };
+  jre-22 = common { sourcePerArch = sources.jre.openjdk22; };
 }

--- a/pkgs/development/compilers/temurin-bin/jdk-linux-base.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-linux-base.nix
@@ -1,7 +1,7 @@
 { name-prefix ? "temurin"
 , brand-name ? "Eclipse Temurin"
 , sourcePerArch
-, knownVulnerabilities ? []
+, knownVulnerabilities ? [ ]
 }:
 
 { stdenv
@@ -10,18 +10,18 @@
 , autoPatchelfHook
 , makeWrapper
 , setJavaClassPath
-# minimum dependencies
+  # minimum dependencies
 , alsa-lib
 , fontconfig
 , freetype
 , libffi
 , xorg
 , zlib
-# runtime dependencies
+  # runtime dependencies
 , cups
-# runtime dependencies for GTK+ Look and Feel
-# TODO(@sternenseemann): gtk3 fails to evaluate in pkgsCross.ghcjs.buildPackages
-# which should be fixable, this is a no-rebuild workaround for GHC.
+  # runtime dependencies for GTK+ Look and Feel
+  # TODO(@sternenseemann): gtk3 fails to evaluate in pkgsCross.ghcjs.buildPackages
+  # which should be fixable, this is a no-rebuild workaround for GHC.
 , gtkSupport ? !stdenv.targetPlatform.isGhcjs
 , cairo
 , glib
@@ -33,7 +33,9 @@ let
   runtimeDependencies = [
     cups
   ] ++ lib.optionals gtkSupport [
-    cairo glib gtk3
+    cairo
+    glib
+    gtk3
   ];
   runtimeLibraryPath = lib.makeLibraryPath runtimeDependencies;
   validCpuTypes = builtins.attrNames lib.systems.parse.cpuTypes;
@@ -41,7 +43,8 @@ let
     (arch: builtins.elem arch validCpuTypes)
     (builtins.attrNames sourcePerArch);
   result = stdenv.mkDerivation {
-    pname = if sourcePerArch.packageType == "jdk"
+    pname =
+      if sourcePerArch.packageType == "jdk"
       then "${name-prefix}-bin"
       else "${name-prefix}-${sourcePerArch.packageType}-bin";
 
@@ -123,10 +126,11 @@ let
       license = licenses.gpl2Classpath;
       sourceProvenance = with sourceTypes; [ binaryNativeCode binaryBytecode ];
       description = "${brand-name}, prebuilt OpenJDK binary";
-      platforms = builtins.map (arch: arch + "-linux") providedCpuTypes;  # some inherit jre.meta.platforms
+      platforms = builtins.map (arch: arch + "-linux") providedCpuTypes; # some inherit jre.meta.platforms
       maintainers = with maintainers; [ taku0 ];
       inherit knownVulnerabilities;
       mainProgram = "java";
     };
   };
-in result
+in
+result

--- a/pkgs/development/compilers/temurin-bin/jdk-linux.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-linux.nix
@@ -3,15 +3,17 @@
 let
   variant = if stdenv.hostPlatform.isMusl then "alpine-linux" else "linux";
   sources = (lib.importJSON ./sources.json).hotspot.${variant};
-  common = opts: callPackage (import ./jdk-linux-base.nix opts) {};
+  common = opts: callPackage (import ./jdk-linux-base.nix opts) { };
 
   EOL = [ "This JDK version has reached End of Life." ];
 in
 {
   jdk-8 = common { sourcePerArch = sources.jdk.openjdk8; };
   jre-8 = common { sourcePerArch = sources.jre.openjdk8; };
+
   jdk-11 = common { sourcePerArch = sources.jdk.openjdk11; };
   jre-11 = common { sourcePerArch = sources.jre.openjdk11; };
+
   jdk-16 = common { sourcePerArch = sources.jdk.openjdk16; knownVulnerabilities = EOL; };
 
   jdk-17 = common { sourcePerArch = sources.jdk.openjdk17; };

--- a/pkgs/development/compilers/temurin-bin/jdk-linux.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-linux.nix
@@ -26,4 +26,7 @@ in
 
   jdk-21 = common { sourcePerArch = sources.jdk.openjdk21; };
   jre-21 = common { sourcePerArch = sources.jre.openjdk21; };
+
+  jdk-22 = common { sourcePerArch = sources.jdk.openjdk22; };
+  jre-22 = common { sourcePerArch = sources.jre.openjdk22; };
 }

--- a/pkgs/development/compilers/temurin-bin/jdk-linux.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-linux.nix
@@ -4,25 +4,27 @@ let
   variant = if stdenv.hostPlatform.isMusl then "alpine-linux" else "linux";
   sources = (lib.importJSON ./sources.json).hotspot.${variant};
   common = opts: callPackage (import ./jdk-linux-base.nix opts) {};
+
+  EOL = [ "This JDK version has reached End of Life." ];
 in
 {
   jdk-8 = common { sourcePerArch = sources.jdk.openjdk8; };
   jre-8 = common { sourcePerArch = sources.jre.openjdk8; };
   jdk-11 = common { sourcePerArch = sources.jdk.openjdk11; };
   jre-11 = common { sourcePerArch = sources.jre.openjdk11; };
-  jdk-16 = common { sourcePerArch = sources.jdk.openjdk16; };
+  jdk-16 = common { sourcePerArch = sources.jdk.openjdk16; knownVulnerabilities = EOL; };
 
   jdk-17 = common { sourcePerArch = sources.jdk.openjdk17; };
   jre-17 = common { sourcePerArch = sources.jre.openjdk17; };
 
-  jdk-18 = common { sourcePerArch = sources.jdk.openjdk18; };
-  jre-18 = common { sourcePerArch = sources.jre.openjdk18; };
+  jdk-18 = common { sourcePerArch = sources.jdk.openjdk18; knownVulnerabilities = EOL; };
+  jre-18 = common { sourcePerArch = sources.jre.openjdk18; knownVulnerabilities = EOL; };
 
-  jdk-19 = common { sourcePerArch = sources.jdk.openjdk19; };
-  jre-19 = common { sourcePerArch = sources.jre.openjdk19; };
+  jdk-19 = common { sourcePerArch = sources.jdk.openjdk19; knownVulnerabilities = EOL; };
+  jre-19 = common { sourcePerArch = sources.jre.openjdk19; knownVulnerabilities = EOL; };
 
-  jdk-20 = common { sourcePerArch = sources.jdk.openjdk20; };
-  jre-20 = common { sourcePerArch = sources.jre.openjdk20; };
+  jdk-20 = common { sourcePerArch = sources.jdk.openjdk20; knownVulnerabilities = EOL; };
+  jre-20 = common { sourcePerArch = sources.jre.openjdk20; knownVulnerabilities = EOL; };
 
   jdk-21 = common { sourcePerArch = sources.jdk.openjdk21; };
   jre-21 = common { sourcePerArch = sources.jre.openjdk21; };

--- a/pkgs/development/compilers/temurin-bin/sources.json
+++ b/pkgs/development/compilers/temurin-bin/sources.json
@@ -78,6 +78,22 @@
             "version": "21.0.3"
           }
         },
+        "openjdk22": {
+          "aarch64": {
+            "build": "8",
+            "sha256": "86a7b47c9277f2fd063ec910616b3676d86553ab7d23aa3bd365e51a57be1dc5",
+            "url": "https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jdk_aarch64_alpine-linux_hotspot_22.0.1_8.tar.gz",
+            "version": "22.0.1"
+          },
+          "packageType": "jdk",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "8",
+            "sha256": "d226e44b3513942db855df9a8737d848f64069848970d4cfd35ee3c38f2525c1",
+            "url": "https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jdk_x64_alpine-linux_hotspot_22.0.1_8.tar.gz",
+            "version": "22.0.1"
+          }
+        },
         "openjdk8": {
           "packageType": "jdk",
           "vmType": "hotspot",
@@ -154,6 +170,22 @@
             "sha256": "b3e7170deab11a7089fe8e14f9f398424fd86db085f745dad212f6cfc4121df6",
             "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jre_x64_alpine-linux_hotspot_21.0.3_9.tar.gz",
             "version": "21.0.3"
+          }
+        },
+        "openjdk22": {
+          "aarch64": {
+            "build": "8",
+            "sha256": "6cac56dde6793d887deea101cfff283dc5f285e1118c21cbd1c4cb69f1072e55",
+            "url": "https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jre_aarch64_alpine-linux_hotspot_22.0.1_8.tar.gz",
+            "version": "22.0.1"
+          },
+          "packageType": "jre",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "8",
+            "sha256": "e7c26ad00e3ded356b8c4b20b184ccf5bd63ccdccabde8d4a892389f178f1d5b",
+            "url": "https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jre_x64_alpine-linux_hotspot_22.0.1_8.tar.gz",
+            "version": "22.0.1"
           }
         },
         "openjdk8": {
@@ -384,6 +416,28 @@
             "version": "21.0.3"
           }
         },
+        "openjdk22": {
+          "aarch64": {
+            "build": "8",
+            "sha256": "d8488fa1e4e8c1e318cef4c0fc3842a7f15a4cf52b27054663bb94471f54b3fa",
+            "url": "https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jdk_aarch64_linux_hotspot_22.0.1_8.tar.gz",
+            "version": "22.0.1"
+          },
+          "packageType": "jdk",
+          "powerpc64le": {
+            "build": "8",
+            "sha256": "4113606ba65044a3cbd7678e1c0d41881d24a2441c8ab8b658b4ac58da624de5",
+            "url": "https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jdk_ppc64le_linux_hotspot_22.0.1_8.tar.gz",
+            "version": "22.0.1"
+          },
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "8",
+            "sha256": "e59c6bf801cc023a1ea78eceb5e6756277f1564cd0a421ea984efe6cb96cfcf8",
+            "url": "https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jdk_x64_linux_hotspot_22.0.1_8.tar.gz",
+            "version": "22.0.1"
+          }
+        },
         "openjdk8": {
           "aarch64": {
             "build": "8",
@@ -600,6 +654,28 @@
             "version": "21.0.3"
           }
         },
+        "openjdk22": {
+          "aarch64": {
+            "build": "8",
+            "sha256": "8e5996a2bbae2da9797cff5a62cb2080965e08fd66de24673b29a8e481ec769e",
+            "url": "https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jre_aarch64_linux_hotspot_22.0.1_8.tar.gz",
+            "version": "22.0.1"
+          },
+          "packageType": "jre",
+          "powerpc64le": {
+            "build": "8",
+            "sha256": "7df4a10fab324181a6c9e8b1e2a45042b8d30490f0fdb937a536f6cd17c907ef",
+            "url": "https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jre_ppc64le_linux_hotspot_22.0.1_8.tar.gz",
+            "version": "22.0.1"
+          },
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "8",
+            "sha256": "154dbc7975cf765c59bdaa1e693d6c8b009635c9a182d6d6d9f0cfbec5317b4c",
+            "url": "https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jre_x64_linux_hotspot_22.0.1_8.tar.gz",
+            "version": "22.0.1"
+          }
+        },
         "openjdk8": {
           "aarch64": {
             "build": "8",
@@ -744,6 +820,22 @@
             "version": "21.0.3"
           }
         },
+        "openjdk22": {
+          "aarch64": {
+            "build": "8",
+            "sha256": "80d6fa75e87280202ae7660139870fe50f07fca9dc6c4fbd3f2837cbd70ec902",
+            "url": "https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jdk_aarch64_mac_hotspot_22.0.1_8.tar.gz",
+            "version": "22.0.1"
+          },
+          "packageType": "jdk",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "8",
+            "sha256": "9445952d4487451af024a9a3f56373df76fbd928d9ff9186988aa27be2e4f10c",
+            "url": "https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jdk_x64_mac_hotspot_22.0.1_8.tar.gz",
+            "version": "22.0.1"
+          }
+        },
         "openjdk8": {
           "packageType": "jdk",
           "vmType": "hotspot",
@@ -850,6 +942,22 @@
             "sha256": "d7fc89c196ed03deb8a98f6599e1b2e78859ec8ec752142549cd3710f3e1a025",
             "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jre_x64_mac_hotspot_21.0.3_9.tar.gz",
             "version": "21.0.3"
+          }
+        },
+        "openjdk22": {
+          "aarch64": {
+            "build": "8",
+            "sha256": "73a8a0270534db7b4760399f41c573fd1cff5f86f4e68b08988afee0df814889",
+            "url": "https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jre_aarch64_mac_hotspot_22.0.1_8.tar.gz",
+            "version": "22.0.1"
+          },
+          "packageType": "jre",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "8",
+            "sha256": "d21e84edc1d7cc58fc04bcd9a214b71bf85e8ea348f8659197be3383afcb2b9a",
+            "url": "https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.1%2B8/OpenJDK22U-jre_x64_mac_hotspot_22.0.1_8.tar.gz",
+            "version": "22.0.1"
           }
         },
         "openjdk8": {

--- a/pkgs/development/compilers/temurin-bin/sources.json
+++ b/pkgs/development/compilers/temurin-bin/sources.json
@@ -7,9 +7,9 @@
           "vmType": "hotspot",
           "x86_64": {
             "build": "9",
-            "sha256": "d5e2235d3707526f7c9ba3f0dc194e60d5dec33eceff2a2dcf9d874464cc0e9e",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.21%2B9/OpenJDK11U-jdk_x64_alpine-linux_hotspot_11.0.21_9.tar.gz",
-            "version": "11.0.21"
+            "sha256": "b45c467be52fe11ffd9bf69b3a035068134b305053874de4f3b3c5e5e1419659",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_x64_alpine-linux_hotspot_11.0.23_9.tar.gz",
+            "version": "11.0.23"
           }
         },
         "openjdk16": {
@@ -27,9 +27,9 @@
           "vmType": "hotspot",
           "x86_64": {
             "build": "9",
-            "sha256": "c2a571a56e5bd3f30956b17b048880078c7801ed9e8754af6d1e38b9176059a9",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_alpine-linux_hotspot_17.0.9_9.tar.gz",
-            "version": "17.0.9"
+            "sha256": "839326b5b4b3e4ac2edc3b685c8ab550f9b6d267eddf966323c801cb21e3e018",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_x64_alpine-linux_hotspot_17.0.11_9.tar.gz",
+            "version": "17.0.11"
           }
         },
         "openjdk18": {
@@ -64,28 +64,28 @@
         },
         "openjdk21": {
           "aarch64": {
-            "build": "12",
-            "sha256": "77006c0a753808c2a6662007906eb6eb230f2fb6eb9d201a39cc46113e68f82c",
-            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_aarch64_alpine-linux_hotspot_21.0.1_12.tar.gz",
-            "version": "21.0.1"
+            "build": "9",
+            "sha256": "0f68a9122054149861f6ce9d1b1c176bbe30dd76b36b74c916ba897c12e9d970",
+            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jdk_aarch64_alpine-linux_hotspot_21.0.3_9.tar.gz",
+            "version": "21.0.3"
           },
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "12",
-            "sha256": "422f23f5109056cacb9227247bebf8532e2dc3c9d505e71637ba610569d6b3ff",
-            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_x64_alpine-linux_hotspot_21.0.1_12.tar.gz",
-            "version": "21.0.1"
+            "build": "9",
+            "sha256": "8e861638bf6b08c6d5837de6dc929930550928ec5fcc81b9fa7e8296afd0f9c0",
+            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jdk_x64_alpine-linux_hotspot_21.0.3_9.tar.gz",
+            "version": "21.0.3"
           }
         },
         "openjdk8": {
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "5",
-            "sha256": "6cf2d4925c387c4cdc0bf2e71de3690527141b5244695d0b3109ce83a8512235",
-            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jdk_x64_alpine-linux_hotspot_8u382b05.tar.gz",
-            "version": "8.0.382"
+            "build": "8",
+            "sha256": "409091665e5f8cf678938bbbc0d377122ef8bad7b1c97a0f809da054db956e51",
+            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jdk_x64_alpine-linux_hotspot_8u412b08.tar.gz",
+            "version": "8.0.412"
           }
         }
       },
@@ -95,9 +95,9 @@
           "vmType": "hotspot",
           "x86_64": {
             "build": "9",
-            "sha256": "6a3d1759bdf91433411d37ca2ad1505a7f214c1401797834e9884165c2457368",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.21%2B9/OpenJDK11U-jre_x64_alpine-linux_hotspot_11.0.21_9.tar.gz",
-            "version": "11.0.21"
+            "sha256": "6972a6251bc88d6fbb64a188557cf165f1c415ded550d2a280bbcbc4272caff1",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jre_x64_alpine-linux_hotspot_11.0.23_9.tar.gz",
+            "version": "11.0.23"
           }
         },
         "openjdk17": {
@@ -105,9 +105,9 @@
           "vmType": "hotspot",
           "x86_64": {
             "build": "9",
-            "sha256": "70e5d108f51ae7c7b2435d063652df058723e303a18b4f72f17f75c5320052d3",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jre_x64_alpine-linux_hotspot_17.0.9_9.tar.gz",
-            "version": "17.0.9"
+            "sha256": "b5dffd0be08c464d9c3903e2947508c1a5c21804ea1cff5556991a2a47d617d8",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jre_x64_alpine-linux_hotspot_17.0.11_9.tar.gz",
+            "version": "17.0.11"
           }
         },
         "openjdk18": {
@@ -142,28 +142,28 @@
         },
         "openjdk21": {
           "aarch64": {
-            "build": "12",
-            "sha256": "2898ea1ddf6f70f09b09cf99d928f6d4c862f78f81104f5dce3e44a832b8444a",
-            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jre_aarch64_alpine-linux_hotspot_21.0.1_12.tar.gz",
-            "version": "21.0.1"
+            "build": "9",
+            "sha256": "54e8618da373258654fe788d509f087d3612de9e080eb6831601069dbc8a4b2b",
+            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jre_aarch64_alpine-linux_hotspot_21.0.3_9.tar.gz",
+            "version": "21.0.3"
           },
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "12",
-            "sha256": "a8fcc43927664ba191c9a77d1013f1f32fec1acc22fe6f0c29d687221f2cc95d",
-            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jre_x64_alpine-linux_hotspot_21.0.1_12.tar.gz",
-            "version": "21.0.1"
+            "build": "9",
+            "sha256": "b3e7170deab11a7089fe8e14f9f398424fd86db085f745dad212f6cfc4121df6",
+            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jre_x64_alpine-linux_hotspot_21.0.3_9.tar.gz",
+            "version": "21.0.3"
           }
         },
         "openjdk8": {
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "5",
-            "sha256": "7040d865493f13204194c5a1add63e22516b1fa4481264baa6a5b2614a275a0e",
-            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jre_x64_alpine-linux_hotspot_8u382b05.tar.gz",
-            "version": "8.0.382"
+            "build": "8",
+            "sha256": "c82962d7378d1fd415db594fce6ec047939e9fab5301fa4407cd7faea9ea7e31",
+            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jre_x64_alpine-linux_hotspot_8u412b08.tar.gz",
+            "version": "8.0.412"
           }
         }
       }
@@ -173,35 +173,35 @@
         "openjdk11": {
           "aarch64": {
             "build": "9",
-            "sha256": "8c3146035b99c55ab26a2982f4b9abd2bf600582361cf9c732539f713d271faf",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.21%2B9/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.21_9.tar.gz",
-            "version": "11.0.21"
+            "sha256": "e00476a7be3c4adfa9b3d55d30768967fd246a8352e518894e183fa444d4d3ce",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.23_9.tar.gz",
+            "version": "11.0.23"
           },
           "armv6l": {
-            "build": "1",
-            "sha256": "e83674aee238ebb5f359b9395b3c5e3fad5b645846095494662802d2f0fd01c9",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1%2B1/OpenJDK11U-jdk_arm_linux_hotspot_11.0.20.1_1.tar.gz",
-            "version": "11.0.20"
+            "build": "9",
+            "sha256": "8077edc07a57d846c3d11286a7caf05ed6ca6d6c1234bf0e03611f18e187f075",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_arm_linux_hotspot_11.0.23_9.tar.gz",
+            "version": "11.0.23"
           },
           "armv7l": {
-            "build": "1",
-            "sha256": "e83674aee238ebb5f359b9395b3c5e3fad5b645846095494662802d2f0fd01c9",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1%2B1/OpenJDK11U-jdk_arm_linux_hotspot_11.0.20.1_1.tar.gz",
-            "version": "11.0.20"
+            "build": "9",
+            "sha256": "8077edc07a57d846c3d11286a7caf05ed6ca6d6c1234bf0e03611f18e187f075",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_arm_linux_hotspot_11.0.23_9.tar.gz",
+            "version": "11.0.23"
           },
           "packageType": "jdk",
           "powerpc64le": {
             "build": "9",
-            "sha256": "262ff98d6d88a7c7cc522cb4ec4129491a0eb04f5b17dcca0da57cfcdcf3830d",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.21%2B9/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.21_9.tar.gz",
-            "version": "11.0.21"
+            "sha256": "f56068bb64c6bf858894f75c2bc261f54db32932422eb07527f36ae40046e9a0",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.23_9.tar.gz",
+            "version": "11.0.23"
           },
           "vmType": "hotspot",
           "x86_64": {
             "build": "9",
-            "sha256": "60ea98daa09834fdd3162ca91ddc8d92a155ab3121204f6f643176ee0c2d0d5e",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.21%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.21_9.tar.gz",
-            "version": "11.0.21"
+            "sha256": "23e47ea7a3015be3240f21185fd902adebdcf76530757c9b482c7eb5bd3417c2",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.23_9.tar.gz",
+            "version": "11.0.23"
           }
         },
         "openjdk16": {
@@ -241,35 +241,35 @@
         "openjdk17": {
           "aarch64": {
             "build": "9",
-            "sha256": "e2c5e26f8572544b201bc22a9b28f2b1a3147ab69be111cea07c7f52af252e75",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.9_9.tar.gz",
-            "version": "17.0.9"
+            "sha256": "a900acf3ae56b000afc35468a083b6d6fd695abec87a8abdb02743d5c72f6d6d",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.11_9.tar.gz",
+            "version": "17.0.11"
           },
           "armv6l": {
-            "build": "1",
-            "sha256": "b1f1d8b7fcb159a0a8029b6c3106d1d16207cecbb2047f9a4be2a64d29897da5",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_arm_linux_hotspot_17.0.8.1_1.tar.gz",
-            "version": "17.0.8"
+            "build": "9",
+            "sha256": "9b5c375ed7ce654083c6c1137d8daadebaf8657650576115f0deafab00d0f1d7",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_arm_linux_hotspot_17.0.11_9.tar.gz",
+            "version": "17.0.11"
           },
           "armv7l": {
-            "build": "1",
-            "sha256": "b1f1d8b7fcb159a0a8029b6c3106d1d16207cecbb2047f9a4be2a64d29897da5",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_arm_linux_hotspot_17.0.8.1_1.tar.gz",
-            "version": "17.0.8"
+            "build": "9",
+            "sha256": "9b5c375ed7ce654083c6c1137d8daadebaf8657650576115f0deafab00d0f1d7",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_arm_linux_hotspot_17.0.11_9.tar.gz",
+            "version": "17.0.11"
           },
           "packageType": "jdk",
           "powerpc64le": {
             "build": "9",
-            "sha256": "3ae4b254d5b720f94f986481e787fbd67f0667571140ba2e2ae5020ceddbc826",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_ppc64le_linux_hotspot_17.0.9_9.tar.gz",
-            "version": "17.0.9"
+            "sha256": "44bdd662c3b832cfe0b808362866b8d7a700dd60e6e39716dee97211d35c230f",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_ppc64le_linux_hotspot_17.0.11_9.tar.gz",
+            "version": "17.0.11"
           },
           "vmType": "hotspot",
           "x86_64": {
             "build": "9",
-            "sha256": "7b175dbe0d6e3c9c23b6ed96449b018308d8fc94a5ecd9c0df8b8bc376c3c18a",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.9_9.tar.gz",
-            "version": "17.0.9"
+            "sha256": "aa7fb6bb342319d227a838af5c363bfa1b4a670c209372f9e6585bd79da6220c",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.11_9.tar.gz",
+            "version": "17.0.11"
           }
         },
         "openjdk18": {
@@ -364,58 +364,58 @@
         },
         "openjdk21": {
           "aarch64": {
-            "build": "12",
-            "sha256": "e184dc29a6712c1f78754ab36fb48866583665fa345324f1a79e569c064f95e9",
-            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.1_12.tar.gz",
-            "version": "21.0.1"
+            "build": "9",
+            "sha256": "7d3ab0e8eba95bd682cfda8041c6cb6fa21e09d0d9131316fd7c96c78969de31",
+            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.3_9.tar.gz",
+            "version": "21.0.3"
           },
           "packageType": "jdk",
           "powerpc64le": {
-            "build": "12",
-            "sha256": "9574828ef3d735a25404ced82e09bf20e1614f7d6403956002de9cfbfcb8638f",
-            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_ppc64le_linux_hotspot_21.0.1_12.tar.gz",
-            "version": "21.0.1"
+            "build": "9",
+            "sha256": "9a1079d7f0fc72951fdc9a0029e49a15f6ba114683aee626f882ee2c761f1d57",
+            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jdk_ppc64le_linux_hotspot_21.0.3_9.tar.gz",
+            "version": "21.0.3"
           },
           "vmType": "hotspot",
           "x86_64": {
-            "build": "12",
-            "sha256": "1a6fa8abda4c5caed915cfbeeb176e7fbd12eb6b222f26e290ee45808b529aa1",
-            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_x64_linux_hotspot_21.0.1_12.tar.gz",
-            "version": "21.0.1"
+            "build": "9",
+            "sha256": "fffa52c22d797b715a962e6c8d11ec7d79b90dd819b5bc51d62137ea4b22a340",
+            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jdk_x64_linux_hotspot_21.0.3_9.tar.gz",
+            "version": "21.0.3"
           }
         },
         "openjdk8": {
           "aarch64": {
             "build": "8",
-            "sha256": "70636c2fa4927913e9e869d471607a99d3a521c1fa3f3687b889c2acba67c493",
-            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u392-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_8u392b08.tar.gz",
-            "version": "8.0.392"
+            "sha256": "3504d748a93f23cac8c060bd33231bd51e90dcb620f38dadc6239b6cd2a5011c",
+            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_8u412b08.tar.gz",
+            "version": "8.0.412"
           },
           "armv6l": {
-            "build": "5",
-            "sha256": "5d805ff157f272acf0f7d192f21af4a3b68c840333ca95568e4e07142efc369d",
-            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jdk_arm_linux_hotspot_8u382b05.tar.gz",
-            "version": "8.0.382"
+            "build": "8",
+            "sha256": "be4aff6fa7bf6515f16f93dcaf9fdc61853fe1ef0d25b08a1bb1cf6e3d047391",
+            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jdk_arm_linux_hotspot_8u412b08.tar.gz",
+            "version": "8.0.412"
           },
           "armv7l": {
-            "build": "5",
-            "sha256": "5d805ff157f272acf0f7d192f21af4a3b68c840333ca95568e4e07142efc369d",
-            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jdk_arm_linux_hotspot_8u382b05.tar.gz",
-            "version": "8.0.382"
+            "build": "8",
+            "sha256": "be4aff6fa7bf6515f16f93dcaf9fdc61853fe1ef0d25b08a1bb1cf6e3d047391",
+            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jdk_arm_linux_hotspot_8u412b08.tar.gz",
+            "version": "8.0.412"
           },
           "packageType": "jdk",
           "powerpc64le": {
             "build": "8",
-            "sha256": "9d9813d2840360ffdbc449c45e71124e8170c31a3b6cce9151fbb31352064406",
-            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u392-b08/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u392b08.tar.gz",
-            "version": "8.0.392"
+            "sha256": "6b7ed7996788075e182dd33349288346240fbce540e50fd77aecfc309a5ada19",
+            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u412b08.tar.gz",
+            "version": "8.0.412"
           },
           "vmType": "hotspot",
           "x86_64": {
             "build": "8",
-            "sha256": "15d091e22aa0cad12a241acff8c1634e7228b9740f8d19634250aa6fe0c19a33",
-            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u392-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u392b08.tar.gz",
-            "version": "8.0.392"
+            "sha256": "b9884a96f78543276a6399c3eb8c2fd8a80e6b432ea50e87d3d12d495d1d2808",
+            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u412b08.tar.gz",
+            "version": "8.0.412"
           }
         }
       },
@@ -423,69 +423,69 @@
         "openjdk11": {
           "aarch64": {
             "build": "9",
-            "sha256": "8dc527e5c5da62f80ad3b6a2cd7b1789f745b1d90d5e83faba45f7a1d0b6cab8",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.21%2B9/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.21_9.tar.gz",
-            "version": "11.0.21"
+            "sha256": "7290ace47a030d89ea023c28e7aa555c9da72b4194f73b39ec9d058011bf06dd",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.23_9.tar.gz",
+            "version": "11.0.23"
           },
           "armv6l": {
-            "build": "1",
-            "sha256": "2fc1cc935897312c0bc2515b2e7ea1fa3b267e77305a1b51a8c3917d92af380f",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1%2B1/OpenJDK11U-jre_arm_linux_hotspot_11.0.20.1_1.tar.gz",
-            "version": "11.0.20"
+            "build": "9",
+            "sha256": "025f994549708f7291ce3b0fa7c41f7e78ec3af3eae3f85fffe9c5fa4a54889f",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jre_arm_linux_hotspot_11.0.23_9.tar.gz",
+            "version": "11.0.23"
           },
           "armv7l": {
-            "build": "1",
-            "sha256": "2fc1cc935897312c0bc2515b2e7ea1fa3b267e77305a1b51a8c3917d92af380f",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1%2B1/OpenJDK11U-jre_arm_linux_hotspot_11.0.20.1_1.tar.gz",
-            "version": "11.0.20"
+            "build": "9",
+            "sha256": "025f994549708f7291ce3b0fa7c41f7e78ec3af3eae3f85fffe9c5fa4a54889f",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jre_arm_linux_hotspot_11.0.23_9.tar.gz",
+            "version": "11.0.23"
           },
           "packageType": "jre",
           "powerpc64le": {
             "build": "9",
-            "sha256": "286e37ce06316185377eea847d2aa9f1523b9f1428684e59e772f2f6055e89b9",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.21%2B9/OpenJDK11U-jre_ppc64le_linux_hotspot_11.0.21_9.tar.gz",
-            "version": "11.0.21"
+            "sha256": "3b3fbd324620fd914bd8462e292124493fcf846fd69195c4b9a231131dc68d5f",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jre_ppc64le_linux_hotspot_11.0.23_9.tar.gz",
+            "version": "11.0.23"
           },
           "vmType": "hotspot",
           "x86_64": {
             "build": "9",
-            "sha256": "156861bb901ef18759e05f6f008595220c7d1318a46758531b957b0c950ef2c3",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.21%2B9/OpenJDK11U-jre_x64_linux_hotspot_11.0.21_9.tar.gz",
-            "version": "11.0.21"
+            "sha256": "786a72296189ba8e43999532aa73730d87ec1fce558eb3c4e98b611b423375e3",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jre_x64_linux_hotspot_11.0.23_9.tar.gz",
+            "version": "11.0.23"
           }
         },
         "openjdk17": {
           "aarch64": {
             "build": "9",
-            "sha256": "05b192f81ed478178ba953a2a779b67fc5a810acadb633ad69f8c4412399edb8",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jre_aarch64_linux_hotspot_17.0.9_9.tar.gz",
-            "version": "17.0.9"
+            "sha256": "ccfa23c25790475c84df983cc5f729b94c04d9ea9863912deb15c6266782cf16",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jre_aarch64_linux_hotspot_17.0.11_9.tar.gz",
+            "version": "17.0.11"
           },
           "armv6l": {
-            "build": "1",
-            "sha256": "8af898c5d356f0b2cee2db67ff9c8e7a8e738c0f6b3a61c383150b3168b9ea58",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jre_arm_linux_hotspot_17.0.8.1_1.tar.gz",
-            "version": "17.0.8"
+            "build": "9",
+            "sha256": "2e06401aa3aa7a825d73a6af8e9462449b1a86e7705b793dc8ec90423b602ee2",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jre_arm_linux_hotspot_17.0.11_9.tar.gz",
+            "version": "17.0.11"
           },
           "armv7l": {
-            "build": "1",
-            "sha256": "8af898c5d356f0b2cee2db67ff9c8e7a8e738c0f6b3a61c383150b3168b9ea58",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jre_arm_linux_hotspot_17.0.8.1_1.tar.gz",
-            "version": "17.0.8"
+            "build": "9",
+            "sha256": "2e06401aa3aa7a825d73a6af8e9462449b1a86e7705b793dc8ec90423b602ee2",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jre_arm_linux_hotspot_17.0.11_9.tar.gz",
+            "version": "17.0.11"
           },
           "packageType": "jre",
           "powerpc64le": {
             "build": "9",
-            "sha256": "79c85ecf1320c67b828310167e1ced62e402bc86a5d47ca9cc7bfa3b708cb07a",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jre_ppc64le_linux_hotspot_17.0.9_9.tar.gz",
-            "version": "17.0.9"
+            "sha256": "884b5cb817e50010b4d0a3252afb6a80db18995af19bbd16a37348b2c37949bc",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jre_ppc64le_linux_hotspot_17.0.11_9.tar.gz",
+            "version": "17.0.11"
           },
           "vmType": "hotspot",
           "x86_64": {
             "build": "9",
-            "sha256": "c37f729200b572884b8f8e157852c739be728d61d9a1da0f920104876d324733",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jre_x64_linux_hotspot_17.0.9_9.tar.gz",
-            "version": "17.0.9"
+            "sha256": "bcb1b7b8ad68c93093f09b591b7cb17161d39891f7d29d33a586f5a328603707",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jre_x64_linux_hotspot_17.0.11_9.tar.gz",
+            "version": "17.0.11"
           }
         },
         "openjdk18": {
@@ -580,58 +580,58 @@
         },
         "openjdk21": {
           "aarch64": {
-            "build": "12",
-            "sha256": "4582c4cc0c6d498ba7a23fdb0a5179c9d9c0d7a26f2ee8610468d5c2954fcf2f",
-            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jre_aarch64_linux_hotspot_21.0.1_12.tar.gz",
-            "version": "21.0.1"
+            "build": "9",
+            "sha256": "c7c31bc6f5ab4c4b6f4559e11c2fa9541ae6757ab8da6dd85c29163913bd9238",
+            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jre_aarch64_linux_hotspot_21.0.3_9.tar.gz",
+            "version": "21.0.3"
           },
           "packageType": "jre",
           "powerpc64le": {
-            "build": "12",
-            "sha256": "05cc9b7bfbe246c27d307783b3d5095797be747184b168018ae3f7cc55608db2",
-            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jre_ppc64le_linux_hotspot_21.0.1_12.tar.gz",
-            "version": "21.0.1"
+            "build": "9",
+            "sha256": "aa628c6accc9d075b7b0f2bff6487f8ca0b8f057af31842a85fc8b363e1e10f3",
+            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jre_ppc64le_linux_hotspot_21.0.3_9.tar.gz",
+            "version": "21.0.3"
           },
           "vmType": "hotspot",
           "x86_64": {
-            "build": "12",
-            "sha256": "277f4084bee875f127a978253cfbaad09c08df597feaf5ccc82d2206962279a3",
-            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jre_x64_linux_hotspot_21.0.1_12.tar.gz",
-            "version": "21.0.1"
+            "build": "9",
+            "sha256": "f1af100c4afca2035f446967323230150cfe5872b5a664d98c86963e5c066e0d",
+            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jre_x64_linux_hotspot_21.0.3_9.tar.gz",
+            "version": "21.0.3"
           }
         },
         "openjdk8": {
           "aarch64": {
             "build": "8",
-            "sha256": "37b997f12cd572da979283fccafec9ba903041a209605b50fcb46cc34f1a9917",
-            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u392-b08/OpenJDK8U-jre_aarch64_linux_hotspot_8u392b08.tar.gz",
-            "version": "8.0.392"
+            "sha256": "17550a6a4ddf71ac81ba8f276467bc58f036c123c0f1bafcafd69f70e3e49cf5",
+            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jre_aarch64_linux_hotspot_8u412b08.tar.gz",
+            "version": "8.0.412"
           },
           "armv6l": {
-            "build": "5",
-            "sha256": "b92fb3972372b5d1f9fb51815def903105722b747f680b7ecf2ba2ba863ab156",
-            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jre_arm_linux_hotspot_8u382b05.tar.gz",
-            "version": "8.0.382"
+            "build": "8",
+            "sha256": "1a6b470ac83b241223447a1e6cb55c4a8f78af0146b9387e9842625041226654",
+            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jre_arm_linux_hotspot_8u412b08.tar.gz",
+            "version": "8.0.412"
           },
           "armv7l": {
-            "build": "5",
-            "sha256": "b92fb3972372b5d1f9fb51815def903105722b747f680b7ecf2ba2ba863ab156",
-            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jre_arm_linux_hotspot_8u382b05.tar.gz",
-            "version": "8.0.382"
+            "build": "8",
+            "sha256": "1a6b470ac83b241223447a1e6cb55c4a8f78af0146b9387e9842625041226654",
+            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jre_arm_linux_hotspot_8u412b08.tar.gz",
+            "version": "8.0.412"
           },
           "packageType": "jre",
           "powerpc64le": {
             "build": "8",
-            "sha256": "0ecb0aeb54fb9d3c9e1a7ea411490127e8e298d93219fafc4dd6051a5b74671f",
-            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u392-b08/OpenJDK8U-jre_ppc64le_linux_hotspot_8u392b08.tar.gz",
-            "version": "8.0.392"
+            "sha256": "d3157230c01b320e47ad6df650e83b15f8f76294d0df9f1c03867d07fe2883c9",
+            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jre_ppc64le_linux_hotspot_8u412b08.tar.gz",
+            "version": "8.0.412"
           },
           "vmType": "hotspot",
           "x86_64": {
             "build": "8",
-            "sha256": "91d31027da0d985be3549714389593d9e0da3da5057d87e3831c7c538b9a2a0f",
-            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u392-b08/OpenJDK8U-jre_x64_linux_hotspot_8u392b08.tar.gz",
-            "version": "8.0.392"
+            "sha256": "a8d994332a2ff15d48bf04405c3b2f6bd331a928dd96639b15e62891f7172363",
+            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jre_x64_linux_hotspot_8u412b08.tar.gz",
+            "version": "8.0.412"
           }
         }
       }
@@ -641,17 +641,17 @@
         "openjdk11": {
           "aarch64": {
             "build": "9",
-            "sha256": "3be236f2cf9612cd38cd6b7cfa4b8eef642a88beab0cd37c6ccf1766d755b4cc",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.21%2B9/OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.21_9.tar.gz",
-            "version": "11.0.21"
+            "sha256": "49122443bdeab2c9f468bd400f58f85a9ea462846faa79084fd6fd786d9b492d",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.23_9.tar.gz",
+            "version": "11.0.23"
           },
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
             "build": "9",
-            "sha256": "39e30e333d01f70765f0fdc57332bc2c5ae101392bcc315ef06f472d80d8e2d7",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.21%2B9/OpenJDK11U-jdk_x64_mac_hotspot_11.0.21_9.tar.gz",
-            "version": "11.0.21"
+            "sha256": "4dbd21d9a0311d321f5886eda50c3086026ed61d02e1a85f7b8c2e9ad557bf03",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jdk_x64_mac_hotspot_11.0.23_9.tar.gz",
+            "version": "11.0.23"
           }
         },
         "openjdk16": {
@@ -667,17 +667,17 @@
         "openjdk17": {
           "aarch64": {
             "build": "9",
-            "sha256": "823777266415347983bbd87ccd8136537242ff27e62f307b7e8521494c665f0d",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.9_9.tar.gz",
-            "version": "17.0.9"
+            "sha256": "09a162c58dd801f7cfacd87e99703ed11fb439adc71cfa14ceb2d3194eaca01c",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.11_9.tar.gz",
+            "version": "17.0.11"
           },
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
             "build": "9",
-            "sha256": "c69b37ea72136df49ce54972408803584b49b2c91b0fbc876d7125e963c7db37",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jdk_x64_mac_hotspot_17.0.9_9.tar.gz",
-            "version": "17.0.9"
+            "sha256": "f8b96724618f4df557c47f11048d1084e98ed3eb87f0dbd5b84f768a80c3348e",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_x64_mac_hotspot_17.0.11_9.tar.gz",
+            "version": "17.0.11"
           }
         },
         "openjdk18": {
@@ -730,18 +730,18 @@
         },
         "openjdk21": {
           "aarch64": {
-            "build": "12",
-            "sha256": "0d29257c9bcb5f20f5c4643ef9437f36b10376863eddaf6248d09093796c6b30",
-            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.1_12.tar.gz",
-            "version": "21.0.1"
+            "build": "9",
+            "sha256": "b6be6a9568be83695ec6b7cb977f4902f7be47d74494c290bc2a5c3c951e254f",
+            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.3_9.tar.gz",
+            "version": "21.0.3"
           },
           "packageType": "jdk",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "12",
-            "sha256": "35f3cbc86d7ff0a01facefd741d5cfb675867e0a5ec137f62ba071d2511a45c9",
-            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_x64_mac_hotspot_21.0.1_12.tar.gz",
-            "version": "21.0.1"
+            "build": "9",
+            "sha256": "f777103aab94330d14a29bd99f3a26d60abbab8e2c375cec9602746096721a7c",
+            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jdk_x64_mac_hotspot_21.0.3_9.tar.gz",
+            "version": "21.0.3"
           }
         },
         "openjdk8": {
@@ -749,9 +749,9 @@
           "vmType": "hotspot",
           "x86_64": {
             "build": "8",
-            "sha256": "d152f5b2ed8473ee0eb29c7ee134958d75ea86c8ccbafb5ee04a5545dd76108f",
-            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u392-b08/OpenJDK8U-jdk_x64_mac_hotspot_8u392b08.tar.gz",
-            "version": "8.0.392"
+            "sha256": "fd62491f7634c1cbed7557d6b21db7ef4818fbc0e63e678110d9d92cbea4ad8c",
+            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jdk_x64_mac_hotspot_8u412b08.tar.gz",
+            "version": "8.0.412"
           }
         }
       },
@@ -759,33 +759,33 @@
         "openjdk11": {
           "aarch64": {
             "build": "9",
-            "sha256": "bcac3231195a95cac397a35410bfa3f0945ec03e5194e7b0c1d0e785a48f8b76",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.21%2B9/OpenJDK11U-jre_aarch64_mac_hotspot_11.0.21_9.tar.gz",
-            "version": "11.0.21"
+            "sha256": "8ecc59f0bda845717cecbc6025c4c7fcc26d6ffe48824b8f7a5db024216c5fb4",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jre_aarch64_mac_hotspot_11.0.23_9.tar.gz",
+            "version": "11.0.23"
           },
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
             "build": "9",
-            "sha256": "43d29affe994a09de31bf2fb6f8ab6d6792ba4267b9a2feacaa1f6e042481b9b",
-            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.21%2B9/OpenJDK11U-jre_x64_mac_hotspot_11.0.21_9.tar.gz",
-            "version": "11.0.21"
+            "sha256": "9855769dddc3f3b5a1fb530ce953025b1f7b3fac861628849b417676b1310b1f",
+            "url": "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.23%2B9/OpenJDK11U-jre_x64_mac_hotspot_11.0.23_9.tar.gz",
+            "version": "11.0.23"
           }
         },
         "openjdk17": {
           "aarch64": {
             "build": "9",
-            "sha256": "89831d03b7cd9922bd178f1a9c8544a36c54d52295366db4e6628454b01acaef",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jre_aarch64_mac_hotspot_17.0.9_9.tar.gz",
-            "version": "17.0.9"
+            "sha256": "003d3e0a65a2f0633b8bfed42be133724b490acb323c174c708d3a446d5fc660",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jre_aarch64_mac_hotspot_17.0.11_9.tar.gz",
+            "version": "17.0.11"
           },
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
             "build": "9",
-            "sha256": "ba214f2217dc134e94432085cff4fc5a97e964ffc211d343725fd535f3cd98a0",
-            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.9%2B9/OpenJDK17U-jre_x64_mac_hotspot_17.0.9_9.tar.gz",
-            "version": "17.0.9"
+            "sha256": "232c40bebd6ddbb673862e86e7e6e09bcfe399e5a53c8a6b77bf1ceab8edefd0",
+            "url": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jre_x64_mac_hotspot_17.0.11_9.tar.gz",
+            "version": "17.0.11"
           }
         },
         "openjdk18": {
@@ -838,18 +838,18 @@
         },
         "openjdk21": {
           "aarch64": {
-            "build": "12",
-            "sha256": "bc384961d3a866198b1055a80fdff7fb6946aa6823b3ce624cc8c3125a26bed5",
-            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jre_aarch64_mac_hotspot_21.0.1_12.tar.gz",
-            "version": "21.0.1"
+            "build": "9",
+            "sha256": "8df56361b834c4681ef304ae9dc8406ce3d79c8572d2d6c2fefcbea55be7d86b",
+            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jre_aarch64_mac_hotspot_21.0.3_9.tar.gz",
+            "version": "21.0.3"
           },
           "packageType": "jre",
           "vmType": "hotspot",
           "x86_64": {
-            "build": "12",
-            "sha256": "c21a2648ec21bc4701acfb6b7a1fd90aca001db1efb8454e2980d4c8dcd9e310",
-            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jre_x64_mac_hotspot_21.0.1_12.tar.gz",
-            "version": "21.0.1"
+            "build": "9",
+            "sha256": "d7fc89c196ed03deb8a98f6599e1b2e78859ec8ec752142549cd3710f3e1a025",
+            "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.3%2B9/OpenJDK21U-jre_x64_mac_hotspot_21.0.3_9.tar.gz",
+            "version": "21.0.3"
           }
         },
         "openjdk8": {
@@ -857,9 +857,9 @@
           "vmType": "hotspot",
           "x86_64": {
             "build": "8",
-            "sha256": "f1f15920ed299e10c789aef6274d88d45eb21b72f9a7b0d246a352107e344e6a",
-            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u392-b08/OpenJDK8U-jre_x64_mac_hotspot_8u392b08.tar.gz",
-            "version": "8.0.392"
+            "sha256": "1237e4f4238211d9137eec838e5d7cabdc9d93d41001cf41f6de3a4eb90884ef",
+            "url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u412-b08/OpenJDK8U-jre_x64_mac_hotspot_8u412b08.tar.gz",
+            "version": "8.0.412"
           }
         }
       }

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -423,22 +423,22 @@ self: super: {
 
   # Manually maintained
   cachix-api = overrideCabal (drv: {
-    version = "1.7.3";
+    version = "1.7.4";
     src = pkgs.fetchFromGitHub {
       owner = "cachix";
       repo = "cachix";
-      rev = "v1.7.3";
-      sha256 = "sha256-BBhOFK4OuCD7ilNrdfeAILBR2snxl29gBk58szZ4460=";
+      rev = "v1.7.4";
+      sha256 = "sha256-lHy5kgx6J8uD+16SO47dPrbob98sh+W1tf4ceSqPVK4=";
     };
     postUnpack = "sourceRoot=$sourceRoot/cachix-api";
   }) super.cachix-api;
   cachix = (overrideCabal (drv: {
-    version = "1.7.3";
+    version = "1.7.4";
     src = pkgs.fetchFromGitHub {
       owner = "cachix";
       repo = "cachix";
-      rev = "v1.7.3";
-      sha256 = "sha256-BBhOFK4OuCD7ilNrdfeAILBR2snxl29gBk58szZ4460=";
+      rev = "v1.7.4";
+      sha256 = "sha256-lHy5kgx6J8uD+16SO47dPrbob98sh+W1tf4ceSqPVK4=";
     };
     postUnpack = "sourceRoot=$sourceRoot/cachix";
   }) (lib.pipe
@@ -448,13 +448,6 @@ self: super: {
         [
          (addBuildTool self.hercules-ci-cnix-store.nixPackage)
          (addBuildTool pkgs.buildPackages.pkg-config)
-         (addBuildDepend self.immortal)
-         # should be removed once hackage packages catch up
-         (addBuildDepend self.crypton)
-         (addBuildDepend self.generic-lens)
-         (addBuildDepend self.amazonka)
-         (addBuildDepend self.amazonka-core)
-         (addBuildDepend self.amazonka-s3)
         ]
   ));
 

--- a/pkgs/development/php-packages/phpstan/default.nix
+++ b/pkgs/development/php-packages/phpstan/default.nix
@@ -6,16 +6,16 @@
 
 php.buildComposerProject (finalAttrs: {
   pname = "phpstan";
-  version = "1.11.1";
+  version = "1.11.2";
 
   src = fetchFromGitHub {
     owner = "phpstan";
     repo = "phpstan-src";
     rev = finalAttrs.version;
-    hash = "sha256-CMIWxxryDDA38uyGl3SIooliU0ElAY1iAqnexn2Uq58=";
+    hash = "sha256-g1YIFqNo1UTmNrgS+lAkDXSnKsmhLj+Itoi3tgxdx4Y=";
   };
 
-  vendorHash = "sha256-CSkwBBV6b2inpQu4TKBR23Du11mzr3rV6GtprzHAOgQ=";
+  vendorHash = "sha256-sFV22B5ohbDvclb1nuvpMhhfKjEe7FAFCqWfIguAY8M=";
   composerStrictValidation = false;
 
   meta = {

--- a/pkgs/development/python-modules/boto3-stubs/default.nix
+++ b/pkgs/development/python-modules/boto3-stubs/default.nix
@@ -366,7 +366,7 @@
 
 buildPythonPackage rec {
   pname = "boto3-stubs";
-  version = "1.34.111";
+  version = "1.34.112";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -374,7 +374,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "boto3_stubs";
     inherit version;
-    hash = "sha256-6uJopdcNK4gLgHoVOWAvLInUCQ3m3bAuP+wURmC8H9E=";
+    hash = "sha256-70UVtT3M5NhRaPoYXcgDU3xMiC1bDas+XDSJPIPI26o=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/clickhouse-connect/default.nix
+++ b/pkgs/development/python-modules/clickhouse-connect/default.nix
@@ -24,7 +24,7 @@
 }:
 buildPythonPackage rec {
   pname = "clickhouse-connect";
-  version = "0.7.8";
+  version = "0.7.10";
 
   format = "setuptools";
 
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     repo = "clickhouse-connect";
     owner = "ClickHouse";
     rev = "refs/tags/v${version}";
-    hash = "sha256-tdf9aYKAFpRyaqGGNxXs4bzmY6mdhKZ5toFBJRmD2VY=";
+    hash = "sha256-joY8T0BrqoysHl3PFmx8BqQjvROAD67O0nDLOOEZ7OI=";
   };
 
   nativeBuildInputs = [ cython ];

--- a/pkgs/development/python-modules/duckdb-engine/default.nix
+++ b/pkgs/development/python-modules/duckdb-engine/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "duckdb-engine";
-  version = "0.12.0";
+  version = "0.12.1";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     repo = "duckdb_engine";
     owner = "Mause";
     rev = "refs/tags/v${version}";
-    hash = "sha256-cm0vbz0VZ2Ws6FDWJO16q4KZW2obs0CBNrfY9jmR+6A=";
+    hash = "sha256-+l6sRZHJnLfei1LR8WHqpC+0+91VLYKXn2e0w9+QRyk=";
   };
 
   nativeBuildInputs = [ poetry-core ];

--- a/pkgs/development/python-modules/langsmith/default.nix
+++ b/pkgs/development/python-modules/langsmith/default.nix
@@ -22,7 +22,7 @@
 
 buildPythonPackage rec {
   pname = "langsmith";
-  version = "0.1.60";
+  version = "0.1.63";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     owner = "langchain-ai";
     repo = "langsmith-sdk";
     rev = "refs/tags/v${version}";
-    hash = "sha256-YoJ9rdbc4lcQ0ZxE0bYCa+VMKO2kqJRTpxZz4QGPzzM=";
+    hash = "sha256-zIrSQubYB5AuwAF0hktT/wY5/ktwQJ4Z/3F6po2wC3o=";
   };
 
   sourceRoot = "${src.name}/python";

--- a/pkgs/development/python-modules/quantile-forest/default.nix
+++ b/pkgs/development/python-modules/quantile-forest/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "quantile-forest";
-  version = "1.3.5";
+  version = "1.3.6";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "zillow";
     repo = "quantile-forest";
     rev = "refs/tags/v${version}";
-    hash = "sha256-0zlj9nks5KsgsLSflRW+4uiYlYVQsF0HMkZ3zG3if2E=";
+    hash = "sha256-cYi4idA6gcUd/aVMlIwlCB/jdKpxZtc6xQEhxNSY08Y=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/scikit-hep-testdata/default.nix
+++ b/pkgs/development/python-modules/scikit-hep-testdata/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "scikit-hep-testdata";
-  version = "0.4.44";
+  version = "0.4.45";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "scikit-hep";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-7a1F7180mnbMiEwRWzDQt2EhRsleSoVhWtTc+5DR/2o=";
+    hash = "sha256-Kpn7Z+LJPZ9rNxQLXFtACJvfpRdDs58cy+1QlbbODLA=";
   };
 
   nativeBuildInputs = [ setuptools-scm ];

--- a/pkgs/development/python-modules/tencentcloud-sdk-python/default.nix
+++ b/pkgs/development/python-modules/tencentcloud-sdk-python/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "tencentcloud-sdk-python";
-  version = "3.0.1153";
+  version = "3.0.1154";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "TencentCloud";
     repo = "tencentcloud-sdk-python";
     rev = "refs/tags/${version}";
-    hash = "sha256-BDBRE7AKT5rKWW62Sx5M5jtF+ANU//Z9AUt1Jh1wFpo=";
+    hash = "sha256-rVNmNnLRtW7ZhJgNUoZvYlbU9dkiXXOv7/vBAvaQ18w=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/tools/language-servers/fortls/default.nix
+++ b/pkgs/development/tools/language-servers/fortls/default.nix
@@ -8,13 +8,13 @@
 
 buildPythonApplication rec {
   pname = "fortls";
-  version = "3.0.0";
+  version = "3.1.0";
 
   src = fetchFromGitHub {
     owner = "fortran-lang";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-kRL4kLX1T2Sontl8f3VO8Hb7uI41JwhZBiH//gdcmNE=";
+    hash = "sha256-4iOE9OkqSu7enEMx4aAaGZ0KDKCT1377Su728JncIso=";
   };
 
   nativeBuildInputs = [ setuptools-scm ];

--- a/pkgs/development/tools/misc/blackfire/default.nix
+++ b/pkgs/development/tools/misc/blackfire/default.nix
@@ -10,7 +10,7 @@
 
 stdenv.mkDerivation rec {
   pname = "blackfire";
-  version = "2.28.2";
+  version = "2.28.3";
 
   src = passthru.sources.${stdenv.hostPlatform.system} or (throw "Unsupported platform for blackfire: ${stdenv.hostPlatform.system}");
 
@@ -57,23 +57,23 @@ stdenv.mkDerivation rec {
     sources = {
       "x86_64-linux" = fetchurl {
         url = "https://packages.blackfire.io/debian/pool/any/main/b/blackfire/blackfire_${version}_amd64.deb";
-        sha256 = "ECUWjBlWr2QSvYvzep7MVOrufCRTgLibkmOHAEhg36w=";
+        sha256 = "nku9F29PjoPZL/PppK6HuC5Mk7TEWv4iAUVgoiYmaG8=";
       };
       "i686-linux" = fetchurl {
         url = "https://packages.blackfire.io/debian/pool/any/main/b/blackfire/blackfire_${version}_i386.deb";
-        sha256 = "cU9WpD+mIcAn1eYc9n6rGi/jML5F7g6BoXtfWAI4P+Y=";
+        sha256 = "xZfjCn0HXqw0fBrZEKc4X2m8aTEiXOFjSEpSdFq9Wvc=";
       };
       "aarch64-linux" = fetchurl {
         url = "https://packages.blackfire.io/debian/pool/any/main/b/blackfire/blackfire_${version}_arm64.deb";
-        sha256 = "Ej2uFxl8gIW6V7hEGauRWhfdevxoAb5s+yyQi1TYQWQ=";
+        sha256 = "05aI2Ao0++bTiwt6TygY/yvLkmByH604t8EX8T2bGZs=";
       };
       "aarch64-darwin" = fetchurl {
         url = "https://packages.blackfire.io/blackfire/${version}/blackfire-darwin_arm64.pkg.tar.gz";
-        sha256 = "brcOya9uqicGXGVRggYP6yiOriho7zrbO5b3F1XMW+M=";
+        sha256 = "ICG0SGBzpSQoug+5kl7kQ05Q0+0BAKdhRdUUwxgPEb4=";
       };
       "x86_64-darwin" = fetchurl {
         url = "https://packages.blackfire.io/blackfire/${version}/blackfire-darwin_amd64.pkg.tar.gz";
-        sha256 = "M90t91STPtLnW3yd5gvhNC0RQ8aDLPmdXV7dZ03gp/4=";
+        sha256 = "qbhFK8Oe7565sOQMGE68TlyYN1B56kk2ibiBiDWw7VE=";
       };
     };
 

--- a/pkgs/os-specific/linux/nvidia-x11/libxnvctrl-build-shared-3xx.patch
+++ b/pkgs/os-specific/linux/nvidia-x11/libxnvctrl-build-shared-3xx.patch
@@ -1,0 +1,24 @@
+--- a/src/libXNVCtrl/Makefile
++++ b/src/libXNVCtrl/Makefile
+@@ -33,6 +33,8 @@
+ 
+ LIBXNVCTRL = libXNVCtrl.a
+ 
++LIBXNVCTRL_SHARED = $(OUTPUTDIR)/libXNVCtrl.so
++
+ LIBXNVCTRL_PROGRAM_NAME = "libXNVCtrl"
+ 
+ LIBXNVCTRL_VERSION := $(NVIDIA_VERSION)
+@@ -62,6 +64,12 @@
+ $(LIBXNVCTRL) : $(OBJS)
+ 	$(AR) ru $@ $(OBJS)
+ 
++$(LIBXNVCTRL_SHARED): $(LIBXNVCTRL_OBJ)
++	$(RM) $@ $@.*
++	$(CC) -shared -Wl,-soname=$(@F).0 -o $@.0.0.0 $(LDFLAGS) $^ -lXext -lX11
++	ln -s $(@F).0.0.0 $@.0
++	ln -s $(@F).0 $@
++
+ # define the rule to build each object file
+ $(foreach src,$(SRC),$(eval $(call DEFINE_OBJECT_RULE,TARGET,$(src))))
+ 

--- a/pkgs/os-specific/linux/nvidia-x11/libxnvctrl-build-shared.patch
+++ b/pkgs/os-specific/linux/nvidia-x11/libxnvctrl-build-shared.patch
@@ -1,0 +1,21 @@
+--- a/src/libXNVCtrl/xnvctrl.mk
++++ b/src/libXNVCtrl/xnvctrl.mk
+@@ -39,6 +39,8 @@
+ 
+ LIBXNVCTRL = $(OUTPUTDIR)/libXNVCtrl.a
+ 
++LIBXNVCTRL_SHARED = $(OUTPUTDIR)/libXNVCtrl.so
++
+ LIBXNVCTRL_SRC = $(XNVCTRL_DIR)/NVCtrl.c
+ 
+ LIBXNVCTRL_OBJ = $(call BUILD_OBJECT_LIST,$(LIBXNVCTRL_SRC))
+@@ -47,3 +49,9 @@
+ 
+ $(LIBXNVCTRL) : $(LIBXNVCTRL_OBJ)
+ 	$(call quiet_cmd,AR) ru $@ $(LIBXNVCTRL_OBJ)
++
++$(LIBXNVCTRL_SHARED): $(LIBXNVCTRL_OBJ)
++	$(RM) $@ $@.*
++	$(CC) -shared -Wl,-soname=$(@F).0 -o $@.0.0.0 $(LDFLAGS) $^ -lXext -lX11
++	ln -s $(@F).0.0.0 $@.0
++	ln -s $(@F).0 $@

--- a/pkgs/os-specific/linux/nvidia-x11/settings.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/settings.nix
@@ -147,6 +147,6 @@ stdenv.mkDerivation {
     license = licenses.unfreeRedistributable;
     platforms = nvidia_x11.meta.platforms;
     mainProgram = "nvidia-settings";
-    maintainers = with maintainers; [ abbradar ];
+    maintainers = with maintainers; [ abbradar aidalgol ];
   };
 }

--- a/pkgs/os-specific/linux/nvidia-x11/settings.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/settings.nix
@@ -43,6 +43,14 @@ let
 
     makeFlags = [
       "OUTPUTDIR=." # src/libXNVCtrl
+      "libXNVCtrl.a"
+      "libXNVCtrl.so"
+    ];
+
+    patches = [
+      # Patch the Makefile to also produce a shared library.
+      (if lib.versionOlder nvidia_x11.settingsVersion "400" then ./libxnvctrl-build-shared-3xx.patch
+      else ./libxnvctrl-build-shared.patch)
     ];
 
     installPhase = ''
@@ -52,6 +60,7 @@ let
       cp libXNVCtrl.a $out/lib
       cp NVCtrl.h     $out/include/NVCtrl
       cp NVCtrlLib.h  $out/include/NVCtrl
+      cp -P libXNVCtrl.so* $out/lib
     '';
   };
 

--- a/pkgs/tools/admin/drawterm/default.nix
+++ b/pkgs/tools/admin/drawterm/default.nix
@@ -19,13 +19,13 @@
 
 stdenv.mkDerivation {
   pname = "drawterm";
-  version = "0-unstable-2024-04-23";
+  version = "0-unstable-2024-05-23";
 
   src = fetchFrom9Front {
     owner = "plan9front";
     repo = "drawterm";
-    rev = "c0951f2a3182d8b70ffe579bfd9da24c2b86e232";
-    hash = "sha256-7y2Mte6R4yeayxdFSFGb9Q5M/GQwqyFb+AW/BFsQeZc=";
+    rev = "8391a9e364622cb7d85e128b427fb96c75e18265";
+    hash = "sha256-YHko0lCCn7SydnKbepZpt4Ua6NdvuPD3Y3ZQ1Ysb0+g=";
   };
 
   enableParallelBuilding = true;

--- a/pkgs/tools/networking/cfspeedtest/default.nix
+++ b/pkgs/tools/networking/cfspeedtest/default.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cfspeedtest";
-  version = "1.2.3";
+  version = "1.2.4";
 
   src = fetchFromGitHub {
     owner = "code-inflation";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-xg5jSA3J6QzqiItNV+poVxxXmKKPE7TsEYMGdKv4k+k=";
+    hash = "sha256-55g3dskYlAJNnoLwjTL0XvpDIk2l53EQ+CZ1MzhuxNI=";
   };
 
-  cargoHash = "sha256-ZXETP60R2121xTFqsvIFziUtKhL+ODGCpG98Mlt/zlg=";
+  cargoHash = "sha256-lTYiL5kCm9NClN4YjIlHz6aQlEwrESE25lOdJGkLMDA=";
 
   meta = with lib; {
     description = "Unofficial CLI for speed.cloudflare.com";

--- a/pkgs/tools/networking/flannel/default.nix
+++ b/pkgs/tools/networking/flannel/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "flannel";
-  version = "0.25.1";
+  version = "0.25.2";
   rev = "v${version}";
 
-  vendorHash = "sha256-hitYX6Y2ElDhjwgoX5feSNwpTUA6PXqpH70ZnIW9RaM=";
+  vendorHash = "sha256-Oo5vguQJOV0rh9gjFO9WdDWZFep3tdUg0ItMo8x4Lkk=";
 
   src = fetchFromGitHub {
     inherit rev;
     owner = "flannel-io";
     repo = "flannel";
-    sha256 = "sha256-Aa+LPn5fRrv7vzCqqbHzNaVn5nU6/mi09t6y/5nx0+s=";
+    sha256 = "sha256-OyYZMSQGsJaYvGwMC2JpJDosYSjIP7c4/CgwcmYEr5Q=";
   };
 
   ldflags = [ "-X github.com/flannel-io/flannel/pkg/version.Version=${rev}" ];

--- a/pkgs/tools/networking/xray/default.nix
+++ b/pkgs/tools/networking/xray/default.nix
@@ -11,16 +11,16 @@
 
 buildGoModule rec {
   pname = "xray";
-  version = "1.8.11";
+  version = "1.8.13";
 
   src = fetchFromGitHub {
     owner = "XTLS";
     repo = "Xray-core";
     rev = "v${version}";
-    hash = "sha256-uOE+Gp42WsqSA5/kQRjk+BKq9igmZCrq/9v1BJMXwFc=";
+    hash = "sha256-+npmj8Cz3/XTabAXL+J02EmyvPwtwz9TKazd9z9emwI=";
   };
 
-  vendorHash = "sha256-7E/H8ctv9BU59wPmywNeDhx1R4mqrjpM9E+Hz+AaPlk=";
+  vendorHash = "sha256-55mNCD3p6Xy6S1w8WzJwxKttjEkEjJZcGTLQdWl1bQQ=";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/tools/security/cnquery/default.nix
+++ b/pkgs/tools/security/cnquery/default.nix
@@ -6,18 +6,18 @@
 
 buildGoModule rec {
   pname = "cnquery";
-  version = "11.4.3";
+  version = "11.5.0";
 
   src = fetchFromGitHub {
     owner = "mondoohq";
     repo = "cnquery";
     rev = "refs/tags/v${version}";
-    hash = "sha256-j2cBoeUpxZV8NlC0D3e6bF533LVN0eIRqE7PSIWBGEw=";
+    hash = "sha256-Fp+NYMAOIiw8g4awfSYMvbjThwfGt87q3Nv7O36IkAk=";
   };
 
   subPackages = [ "apps/cnquery" ];
 
-  vendorHash = "sha256-kovSP+ru32vxve8tmeTRS1fsWTpyBTWhLp5iexKo0Fk=";
+  vendorHash = "sha256-MtOqop0FIuNbhG+gL5fRcMZZn5QC6tXzWHxX+NI0CYg=";
 
   ldflags = [
     "-w"

--- a/pkgs/tools/security/sherlock/default.nix
+++ b/pkgs/tools/security/sherlock/default.nix
@@ -7,14 +7,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "sherlock";
-  version = "0-unstable-2024-05-15";
+  version = "0-unstable-2024-05-22";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "sherlock-project";
     repo = "sherlock";
-    rev = "0ecb496ae91bc36476e3e6800aa3928c5dcd82f8";
-    hash = "sha256-CikQaQsiwKz0yEk3rA6hi570LIobEaxxgQ5I/B6OxWk=";
+    rev = "ab5fcbb90f592ea97239ceab5e8ca3a8d3f7f08b";
+    hash = "sha256-F793Co7CdpNrMFM7SHy/hrmzPKo5hiSHF3BqGtjmJbc=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/tools/security/vault-medusa/default.nix
+++ b/pkgs/tools/security/vault-medusa/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "vault-medusa";
-  version = "0.7.0";
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "jonasvinther";
     repo = "medusa";
     rev = "v${version}";
-    sha256 = "sha256-8lbaXcu+o+grbFPJxZ6p/LezxDFCUvOQyX49zX4V/v0=";
+    sha256 = "sha256-4fYtWRWonZC9HSNGMqZZPH3xHi6wPk3vSF+htu34g6A=";
   };
 
-  vendorHash = "sha256-/8wusZt0BQ//HCokjiSpsgsGb19FggrGrEuhCrwm9L0=";
+  vendorHash = "sha256-GdQiPeU5SWZlqWkyk8gU9yVTUQxJlurhY3l1xZXKeJY=";
 
   meta = with lib; {
     description = "A cli tool for importing and exporting Hashicorp Vault secrets";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15098,6 +15098,8 @@ with pkgs;
   temurin-bin = temurin-bin-22;
   temurin-jre-bin = temurin-jre-bin-22;
 
+  semeru-bin-21 = javaPackages.compiler.semeru-bin.jdk-21;
+  semeru-jre-bin-21 = javaPackages.compiler.semeru-bin.jre-21;
   semeru-bin-17 = javaPackages.compiler.semeru-bin.jdk-17;
   semeru-jre-bin-17 = javaPackages.compiler.semeru-bin.jre-17;
   semeru-bin-16 = javaPackages.compiler.semeru-bin.jdk-16;
@@ -15107,8 +15109,8 @@ with pkgs;
   semeru-bin-8 = javaPackages.compiler.semeru-bin.jdk-8;
   semeru-jre-bin-8 = javaPackages.compiler.semeru-bin.jre-8;
 
-  semeru-bin = semeru-bin-17;
-  semeru-jre-bin = semeru-jre-bin-17;
+  semeru-bin = semeru-bin-21;
+  semeru-jre-bin = semeru-jre-bin-21;
 
   adoptopenjdk-bin-17-packages-linux = import ../development/compilers/adoptopenjdk-bin/jdk17-linux.nix { inherit stdenv lib; };
   adoptopenjdk-bin-17-packages-darwin = import ../development/compilers/adoptopenjdk-bin/jdk17-darwin.nix { inherit lib; };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16099,8 +16099,6 @@ with pkgs;
   jdk17 = openjdk17;
   jdk17_headless = openjdk17_headless;
 
-  openjdk16-bootstrap = javaPackages.compiler.openjdk16-bootstrap;
-
   openjdk19 = javaPackages.compiler.openjdk19;
   openjdk19_headless = javaPackages.compiler.openjdk19.headless;
   jdk19 = openjdk19;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15071,6 +15071,9 @@ with pkgs;
 
   ### DEVELOPMENT / COMPILERS
 
+  temurin-bin-22 = javaPackages.compiler.temurin-bin.jdk-22;
+  temurin-jre-bin-22 = javaPackages.compiler.temurin-bin.jre-22;
+
   temurin-bin-21 = javaPackages.compiler.temurin-bin.jdk-21;
   temurin-jre-bin-21 = javaPackages.compiler.temurin-bin.jre-21;
 
@@ -15092,8 +15095,8 @@ with pkgs;
   temurin-bin-8 = javaPackages.compiler.temurin-bin.jdk-8;
   temurin-jre-bin-8 = javaPackages.compiler.temurin-bin.jre-8;
 
-  temurin-bin = temurin-bin-21;
-  temurin-jre-bin = temurin-jre-bin-21;
+  temurin-bin = temurin-bin-22;
+  temurin-jre-bin = temurin-jre-bin-22;
 
   semeru-bin-17 = javaPackages.compiler.semeru-bin.jdk-17;
   semeru-jre-bin-17 = javaPackages.compiler.semeru-bin.jre-17;

--- a/pkgs/top-level/java-packages.nix
+++ b/pkgs/top-level/java-packages.nix
@@ -227,7 +227,7 @@ in {
       ../development/compilers/openjdk/22.nix
       ../development/compilers/zulu/22.nix
       {
-        openjdk22-bootstrap = temurin-bin.jdk-21;
+        openjdk22-bootstrap = temurin-bin.jdk-22;
         openjfx = openjfx22;
       };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -10397,10 +10397,10 @@ with self; {
 
   FinanceQuote = buildPerlPackage rec {
     pname = "Finance-Quote";
-    version = "1.61";
+    version = "1.62";
     src = fetchurl {
       url = "mirror://cpan/authors/id/B/BP/BPSCHUCK/Finance-Quote-${version}.tar.gz";
-      hash = "sha256-Qw7p3yLcqjLrYwpNf7V6KFQvn+UHsmawo39nVLTzWgg=";
+      hash = "sha256-DTEzsL89d5WCxWaFDVd/K76OGsvRFJeDHNQ9jzFgZII=";
     };
     buildInputs = [ DateManip DateRange DateSimple DateTime DateTimeFormatISO8601 StringUtil TestKwalitee TestPerlCritic TestPod TestPodCoverage ];
     propagatedBuildInputs = [ DateManip DateTimeFormatStrptime Encode HTMLTableExtract HTMLTokeParserSimple HTMLTree HTMLTreeBuilderXPath HTTPCookies HTTPCookieJar JSON IOCompress IOString LWPProtocolHttps Readonly StringUtil SpreadsheetXLSX TextTemplate TryTiny WebScraper XMLLibXML libwwwperl ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16564,6 +16564,10 @@ self: super: with self; {
 
   utils = callPackage ../development/python-modules/utils { };
 
+  uv = toPythonModule (pkgs.uv.override {
+    python3Packages = self;
+  });
+
   uvcclient = callPackage ../development/python-modules/uvcclient { };
 
   uvicorn = callPackage ../development/python-modules/uvicorn { };


### PR DESCRIPTION
## Description of changes

Bumps all of the OpenJDK packages to the latest versions, with the exception of `oraclejdk`, as that requires an Oracle account to properly bump.

I have built all of the normal OpenJDK versions personally, but will let ofborg check the others.

Notes:
- The OpenJDK 16 & 18 bumps were done to ensure that, though EOL and insecure, they are up-to-date with the last tagged release.
- The 16 bump has the build number set to 1 despite the release tag being `-ga` in order to let it build. Let me know if this should be changed.
- Modified several packages to use the latest JRE/JDK instead of pinning a now EOL version.
- Marked JDK 19/20 as EOL, but did not remove the `all-package.nix` bindings yet. Let me know if I should. I'll double check for usages first.

This PR, in conjunction with #273811, addresses concerns raised by #280901.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
