### PR TITLE
zulu17: 17.0.8.1 -> 17.0.10

### DIFF
--- a/pkgs/development/compilers/zulu/17.nix
+++ b/pkgs/development/compilers/zulu/17.nix
@@ -8,35 +8,35 @@ callPackage ./common.nix ({
   # Note that the latest build may differ by platform
   dists = {
     x86_64-linux = {
-      zuluVersion = "17.44.53";
-      jdkVersion = "17.0.8.1";
+      zuluVersion = "17.48.15";
+      jdkVersion = "17.0.10";
       hash =
-        if enableJavaFX then "sha256-R6VJcSjpKFfsO3l32+8s+wlcuAVoXcSsW5Dg2M/hjpI="
-        else "sha256-uUgvIwShpophTfrN3PKVaacvD6wy5sdPg9wbmhV7g0A=";
+        if enableJavaFX then "sha256-YvuD/n84+DARPm+38TxIUB727SIhASFo+WX9+PtJqyw="
+        else "sha256-VyhNob2G1Tq/WCKT0g0Y//f+JD2hWgj6QU9idfvUj+I=";
     };
 
     aarch64-linux = {
-      zuluVersion = "17.44.53";
-      jdkVersion = "17.0.8.1";
+      zuluVersion = "17.48.15";
+      jdkVersion = "17.0.10";
       hash =
         if enableJavaFX then throw "JavaFX is not available for aarch64-linux"
-        else "sha256-ZTHO9h5BbVp7aRVVyM8r3/aJIBuKAB/0WrZ0AGK0QxM=";
+        else "sha256-9OZl8ruaLvjdpg42fC3IM5mC/9lmshCppNfUuz/Sf8E=";
     };
 
     x86_64-darwin = {
-      zuluVersion = "17.44.53";
-      jdkVersion = "17.0.8.1";
+      zuluVersion = "17.48.15";
+      jdkVersion = "17.0.10";
       hash =
-        if enableJavaFX then "sha256-9U0XYZRA+LZTQ7eHrT5SWhgcxv43ajC9n9Tj3qPPLWA="
-        else "sha256-ZART6K/o/+D7Tc60U1+1DbnCg8ZGZe67C6aLGeZfSx8=";
+        if enableJavaFX then "sha256-VOIcFtjQiYsA4AiP1TCa0Q76Ew5FdeJCICwsYGU+Dnw="
+        else "sha256-huSKGvOnrEUAiE2MJbdHWtF2saeLGaQkZllXzDo8o+g=";
     };
 
     aarch64-darwin = {
-      zuluVersion = "17.44.53";
-      jdkVersion = "17.0.8.1";
+      zuluVersion = "17.48.15";
+      jdkVersion = "17.0.10";
       hash =
-        if enableJavaFX then "sha256-udYW3nOADclWqVcVtS9dgjSY0w6xf2nsBpLzPmQCYlI="
-        else "sha256-MUsEVo7Arps2ugPJy9Qq3J4SZfdGeJI7GSl9ZuuE3Mo=";
+        if enableJavaFX then "sha256-fxBDhHMeL5IP4eRw9ykXrRRh7Nl9DnvDB1YLaQwFHLg="
+        else "sha256-kuEiHSkb4WFtPB3m0A968LPZw7Wl0sKquhbzDF8vQS8=";
     };
   };
 } // builtins.removeAttrs args [ "callPackage" ])


### PR DESCRIPTION
## Description of changes

https://www.azul.com/downloads/?version=java-17-lts&package=jdk

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
