### PR TITLE
python311Packages.openai-triton: remove ptxas --version call when built without cuda support

### DIFF
--- a/pkgs/development/python-modules/openai-triton/0001-ptxas-disable-version-key-for-non-cuda-targets.patch
+++ b/pkgs/development/python-modules/openai-triton/0001-ptxas-disable-version-key-for-non-cuda-targets.patch
@@ -1,0 +1,27 @@
+From 10f3d49aa6084d1b9b9624017cce7df106b9fb7e Mon Sep 17 00:00:00 2001
+From: Yaroslav Bolyukin <iam@lach.pw>
+Date: Tue, 6 Feb 2024 13:51:28 +0100
+Subject: [PATCH] ptxas: disable version key for non-cuda targets
+
+---
+ python/triton/runtime/jit.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/python/triton/runtime/jit.py b/python/triton/runtime/jit.py
+index d55972b4b..bd875a701 100644
+--- a/python/triton/runtime/jit.py
++++ b/python/triton/runtime/jit.py
+@@ -117,8 +117,8 @@ def version_key():
+         with open(lib.module_finder.find_spec(lib.name).origin, "rb") as f:
+             contents += [hashlib.md5(f.read()).hexdigest()]
+     # ptxas version
+-    ptxas = path_to_ptxas()[0]
+-    ptxas_version = hashlib.md5(subprocess.check_output([ptxas, "--version"])).hexdigest()
++    # ptxas = path_to_ptxas()[0]
++    ptxas_version = "noptxas"
+     return '-'.join(TRITON_VERSION) + '-' + ptxas_version + '-' + '-'.join(contents)
+ 
+ 
+-- 
+2.43.0
+

--- a/pkgs/development/python-modules/openai-triton/default.nix
+++ b/pkgs/development/python-modules/openai-triton/default.nix
@@ -46,6 +46,9 @@ buildPythonPackage rec {
     })
   ] ++ lib.optionals (!cudaSupport) [
     ./0000-dont-download-ptxas.patch
+    # openai-triton wants to get ptxas version even if ptxas is not
+    # used, resulting in ptxas not found error.
+    ./0001-ptxas-disable-version-key-for-non-cuda-targets.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/openai-triton/default.nix
+++ b/pkgs/development/python-modules/openai-triton/default.nix
@@ -74,7 +74,12 @@ buildPythonPackage rec {
     zlib
   ];
 
-  propagatedBuildInputs = [ filelock ];
+  propagatedBuildInputs = [
+    filelock
+    # openai-triton uses setuptools at runtime:
+    # https://github.com/NixOS/nixpkgs/pull/286763/#discussion_r1480392652
+    setuptools
+  ];
 
   postPatch = let
     # Bash was getting weird without linting,


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Removing dependency on cuda (done in https://github.com/nixos/nixpkgs/commit/6e69f004639de5a86af51aa6d9b89ef5c289ad75) by dropping ptxas works for triton, however, triton still wants to use ptxas version for cache key, even on rocm backend, which doesn't use ptxas for compilation.

Unblocks removing explicit dependency on `openai-triton-with-cuda` in some packages (Namely `xformers` and `torch`), but that will be done in separate PRs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
