### PR TITLE
pkgs.formats: pkgs.formats version of lib.generators.toINIWithGlobalSection

### DIFF
--- a/nixos/doc/manual/development/settings-options.section.md
+++ b/nixos/doc/manual/development/settings-options.section.md
@@ -73,6 +73,34 @@ have a predefined type and string generator already declared under
 
     It returns a set with INI-specific attributes `type` and `generate`
     as specified [below](#pkgs-formats-result).
+    The type of the input is an *attrset* of sections; key-value pairs where
+    the key is the section name and the value is the corresponding content
+    which is also an *attrset* of key-value pairs for the actual key-value
+    mappings of the INI format.
+    The values of the INI atoms are subject to the above parameters (e.g. lists
+    may be transformed into multiple key-value pairs depending on
+    `listToValue`).
+
+`pkgs.formats.iniWithGlobalSection` { *`listsAsDuplicateKeys`* ? false, *`listToValue`* ? null, \.\.\. }
+
+:   A function taking an attribute set with values
+
+    `listsAsDuplicateKeys`
+
+    :   A boolean for controlling whether list values can be used to
+        represent duplicate INI keys
+
+    `listToValue`
+
+    :   A function for turning a list of values into a single value.
+
+    It returns a set with INI-specific attributes `type` and `generate`
+    as specified [below](#pkgs-formats-result).
+    The type of the input is an *attrset* of the structure
+    `{ sections = {}; globalSection = {}; }` where *sections* are several
+    sections as with *pkgs.formats.ini* and *globalSection* being just a single
+    attrset of key-value pairs for a single section, the global section which
+    preceedes the section definitions.
 
 `pkgs.formats.toml` { }
 

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -95,29 +95,13 @@ rec {
 
   };
 
-  ini = {
-    # Represents lists as duplicate keys
-    listsAsDuplicateKeys ? false,
-    # Alternative to listsAsDuplicateKeys, converts list to non-list
-    # listToValue :: [IniAtom] -> IniAtom
-    listToValue ? null,
-    ...
-    }@args:
-    assert !listsAsDuplicateKeys || listToValue == null;
-    {
-
-    type = with lib.types; let
-
-      singleIniAtom = nullOr (oneOf [
-        bool
-        int
-        float
-        str
-      ]) // {
+  # the ini formats share a lot of code
+  inherit (
+    let
+      singleIniAtom = with lib.types; nullOr (oneOf [ bool int float str ]) // {
         description = "INI atom (null, bool, int, float or string)";
       };
-
-      iniAtom =
+      iniAtom = with lib.types; { listsAsDuplicateKeys, listToValue }:
         if listsAsDuplicateKeys then
           coercedTo singleIniAtom lib.singleton (listOf singleIniAtom) // {
             description = singleIniAtom.description + " or a list of them for duplicate keys";
@@ -128,21 +112,79 @@ rec {
           }
         else
           singleIniAtom;
+      iniSection = with lib.types; { listsAsDuplicateKeys, listToValue }@args:
+        attrsOf (iniAtom args) // {
+          description = "section of an INI file (attrs of " + (iniAtom args).description + ")";
+        };
 
-    in attrsOf (attrsOf iniAtom);
+      maybeToList = listToValue: if listToValue != null then lib.mapAttrs (key: val: if lib.isList val then listToValue val else val) else lib.id;
+    in {
+      ini = {
+        # Represents lists as duplicate keys
+        listsAsDuplicateKeys ? false,
+        # Alternative to listsAsDuplicateKeys, converts list to non-list
+        # listToValue :: [IniAtom] -> IniAtom
+        listToValue ? null,
+        ...
+        }@args:
+        assert listsAsDuplicateKeys -> listToValue == null;
+        {
 
-    generate = name: value:
-      let
-        transformedValue =
-          if listToValue != null
-          then
-            lib.mapAttrs (section: lib.mapAttrs (key: val:
-              if lib.isList val then listToValue val else val
-            )) value
-          else value;
-      in pkgs.writeText name (lib.generators.toINI (removeAttrs args ["listToValue"]) transformedValue);
+        type = lib.types.attrsOf (iniSection { listsAsDuplicateKeys = listsAsDuplicateKeys; listToValue = listToValue; });
 
-  };
+        generate = name: value:
+          lib.pipe value
+          [
+            (lib.mapAttrs (_: maybeToList listToValue))
+            (lib.generators.toINI (removeAttrs args ["listToValue"]))
+            (pkgs.writeText name)
+          ];
+      };
+
+      iniWithGlobalSection = {
+        # Represents lists as duplicate keys
+        listsAsDuplicateKeys ? false,
+        # Alternative to listsAsDuplicateKeys, converts list to non-list
+        # listToValue :: [IniAtom] -> IniAtom
+        listToValue ? null,
+        ...
+        }@args:
+        assert listsAsDuplicateKeys -> listToValue == null;
+        {
+          type = lib.types.submodule {
+            options = {
+              sections = lib.mkOption rec {
+                type = lib.types.attrsOf (iniSection { listsAsDuplicateKeys = listsAsDuplicateKeys; listToValue = listToValue; });
+                default = {};
+                description = type.description;
+              };
+              globalSection = lib.mkOption rec {
+                type = iniSection { listsAsDuplicateKeys = listsAsDuplicateKeys; listToValue = listToValue; };
+                default = {};
+                description = "global " + type.description;
+              };
+            };
+          };
+          generate = name: { sections ? {}, globalSection ? {}, ... }:
+            pkgs.writeText name (lib.generators.toINIWithGlobalSection (removeAttrs args ["listToValue"])
+            {
+              globalSection = maybeToList listToValue globalSection;
+              sections = lib.mapAttrs (_: maybeToList listToValue) sections;
+            });
+        };
+
+      gitIni = { listsAsDuplicateKeys ? false, ... }@args: {
+        type = let
+          atom = iniAtom {
+            listsAsDuplicateKeys = listsAsDuplicateKeys;
+            listToValue = null;
+          };
+        in with lib.types; attrsOf (attrsOf (either atom (attrsOf atom)));
+
+        generate = name: value: pkgs.writeText name (lib.generators.toGitINI value);
+      };
+
+    }) ini iniWithGlobalSection gitIni;
 
   # As defined by systemd.syntax(7)
   #
