### PR TITLE
surge-XT: 1.2.3 -> 1.3.1

### DIFF
--- a/pkgs/applications/audio/surge-XT/default.nix
+++ b/pkgs/applications/audio/surge-XT/default.nix
@@ -14,37 +14,16 @@
 , libXrandr
 }:
 
-let
-  juce-lv2 = stdenv.mkDerivation {
-    pname = "juce-lv2";
-    version = "unstable-2023-03-04";
-
-    # lv2 branch
-    src = fetchFromGitHub {
-      owner = "lv2-porting-project";
-      repo = "JUCE";
-      rev = "e825ad977cf4499a7bfa05b97b208236f8fd253b";
-      sha256 = "sha256-Fqp1y9BN0E9p/12ukG1oh3COhXNRWBAlFRSl0LPyiFc=";
-    };
-
-    dontConfigure = true;
-    dontBuild = true;
-
-    installPhase = ''
-      cp -r . $out
-    '';
-  };
-in
 stdenv.mkDerivation rec {
   pname = "surge-XT";
-  version = "1.2.3";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
     owner = "surge-synthesizer";
     repo = "surge";
     rev = "release_xt_${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-DGzdzoCjMGEDltEwlPvLk2tyMVRH1Ql2Iq1ypogw/m0=";
+    sha256 = "sha256-xcbZ5TC2W2PVzAkpoKPFIgW1oRGaC+ynQYot3cb5NAQ=";
   };
 
   nativeBuildInputs = [
@@ -67,8 +46,7 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   cmakeFlags = [
-    "-DJUCE_SUPPORTS_LV2=ON"
-    "-DSURGE_JUCE_PATH=${juce-lv2}"
+    "-DSURGE_BUILD_LV2=TRUE"
   ];
 
   CXXFLAGS = [

--- a/pkgs/applications/audio/surge-XT/default.nix
+++ b/pkgs/applications/audio/surge-XT/default.nix
@@ -2,6 +2,7 @@
 , lib
 , fetchFromGitHub
 , cmake
+, gitMinimal
 , pkg-config
 , alsa-lib
 , freetype
@@ -22,12 +23,15 @@ stdenv.mkDerivation rec {
     owner = "surge-synthesizer";
     repo = "surge";
     rev = "release_xt_${version}";
+    branchName = "release-xt/${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-xcbZ5TC2W2PVzAkpoKPFIgW1oRGaC+ynQYot3cb5NAQ=";
+    leaveDotGit = true;
+    sha256 = "sha256-q6qs/OhIakF+Gc8Da3pnfkUGYDUoJbvee0o8dfrRI2U=";
   };
 
   nativeBuildInputs = [
     cmake
+    gitMinimal
     pkg-config
   ];
 


### PR DESCRIPTION
The VST3 and the standalone work as expected, but the LV2 instrument doesn't show up in Ardour, not even as a failed load:

![image](https://github.com/NixOS/nixpkgs/assets/7645711/b3696273-0846-4960-96c6-a31d55506b02)

In the picture are:
- the 1.2.3 instrument and FX for both LV2 and VST3 an
- the 1.3.1 instrument and FX for VST3
- the 1.3.1 FX for LV2
But not the 1.3.1 instrument for LV2.

Any ideas?

Ping @orivej @luzpaz 

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
