### PR TITLE
arrpc: 3.2.0 -> 3.3.0

### DIFF
--- a/pkgs/by-name/ar/arrpc/package.nix
+++ b/pkgs/by-name/ar/arrpc/package.nix
@@ -1,41 +1,31 @@
 { lib
 , buildNpmPackage
 , fetchFromGitHub
-, fetchpatch
-}:
-
-buildNpmPackage {
+}: buildNpmPackage rec {
   pname = "arrpc";
-  version = "3.2.0";
+  version = "3.3.0";
 
   src = fetchFromGitHub {
     owner = "OpenAsar";
     repo = "arrpc";
     # Release commits are not tagged
-    # release: 3.2.0
-    rev = "9c3e981437b75606c74ef058c67d1a8c083ce49a";
-    hash = "sha256-tsO58q6tqqXCJLjZmLQGt1VtKsuoqWmh5SlnuDtJafg=";
+    # release: 3.3.0
+    rev = "c6e23e7eb733ad396d3eebc328404cc656fed581";
+    hash = "sha256-OeEFNbmGp5SWVdJJwXZUkkNrei9jyuPc+4E960l8VRA=";
   };
 
-  # Make installation less cumbersome
-  # Remove after next release
-  patches = [
-    (fetchpatch {
-      # https://github.com/OpenAsar/arrpc/pull/50
-      url = "https://github.com/OpenAsar/arrpc/commit/7fa6c90204450eb3952ce9cddfecb0a5ba5e4313.patch";
-      hash = "sha256-qFlrbe2a4x811wpmWUcGDe2CPlt9x3HI+/t0P2v4kPc=";
-    })
-  ];
-
-  npmDepsHash = "sha256-vxx0w6UjwxIK4cgpivtjNbIgkb4wKG4ijSHdP/FeQZ4=";
+  npmDepsHash = "sha256-YlSUGncpY0MyTiCfZcPsfcNx3fR+SCtkOFWbjOPLUzk=";
 
   dontNpmBuild = true;
 
-  meta = with lib; {
+  meta = {
+    # ideally we would do blob/${version}/changelog.md here
+    # upstream does not tag releases
+    changelog = "https://github.com/OpenAsar/arrpc/blob/${src.rev}/changelog.md";
     description = "Open Discord RPC server for atypical setups";
     homepage = "https://arrpc.openasar.dev/";
-    license = licenses.mit;
-    maintainers = with maintainers; [ anomalocaris ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ anomalocaris NotAShelf ];
     mainProgram = "arrpc";
   };
 }


### PR DESCRIPTION
## Description of changes

Bumps arrpc from 3.2.0 to 3.3.0, adds changelogs and removes the `with lib;` anti-pattern in the meta section. I was not able to tag the changelogs as upstream does not tag releases.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
