### PR TITLE
nixos/getty: add option to autologin once per boot

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -275,6 +275,9 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
   existing process, but will need to start that process from gdb (so it is a
   child). Or you can set `boot.kernel.sysctl."kernel.yama.ptrace_scope"` to 0.
 
+- The new option `services.getty.autologinOnce` was added to limit the automatic login to once per boot and on the first tty only.
+  When using full disk encryption, this option allows to unlock the system without retyping the passphrase while keeping the other ttys protected.
+
 - The netbird module now allows running multiple tunnels in parallel through [`services.netbird.tunnels`](#opt-services.netbird.tunnels).
 
 - [Nginx virtual hosts](#opt-services.nginx.virtualHosts) using `forceSSL` or

--- a/nixos/modules/services/ttys/getty.nix
+++ b/nixos/modules/services/ttys/getty.nix
@@ -7,14 +7,26 @@ let
 
   baseArgs = [
     "--login-program" "${cfg.loginProgram}"
-  ] ++ optionals (cfg.autologinUser != null) [
+  ] ++ optionals (cfg.autologinUser != null && !cfg.autologinOnce) [
     "--autologin" cfg.autologinUser
   ] ++ optionals (cfg.loginOptions != null) [
     "--login-options" cfg.loginOptions
   ] ++ cfg.extraArgs;
 
   gettyCmd = args:
-    "@${pkgs.util-linux}/sbin/agetty agetty ${escapeShellArgs baseArgs} ${args}";
+    "${pkgs.util-linux}/sbin/agetty ${escapeShellArgs baseArgs} ${args}";
+
+  autologinScript = ''
+    otherArgs="--noclear --keep-baud $TTY 115200,38400,9600 $TERM";
+    ${lib.optionalString cfg.autologinOnce ''
+      autologged="/run/agetty.autologged"
+      if test "$TTY" = tty1 && ! test -f "$autologged"; then
+        touch "$autologged"
+        exec ${gettyCmd "$otherArgs --autologin ${cfg.autologinUser}"}
+      fi
+    ''}
+    exec ${gettyCmd "$otherArgs"}
+  '';
 
 in
 
@@ -37,6 +49,16 @@ in
         description = lib.mdDoc ''
           Username of the account that will be automatically logged in at the console.
           If unspecified, a login prompt is shown as usual.
+        '';
+      };
+
+      autologinOnce = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          If enabled the automatic login will only happen in the first tty
+          once per boot. This can be useful to avoid retyping the account
+          password on systems with full disk encrypted.
         '';
       };
 
@@ -106,9 +128,11 @@ in
 
     systemd.services."getty@" =
       { serviceConfig.ExecStart = [
-          "" # override upstream default with an empty ExecStart
-          (gettyCmd "--noclear --keep-baud %I 115200,38400,9600 $TERM")
+          # override upstream default with an empty ExecStart
+          ""
+          (pkgs.writers.writeDash "getty" autologinScript)
         ];
+        environment.TTY = "%I";
         restartIfChanged = false;
       };
 


### PR DESCRIPTION
## Description of changes

## Things done

- Tested
  - [x] nixosTests.simple
  - [x] nixosTests.gnupg (uses `autologinUser`)
  - [x] that with `autologinOnce` user is logged in on tty1 only
  - [x] that with `autologinOnce` logging out does not retrigger autologin
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
