### PR TITLE
opensmalltalk-vm: 202206021410 -> 202312181441

### DIFF
--- a/pkgs/development/compilers/opensmalltalk-vm/default.nix
+++ b/pkgs/development/compilers/opensmalltalk-vm/default.nix
@@ -14,6 +14,7 @@
 , pango
 , pkg-config
 , xorg
+, libGL
 }:
 let
   buildVM =
@@ -29,8 +30,8 @@ let
       src = fetchFromGitHub {
         owner = "OpenSmalltalk";
         repo = "opensmalltalk-vm";
-        rev = "202206021410";
-        hash = "sha256-QqElPiJuqD5svFjWrLz1zL0Tf+pHxQ2fPvkVRn2lyBI=";
+        rev = "202312181441";
+        hash = "sha256-j8fVL8072ccdaRyW5sPDcYXxMcIZIvSFJ+4Q1+41ey0=";
       };
     in
     stdenv.mkDerivation {
@@ -40,6 +41,10 @@ let
       version = src.rev;
 
       inherit src;
+
+      # Fixes build errors triggered by the format-security compiler flag
+      # and caused by passing non-literals as the first argument to printf.
+      patches = [ ./printOptionStrings.patch ];
 
       postPatch =
         ''
@@ -71,7 +76,7 @@ let
 
       configureFlags = [ "--with-scriptname=${scriptName}" ] ++ configureFlags;
 
-      buildFlags = [ "all" ];
+      buildFlags = [ "getversion" "all" ];
 
       enableParallelBuilding = true;
 
@@ -83,6 +88,7 @@ let
       buildInputs = [
         alsa-lib
         freetype
+        libGL
         libpulseaudio
         libtool
         libuuid

--- a/pkgs/development/compilers/opensmalltalk-vm/printOptionStrings.patch
+++ b/pkgs/development/compilers/opensmalltalk-vm/printOptionStrings.patch
@@ -1,0 +1,26 @@
+diff --git a/platforms/iOS/vm/OSX/sqSqueakOSXApplication.m b/platforms/iOS/vm/OSX/sqSqueakOSXApplication.m
+index d248e9fd0..0ae695061 100644
+--- a/platforms/iOS/vm/OSX/sqSqueakOSXApplication.m
++++ b/platforms/iOS/vm/OSX/sqSqueakOSXApplication.m
+@@ -559,7 +559,7 @@ printOptionStrings()
+ 			sizeof(char *),
+ 			(int (*)(const void*,const void*))sortStrings);
+ 	while (--count >= 0)
+-		printf(optionStrings[count]);
++		printf("%s", optionStrings[count]);
+ }
+ 
+ - (void) printUsage {
+diff --git a/platforms/unix/vm/sqUnixMain.c b/platforms/unix/vm/sqUnixMain.c
+index 4795563f5..419f527e3 100644
+--- a/platforms/unix/vm/sqUnixMain.c
++++ b/platforms/unix/vm/sqUnixMain.c
+@@ -1829,7 +1829,7 @@ printOptionStrings()
+ 			sizeof(char *),
+ 			(int (*)(const void*,const void*))sortStrings);
+ 	while (--count >= 0)
+-		printf(optionStrings[count]);
++		printf("%s", optionStrings[count]);
+ }
+ 
+ void


### PR DESCRIPTION
## Description of changes

Updated to the latest release of `opensmalltalk-vm`, `202312181441`. This addresses in part #282414, because this updates the VM, and the lastest image is available for download from https://squeak.org/downloads/.

The main issue was an error triggered by the [`format-security`](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#:~:text=format-security) compiler flag. When I have time I'll submit the patch upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
