### PR TITLE
php82Extensions.zstd: init at 0.13.3

### DIFF
--- a/pkgs/development/php-packages/zstd/default.nix
+++ b/pkgs/development/php-packages/zstd/default.nix
@@ -1,0 +1,32 @@
+{ buildPecl, lib, zstd, pkg-config, fetchFromGitHub }:
+
+let
+  version = "0.13.3";
+in buildPecl {
+  inherit version;
+  pname = "zstd";
+
+  src = fetchFromGitHub {
+    owner = "kjdev";
+    repo = "php-ext-zstd";
+    rev = version;
+    hash = "sha256-jEuL93ScF0/FlfUvib6uZafOkIe0+VkWV/frpSjTkvY=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [ zstd ];
+
+  configureFlags = [
+    "--with-libzstd"
+  ];
+
+  meta = with lib; {
+    description = "Zstd Extension for PHP";
+    license = licenses.mit;
+    homepage = "https://github.com/kjdev/php-ext-zstd";
+    maintainers = with lib.maintainers; [ shyim ];
+  };
+}

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -343,6 +343,8 @@ lib.makeScope pkgs.newScope (self: with self; {
     xdebug = callPackage ../development/php-packages/xdebug { };
 
     yaml = callPackage ../development/php-packages/yaml { };
+
+    zstd = callPackage ../development/php-packages/zstd { };
   } // lib.optionalAttrs config.allowAliases {
     php-spx = throw "php-spx is deprecated, use spx instead";
   } // (


### PR DESCRIPTION
## Description of changes

With zstd extension, we can compress better data in PHP. It's a really simple extension. I preferred the Git repository over Pecl, as it's slow and unreliable. We can maybe use pecl as source when they migrated to the new system

## Things done


- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

