### PR TITLE
firefox-unwrapped: 122.0 -> 122.0.1

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,1025 +1,1025 @@
 {
-  version = "122.0";
+  version = "122.0.1";
   sources = [
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/ach/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/ach/firefox-122.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "bb0c03bf40765e5b2e553a7693766daba742d8a0d77da83aed70ce3ec9a17caa";
+      sha256 = "87d2fb3c8ab5b05dbaafabadde9e56abecb3897d331186cdaf6fb1fe27cb362b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/af/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/af/firefox-122.0.1.tar.bz2";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "bc1fd09149a5ff00b7f44791a51fcb81f5853cfa38c33f120e4c96043e36cc5e";
+      sha256 = "8f478df085d0312e7fecf76057b3e006c3c1297bcb620957edac97084bc87466";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/an/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/an/firefox-122.0.1.tar.bz2";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "796c926a60c54a4be9b477588b93138d7103687f9ee8e735c8e55115f1356cdf";
+      sha256 = "310341a1d14cc978d855e30abac4af29538e70afc90f9f50510597de6864b570";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/ar/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/ar/firefox-122.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "c6186ad7097820b9507f8e6067e06aa5dfebaa93b09879903a328c870eac0ab8";
+      sha256 = "054475b5c77c452062d89c37617fc0f6cffdf8786ee149bebabb55a2348348f0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/ast/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/ast/firefox-122.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "441d7e23cc0ed5f9a8d66da39ad985710823601755905d15c1dfea7cde49a75c";
+      sha256 = "c8a6ba8934b1b9161c68749d6585ebdb3c561fe8c0e5c3abb91862c963e4319e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/az/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/az/firefox-122.0.1.tar.bz2";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "76689f98d93c6218da2a9c5a5b412572e68d7c2168632339af9df6061f15476a";
+      sha256 = "9bbd6a72a86910c51b99b82521bd3af8b045b470079349f6491369aed2c2c6c5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/be/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/be/firefox-122.0.1.tar.bz2";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "548528fa7b2815aa8042c0e1629cd3fe36b2c2a1e435092c6a93205fd50500fd";
+      sha256 = "3a1fb23201159ac602c7441b9003a128c1c42f82564285739ddffe911cfaebf5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/bg/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/bg/firefox-122.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "997fb10d98c39db1fa46f1df7f9d1ab38f606236f5a0303677649565ec09f538";
+      sha256 = "fe7a0de5955d5d8d7f07550a2285110f4efc4a8dcc42a3a4454d3f5e4b535b7f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/bn/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/bn/firefox-122.0.1.tar.bz2";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "ef113efc582e0116e533263882740809f89575f4e6b0b4edc1710905c5b1ca12";
+      sha256 = "6c9710e8addf0476ce6848136eb3ef4e95c65ac2e31c1f5894e427ed670a2bf1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/br/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/br/firefox-122.0.1.tar.bz2";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "dfd901e4ca5fc61ef44a8524ec8031973d66e2c63505990b28778b738ed03366";
+      sha256 = "b5527d9fde97249e45d1a8b3803c1afbb7afd233ded8a2782c0784176c964411";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/bs/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/bs/firefox-122.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "8f8999994390668970ce257fd4f5bfd52fb862d48bca79cd4fbad3081a0188c0";
+      sha256 = "9120cfe7387e4d9e7326aa8528c412195c5dc71eb28f38547d06b50ae3b3ea72";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/ca-valencia/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/ca-valencia/firefox-122.0.1.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "d9631bb33c0c8c5de3d2e633c1f6ad6d428470e881bd5a1f1177669a81d7ec65";
+      sha256 = "ad08b8988eed1f8e863f38489425a3c22baf5592d30a9a3aef483e5e79cbeb6e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/ca/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/ca/firefox-122.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "736fea375d5c4ee7f6b92fb7321918fb1a09f875a3997bac17d42c685c734814";
+      sha256 = "b3e83eec3ee87adbce9d71454fc5d724b978d2be8547e4290586583f792fe943";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/cak/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/cak/firefox-122.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "1164d466733aca74a5dcc612e9e961b9dd0593b7df37e626949df258e80a844c";
+      sha256 = "e533367b100edec15744200bab031d4ea209950022cbead53182b5848ecc962f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/cs/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/cs/firefox-122.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "bf24977841d5d38612253c4588a76ec574e85ace20ccbb55a01bcd0061951067";
+      sha256 = "9170ab278d48571e17ac97d26f4b92cee13d6a7bebe96dd2f2b41934bba6d6a2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/cy/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/cy/firefox-122.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "bce32d8c38626c8d3dbeda506575e061ac8b20ef8db7c0a7ffcd7bbf2e7f87af";
+      sha256 = "a17f5c48be514e815a4f590f23dac58719dfaaa4cfd422406bfe349ee77cb105";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/da/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/da/firefox-122.0.1.tar.bz2";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "f9ecbb977e72298703d9c6161ce6aa7bdcd7a643d5c59e078ecfcd75796e07cb";
+      sha256 = "bda93ef58e555bdd42bde9e06441109ec756964de5e28e64eda09f27de8af736";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/de/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/de/firefox-122.0.1.tar.bz2";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "aca434638bb6fd872c6aa3c8a934d80330d5d4975e9752d807b4cac17e2d98d7";
+      sha256 = "9922a6f2773c57e20348f3fe7c3992a4f4940ecc7eb9b1dd3465a9ec91095083";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/dsb/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/dsb/firefox-122.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "0cd047af08c7f44f826b9aeb8d7e08fd62a5598fd3acf4711e484668200c4336";
+      sha256 = "f05a2d8fa31ae73d40e95171902fe231091043e23ebc6765a2e1817c2cee150b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/el/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/el/firefox-122.0.1.tar.bz2";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "e00042c3997c4c07af3d7e6ba1bf64f78a9d6df102e3aa46fc6159deb0815ff0";
+      sha256 = "d54bb7bfe7d0b4419429ac94dc3de14a302b44815d4e421a07850e97bce0544c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/en-CA/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/en-CA/firefox-122.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "b77986bb7f76b40920fc11144555f8a5c8d2b5ee3c1c0d1c30d5db986c82728a";
+      sha256 = "90bf34f39f1994d95620da4dc9ab7a9c158058f7fd4f8513b98faeac4e492270";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/en-GB/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/en-GB/firefox-122.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "be0feea0abb2c0cda665a1e0c179f6f50f41ad0ef4ce70a08d56c62f3ae9e1e0";
+      sha256 = "ba7e41efadd6c562a82007934d3bb8d7fb0e144e57c427973d02b2ded9df6a04";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/en-US/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/en-US/firefox-122.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "0b36d796ba88d48000b0a3e43854a00556148221776879c91fae03735a0e5c21";
+      sha256 = "1c502c15f71bb729e6506667c32de525849d6571f4a3a21e5b02fc08312b20e7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/eo/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/eo/firefox-122.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "9d83057fa4c65b90590fbf9cbdf92d82acb9c62472b79e65995ad9553fadf65e";
+      sha256 = "ab5afc9cff7bcac9e85dbf2b09f4b3ad53bdc89e979490d30b055eed21736cba";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/es-AR/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/es-AR/firefox-122.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "7fa85de5f0bde59eabc0b87de4debc8dedfa5a548076841268e02934c3e22ee9";
+      sha256 = "7675c6a57e611488d0261eebd459e92964f89e82089935857b6988ba9a7c9cc3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/es-CL/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/es-CL/firefox-122.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "43b424a1e5b20636f1fd0931254336b96ed0e45a6805aa373bea12264b64592f";
+      sha256 = "a05422ec2138dc17caa34df9b62e39034c3acd34ee80f9933a469a1729629900";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/es-ES/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/es-ES/firefox-122.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "8f5422259159b82e31c0a548bd2650aeffe0e8cf86d601a62aed75762f85030e";
+      sha256 = "755c91a99272198b9eacfc6e3bbc25779cad7023de2c20f8c7668894f0402c00";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/es-MX/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/es-MX/firefox-122.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "f5313ba7b8c0804bba54adaf110252666314c776b2d4db7c5e1c1aedb8e0c8a1";
+      sha256 = "3c879c3a04dfc3af235963fb48f822383e3f35132c4d4aad7d498de12314a039";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/et/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/et/firefox-122.0.1.tar.bz2";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "6212585fe75e7f098c98cd1288c916b210e38d835929307438c1d46bfa0ee87b";
+      sha256 = "2051ddebd23a9472bd00ddbd17284d1a54c5f4fed5aac551a8bb3a7c00219407";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/eu/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/eu/firefox-122.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "98f364584d93ed2b67c971a22d7e11da81fb1bb7dda8b1800ad622b42bd7666d";
+      sha256 = "741782b9c5148b7c75cad4af2bd09494dc13a27c314d2aa597121485b80f5b92";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/fa/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/fa/firefox-122.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "d22df3f341cb7891dfc90d191d3a3d5b7e6ad05cf5349cb6f5576f083ca03e2f";
+      sha256 = "06da8e5ae2e43a1f288c6c9c600c6b4756e47cff9e8f7289c5fd3b7fa905f698";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/ff/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/ff/firefox-122.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "357dec46bc93a987c4392c974e5a3743b6968c67d235530c13a33ae5868b43b7";
+      sha256 = "9590a1c0d162b261ff95f6d9091bf01596945b4ab805620ba142635490c592b7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/fi/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/fi/firefox-122.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "fb4f958de96d75d41ed3ea0b217c3d3cb3b03ad81f6a789135bb7b2326037543";
+      sha256 = "1c658c356e27da1258c6c0ab9fbc14b60e606079ad6efad5c1f98f900bb40689";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/fr/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/fr/firefox-122.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "c29bc39e9ef5bb16f55800c31f75f43616cc5cbdebfb0a77fe0782e81f259eed";
+      sha256 = "bfde4cb740bdd5db0e76a96bd6bf8fe51e2c0e27d01a617d3156231ad044f9f4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/fur/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/fur/firefox-122.0.1.tar.bz2";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "fca04eb934b884a3a6422e223d9b97c2a1287637db7f0a97c1b638fae151a970";
+      sha256 = "9d5e9438572e029e7686ad037a68bb9df6818e4277bcdf7c26b80658b7d48733";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/fy-NL/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/fy-NL/firefox-122.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "683111af5d43c9cb375c851c283db5c9de8bd79d8c2024d9b984fb40d0283072";
+      sha256 = "8c33e40731d948a80500562ef8734e8637c94a7e3f46960622cf5ac993ac7188";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/ga-IE/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/ga-IE/firefox-122.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "aa27ff0f94558fb9593e9545e2a1700948c92af4603448a89153d672de035a34";
+      sha256 = "82423f4bea377e33145a3a3924313fda11bded9bf20f3ebca16e945bb0f0d295";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/gd/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/gd/firefox-122.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "b3e1c148a836555d86f5ee5e96d7a47a61ad7f4408dbefbc5985bb32e620e6ce";
+      sha256 = "ffcc242c45924a48506d5bc1946981068fd9f44919d85badeb8164dc827f9bef";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/gl/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/gl/firefox-122.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "3c485a780c04eb6202677b2d28e6e4f75400a8b269590f07d3643be414887db6";
+      sha256 = "a52969ff57c55e3ff699830b057b28a4385f7445cdedac7d5a40676bc12b588e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/gn/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/gn/firefox-122.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "557fa1516bf7923310b0de0fdf808cb7f7ce96f6549382a94d2b09e6e22a97df";
+      sha256 = "f88bebb932b86954aa653acb0ad41b94eecf6f7e175248aa1d00ea2590bd35e9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/gu-IN/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/gu-IN/firefox-122.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "fd3f174a89d9e41a5eb45a6e79d70864e2635be24e353630071c990ee2285371";
+      sha256 = "f887c108bb15eef8eedc36e072fe722acdd40d679d9047a3baaa376233371f34";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/he/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/he/firefox-122.0.1.tar.bz2";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "8c3b6813d10ec8cdea0b3959afbe3463c3672d06bde54f588d271b359559dd92";
+      sha256 = "420af3bd36a698d513d3505e06e8fcfc966281d25f92c22482e680e3ace16cb5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/hi-IN/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/hi-IN/firefox-122.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "c51d6de45469a5dad56a310023ca4436cce41e9a0be6a884a1be993d3ee7e203";
+      sha256 = "ef5fa866483a47a8f6653071d13e98a2bb2c0b393b91ba65bfb8cea63c4ad3b7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/hr/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/hr/firefox-122.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "70e5fb958c82e2b441e5b91f2470b08751e9d341335cfd974154a53999344ecf";
+      sha256 = "e3a148bb810559956fc864d8676707e079698a8047d80faf8a49b709f7a82ca2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/hsb/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/hsb/firefox-122.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "a3a8ac0c3f2f23d9f8e293c7e759045594120866dce5df2471e186ce3867c1f2";
+      sha256 = "efd884097d7f1691adf4c71f76fc2d583312e3f2a604701ba9c7f3849f7bbe95";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/hu/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/hu/firefox-122.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "cf0468a1c5c53f989180a0ed86beb548230b1c25b9de8196a329c32726c2efdd";
+      sha256 = "14ae9e0897ee1845f170377b2cd38129a98e28ce41124b7889be4deb1311c61c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/hy-AM/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/hy-AM/firefox-122.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "6cf5039a94634489a896679af07e224458d3a8bd6bdf18032788f91a48d4ca0c";
+      sha256 = "8256c6ad0ad1f3380aaabb83683b906f0cd2b0b058a2746a9a8d9cca095a1b04";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/ia/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/ia/firefox-122.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "0d6fa6a364dc38f168f695a43dd5b42c671c459aa203471d0465fdfcb382bda6";
+      sha256 = "8625909890df1bc6e8e88df8cc889ac6f05a548d96617a175bc9aeb97be85c30";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/id/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/id/firefox-122.0.1.tar.bz2";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "29c0c76d27b7dea36a443b807ab68df3bf1013b86465f87d396c2a71ee0b8a70";
+      sha256 = "5b137a307ce81c637e4b26bbde5abbdc1a6ac483bf6ec5c28473f4e9fac2d9af";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/is/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/is/firefox-122.0.1.tar.bz2";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "b191cd12b939023feabfd10486380580e34dbe14aee0ba6e1e6db792855e5619";
+      sha256 = "b17e1f2e1386a25ddbc4c956b8cdf1452a1b26b963f97a422702388b4195558d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/it/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/it/firefox-122.0.1.tar.bz2";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "688bce209564a16f91420fb0e99979aa566c144affa224ac1b9385687cb0b748";
+      sha256 = "40697742feddd0cae8592f9bd1dee30e24d4e41684e645d4ae890ad1743312f9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/ja/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/ja/firefox-122.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "e79d54301dce43bdc2335b477a19fb76e9f5fadcf3635b0b74e7e65327f2c2d5";
+      sha256 = "6a04035aebed5649fb962aaea113db85c6284319ca18c741d4ce67576c452d13";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/ka/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/ka/firefox-122.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "4619466e8dfb174d1a983d296cb322cd237717c2ee792073dbaa72f5f9d4f2b4";
+      sha256 = "951ac43e83f1c3813efe6362cc30d3407b71e8849bdeca459f1d0f507fe24e0f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/kab/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/kab/firefox-122.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "b52cb83f7a9f325d03d757c096e2448d833badcecc77d8016a0814e94c74adf0";
+      sha256 = "98eea4f28bcf2627a10a87f795048bc1aa78f3a285ae051ebafa0cd4d2bf5e90";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/kk/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/kk/firefox-122.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "d5cf68d5aade5afd1f155fd99071e1d43062a56c1b5a0e5f3005d238a2a1dc87";
+      sha256 = "706dc890046e95acb887bded8237eed722218935194e1c6a6a7676452cbc17ec";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/km/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/km/firefox-122.0.1.tar.bz2";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "ab3c15916ca629202e4d036c97cbd2e0dd04ce72bf02195ef6c7f5b48ddab100";
+      sha256 = "b517a7f8bc031ddd1782e61377d1febafeafd2bc235ff1bb3893456ef9b686d6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/kn/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/kn/firefox-122.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "cd0126a083d49af80eb09a085ff8cf731498674c7d13c7fa8e38178daf76e6c2";
+      sha256 = "90f99fda8b1ba5f1bba3130c51f38666107be2f74a0235bd33f2a0064041cb0e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/ko/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/ko/firefox-122.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "ddde97ae15b5333b6b78191e175f8045bd1ffdd744e4930d144c7ea8b3e888c7";
+      sha256 = "95b189b69477197bb7014cfc8299d35a07b253890e05a0241e74bf1428621fe1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/lij/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/lij/firefox-122.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "cdf61e8aaa1e420e222e64e41db5b7ed45215e0b93472a7d197384ae8de30507";
+      sha256 = "17e3d23d36c1a8d69bd396255966c77dc0346a939e2bb4e07c30d9df94206fe1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/lt/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/lt/firefox-122.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "ef64144d0a591e5707cf21283ce1ede94a2b1a07244a0fa4e1f592af6beeca15";
+      sha256 = "e5b15d7476498388b2b083d5d4df6753b1793668ad5b03d5d180347ef2b6956e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/lv/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/lv/firefox-122.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "2604ae939d1075b98f1fa064c4b001be54cfb342d6b40b0d960b1b347fee158a";
+      sha256 = "781bc0a84e021a2967e96eb0b123b8697fe0085602b91155c0ab5f81b07e0ba7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/mk/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/mk/firefox-122.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "eb0cd5d62cc903f8b5c5469c6c9053b103c9e92ee597ef396130948fc27e1462";
+      sha256 = "cc6e48f58dfe64fcc3b3361ccc9013392c704053235d2521da0ef206762857e9";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/mr/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/mr/firefox-122.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "3669548d9665421ddb5af2b1baf1707e5da701a89dec3813a7912b085d1afab5";
+      sha256 = "cab1fc74b0f325afec17acb7b49ca5a3166b65686fe15ad14adfe868aa6cc010";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/ms/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/ms/firefox-122.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "11068c06792bbb53b0525d3d75f06fa6dc399db7bb03096ef3a9aa0aade14289";
+      sha256 = "0d3a46f193032b2c3633a9bf4e228a4cc6ba66536d849b4c299b63f42b9c0435";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/my/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/my/firefox-122.0.1.tar.bz2";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "f4229d7a53134e686b7c61005544d25de6742220e044f89b86a4345d650b511c";
+      sha256 = "e429d77852544239e9055c128a44097ca47aed391f202549d0d6b01251b4f1a7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/nb-NO/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/nb-NO/firefox-122.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "ccc37e4a92b444734317df226b678bfee522869b1850b62841633450a9bfee20";
+      sha256 = "177744ba68ab213e286267b9a86a47de75c18fc77f779e8e7989239768e35d5f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/ne-NP/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/ne-NP/firefox-122.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "d48528020122b32d6952f519b88ad9d2da482a0cbf7dfcbde34e574c1779a207";
+      sha256 = "59e4d7905ee970afa8b3cbdab92d3dbb696af8d50d388efe6fda24ba704f2aa6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/nl/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/nl/firefox-122.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "c8913e0a9b77eecec67786adcb019bbcfc9a218f9818a69d959cc8577b8f20cf";
+      sha256 = "a7b143950ce826873f9ac2a16ecb40da4e4fa4f5fc4485375d473567dc46a8ff";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/nn-NO/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/nn-NO/firefox-122.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "140795468318887e190e8b8bf464817ea319fff813fca92df89417ecfd414c0c";
+      sha256 = "bae2a2d29404b2e8b774036118b581255246048dc2db3d1d5c1df0a4d357d46b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/oc/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/oc/firefox-122.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "5a4b759fb5e08023cd249d0584ed15eb5351a8dc327eb05c4d87d215b7594ba8";
+      sha256 = "fb0cdc063b703e83dade0de48d9755e80c441f52b251918be87679ed26c35e50";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/pa-IN/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/pa-IN/firefox-122.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "19d7b4613d4ac790921450ddf633b55f21d36306c65de104ba52e4b369aad0f9";
+      sha256 = "40d614dd180de1bdcded224461552841211460c58199c6b727bfdebe4c5110e2";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/pl/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/pl/firefox-122.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "2baf15f6eeb5707e55ef3d4129b23cf3b596f4dfa9cedb1d11c7a30362b70b2c";
+      sha256 = "6074705678ebee6b0d6e39bdf7db4cf1de4ee95b04219cda1360f45b78bd8245";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/pt-BR/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/pt-BR/firefox-122.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "305cc2ba9ab3b276a2d309f326ae952b09d0b48500ad45c47b4dbbdd84f4df80";
+      sha256 = "06f6e69bb03cd841e671744b055fe68b60aa6d175d4f6d9305f800c1a4adedea";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/pt-PT/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/pt-PT/firefox-122.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "cae60f468704965b0c3352dd7acc0dd4e02c7cf3b3ede1fe7defdb266a7aabf1";
+      sha256 = "f8422d0279fc3aa964260b1640779bf9779440122d0d218ef561ff6aad5a1b99";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/rm/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/rm/firefox-122.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "028a93ba226dd67b14341c23296c908702a8660672855fd9ffa9f8eec4e35943";
+      sha256 = "cabc9c53234221702d14185197facabc5e0985cd1792f3e7f70ddd4390d32640";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/ro/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/ro/firefox-122.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "965c88713019ef207e210b9c43a17d5d35cd897c9357e0dd6ac6a97f95c53369";
+      sha256 = "37007221fed3907845ba83d61ca2cc80aad46abef89f239e79a408f723539219";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/ru/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/ru/firefox-122.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "3781cee3ecf3f016f880220d5bacf81e286d9276e39ac22afd9e40555a463ea5";
+      sha256 = "d3a20fc678dd39c645a2243bc381e28172a7724d521ed469f61f46dfca251dfb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/sat/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/sat/firefox-122.0.1.tar.bz2";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "35c808531d34fb95441612e9461e34f501e4127b6eb44a6b8a2f8e462ef7dc6e";
+      sha256 = "d2e862396f4d639cddf24cb7ce095e8250524707c8fe0101442fed8012c6b3ef";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/sc/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/sc/firefox-122.0.1.tar.bz2";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "a8816c31d608b64e63ba4ef686d5abbd4dba934128060f854022bdfc9f703c39";
+      sha256 = "e738bcd151599587a191e91f69a19eeb93b54a9d2c286cb26a036096dedee314";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/sco/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/sco/firefox-122.0.1.tar.bz2";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "10b0712f66555fee289b6f0d11cf7d32ed10b879d9037c0f147a02f3396d4922";
+      sha256 = "13dedb8a3bd4f3b3829a89631eb89050bc8bf8900eac255a3b1bf5262f5b0315";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/si/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/si/firefox-122.0.1.tar.bz2";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "aabcc75f94b28fe2d9f412a39da1426f1a83ae26cdfd68de2b6b9cd74a5c09aa";
+      sha256 = "fb8aea5f87e783a5b2093e47d161941dad0e3361d11cb38fe58fb9ada8bed817";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/sk/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/sk/firefox-122.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "4366d0accd52c927e8a3d75d97653830de5c469e2ced3b928de65a084aab205b";
+      sha256 = "6b8e48667c8dfe2f6653cb1f01f70be5a03dea65093328a4853f3d394bd4e9cc";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/sl/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/sl/firefox-122.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "fd8722201c5b1a7fcfcf4cb1bceb9a2c3d7f17add7779e69c15dee1bb74704b4";
+      sha256 = "8ba5e3b60c7ebaf67152159bf70a3994665e558116ab53b14726d34e6de4293e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/son/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/son/firefox-122.0.1.tar.bz2";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "4371b1ee224941d7d8586c7269fa8a1286baa830e052771d776856e8895cb75d";
+      sha256 = "4f3cd3cd5bcf33a56b30ff4e13fe15f430efd388b07cab3e00b2ffbece14723f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/sq/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/sq/firefox-122.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "37686b8accfa9b95748963bdca065df374891f93e2a1c41e048c6abaad761316";
+      sha256 = "4527ebdf68a826e0466e70a4d950def970f95ee7643869d6af5637b4160304d7";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/sr/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/sr/firefox-122.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "b6d7134bfb0219d98ebabb6139c002e444b2315bc8bbf82006ce90ef8c9be265";
+      sha256 = "7561bc0453c754ad669d23fec2514686ec00764370573a41ee0a6e15193a78bb";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/sv-SE/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/sv-SE/firefox-122.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "e6832b11fb4c965a344ef5705888c61ed4d292c33ea74439987b74c43db3ba31";
+      sha256 = "839238e8c0fcb271aa31b86a6b0f1263e27a7e772e30caae2b54b54efaa0eb6b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/szl/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/szl/firefox-122.0.1.tar.bz2";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "3f5e1a07bd88fbb0e6a162595ddc1d54b4352a0e1229e7573bbff4ec3ac66c44";
+      sha256 = "40432314dd689be9dd7533f5bee389a737a2f4b3a652be9807ce69c65a565d5b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/ta/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/ta/firefox-122.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "aa00eb6af5a0a58983c68a79e9a48659d5cae07647a8147556f959b23e9242c9";
+      sha256 = "178605125e37528925892974f166183426bb73372e55f733cf8684802b0ed734";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/te/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/te/firefox-122.0.1.tar.bz2";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "acd618453cb18228252d7d818d6a0c71223043668c4916a04ac58e1433dcae96";
+      sha256 = "87be183215ec6cd002f2038bdabd58687fd5cb09a850969066ca8171ce8f8849";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/tg/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/tg/firefox-122.0.1.tar.bz2";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "7054fcf2a1371b29b84b96377518dd8c44316f1c8aaf160b4c5b0a4d86d058e8";
+      sha256 = "46884de41e3d92fbee26eaba661ec83dbf98774c06a7ff78d127beb191aabc91";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/th/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/th/firefox-122.0.1.tar.bz2";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "2bf08d225ff875ed2328dce2519434be36f5177d4a76f9c5c4509e3f9b0c966f";
+      sha256 = "9bd390a57fad34758f803ee8adb84ec97904eecb78ff6564bed4edc7c8b8aab1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/tl/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/tl/firefox-122.0.1.tar.bz2";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "7ad85c26c897264f99bfcaa6ed69a18a6cc42676cdbc470d02cb281c8b0530f0";
+      sha256 = "b46eb8372d30931ee08603c093b563fbf7e461e27e008cbc9055b52a0f255a93";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/tr/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/tr/firefox-122.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "da94f9df9155cc6e550a49cc61492688e599a50b7e4421bd0ecaeaece8554781";
+      sha256 = "576c4c8a916c7dc56d7c9d05c0c408e6744cbf3bd18a384b09070eff58cebae4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/trs/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/trs/firefox-122.0.1.tar.bz2";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "c082244b7e813df67191d5c1621b73b8d9e5b571d6625df92d9cedc1864624ea";
+      sha256 = "2e2688d77c6618cd9af6a7ea7ad25d2e1889e58f048ea2cad3cb031bfccd67a4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/uk/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/uk/firefox-122.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "635e81988e47a00eb00919b008ea4c44c258050b612189de16ea29e62b40aaac";
+      sha256 = "e68d443391893283076d55ec7eec4bc3e6294fef71a5e46d29937b6aa2cdfe63";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/ur/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/ur/firefox-122.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "8a544ec98fdf2914144db0bf9591c18f5514637608b648211dcef1dc1e4169f0";
+      sha256 = "18674f0245e0d5494ada3aac535b6514ef11791efc9cc1937c5244a96356f3bd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/uz/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/uz/firefox-122.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "ea95c1d014c8c63cdad1e23353bf369639714770e43bb7ef86a382ad222a2327";
+      sha256 = "e8f62d7c923a41e2f56927a0a535684879bd0fcb32153b400696b655f40ed6da";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/vi/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/vi/firefox-122.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "4477b528236321ecf7b6e08c7fd01f0889907787bc0ba1a79458955780ed5d6f";
+      sha256 = "bff26ad0736edb6acfef09fd9bc9e075b63f1a1f4372db8b40df958ba3ddac82";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/xh/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/xh/firefox-122.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "1e617fc2a8a30a5118547e5aefb76cfb2f90382b11cc6a8a6cceab32dcf57764";
+      sha256 = "d926d0c95fdaa190c7eb50d0bbbcc4645f8313cd7327eb47880ad713293a27b8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/zh-CN/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/zh-CN/firefox-122.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "1068bb915bb6b9bf5ca8bafe4a43f825d873d07236f6d40234395995c54ce5c3";
+      sha256 = "b8e8fc2ed7f12f6caecbecfc1f9ffdfe3d4c786885b3b2dbb9af3164bb878d99";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-x86_64/zh-TW/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-x86_64/zh-TW/firefox-122.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "2f2364d8e4423d51ddb35057fb48b4b60257de717aa0f6d659afa0b9cee519fd";
+      sha256 = "27e798e5e16fb4cff152c5c0a87f0961a5fafc3a286d6a2c01903ca68b55299a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/ach/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/ach/firefox-122.0.1.tar.bz2";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "bf2f1b1a070df21f72006ea3c8ae19a8f65ff128d1c72f51a67e4a451ab599de";
+      sha256 = "8c42826fc2d06a64f7f8119c9d627a8d7295ec31a61b4a4ce418da2d1c67e49f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/af/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/af/firefox-122.0.1.tar.bz2";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "41cf5de86e51a6fc9e1df5d2575092649b1b3ac70750e7a9bf6500c04ae140ec";
+      sha256 = "61108266d21b7b4d52214232738f228d2c3fce60eedeaea10e244614239b9d7c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/an/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/an/firefox-122.0.1.tar.bz2";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "1c0850200cd28e58505282d146e277a51b5957cbdb19818ef613d269b1aaf414";
+      sha256 = "c068faeab22065aec67ed8ac08ca71b9f3e64cb65cffe140e7763111c8c7a809";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/ar/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/ar/firefox-122.0.1.tar.bz2";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "ac2ca1545684cd590d15b01b436d822a9448a816f7c2d85875a84f6789b522ff";
+      sha256 = "168b4e1b40626a2c17a7a45857d988cabbccb8e24a23601a6dc6f9f47a8a5e22";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/ast/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/ast/firefox-122.0.1.tar.bz2";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "1b740544ec78fce4dd8be4b9401f9152256d358423ce35f19c2e5ff956095a08";
+      sha256 = "46c659a452700f3cb2170c6ee3387eec173f33d8f3fdecb407dbabca75c96eef";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/az/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/az/firefox-122.0.1.tar.bz2";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "f105fab54e3ebf0c2b42f3f88731633647b53e0cdf70037a713886cb6c948806";
+      sha256 = "26c2995c9d4445e9fa8b3cb677600bffee8de65195d51f7f8f9b53e3233ce4d0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/be/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/be/firefox-122.0.1.tar.bz2";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "ec1b5c0f353b72943c2317a86b4e297f330e0ffa50730c74bccab1e07fc395e4";
+      sha256 = "c69b550e4c535a70bf56b0cc6293d56258c287073b5363abbcd02c67ba89d35c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/bg/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/bg/firefox-122.0.1.tar.bz2";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "7e789444be58159f5c8e14a6cf8c6946717b08bcacf39dcfe93b78b85d4c4f45";
+      sha256 = "934f9ad4a956f8b123cb3df5611ddb9335e74793de149d68ec326e297b003553";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/bn/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/bn/firefox-122.0.1.tar.bz2";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "28e8a7e462f9acc813487fa5e3b84b3a0837e68c0bc58735b1c5f45ca7c0c452";
+      sha256 = "f87a72cc2ad4f1252a68f9f36fe6ac1c0ac0e855d8f69ead51a44e7c9ae8dba6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/br/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/br/firefox-122.0.1.tar.bz2";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "71937b4cdff939baa81464982f1bdb0d658948b96b1411aa22952ef98641cbf4";
+      sha256 = "b7a173f62afa300ac17f2cb4e37cbbdc96d8a57392b9ff2c4017122582a3de25";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/bs/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/bs/firefox-122.0.1.tar.bz2";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "371a9d7bea4713e7382f52dc2e9ab5514229e86e830770dc5478f8275a1d5e4f";
+      sha256 = "0419834292bb48d0b1512d3939d999937f9cdc5cc2c0c4417ec0e378c23fd9d0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/ca-valencia/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/ca-valencia/firefox-122.0.1.tar.bz2";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "8f0e6eac071866fd5d7bae3b1d48a9f56d0a0183cefb0d1b4fcdcce9c166af49";
+      sha256 = "733def892b1a1455a86ed16f9d6ffacb4d6f4db7b84abf6b480b689ec0db435f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/ca/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/ca/firefox-122.0.1.tar.bz2";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "7d09db24488d192b1983721131de578d42735625a5910121a2a0925476b17ac2";
+      sha256 = "318795845f45d3fd17496fead10cdf283909d00b4235a663372967b6fa4b4775";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/cak/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/cak/firefox-122.0.1.tar.bz2";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "40f257f205e802d99ef74bfb9f58ec39ea051c84e7e76f09f3f76b919c6b64d9";
+      sha256 = "ebb2d1044837615b2ff3ea53e68051abeb9cba027c046f26a3a728f94115df9c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/cs/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/cs/firefox-122.0.1.tar.bz2";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "e1dc288c7b5e7b620dfa78973d2899a77961e897e5c033f63616909677dc0965";
+      sha256 = "9d26dda1a043c926501d9d6c33474de1615dd340c94e8c742d10602fda9cf0e8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/cy/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/cy/firefox-122.0.1.tar.bz2";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "cdadf55601f6b06d2aaefb75230cd3034ac6e03aba1a21ff83ee2600f4e08756";
+      sha256 = "5bd8d1d29d0545756ea6b11feb116f09daaa67b9087cafcf6ca1a0e71ad9504f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/da/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/da/firefox-122.0.1.tar.bz2";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "7177b1e2586ef1e2be51a16819ad5824ac99afbff3ce53005433c9a0d3b4be49";
+      sha256 = "0f46031ddd3d88d7f2cd28377d0bd6b3acc8cb2b2d5cfb0726083bc45136f825";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/de/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/de/firefox-122.0.1.tar.bz2";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "df4532415f792b59ea91e3865f46b36a2bd31e2e009cf582278f7136be6bac3a";
+      sha256 = "96fe952a4518d40b3e66fad2fe6d785f74e82f6cea30a36c9952a91f934cdda5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/dsb/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/dsb/firefox-122.0.1.tar.bz2";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "51819e3740ad873f32826e63ebe4c829e8d9afce9e3a57dad538002488df8766";
+      sha256 = "d2733aadd255232f06095af0b3c5821832648a038eddfe5442e78ec5ec13e898";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/el/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/el/firefox-122.0.1.tar.bz2";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "576accdecde74e37f2a02f66cd793a2df9f4aa3546f02c542df71a8f0fe3251e";
+      sha256 = "81f92fcfc5326e8a3838c62d899a4b03c0af5608ef9b553af467dbd0fe46234a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/en-CA/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/en-CA/firefox-122.0.1.tar.bz2";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "2ee107f5d5dca5844422e4dfa85b8b92326e5c874130ea262a3b01505f47bd6e";
+      sha256 = "c503f40b269ee94336987aefffd38ebb545f3e126d98e24be3f17a66b57d2dbd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/en-GB/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/en-GB/firefox-122.0.1.tar.bz2";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "cddbf721381853960514f458b9d71380f4b8258e95dd53b75f944124599c5a07";
+      sha256 = "f4d77eb0178cae7fb8c4f01a4442a172b3d69674e9fc12e2bb1afa9a95c13c5b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/en-US/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/en-US/firefox-122.0.1.tar.bz2";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "d986a5321fd200f22cf6c0104725637712f107ab2b38f34ad61e6712aee3e4d8";
+      sha256 = "962bd73ee0f4769c6dc16c93d8ca55f76cff7868e59ada6041e351d3fdefc088";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/eo/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/eo/firefox-122.0.1.tar.bz2";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "6eb58251300032b8946c05e4866572beda74043042326f9675c4dfced77a5ff6";
+      sha256 = "25365b28eb2ca306fdd84ed3770f31b1ce1a90a07f7ab5c4dcce259b50637bfa";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/es-AR/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/es-AR/firefox-122.0.1.tar.bz2";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "1aa1487a3ee5250ad8f8cda01bf8fad8fab713107c850ebae81386246f099b92";
+      sha256 = "930be4e579d4a750c0652ef51c2a4e57afae57715ee124479a448ac1a5e0022e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/es-CL/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/es-CL/firefox-122.0.1.tar.bz2";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "32fa4aab7815a04e13ed955787e14fe9519833147b2a03bf921a5a029d43198b";
+      sha256 = "421e2c9b51cc4290a42bc19914e76d85aa9f67eeefbce4898c3de5a5744e92e8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/es-ES/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/es-ES/firefox-122.0.1.tar.bz2";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "f6aa82846e4116ff2ece3db9092c117d1cdc18abb7952504ae4b4e8bd73f1e3f";
+      sha256 = "e1d1456c80a1b05a698e7391c8d147e0d8b02693fd9d9f39ecd2c3df2a497804";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/es-MX/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/es-MX/firefox-122.0.1.tar.bz2";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "22a540d78fd115ecbb7068b9b8e7a15a1824af9de4acda9e79ea197360337122";
+      sha256 = "97653e79fbc1420c423cd125f92f445c95c23a00c33f4753424d3812d6b9ff78";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/et/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/et/firefox-122.0.1.tar.bz2";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "39e3417d4a3c3531f3593e464436a0483e637f6724a5aac0c45f5bbf06551c59";
+      sha256 = "c99a9d96f26fdbe598c5bd4c3e85dc91688d2e38568bc2464a3ba26456a56d84";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/eu/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/eu/firefox-122.0.1.tar.bz2";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "6d8124d8855e7ce52dae997d02ae58234628eec8f069ee0174d9a95636b6d703";
+      sha256 = "80fe7311c034ee2fb5a1c5b13687945ddddbe6516b7ed55a3bc1b79c43555faf";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/fa/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/fa/firefox-122.0.1.tar.bz2";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "3577705cccec3c3c27a5953c6a0f07d6c96bfa42f0b3decb71b61ac670f52ca2";
+      sha256 = "4823668ef67f88cafcc63f85ae8e9bf4438ad6ed9ab78c229cb6d69b2e64592d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/ff/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/ff/firefox-122.0.1.tar.bz2";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "2a0244a6ac7cc6ac4c7bfe0b4f9bc627cbd8f16b7605dfc442d58adc5a825584";
+      sha256 = "3ce1d6d0d778c1b54238cfe49ce840696b434def6bfc4fe8c9c2ccf40ed9a871";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/fi/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/fi/firefox-122.0.1.tar.bz2";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "3bbbb8aa58b479fff4bff21a2aaf2be815c2fef9e7f3c0299d0cc1448a9c8c0a";
+      sha256 = "adbfe2b24b91c9eb995e6c313b14924912d8ea4bd61ff9703f1a1647f3ecb228";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/fr/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/fr/firefox-122.0.1.tar.bz2";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "5582654f0d5e847a06b645a59cbb51687e680522c927030628ac3e7f6a08d8e0";
+      sha256 = "9bdec1fab6941c94b1886ab24698328fd860d87fde22dc406b51cc974a5d9984";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/fur/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/fur/firefox-122.0.1.tar.bz2";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "6b320f3d5daffed93d31370399b72d5ef41fc7875e6cdc6c39bd0b6d6a94fd7c";
+      sha256 = "108ee2a6feef00db395d1d600f110c9cc37991bac9438b9e97d5f4ffa18b45a1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/fy-NL/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/fy-NL/firefox-122.0.1.tar.bz2";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "6de37790f16c17d75b9dd2a9c5445558fb9cf5dabcf6cd32fc957aef6970c940";
+      sha256 = "ebc3f4fda7d7988b627762503dca60a58612b5ed8bffec49d993f19a3bb63961";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/ga-IE/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/ga-IE/firefox-122.0.1.tar.bz2";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "a65f70d0cf29980868ab026d381473f5520bb92d16772fe77bc4ed678497ff6f";
+      sha256 = "dbe96f67558387dfb3c3ec5077838c71b9bb67e10b81db0be618159da08bf7e6";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/gd/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/gd/firefox-122.0.1.tar.bz2";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "af8210456340b688ac4dad70e2f637a4b762b0380ea34c4610187b8aa1de8f4d";
+      sha256 = "99117b23101e08d0c5211164f7037ea9f86abbbfcd86a39771a8a96e3d513b36";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/gl/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/gl/firefox-122.0.1.tar.bz2";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "de5cb12b80e31aebd957767934af0a0db9d339d2f3f27dc8873d7d8141239150";
+      sha256 = "a87f29ceedb296ee6ddcd7ae12a2d76ec0a8ac84e1053ca5574a19d3c89dc3b0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/gn/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/gn/firefox-122.0.1.tar.bz2";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "487fa3ddeeab0a50122cec0fc89672954c35ba561121c141114b2ef064d0436b";
+      sha256 = "6a9c258ef059b08a4efdedbb563bf7ce5eb2012f7555e9396646895b0dd49455";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/gu-IN/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/gu-IN/firefox-122.0.1.tar.bz2";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "7f2fccc12480bc85cd40e592850445d56b869507d01c2529f92136466d77eb8e";
+      sha256 = "4f1c540295696288e48c60e09127149040f0855ef18fdce807147295fb10edb1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/he/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/he/firefox-122.0.1.tar.bz2";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "0d267c96bd38921285eea68235a6acdd8eea338570c623a4daec26359c725065";
+      sha256 = "e579f5746ac7c33aac50ed1c16b414c3c6689ad6b7a9168978d01a619db6a64d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/hi-IN/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/hi-IN/firefox-122.0.1.tar.bz2";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "d39615f3e9453d863516e8b1a1bb9a5d2accf923d3c763742325a297d762d508";
+      sha256 = "51f89a45ecab2d9d84770bca4b6984ebeaf3149021ba048ef8344aae73d1d00a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/hr/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/hr/firefox-122.0.1.tar.bz2";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "54eb053fe03b489ca35e85adccbfd311bbe228f045a71a28aab9b4d1993b96af";
+      sha256 = "e21df40e75be3838c9745187c96614cb5ceb1607a7e70c3260b8bbf90c361655";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/hsb/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/hsb/firefox-122.0.1.tar.bz2";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "b2ebe6a414e9b0f11488eb6b689d53ce16101041ddfcbebebcfd671e74ca1904";
+      sha256 = "443d403f438967426e342dc02291070208e3263e5f1e7df20e1a8fe27e367c3e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/hu/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/hu/firefox-122.0.1.tar.bz2";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "9b6a414b884525a2c3140566bd10d49fc24a62eb6a65c0c955ae1e1be0ed31e0";
+      sha256 = "81a2efeef635fe56424bce4fe384dd478b6f661898632f6f7516a1e438897100";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/hy-AM/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/hy-AM/firefox-122.0.1.tar.bz2";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "57b16cfd5b9a318434bcbfe90773e7746c5a3db7583802e170a10dbc8a158892";
+      sha256 = "e453ccbe2bc84c5ffa62e2e1770d74ccafb68fe6a19deeed128c76aa38b5bb76";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/ia/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/ia/firefox-122.0.1.tar.bz2";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "0618ba2f38d169c09f41eb7e3a86515e015610f6b0425c3b7ab07bb950152350";
+      sha256 = "4ba5033f0a92a53e32a8a6bfabf53c77630f6189ee3500a059b271621168a3df";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/id/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/id/firefox-122.0.1.tar.bz2";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "7101456a90d9d6902a5ce56eea04109bee12f1f5826e6720be05f9f6a9a740a1";
+      sha256 = "f910310581790dbe915283efec2fbb369f7c352c4a29ccd0026d71b7db915e21";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/is/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/is/firefox-122.0.1.tar.bz2";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "d8ead0d98c11df6f4d63ddbd552db2c4ec37c6132bf908777aecbbe6936aae5e";
+      sha256 = "da3bf47c84a32260e6e50c1b23d0013904343a87340eaa7748ffac07433a0472";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/it/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/it/firefox-122.0.1.tar.bz2";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "68b5667a37d3e8b42cb28c55aabdf183df7af2a025096086a9d733955c0d94f5";
+      sha256 = "73b02550cd2e4df3e959b81dc0a37ab7ed8a4899717380a9d2a9685bd87393af";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/ja/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/ja/firefox-122.0.1.tar.bz2";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "f6de03601c46f82da095bfa4ecf02119c2b6a530bf4c797bac0e84bf0dd4549d";
+      sha256 = "bd3074689b47b6f175279ee747e07f875ab6dfc9697921b36cf619c2b81bd65e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/ka/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/ka/firefox-122.0.1.tar.bz2";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "e73d6bd6c1b6f2e20311218d25486f96655bd2b4f826a5820b9e76d682877b45";
+      sha256 = "bbcfd4ba5fd38e517e895dd781dc647dcaf44d45b87fc6fd70a382127bbfe95f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/kab/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/kab/firefox-122.0.1.tar.bz2";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "9efb6e625be4088251ea3e5cbcd56a1c9164b055e359775cc2352d58a04ed305";
+      sha256 = "93a251b0c97c38612791548085e76678def6ebdca4f36273839613b646c48304";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/kk/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/kk/firefox-122.0.1.tar.bz2";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "b89918b3d3cb50641beb5391a62c46056e6ab278a9829756f2bf4fa2aa6c0521";
+      sha256 = "d4e12d3c61e169e1ca6f69c43d3f8a00e9043062194ba8a5550ff77ab2ee32b3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/km/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/km/firefox-122.0.1.tar.bz2";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "67ca338b79e5ed74819bc51a07e33b604675ab6c44ce5961b0ba1728b9a43c7c";
+      sha256 = "e2faec4305bdeddb9b9062968d02aab6a5e1d2ac862fb2169ef242d2a8c90e8b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/kn/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/kn/firefox-122.0.1.tar.bz2";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "6627b8320a6276a55b568dd1e0eb66dd1cc0cdba0a4befb0111795c43b3b4d2e";
+      sha256 = "7f1b1786fa92b2181e90c9512013d36adff640e6a6bd75a8108d8cf2152b7019";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/ko/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/ko/firefox-122.0.1.tar.bz2";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "53dab7c6cf81731edeae3be49cdb17f752e1211ebeb104b0372e26180f6811a7";
+      sha256 = "4ab5d6a270d1cc146e5452d4b82cd9f7f817879d78e29884091001c953b343bd";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/lij/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/lij/firefox-122.0.1.tar.bz2";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "e2bd53a9b9e6444c049b4c5f0c032b922366f98f411d08e860dba022fa949491";
+      sha256 = "a22deb4303a74ed45dd9f46c19543852aa87a4091910350b3e97645f651eb7e3";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/lt/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/lt/firefox-122.0.1.tar.bz2";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "34aaa20ca7376b126b84def8ae4f29d483c653929c24b73f64190c447272228d";
+      sha256 = "944e1d73a6a1e97fb76c2b2b4e16d9af3a4f6e0d7d73bc57a092cee36f334dc4";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/lv/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/lv/firefox-122.0.1.tar.bz2";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "d7e008114a10a7eaeaf984025c518176647195695700c6ccc9a0bcac585753b0";
+      sha256 = "d197fcdf8158132f3c3f7decd6fc94bd908ab98b78750431ffc569ba9509406a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/mk/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/mk/firefox-122.0.1.tar.bz2";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "8372330bfc52b6d33735250d2d7a49456f3f5209107fd3a1b913233b579e49da";
+      sha256 = "bf39f56a838ad8aff227c74c14aba89bddae5e31954458d1e721105e6bb8a36a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/mr/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/mr/firefox-122.0.1.tar.bz2";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "758edf696dcfc25a2da431152b0af1216da5463ed92667ce81f34a08b720c4c4";
+      sha256 = "2b76724ff6a72eb1446d29aa5da5c2c3ded2d268b268ce1343ab97f2678a603a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/ms/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/ms/firefox-122.0.1.tar.bz2";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "f1a9de0bfcdc72f07b41a31697ba32fef9f78a763637ce043fade574dfeb3e36";
+      sha256 = "55779e68b20c726a3979551a359fb3a8625c1366e0707d060fb39a78bfb1cb0f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/my/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/my/firefox-122.0.1.tar.bz2";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "850902dd1f2d2c28ab5870a65e64656967006e20c7f702e539ea03f334dff986";
+      sha256 = "19c5629516881675ebaa1bc22905616f5f7aa02105419fa38aa0fb31fef5ef44";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/nb-NO/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/nb-NO/firefox-122.0.1.tar.bz2";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "d49689490f5b60544e187a31049b975d2823700337acc9045364c964d7e39bc4";
+      sha256 = "de8eaed1e26851841b26a427c9fa1553edf3a0dc13a98a8f09ae658a0d1fbe67";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/ne-NP/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/ne-NP/firefox-122.0.1.tar.bz2";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "9aed3666974eb0ffb12fcc1b6b8c34dc08c217e7b63022e1e127acd8be9d5989";
+      sha256 = "1c40693435f64d2d5465bfe7efebec3e93d44d060e17a15b3994feebb7b22092";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/nl/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/nl/firefox-122.0.1.tar.bz2";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "be81c6b63826ddf4f10bad10ff0c20732fd388bcf459fa460b8d2b5d898fa1f4";
+      sha256 = "ba86d009f88c4101485b093b6de945c5b610c6b85bfc01f018a1c4b362962dc1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/nn-NO/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/nn-NO/firefox-122.0.1.tar.bz2";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "503296da94916161cda2da72216ae8032723bea1119dd38e33e9763f36b771b4";
+      sha256 = "3678a4db0b45b17d259450b6604439b55350ff2893d9e248a9806c44b69d13ad";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/oc/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/oc/firefox-122.0.1.tar.bz2";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "ef2f5d9b9c977aadf00cba7a4dd87a289d3fe45efb6d151ed8ebb1c87aaeb391";
+      sha256 = "defd7b804c3f9e1fe461db1fd64c34c0ff67b90782257bbece440c08172f87df";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/pa-IN/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/pa-IN/firefox-122.0.1.tar.bz2";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "d46105671d8c94a911c8fe3e30da6617f7c985cabc485fed1d8fd6f4db1a7e2c";
+      sha256 = "8f934f3cfd335cd46c9be9341d43bdfcb6faeff2bb6bcdb4b62b28a89f071163";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/pl/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/pl/firefox-122.0.1.tar.bz2";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "96658ac87abcc79757c338a46bd94f99efa8dc35d4c2c21ca9012cc8d0fa8f31";
+      sha256 = "23040ccf99acedb9c43e085d908abf90a9c2900889fa29aabc376e5ab5cf201e";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/pt-BR/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/pt-BR/firefox-122.0.1.tar.bz2";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "856f8a7fea1ae6be351b00ff7efef744d822c27fbb5dd6bbd0557038d68c5ff1";
+      sha256 = "ee82f5af259ff705e2aac90aedc6625dec39858b7ac09091026ca3211b1a2774";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/pt-PT/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/pt-PT/firefox-122.0.1.tar.bz2";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "cec58e5b5862a76900bdbebbc340623f4d96d37df2cd25b34bad2fad71329e72";
+      sha256 = "c98a69e2df896b6214dcfb1ede0bcc7ccd104937f621bc85c137d7b64f348e6b";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/rm/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/rm/firefox-122.0.1.tar.bz2";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "0cdfd054681d5f0dbe33be2cc3516dd2602d289682cdd74ad456cb0d8e63226b";
+      sha256 = "05f81db7c1781a5ba8453afd44adff343985e666b91f7a07a782b57680296534";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/ro/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/ro/firefox-122.0.1.tar.bz2";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "de54a0660b17163f36501c06557c372fe418429cf3681f41d1f5caa6470f8366";
+      sha256 = "14609104e99ca7dab6f9b1fa839509e58f57a99c9ba9275e04a2d1e54769980d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/ru/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/ru/firefox-122.0.1.tar.bz2";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "4f601bf1eeface322a473988302bcc945223f29411bec638a63baeafdb1036a8";
+      sha256 = "90b3c054d9759365ff51334d46006837ccaf74f1151f2963e3f093f307a5b5e8";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/sat/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/sat/firefox-122.0.1.tar.bz2";
       locale = "sat";
       arch = "linux-i686";
-      sha256 = "180485e54cee485325d6336de8194e5cb8294aa349507649731d5ed67d1d0dcd";
+      sha256 = "5b53e9ceca6bec9e2ff07813d4d9a1733dd75bfbe7e80a688ccd761f86c615d0";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/sc/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/sc/firefox-122.0.1.tar.bz2";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "4ebc01d09eeb4e36bf6e44c37c3e3a3696fb7c061f4977d722c723c1ff55928e";
+      sha256 = "9f4ef95620876739ad590f7f0c406eef650114f1ebfe77ef9c9ab3434711489a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/sco/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/sco/firefox-122.0.1.tar.bz2";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "c88a5703ee9c4f1f5a2028096d8ca275c515c09c3de1b7c734ea25e97785f039";
+      sha256 = "d8503bc0fdc4eb7a0468f58d065f42c304b4badd032bd6d20d539924a4d89e59";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/si/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/si/firefox-122.0.1.tar.bz2";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "34b3081d1f597e7cdaeb6235dd4fc6ac4436d182b24eeb8791d44018707cfd8c";
+      sha256 = "9988e5f7d55c2c5b08207c4bf94809a53387f05835e0e54e4e26965823809338";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/sk/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/sk/firefox-122.0.1.tar.bz2";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "1ed9e257abcac3b5b734e087e5809e58224c0a86f9c746b7d587c4143d3500be";
+      sha256 = "0adc99fb2eba6946e95df1e9321f2b72799a473250f8b00def8c949f0488f61c";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/sl/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/sl/firefox-122.0.1.tar.bz2";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "1f41c9802f550f257a9cb82bf801406fad941eeb2e9e1715aab7d1fc64c5ed2c";
+      sha256 = "2f123577501c774fe9a1b9d8c75aea79de4abd17d38bec872bf9d8888c28af59";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/son/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/son/firefox-122.0.1.tar.bz2";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "031a624d34adb8c1fde60f3c028d655d26969edc39f89fb601b62683b635f483";
+      sha256 = "7cf067d05270b6578b2ee18e397310714b16af4b8575449c25386a4b283d576a";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/sq/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/sq/firefox-122.0.1.tar.bz2";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "39eb3b12bcfff71a887c76eb4c4771528604d41c568ee0ddb62f68e60c4f59c1";
+      sha256 = "a4410f567b1f0be814813475a008ed8351b81e281fd56c3600fee2e82f376d53";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/sr/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/sr/firefox-122.0.1.tar.bz2";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "47b6800a4e306707047aed1b7a848651d5cebc6ff3abd95a1ba66df5ac398d15";
+      sha256 = "12bdd341c317fe2e8482b6252d11bb6aa9b1b5fb9d580cd3b29c0d390bfdb313";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/sv-SE/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/sv-SE/firefox-122.0.1.tar.bz2";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "086294e4e9e8d550989b968967e4eddaac15f0502f5d056900fbb26fc04d014b";
+      sha256 = "401bd2e9b6c111c073b47d211ff675875bd81702d69348ea984ce1d73c488ed1";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/szl/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/szl/firefox-122.0.1.tar.bz2";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "a47e0340a7bde6d1dc1304bec824132ed28a1c63cd3d200efcc50f45c9bdd191";
+      sha256 = "8b5bdbe0da8d313467c593214619f82519628dd5437b26a75512d445cba9d487";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/ta/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/ta/firefox-122.0.1.tar.bz2";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "190097ef8f785e17e75fa94a5d788b66a34b5030990239f792b8faffb1af1955";
+      sha256 = "28353ecdd5bcab284e72d75cb1f941fb544647a8b9d7414adb7340a069c974ce";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/te/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/te/firefox-122.0.1.tar.bz2";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "082fd32a1092a3209e515def9f7f31c6d2db37304828c39f00097957ac97c715";
+      sha256 = "ee22377e923bd420f7ecf7be062f05b4148c8b0cee1d32653ae7e1dc351b1693";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/tg/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/tg/firefox-122.0.1.tar.bz2";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "19f0337818c5a5600ccf34b59b3b622cfe30500d0c2b79e56d687e14a34a13c0";
+      sha256 = "737dcddc4af3038ea8e5efb410b7207d51338e074012416a5059019604bbb433";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/th/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/th/firefox-122.0.1.tar.bz2";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "0d316e29b5e557a554700837e9cd09a7abb40049fa587283bfaefd4ae34346cc";
+      sha256 = "3a9e64df862df2856372473d958748a1769eddb113bc59e3962f6e4e079ee392";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/tl/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/tl/firefox-122.0.1.tar.bz2";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "b5efd0502f84112eb9dccfddae3d32df34177e7ca6b5490a21a2ba73f401a703";
+      sha256 = "44859c949a37ab3155ca30f1fe072f156da980c982db889de92a9a36c416f64d";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/tr/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/tr/firefox-122.0.1.tar.bz2";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "b1441ef089b5612080e7b4b7c29a7e37c3cbf3ecae2ec7cca63acbf9f1390fca";
+      sha256 = "4d35be66330b611ffd7eb2202498bbc11545c29bbc0819b5603d6185918851c5";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/trs/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/trs/firefox-122.0.1.tar.bz2";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "b404c12813b158d51c9691905f6ff6464bcd97eb8147e5356b00498f2d334fbd";
+      sha256 = "b97c43e287b01b4068cf12c3e3f86314df86f2fb64a9adeedf5123bc0c68abac";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/uk/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/uk/firefox-122.0.1.tar.bz2";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "49922dd22c18a4d216a50961418db65c4d645c417fb7211c5ef216c0c344a99e";
+      sha256 = "37169aa34b014f1472cab9b9cb35cf47d20d5e060b543364bf74c4fe1c226d16";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/ur/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/ur/firefox-122.0.1.tar.bz2";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "e587054e130f8de5b6e2311595f79ac7e74420d1089163e1248601e70c33b3dc";
+      sha256 = "f52f30613d9ab195cabdf5f31d50b3232e2c0fd905d9e57d9b9c100276c07805";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/uz/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/uz/firefox-122.0.1.tar.bz2";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "6ec00c8f9e2b854ebd8d162728aa4a2d84ca726d852f15138ee8e572a6fd6991";
+      sha256 = "33ddafa1d0f02ecbcad705ce0863f99e83aace8d44a115a643b3e49dc94aa624";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/vi/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/vi/firefox-122.0.1.tar.bz2";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "2b2888f708a7a0ea16f1b4a0e6a211d1ec17ed87eb39379e4d1848da50583412";
+      sha256 = "6b167ea7ed46a891d2be3b957920a53152284144cea5de538c6ad1a3e8d2c42f";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/xh/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/xh/firefox-122.0.1.tar.bz2";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "de2529fb6194bd0b132acd27d260ec7dac113f598945c60e121c2637ce5aeb16";
+      sha256 = "d4feaa8a5fbedbff6b897484ca636e15a9235f67c1eb1eee52ffccaebb2e3bfa";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/zh-CN/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/zh-CN/firefox-122.0.1.tar.bz2";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "8a649732f74f41ca57c3d89c7a6c4078e97cf47ebf07ab1be07d582eb3a008a4";
+      sha256 = "5ded51e830879a1065f9768e0206874f154e82019d06e37e6ca73a10e1110c35";
     }
-    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0/linux-i686/zh-TW/firefox-122.0.tar.bz2";
+    { url = "https://archive.mozilla.org/pub/firefox/releases/122.0.1/linux-i686/zh-TW/firefox-122.0.1.tar.bz2";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "83dd320e900c8de2d3555c0b94291b484c5e331047723820b37b8b9522380b6b";
+      sha256 = "22cf838196513e44940be27a6f6c9f2b468c9374117be3d24ffba5afebdfda52";
     }
     ];
 }

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -245,7 +245,7 @@ buildStdenv.mkDerivation {
       hash = "sha256-cWOyvjIPUU1tavPRqg61xJ53XE4EJTdsFzadfVxyTyM=";
     })
   ]
-  ++ lib.optionals (lib.versionAtLeast version "122" && lib.versionOlder version "122.0.1") [
+  ++ lib.optionals (lib.versionAtLeast version "122" && lib.versionOlder version "123") [
     ./122.0-libvpx-mozbz1875201.patch
   ]
   ++ extraPatches;

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -3,10 +3,10 @@
 {
   firefox = buildMozillaMach rec {
     pname = "firefox";
-    version = "122.0";
+    version = "122.0.1";
     src = fetchurl {
       url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-      sha512 = "619b735c16970207f3f8fb31dd2350a5e665a802c30501c89aee4817b8b0f7f466da93c66ab238e94967587e538e6858934b18164ff312dbdbfbc3b2bf8bd824";
+      sha512 = "1d4fe1ed351edd748ede2ef6448798a32de9ed7a075a54a7ed5f7baa7b0c4c7f932c2e29f443c9066829e39f22a1dc94be5d00cc994193e949b72aa4a1c8ba41";
     };
 
     extraPatches = [


### PR DESCRIPTION
https://www.mozilla.org/en-US/firefox/122.0.1/releasenotes/

[mozbz#1875201](https://bugzilla.mozilla.org/show_bug.cgi?id=1875201) is wontfix for 122

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
