### PR TITLE
tor: disabled tests on aarch32

### DIFF
--- a/pkgs/tools/security/tor/default.nix
+++ b/pkgs/tools/security/tor/default.nix
@@ -70,14 +70,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  # disable tests on aarch64-darwin, the following tests fail there:
-  # oom/circbuf: [forking]
-  #   FAIL src/test/test_oom.c:187: assert(c1->marked_for_close)
-  #   [circbuf FAILED]
-  # oom/streambuf: [forking]
-  #   FAIL src/test/test_oom.c:287: assert(x_ OP_GE 500 - 5): 0 vs 495
-  #   [streambuf FAILED]
-  # disable tests on aarch32, the following tests fail there:
+  # disable tests on linux aarch32, the following tests fail there:
   # sandbox/is_active: [forking] Feb 06 17:43:14.224 [err] install_syscall_filter(): Bug: (Sandbox) failed to load: -125 (Operation canceled)! Are you sure that your kernel has seccomp2 support? The sandbox won't work without it. (on Tor 0.4.8.10 )
   #   FAIL src/test/test_sandbox.c:146: assert(sandbox_is_active())
   #   [is_active FAILED]
@@ -99,8 +92,7 @@ stdenv.mkDerivation rec {
   # sandbox/rename_filename: [forking] Feb 06 17:43:14.629 [err] install_syscall_filter(): Bug: (Sandbox) failed to load: -125 (Operation canceled)! Are you sure that your kernel has seccomp2 support? The sandbox won't work without it. (on Tor 0.4.8.10 )
   #   FAIL src/test/test_sandbox.c:228: assert(rc OP_EQ -1): 0 vs -1
   #   [rename_filename FAILED]
-
-  doCheck = !(stdenv.isDarwin && stdenv.isAarch64) && !(stdenv.isLinux && stdenv.isAarch32);
+  doCheck = !(stdenv.isLinux && stdenv.isAarch32);
 
   postInstall = ''
     mkdir -p $geoip/share/tor

--- a/pkgs/tools/security/tor/default.nix
+++ b/pkgs/tools/security/tor/default.nix
@@ -77,7 +77,30 @@ stdenv.mkDerivation rec {
   # oom/streambuf: [forking]
   #   FAIL src/test/test_oom.c:287: assert(x_ OP_GE 500 - 5): 0 vs 495
   #   [streambuf FAILED]
-  doCheck = !(stdenv.isDarwin && stdenv.isAarch64);
+  # disable tests on aarch32, the following tests fail there:
+  # sandbox/is_active: [forking] Feb 06 17:43:14.224 [err] install_syscall_filter(): Bug: (Sandbox) failed to load: -125 (Operation canceled)! Are you sure that your kernel has seccomp2 support? The sandbox won't work without it. (on Tor 0.4.8.10 )
+  #   FAIL src/test/test_sandbox.c:146: assert(sandbox_is_active())
+  #   [is_active FAILED]
+  # sandbox/open_filename: [forking] Feb 06 17:43:14.279 [err] install_syscall_filter(): Bug: (Sandbox) failed to load: -125 (Operation canceled)! Are you sure that your kernel has seccomp2 support? The sandbox won't work without it. (on Tor 0.4.8.10 )
+  #   FAIL src/test/test_sandbox.c:170: assert(fd OP_EQ -1): 9 vs -1
+  #   [open_filename FAILED]
+  # sandbox/opendir_dirname: [forking] Feb 06 17:43:14.343 [err] install_syscall_filter(): Bug: (Sandbox) failed to load: -125 (Operation canceled)! Are you sure that your kernel has seccomp2 support? The sandbox won't work without it. (on Tor 0.4.8.10 )
+  #   FAIL src/test/test_sandbox.c:271: assert(dir OP_EQ NULL): 0xdf8300 vs (nil)
+  #   [opendir_dirname FAILED]
+  # sandbox/openat_filename: [forking] Feb 06 17:43:14.400 [err] install_syscall_filter(): Bug: (Sandbox) failed to load: -125 (Operation canceled)! Are you sure that your kernel has seccomp2 support? The sandbox won't work without it. (on Tor 0.4.8.10 )
+  #   FAIL src/test/test_sandbox.c:249: assert(fd OP_EQ -1): 9 vs -1
+  #   [openat_filename FAILED]
+  # sandbox/chmod_filename: [forking] Feb 06 17:43:14.493 [err] install_syscall_filter(): Bug: (Sandbox) failed to load: -125 (Operation canceled)! Are you sure that your kernel has seccomp2 support? The sandbox won't work without it. (on Tor 0.4.8.10 )
+  #   FAIL src/test/test_sandbox.c:190: assert(rc OP_EQ -1): 0 vs -1
+  #   [chmod_filename FAILED]
+  # sandbox/chown_filename: [forking] Feb 06 17:43:14.561 [err] install_syscall_filter(): Bug: (Sandbox) failed to load: -125 (Operation canceled)! Are you sure that your kernel has seccomp2 support? The sandbox won't work without it. (on Tor 0.4.8.10 )
+  #   FAIL src/test/test_sandbox.c:208: assert(rc OP_EQ -1): 0 vs -1
+  #   [chown_filename FAILED]
+  # sandbox/rename_filename: [forking] Feb 06 17:43:14.629 [err] install_syscall_filter(): Bug: (Sandbox) failed to load: -125 (Operation canceled)! Are you sure that your kernel has seccomp2 support? The sandbox won't work without it. (on Tor 0.4.8.10 )
+  #   FAIL src/test/test_sandbox.c:228: assert(rc OP_EQ -1): 0 vs -1
+  #   [rename_filename FAILED]
+
+  doCheck = !(stdenv.isDarwin && stdenv.isAarch64) && !(stdenv.isLinux && stdenv.isAarch32);
 
   postInstall = ''
     mkdir -p $geoip/share/tor

--- a/pkgs/tools/security/tor/default.nix
+++ b/pkgs/tools/security/tor/default.nix
@@ -70,28 +70,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  # disable tests on linux aarch32, the following tests fail there:
-  # sandbox/is_active: [forking] Feb 06 17:43:14.224 [err] install_syscall_filter(): Bug: (Sandbox) failed to load: -125 (Operation canceled)! Are you sure that your kernel has seccomp2 support? The sandbox won't work without it. (on Tor 0.4.8.10 )
-  #   FAIL src/test/test_sandbox.c:146: assert(sandbox_is_active())
-  #   [is_active FAILED]
-  # sandbox/open_filename: [forking] Feb 06 17:43:14.279 [err] install_syscall_filter(): Bug: (Sandbox) failed to load: -125 (Operation canceled)! Are you sure that your kernel has seccomp2 support? The sandbox won't work without it. (on Tor 0.4.8.10 )
-  #   FAIL src/test/test_sandbox.c:170: assert(fd OP_EQ -1): 9 vs -1
-  #   [open_filename FAILED]
-  # sandbox/opendir_dirname: [forking] Feb 06 17:43:14.343 [err] install_syscall_filter(): Bug: (Sandbox) failed to load: -125 (Operation canceled)! Are you sure that your kernel has seccomp2 support? The sandbox won't work without it. (on Tor 0.4.8.10 )
-  #   FAIL src/test/test_sandbox.c:271: assert(dir OP_EQ NULL): 0xdf8300 vs (nil)
-  #   [opendir_dirname FAILED]
-  # sandbox/openat_filename: [forking] Feb 06 17:43:14.400 [err] install_syscall_filter(): Bug: (Sandbox) failed to load: -125 (Operation canceled)! Are you sure that your kernel has seccomp2 support? The sandbox won't work without it. (on Tor 0.4.8.10 )
-  #   FAIL src/test/test_sandbox.c:249: assert(fd OP_EQ -1): 9 vs -1
-  #   [openat_filename FAILED]
-  # sandbox/chmod_filename: [forking] Feb 06 17:43:14.493 [err] install_syscall_filter(): Bug: (Sandbox) failed to load: -125 (Operation canceled)! Are you sure that your kernel has seccomp2 support? The sandbox won't work without it. (on Tor 0.4.8.10 )
-  #   FAIL src/test/test_sandbox.c:190: assert(rc OP_EQ -1): 0 vs -1
-  #   [chmod_filename FAILED]
-  # sandbox/chown_filename: [forking] Feb 06 17:43:14.561 [err] install_syscall_filter(): Bug: (Sandbox) failed to load: -125 (Operation canceled)! Are you sure that your kernel has seccomp2 support? The sandbox won't work without it. (on Tor 0.4.8.10 )
-  #   FAIL src/test/test_sandbox.c:208: assert(rc OP_EQ -1): 0 vs -1
-  #   [chown_filename FAILED]
-  # sandbox/rename_filename: [forking] Feb 06 17:43:14.629 [err] install_syscall_filter(): Bug: (Sandbox) failed to load: -125 (Operation canceled)! Are you sure that your kernel has seccomp2 support? The sandbox won't work without it. (on Tor 0.4.8.10 )
-  #   FAIL src/test/test_sandbox.c:228: assert(rc OP_EQ -1): 0 vs -1
-  #   [rename_filename FAILED]
+  # disable tests on linux aarch32
+  # https://gitlab.torproject.org/tpo/core/tor/-/issues/40912
   doCheck = !(stdenv.isLinux && stdenv.isAarch32);
 
   postInstall = ''


### PR DESCRIPTION
## Description of changes

I added aarch32 on the "doNotCheck" list because the current upstream tests are failing for aarch32 builds.

Removed aarch64 darwin from `doCheck` as requested.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Built on a x86_64 remote for an aarch32 machine. The build succeeds with the current doCheck expression.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

Ping maintainers: @thoughtpolice @joachifm @prusnak