### PR TITLE
postgresqlPackages.pg_squeeze: init at 1.5.2

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_squeeze.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_squeeze.nix
@@ -1,0 +1,67 @@
+{ lib, stdenv, fetchFromGitHub, postgresql, postgresqlTestHook }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pg_squeeze";
+  version = "1.5.2";
+
+  src = fetchFromGitHub {
+    owner = "cybertec-postgresql";
+    repo = "pg_squeeze";
+    rev = finalAttrs.version;
+    hash = "sha256-Sa5mVaUhuRHUjbcORVXe+3uwI1RxfsL6zaZixtU0BcU=";
+  };
+
+  buildInputs = [
+    postgresql
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -t $out/lib pg_squeeze${postgresql.dlSuffix}
+    install -D -t $out/share/postgresql/extension pg_squeeze-*.sql
+    install -D -t $out/share/postgresql/extension pg_squeeze.control
+
+    runHook postInstall
+  '';
+
+  passthru.tests.extension = stdenv.mkDerivation {
+    name = "pg_squeeze-test";
+    dontUnpack = true;
+    doCheck = true;
+    nativeCheckInputs = [ postgresqlTestHook (postgresql.withPackages (_: [ finalAttrs.finalPackage ])) ];
+    failureHook = "postgresqlStop";
+    postgresqlTestUserOptions = "LOGIN SUPERUSER";
+    postgresqlExtraSettings = ''
+      wal_level = logical
+      shared_preload_libraries = 'pg_squeeze'
+    '';
+    passAsFile = [ "sql" ];
+    sql = ''
+      CREATE EXTENSION pg_squeeze;
+
+      SELECT squeeze.start_worker();
+
+      CREATE TABLE a(i int PRIMARY KEY, j int);
+      INSERT INTO a(i, j) SELECT x, x FROM generate_series(1, 20) AS g(x);
+      INSERT INTO squeeze.tables (tabschema, tabname, schedule)
+      VALUES ('public', 'a', ('{30}', '{22}', NULL, NULL, '{3, 5}'));
+      SELECT squeeze.squeeze_table('public', 'a', NULL, NULL, NULL);
+    '';
+    checkPhase = ''
+      runHook preCheck
+      psql -a -v ON_ERROR_STOP=1 -f $sqlPath
+      runHook postCheck
+    '';
+    installPhase = "touch $out";
+  };
+
+  meta = with lib; {
+    description = "A PostgreSQL extension for automatic bloat cleanup";
+    homepage = "https://github.com/cybertec-postgresql/pg_squeeze";
+    changelog = "https://github.com/cybertec-postgresql/pg_squeeze/blob/${finalAttrs.src.rev}/NEWS";
+    license = licenses.mit;
+    maintainers = [ maintainers.marsam ];
+    platforms = postgresql.meta.platforms;
+  };
+})

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -85,6 +85,8 @@ self: super: {
 
     pg_safeupdate = super.callPackage ./ext/pg_safeupdate.nix { };
 
+    pg_squeeze = super.callPackage ./ext/pg_squeeze.nix { };
+
     pg_uuidv7 = super.callPackage ./ext/pg_uuidv7.nix { };
 
     promscale_extension = super.callPackage ./ext/promscale_extension.nix { };


### PR DESCRIPTION
## Description of changes
Add https://github.com/cybertec-postgresql/pg_squeeze
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
