### PR TITLE
nixos/knot: add support for XDP setups

### DIFF
--- a/nixos/tests/knot.nix
+++ b/nixos/tests/knot.nix
@@ -114,11 +114,14 @@ in {
       services.knot.extraArgs = [ "-v" ];
       services.knot.settings = {
         server = {
-          listen = [
-            "0.0.0.0@53"
-            "::@53"
-          ];
           automatic-acl = true;
+        };
+
+        xdp = {
+          listen = [
+            "eth1"
+          ];
+          tcp = true;
         };
 
         remote.primary = {
@@ -140,7 +143,7 @@ in {
           "sub.example.com".file = "sub.example.com.zone";
         };
 
-        log.syslog.any = "info";
+        log.syslog.any = "debug";
       };
     };
     client = { lib, nodes, ... }: {


### PR DESCRIPTION
## Description of changes

The Express Data Path (XDP) is a way to circumvent the traditional Linux
networking stack and instead run an eBPF program on your NIC, that makes
the decision to provide Knot with certain packets. This is way faster
and more scalable but comes at the cost of reduced introspection.

Unfortunately the `knotc conf-check` command fails hard with missing
interfaces or IP addresses configured in `xdp.listen`, so we disable it
for now, once the `xdp` config section is set. We also promote the config
check condition to a proper option, so our conditions become public
documentation, and we allow users to deal with corner cases, that we have
not thought of yet.

We follow the pre-requisites documented in the Knot 3.3 manual, and set
up the required capabilities and allow the AF_XDP address family.

But on top of that, due to our strict hardening, we found two more
requirements, that were communicated upstream while debugging this.

- There is a requirement on AF_NETLINK, likely to query for and reconfigure
  the relevant network interfaces
- Running eBPF programs requires access to the `bpf` syscall, which we
  deny through the `~@privileged` configuration.

In summary We now conditionally loosen the hardening of the unit once we
detect that an XDP configuration is wanted. And since we cannot
introspect arbitrary files from the `settingsFiles` option, we expose XDP
support through the `enableXDP` toggle option on the module.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
