### PR TITLE
libvirt: substitute modules path

### DIFF
--- a/pkgs/development/libraries/libvirt/0003-substitute-modules-path.patch
+++ b/pkgs/development/libraries/libvirt/0003-substitute-modules-path.patch
@@ -1,14 +1,15 @@
 diff --git a/src/util/virpci.c b/src/util/virpci.c
-index 780b4f9..41cb855 100644
+index 780b4f9..a383df1 100644
 --- a/src/util/virpci.c
 +++ b/src/util/virpci.c
-@@ -1460,8 +1460,11 @@ virPCIDeviceFindBestVFIOVariant(virPCIDevice *dev,
+@@ -1460,8 +1460,12 @@ virPCIDeviceFindBestVFIOVariant(virPCIDevice *dev,
  
      uname(&unameInfo);
      modulesAliasPath = g_strdup_printf("/lib/modules/%s/modules.alias", unameInfo.release);
 -    if (virFileReadAll(modulesAliasPath, 8 * 1024 * 1024, &modulesAliasContent) < 0)
 -        return -1;
 +    if (virFileReadAll(modulesAliasPath, 8 * 1024 * 1024, &modulesAliasContent) < 0) {
++        g_clear_pointer(&modulesAliasPath, g_free);
 +        modulesAliasPath = g_strdup_printf("/run/booted-system/kernel-modules/lib/modules/%s/modules.alias", unameInfo.release);
 +        if (virFileReadAll(modulesAliasPath, 8 * 1024 * 1024, &modulesAliasContent) < 0)
 +            return -1;

--- a/pkgs/development/libraries/libvirt/0003-substitute-modules-path.patch
+++ b/pkgs/development/libraries/libvirt/0003-substitute-modules-path.patch
@@ -1,0 +1,15 @@
+diff --git a/src/util/virpci.c b/src/util/virpci.c
+index 780b4f9eec..0edb848d14 100644
+--- a/src/util/virpci.c
++++ b/src/util/virpci.c
+@@ -1461,7 +1461,9 @@ virPCIDeviceFindBestVFIOVariant(virPCIDevice *dev,
+     uname(&unameInfo);
+     modulesAliasPath = g_strdup_printf("/lib/modules/%s/modules.alias", unameInfo.release);
+     if (virFileReadAll(modulesAliasPath, 8 * 1024 * 1024, &modulesAliasContent) < 0)
+-        return -1;
++        modulesAliasPath = g_strdup_printf("/run/booted-system/kernel-modules/lib/modules/%s/modules.alias", unameInfo.release);
++        if (virFileReadAll(modulesAliasPath, 8 * 1024 * 1024, &modulesAliasContent) < 0)
++            return -1;
+ 
+     /* Look for all lines that are aliases for vfio_pci drivers.
+      * (The first line is always a comment, so we can be sure "alias"

--- a/pkgs/development/libraries/libvirt/0003-substitute-modules-path.patch
+++ b/pkgs/development/libraries/libvirt/0003-substitute-modules-path.patch
@@ -1,15 +1,14 @@
 diff --git a/src/util/virpci.c b/src/util/virpci.c
-index 780b4f9..a383df1 100644
+index 780b4f9..41cb855 100644
 --- a/src/util/virpci.c
 +++ b/src/util/virpci.c
-@@ -1460,8 +1460,12 @@ virPCIDeviceFindBestVFIOVariant(virPCIDevice *dev,
+@@ -1460,8 +1460,11 @@ virPCIDeviceFindBestVFIOVariant(virPCIDevice *dev,
  
      uname(&unameInfo);
      modulesAliasPath = g_strdup_printf("/lib/modules/%s/modules.alias", unameInfo.release);
 -    if (virFileReadAll(modulesAliasPath, 8 * 1024 * 1024, &modulesAliasContent) < 0)
 -        return -1;
 +    if (virFileReadAll(modulesAliasPath, 8 * 1024 * 1024, &modulesAliasContent) < 0) {
-+        g_clear_pointer(&modulesAliasPath, g_free);
 +        modulesAliasPath = g_strdup_printf("/run/booted-system/kernel-modules/lib/modules/%s/modules.alias", unameInfo.release);
 +        if (virFileReadAll(modulesAliasPath, 8 * 1024 * 1024, &modulesAliasContent) < 0)
 +            return -1;

--- a/pkgs/development/libraries/libvirt/0003-substitute-modules-path.patch
+++ b/pkgs/development/libraries/libvirt/0003-substitute-modules-path.patch
@@ -1,15 +1,19 @@
 diff --git a/src/util/virpci.c b/src/util/virpci.c
-index 780b4f9eec..0edb848d14 100644
+index 780b4f9..a383df1 100644
 --- a/src/util/virpci.c
 +++ b/src/util/virpci.c
-@@ -1461,7 +1461,9 @@ virPCIDeviceFindBestVFIOVariant(virPCIDevice *dev,
+@@ -1460,8 +1460,12 @@ virPCIDeviceFindBestVFIOVariant(virPCIDevice *dev,
+ 
      uname(&unameInfo);
      modulesAliasPath = g_strdup_printf("/lib/modules/%s/modules.alias", unameInfo.release);
-     if (virFileReadAll(modulesAliasPath, 8 * 1024 * 1024, &modulesAliasContent) < 0)
+-    if (virFileReadAll(modulesAliasPath, 8 * 1024 * 1024, &modulesAliasContent) < 0)
 -        return -1;
++    if (virFileReadAll(modulesAliasPath, 8 * 1024 * 1024, &modulesAliasContent) < 0) {
++        g_clear_pointer(&modulesAliasPath, g_free);
 +        modulesAliasPath = g_strdup_printf("/run/booted-system/kernel-modules/lib/modules/%s/modules.alias", unameInfo.release);
 +        if (virFileReadAll(modulesAliasPath, 8 * 1024 * 1024, &modulesAliasContent) < 0)
 +            return -1;
++    }
  
      /* Look for all lines that are aliases for vfio_pci drivers.
       * (The first line is always a comment, so we can be sure "alias"

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -132,6 +132,8 @@ stdenv.mkDerivation rec {
       zfs = "${zfs}/bin/zfs";
       zpool = "${zfs}/bin/zpool";
     })
+  ] ++ lib.optionalString isLinux [
+    ./0003-substitute-modules-path.patch
   ];
 
   # remove some broken tests


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes [285929](https://github.com/NixOS/nixpkgs/issues/285929) by substituting the hard-coded /lib/modules path with the /run/booted-system/kernel-modules/lib/modules path.

This replaces #286112 due to a bad commit

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
