### PR TITLE
buildMozillaMach: fix vp8/vp9 WebRTC video support

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/122.0-libvpx-mozbz1875201.patch
+++ b/pkgs/applications/networking/browsers/firefox/122.0-libvpx-mozbz1875201.patch
@@ -1,0 +1,80 @@
+This patch is a rebase of https://bugzilla.mozilla.org/attachment.cgi?id=9377318
+on top of Firefox 122.0.
+
+Fixes: https://bugzilla.mozilla.org/show_bug.cgi?id=1875201
+
+diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_libvpx_interface_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_libvpx_interface_gn/moz.build
+index c5dabce8b0..e325905282 100644
+--- a/third_party/libwebrtc/modules/video_coding/webrtc_libvpx_interface_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/webrtc_libvpx_interface_gn/moz.build
+@@ -5,6 +5,8 @@
+ 
+   ### This moz.build was AUTOMATICALLY GENERATED from a GN config,  ###
+   ### DO NOT edit it by hand.                                       ###
++if not CONFIG["MOZ_SYSTEM_LIBVPX"]:
++    LOCAL_INCLUDES += [ "/media/libvpx/libvpx/" ]
+ 
+ COMPILE_FLAGS["OS_INCLUDES"] = []
+ AllowCompilerWarnings()
+@@ -25,7 +27,6 @@ LOCAL_INCLUDES += [
+     "!/ipc/ipdl/_ipdlheaders",
+     "!/third_party/libwebrtc/gen",
+     "/ipc/chromium/src",
+-    "/media/libvpx/libvpx/",
+     "/third_party/libwebrtc/",
+     "/third_party/libwebrtc/third_party/abseil-cpp/",
+     "/tools/profiler/public"
+diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_gn/moz.build
+index 77a6b3870b..d515bc0595 100644
+--- a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_gn/moz.build
+@@ -5,6 +5,8 @@
+ 
+   ### This moz.build was AUTOMATICALLY GENERATED from a GN config,  ###
+   ### DO NOT edit it by hand.                                       ###
++if not CONFIG["MOZ_SYSTEM_LIBVPX"]:
++    LOCAL_INCLUDES += [ "/media/libvpx/libvpx/" ]
+ 
+ COMPILE_FLAGS["OS_INCLUDES"] = []
+ AllowCompilerWarnings()
+@@ -25,7 +27,6 @@ LOCAL_INCLUDES += [
+     "!/ipc/ipdl/_ipdlheaders",
+     "!/third_party/libwebrtc/gen",
+     "/ipc/chromium/src",
+-    "/media/libvpx/libvpx/",
+     "/media/libyuv/",
+     "/media/libyuv/libyuv/include/",
+     "/third_party/libwebrtc/",
+diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_vp9_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_vp9_gn/moz.build
+index 4bece72807..5cc8d30e1a 100644
+--- a/third_party/libwebrtc/modules/video_coding/webrtc_vp9_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/webrtc_vp9_gn/moz.build
+@@ -5,6 +5,8 @@
+ 
+   ### This moz.build was AUTOMATICALLY GENERATED from a GN config,  ###
+   ### DO NOT edit it by hand.                                       ###
++if not CONFIG["MOZ_SYSTEM_LIBVPX"]:
++    LOCAL_INCLUDES += [ "/media/libvpx/libvpx/" ]
+ 
+ COMPILE_FLAGS["OS_INCLUDES"] = []
+ AllowCompilerWarnings()
+@@ -25,7 +27,6 @@ LOCAL_INCLUDES += [
+     "!/ipc/ipdl/_ipdlheaders",
+     "!/third_party/libwebrtc/gen",
+     "/ipc/chromium/src",
+-    "/media/libvpx/libvpx/",
+     "/media/libyuv/",
+     "/media/libyuv/libyuv/include/",
+     "/third_party/libwebrtc/",
+diff --git a/third_party/libwebrtc/moz.build b/third_party/libwebrtc/moz.build
+index 7baea55b7e..86d4f0f288 100644
+--- a/third_party/libwebrtc/moz.build
++++ b/third_party/libwebrtc/moz.build
+@@ -436,7 +436,6 @@ DIRS += [
+     "/third_party/libwebrtc/third_party/abseil-cpp/absl/types/span_gn",
+     "/third_party/libwebrtc/third_party/abseil-cpp/absl/types/variant_gn",
+     "/third_party/libwebrtc/third_party/abseil-cpp/absl/utility/utility_gn",
+-    "/third_party/libwebrtc/third_party/libvpx/libvpx_gn",
+     "/third_party/libwebrtc/third_party/libyuv/libyuv_gn",
+     "/third_party/libwebrtc/third_party/pffft/pffft_gn",
+     "/third_party/libwebrtc/third_party/rnnoise/rnn_vad_gn",

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -245,6 +245,9 @@ buildStdenv.mkDerivation {
       hash = "sha256-cWOyvjIPUU1tavPRqg61xJ53XE4EJTdsFzadfVxyTyM=";
     })
   ]
+  ++ lib.optionals (lib.versionAtLeast version "122" && lib.versionOlder version "122.0.1") [
+    ./122.0-libvpx-mozbz1875201.patch
+  ]
   ++ extraPatches;
 
   postPatch = ''


### PR DESCRIPTION
The WebRTC parts of Firefox 122.0 are unconditionally linked against the vendored libvpx that they ship with This lead to an ABI mismatch¹, when building with --with-system-libvpx, since our libvpx version differs.

An upstream fix is expected to be shipped in Firefox 122.0.1, which is due in the next few days.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1875201#c11

cc #283010 

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
