### PR TITLE
Add Crust-Firmware Package + OLIMEX Teres-I configuration

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10200,6 +10200,12 @@
     githubId = 4032;
     name = "Kristoffer Thømt Ravneberg";
   };
+  kreyren = {
+    email = "kreyren@proton.me";
+    github = "kreyren";
+    githubId = 11302521;
+    name = "Jacob KREYREN Hrbek";
+  };
   kristian-brucaj = {
     email = "kbrucaj@gmail.com";
     github = "Flameslice";

--- a/pkgs/misc/crust/default.nix
+++ b/pkgs/misc/crust/default.nix
@@ -1,0 +1,105 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, fetchpatch
+, bison
+, flex
+, buildPackages
+}:
+
+let
+  defaultVersion = "0.6";
+
+  defaultSrc = fetchFromGitHub {
+    owner = "crust-firmware";
+    repo = "crust";
+    rev = "v${defaultVersion}";
+    sha256 = "zalBVP9rI81XshcurxmvoCwkdlX3gMw5xuTVLOIymK4=";
+  };
+
+  buildCrust = {
+    version ? defaultVersion
+  , src ? defaultSrc
+  , defconfig
+  , extraConfig ? ""
+  , extraPatches ? []
+  , extraMakeFlags ? []
+  , extraMeta ? {}
+  , ... } @ args: stdenv.mkDerivation ({
+    pname = if (builtins.isNull ((builtins.match "_defconfig$" defconfig)))
+      then "crust-${lib.strings.removeSuffix "_defconfig" defconfig}"
+      else "crust-${defconfig}";
+
+    inherit version;
+    inherit src;
+
+    # Only for global crust patches, per-device paches should be included as extras to avoid adding noise which would complicate debugging
+    patches = [] ++ extraPatches;
+
+    postPatch = "";
+
+    nativeBuildInputs = [
+      flex
+      bison
+    ];
+
+    depsBuildBuild = [ buildPackages.stdenv.cc ];
+
+    makeFlags = [
+      "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+    ] ++ extraMakeFlags;
+
+    configurePhase = ''
+      runHook preConfigure
+
+      echo "Configuring for ${defconfig}"
+      make "${defconfig}"
+
+      # The variable 'extraConfigPath' is often parsed as blank resulting in a scenario where `cat` is expecting interactive input followed by line-break to continue, this is to reduce the risk of that happening
+      [ -z "$extraConfigPath" ] || {
+        cat $extraConfigPath >> .config
+      }
+
+      runHook postConfigure
+    '';
+
+    # The package has only one output which is located in `build/scp/scp.bin`
+    installPhase = ''
+      runHook preInstall
+
+      mkdir "$out"
+      cp -v "build/scp/scp.bin" "$out/scp.bin"
+
+      runHook postInstall
+    '';
+
+    hardeningDisable = [ "all" ];
+
+    # Default Metadata
+    meta = with lib; {
+      homepage = "https://github.com/crust-firmware/crust";
+      description = "SCP (power management) firmware for sunxi SoCs";
+      # Project using 3rdparty components https://github.com/crust-firmware/crust/blob/master/LICENSE.md#crust-firmware-licensing
+      platforms = [ "or1k-none" ];
+      license = with licenses; [
+        bsd1
+        bsd3
+        mit
+        gpl2
+      ];
+    } // extraMeta;
+  } // removeAttrs args [ "extraMeta" ]);
+
+in {
+  inherit buildCrust;
+
+  # Example configuration:
+  ## crustExample = buildCrust {
+  ##   defconfig = "example_defconfig";
+  ##   extraMeta = {
+  ##     description = "SCP (power management) firmware for Example";
+  ##     platforms = [ "or1k-none" ];
+  ##     maintainers = with lib.maintainers; [ your-usename-here ];
+  ##   };
+  ## };
+}

--- a/pkgs/misc/crust/default.nix
+++ b/pkgs/misc/crust/default.nix
@@ -102,4 +102,12 @@ in {
   ##     maintainers = with lib.maintainers; [ your-usename-here ];
   ##   };
   ## };
+
+  crustOlimexA64Teres1 = buildCrust {
+    defconfig = "teres_i_defconfig";
+    extraMeta = {
+      description = "SCP (power management) firmware for TERES-1";
+      maintainers = with lib.maintainers; [ kreyren ];
+    };
+  };
 }

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -21,7 +21,9 @@
 , armTrustedFirmwareRK3328
 , armTrustedFirmwareRK3399
 , armTrustedFirmwareS905
+, crustOlimexA64Teres1
 , buildPackages
+, pkgsCross
 }:
 
 let
@@ -357,8 +359,7 @@ in {
     defconfig = "teres_i_defconfig";
     extraMeta.platforms = ["aarch64-linux"];
     BL31 = "${armTrustedFirmwareAllwinner}/bl31.bin";
-    # Using /dev/null here is upstream-specified way that disables the inclusion of crust-firmware as it's not yet packaged and without which the build will fail -- https://docs.u-boot.org/en/latest/board/allwinner/sunxi.html#building-the-crust-management-processor-firmware
-    SCP = "/dev/null";
+    SCP = "${pkgsCross.or1k.crustOlimexA64Teres1}/scp.bin";
     filesToInstall = ["u-boot-sunxi-with-spl.bin"];
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27642,6 +27642,12 @@ with pkgs;
 
   criu = callPackage ../os-specific/linux/criu { };
 
+  # Upstream Crust:
+  inherit (callPackage ../misc/crust {})
+    buildCrust
+    crustOlimexA64Teres1
+    ;
+
   cryptomator = callPackage ../tools/security/cryptomator {
     jdk = jdk21.override { enableJavaFX = true; };
   };


### PR DESCRIPTION
## Description of changes

The Crust-Firmware is an SCP responsible for power management on sunxi devices, my main motivation is to get suspend and hibernation to work on OLIMEX Teres-I as that feature is critical for it's practical use to have a reasonable battery life.

I tried to write the package to be follow the design of uboot package for easier management.

Fixes: https://github.com/NixOS/nixpkgs/issues/240846

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux - Cross-Compiled
  - [-] aarch64-linux
  - [-] x86_64-darwin
  - [-] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [-] `sandbox = relaxed`
  - [-] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [-] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [-] (Package updates) Added a release notes entry if the change is major or breaking
  - [-] (Module updates) Added a release notes entry if the change is significant
  - [-] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
