### PR TITLE
[Backport release-23.11]: Cargo tools updates

### DIFF
--- a/pkgs/development/tools/rust/cargo-about/default.nix
+++ b/pkgs/development/tools/rust/cargo-about/default.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-about";
-  version = "0.5.7";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "EmbarkStudios";
     repo = "cargo-about";
     rev = version;
-    sha256 = "sha256-AROT/Q/C0lbkeoMYmY2Tzt0+yRVA8ESRo5mPM1h0HJs=";
+    sha256 = "sha256-srJ5NyO+kySFCcqyF0i99Zvh2XsNAyFvTUcks/kt0qs=";
   };
 
-  cargoSha256 = "sha256-9HkaCUGo6jpzQn851ACM7kcBCkyMJJ/bb/qtV4Hp0lI=";
+  cargoHash = "sha256-eO4dBXVBjuN68cTvw8LzzJEedu5+dizOMu4QFEOzKK8=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/tools/rust/cargo-careful/default.nix
+++ b/pkgs/development/tools/rust/cargo-careful/default.nix
@@ -5,16 +5,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-careful";
-  version = "0.4.0";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "RalfJung";
     repo = "cargo-careful";
     rev = "v${version}";
-    hash = "sha256-5FteKVlEx5NSj3lzRRj3qerkyK+UdJfTWtG6xEzI4t4=";
+    hash = "sha256-oiwR6NgHHu9B1L6dSK6KZfgcSdwBPEzUZONwPHr0a4k=";
   };
 
-  cargoHash = "sha256-gs8o+tWvC4cgIITpfvJqfTquyYaEbvNMeZEJKFzd83I=";
+  cargoHash = "sha256-sVIAY9eYlpyS/PU6kLInc4hMeD3qcewoMbTH+wTIBuI=";
 
   meta = with lib; {
     description = "A tool to execute Rust code carefully, with extra checking along the way";

--- a/pkgs/development/tools/rust/cargo-clone/default.nix
+++ b/pkgs/development/tools/rust/cargo-clone/default.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-clone";
-  version = "1.1.0";
+  version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "janlikar";
     repo = pname;
     rev = "v${version}";
-    sha256 = "1lfg47kw07k4r795n0iixl5cnrb13g74hqlbp8jzbypr255bc16q";
+    sha256 = "sha256-al+C3p9jzPbykflt3WN+SibHm/AN4BdTxuTGmFiGGrE=";
   };
 
-  cargoSha256 = "sha256-rJcTl5fe3vkNNyLRvm7q5KmzyJXchh1/JuzK0GFhHLk=";
+  cargoHash = "sha256-sQVjK6i+wXwOfQMvnatl6PQ1S+91I58YEtRjzjSNNo8=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/tools/rust/cargo-crev/default.nix
+++ b/pkgs/development/tools/rust/cargo-crev/default.nix
@@ -14,16 +14,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-crev";
-  version = "0.25.4";
+  version = "0.25.6";
 
   src = fetchFromGitHub {
     owner = "crev-dev";
     repo = "cargo-crev";
     rev = "v${version}";
-    sha256 = "sha256-cXGZhTLIxR9VHrQT+unbl69AviiQ6FCOJTdOP/4fRYI=";
+    sha256 = "sha256-kMbbUXiU549JwblLzcP4X5rs6Qu8vaLKB5rnZSpKHKQ=";
   };
 
-  cargoHash = "sha256-H/5OZCnshGOUKVaBTbFAiMpYdsNC/96gV+rOgiuwDYc=";
+  cargoHash = "sha256-gUHy8yXTiQd3/7IyVmiq0QqXKF4ZVhF+riryEj/w2NI=";
 
   preCheck = ''
     export HOME=$(mktemp -d)

--- a/pkgs/development/tools/rust/cargo-dist/default.nix
+++ b/pkgs/development/tools/rust/cargo-dist/default.nix
@@ -14,16 +14,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-dist";
-  version = "0.8.0";
+  version = "0.8.2";
 
   src = fetchFromGitHub {
     owner = "axodotdev";
     repo = "cargo-dist";
     rev = "v${version}";
-    hash = "sha256-AyxC1YS1VvCBIS6lKDtT2zX3bhorF4G+qg+brm4tJm8=";
+    hash = "sha256-Y4jXAZgJj0d1fUFuM94umlj/JsawWs3KxEQAucsT24s=";
   };
 
