### PR TITLE
lib/modules: implement a way to override a property based on its previous value

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -817,46 +817,63 @@ let
       };
 
   # Merge definitions of a value of a given type.
-  mergeDefinitions = loc: type: defs: rec {
-    defsFinal' =
-      let
-        # Process mkMerge and mkIf properties.
-        defs' = concatMap (m:
-          map (value: { inherit (m) file; inherit value; }) (builtins.addErrorContext "while evaluating definitions from `${m.file}':" (dischargeProperties m.value))
-        ) defs;
+  mergeDefinitions = loc: type: defs: let
+    # Process mkMerge and mkIf properties.
+    defs' = concatMap (m:
+      map (value: { inherit (m) file; inherit value; }) (builtins.addErrorContext "while evaluating definitions from `${m.file}':" (dischargeProperties m.value))
+    ) defs;
+    getPrio = def: if lib.elem def.value._type or "" [ "override" "overrideWith" ] then def.value.priority else defaultOverridePriority;
+    highestPrioBelow = thresh: foldl' (prio: def: let p = getPrio def; in if p <= thresh then prio else (min p prio)) 9999 defs';
+    highestPrio = highestPrioBelow (-1);
+    filterOverrides = prio: let
+      strip = def: if def.value._type or "" == "override" then def // { value = def.value.content; } else def;
+    in {
+      values = concatMap (def: if getPrio def == prio then [(strip def)] else []) defs';
+      highestPrio = prio;
+    };
+    mergedForPrio = prio: rec {
+      defsFinal' =
+        let
+          # Process mkOverride properties.
+          defs'' = filterOverrides prio;
 
-        # Process mkOverride properties.
-        defs'' = filterOverrides' defs';
+          # Process mkOverrideWith
+          defs''' = let
+            p = highestPrioBelow prio;
+            mergedBelow = mergedForPrio p;
+            mapOverrideWith = def: def // { value = def.value.fn mergedBelow.mergedValue; };
+          in map (def: if def.value._type or "" == "overrideWith" then mapOverrideWith def else def) defs''.values;
 
-        # Sort mkOrder properties.
-        defs''' =
-          # Avoid sorting if we don't have to.
-          if any (def: def.value._type or "" == "order") defs''.values
-          then sortProperties defs''.values
-          else defs''.values;
-      in {
-        values = defs''';
-        inherit (defs'') highestPrio;
-      };
-    defsFinal = defsFinal'.values;
+          # Sort mkOrder properties.
+          defs'''' =
+            # Avoid sorting if we don't have to.
+            if any (def: def.value._type or "" == "order") defs'''
+            then sortProperties defs'''
+            else defs''';
+        in {
+          values = defs'''';
+          inherit (defs'') highestPrio;
+        };
+      defsFinal = defsFinal'.values;
 
-    # Type-check the remaining definitions, and merge them. Or throw if no definitions.
-    mergedValue =
-      if isDefined then
-        if all (def: type.check def.value) defsFinal then type.merge loc defsFinal
-        else let allInvalid = filter (def: ! type.check def.value) defsFinal;
-        in throw "A definition for option `${showOption loc}' is not of type `${type.description}'. Definition values:${showDefs allInvalid}"
-      else
-        # (nixos-option detects this specific error message and gives it special
-        # handling.  If changed here, please change it there too.)
-        throw "The option `${showOption loc}' is used but not defined.";
+      # Type-check the remaining definitions, and merge them. Or throw if no definitions.
+      mergedValue =
+        if isDefined then
+          if all (def: type.check def.value) defsFinal then type.merge loc defsFinal
+          else let allInvalid = filter (def: ! type.check def.value) defsFinal;
+          in throw "A definition for option `${showOption loc}' is not of type `${type.description}'. Definition values:${showDefs allInvalid}"
+        else
+          # (nixos-option detects this specific error message and gives it special
+          # handling.  If changed here, please change it there too.)
+          throw "The option `${showOption loc}' is used but not defined.";
 
-    isDefined = defsFinal != [];
+      isDefined = defsFinal != [];
 
-    optionalValue =
-      if isDefined then { value = mergedValue; }
-      else {};
-  };
+      optionalValue =
+        if isDefined then { value = mergedValue; }
+        else {};
+    };
+  in mergedForPrio highestPrio;
 
   /* Given a config set, expand mkMerge properties, and push down the
      other properties into the children.  The result is a list of
@@ -1016,11 +1033,17 @@ let
       inherit priority content;
     };
 
+  mkOverrideWith = priority: fn:
+    { _type = "overrideWith";
+      inherit priority fn;
+    };
+
   mkOptionDefault = mkOverride 1500; # priority of option defaults
   mkDefault = mkOverride 1000; # used in config sections of non-user modules to set a default
   defaultOverridePriority = 100;
   mkImageMediaOverride = mkOverride 60; # image media profiles can be derived by inclusion into host config, hence needing to override host config, but do allow user to mkForce
   mkForce = mkOverride 50;
+  mkForceWith = mkOverrideWith 50;
   mkVMOverride = mkOverride 10; # used by ‘nixos-rebuild build-vm’
 
   defaultPriority = lib.warnIf (lib.isInOldestRelease 2305) "lib.modules.defaultPriority is deprecated, please use lib.modules.defaultOverridePriority instead." defaultOverridePriority;
@@ -1351,6 +1374,7 @@ private //
     mkDerivedConfig
     mkFixStrictness
     mkForce
+    mkForceWith
     mkIf
     mkImageMediaOverride
     mkMerge
@@ -1358,6 +1382,7 @@ private //
     mkOptionDefault
     mkOrder
     mkOverride
+    mkOverrideWith
     mkRemovedOptionModule
     mkRenamedOptionModule
     mkRenamedOptionModuleWith


### PR DESCRIPTION
## Description of changes

This is by no means meant to be a complete implementation. It's in fact suboptimal and not even fully functional, but I got it done to show that it's possible and that it could prove useful.
My idea is to introduce `mkOverrideWith` (name subject to change) which would work like the current `mkOverride` with one caveat: instead of taking an attrset it takes a lambda, which accepts the next highest priority value as its argument. This allows to set a new value for a given property while reusing the previous value.

### Why would this be useful
Personally I see one big upside of having a mechanism like this: not having to introduce IFD or having to resort to `extendModules`.
Examples:
- [stylix](https://github.com/danth/stylix) works by generating the palette in a derivation, then imports said derivation and lets the user use the colors in their config. With this approach, one could simply assign placeholders values to properties, and the colors would be substituted at build time. The code for that could look something like this
```nix
# helix.nix
{
	programs.helix = {
		enable = true;
		settings.themes = {
			stylix = {
				"ui.background" = {bg = "@base00@";};
				"ui.virtual" = "@base03@";
				"ui.menu" = {
					fg = "@base05@";
					bg = "@base01@";
				};
			};
		};
	};
}
# stylix.nix
{lib, pkgs, ...}: {
	xdg.configFile."helix/themes/stylix.toml".source =
		lib.mkForceWith
		(prev: pkgs.runCommand "helix-theme" {} ''
			substituteColors ${prev} > $out
		'');
}
```
- Secrets in configuration files: Currently the only way to have secrets in configuration files is to write the whole configuration by hand, encrypt it, and then give path to it with [sops](https://github.com/Mic92/sops-nix) or [agenix](https://github.com/ryantm/agenix). The alternative is to use [scalpel](https://github.com/polygon/scalpel) (or handroll a similar solution) but that requires using `extendModules` or other suboptimal solutions. While what I'm proposing here still wouldn't be ideal (I'm happy for someone more knowledgable about the module system to come up with a better solution based on this idea), you could potentially do something like this
```nix
# config.nix
{
	services.mosquitto = {
		enable = true;
		bridges.br1.settings = {
			remote_password = "!!BR1_PASSWORD!!";
		};
	};
}
# secrets.nix
{config, lib, pkgs, ...}: {
	config = lib.mkOverrideWith 20 (prev: lib.recursiveUpdate prev (let
		prevVal = prev.systemd.services.mosquitto.serviceConfig.ExecStart;
		prevFile = builtins.head (builtins.match ".*-c ([^[:space:]]+)" prevVal;
	in {
		systemd.services.mosquitto.serviceConfig.ExecStart =
			builtins.replaceStrings
			[ prevFile ]
			[ "${config.scalpel.trafos."mosquitto.conf".destination} "]
			prevVal;
		scalpel.trafos."mosquitto.conf" = {
			source = prevFile;
			matchers."BR1_PASSWORD".secret = config.sops.secrets.br1passwd.path;
			owner = "mosquitto";
			group = "mosquitto";
			mode = "0440";
		};
	}));
}
```
- Patching packages for modules which themselves apply some patches. Now, this is probably a sign that a module has subpar API, but I think we've all seen that happen in nixpkgs and having a way of easily dealing with that could be beneficial. Instead of replicating what the module does with the package one could simply do
```nix
{lib, ...}: {
	programs.foo.package = lib.mkForceWith (pkg: pkg.overrideAttrs { ... });
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
