### PR TITLE
starsector: 0.96a-RC10 -> 0.97a-RC8

### DIFF
--- a/pkgs/games/starsector/default.nix
+++ b/pkgs/games/starsector/default.nix
@@ -63,12 +63,14 @@ stdenv.mkDerivation rec {
   # it tries to run everything with relative paths, which makes it CWD dependent
   # also point mod, screenshot, and save directory to $XDG_DATA_HOME
   # additionally, add some GC options to improve performance of the game
+  # and remove flags "PermSize" and "MaxPermSize" that were removed with Java 8
   postPatch = ''
     substituteInPlace starsector.sh \
-      --replace "./jre_linux/bin/java" "${openjdk}/bin/java" \
-      --replace "./native/linux" "$out/share/starsector/native/linux" \
-      --replace "=." "=\''${XDG_DATA_HOME:-\$HOME/.local/share}/starsector" \
-      --replace "-XX:+CompilerThreadHintNoPreempt" "-XX:+UnlockDiagnosticVMOptions -XX:-BytecodeVerificationRemote -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSConcurrentMTEnabled -XX:+DisableExplicitGC"
+      --replace-fail "./jre_linux/bin/java" "${openjdk}/bin/java" \
+      --replace-fail "./native/linux" "$out/share/starsector/native/linux" \
+      --replace-fail "=." "=\''${XDG_DATA_HOME:-\$HOME/.local/share}/starsector" \
+      --replace-warn "-XX:+CompilerThreadHintNoPreempt" "-XX:+UnlockDiagnosticVMOptions -XX:-BytecodeVerificationRemote -XX:+CMSConcurrentMTEnabled -XX:+DisableExplicitGC" \
+      --replace-quiet " -XX:PermSize=192m -XX:MaxPermSize=192m" ""
   '';
 
   meta = with lib; {

--- a/pkgs/games/starsector/default.nix
+++ b/pkgs/games/starsector/default.nix
@@ -14,11 +14,11 @@
 
 stdenv.mkDerivation rec {
   pname = "starsector";
-  version = "0.96a-RC10";
+  version = "0.97a-RC8";
 
   src = fetchzip {
     url = "https://f005.backblazeb2.com/file/fractalsoftworks/release/starsector_linux-${version}.zip";
-    sha256 = "sha256-RBSnms+QlKgTOhm3t2hDfv7OcMrQCk1rfkz9GaM74WM=";
+    sha256 = "sha256-mfx6tmgIT+bMEpMXAcHVMMJMr1zlALStpoUxYw8MYsY=";
   };
 
   nativeBuildInputs = [ copyDesktopItems makeWrapper ];


### PR DESCRIPTION
  During this update, due to a new version of Java, the software broke.
  On startup it crashed with the error: "Conflicting collector
  combinations in option list". This was due to mixing the default
  `-XX:+UseG1GC` and the `-XX:+UseConcMarkSweepGC -XX:+UseParNewGC` flags.
  I removed the latter flags, leaving the default garbage collector
  
  Furthermore, on succesful launch, the game wound warn about the
  `-XX:PermSize=192m -XX:MaxPermSize=192m` flags, that were removed in
  Java 8. Thus, those flags were also removed.
  
  The `substituteInPlace` deprecated `--replace` argument was also
  replaced by the new alternatives.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release notes of 0.97a-RC7: [https://fractalsoftworks.com/2024/02/02/starsector-0-97a-release/](https://fractalsoftworks.com/2024/02/02/starsector-0-97a-release/)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
