### PR TITLE
freefilesync: add disable update patch

### DIFF
--- a/pkgs/by-name/fr/freefilesync/package.nix
+++ b/pkgs/by-name/fr/freefilesync/package.nix
@@ -64,6 +64,14 @@ stdenv.mkDerivation (finalAttrs: {
       patch = "revert_buggy_gtk3_change_in_12.1.patch";
       hash = "sha256-eqush3zXxypQUxtO5110GoOJ30F5LZcF8XIC/Y8/fgM=";
     })
+    # Disable update patch
+    (fetchDebianPatch {
+      pname = "freefilesync";
+      version = "13.3";
+      debianRevision = "1";
+      patch = "ffs_no_check_updates.patch";
+      hash = "sha256-lPyHpxhZz8BSnDI8QfAzKpKwVkp2jiF49RWjKNuZGII=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

This patch from Debian removes update functionality. After this, we won't see notification window that newer version is available. Also, this removes option in "Help" - "Check for update now".

![Снимок экрана от 2024-02-05 14-11-00](https://github.com/NixOS/nixpkgs/assets/20269529/70c800a9-ca8e-4cbb-9ee0-7e8560efbb7d)

More about changes in this patch you can find here: https://sources.debian.org/data/main/f/freefilesync/13.3-1/debian/patches/ffs_no_check_updates.patch

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
