### PR TITLE
gitstatus: disable checks for forked libgit2 dep, fix broken build

### DIFF
--- a/pkgs/applications/version-management/gitstatus/romkatv_libgit2.nix
+++ b/pkgs/applications/version-management/gitstatus/romkatv_libgit2.nix
@@ -21,5 +21,9 @@ libgit2.overrideAttrs (oldAttrs: {
     hash = "sha256-Bm3Gj9+AhNQMvkIqdrTkK5D9vrZ1qq6CS8Wrn9kfKiw=";
   };
 
+  # this is a heavy fork of the original libgit2
+  # the original checkPhase does not work for this fork
+  doCheck = false;
+
   patches = [ ];
 })

--- a/pkgs/development/libraries/libgit2/default.nix
+++ b/pkgs/development/libraries/libgit2/default.nix
@@ -15,6 +15,7 @@
 # for passthru.tests
 , libgit2-glib
 , python3Packages
+, gitstatus
 }:
 
 stdenv.mkDerivation rec {
@@ -51,6 +52,7 @@ stdenv.mkDerivation rec {
   passthru.tests = {
     inherit libgit2-glib;
     inherit (python3Packages) pygit2;
+    inherit gitstatus;
   };
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

The checkPhase of `libgit2` was activated since #282524. This cause gitstatus to fail in staging-next: https://hydra.nixos.org/job/nixpkgs/staging-next/gitstatus.x86_64-linux as it depends on an overridden, heavily forked libgit2, and the original checkPhase fails. This commit ensures that the checks for this fork are disabled as before. Also, gitstatus is added to `libgit2.passthru.tests` to prevent future breakage.

This is a trivial (no rebuild) commit for master, but would fix the broken build once the next staging-next is merged. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
