### PR TITLE
nixos/security/ca: enable support for compatibility bundles

### DIFF
--- a/nixos/modules/security/ca.nix
+++ b/nixos/modules/security/ca.nix
@@ -11,7 +11,8 @@ let
     extraCertificateFiles = cfg.certificateFiles;
     extraCertificateStrings = cfg.certificates;
   };
-  caBundle = "${cacertPackage}/etc/ssl/certs/ca-bundle.crt";
+  caBundleName = if cfg.useCompatibleBundle then "ca-no-trust-rules-bundle.crt" else "ca-bundle.crt";
+  caBundle = "${cacertPackage}/etc/ssl/certs/${caBundleName}";
 
 in
 
@@ -22,6 +23,17 @@ in
       default = true;
       internal = true;
     };
+
+    security.pki.useCompatibleBundle = mkEnableOption ''usage of a compatibility bundle.
+
+      Such a bundle consist exclusively of `BEGIN CERTIFICATE` and no `BEGIN TRUSTED CERTIFICATE`,
+      which is a OpenSSL specific PEM format.
+
+      It is known to be incompatible with certain software stacks.
+
+      Nevertheless, enabling this will strip all additional trust rules provided by the
+      certificates themselves, this can have security consequences depending on your usecases.
+    '';
 
     security.pki.certificateFiles = mkOption {
       type = types.listOf types.path;

--- a/pkgs/data/misc/cacert/default.nix
+++ b/pkgs/data/misc/cacert/default.nix
@@ -71,12 +71,16 @@ stdenv.mkDerivation rec {
       --ca_bundle_input "${extraCertificatesBundle}" ${lib.escapeShellArgs (map (arg: "${arg}") extraCertificateFiles)} \
       --blocklist "${blocklist}" \
       --ca_bundle_output ca-bundle.crt \
+      --ca_standard_bundle_output ca-no-trust-rules-bundle.crt \
       --ca_unpacked_output unbundled \
       --p11kit_output ca-bundle.trust.p11-kit
   '';
 
   installPhase = ''
     install -D -t "$out/etc/ssl/certs" ca-bundle.crt
+
+    # install standard PEM compatible bundle
+    install -D -t "$out/etc/ssl/certs" ca-no-trust-rules-bundle.crt
 
     # install p11-kit specific output to p11kit output
     install -D -t "$p11kit/etc/ssl/trust-source" ca-bundle.trust.p11-kit

--- a/pkgs/development/python-modules/buildcatrust/default.nix
+++ b/pkgs/development/python-modules/buildcatrust/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "buildcatrust";
-  version = "0.1.3";
+  version = "0.2.1";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256:0s0m0fy943dakw9cbd40h46qmrhhgrcp292kppyb34m6y27sbagy";
+    hash = "sha256-mjX+T5xo6cD1GxJ49Tx7zthPbGPFPYaf2qcNKVHEzJA=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

Certain software stacks have no support for OpenSSL non-standard PEM format and will fail to use our NixOS CA bundle.

For this, it is necessary to fallback on a 'compatibility' bundle, which will contain no additional trust rules.

Open questions:

- Add a NixOS test?
- Make it configurable at the `cacert` package level to save on space?
- Document it in the release notes as a highlight?

~~Depends on https://github.com/lukegb/buildcatrust/pull/4.~~ ~~Depends on stable release of buildcatrust.~~
Closes #286722.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
