### PR TITLE
etcd_3_5: 3.5.11 -> 3.5.12

### DIFF
--- a/pkgs/servers/etcd/3.5.nix
+++ b/pkgs/servers/etcd/3.5.nix
@@ -1,13 +1,13 @@
 { lib, buildGoModule, fetchFromGitHub, symlinkJoin, nixosTests }:
 
 let
-  version = "3.5.11";
+  version = "3.5.12";
 
   src = fetchFromGitHub {
     owner = "etcd-io";
     repo = "etcd";
     rev = "v${version}";
-    hash = "sha256-OjAWi5EXy1d1O6HLBzHcSfeCNmZZLNtrQXpTJ075B0I=";
+    hash = "sha256-Z2WXNzFJYfRQCldUspQjUR5NyUzCCINycuEXWaTn4vU=";
   };
 
   CGO_ENABLED = 0;
@@ -25,7 +25,7 @@ let
 
     inherit CGO_ENABLED meta src version;
 
-    vendorHash = "sha256-1/ma737hGdek+263w5OuO5iN5DTA8fpb6m0Fefyww20=";
+    vendorHash = "sha256-S5cEIV4hKRjn9JFEKWBiSEPytHtVacsSnG6T8dofgyk=";
 
     modRoot = "./server";
 
@@ -45,7 +45,7 @@ let
 
     inherit CGO_ENABLED meta src version;
 
-    vendorHash = "sha256-AMN8iWTIFeT0HLqxYrp7sieT0nEKBNwFXV9mZG3xG5I=";
+    vendorHash = "sha256-Vgp44Kg6zUDYVJU6SiYd8ZEcAWqKPPTsqYafcfk89Cc=";
 
     modRoot = "./etcdutl";
   };
@@ -55,7 +55,7 @@ let
 
     inherit CGO_ENABLED meta src version;
 
-    vendorHash = "sha256-zwafVpNBvrRUbL0qkDK9TOyo8KCiGjpZhvdUrgklG5Y=";
+    vendorHash = "sha256-PZLsekZzwlGzccCirNk9uUj70Ue5LMDs6LMWBI9yivs=";
 
     modRoot = "./etcdctl";
   };


### PR DESCRIPTION
etcd_3_5: 3.5.11 -> 3.5.12

Release: https://github.com/etcd-io/etcd/releases/tag/v3.5.12

Changelog: https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.5.md

* etcd NixOS tests passes.
* I'm using `etcd 3.5.12` in both `aarch64-linux` and `x86_64-linux` in my environment. So far, I'm unaware of a problem.