### PR TITLE
xdg-utils: 1.2.0 -> 1.2.1

### DIFF
--- a/pkgs/tools/X11/xdg-utils/default.nix
+++ b/pkgs/tools/X11/xdg-utils/default.nix
@@ -214,33 +214,17 @@ in
 
 stdenv.mkDerivation rec {
   pname = "xdg-utils";
-  version = "1.2.0";
+  version = "1.2.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "xdg";
     repo = "xdg-utils";
     rev = "v${version}";
-    hash = "sha256-rjNIO4B9jHsBmPaugWTMqTGNpjiw0MTEmf9/ds2Mud4=";
+    hash = "sha256-58ElbrVlk+13DUODSEHBPcDDt9H+Kuee8Rz9CIcoy0I=";
   };
 
-  patches = [
-    # Backport typo fix
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/xdg/xdg-utils/-/commit/af2fe0d1dcbcd982d84ddf2bbd174afe90976ed9.patch";
-      hash = "sha256-HhQk06wWkyWjSxjXet+sADKf1irswKxDA8WuOknZKRs=";
-    })
-    # Backport docs rendering fixes
-    # See: https://gitlab.freedesktop.org/xdg/xdg-utils/-/merge_requests/106
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/xdg/xdg-utils/-/commit/403a720ad18920030418a7c3d1f2caba9ce3892d.patch";
-      hash = "sha256-XxFUeyXENHCy+wplIJ5OzoU5oyA4v1bz/9qMXp1ZwsE=";
-    })
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/xdg/xdg-utils/-/commit/a137f2ba87620402aca21b14fb1d79517782dd29.patch";
-      hash = "sha256-XFUAWn4uOyzgLdvupBxsO7wm6VDSzYj1SGZEM+9ouec=";
-    })
-  ] ++ lib.optionals withXdgOpenUsePortalPatch [
+  patches = lib.optionals withXdgOpenUsePortalPatch [
     # Allow forcing the use of XDG portals using NIXOS_XDG_OPEN_USE_PORTAL environment variable.
     # Upstream PR: https://github.com/freedesktop/xdg-utils/pull/12
     ./allow-forcing-portal-use.patch


### PR DESCRIPTION
## Description of changes

Basically the same backports as we're applying, but with a tag now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
