### PR TITLE
q2pro: init at r3510

### DIFF
--- a/pkgs/by-name/q2/q2pro/package.nix
+++ b/pkgs/by-name/q2/q2pro/package.nix
@@ -1,0 +1,109 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  pkg-config,
+  ninja,
+  zlib,
+  libpng,
+  libjpeg,
+  curl,
+  SDL2,
+  openalSoft,
+  libogg,
+  libvorbis,
+  libXi,
+  wayland,
+  wayland-protocols,
+  libdecor,
+  ffmpeg,
+  wayland-scanner,
+  makeWrapper,
+  versionCheckHook,
+  x11Support ? stdenv.isLinux,
+  waylandSupport ? stdenv.isLinux,
+}:
+
+stdenv.mkDerivation (finalAttrs: rec {
+  pname = "q2pro";
+  version = "3510";
+
+  src = fetchFromGitHub {
+    owner = "skullernet";
+    repo = "q2pro";
+    rev = "refs/tags/r${version}";
+    hash = "sha256-LNOrGJarXnf4QqFXDkUfUgLGrjSqbjncpIN2yttbMuk=";
+  };
+
+  nativeBuildInputs =
+    [
+      meson
+      pkg-config
+      ninja
+      makeWrapper
+    ]
+    ++ lib.optionals waylandSupport [
+      wayland-scanner
+    ];
+
+  buildInputs =
+    [
+      zlib
+      libpng
+      libjpeg
+      curl
+      SDL2
+      libogg
+      libvorbis
+      ffmpeg
+      openalSoft
+    ]
+    ++ lib.optionals waylandSupport [
+      wayland
+      wayland-protocols
+      libdecor
+    ]
+    ++ lib.optionals x11Support [ libXi ];
+
+  mesonBuildType = "release";
+
+  mesonFlags = [
+    (lib.mesonBool "anticheat-server" true)
+    (lib.mesonBool "client-gtv" true)
+    (lib.mesonBool "packetdup-hack" true)
+    (lib.mesonBool "variable-fps" true)
+    (lib.mesonEnable "wayland" waylandSupport)
+    (lib.mesonEnable "x11" x11Support)
+    (lib.mesonEnable "icmp-errors" stdenv.isLinux)
+    (lib.mesonEnable "windows-crash-dumps" false)
+  ];
+
+  postPatch = ''
+    echo 'r${version}' > VERSION
+  '';
+
+  postInstall =
+    let
+      ldLibraryPathEnvName =
+        if stdenv.hostPlatform.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH";
+    in
+    ''
+      mv -v $out/bin/q2pro $out/bin/q2pro-unwrapped
+      makeWrapper $out/bin/q2pro-unwrapped $out/bin/q2pro \
+        --prefix ${ldLibraryPathEnvName} : "${lib.makeLibraryPath finalAttrs.buildInputs}"
+    '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  meta = {
+    description = "Enhanced Quake 2 client and server focused on multiplayer";
+    homepage = "https://github.com/skullernet/q2pro";
+    license = lib.licenses.gpl2;
+    maintainers = with lib.maintainers; [ carlossless ];
+    platforms = lib.platforms.unix;
+    mainProgram = "q2pro";
+  };
+})


### PR DESCRIPTION
## Description of changes

Enhanced Quake 2 client and server focused on multiplayer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