-  cargoHash = "sha256-kStLY/Hjj0DeisjXzw2BbmJalNljUP0ogBEXcoDX3FE=";
+  cargoHash = "sha256-Jza9U5vL45rvDPLb4/iELneKgy1OTCMBM1JxfuxZigQ=";
 
   nativeBuildInputs = [
     pkg-config
@@ -46,10 +46,9 @@ rustPlatform.buildRustPackage rec {
     ZSTD_SYS_USE_PKG_CONFIG = true;
   };
 
-  # remove tests that require internet access and a git repo
+  # remove tests that require internet access
   postPatch = ''
     rm cargo-dist/tests/integration-tests.rs
-    rm cargo-dist/tests/cli-tests.rs
   '';
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/development/tools/rust/cargo-dist/default.nix
+++ b/pkgs/development/tools/rust/cargo-dist/default.nix
@@ -13,16 +13,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-dist";
-  version = "0.4.3";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "axodotdev";
     repo = "cargo-dist";
     rev = "v${version}";
-    hash = "sha256-QN+fO8aH4z0gtbDhS3BLKpiWMFoYP1JjPehWHUjR9z4=";
+    hash = "sha256-Km/vaEOna+RvckNawIQTSp+FW49P5jx9euKeMaLuOsw=";
   };
 
-  cargoHash = "sha256-tNRZx5i5noahhoxJ15rBSnPxqoJ4MlBRjcuUYmrNDVg=";
+  cargoHash = "sha256-ccVflBHwEAuG0Y9Mmit1X6FLsM4bbt8Kd7fB6zBwKMc=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/development/tools/rust/cargo-dist/default.nix
+++ b/pkgs/development/tools/rust/cargo-dist/default.nix
@@ -13,16 +13,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-dist";
-  version = "0.5.0";
+  version = "0.7.2";
 
   src = fetchFromGitHub {
     owner = "axodotdev";
     repo = "cargo-dist";
     rev = "v${version}";
-    hash = "sha256-Km/vaEOna+RvckNawIQTSp+FW49P5jx9euKeMaLuOsw=";
+    hash = "sha256-K+pqyH3Ajfp+tPhAuK7XCNfGdXa15oNqfsQcogvmQ8o=";
   };
 
