### PR TITLE
dcm2niix: 1.0.20211006 -> 1.0.20230411

### DIFF
--- a/pkgs/applications/science/biology/dcm2niix/default.nix
+++ b/pkgs/applications/science/biology/dcm2niix/default.nix
@@ -15,21 +15,21 @@ let
   cloudflareZlib = fetchFromGitHub {
     owner = "ningfei";
     repo = "zlib";
-    # HEAD revision of the gcc.amd64 branch on 2022-04-14. Reminder to update
+    # HEAD revision of the gcc.amd64 branch on 2023-03-28. Reminder to update
     # whenever bumping package version.
-    rev = "fda61188d1d4dcd21545c34c2a2f5cc9b0f5db4b";
-    sha256 = "sha256-qySFwY0VI2BQLO2XoCZeYshXEDnHh6SmJ3MvcBUROWU=";
+    rev = "f49b13c3380cf9677ae9a93641ebc6f770899def";
+    sha256 = "sha256-8HNFUGx2uuEb8UrGUiqkN+uVDX83YIisT2uO1Z7GCxc=";
   };
 in
 stdenv.mkDerivation rec {
-  version = "1.0.20211006";
+  version = "1.0.20230411";
   pname = "dcm2niix";
 
   src = fetchFromGitHub {
     owner = "rordenlab";
     repo = "dcm2niix";
     rev = "v${version}";
-    sha256 = "sha256-fQAVOzynMdSLDfhcYWcaXkFW/mnv4zySGLVJNE7ql/c=";
+    sha256 = "sha256-kOVEoqrk4l6sH8iDVx1QmOYP5tCufxsWnCnn9BibZ08=";
   };
 
   patches = lib.optionals withCloudflareZlib [

--- a/pkgs/applications/science/biology/dcm2niix/dont-fetch-external-libs.patch
+++ b/pkgs/applications/science/biology/dcm2niix/dont-fetch-external-libs.patch
@@ -6,7 +6,7 @@ index 9f064eb..fe74df5 100644
 -set(CLOUDFLARE_BRANCH gcc.amd64) # Cloudflare zlib branch
 -
  ExternalProject_Add(zlib
--    GIT_REPOSITORY "${git_protocol}://github.com/ningfei/zlib.git"
+-    GIT_REPOSITORY "https://github.com/ningfei/zlib.git"
 -    GIT_TAG "${CLOUDFLARE_BRANCH}"
 +    URL file://@cloudflareZlib@
      SOURCE_DIR cloudflare-zlib
@@ -16,21 +16,10 @@ diff --git a/SuperBuild/SuperBuild.cmake b/SuperBuild/SuperBuild.cmake
 index 2a0a956..81354a7 100644
 --- a/SuperBuild/SuperBuild.cmake
 +++ b/SuperBuild/SuperBuild.cmake
-@@ -1,17 +1,3 @@
+@@ -1,6 +1,1 @@
 -# Check if git exists
 -find_package(Git)
 -if(NOT GIT_FOUND)
 -    message(FATAL_ERROR "Cannot find Git. Git is required for Superbuild")
 -endif()
--
--# Use git protocol or not
--option(USE_GIT_PROTOCOL "If behind a firewall turn this off to use http instead." ON)
--if(USE_GIT_PROTOCOL)
--    set(git_protocol "git")
--else()
--    set(git_protocol "https")
--endif()
--
- # Basic CMake build settings
- if(NOT CMAKE_BUILD_TYPE)
-     set(CMAKE_BUILD_TYPE "Release" CACHE STRING
+ 


### PR DESCRIPTION
## Description of changes

Update from fairly old previous version.
https://github.com/rordenlab/dcm2niix/releases/tag/v1.0.20230411

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Compliled and tested. Sadly not w/ sandbox due to https://github.com/NixOS/nix/issues/4119

However this is a low-risk project with only one python package declaring a depencency (is uses the binary).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
