### PR TITLE
photonvision: init at 2024.2.3

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -42,6 +42,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [Guix](https://guix.gnu.org), a functional package manager inspired by Nix. Available as [services.guix](#opt-services.guix.enable).
 
+- [PhotonVision](https://photonvision.org/), a free, fast, and easy-to-use computer vision solution for the FIRST® Robotics Competition.
+
 - [pyLoad](https://pyload.net/), a FOSS download manager written in Python. Available as [services.pyload](#opt-services.pyload.enable)
 
 - [maubot](https://github.com/maubot/maubot), a plugin-based Matrix bot framework. Available as [services.maubot](#opt-services.maubot.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1259,6 +1259,7 @@
   ./services/video/go2rtc/default.nix
   ./services/video/frigate.nix
   ./services/video/mirakurun.nix
+  ./services/video/photonvision.nix
   ./services/video/replay-sorcery.nix
   ./services/video/mediamtx.nix
   ./services/video/unifi-video.nix

--- a/nixos/modules/services/video/photonvision.nix
+++ b/nixos/modules/services/video/photonvision.nix
@@ -1,0 +1,64 @@
+{ config, pkgs, lib, ... }:
+
+let
+  cfg = config.services.photonvision;
+in
+{
+  options = {
+    services.photonvision = {
+      enable = lib.mkEnableOption (lib.mdDoc "Enable PhotonVision");
+
+      package = lib.mkPackageOption pkgs "photonvision" {};
+
+      openFirewall = lib.mkOption {
+        description = lib.mdDoc ''
+          Whether to open the required ports in the firewall.
+        '';
+        default = false;
+        type = lib.types.bool;
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.photonvision = {
+      description = "PhotonVision, the free, fast, and easy-to-use computer vision solution for the FIRST Robotics Competition";
+
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        ExecStart = lib.getExe cfg.package;
+
+        # ephemeral root directory
+        RuntimeDirectory = "photonvision";
+        RootDirectory = "/run/photonvision";
+
+        # setup persistent state and logs directories
+        StateDirectory = "photonvision";
+        LogsDirectory = "photonvision";
+
+        BindReadOnlyPaths = [
+          # mount the nix store read-only
+          "/nix/store"
+
+          # the JRE reads the user.home property from /etc/passwd
+          "/etc/passwd"
+        ];
+        BindPaths = [
+          # mount the configuration and logs directories to the host
+          "/var/lib/photonvision:/photonvision_config"
+          "/var/log/photonvision:/photonvision_config/logs"
+        ];
+
+        # for PhotonVision's dynamic libraries, which it writes to /tmp
+        PrivateTmp = true;
+      };
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [ 5800 ];
+      allowedTCPPortRanges = [{ from = 1180; to = 1190; }];
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -679,6 +679,7 @@ in {
   pgjwt = handleTest ./pgjwt.nix {};
   pgmanage = handleTest ./pgmanage.nix {};
   phosh = handleTest ./phosh.nix {};
+  photonvision = handleTest ./photonvision.nix {};
   photoprism = handleTest ./photoprism.nix {};
   php = handleTest ./php {};
   php81 = handleTest ./php { php = pkgs.php81; };

--- a/nixos/tests/photonvision.nix
+++ b/nixos/tests/photonvision.nix
@@ -1,0 +1,21 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }:
+{
+  name = "photonvision";
+
+  nodes = {
+    machine = { pkgs, ... }: {
+      services.photonvision = {
+        enable = true;
+      };
+    };
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("photonvision.service")
+    machine.wait_for_open_port(5800)
+  '';
+
+  meta.maintainers = with lib.maintainers; [ max-niederman ];
+})
+

--- a/pkgs/by-name/ph/photonvision/package.nix
+++ b/pkgs/by-name/ph/photonvision/package.nix
@@ -5,6 +5,7 @@
 , temurin-jre-bin-11
 , bash
 , suitesparse
+, nixosTests
 }:
 
 stdenv.mkDerivation rec {
@@ -38,6 +39,10 @@ stdenv.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  passthru.tests = {
+    starts-web-server = nixosTests.photonvision;
+  };
 
   meta = with lib; {
     description = "The free, fast, and easy-to-use computer vision solution for the FIRST Robotics Competition";

--- a/pkgs/by-name/ph/photonvision/package.nix
+++ b/pkgs/by-name/ph/photonvision/package.nix
@@ -1,0 +1,50 @@
+{ lib
+, stdenv
+, fetchurl
+, makeWrapper
+, temurin-jre-bin-11
+, bash
+, suitesparse
+}:
+
+stdenv.mkDerivation rec {
+  pname = "photonvision";
+  version = "2024.2.3";
+
+  src = {
+    "x86_64-linux" = fetchurl {
+      url = "https://github.com/PhotonVision/photonvision/releases/download/v${version}/photonvision-v${version}-linuxx64.jar";
+      hash = "sha256-45ae9sElAmN6++F9OGAvY/nUl/9UxvHtFxhetKVKfDc=";
+    };
+    "aarch64-linux" = fetchurl {
+      url = "https://github.com/PhotonVision/photonvision/releases/download/v${version}/photonvision-v${version}-linuxarm64.jar";
+      hash = "sha256-i/osKO+RAg2nFUPjBdkn3q0Id+uCSTiucfKFVVlEqgs=";
+    };
+  }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D $src $out/lib/photonvision.jar
+
+    makeWrapper ${temurin-jre-bin-11}/bin/java $out/bin/photonvision \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ stdenv.cc.cc.lib suitesparse ]} \
+      --prefix PATH : ${lib.makeBinPath [ temurin-jre-bin-11 bash.out ]} \
+      --add-flags "-jar $out/lib/photonvision.jar"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "The free, fast, and easy-to-use computer vision solution for the FIRST Robotics Competition";
+    homepage = "https://photonvision.org/";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ max-niederman ];
+    mainProgram = "photonvision";
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+  };
+}


### PR DESCRIPTION
- photonvision: init at 2024.2.3
- nixos/photonvision: init module
- nixos/tests/photonvision: init

## Description of changes

Adds a package, NixOS module, and NixOS test for [PhotonVision](https://github.com/PhotonVision/photonvision), a computer vision server used by [FIRST Robotics Competition](https://www.firstinspires.org/robotics/frc) teams. This is part of a wider effort I'm working on to make NixOS usable in FRC.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [X] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