-  cargoHash = "sha256-ccVflBHwEAuG0Y9Mmit1X6FLsM4bbt8Kd7fB6zBwKMc=";
+  cargoHash = "sha256-ZJdVhSznznnF1P28XkwtoeWoeymtPNaAZgOaKby+gnk=";
 
   nativeBuildInputs = [
     pkg-config
@@ -45,9 +45,10 @@ rustPlatform.buildRustPackage rec {
     ZSTD_SYS_USE_PKG_CONFIG = true;
   };
 
-  # remove tests that require internet access
+  # remove tests that require internet access and a git repo
   postPatch = ''
     rm cargo-dist/tests/integration-tests.rs
+    rm cargo-dist/tests/cli-tests.rs
   '';
 
   meta = with lib; {

--- a/pkgs/development/tools/rust/cargo-dist/default.nix
+++ b/pkgs/development/tools/rust/cargo-dist/default.nix
@@ -1,6 +1,7 @@
 { lib
 , rustPlatform
 , fetchFromGitHub
+, nix-update-script
 , pkg-config
 , bzip2
 , xz
@@ -13,16 +14,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-dist";
-  version = "0.7.2";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "axodotdev";
     repo = "cargo-dist";
     rev = "v${version}";
-    hash = "sha256-K+pqyH3Ajfp+tPhAuK7XCNfGdXa15oNqfsQcogvmQ8o=";
+    hash = "sha256-AyxC1YS1VvCBIS6lKDtT2zX3bhorF4G+qg+brm4tJm8=";
   };
 
-  cargoHash = "sha256-ZJdVhSznznnF1P28XkwtoeWoeymtPNaAZgOaKby+gnk=";
+  cargoHash = "sha256-kStLY/Hjj0DeisjXzw2BbmJalNljUP0ogBEXcoDX3FE=";
 
   nativeBuildInputs = [
     pkg-config
@@ -50,6 +51,8 @@ rustPlatform.buildRustPackage rec {
     rm cargo-dist/tests/integration-tests.rs
     rm cargo-dist/tests/cli-tests.rs
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "A tool for building final distributable artifacts and uploading them to an archive";

--- a/pkgs/development/tools/rust/cargo-fuzz/default.nix
+++ b/pkgs/development/tools/rust/cargo-fuzz/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-fuzz";
-  version = "0.11.2";
+  version = "0.11.3";
 
   src = fetchFromGitHub {
     owner = "rust-fuzz";
     repo = "cargo-fuzz";
     rev = version;
-    sha256 = "sha256-qbeNQM3ODkstXQTbrCv8bbkwYDBU/HB+L1k66vY4494=";
+    sha256 = "sha256-itChRuBl5n6lo/d7F5pVth5EbtWPleBcE8ReErmfv9M=";
   };
 
-  cargoSha256 = "sha256-1CTwVHOG8DOObfaGK1eGn9HDM755hf7NlqheBTJcCig=";
+  cargoHash = "sha256-AWtycqlmCPISfgX47DXOE6l3jPM1gng9ALTiF87NozI=";
 
   buildInputs = lib.optional stdenv.isDarwin libiconv;
 

--- a/pkgs/development/tools/rust/cargo-fuzz/default.nix
+++ b/pkgs/development/tools/rust/cargo-fuzz/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-fuzz";
-  version = "0.11.4";
+  version = "0.12.0";
 
   src = fetchFromGitHub {
     owner = "rust-fuzz";
     repo = "cargo-fuzz";
     rev = version;
-    hash = "sha256-+k1kHiHRQER/8JTOeQdxcbsfMvS6eC74Wkd9IlLldok=";
+    hash = "sha256-PC36O5+eB+yVLpz+EywBDGcMAtHl79FYwUo/l/JL8hM=";
   };
 
-  cargoHash = "sha256-N3niTnSSIfOVOGhcHHgTbLnpYNmM4bow7qX539P+kHQ=";
+  cargoHash = "sha256-sfvepPpYtgA0TuUlu0CD50HX933AVQbUGzJBNAzFR94=";
 
   buildInputs = lib.optional stdenv.isDarwin libiconv;
 

--- a/pkgs/development/tools/rust/cargo-fuzz/default.nix
+++ b/pkgs/development/tools/rust/cargo-fuzz/default.nix
@@ -8,7 +8,7 @@ rustPlatform.buildRustPackage rec {
     owner = "rust-fuzz";
     repo = "cargo-fuzz";
     rev = version;
-    sha256 = "sha256-+k1kHiHRQER/8JTOeQdxcbsfMvS6eC74Wkd9IlLldok=";
+    hash = "sha256-+k1kHiHRQER/8JTOeQdxcbsfMvS6eC74Wkd9IlLldok=";
   };
 
   cargoHash = "sha256-N3niTnSSIfOVOGhcHHgTbLnpYNmM4bow7qX539P+kHQ=";

--- a/pkgs/development/tools/rust/cargo-fuzz/default.nix
+++ b/pkgs/development/tools/rust/cargo-fuzz/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-fuzz";
-  version = "0.11.3";
+  version = "0.11.4";
 
   src = fetchFromGitHub {
     owner = "rust-fuzz";
     repo = "cargo-fuzz";
     rev = version;
-    sha256 = "sha256-itChRuBl5n6lo/d7F5pVth5EbtWPleBcE8ReErmfv9M=";
+    sha256 = "sha256-+k1kHiHRQER/8JTOeQdxcbsfMvS6eC74Wkd9IlLldok=";
   };
 
-  cargoHash = "sha256-AWtycqlmCPISfgX47DXOE6l3jPM1gng9ALTiF87NozI=";
+  cargoHash = "sha256-N3niTnSSIfOVOGhcHHgTbLnpYNmM4bow7qX539P+kHQ=";
 
   buildInputs = lib.optional stdenv.isDarwin libiconv;
 

--- a/pkgs/development/tools/rust/cargo-generate/default.nix
+++ b/pkgs/development/tools/rust/cargo-generate/default.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-generate";
-  version = "0.18.5";
+  version = "0.19.0";
 
   src = fetchFromGitHub {
     owner = "cargo-generate";
     repo = "cargo-generate";
     rev = "v${version}";
-    sha256 = "sha256-be0jgjhaboutT+c3rRyp6fjmv8nAkggkcqofWmH83Zc=";
+    sha256 = "sha256-OT2cjNYcEKk6Thnlq7SZvK2RJ6M1Zn62GrqpKbtrUdM=";
   };
 
-  cargoHash = "sha256-Sset3+jRm6yOUkvLYxBHdFvVCYOq3bvix9b3pnt7AV8=";
+  cargoHash = "sha256-DAJsW3uKrSyIju7K13dMQFNOwE9WDuBuPx8imdPAxqk=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/tools/rust/cargo-license/default.nix
+++ b/pkgs/development/tools/rust/cargo-license/default.nix
@@ -2,14 +2,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-license";
-  version = "0.6.0";
+  version = "0.6.1";
 
   src = fetchCrate {
     inherit pname version;
-    sha256 = "sha256-hBlyRk23gRfKdYuVnrFoDE883S32X9DFvTIsR2zfJck=";
+    sha256 = "sha256-qwyWj0vPWQOZYib2ZZutX25a4wwnG1kFAiRCWqGyVms=";
   };
 
-  cargoHash = "sha256-4P2kR+Jxki62IdUKpMNL7hzBQWci2tKWrQXV5rkMXkw=";
+  cargoHash = "sha256-ifw/n7eejUWUqhieDLojuO3xgosn28NnjAKkq/ZSLEI=";
 
   meta = with lib; {
     description = "Cargo subcommand to see license of dependencies";

--- a/pkgs/development/tools/rust/cargo-nextest/default.nix
+++ b/pkgs/development/tools/rust/cargo-nextest/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-nextest";
-  version = "0.9.66";
+  version = "0.9.67";
 
   src = fetchFromGitHub {
     owner = "nextest-rs";
     repo = "nextest";
     rev = "cargo-nextest-${version}";
-    hash = "sha256-MHXQnOUtFIRak05IX6oge3AyRC6M1XHwjpAPWBc8ByQ=";
+    hash = "sha256-M2WkgECTAKux+sq+1rYt2rg/LP4ctMMprY3MsBO5cn4=";
   };
 
-  cargoHash = "sha256-AqWySq72teaVv6xFmIgcL7uufBQdaFO5DrAIy8mfh34=";
+  cargoHash = "sha256-hJAsmT8T3YGSWjishSQeVMFty6HmdNewRR9nr66fRN0=";
 
   buildInputs = lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.SystemConfiguration

--- a/pkgs/development/tools/rust/cargo-nextest/default.nix
+++ b/pkgs/development/tools/rust/cargo-nextest/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-nextest";
-  version = "0.9.63";
+  version = "0.9.64";
 
   src = fetchFromGitHub {
     owner = "nextest-rs";
     repo = "nextest";
     rev = "cargo-nextest-${version}";
-    hash = "sha256-xAFpTcugAWUmHwWe2Ny1urxrIzRXyfxUMb9kBoGa3SA=";
+    hash = "sha256-nP5G6o0/Ce0ywdi3E5R/Pbh14zLn1UzagN+DMBch+cg=";
   };
 
-  cargoHash = "sha256-ase0pfcDDkQGnTEtAD2ZTnBP7jdGS9pki1BoFbfUuFk=";
+  cargoHash = "sha256-vrMxIEDsiVAGdznog4pJDQpQmbXW6qsHqBuS1e/0nMo=";
 
   buildInputs = lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.SystemConfiguration

--- a/pkgs/development/tools/rust/cargo-nextest/default.nix
+++ b/pkgs/development/tools/rust/cargo-nextest/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-nextest";
-  version = "0.9.64";
+  version = "0.9.66";
 
   src = fetchFromGitHub {
     owner = "nextest-rs";
     repo = "nextest";
     rev = "cargo-nextest-${version}";
-    hash = "sha256-nP5G6o0/Ce0ywdi3E5R/Pbh14zLn1UzagN+DMBch+cg=";
+    hash = "sha256-MHXQnOUtFIRak05IX6oge3AyRC6M1XHwjpAPWBc8ByQ=";
   };
 
-  cargoHash = "sha256-vrMxIEDsiVAGdznog4pJDQpQmbXW6qsHqBuS1e/0nMo=";
+  cargoHash = "sha256-AqWySq72teaVv6xFmIgcL7uufBQdaFO5DrAIy8mfh34=";
 
   buildInputs = lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.SystemConfiguration

--- a/pkgs/development/tools/rust/cargo-public-api/default.nix
+++ b/pkgs/development/tools/rust/cargo-public-api/default.nix
@@ -10,14 +10,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-public-api";
-  version = "0.32.0";
+  version = "0.33.0";
 
   src = fetchCrate {
     inherit pname version;
-    hash = "sha256-etEwMmfwyOTHRb/UfkcHvmnLVVqeSagWJ5HjuJ6gZVo=";
+    hash = "sha256-tTmFUqFTzhr/dyHnHKaK3Soz+EFi1jaEtyL3Ns2vFiI=";
   };
 
-  cargoHash = "sha256-7GyPjEit3FEjnegLnZt9TMLBI3BtzcDssrJPj60gpTo=";
+  cargoHash = "sha256-ZqCiH8fj4S0EF7aYdN8yvxb/718GNngHBmO8C5Y6WRI=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/tools/rust/cargo-public-api/default.nix
+++ b/pkgs/development/tools/rust/cargo-public-api/default.nix
@@ -10,14 +10,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-public-api";
-  version = "0.33.0";
+  version = "0.33.1";
 
   src = fetchCrate {
     inherit pname version;
-    hash = "sha256-tTmFUqFTzhr/dyHnHKaK3Soz+EFi1jaEtyL3Ns2vFiI=";
+    hash = "sha256-poS8s4rfktNKQ0co8G4RLXUJAeUAGcS8YIvb4W0IFNo=";
   };
 
-  cargoHash = "sha256-ZqCiH8fj4S0EF7aYdN8yvxb/718GNngHBmO8C5Y6WRI=";
+  cargoHash = "sha256-+tmLUxDxI/W2g7cdQD/Ph5wBpW3QbZzH2M/oRXLzsgU=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/tools/rust/cargo-run-bin/default.nix
+++ b/pkgs/development/tools/rust/cargo-run-bin/default.nix
@@ -5,14 +5,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-run-bin";
-  version = "1.6.0";
+  version = "1.6.1";
 
   src = fetchCrate {
     inherit pname version;
-    hash = "sha256-PB44m39TDH1z8N3DrxAlZ/FKOdZmpe+U84tbmBBP9VQ=";
+    hash = "sha256-B4tkP2QuL3MFQn3iAPg4TMJfFbn1D8w/C1OX+TbpgSE=";
   };
 
-  cargoHash = "sha256-FMlirUr3c8QhnTmTHvfNPff7PYlWSl83vCGLOLbyaR4=";
+  cargoHash = "sha256-tn+NqugSK5R/lIQVF1URWoDbdsSCvi5tjdjOlT293tg=";
 
   # multiple impurities in tests
   doCheck = false;

--- a/pkgs/development/tools/rust/cargo-run-bin/default.nix
+++ b/pkgs/development/tools/rust/cargo-run-bin/default.nix
@@ -5,14 +5,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-run-bin";
-  version = "1.6.1";
+  version = "1.7.0";
 
   src = fetchCrate {
     inherit pname version;
-    hash = "sha256-B4tkP2QuL3MFQn3iAPg4TMJfFbn1D8w/C1OX+TbpgSE=";
+    hash = "sha256-1+Xt+q2PgqMrSXhOkZ6+m1tqmgKICuIZe7vEmdSDdqI=";
   };
 
-  cargoHash = "sha256-tn+NqugSK5R/lIQVF1URWoDbdsSCvi5tjdjOlT293tg=";
+  cargoHash = "sha256-+avbhdKLUMqPFI8A/0w+Bne9/8KOKAJxJIMa4pSgRXs=";
 
   # multiple impurities in tests
   doCheck = false;

--- a/pkgs/development/tools/rust/cargo-run-bin/default.nix
+++ b/pkgs/development/tools/rust/cargo-run-bin/default.nix
@@ -5,14 +5,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-run-bin";
-  version = "1.5.0";
+  version = "1.6.0";
 
   src = fetchCrate {
     inherit pname version;
-    hash = "sha256-FPkZk5qKHrRR3V8s04yLgOVOKj+Rln3Cu/VW2bnr2fE=";
+    hash = "sha256-PB44m39TDH1z8N3DrxAlZ/FKOdZmpe+U84tbmBBP9VQ=";
   };
 
-  cargoHash = "sha256-aFHuIEDpGCel1FC7D0hTUmzHbEj7wVarsE0wNZ/3Khw=";
+  cargoHash = "sha256-FMlirUr3c8QhnTmTHvfNPff7PYlWSl83vCGLOLbyaR4=";
 
   # multiple impurities in tests
   doCheck = false;

--- a/pkgs/development/tools/rust/cargo-run-bin/default.nix
+++ b/pkgs/development/tools/rust/cargo-run-bin/default.nix
@@ -5,14 +5,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-run-bin";
-  version = "1.7.0";
+  version = "1.7.2";
 
   src = fetchCrate {
     inherit pname version;
-    hash = "sha256-1+Xt+q2PgqMrSXhOkZ6+m1tqmgKICuIZe7vEmdSDdqI=";
+    hash = "sha256-VhDCOTabj/HHc6bYdAUOErvxXOzyY3+e7GccZcb1cSQ=";
   };
 
-  cargoHash = "sha256-+avbhdKLUMqPFI8A/0w+Bne9/8KOKAJxJIMa4pSgRXs=";
+  cargoHash = "sha256-riWWxv3FsBrgzVUWGtKvV4WjhgsXImLpiS9EJ40kCn8=";
 
   # multiple impurities in tests
   doCheck = false;

--- a/pkgs/development/tools/rust/cargo-semver-checks/default.nix
+++ b/pkgs/development/tools/rust/cargo-semver-checks/default.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-semver-checks";
-  version = "0.27.0";
+  version = "0.28.0";
 
   src = fetchFromGitHub {
     owner = "obi1kenobi";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-DN50syZ965MWXKg3lhEhvINeqZUtZgJNjusevf4EIUw=";
+    hash = "sha256-5QXTbsNp36jYrcSDmCXT5Nmhhr9TaWpF3QqaCKv5TTg=";
   };
 
-  cargoHash = "sha256-ulsU/QSSNqyZTjM77PQnr3HVUg2dS8SxHv2y6Lsvths=";
+  cargoHash = "sha256-uRgSNVleGzD75q16hd/AOl23DT1btWGuNgZ2IprGa7k=";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/development/tools/rust/cargo-semver-checks/default.nix
+++ b/pkgs/development/tools/rust/cargo-semver-checks/default.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-semver-checks";
-  version = "0.28.0";
+  version = "0.29.0";
 
   src = fetchFromGitHub {
     owner = "obi1kenobi";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-5QXTbsNp36jYrcSDmCXT5Nmhhr9TaWpF3QqaCKv5TTg=";
+    hash = "sha256-RclZ52E8xslHO5M+jwwC3BVe8QFam9/j7rlh/FoNgN8=";
   };
 
-  cargoHash = "sha256-uRgSNVleGzD75q16hd/AOl23DT1btWGuNgZ2IprGa7k=";
+  cargoHash = "sha256-On6MU76Ehk2b+9hzUXN/PHr5BQTNcGIgQZUkPFBIl2Y=";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/development/tools/rust/cargo-udeps/default.nix
+++ b/pkgs/development/tools/rust/cargo-udeps/default.nix
@@ -2,16 +2,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-udeps";
-  version = "0.1.43";
+  version = "0.1.45";
 
   src = fetchFromGitHub {
     owner = "est31";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-aZzkVyRWxpSB0lPD7A8kbZc93h43OyPn0Pk9tCIZRnA=";
+    sha256 = "sha256-pfEvztV/DAPPOxm8An/PsBdoF8S/AK+/S+vllezYCeo=";
   };
 
-  cargoHash = "sha256-kQ1NQDvOBU8mmQQgNR4l1bBN0nr/ZSudJkL7Gf9hpgU=";
+  cargoHash = "sha256-SYlFENdnMeKxeDDHw73/edu1807rgrg8ncWTBsmgPtY=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/tools/rust/cargo-update/default.nix
+++ b/pkgs/development/tools/rust/cargo-update/default.nix
@@ -16,14 +16,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-update";
-  version = "13.2.0";
+  version = "13.3.0";
 
   src = fetchCrate {
     inherit pname version;
-    sha256 = "sha256-yMHGn/RPtYuxS3rHzm87mW7nBUEaSOGsCT7Ckxvhabk=";
+    sha256 = "sha256-owiMVeH7m4LoM8c4qjLyFx3v/+Flzt+C+O8qEuXazvc=";
   };
 
-  cargoHash = "sha256-hO2W0NRV9fGHnnS1kOkQ+e0sFzVSBQk3MOm8qDYbA00=";
+  cargoHash = "sha256-WtNH62DBo6WFOUcHnZxn0Jco4SUmhO0+1wXPRB2wxic=";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/development/tools/rust/cargo-workspaces/default.nix
+++ b/pkgs/development/tools/rust/cargo-workspaces/default.nix
@@ -12,14 +12,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-workspaces";
-  version = "0.3.0";
+  version = "0.3.1";
 
   src = fetchCrate {
     inherit pname version;
-    hash = "sha256-1wNoMVfouuPRGFGB6XIhgeeWgknxMctrBl5Vfco6qug=";
+    hash = "sha256-1YFTBzFr11FUfwgdGJgyF1lWvrfQ6ZPIkYAG7vySfFA=";
   };
 
-  cargoHash = "sha256-OJGqIo6mYqXjmQb/2CVVTskecYZretw+K46Fvbu/PcQ=";
+  cargoHash = "sha256-wL1DKZ1QhBKB4Gy2rbwe4y/hR4A/wiiVqGAIcM+Om8E=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
## Description of changes

This PR backports a bunch of `cargo-*` subcommands from master to the latest release (`release-23.11`).

A release maintainer should probably have a look whether this is okay to be backported.

---

The list of commits that are backported:

* [cargo-udeps: 0.1.43 -> 0.1.45](https://github.com/matthiasbeyer/nixpkgs/commit/b788592ce55c65cccbb40bd20f582fab3da5d733)                                                                                                                                                                                                                                                    
* [cargo-tally: 1.0.36 -> 1.0.38](https://github.com/matthiasbeyer/nixpkgs/commit/02eec70ed9fcc039eadc6d1acbdf6c0ef303aa82)
* [cargo-tally: 1.0.35 -> 1.0.36](https://github.com/matthiasbeyer/nixpkgs/commit/130a7fdf7b721e2d5c363de6590b92c91b9b74bc)                                                                                                                                                                                                              
* [cargo-tally: 1.0.34 -> 1.0.35](https://github.com/matthiasbeyer/nixpkgs/commit/1360af01110c87613116db7917bc447e88b3ca10)                                                                                                                                                                                                                                                    
* [cargo-tally: 1.0.33 -> 1.0.34](https://github.com/matthiasbeyer/nixpkgs/commit/29eabaf9a3bc795d0b5f58f2bc03ba1b3131f62e)                                                                                                                                                                                                                                                    
* [cargo-tally: 1.0.32 -> 1.0.33](https://github.com/matthiasbeyer/nixpkgs/commit/0c9dbdf9a5d92bcfbab9e9a357d99a6dc10c7396)                                                                                                                                                                                                                                                    
* [cargo-tally: 1.0.31 -> 1.0.32](https://github.com/matthiasbeyer/nixpkgs/commit/ffe99f3f594407d2af562c7c78689eb1a1b652c0)  
* [cargo-semver-checks: 0.27.0 -> 0.28.0](https://github.com/matthiasbeyer/nixpkgs/commit/15e70dbab75da3dd9676013c76035746dcce55b1)                                                                                                                                                                                                                                            
* [cargo-semver-checks: 0.28.0 -> 0.29.0](https://github.com/matthiasbeyer/nixpkgs/commit/043b7d3ad7735c60ffc151a515f34322e0ca1ef2)    
* [cargo-run-bin: 1.7.0 -> 1.7.2](https://github.com/matthiasbeyer/nixpkgs/commit/748aa8db1847784cb09a51f811580c9435423f79)                                                                                                                                                                                                                                                    
* [cargo-run-bin: 1.6.1 -> 1.7.0](https://github.com/matthiasbeyer/nixpkgs/commit/dffd27e489225425b3991df87ea868b7a6f9c9ef)                                                                                                                                                                                                                                                    
* [cargo-run-bin: 1.6.0 -> 1.6.1](https://github.com/matthiasbeyer/nixpkgs/commit/d1ea7f192477e69b889c7f165dbd6e818af51f93)                                                                                                                                                                                                                                                    
* [cargo-run-bin: 1.5.0 -> 1.6.0](https://github.com/matthiasbeyer/nixpkgs/commit/c0a56eb2e801c3938a6e6c1dc70ec2e8a676adad)                                                                                                                                                                                                                                                    
* [cargo-public-api: 0.33.0 -> 0.33.1](https://github.com/matthiasbeyer/nixpkgs/commit/5cdd0b9a38b8463d8210dbe092f6b5a7b1af8456)                                                                                                                                                                                                                                               
* [cargo-public-api: 0.32.0 -> 0.33.0](https://github.com/matthiasbeyer/nixpkgs/commit/e5be54d129670cd46863b9e657a6f8cecd7df6d2)                                                                                                                                                                                                                                               
* [cargo-nextest: 0.9.66 -> 0.9.67](https://github.com/matthiasbeyer/nixpkgs/commit/afc467ae76555b2199902abc031478371c821631)                                                                                                                                                                                                                                                  
* [cargo-nextest: 0.9.64 -> 0.9.66](https://github.com/matthiasbeyer/nixpkgs/commit/919d687e2e331a1a3a5a8dc12d19b3e968d14813)                                                                                                                                                                                                                                                  
* [cargo-nextest: 0.9.63 -> 0.9.64](https://github.com/matthiasbeyer/nixpkgs/commit/2ba030352fcf58482a40717e04c0306ecee14f90)                                                                                                                                                                                                                                                  
* [cargo-license: 0.6.0 -> 0.6.1](https://github.com/matthiasbeyer/nixpkgs/commit/4b595655e9284514cf0e62551402d0c187d6c0ea)                                                                                                                                                                                                                                                    
* [cargo-generate: 0.18.5 -> 0.19.0](https://github.com/matthiasbeyer/nixpkgs/commit/715d39b1b1ee6f43e4d98f55986104e87bf0c76b)                                                                                                                                                                                                                                                 
* [cargo-dist: 0.8.0 -> 0.8.2](https://github.com/matthiasbeyer/nixpkgs/commit/3a44e8302f9d7df06fdfa8d610befa4126bcc10e)                                                                                                                                                                                                                                                       
* [cargo-dist: 0.7.2 -> 0.8.0](https://github.com/matthiasbeyer/nixpkgs/commit/0a0b8c1facc8deb98c60ee92ae9046cfd0010508)                                                                                                                                                                                                                                                       
* [cargo-dist: 0.5.0 -> 0.7.2](https://github.com/matthiasbeyer/nixpkgs/commit/0c69a9bd64af0c31cc93529dd5eec01055a56550)                                                                                                                                                                                                                                                       
* [cargo-dist: 0.4.3 -> 0.5.0](https://github.com/matthiasbeyer/nixpkgs/commit/ec383f5377c76a1f3cac0edceb3ee0a7bda775df)                                                                                                                                                                                                                                                       
* [cargo-crev: 0.25.4 -> 0.25.6](https://github.com/matthiasbeyer/nixpkgs/commit/279710140a1ba327a73add25856ad8379b15f561)                                                                                                                                                                                                                                                     
* [cargo-clone: 1.1.0 -> 1.2.1](https://github.com/matthiasbeyer/nixpkgs/commit/9acfeb00f1959e2cddac9638910bc66e8ddb9997)                                                                                                                                                                                                                                                      
* [cargo-careful: 0.4.0 -> 0.4.1](https://github.com/matthiasbeyer/nixpkgs/commit/f577e0844ec514d3498268cab115044daf1c95d8)                                                                                                                                                                                                                                                    
* [cargo-about: 0.5.7 -> 0.6.0](https://github.com/matthiasbeyer/nixpkgs/commit/be7d6c2a7acdf7942f1c8faf5bf69141f2ae307f)  
* [cargo-fuzz: 0.11.4 -> 0.12.0](https://github.com/matthiasbeyer/nixpkgs/commit/896195fd6f69996baf50bdaaff5d8dcaa968aa17)
* [cargo-fuzz: use hash instead of sha256](https://github.com/matthiasbeyer/nixpkgs/commit/15d6ecf2784bbb544989b979e4f4fb0cac812d0b)
* [cargo-fuzz: 0.11.3 -> 0.11.4](https://github.com/matthiasbeyer/nixpkgs/commit/9e212d203e06742aa94ec90c5456c6493e9658eb)
* [cargo-fuzz: 0.11.2 -> 0.11.3 (#278558)](https://github.com/matthiasbeyer/nixpkgs/commit/bada7e57a83eea053e2fc4ab687b6c5e5dc2ae0d)


All of those commits are reachable from `master`.

---

CC @figsoda for an opinion on this PR.