### PR TITLE
xfce.xfce4-screenshooter: 1.10.4 -> 1.10.5

### DIFF
--- a/pkgs/desktops/xfce/applications/xfce4-screenshooter/default.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-screenshooter/default.nix
@@ -7,15 +7,19 @@
 , libxfce4util
 , xfce4-panel
 , xfconf
+, curl
+, gnome
+, jq
+, xclip
 }:
 
 mkXfceDerivation {
   category = "apps";
   pname = "xfce4-screenshooter";
-  version = "1.10.4";
+  version = "1.10.5";
   odd-unstable = false;
 
-  sha256 = "sha256-jikvMHpmBLTqwDjTxx4AMU8CnfrtSExFauq+gcTX2E8=";
+  sha256 = "sha256-x1uQIfiUNMYowrCLpwdt1IsHfJLn81f8I/4NBwX/z9k=";
 
   buildInputs = [
     exo
@@ -26,6 +30,14 @@ mkXfceDerivation {
     xfce4-panel
     xfconf
   ];
+
+  preFixup = ''
+    # For Imgur upload action
+    # https://gitlab.xfce.org/apps/xfce4-screenshooter/-/merge_requests/51
+    gappsWrapperArgs+=(
+      --prefix PATH : ${lib.makeBinPath [ curl gnome.zenity jq xclip ]}
+    )
+  '';
 
   meta = with lib; {
     description = "Screenshot utility for the Xfce desktop";


### PR DESCRIPTION
https://gitlab.xfce.org/apps/xfce4-screenshooter/-/compare/xfce4-screenshooter-1.10.4...xfce4-screenshooter-1.10.5

From https://gitlab.xfce.org/apps/xfce4-screenshooter/-/merge_requests/51:

> - Install shell script to upload screenshots to Imgur
>   - Depends on: curl, jq, zenity and xclip
>   - I wonder if packagers will take care of this

Tested an upload using the action.

![图片](https://github.com/NixOS/nixpkgs/assets/20080233/93a6bf33-c1fa-4374-9934-0457603936bd)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->


