### PR TITLE
haskell-modules: Pass -split-sections when cross-compiling

### DIFF
--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -245,8 +245,7 @@ let
     (enableFeature doBenchmark "benchmarks")
     "--enable-library-vanilla"  # TODO: Should this be configurable?
     (enableFeature enableLibraryForGhci "library-for-ghci")
-  ] ++ optionals (enableDeadCodeElimination && (lib.versionOlder "8.0.1" ghc.version)) [
-     "--ghc-option=-split-sections"
+    (enableFeature enableDeadCodeElimination "split-sections")
   ] ++ optionals dontStrip [
     "--disable-library-stripping"
     "--disable-executable-stripping"


### PR DESCRIPTION
This works around #286285 by passing [--enable-split-sections](https://cabal.readthedocs.io/en/3.10/cabal-project.html#cfg-flag---enable-split-sections) instead of ghc-options.

This enables dead code elimination for `pkgsCross` and `pkgsStatic`, which did not work before.

Example: `pkgsStatic.haskellPackages.cabal2nix`

Before this change:

```
% du -h /nix/store/p9cl25mfl1l1gg5g9yvjfrqrrnywk9z0-cabal2nix-static-x86_64-unknown-linux-musl-2.19.1/bin/*
35M	/nix/store/p9cl25mfl1l1gg5g9yvjfrqrrnywk9z0-cabal2nix-static-x86_64-unknown-linux-musl-2.19.1/bin/cabal2nix
24M	/nix/store/p9cl25mfl1l1gg5g9yvjfrqrrnywk9z0-cabal2nix-static-x86_64-unknown-linux-musl-2.19.1/bin/hackage2nix
```

With this change:

```
% du -h /nix/store/q6nmkykk3im40lgvgy77njpr1d93gv7k-cabal2nix-static-x86_64-unknown-linux-musl-2.19.1/bin/*
15M	/nix/store/q6nmkykk3im40lgvgy77njpr1d93gv7k-cabal2nix-static-x86_64-unknown-linux-musl-2.19.1/bin/cabal2nix
9,5M	/nix/store/q6nmkykk3im40lgvgy77njpr1d93gv7k-cabal2nix-static-x86_64-unknown-linux-musl-2.19.1/bin/hackage2nix
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux: `pkgsStatic.haskellPackages.cabal2nix`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
