### PR TITLE
nixos/systemd-boot: Add rememberLastChoice option.

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -34,6 +34,7 @@ GRACEFUL = "@graceful@"
 COPY_EXTRA_FILES = "@copyExtraFiles@"
 CHECK_MOUNTPOINTS = "@checkMountpoints@"
 STORE_DIR = "@storeDir@"
+REMEMBER_LAST_CHOICE = "@rememberLastChoice"
 
 @dataclass
 class BootSpec:
@@ -103,7 +104,12 @@ def generation_conf_filename(profile: str | None, generation: int, specialisatio
 def write_loader_conf(profile: str | None, generation: int, specialisation: str | None) -> None:
     with open(f"{LOADER_CONF}.tmp", 'w') as f:
         f.write(f"timeout {TIMEOUT}\n")
-        f.write("default %s\n" % generation_conf_filename(profile, generation, specialisation))
+        if REMEMBER_LAST_CHOICE != "":
+            default_setting = generation_conf_filename(profile, generation, specialisation)
+        else:
+            default_setting = "@saved"
+        f.write("default %s\n" % default_setting)
+
         if not EDITOR:
             f.write("editor 0\n")
         if REBOOT_FOR_BITLOCKER:

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -515,6 +515,20 @@ in
         )
       );
     };
+
+    rememberLastChoice = mkOption {
+      default = false;
+
+      type = types.bool;
+
+      description = ''
+        Remembers the last chosen systemd-boot entry. For example, given entries A and B. If B is
+        is selected, next boot B will automatically be highlighted instead of the latest generation.
+        This is done by setting `default @saved` within the systemd-boot config.
+
+        This option will not work properly unless `boot.loader.canTouchEfiVariables = true`
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -552,6 +566,11 @@ in
         {
           assertion = hasSuffix ".conf" filename;
           message = "boot.loader.systemd-boot.extraEntries.${lib.strings.escapeNixIdentifier filename} is invalid: entries must have a .conf file extension";
+        }
+        {
+          assertion =
+            config.boot.loader.systemd-boot.rememberlastchoice -> config.boot.loader.efi.cantouchefivariables;
+          message = "systemd-boot rememberlastchoice requires mutable efi variables.";
         }
       ]) (builtins.attrNames cfg.extraEntries)
       ++ concatMap (filename: [

--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -598,4 +598,30 @@ in
       machine.wait_for_unit("multi-user.target")
     '';
   };
+
+  rememberLastChoice = makeTest {
+    name = "systemd-remember-last-choice";
+    meta.maintainers = with pkgs.lib.maintainers; [ noar-t ];
+    nodes.machine =
+      { pkgs, lib, ... }:
+      {
+        imports = [ common ];
+        boot.loader.systemd-boot.rememberLastChoice = true;
+
+      };
+
+    testScript =
+      { nodes, ... }:
+      ''
+        machine.start()
+        machine.wait_for_unit("multi-user.target")
+
+        machine.succeed(
+            "test -e /boot/loader/loader.conf"
+        )
+        machine.succeed(
+            "grep -q '@saved' /boot/loader.conf"
+        )
+      '';
+  };
 }


### PR DESCRIPTION
The systemd-boot configuration lacks the ability to remember the last used choice. This feature is included with systemd-boot via the `default @saved` option, which saves the last choice into an EFI variable. Having this option is useful for when users have mutliple OSes installed on a single machine but the boot loader is managed by nix-os.

## Description of changes
This adds the ability to enable the systemd-boot flag to remember last selected entry. The change requires changes to the both the configuration and the python script that generates the /boot/loader/loader.conf file.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
