### PR TITLE
inotify-info: init at unstable-2024-01-05

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12836,6 +12836,16 @@
     githubId = 10601196;
     name = "Jérémie Ferry";
   };
+  motiejus = {
+    email = "motiejus@jakstys.lt";
+    github = "motiejus";
+    githubId = 107720;
+    keys = [{
+      fingerprint = "5F6B 7A8A 92A2 60A4 3704  9BEB 6F13 3A0C 1C28 48D7";
+    }];
+    matrix = "@motiejus:jakstys.lt";
+    name = "Motiejus Jakštys";
+  };
   mounium = {
     email = "muoniurn@gmail.com";
     github = "Mounium";

--- a/pkgs/by-name/in/inotify-info/package.nix
+++ b/pkgs/by-name/in/inotify-info/package.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "inotify-info";
+  version = "unstable-2024-01-05";
+
+  src = fetchFromGitHub {
+    owner = "mikesart";
+    repo = "inotify-info";
+    rev = "a7ff6fa62ed96ec5d2195ef00756cd8ffbf23ae1";
+    hash = "sha256-yY+hjdb5J6dpFkIMMUWvZlwoGT/jqOuQIcFp3Dv+qB8=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 _release/inotify-info $out/bin/inotify-info
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Easily track down the number of inotify watches, instances, and which files are being watched.";
+    homepage = "https://github.com/mikesart/inotify-info";
+    license = licenses.mit;
+    mainProgram = "inotify-info";
+    maintainers = with maintainers; [ motiejus ];
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
