### PR TITLE
retroarch: 1.16.0.3 -> 1.17.0; libretro: update cores

### DIFF
--- a/pkgs/applications/emulators/retroarch/cores.nix
+++ b/pkgs/applications/emulators/retroarch/cores.nix
@@ -828,6 +828,9 @@ in
     makefile = "Makefile";
     cmakeFlags = [ "-DBUILD_PLAY=OFF" "-DBUILD_LIBRETRO_CORE=ON" ];
     postBuild = "cd Source/ui_libretro";
+    # FIXME: workaround the following GCC 13 error:
+    # error: 'printf' was not declared in this scop
+    CXXFLAGS = "-include cstdio";
     meta = {
       description = "Port of Play! to libretro";
       license = lib.licenses.bsd2;

--- a/pkgs/applications/emulators/retroarch/cores.nix
+++ b/pkgs/applications/emulators/retroarch/cores.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, gcc12Stdenv
 , alsa-lib
 , boost
 , bzip2
@@ -303,15 +304,21 @@ in
     };
   };
 
-  citra = mkLibretroCore {
+  citra = mkLibretroCore rec {
     core = "citra";
     extraBuildInputs = [ libGLU libGL boost ffmpeg nasm ];
     makefile = "Makefile";
     makeFlags = [
       "HAVE_FFMPEG_STATIC=0"
-      # https://github.com/libretro/citra/blob/1a66174355b5ed948de48ef13c0ed508b6d6169f/Makefile#L90
+      # https://github.com/libretro/citra/blob/1a66174355b5ed948de48ef13c0ed508b6d6169f/Makefile#L87-L90
+      "GIT_REV=${(getCoreSrc core).rev}"
+      "GIT_DESC=${lib.substring 0 8 (getCoreSrc core).rev}"
+      "GIT_BRANCH=master"
       "BUILD_DATE=01/01/1970_00:00"
     ];
+    # FIXME: build fail with GCC13:
+    # error: 'mic_device_name' has incomplete type
+    stdenv = gcc12Stdenv;
     meta = {
       description = "Port of Citra to libretro";
       license = lib.licenses.gpl2Plus;

--- a/pkgs/applications/emulators/retroarch/cores.nix
+++ b/pkgs/applications/emulators/retroarch/cores.nix
@@ -44,13 +44,21 @@
 let
   hashesFile = lib.importJSON ./hashes.json;
 
+  getCore = core: (lib.getAttr core hashesFile);
+
   getCoreSrc = core:
-    fetchFromGitHub (builtins.getAttr core hashesFile);
+    (lib.pipe core [
+      getCore
+      (x: builtins.removeAttrs x [ "date" ])
+      fetchFromGitHub
+    ]);
+
+  getCoreDate = core: (getCore core).date or "unstable-1970-01-01";
 
   mkLibretroCore =
     { core
     , src ? (getCoreSrc core)
-    , version ? "unstable-2023-09-24"
+    , version ? (getCoreDate core)
     , ...
     }@args:
     import ./mkLibretroCore.nix ({

--- a/pkgs/applications/emulators/retroarch/cores.nix
+++ b/pkgs/applications/emulators/retroarch/cores.nix
@@ -594,7 +594,8 @@ in
     extraNativeBuildInputs = [ python3 ];
     extraBuildInputs = [ alsa-lib ];
     makefile = "Makefile";
-    enableParallelBuilding = false;
+    # Build failures when this is set to a bigger number
+    NIX_BUILD_CORES = 8;
     meta = {
       description = "Port of MAME ~2015 to libretro, compatible with MAME 0.160 sets";
       # MAME license, non-commercial clause

--- a/pkgs/applications/emulators/retroarch/cores.nix
+++ b/pkgs/applications/emulators/retroarch/cores.nix
@@ -914,6 +914,9 @@ in
     core = "same_cdi";
     extraNativeBuildInputs = [ python3 ];
     extraBuildInputs = [ alsa-lib libGLU libGL portaudio xorg.libX11 ];
+    # FIXME: build fail with GCC13:
+    # error: 'uint8_t' in namespace 'std' does not name a type; did you mean 'wint_t'?
+    stdenv = gcc12Stdenv;
     meta = {
       description = "SAME_CDI is a libretro core to play CD-i games";
       license = with lib.licenses; [ bsd3 gpl2Plus ];

--- a/pkgs/applications/emulators/retroarch/cores.nix
+++ b/pkgs/applications/emulators/retroarch/cores.nix
@@ -610,6 +610,8 @@ in
     makeFlags = [ "PYTHON_EXECUTABLE=python3" ];
     # Build failures when this is set to a bigger number
     NIX_BUILD_CORES = 8;
+    # Fix build errors in GCC13
+    NIX_CFLAGS_COMPILE = "-Wno-error -fpermissive";
     meta = {
       description = "Port of MAME ~2016 to libretro, compatible with MAME 0.174 sets";
       license = with lib.licenses; [ bsd3 gpl2Plus ];

--- a/pkgs/applications/emulators/retroarch/cores.nix
+++ b/pkgs/applications/emulators/retroarch/cores.nix
@@ -608,7 +608,8 @@ in
     extraNativeBuildInputs = [ python3 ];
     extraBuildInputs = [ alsa-lib ];
     makeFlags = [ "PYTHON_EXECUTABLE=python3" ];
-    enableParallelBuilding = false;
+    # Build failures when this is set to a bigger number
+    NIX_BUILD_CORES = 8;
     meta = {
       description = "Port of MAME ~2016 to libretro, compatible with MAME 0.174 sets";
       license = with lib.licenses; [ bsd3 gpl2Plus ];

--- a/pkgs/applications/emulators/retroarch/cores.nix
+++ b/pkgs/applications/emulators/retroarch/cores.nix
@@ -678,11 +678,6 @@ in
       "LLE=1"
       "WITH_DYNAREC=${stdenv.hostPlatform.parsed.cpu.name}"
     ];
-    # This CXXFLAGS hack works around the GCC 13 error:
-    # 'uint32_t' was not declared in this scope
-    # It can be removed if the issue filed upstream is resolved:
-    # https://github.com/libretro/mupen64plus-libretro-nx/issues/515
-    env.CXXFLAGS = "-include cstdint";
     meta = {
       description = "Libretro port of Mupen64 Plus, GL only";
       license = lib.licenses.gpl3Only;

--- a/pkgs/applications/emulators/retroarch/cores.nix
+++ b/pkgs/applications/emulators/retroarch/cores.nix
@@ -44,25 +44,33 @@
 let
   hashesFile = lib.importJSON ./hashes.json;
 
-  getCore = core: (lib.getAttr core hashesFile);
+  getCore = repo: (lib.getAttr repo hashesFile);
 
-  getCoreSrc = core:
-    (lib.pipe core [
+  getCoreSrc = repo:
+    (lib.pipe repo [
       getCore
       (x: builtins.removeAttrs x [ "date" ])
       fetchFromGitHub
     ]);
 
-  getCoreDate = core: (getCore core).date or "unstable-1970-01-01";
+  getCoreDate = repo: (getCore repo).date or "unstable-1970-01-01";
 
   mkLibretroCore =
+    # Sometimes core name != repo name, so you may need to set them differently
+    # when necessary:
+    # - core: used by the resulting core library name, e.g.:
+    #   `${core}_libretro.so`. Needs to match their respectful core info file
+    #   (see https://github.com/libretro/libretro-core-info/)
+    # - repo: the repository name on GitHub
+    # See `update_cores.py` for instruction on how to add a new core.
     { core
-    , src ? (getCoreSrc core)
-    , version ? (getCoreDate core)
+    , repo ? core
+    , src ? (getCoreSrc repo)
+    , version ? (getCoreDate repo)
     , ...
     }@args:
     import ./mkLibretroCore.nix ({
-      inherit lib stdenv core src version makeWrapper retroarch zlib;
+      inherit lib stdenv core repo src version makeWrapper retroarch zlib;
     } // args);
 in
 {
@@ -80,7 +88,7 @@ in
 
   beetle-gba = mkLibretroCore {
     core = "mednafen-gba";
-    src = getCoreSrc "beetle-gba";
+    repo = "beetle-gba";
     makefile = "Makefile";
     meta = {
       description = "Port of Mednafen's GameBoy Advance core to libretro";
@@ -90,7 +98,7 @@ in
 
   beetle-lynx = mkLibretroCore {
     core = "mednafen-lynx";
-    src = getCoreSrc "beetle-lynx";
+    repo = "beetle-lynx";
     makefile = "Makefile";
     meta = {
       description = "Port of Mednafen's Lynx core to libretro";
@@ -100,7 +108,7 @@ in
 
   beetle-ngp = mkLibretroCore {
     core = "mednafen-ngp";
-    src = getCoreSrc "beetle-ngp";
+    repo = "beetle-ngp";
     makefile = "Makefile";
     meta = {
       description = "Port of Mednafen's NeoGeo Pocket core to libretro";
@@ -110,7 +118,7 @@ in
 
   beetle-pce = mkLibretroCore {
     core = "mednafen-pce";
-    src = getCoreSrc "beetle-pce";
+    repo = "beetle-pce";
     makefile = "Makefile";
     meta = {
       description = "Port of Mednafen's PC Engine core to libretro";
@@ -120,7 +128,7 @@ in
 
   beetle-pce-fast = mkLibretroCore {
     core = "mednafen-pce-fast";
-    src = getCoreSrc "beetle-pce-fast";
+    repo = "beetle-pce-fast";
     makefile = "Makefile";
     meta = {
       description = "Port of Mednafen's PC Engine fast core to libretro";
@@ -130,7 +138,7 @@ in
 
   beetle-pcfx = mkLibretroCore {
     core = "mednafen-pcfx";
-    src = getCoreSrc "beetle-pcfx";
+    repo = "beetle-pcfx";
     makefile = "Makefile";
     meta = {
       description = "Port of Mednafen's PCFX core to libretro";
@@ -140,7 +148,7 @@ in
 
   beetle-psx = mkLibretroCore {
     core = "mednafen-psx";
-    src = getCoreSrc "beetle-psx";
+    repo = "beetle-psx";
     makefile = "Makefile";
     makeFlags = [ "HAVE_HW=0" "HAVE_LIGHTREC=1" ];
     meta = {
@@ -151,7 +159,7 @@ in
 
   beetle-psx-hw = mkLibretroCore {
     core = "mednafen-psx-hw";
-    src = getCoreSrc "beetle-psx";
+    repo = "beetle-psx";
     extraBuildInputs = [ libGL libGLU ];
     makefile = "Makefile";
     makeFlags = [ "HAVE_VULKAN=1" "HAVE_OPENGL=1" "HAVE_HW=1" "HAVE_LIGHTREC=1" ];
@@ -163,7 +171,7 @@ in
 
   beetle-saturn = mkLibretroCore {
     core = "mednafen-saturn";
-    src = getCoreSrc "beetle-saturn";
+    repo = "beetle-saturn";
     makefile = "Makefile";
     meta = {
       description = "Port of Mednafen's Saturn core to libretro";
@@ -174,7 +182,7 @@ in
 
   beetle-supafaust = mkLibretroCore {
     core = "mednafen-supafaust";
-    src = getCoreSrc "beetle-supafaust";
+    repo = "beetle-supafaust";
     makefile = "Makefile";
     meta = {
       description = "Port of Mednafen's experimental snes_faust core to libretro";
@@ -184,7 +192,7 @@ in
 
   beetle-supergrafx = mkLibretroCore {
     core = "mednafen-supergrafx";
-    src = getCoreSrc "beetle-supergrafx";
+    repo = "beetle-supergrafx";
     makefile = "Makefile";
     meta = {
       description = "Port of Mednafen's SuperGrafx core to libretro";
@@ -194,7 +202,7 @@ in
 
   beetle-vb = mkLibretroCore {
     core = "mednafen-vb";
-    src = getCoreSrc "beetle-vb";
+    repo = "beetle-vb";
     makefile = "Makefile";
     meta = {
       description = "Port of Mednafen's VirtualBoy core to libretro";
@@ -204,7 +212,7 @@ in
 
   beetle-wswan = mkLibretroCore {
     core = "mednafen-wswan";
-    src = getCoreSrc "beetle-wswan";
+    repo = "beetle-wswan";
     makefile = "Makefile";
     meta = {
       description = "Port of Mednafen's WonderSwan core to libretro";
@@ -240,7 +248,7 @@ in
 
   bsnes-hd = mkLibretroCore {
     core = "bsnes-hd-beta";
-    src = getCoreSrc "bsnes-hd";
+    repo = "bsnes-hd";
     makefile = "GNUmakefile";
     makeFlags =
       let
@@ -264,7 +272,7 @@ in
 
   bsnes-mercury = mkLibretroCore {
     core = "bsnes-mercury-accuracy";
-    src = getCoreSrc "bsnes-mercury";
+    repo = "bsnes-mercury";
     makefile = "Makefile";
     makeFlags = [ "PROFILE=accuracy" ];
     meta = {
@@ -275,7 +283,7 @@ in
 
   bsnes-mercury-balanced = mkLibretroCore {
     core = "bsnes-mercury-balanced";
-    src = getCoreSrc "bsnes-mercury";
+    repo = "bsnes-mercury";
     makefile = "Makefile";
     makeFlags = [ "PROFILE=balanced" ];
     meta = {
@@ -286,7 +294,7 @@ in
 
   bsnes-mercury-performance = mkLibretroCore {
     core = "bsnes-mercury-performance";
-    src = getCoreSrc "bsnes-mercury";
+    repo = "bsnes-mercury";
     makefile = "Makefile";
     makeFlags = [ "PROFILE=performance" ];
     meta = {
@@ -385,7 +393,7 @@ in
 
   eightyone = mkLibretroCore {
     core = "81";
-    src = getCoreSrc "eightyone";
+    repo = "eightyone";
     meta = {
       description = "Port of EightyOne to libretro";
       license = lib.licenses.gpl3Only;
@@ -660,7 +668,7 @@ in
 
   mupen64plus = mkLibretroCore {
     core = "mupen64plus-next";
-    src = getCoreSrc "mupen64plus";
+    repo = "mupen64plus";
     extraBuildInputs = [ libGLU libGL libpng nasm xorg.libX11 ];
     makefile = "Makefile";
     makeFlags = [
@@ -711,11 +719,10 @@ in
 
   np2kai = mkLibretroCore rec {
     core = "np2kai";
-    src = getCoreSrc core;
     makeFlags = [
       # See https://github.com/AZO234/NP2kai/tags
       "NP2KAI_VERSION=rev.22"
-      "NP2KAI_HASH=${src.rev}"
+      "NP2KAI_HASH=${(getCoreSrc core).rev}"
     ];
     preBuild = "cd sdl";
     meta = {
@@ -921,7 +928,7 @@ in
 
   smsplus-gx = mkLibretroCore {
     core = "smsplus";
-    src = getCoreSrc "smsplus-gx";
+    repo = "smsplus-gx";
     meta = {
       description = "SMS Plus GX libretro port";
       license = lib.licenses.gpl2Plus;
@@ -961,7 +968,7 @@ in
 
   snes9x2005-plus = mkLibretroCore {
     core = "snes9x2005-plus";
-    src = getCoreSrc "snes9x2005";
+    repo = "snes9x2005";
     makefile = "Makefile";
     makeFlags = [ "USE_BLARGG_APU=1" ];
     meta = {
@@ -1063,7 +1070,7 @@ in
 
   vba-m = mkLibretroCore {
     core = "vbam";
-    src = getCoreSrc "vba-m";
+    repo = "vba-m";
     makefile = "Makefile";
     preBuild = "cd src/libretro";
     meta = {

--- a/pkgs/applications/emulators/retroarch/cores.nix
+++ b/pkgs/applications/emulators/retroarch/cores.nix
@@ -790,18 +790,18 @@ in
       xxd
     ];
     makefile = "Makefile";
-    cmakeFlags = [
-      "-DLIBRETRO=ON"
-    ];
+    cmakeFlags = [ "-DLIBRETRO=ON" ];
+    # remove ccache
     postPatch = ''
-      # remove ccache
       substituteInPlace CMakeLists.txt --replace "ccache" ""
     '';
-
+    postBuild = "cd pcsx2";
     # causes redefinition of _FORTIFY_SOURCE
     hardeningDisable = [ "fortify3" ];
-
-    postBuild = "cd pcsx2";
+    # FIXME: multiple build errors with GCC13.
+    # Unlikely to be fixed until we switch to libretro/pcsx2 that is a more
+    # up-to-date port (but still WIP).
+    stdenv = gcc12Stdenv;
     meta = {
       description = "Port of PCSX2 to libretro";
       license = lib.licenses.gpl3Plus;

--- a/pkgs/applications/emulators/retroarch/default.nix
+++ b/pkgs/applications/emulators/retroarch/default.nix
@@ -46,12 +46,12 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "retroarch-bare";
-  version = "1.16.0.3";
+  version = "1.17.0";
 
   src = fetchFromGitHub {
     owner = "libretro";
     repo = "RetroArch";
-    hash = "sha256-BT+LzRDoQF03aNT2Kg7YaSWhK74CvOOiHUeHDtFpe9s=";
+    hash = "sha256-8Y8ZYZFNK7zk0bQRiWwoQbu6q3r25bN3EvLOA3kIxdU=";
     rev = "v${version}";
   };
 

--- a/pkgs/applications/emulators/retroarch/default.nix
+++ b/pkgs/applications/emulators/retroarch/default.nix
@@ -12,6 +12,7 @@
 , flac
 , freetype
 , gamemode
+, gitUpdater
 , libdrm
 , libGL
 , libGLU
@@ -122,7 +123,12 @@ stdenv.mkDerivation rec {
     rm $out/share/man/man6/retroarch-cg2glsl.6*
   '';
 
-  passthru.tests = nixosTests.retroarch;
+  passthru = {
+    tests = nixosTests.retroarch;
+    updateScript = gitUpdater {
+      rev-prefix = "v";
+    };
+  };
 
   meta = with lib; {
     homepage = "https://libretro.com";

--- a/pkgs/applications/emulators/retroarch/hashes.json
+++ b/pkgs/applications/emulators/retroarch/hashes.json
@@ -3,536 +3,624 @@
         "owner": "libretro",
         "repo": "libretro-2048",
         "rev": "331c1de588ed8f8c370dcbc488e5434a3c09f0f2",
-        "hash": "sha256-gPrAmoBnfuTnW6t699pqS43vE6t0ca3jZcqTNRaJipA="
+        "hash": "sha256-gPrAmoBnfuTnW6t699pqS43vE6t0ca3jZcqTNRaJipA=",
+        "date": "unstable-2023-02-20"
     },
     "atari800": {
         "owner": "libretro",
         "repo": "libretro-atari800",
-        "rev": "20d59afb3f19065749549732f20845c3be82e68c",
-        "hash": "sha256-5cxBubhw60Jmp1p5TQ/L6RLaLANctG0TdpzGnpCadIM="
+        "rev": "410d7bf0c215f3444793a9cec51c129e7b67c400",
+        "hash": "sha256-mUhAraZrmElB6rxQziQG6I2sCdkiX5wYBJhkZgpMSa0=",
+        "date": "unstable-2023-11-14"
     },
     "beetle-gba": {
         "owner": "libretro",
         "repo": "beetle-gba-libretro",
         "rev": "38182572571a48cb58057cde64b915237c4e2d58",
-        "hash": "sha256-4xnXWswozlcXBNI1lbGSNW/gAdIeLLO9Bf1SxOFLhSo="
+        "hash": "sha256-4xnXWswozlcXBNI1lbGSNW/gAdIeLLO9Bf1SxOFLhSo=",
+        "date": "unstable-2021-09-18"
     },
     "beetle-lynx": {
         "owner": "libretro",
         "repo": "beetle-lynx-libretro",
-        "rev": "fab3ac02d5622eb53a707bd392cc037282e9d8b4",
-        "hash": "sha256-+MKH8LmqDqznDIca/Q129zIXYI23V7s38sCD6rKiZlk="
+        "rev": "48909ddd1aba4de034d9c1da70c460b1724daa3b",
+        "hash": "sha256-aAS9N54kA2st1+3BodiXDR4sbUDSvoFHpa28D9sohx4=",
+        "date": "unstable-2023-11-01"
     },
     "beetle-ngp": {
         "owner": "libretro",
         "repo": "beetle-ngp-libretro",
-        "rev": "65460e3a9ad529f6901caf669abbda11f437ab55",
-        "hash": "sha256-+xfD1ZMKtbv5Lp12+5RM7Vl3eEF38kykKW8wj/2EN5w="
+        "rev": "673c3d924ff33d71c6a342b170eff5359244df1f",
+        "hash": "sha256-V3zcbEwqay3eXwXzXZkmHj3+rx9KY4r0WkzAYFZXlgY=",
+        "date": "unstable-2023-11-01"
     },
     "beetle-pce": {
         "owner": "libretro",
         "repo": "beetle-pce-libretro",
-        "rev": "541463bd937dad175aec09c2a0c8d6a52d175386",
-        "hash": "sha256-wWS9reb6aN71Q7OlGst+32T8XX1yMCSOHUKHkXht3hg="
+        "rev": "e8870b170ad4135bf5738c7206d7a27488d388ab",
+        "hash": "sha256-c+LsfuX/3HxJTaIlZeGkGif+D1c7OpIhRUVbWuT8Kc0=",
+        "date": "unstable-2024-02-02"
     },
     "beetle-pce-fast": {
         "owner": "libretro",
         "repo": "beetle-pce-fast-libretro",
-        "rev": "f2ff19e56fb33361793f9fdaf44c1ea28bce1da3",
-        "hash": "sha256-w7weSz8HR4YNPiBPqa81s3/8b9oFijr6DxNeQ/+I9OE="
+        "rev": "cfb9362fd0de38141d40266725829f25f574162a",
+        "hash": "sha256-D/qAFFKe0mI/W4RnLwcB5lpwI+AlPjTfyo0SH6IZZkU=",
+        "date": "unstable-2024-02-02"
     },
     "beetle-pcfx": {
         "owner": "libretro",
         "repo": "beetle-pcfx-libretro",
         "rev": "47c355b6a515aef6dc57f57df1535570108a0e21",
-        "hash": "sha256-ylFo/wmLQpQGYSrv9PF2DBmr/8rklmHF9R+3y8v93Rs="
+        "hash": "sha256-ylFo/wmLQpQGYSrv9PF2DBmr/8rklmHF9R+3y8v93Rs=",
+        "date": "unstable-2023-05-28"
     },
     "beetle-psx": {
         "owner": "libretro",
         "repo": "beetle-psx-libretro",
-        "rev": "f256cc3dc3ec2f6017f7088f056996f8f155db64",
-        "hash": "sha256-McMV5p1qEvqkeTjqOaD+xHNRQly+CNen9YUJxqLpJzk="
+        "rev": "fb579de80d7b9ca09940602c14e657f6317dd046",
+        "hash": "sha256-NRnznhvmgOQdNuEYyi0HIeVPzPz7ILEQ3vsYTZY8AbE=",
+        "date": "unstable-2024-02-02"
     },
     "beetle-saturn": {
         "owner": "libretro",
         "repo": "beetle-saturn-libretro",
         "rev": "cd395e9e3ee407608450ebc565e871b24e7ffed6",
-        "hash": "sha256-EIZRv1EydfLWFoBb8TzvAY3kkL9Qr2OrwrljOnnM92A="
+        "hash": "sha256-EIZRv1EydfLWFoBb8TzvAY3kkL9Qr2OrwrljOnnM92A=",
+        "date": "unstable-2023-05-28"
     },
     "beetle-supafaust": {
         "owner": "libretro",
         "repo": "supafaust",
         "rev": "6b639c98372d1c9bac885c55d772c812d2a9d525",
-        "hash": "sha256-EVXwjrxooZm1JqG4HswUe8zwN81Rm7SPB5Fr4WfpTnc="
+        "hash": "sha256-EVXwjrxooZm1JqG4HswUe8zwN81Rm7SPB5Fr4WfpTnc=",
+        "date": "unstable-2023-06-19"
     },
     "beetle-supergrafx": {
         "owner": "libretro",
         "repo": "beetle-supergrafx-libretro",
-        "rev": "56261ccd56f576a42a2d22190c09eb326a4331da",
-        "hash": "sha256-aoEq4o9uZIAsjQQsN+tJNhOuFA9SNb7RKIUwqUGPhJQ="
+        "rev": "d24d383f88ff892e9f8dce7c1f3ce491f2f7731a",
+        "hash": "sha256-Cbol57jpDpkMnfKCULw6DgJwcnfTNexZ1hSw817z+E8=",
+        "date": "unstable-2024-02-02"
     },
     "beetle-vb": {
         "owner": "libretro",
         "repo": "beetle-vb-libretro",
-        "rev": "732a8f701e671bf032165730fdf8bd96fb5ca7bb",
-        "hash": "sha256-M19+ZidqqDdohuAVPxGVFQDQqoMl2QYM+K1WToqeOWM="
+        "rev": "9d1bd03f21dac7897f65269e1095496331efce8b",
+        "hash": "sha256-CT6CfRe8TOgXuJoUA0TKl71m10XeocUCTUjh88eCenU=",
+        "date": "unstable-2023-11-01"
     },
     "beetle-wswan": {
         "owner": "libretro",
         "repo": "beetle-wswan-libretro",
-        "rev": "a0ddcd3f084f5b4eb06acb6e03b8c4707a2f6123",
-        "hash": "sha256-FJfznSo/3YKecVSU9mZW6yzd4/8vf2qrX4xhWjptd+A="
+        "rev": "32bf70a3032a138baa969c22445f4b7821632c30",
+        "hash": "sha256-dDph7LNlvzVMVTzkUfGErMEb/tALpCADgTjnzjUHYJU=",
+        "date": "unstable-2023-11-01"
     },
     "blastem": {
         "owner": "libretro",
         "repo": "blastem",
         "rev": "277e4a62668597d4f59cadda1cbafb844f981d45",
-        "hash": "sha256-EHvKElPw8V5Z6LnMaQXBCdM4niLIlF3aBm8dRbeYXHs="
+        "hash": "sha256-EHvKElPw8V5Z6LnMaQXBCdM4niLIlF3aBm8dRbeYXHs=",
+        "date": "unstable-2022-07-26"
     },
     "bluemsx": {
         "owner": "libretro",
         "repo": "bluemsx-libretro",
-        "rev": "e21bf74bddb79ad1bbe20b4d964e7515269c669b",
-        "hash": "sha256-U58zJd7txOyd9jymVmogQMIH5Av2kjO5MOn49T2FmqQ="
+        "rev": "e8a4280bcbd149d1e020adcd9469ad9d8bd67412",
+        "hash": "sha256-uh4lMOCN1WXKVJybFkkGxIRWAlde74yPH5eaB1/1qsk=",
+        "date": "unstable-2023-11-10"
     },
     "bsnes": {
         "owner": "libretro",
         "repo": "bsnes-libretro",
-        "rev": "3fe4f9049f99ac71d038b3cb684ebfc8e6cef15a",
-        "hash": "sha256-fUcJQGkLGTgxEGwWVoZ4Hys9kOKAft7CDTTdQ8j4+Do="
+        "rev": "dda5b43ed6a552310528509af59bed26af2527f5",
+        "hash": "sha256-7AXHq6ASQ+42yef/jQ74kZtpW9SUuXpmWZbtO84/COg=",
+        "date": "unstable-2024-02-02"
     },
     "bsnes-hd": {
         "owner": "DerKoun",
         "repo": "bsnes-hd",
         "rev": "f46b6d6368ea93943a30b5d4e79e8ed51c2da5e8",
-        "hash": "sha256-Y3FhGtcz7BzwUSBy1SGMuylJdZti/JB8qQnabIkG/dI="
+        "hash": "sha256-Y3FhGtcz7BzwUSBy1SGMuylJdZti/JB8qQnabIkG/dI=",
+        "date": "unstable-2023-04-26"
     },
     "bsnes-mercury": {
         "owner": "libretro",
         "repo": "bsnes-mercury",
-        "rev": "fb9a41fe9bc230a07c4506cad3cbf21d3fa635b4",
-        "hash": "sha256-gBOxKSv3j229IVdtffqFV/zSSacEs8UsBERnQgdFw4Y="
+        "rev": "60c204ca17941704110885a815a65c740572326f",
+        "hash": "sha256-eJ0lac1I7E4YdsVVrIuXx31UL9w3OR6QTVHq5YBgnJU=",
+        "date": "unstable-2023-11-01"
     },
     "citra": {
         "owner": "libretro",
         "repo": "citra",
-        "rev": "d7e1612c17b1acb5d5eb68bb046820db49aeea5e",
+        "rev": "2d67658e85de4767c0eefeb2829d710401c5c802",
         "hash": "sha256-u2XwAudFgI7j/k6Bq5fk874aI6KpZawlBoIs2+M+eZY=",
-        "fetchSubmodules": true
+        "fetchSubmodules": true,
+        "date": "unstable-2024-01-24"
     },
     "desmume": {
         "owner": "libretro",
         "repo": "desmume",
-        "rev": "cf0fcc6ea4a85b7491bdf9adc7bf09748b4be7da",
-        "hash": "sha256-ne4Tu8U/WSB4vlwBQMK7Ss3UEpDxsOFltpMk2hIx23M="
+        "rev": "b518fec54b79f2f71a7536715efcdcd7f60638a8",
+        "hash": "sha256-X6ZL+XdsrdPoOU5zqNsUraMrlPU/HmKWUolrWjFcbDQ=",
+        "date": "unstable-2024-01-11"
     },
     "desmume2015": {
         "owner": "libretro",
         "repo": "desmume2015",
         "rev": "af397ff3d1f208c27f3922cc8f2b8e08884ba893",
-        "hash": "sha256-kEb+og4g7rJvCinBZKcb42geZO6W8ynGsTG9yqYgI+U="
+        "hash": "sha256-kEb+og4g7rJvCinBZKcb42geZO6W8ynGsTG9yqYgI+U=",
+        "date": "unstable-2022-04-05"
     },
     "dolphin": {
         "owner": "libretro",
         "repo": "dolphin",
         "rev": "2f4b0f7902257d40a054f60b2c670d6e314f2a04",
-        "hash": "sha256-9WYWbLehExYbPmGJpguhVFXqFJ9aR6VxzFVChd4QOEg="
+        "hash": "sha256-9WYWbLehExYbPmGJpguhVFXqFJ9aR6VxzFVChd4QOEg=",
+        "date": "unstable-2022-12-17"
     },
     "dosbox": {
         "owner": "libretro",
         "repo": "dosbox-libretro",
         "rev": "b7b24262c282c0caef2368c87323ff8c381b3102",
-        "hash": "sha256-PG2eElenlEpu0U/NIh53p0uLqewnEdaq6Aoak5E1P3I="
+        "hash": "sha256-PG2eElenlEpu0U/NIh53p0uLqewnEdaq6Aoak5E1P3I=",
+        "date": "unstable-2022-07-18"
     },
     "dosbox-pure": {
         "owner": "schellingb",
         "repo": "dosbox-pure",
-        "rev": "e8396b8564ed88d87702ee40b935dec6384c0e5a",
-        "hash": "sha256-rD7b1uX/Wsu2ik06IiHKbUHT05IllCoBcPMN9OJ0+X4="
+        "rev": "87bf6365158325b76ff238c1ad8daf16a859bbe8",
+        "hash": "sha256-IU5AnOEuwZm/bJ9NuxhTQ8Tb5ngmjysLj/om/6P730s=",
+        "date": "unstable-2023-12-29"
     },
     "eightyone": {
         "owner": "libretro",
         "repo": "81-libretro",
-        "rev": "6d1b4d26aa9870133616fcfb5a763ca138ae25d1",
-        "hash": "sha256-KCtJvYWcS3DjAZfyP4sG496X9fOHji/ZwpjiZD0OFDY="
+        "rev": "525d5c18f1ff3fc54c37e083a475225d9179d59d",
+        "hash": "sha256-H0w9hcAUVOGr0PtNLVdFQScxd3ildZZ68w+TL7vG4jk=",
+        "date": "unstable-2023-11-01"
     },
     "fbalpha2012": {
         "owner": "libretro",
         "repo": "fbalpha2012",
-        "rev": "7f8860543a81ba79c0e1ce1aa219af44568c628a",
-        "hash": "sha256-r1lH+CR+nVRCPkVo0XwLi35/ven/FEkNhWUTA6cUVxc="
+        "rev": "b7ac554c53561d41640372f23dab15cd6fc4f0c4",
+        "hash": "sha256-BaeMLej2MLc4uipqTD2z2sHUeOsc50Q1c+PEiPD1cks=",
+        "date": "unstable-2023-11-01"
     },
     "fbneo": {
         "owner": "libretro",
         "repo": "fbneo",
-        "rev": "9e22c4c7ac42d5f1e5ffacdecb26acae60c663eb",
-        "hash": "sha256-obzPz5lPqcQzLbB7cFGI50W1rFnF8tqZkpocETSAH0Q="
+        "rev": "e8cd9f81bc974f7427d9cff9ffc1d2f3a8d15f1f",
+        "hash": "sha256-XR/pLOvQ8L2dLguC1I2C7z8FoBid6oFSudnQNY3ub7c=",
+        "date": "unstable-2024-01-30"
     },
     "fceumm": {
         "owner": "libretro",
         "repo": "libretro-fceumm",
-        "rev": "7fad08e5522e5396a1196055fc106be9b5d5de77",
-        "hash": "sha256-XHutsAc2PD8INP2u8WTmr2+rxuklXjBruH/mNl5Ro34="
+        "rev": "63643ba02c8eaea15dbe167ef907f3da7a3e6fd7",
+        "hash": "sha256-xy8hzZ7nt2hHjRJmsty/w/cPzEtdlSkmNAsog3+h5YU=",
+        "date": "unstable-2024-01-25"
     },
     "flycast": {
         "owner": "flyinghead",
         "repo": "flycast",
-        "rev": "39a212140a159e7e7a183a40a201863c0560a945",
-        "hash": "sha256-lvagJRedkh9m48yHo7ErsIyW9W2QXs6wnEjSgtrHE74=",
-        "fetchSubmodules": true
+        "rev": "c146a92f83ae2cba8df8970e21efc54301b9ade1",
+        "hash": "sha256-+ZED9pLfPr4uNNMNTmsrQWUgbKLW3DnPBdniwQ1fr9U=",
+        "fetchSubmodules": true,
+        "date": "unstable-2024-02-03"
     },
     "fmsx": {
         "owner": "libretro",
         "repo": "fmsx-libretro",
         "rev": "1806eed4376fbe2fad82fa19271ea298cfbb7795",
-        "hash": "sha256-nX0H/+iEq7eBN4tm1+dT6/3BYLCpoyiE/L6waDPmUZI="
+        "hash": "sha256-nX0H/+iEq7eBN4tm1+dT6/3BYLCpoyiE/L6waDPmUZI=",
+        "date": "unstable-2023-04-17"
     },
     "freeintv": {
         "owner": "libretro",
         "repo": "freeintv",
         "rev": "85bf25a39a34bbc39fe36677175d87c2b597dbe7",
-        "hash": "sha256-4cU/YRZZb7EWNBJX8M91Lb+bCCIlks6xX2Cf6Iq/g9g="
+        "hash": "sha256-4cU/YRZZb7EWNBJX8M91Lb+bCCIlks6xX2Cf6Iq/g9g=",
+        "date": "unstable-2023-04-17"
     },
     "fuse": {
         "owner": "libretro",
         "repo": "fuse-libretro",
         "rev": "847dbbd6f787823ac9a5dfacdd68ab181063374e",
-        "hash": "sha256-jzS7SFALV/YjI77ST+IWHwUsuhT+Zr5w4t6C7O8yzFM="
+        "hash": "sha256-jzS7SFALV/YjI77ST+IWHwUsuhT+Zr5w4t6C7O8yzFM=",
+        "date": "unstable-2023-06-23"
     },
     "gambatte": {
         "owner": "libretro",
         "repo": "gambatte-libretro",
-        "rev": "64561b7e1b21dfa42eecb94963c1c495ba332466",
-        "hash": "sha256-BRh357MGHlglGSs48LhhRNTTyAUD9O0QmGeqLnyYap0="
+        "rev": "c9a07107f121498a158762116d47d7068a247d3c",
+        "hash": "sha256-U4FR794/hB3tHsdbtnC7qL0qr1oi1ZF4PYFTu+sVMVI=",
+        "date": "unstable-2024-02-02"
     },
     "genesis-plus-gx": {
         "owner": "libretro",
         "repo": "Genesis-Plus-GX",
-        "rev": "141257e1e2104c4e4a49dc771d9f3c06e00292ec",
-        "hash": "sha256-voNDwfwBIzuq9peNJ2CtF6UBnaJCDpiWmqPgtrPZplU="
+        "rev": "59cdc560e21eeddfa4d5a5c935413cdaa9d660f3",
+        "hash": "sha256-FB0znNFG6T67V63jm7WprhGRw9rHNJgH4SZ/BtgAyFg=",
+        "date": "unstable-2024-02-02"
     },
     "gpsp": {
         "owner": "libretro",
         "repo": "gpsp",
-        "rev": "c0d8ffaa384f724e1a0743e18cb042c29dd48f7f",
-        "hash": "sha256-KKO0bBV+5+8UcSspZHfinntp/mxukcf6/P4kIi6doUs="
+        "rev": "9fc117ef5c719047818513c7e394c24371cb1dbd",
+        "hash": "sha256-6dPuj+uzqSYA2+Jm+G3u0HEeBFW2i+KmWd3PYbSxBu8=",
+        "date": "unstable-2024-01-15"
     },
     "gw": {
         "owner": "libretro",
         "repo": "gw-libretro",
         "rev": "0ecff52b11c327af52b22ea94b268c90472b6732",
-        "hash": "sha256-N/nZoo+duk7XhRtNdV1paWzxYUhv8nLUcnnOs2gbZuQ="
+        "hash": "sha256-N/nZoo+duk7XhRtNdV1paWzxYUhv8nLUcnnOs2gbZuQ=",
+        "date": "unstable-2023-05-28"
     },
     "handy": {
         "owner": "libretro",
         "repo": "libretro-handy",
-        "rev": "0559d3397f689ea453b986311aeac8dbd33afb0b",
-        "hash": "sha256-Nsp0jiOLWjTGJRURkwx8mj7bBG8nM5fRqE93Lo9n4ac="
+        "rev": "65d6b865544cd441ef2bd18cde7bd834c23d0e48",
+        "hash": "sha256-F4WyiZBNTh8hjuCooZXQkzov0vcHNni6d5mbAMgzAiA=",
+        "date": "unstable-2024-01-01"
     },
     "hatari": {
         "owner": "libretro",
         "repo": "hatari",
-        "rev": "d0903a9447323e647ed9756238ba1550cac92940",
-        "hash": "sha256-kSdK7rkORgTkMg8kL56pNb+wU+m2413shEt7UQ9SCjM="
+        "rev": "a4c9eb0bb79e47a2870c12b04566c1f8d25e4bf3",
+        "hash": "sha256-mHz2nB9Vr/PVifd6w+kz7ZCH+N8igmcS8InvevZoSpE=",
+        "date": "unstable-2023-09-29"
     },
     "mame": {
         "owner": "libretro",
         "repo": "mame",
-        "rev": "3d612fb19eb95c0ae322c3cab343857b14a65a9c",
-        "hash": "sha256-ibd8HEKQJo7hrhzqYDu6LzMmIFncXCafod9VXBx9OU0="
+        "rev": "68520cf9defd1c2762bca7f266f13ad593b7b3f3",
+        "hash": "sha256-moYxyoa6QUCvxVPTr4NpRiEC+7bPETohVSYu4EYegFA=",
+        "date": "unstable-2024-01-03"
     },
     "mame2000": {
         "owner": "libretro",
         "repo": "mame2000-libretro",
-        "rev": "720b8ad4cbd76abd57b9aeced9ba541dc8476f7f",
-        "hash": "sha256-3HnDsZQRjp7PqUdYTAEGsroP1paoTAcTBb1fd7/LBJA="
+        "rev": "1472da3a39ab14fff8325b1f51a1dfdb8eabb5c8",
+        "hash": "sha256-Nd5OqkoMJZ8TzEZGqDT0YX6lHK/H3I5EqJ841PteLi8=",
+        "date": "unstable-2023-10-31"
     },
     "mame2003": {
         "owner": "libretro",
         "repo": "mame2003-libretro",
-        "rev": "105ca02fb85e92b9dd5d6ee43f7152d1199eb149",
-        "hash": "sha256-zYv3OIgapglsyjWs69IhSJGVQ7CkviKJjKnVom5f9/c="
+        "rev": "be247427a8a68f8401ce40c830e2d8767d000f84",
+        "hash": "sha256-ZQ0DWok6EmVEDOhcN7LsK5T4XXHpH9Cyd22KP/UjMok=",
+        "date": "unstable-2023-11-22"
     },
     "mame2003-plus": {
         "owner": "libretro",
         "repo": "mame2003-plus-libretro",
-        "rev": "a1ff7485de011926ab21309ad1766f9cad3af58e",
-        "hash": "sha256-Amp+Fcl2dWS1qDMaa/QL0X5loXRYmnByUjUzliQmLvY="
+        "rev": "53c6083a2044c3529a436b51c5206cd9a896d12c",
+        "hash": "sha256-k4jl3cN18HQya3F4DXHN/Hoq7UXKVmJg5Lgp08n6M/M=",
+        "date": "unstable-2024-02-03"
     },
     "mame2010": {
         "owner": "libretro",
         "repo": "mame2010-libretro",
         "rev": "5f524dd5fca63ec1dcf5cca63885286109937587",
-        "hash": "sha256-OmJgDdlan/niGQfajv0KNG8NJfEKn7Nfe6GRQD+TZ8M="
+        "hash": "sha256-OmJgDdlan/niGQfajv0KNG8NJfEKn7Nfe6GRQD+TZ8M=",
+        "date": "unstable-2022-06-14"
     },
     "mame2015": {
         "owner": "libretro",
         "repo": "mame2015-libretro",
-        "rev": "2599c8aeaf84f62fe16ea00daa460a19298c121c",
-        "hash": "sha256-TURTX0XrvqwqKG3O3aCttDAdicBdge5F1thVvYgEHaw="
+        "rev": "316cd06349f2b34b4719f04f7c0d07569a74c764",
+        "hash": "sha256-CBN04Jf26SIk8mKWlui5spQGokBvgFUCvFiC8NoBGw0=",
+        "date": "unstable-2023-11-01"
     },
     "mame2016": {
         "owner": "libretro",
         "repo": "mame2016-libretro",
         "rev": "01058613a0109424c4e7211e49ed83ac950d3993",
-        "hash": "sha256-IsM7f/zlzvomVOYlinJVqZllUhDfy4NNTeTPtNmdVak="
+        "hash": "sha256-IsM7f/zlzvomVOYlinJVqZllUhDfy4NNTeTPtNmdVak=",
+        "date": "unstable-2022-04-06"
     },
     "melonds": {
         "owner": "libretro",
         "repo": "melonds",
         "rev": "c6488c88cb4c7583dbcd61609e0eef441572fae8",
-        "hash": "sha256-kU0xPM6WBqK6UpMNMotHc3jRFTodahPJRrfbcjdCJTI="
+        "hash": "sha256-kU0xPM6WBqK6UpMNMotHc3jRFTodahPJRrfbcjdCJTI=",
+        "date": "unstable-2023-04-13"
     },
     "mesen": {
         "owner": "libretro",
         "repo": "mesen",
-        "rev": "d25d60fc190f3f7603a1113ef1e11d9da65b7583",
-        "hash": "sha256-C/05mkPHJ8Bsj+uZOqY6rhMc0qx33kSxAT5SNDUPRUU="
+        "rev": "d6f2f1797694f87e698c737b068f621889e96fa9",
+        "hash": "sha256-iLX9UvrjYjGjyaLD4sC10gntWUvgZrwiUqTS7S7YDdc=",
+        "date": "unstable-2024-01-30"
     },
     "mesen-s": {
         "owner": "libretro",
         "repo": "mesen-s",
         "rev": "32a7adfb4edb029324253cb3632dfc6599ad1aa8",
-        "hash": "sha256-/OOMH7kt9Pmkdmy5m+I8FMvog5mqZHyrZvfjHccz8oo="
+        "hash": "sha256-/OOMH7kt9Pmkdmy5m+I8FMvog5mqZHyrZvfjHccz8oo=",
+        "date": "unstable-2022-07-25"
     },
     "meteor": {
         "owner": "libretro",
         "repo": "meteor-libretro",
         "rev": "e533d300d0561564451bde55a2b73119c768453c",
-        "hash": "sha256-zMkgzUz2rk0SD5ojY4AqaDlNM4k4QxuUxVBRBcn6TqQ="
+        "hash": "sha256-zMkgzUz2rk0SD5ojY4AqaDlNM4k4QxuUxVBRBcn6TqQ=",
+        "date": "unstable-2020-12-28"
     },
     "mgba": {
         "owner": "libretro",
         "repo": "mgba",
         "rev": "314bf7b676f5b820f396209eb0c7d6fbe8103486",
-        "hash": "sha256-Rk+glDgSa1J1IIe5NrJElX9zr59+LQynfDXuHWyZcEM="
+        "hash": "sha256-Rk+glDgSa1J1IIe5NrJElX9zr59+LQynfDXuHWyZcEM=",
+        "date": "unstable-2023-05-28"
     },
     "mrboom": {
         "owner": "Javanaise",
         "repo": "mrboom-libretro",
         "rev": "c4ec620424fe79f0d6db719d73628f23ae285ada",
         "hash": "sha256-twocTyayV79a4757Yfoz/P3wnQPgiwsbrBbLmT4EZKQ=",
-        "fetchSubmodules": true
+        "fetchSubmodules": true,
+        "date": "unstable-2024-01-23"
     },
     "mupen64plus": {
         "owner": "libretro",
         "repo": "mupen64plus-libretro-nx",
-        "rev": "26fd1edd640ff3db49dd5ebb7e54f0de6600fc45",
-        "hash": "sha256-JueRR2PheAz8sPG8OIpjp1Xih6z2Xp8f7WD+2MuBPo4="
+        "rev": "0e1dc5abacf91f1640206d32d18735e82071681e",
+        "hash": "sha256-gt9oVJunDCdhHbaqL9xaGlztxdT1D2UvYETqCXogIwU=",
+        "date": "unstable-2024-01-30"
     },
     "neocd": {
         "owner": "libretro",
         "repo": "neocd_libretro",
-        "rev": "2070f5258c9d3feee15962f9db8c8ef20072ece8",
-        "hash": "sha256-X+lS1zW5oTzp7wwurM5xjVqIBwEOCIdj/NX/+33K2qg="
+        "rev": "71ebe5044639b825e5bd1bd590fef3e918133b80",
+        "hash": "sha256-YVxt3bJ54DD91VHkeQyYdo/BEq//lnBKd9Y42Vby3qc=",
+        "date": "unstable-2024-02-01"
     },
     "nestopia": {
         "owner": "libretro",
         "repo": "nestopia",
-        "rev": "3dcbec4682e079312d6943e1357487645ec608c7",
-        "hash": "sha256-+jWedFwuFwZzdYEyKR77AhEBoW6ecY7HAIYEKt9PRg8="
+        "rev": "8050c38e5a1db6927b03510651809e8ef932b888",
+        "hash": "sha256-Vlz69ZpXwawdE+bfjlKNrQNmFHhB53FOKhfMgq4viE0=",
+        "date": "unstable-2024-02-03"
     },
     "np2kai": {
         "owner": "AZO234",
         "repo": "NP2kai",
-        "rev": "6089943a80a45b6c18d765765f7f31d7a5c0d9c6",
-        "hash": "sha256-tdF0Qb+smWAVoPmI0dd5s51cnYxMmqM36rQNMiEjU9A=",
-        "fetchSubmodules": true
+        "rev": "c2ca4046860264cb307e768f529f180caee5e224",
+        "hash": "sha256-RizN+NpVp0paXvdt7OudX9/5GJms1YvJ+NVe9iV3nnw=",
+        "fetchSubmodules": true,
+        "date": "unstable-2024-01-10"
     },
     "nxengine": {
         "owner": "libretro",
         "repo": "nxengine-libretro",
         "rev": "1f371e51c7a19049e00f4364cbe9c68ca08b303a",
-        "hash": "sha256-4XBNTzgN8pLyrK9KsVxTRR1I8CQaZCnVR4gMryYpWW0="
+        "hash": "sha256-4XBNTzgN8pLyrK9KsVxTRR1I8CQaZCnVR4gMryYpWW0=",
+        "date": "unstable-2023-02-21"
     },
     "o2em": {
         "owner": "libretro",
         "repo": "libretro-o2em",
-        "rev": "a2a12472fde910b6089ac3ca6de805bd58a9c999",
-        "hash": "sha256-0cZYw3rrnaR+PfwReRXadLV8RVLblYqlZxJue6OZncg="
+        "rev": "44fe5f306033242f7d74144105e19a7d4939477e",
+        "hash": "sha256-zg8wplVTKRzqa47mmWlqribg+JU4Nap4Ar/iR7y87xs=",
+        "date": "unstable-2023-10-19"
     },
     "opera": {
         "owner": "libretro",
         "repo": "opera-libretro",
-        "rev": "100ae1e7decefe1f17d98cfcb9f2af4ff8452691",
-        "hash": "sha256-GOabGs5JP4hg4y5xEATZMEWuqQxFxdc6ZMnO4oLC2yk="
+        "rev": "35e16483be900ea8aa20e87d2710b677437f73ce",
+        "hash": "sha256-ZNHSxI8l0KGJ6uAvOsEhNpB0IkBxtb9Imj3tA/LiOto=",
+        "date": "unstable-2024-01-13"
     },
     "parallel-n64": {
         "owner": "libretro",
         "repo": "parallel-n64",
-        "rev": "49eadb4da85f7e3bd59b60f61e8fd5dbfb9f07d5",
-        "hash": "sha256-S8gsPOgxdq0SwoYFua4ouT7XjT45d/mwCYmI3VVahdI="
+        "rev": "1b57f9199b1f8a4510f7f89f14afa9cabf9b3bdd",
+        "hash": "sha256-L20RGav0FJfydOICCNhAMGxIuIvPABDtCs5tWzrh768=",
+        "date": "unstable-2024-01-15"
     },
     "pcsx2": {
         "owner": "libretro",
         "repo": "lrps2",
         "rev": "f3c8743d6a42fe429f703b476fecfdb5655a98a9",
-        "hash": "sha256-0piCNWX7QbZ58KyTlWp4h1qLxXpi1z6ML8sBHMTvCY4="
+        "hash": "sha256-0piCNWX7QbZ58KyTlWp4h1qLxXpi1z6ML8sBHMTvCY4=",
+        "date": "unstable-2023-01-30"
     },
     "pcsx_rearmed": {
         "owner": "libretro",
         "repo": "pcsx_rearmed",
-        "rev": "ead6fd751369f6fe50cb5092ab5530fbf1d66b67",
-        "hash": "sha256-JzvcM8T/xMP7MDn/58TDNrHN8bjU63/PBtj7JJYYiVo="
+        "rev": "06cdf83a3a30bfb8cafee768dbe83bbaef6c8ddd",
+        "hash": "sha256-E/+dAcJwfaUMjYJUjfAcn98SIh61BiS5YpcZg99lg+Q=",
+        "date": "unstable-2024-02-04"
     },
     "picodrive": {
         "owner": "libretro",
         "repo": "picodrive",
-        "rev": "570319349588288f64c676123244acdb0be33881",
-        "hash": "sha256-KG5A5NBWi5jKpJOSdSQxjn+wm2F198AINKIU+figoqs=",
-        "fetchSubmodules": true
+        "rev": "d907d65692a45e126d0c7d6685cc8792b52bc577",
+        "hash": "sha256-CJJcWVueg3dbBT4r6W1y8Qj7iRwH7PupvFp+CKEII7o=",
+        "fetchSubmodules": true,
+        "date": "unstable-2024-01-23"
     },
     "play": {
         "owner": "jpd002",
         "repo": "Play-",
-        "rev": "f50566ffdf6a2f1d0cedfb900f1ee24b9c80fd8e",
-        "hash": "sha256-G45UMzNh5I7beO8sBtwc80HPioB907UEPtfB1NSS4OY=",
-        "fetchSubmodules": true
+        "rev": "c0da95cf596834620169173dc12b3f32ca092404",
+        "hash": "sha256-q6ApOsyNS5to+KBYgz+CZJOfNAcII6Eyv0MhcB4Q1bU=",
+        "fetchSubmodules": true,
+        "date": "unstable-2024-01-26"
     },
     "ppsspp": {
         "owner": "hrydgard",
         "repo": "ppsspp",
-        "rev": "638192b0245e73a602c5f0d60e80dc7b78ff0793",
-        "hash": "sha256-Ls9k563j8yEasu6dBs2cmWR+9twBKTolqTLkr3Nt7Uk=",
-        "fetchSubmodules": true
+        "rev": "d479b74ed9c3e321bc3735da29bc125a2ac3b9b2",
+        "hash": "sha256-I84zJqEE1X/eo/ukeGA2iZe3lWKvilk+RNGUzl2wZXY=",
+        "fetchSubmodules": true,
+        "date": "unstable-2024-02-04"
     },
     "prboom": {
         "owner": "libretro",
         "repo": "libretro-prboom",
         "rev": "6ec854969fd9dec33bb2cab350f05675d1158969",
-        "hash": "sha256-y0qZwYNwcO4ofWDZ7UXN9ZVMPFxjCnLDDZKBMdZLxEY="
+        "hash": "sha256-y0qZwYNwcO4ofWDZ7UXN9ZVMPFxjCnLDDZKBMdZLxEY=",
+        "date": "unstable-2023-05-28"
     },
     "prosystem": {
         "owner": "libretro",
         "repo": "prosystem-libretro",
         "rev": "4202ac5bdb2ce1a21f84efc0e26d75bb5aa7e248",
-        "hash": "sha256-BR0DTWcB5g0rEoNSxBx+OxBmLELjdR2fgsmdPU7cK68="
+        "hash": "sha256-BR0DTWcB5g0rEoNSxBx+OxBmLELjdR2fgsmdPU7cK68=",
+        "date": "unstable-2023-08-17"
     },
     "puae": {
         "owner": "libretro",
         "repo": "libretro-uae",
-        "rev": "7bdd798ef14dccafe283588cbf8eb303832a1858",
-        "hash": "sha256-ML3hRYujyh7WPm9Sx6RzQAxaTqlhneVLDi6qcNJ+hi8="
+        "rev": "2cad13f98aa4df272decf2ab99d95aa582cd4cfb",
+        "hash": "sha256-8iGsQJcImL7hUK14X+u2BSq4W9BkosiLImCmzf63o4Q=",
+        "date": "unstable-2024-02-03"
     },
     "quicknes": {
         "owner": "libretro",
         "repo": "QuickNES_Core",
-        "rev": "058d66516ed3f1260b69e5b71cd454eb7e9234a3",
-        "hash": "sha256-eWnbx4NsxanvSls8lguKBijYZ4+uF97d9es9Yn+3PKs="
+        "rev": "cd73f021be7dd5b1a21b71155a320364c02de4ac",
+        "hash": "sha256-fmTAK32ASA8M5nxUUUilm/yMNkmqSAG/gauB7fy1Kbc=",
+        "date": "unstable-2024-02-01"
     },
     "same_cdi": {
         "owner": "libretro",
         "repo": "same_cdi",
         "rev": "54cf493c2dee4c46666059c452f8aaaa0bd7c8e0",
-        "hash": "sha256-/+4coMzj/o82Q04Z65DQiPaykK6N56W6PRQLtyJOd8E="
+        "hash": "sha256-/+4coMzj/o82Q04Z65DQiPaykK6N56W6PRQLtyJOd8E=",
+        "date": "unstable-2023-02-28"
     },
     "sameboy": {
         "owner": "libretro",
         "repo": "sameboy",
         "rev": "09138330990da32362246c7034cf4de2ea0a2a2b",
-        "hash": "sha256-hQWIuNwCykkJR+6naNarR50kUvIFNny+bbZHR6/GA/4="
+        "hash": "sha256-hQWIuNwCykkJR+6naNarR50kUvIFNny+bbZHR6/GA/4=",
+        "date": "unstable-2022-08-19"
     },
     "scummvm": {
         "owner": "libretro-mirrors",
         "repo": "scummvm",
         "rev": "2fb2e4c551c9c1510c56f6e890ee0300b7b3fca3",
-        "hash": "sha256-wrlFqu+ONbYH4xMFDByOgySobGrkhVc7kYWI4JzA4ew="
+        "hash": "sha256-wrlFqu+ONbYH4xMFDByOgySobGrkhVc7kYWI4JzA4ew=",
+        "date": "unstable-2022-04-06"
     },
     "smsplus-gx": {
         "owner": "libretro",
         "repo": "smsplus-gx",
-        "rev": "60af17ddb2231ba98f4ed1203e2a2f58d08ea088",
-        "hash": "sha256-2SZR9BOTYLmtjEF4Bdl49H2pFNEIaU68VqlA7ll5TqU="
+        "rev": "96fa9bc65aa27a5ab2779f9f2ff0439fec7cf513",
+        "hash": "sha256-tlxlI0+5QFgu2IRB4Cpz9XItbhprLNlq1YdCFGXGyIE=",
+        "date": "unstable-2023-10-31"
     },
     "snes9x": {
         "owner": "snes9xgit",
         "repo": "snes9x",
-        "rev": "0e03a36847c2ab14d84963b0263e653aa4087ff4",
-        "hash": "sha256-wRkBT80HBE1JXqNSvm0LhhUSjHe1DP3uMy3fKW71uZA="
+        "rev": "e76abdc4ef8f961ea0f8e87c160cf59cc6d44e42",
+        "hash": "sha256-JERfp69UB/PC2iIjbepOKpPdmZJbrzWbXhaLMJfOaXY=",
+        "date": "unstable-2024-01-28"
     },
     "snes9x2002": {
         "owner": "libretro",
         "repo": "snes9x2002",
         "rev": "540baad622d9833bba7e0696193cb06f5f02f564",
-        "hash": "sha256-WJh8Qf1/uFaL9f9d28qXsbpeAZfYGPgjoty3G6XAKSs="
+        "hash": "sha256-WJh8Qf1/uFaL9f9d28qXsbpeAZfYGPgjoty3G6XAKSs=",
+        "date": "unstable-2022-08-06"
     },
     "snes9x2005": {
         "owner": "libretro",
         "repo": "snes9x2005",
         "rev": "fd45b0e055bce6cff3acde77414558784e93e7d0",
-        "hash": "sha256-zjA/G62V38/hj+WjJDGAs48AcTUIiMWL8feCqLsCRnI="
+        "hash": "sha256-zjA/G62V38/hj+WjJDGAs48AcTUIiMWL8feCqLsCRnI=",
+        "date": "unstable-2022-07-25"
     },
     "snes9x2010": {
         "owner": "libretro",
         "repo": "snes9x2010",
         "rev": "d8b10c4cd7606ed58f9c562864c986bc960faaaf",
-        "hash": "sha256-7FmteYrAYr+pGNXGg9CBC4NFlijGRf7GdtJfiNjmonU="
+        "hash": "sha256-7FmteYrAYr+pGNXGg9CBC4NFlijGRf7GdtJfiNjmonU=",
+        "date": "unstable-2023-02-20"
     },
     "stella": {
         "owner": "stella-emu",
         "repo": "stella",
-        "rev": "85f23044437a5da35d68f96045d363d0e339f872",
-        "hash": "sha256-b/3cq+CdQ6MLFzzF/cFTbL0XCSqZFc0Rj9e+bNiN3WY="
+        "rev": "4557099e5d7a0c0b02424ea85d2a4b093911e048",
+        "hash": "sha256-wyJExpIIScgLTALgvqW5f/QgIsMC19JU8Meh3mV4d2c=",
+        "date": "unstable-2024-02-02"
     },
     "stella2014": {
         "owner": "libretro",
         "repo": "stella2014-libretro",
         "rev": "8ab051edd4816f33a5631d230d54059eeed52c5f",
-        "hash": "sha256-wqssB8WXXF2Lu9heII8nWLLOvI38cIfHSMA7OOd6jx0="
+        "hash": "sha256-wqssB8WXXF2Lu9heII8nWLLOvI38cIfHSMA7OOd6jx0=",
+        "date": "unstable-2023-02-20"
     },
     "swanstation": {
         "owner": "libretro",
         "repo": "swanstation",
-        "rev": "376744746a6880b5eec7ac48b5c006c9ae8c6770",
-        "hash": "sha256-5mKNypA0x/FkDZvWhuEr/J5WP7saR7cKo0DQ2DZ36ZE="
+        "rev": "77aeeea58a45cccae7a8be37645f8f5a27ff101b",
+        "hash": "sha256-z+9Y9hoQ832caip5U+siQXh9GFxLMnX0HcmLa93B/lc=",
+        "date": "unstable-2024-01-26"
     },
     "tgbdual": {
         "owner": "libretro",
         "repo": "tgbdual-libretro",
         "rev": "a6f3018e6a23030afc1873845ee54d4b2d8ec9d3",
-        "hash": "sha256-MBUgYXX/Pc+TkwoS7OwbXSPssKUf6lwWx/bKhvwDkHs="
+        "hash": "sha256-MBUgYXX/Pc+TkwoS7OwbXSPssKUf6lwWx/bKhvwDkHs=",
+        "date": "unstable-2022-08-06"
     },
     "thepowdertoy": {
         "owner": "libretro",
         "repo": "ThePowderToy",
         "rev": "f644498193c4c8be689d8a1d2a70e37e4eff4243",
-        "hash": "sha256-aPUqrrrH2Ia56A3Kx6ClMcZO9nbHGJIcEQ6nFyIMamo="
+        "hash": "sha256-aPUqrrrH2Ia56A3Kx6ClMcZO9nbHGJIcEQ6nFyIMamo=",
+        "date": "unstable-2023-01-17"
     },
     "tic80": {
         "owner": "libretro",
         "repo": "tic-80",
         "rev": "bd6ce86174fc7c9d7d3a86263acf3a7de1b62c11",
         "hash": "sha256-RFp8sTSRwD+cgW3EYk3nBeY+zVKgZVQI5mjtfe2a64Q=",
-        "fetchSubmodules": true
+        "fetchSubmodules": true,
+        "date": "unstable-2022-06-11"
     },
     "vba-m": {
         "owner": "libretro",
         "repo": "vbam-libretro",
         "rev": "a2378f05f600a5a9cf450c60a87976b80d6a895a",
-        "hash": "sha256-vWm28cSEGex5h7JkJjzNPqEGtQWHK0dpK2gVDlQ3NbM="
+        "hash": "sha256-vWm28cSEGex5h7JkJjzNPqEGtQWHK0dpK2gVDlQ3NbM=",
+        "date": "unstable-2023-08-18"
     },
     "vba-next": {
         "owner": "libretro",
         "repo": "vba-next",
         "rev": "ee92625d2f1666496be4f5662508a2430e846b00",
-        "hash": "sha256-r3FKBD4GUUkobMJ33VceseyTyqxm/Wsa5Er6XcfGL2Q="
+        "hash": "sha256-r3FKBD4GUUkobMJ33VceseyTyqxm/Wsa5Er6XcfGL2Q=",
+        "date": "unstable-2023-06-03"
     },
     "vecx": {
         "owner": "libretro",
         "repo": "libretro-vecx",
         "rev": "a401c268e425dc8ae6a301e7fdb9a9e96f39b8ea",
-        "hash": "sha256-24/bcQ5mgLl7zKvpnnSYr5SoLG02al6dP27KoOtnua4="
+        "hash": "sha256-24/bcQ5mgLl7zKvpnnSYr5SoLG02al6dP27KoOtnua4=",
+        "date": "unstable-2023-06-01"
     },
     "virtualjaguar": {
         "owner": "libretro",
         "repo": "virtualjaguar-libretro",
         "rev": "8126e5c504ac7217a638f38e4cd9190822c8abdd",
-        "hash": "sha256-U/qdKApE0OU3jc6ekfgEZ7VCaIqCc2h+Y+IHe7PIRY0="
+        "hash": "sha256-U/qdKApE0OU3jc6ekfgEZ7VCaIqCc2h+Y+IHe7PIRY0=",
+        "date": "unstable-2023-06-01"
     },
     "yabause": {
         "owner": "libretro",
         "repo": "yabause",
         "rev": "4c96b96f7fbe07223627c469ff33376b2a634748",
-        "hash": "sha256-7hEpGh2EcrlUoRiUNntaMZEQtStglYAY1MeCub5p8f8="
+        "hash": "sha256-7hEpGh2EcrlUoRiUNntaMZEQtStglYAY1MeCub5p8f8=",
+        "date": "unstable-2023-01-03"
     }
 }

--- a/pkgs/applications/emulators/retroarch/libretro-core-info.nix
+++ b/pkgs/applications/emulators/retroarch/libretro-core-info.nix
@@ -1,17 +1,18 @@
 { lib
 , stdenvNoCC
 , fetchFromGitHub
+, gitUpdater
 }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "libretro-core-info";
-  version = "unstable-2023-07-31";
+  version = "1.17.0";
 
   src = fetchFromGitHub {
     owner = "libretro";
     repo = "libretro-core-info";
-    hash = "sha256-VdFsrLiJ+Wu1OKvwX9fMI96CxTareOTK8x6OfksBuYs=";
-    rev = "dacae85b406131feb12395a415fdf57fc4745201";
+    rev = "v${version}";
+    hash = "sha256-iJteyqD7hUtBxj+Y2nQZXDJVM4k+TDIKLaLP3IFDOGo=";
   };
 
   makeFlags = [
@@ -22,6 +23,10 @@ stdenvNoCC.mkDerivation rec {
   ];
 
   dontBuild = true;
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+  };
 
   meta = with lib; {
     description = "Libretro's core info files";

--- a/pkgs/applications/emulators/retroarch/mkLibretroCore.nix
+++ b/pkgs/applications/emulators/retroarch/mkLibretroCore.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , core
+, repo
 , makeWrapper
 , retroarch
 , zlib
@@ -70,7 +71,10 @@ stdenv.mkDerivation ({
 
   enableParallelBuilding = true;
 
-  passthru = { inherit core libretroCore; };
+  passthru = {
+    inherit core libretroCore;
+    updateScript = [ ./update_cores.py repo ];
+  };
 
   meta = with lib; {
     inherit mainProgram;

--- a/pkgs/applications/emulators/retroarch/retroarch-assets.nix
+++ b/pkgs/applications/emulators/retroarch/retroarch-assets.nix
@@ -1,17 +1,18 @@
 { lib
 , stdenvNoCC
 , fetchFromGitHub
+, unstableGitUpdater
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation {
   pname = "retroarch-assets";
-  version = "unstable-2023-09-11";
+  version = "unstable-2024-01-02";
 
   src = fetchFromGitHub {
     owner = "libretro";
     repo = "retroarch-assets";
-    rev = "7b735ef18bcc6508b1c9a626eb237779ff787179";
-    hash = "sha256-S9wWag9fNpCTMKY8yQaF7jFuX1P5XLy/Z4vjtVDK7lg=";
+    rev = "923b711dc6772a168d83dc8915e9260730fcf3a1";
+    hash = "sha256-Hwgga2hCJEdf/j2mU+hLGAsWdYcfuzjCycxSF37I4qk=";
   };
 
   makeFlags = [
@@ -22,6 +23,8 @@ stdenvNoCC.mkDerivation rec {
   ];
 
   dontBuild = true;
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = with lib; {
     description = "Assets needed for RetroArch";

--- a/pkgs/applications/emulators/retroarch/retroarch-joypad-autoconfig.nix
+++ b/pkgs/applications/emulators/retroarch/retroarch-joypad-autoconfig.nix
@@ -1,22 +1,27 @@
 { lib
 , stdenvNoCC
 , fetchFromGitHub
+, gitUpdater
 }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "retroarch-joypad-autoconfig";
-  version = "unstable-2023-08-01";
+  version = "1.17.0";
 
   src = fetchFromGitHub {
     owner = "libretro";
     repo = "retroarch-joypad-autoconfig";
-    rev = "5666e46bb89caf4e9af358fdb97a2b384cb62f36";
-    hash = "sha256-5Po0v0E/dc+nVHnHlJRZzv66B/DKYarwqTkS9+/ktC4=";
+    rev = "v${version}";
+    hash = "sha256-rmbZxXxHwIPb/zVBQiWTRPLVS+DXTrsw8d6t9nTg/ng=";
   };
 
   makeFlags = [
     "PREFIX=$(out)"
   ];
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+  };
 
   meta = with lib; {
     description = "Joypad autoconfig files";

--- a/pkgs/applications/emulators/retroarch/update_cores.py
+++ b/pkgs/applications/emulators/retroarch/update_cores.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -I nixpkgs=../../../../ -i python3 -p "python3.withPackages (ps: with ps; [ requests ])" -p git -p nix-prefetch-github
+#!nix-shell -I nixpkgs=./ -i python3 -p "python3.withPackages (ps: with ps; [ requests ])" -p git -p nix-prefetch-github
 
 import json
 import os
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
 from pathlib import Path
 
 import requests
@@ -14,6 +13,16 @@ import requests
 SCRIPT_PATH = Path(__file__).absolute().parent
 HASHES_PATH = SCRIPT_PATH / "hashes.json"
 GET_REPO_THREADS = int(os.environ.get("GET_REPO_THREADS", 8))
+# To add a new core, add it to the dictionary below. You need to set at least
+# `repo`, that is the repository name if the owner of the repository is
+# `libretro` itself, otherwise also set `owner`.
+# You may set `deep_clone`, `fetch_submodules` or `leave_dot_git` options to
+# `True` and they're similar to `fetchgit` options. Also if for some reason you
+# need to pin a specific revision, set `rev` to a commit.
+# To generate the hash file for your new core, you can run `update_cores.py
+# <core>`. The script needs to be run from the root of your `nixpkgs` clone.
+# Do not forget to add your core to `cores.nix` file with the proper overrides
+# so the core can be build.
 CORES = {
     "2048": {"repo": "libretro-2048"},
     "atari800": {"repo": "libretro-atari800"},
@@ -136,6 +145,7 @@ def get_rev_date_fetchFromGitHub(repo, owner, rev):
 
     date = j.get("commit", {}).get("committer", {}).get("date")
     if date:
+        # Date format returned by API: 2023-01-30T06:29:13Z
         return f"unstable-{date[:10]}"
     else:
         return None

--- a/pkgs/applications/emulators/retroarch/update_cores.py
+++ b/pkgs/applications/emulators/retroarch/update_cores.py
@@ -85,8 +85,9 @@ CORES = {
     "opera": {"repo": "opera-libretro"},
     "parallel-n64": {"repo": "parallel-n64"},
     # libretro/lrps2 is a hard-fork of pcsx2 with simplified code to target
-    # only libretro, while libretro/pcsx2 is supposedly closer to upstream.
-    # TODO: switch to libretro/pcsx2 since this is more up-to-date
+    # only libretro, while libretro/pcsx2 is supposedly closer to upstream but
+    # it is a WIP.
+    # TODO: switch to libretro/pcsx2 when upstream switches to it.
     "pcsx2": {"repo": "lrps2"},
     "pcsx_rearmed": {"repo": "pcsx_rearmed"},
     "picodrive": {"repo": "picodrive", "fetch_submodules": True},

--- a/pkgs/applications/emulators/retroarch/wrapper.nix
+++ b/pkgs/applications/emulators/retroarch/wrapper.nix
@@ -1,5 +1,4 @@
 { lib
-, stdenv
 , makeWrapper
 , retroarch
 , symlinkJoin


### PR DESCRIPTION
## Description of changes

Substitute for PR: https://github.com/NixOS/nixpkgs/pull/286263.

New release: https://www.libretro.com/index.php/retroarch-1-17-0-release/.

Also a bunch of improvements in our related retroarch derivations:
- libretro cores now have a proper version date according to their commit instead of having the date when the `update_core.py` script was run
- `retroarch-assets`, `retroarch-joypad-autoconfig`, `libretro-core-info` and libretro cores now have `passthru.updateScript` set

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
