### PR TITLE
libretro: Added Mr.Boom libretro core

### DIFF
--- a/pkgs/applications/emulators/retroarch/cores.nix
+++ b/pkgs/applications/emulators/retroarch/cores.nix
@@ -641,6 +641,15 @@ in
     };
   };
 
+  mrboom = mkLibretroCore {
+    core = "mrboom";
+    makefile = "Makefile";
+    meta = {
+      description = "Port of Mr.Boom to libretro";
+      license = lib.licenses.mit;
+    };
+  };
+
   mupen64plus = mkLibretroCore {
     core = "mupen64plus-next";
     src = getCoreSrc "mupen64plus";

--- a/pkgs/applications/emulators/retroarch/hashes.json
+++ b/pkgs/applications/emulators/retroarch/hashes.json
@@ -307,6 +307,13 @@
         "rev": "314bf7b676f5b820f396209eb0c7d6fbe8103486",
         "hash": "sha256-Rk+glDgSa1J1IIe5NrJElX9zr59+LQynfDXuHWyZcEM="
     },
+    "mrboom": {
+        "owner": "Javanaise",
+        "repo": "mrboom-libretro",
+        "rev": "c4ec620424fe79f0d6db719d73628f23ae285ada",
+        "hash": "sha256-twocTyayV79a4757Yfoz/P3wnQPgiwsbrBbLmT4EZKQ=",
+        "fetchSubmodules": true
+    },
     "mupen64plus": {
         "owner": "libretro",
         "repo": "mupen64plus-libretro-nx",

--- a/pkgs/applications/emulators/retroarch/update_cores.py
+++ b/pkgs/applications/emulators/retroarch/update_cores.py
@@ -62,6 +62,7 @@ CORES = {
     "mesen": {"repo": "mesen"},
     "mesen-s": {"repo": "mesen-s"},
     "meteor": {"repo": "meteor-libretro"},
+    "mrboom": {"repo": "mrboom-libretro", "owner": "Javanaise", "fetch_submodules": True},
     "mgba": {"repo": "mgba"},
     "mupen64plus": {"repo": "mupen64plus-libretro-nx"},
     "neocd": {"repo": "neocd_libretro"},


### PR DESCRIPTION
## Description of changes

Mr.Boom is a Bomberman clone, which was forked to create the libretro port. This patch adds this libretro port to the nixpkgs core suite.

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