@@ -166,7 +208,7 @@ rec {
     listToValue ? null,
     ...
     }@args:
-    assert !listsAsDuplicateKeys || listToValue == null;
+    assert listsAsDuplicateKeys -> listToValue == null;
     {
 
     type = with lib.types; let
@@ -205,17 +247,6 @@ rec {
           else value;
       in pkgs.writeText name (lib.generators.toKeyValue (removeAttrs args ["listToValue"]) transformedValue);
 
-  };
-
-  gitIni = { listsAsDuplicateKeys ? false, ... }@args: {
-
-    type = with lib.types; let
-
-      iniAtom = (ini args).type/*attrsOf*/.functor.wrapped/*attrsOf*/.functor.wrapped;
-
-    in attrsOf (attrsOf (either iniAtom (attrsOf iniAtom)));
-
-    generate = name: value: pkgs.writeText name (lib.generators.toGitINI value);
   };
 
   toml = {}: json {} // {

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -222,6 +222,101 @@ in runBuildTests {
     '';
   };
 
+  iniWithGlobalNoSections = shouldPass {
+    format = formats.iniWithGlobalSection {};
+    input = {};
+    expected = "";
+  };
+
+  iniWithGlobalOnlySections = shouldPass {
+    format = formats.iniWithGlobalSection {};
+    input = {
+      sections = {
+        foo = {
+          bar = "baz";
+        };
+      };
+    };
+    expected = ''
+      [foo]
+      bar=baz
+    '';
+  };
+
+  iniWithGlobalOnlyGlobal = shouldPass {
+    format = formats.iniWithGlobalSection {};
+    input = {
+      globalSection = {
+        bar = "baz";
+      };
+    };
+    expected = ''
+      bar=baz
+
+    '';
+  };
+
+  iniWithGlobalWrongSections = shouldFail {
+    format = formats.iniWithGlobalSection {};
+    input = {
+      foo = {};
+    };
+  };
+
+  iniWithGlobalEverything = shouldPass {
+    format = formats.iniWithGlobalSection {};
+    input = {
+      globalSection = {
+        bar = true;
+      };
+      sections = {
+        foo = {
+          bool = true;
+          int = 10;
+          float = 3.141;
+          str = "string";
+        };
+      };
+    };
+    expected = ''
+      bar=true
+
+      [foo]
+      bool=true
+      float=3.141000
+      int=10
+      str=string
+    '';
+  };
+
+  iniWithGlobalListToValue = shouldPass {
+    format = formats.iniWithGlobalSection { listToValue = lib.concatMapStringsSep ", " (lib.generators.mkValueStringDefault {}); };
+    input = {
+      globalSection = {
+        bar = [ null true "test" 1.2 10 ];
+        baz = false;
+        qux = "qux";
+      };
+      sections = {
+        foo = {
+          bar = [ null true "test" 1.2 10 ];
+          baz = false;
+          qux = "qux";
+        };
+      };
+    };
+    expected = ''
+      bar=null, true, test, 1.200000, 10
+      baz=false
+      qux=qux
+
+      [foo]
+      bar=null, true, test, 1.200000, 10
+      baz=false
+      qux=qux
+    '';
+  };
+
   keyValueAtoms = shouldPass {
     format = formats.keyValue {};
     input = {

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -1,24 +1,21 @@
 { pkgs }:
 let
   inherit (pkgs) lib formats;
-in
-with lib;
-let
 
-  evalFormat = format: args: def:
-    let
-      formatSet = format args;
-      config = formatSet.type.merge [] (imap1 (n: def: {
-        # We check the input values, so that
-        #  - we don't write nonsensical tests that will impede progress
-        #  - the test author has a slightly more realistic view of the
-        #    final format during development.
-        value = lib.throwIfNot (formatSet.type.check def) (builtins.trace def "definition does not pass the type's check function") def;
-        file = "def${toString n}";
-      }) [ def ]);
-    in formatSet.generate "test-format-file" config;
+  # merging allows us to add metadata to the input
+  # this makes error messages more readable during development
+  mergeInput = name: format: input:
+    format.type.merge [] [
+      {
+        # explicitly throw here to trigger the code path that prints the error message for users
+        value = lib.throwIfNot (format.type.check input) (builtins.trace input "definition does not pass the type's check function") input;
+        # inject the name
+        file = "format-test-${name}";
+      }
+    ];
 
-  runBuildTest = name: { drv, expected }: pkgs.runCommand name {
+  # run a diff between expected and real output
+  runDiff = name: drv: expected: pkgs.runCommand name {
     passAsFile = ["expected"];
     inherit expected drv;
   } ''
@@ -31,12 +28,66 @@ let
     fi
   '';
 
-  runBuildTests = tests: pkgs.linkFarm "nixpkgs-pkgs-lib-format-tests" (mapAttrsToList (name: value: { inherit name; path = runBuildTest name value; }) (filterAttrs (name: value: value != null) tests));
+  # use this to check for proper serialization
+  # in practice you do not have to supply the name parameter as this one will be added by runBuildTests
+  shouldPass = { format, input, expected }: name: {
+    name = "pass-${name}";
+    path = runDiff "test-format-${name}" (format.generate "test-format-${name}" (mergeInput name format input)) expected;
+  };
+
+  # use this function to assert that a type check must fail
+  # in practice you do not have to supply the name parameter as this one will be added by runBuildTests
+  # note that as per 352e7d330a26 and 352e7d330a26 the type checking of attrsets and lists are not strict
+  # this means that the code below needs to properly merge the module type definition and also evaluate the (lazy) return value
+  shouldFail = { format, input }: name:
+    let
+      # trigger a deep type check using the module system
+      typeCheck = lib.modules.mergeDefinitions
+        [ "tests" name ]
+        format.type
+        [
+          {
+            file = "format-test-${name}";
+            value = input;
+          }
+        ];
+      # actually use the return value to trigger the evaluation
+      eval = builtins.tryEval (typeCheck.mergedValue == input);
+      # the check failing is what we want, so don't do anything here
+      typeFails = pkgs.runCommand "test-format-${name}" {} "touch $out";
+      # bail with some verbose information in case the type check passes
+      typeSucceeds = pkgs.runCommand "test-format-${name}" {
+          passAsFile = [ "inputText" ];
+          testName = name;
+          # this will fail if the input contains functions as values
+          # however that should get caught by the type check already
+          inputText = builtins.toJSON input;
+        }
+        ''
+          echo "Type check $testName passed when it shouldn't."
+          echo "The following data was used as input:"
+          echo
+          cat "$inputTextPath"
+          exit 1
+        '';
+    in {
+      name = "fail-${name}";
+      path = if eval.success then typeSucceeds else typeFails;
+    };
+
+  # this function creates a linkFarm for all the tests below such that the results are easily visible in the filesystem after a build
+  # the parameters are an attrset of name: test pairs where the name is automatically passed to the test
+  # the test therefore is an invocation of ShouldPass or shouldFail with the attrset parameters but *not* the name (which this adds for convenience)
+  runBuildTests = (lib.flip lib.pipe) [
+    (lib.mapAttrsToList (name: value: value name))
+    (pkgs.linkFarm "nixpkgs-pkgs-lib-format-tests")
+  ];
 
 in runBuildTests {
 
-  testJsonAtoms = {
-    drv = evalFormat formats.json {} {
+  jsonAtoms = shouldPass {
+    format = formats.json {};
+    input = {
       null = null;
       false = false;
       true = true;
@@ -67,8 +118,9 @@ in runBuildTests {
     '';
   };
 
-  testYamlAtoms = {
-    drv = evalFormat formats.yaml {} {
+  yamlAtoms = shouldPass {
+    format = formats.yaml {};
+    input = {
       null = null;
       false = false;
       true = true;
@@ -93,8 +145,9 @@ in runBuildTests {
     '';
   };
 
-  testIniAtoms = {
-    drv = evalFormat formats.ini {} {
+  iniAtoms = shouldPass {
+    format = formats.ini {};
+    input = {
       foo = {
         bool = true;
         int = 10;
@@ -111,8 +164,29 @@ in runBuildTests {
     '';
   };
 
-  testIniDuplicateKeys = {
-    drv = evalFormat formats.ini { listsAsDuplicateKeys = true; } {
+  iniInvalidAtom = shouldFail {
+    format = formats.ini {};
+    input = {
+      foo = {
+        function = _: 1;
+      };
+    };
+  };
+
+  iniDuplicateKeysWithoutList = shouldFail {
+    format = formats.ini {};
+    input = {
+      foo = {
+        bar = [ null true "test" 1.2 10 ];
+        baz = false;
+        qux = "qux";
+      };
+    };
+  };
+
+  iniDuplicateKeys = shouldPass {
+    format = formats.ini { listsAsDuplicateKeys = true; };
+    input = {
       foo = {
         bar = [ null true "test" 1.2 10 ];
         baz = false;
@@ -131,8 +205,9 @@ in runBuildTests {
     '';
   };
 
-  testIniListToValue = {
-    drv = evalFormat formats.ini { listToValue = concatMapStringsSep ", " (generators.mkValueStringDefault {}); } {
+  iniListToValue = shouldPass {
+    format = formats.ini { listToValue = lib.concatMapStringsSep ", " (lib.generators.mkValueStringDefault {}); };
+    input = {
       foo = {
         bar = [ null true "test" 1.2 10 ];
         baz = false;
@@ -147,8 +222,9 @@ in runBuildTests {
     '';
   };
 
-  testKeyValueAtoms = {
-    drv = evalFormat formats.keyValue {} {
+  keyValueAtoms = shouldPass {
+    format = formats.keyValue {};
+    input = {
       bool = true;
       int = 10;
       float = 3.141;
@@ -162,8 +238,9 @@ in runBuildTests {
     '';
   };
 
-  testKeyValueDuplicateKeys = {
-    drv = evalFormat formats.keyValue { listsAsDuplicateKeys = true; } {
+  keyValueDuplicateKeys = shouldPass {
+    format = formats.keyValue { listsAsDuplicateKeys = true; };
+    input = {
       bar = [ null true "test" 1.2 10 ];
       baz = false;
       qux = "qux";
@@ -179,8 +256,9 @@ in runBuildTests {
     '';
   };
 
-  testKeyValueListToValue = {
-    drv = evalFormat formats.keyValue { listToValue = concatMapStringsSep ", " (generators.mkValueStringDefault {}); } {
+  keyValueListToValue = shouldPass {
+    format = formats.keyValue { listToValue = lib.concatMapStringsSep ", " (lib.generators.mkValueStringDefault {}); };
+    input = {
       bar = [ null true "test" 1.2 10 ];
       baz = false;
       qux = "qux";
@@ -192,8 +270,9 @@ in runBuildTests {
     '';
   };
 
-  testTomlAtoms = {
-    drv = evalFormat formats.toml {} {
+  tomlAtoms = shouldPass {
+    format = formats.toml {};
+    input = {
       false = false;
       true = true;
       int = 10;
@@ -222,8 +301,9 @@ in runBuildTests {
   #   1. testing type coercions
   #   2. providing a more readable example test
   # Whereas java-properties/default.nix tests the low level escaping, etc.
-  testJavaProperties = {
-    drv = evalFormat formats.javaProperties {} {
+  javaProperties = shouldPass {
+    format = formats.javaProperties {};
+    input = {
       floaty = 3.1415;
       tautologies = true;
       contradictions = false;


### PR DESCRIPTION
## Description of changes

This allows freeform style options using the `lib.generators.toINIWithGlobalSection` backend.

Usage examples are contained in the tests, for instance:

https://github.com/NixOS/nixpkgs/blob/14b6354312cfa95dcd6592e4b45121f41a9fbae9/pkgs/pkgs-lib/tests/formats.nix#L266-L290

This also includes an extra commit restructuring the tests such that negative tests can be written (aka. `shouldFail`) for types so that we can ensure that type errors are actually caught.
This can be used to expand the tests for other formats too of course.

This PR obsoletes #228051 which contains further information and history on the development of this.

## Meta

Thanks to:

- @tim-tx for writing the above PR (you're retained as co-author as per git commits, pinged FYI)
- @infinisil for the guidance (pinged in case you want to review this one)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- [ ] first and foremost this needs a thorough review (I do expect some of the code to change in response, so that'd be nice to get done first)
- [ ] nixfmt would like to touch a lot of this, and in some instances (e.g. the tests) making it less readable IMHO, input appreciated
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- ~~[24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)~~
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
