### PR TITLE
sourcehut: update all components

### DIFF
--- a/nixos/modules/services/misc/sourcehut/default.nix
+++ b/nixos/modules/services/misc/sourcehut/default.nix
@@ -1370,5 +1370,5 @@ in
   ];
 
   meta.doc = ./default.md;
-  meta.maintainers = with maintainers; [ tomberek nessdoor ];
+  meta.maintainers = with maintainers; [ tomberek nessdoor christoph-heiss ];
 }

--- a/pkgs/applications/version-management/sourcehut/builds.nix
+++ b/pkgs/applications/version-management/sourcehut/builds.nix
@@ -89,6 +89,6 @@ buildPythonPackage rec {
     homepage = "https://git.sr.ht/~sircmpwn/builds.sr.ht";
     description = "Continuous integration service for the sr.ht network";
     license = licenses.agpl3Only;
-    maintainers = with maintainers; [ eadwu ];
+    maintainers = with maintainers; [ eadwu christoph-heiss ];
   };
 }

--- a/pkgs/applications/version-management/sourcehut/builds.nix
+++ b/pkgs/applications/version-management/sourcehut/builds.nix
@@ -16,28 +16,29 @@
 , setuptools
 }:
 let
-  version = "0.86.10";
+  version = "0.89.13";
+  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.39"; };
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "builds.sr.ht";
     rev = version;
-    hash = "sha256-frwJgwJst2/NWd8VR0KbsVwm8JfWuekkY2oIIAdh3Fw=";
+    hash = "sha256-JpRVRzuHB6cgk/qW1j4zF8/K1xwz3J4nZhijmz5kVWU=";
   };
 
   buildsrht-api = buildGoModule ({
     inherit src version;
     pname = "buildsrht-api";
     modRoot = "api";
-    vendorHash = "sha256-2khk7j22KON4MsuvFUNKSUpouJtVIOxE0hkh63iaxZ4=";
-  } // import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.29"; });
+    vendorHash = "sha256-kTqoUfFEoNdDDzVNJ7XIbH7tbsl5MdBL+/UDHFv7D+A=";
+  } // gqlgen);
 
-  buildsrht-worker = buildGoModule {
+  buildsrht-worker = buildGoModule ({
     inherit src version;
-    sourceRoot = "${src.name}/worker";
     pname = "buildsrht-worker";
-    vendorHash = "sha256-obdaeRwMhuiCV2kVwDo1c+rU/hmsbiL1IgAf7AcIpoc=";
-  };
+    modRoot = "worker";
+    vendorHash = "sha256-kTqoUfFEoNdDDzVNJ7XIbH7tbsl5MdBL+/UDHFv7D+A=";
+  } // gqlgen);
 in
 buildPythonPackage rec {
   inherit src version;

--- a/pkgs/applications/version-management/sourcehut/core.nix
+++ b/pkgs/applications/version-management/sourcehut/core.nix
@@ -89,6 +89,6 @@ buildPythonPackage rec {
     homepage = "https://git.sr.ht/~sircmpwn/srht";
     description = "Core modules for sr.ht";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ eadwu ];
+    maintainers = with maintainers; [ eadwu christoph-heiss ];
   };
 }

--- a/pkgs/applications/version-management/sourcehut/core.nix
+++ b/pkgs/applications/version-management/sourcehut/core.nix
@@ -28,7 +28,7 @@
 
 buildPythonPackage rec {
   pname = "srht";
-  version = "0.69.15";
+  version = "0.71.5";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     owner = "~sircmpwn";
     repo = "core.sr.ht";
     rev = version;
-    sha256 = "sha256-T9yewweqnWL3IW5PHGyAcsIWCGn1ayK2rwrHVukYpgE=";
+    hash = "sha256-YIoKOiTi/9X4bSiG+GvnwzvKYhbfywrv/dTjxaJOOTQ=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/version-management/sourcehut/fix-gqlgen-trimpath.nix
+++ b/pkgs/applications/version-management/sourcehut/fix-gqlgen-trimpath.nix
@@ -1,5 +1,5 @@
 { unzip
-, gqlgenVersion ? "0.17.20"
+, gqlgenVersion ? "0.17.42"
 }:
 {
   overrideModAttrs = (_: {

--- a/pkgs/applications/version-management/sourcehut/git.nix
+++ b/pkgs/applications/version-management/sourcehut/git.nix
@@ -13,70 +13,70 @@
 , setuptools
 }:
 let
-  version = "0.84.2";
+  version = "0.85.7";
+  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; };
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "git.sr.ht";
     rev = version;
-    sha256 = "sha256-sAkTsQlWtNDQ5vAhA2EeOvuJcj9A6AG8pgDyIKtr65s=";
+    hash = "sha256-jkESrrVE+0O2g64zzPOpqhl8DpvmosQvuF0s6Xd+lbM=";
   };
 
   gitApi = buildGoModule ({
     inherit src version;
     pname = "gitsrht-api";
     modRoot = "api";
-    vendorHash = "sha256-LAYp0zgosZnFEbtxzjuTH9++0lbxhACr705HqXJz3D0=";
-  } // import ./fix-gqlgen-trimpath.nix { inherit unzip; });
+    vendorHash = "sha256-yWVpldqwpEZmeI18tvdIgof8GgSFEP70c8T5XDkryn0=";
+  } // gqlgen);
 
-  gitDispatch = buildGoModule {
+  gitDispatch = buildGoModule ({
     inherit src version;
     pname = "gitsrht-dispatch";
     modRoot = "gitsrht-dispatch";
-    vendorHash = "sha256-EDvSZ3/g0xDSohrsAIpNhk+F0yy8tbnTW/3tURTonMc=";
+    vendorHash = "sha256-yWVpldqwpEZmeI18tvdIgof8GgSFEP70c8T5XDkryn0=";
 
     postPatch = ''
       substituteInPlace gitsrht-dispatch/main.go \
         --replace /var/log/gitsrht-dispatch /var/log/sourcehut/gitsrht-dispatch
     '';
-  };
+  } // gqlgen);
 
-  gitKeys = buildGoModule {
+  gitKeys = buildGoModule ({
     inherit src version;
     pname = "gitsrht-keys";
     modRoot = "gitsrht-keys";
-    vendorHash = "sha256-9pojS69HCKVHUceyOpGtv9ewcxFD4WsOVsEzkmWJkF4=";
+    vendorHash = "sha256-yWVpldqwpEZmeI18tvdIgof8GgSFEP70c8T5XDkryn0=";
 
     postPatch = ''
       substituteInPlace gitsrht-keys/main.go \
         --replace /var/log/gitsrht-keys /var/log/sourcehut/gitsrht-keys
     '';
-  };
+  } // gqlgen);
 
-  gitShell = buildGoModule {
+  gitShell = buildGoModule ({
     inherit src version;
     pname = "gitsrht-shell";
     modRoot = "gitsrht-shell";
-    vendorHash = "sha256-WqfvSPuVsOHA//86u33atMfeA11+DJhjLmWy8Ivq0NI=";
+    vendorHash = "sha256-yWVpldqwpEZmeI18tvdIgof8GgSFEP70c8T5XDkryn0=";
 
     postPatch = ''
       substituteInPlace gitsrht-shell/main.go \
         --replace /var/log/gitsrht-shell /var/log/sourcehut/gitsrht-shell
     '';
-  };
+  } // gqlgen);
 
-  gitUpdateHook = buildGoModule {
+  gitUpdateHook = buildGoModule ({
     inherit src version;
     pname = "gitsrht-update-hook";
     modRoot = "gitsrht-update-hook";
-    vendorHash = "sha256-Bc3yPabS2S+qiroHFKrtkII/CfzBDYQ6xWxKHAME+Tc=";
+    vendorHash = "sha256-yWVpldqwpEZmeI18tvdIgof8GgSFEP70c8T5XDkryn0=";
 
     postPatch = ''
       substituteInPlace gitsrht-update-hook/main.go \
         --replace /var/log/gitsrht-update-hook /var/log/sourcehut/gitsrht-update-hook
     '';
-  };
-
+  } // gqlgen);
 in
 buildPythonPackage rec {
   inherit src version;

--- a/pkgs/applications/version-management/sourcehut/git.nix
+++ b/pkgs/applications/version-management/sourcehut/git.nix
@@ -122,6 +122,6 @@ buildPythonPackage rec {
     homepage = "https://git.sr.ht/~sircmpwn/git.sr.ht";
     description = "Git repository hosting service for the sr.ht network";
     license = licenses.agpl3Only;
-    maintainers = with maintainers; [ eadwu ];
+    maintainers = with maintainers; [ eadwu christoph-heiss ];
   };
 }

--- a/pkgs/applications/version-management/sourcehut/hg.nix
+++ b/pkgs/applications/version-management/sourcehut/hg.nix
@@ -13,8 +13,7 @@
 , setuptools
 }:
 
-buildPythonPackage rec {
-  pname = "hgsrht";
+let
   version = "0.32.4";
   gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.20"; };
 
@@ -26,17 +25,9 @@ buildPythonPackage rec {
     owner = "~sircmpwn";
     repo = "hg.sr.ht";
     rev = version;
-    sha256 = "mYkA44c9wy/Iy1h1lXkVpc9gN7rQXFm4T3YBlQ1Dj60=";
+    hash = "sha256-mYkA44c9wy/Iy1h1lXkVpc9gN7rQXFm4T3YBlQ1Dj60=";
     vc = "hg";
   };
-
-  postPatch = ''
-    substituteInPlace Makefile \
-      --replace "all: api hgsrht-keys" ""
-
-    substituteInPlace hgsrht-shell \
-      --replace /var/log/hgsrht-shell /var/log/sourcehut/hgsrht-shell
-  '';
 
   hgsrht-api = buildGoModule ({
     inherit src version;
@@ -56,6 +47,18 @@ buildPythonPackage rec {
         --replace /var/log/hgsrht-keys /var/log/sourcehut/hgsrht-keys
     '';
   };
+in
+buildPythonPackage rec {
+  inherit src version;
+  pname = "hgsrht";
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace "all: api hgsrht-keys" ""
+
+    substituteInPlace hgsrht-shell \
+      --replace /var/log/hgsrht-shell /var/log/sourcehut/hgsrht-shell
+  '';
 
   nativeBuildInputs = [
     pip

--- a/pkgs/applications/version-management/sourcehut/hg.nix
+++ b/pkgs/applications/version-management/sourcehut/hg.nix
@@ -16,6 +16,8 @@
 buildPythonPackage rec {
   pname = "hgsrht";
   version = "0.32.4";
+  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.20"; };
+
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -41,7 +43,7 @@ buildPythonPackage rec {
     pname = "hgsrht-api";
     modRoot = "api";
     vendorHash = "sha256-vuOYpnF3WjA6kOe9MVSuVMhJBQqCmIex+QUBJrP+VDs=";
-  } // import ./fix-gqlgen-trimpath.nix { inherit unzip; });
+  } // gqlgen);
 
   hgsrht-keys = buildGoModule {
     inherit src version;

--- a/pkgs/applications/version-management/sourcehut/hg.nix
+++ b/pkgs/applications/version-management/sourcehut/hg.nix
@@ -88,6 +88,6 @@ buildPythonPackage rec {
     homepage = "https://git.sr.ht/~sircmpwn/hg.sr.ht";
     description = "Mercurial repository hosting service for the sr.ht network";
     license = licenses.agpl3Only;
-    maintainers = with maintainers; [ eadwu ];
+    maintainers = with maintainers; [ eadwu christoph-heiss ];
   };
 }

--- a/pkgs/applications/version-management/sourcehut/hub.nix
+++ b/pkgs/applications/version-management/sourcehut/hub.nix
@@ -71,6 +71,6 @@ buildPythonPackage rec {
     homepage = "https://git.sr.ht/~sircmpwn/hub.sr.ht";
     description = "Project hub service for the sr.ht network";
     license = licenses.agpl3Only;
-    maintainers = with maintainers; [ eadwu ];
+    maintainers = with maintainers; [ eadwu christoph-heiss ];
   };
 }

--- a/pkgs/applications/version-management/sourcehut/hub.nix
+++ b/pkgs/applications/version-management/sourcehut/hub.nix
@@ -11,30 +11,34 @@
 , unzip
 }:
 
-buildPythonPackage rec {
-  pname = "hubsrht";
-  version = "0.17.2";
-  pyproject = true;
-
-  disabled = pythonOlder "3.7";
+let
+  version = "0.17.5";
+  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.41"; };
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "hub.sr.ht";
     rev = version;
-    sha256 = "sha256-A+lvRsPz5EBnM0gB4PJuxSMpELZTrK14ORxDbTKPXWg=";
+    hash = "sha256-GbBxK3XE+Y6Jiap0Nxa8vk4Kv6IbcdSi4NN59AeKwjA=";
   };
-
-  postPatch = ''
-    substituteInPlace Makefile --replace "all: api" ""
-  '';
 
   hubsrht-api = buildGoModule ({
     inherit src version;
     pname = "hubsrht-api";
     modRoot = "api";
-    vendorHash = "sha256-K5EmZ4U+xItTR85+SCwhwg5KUGLkKHo9Nr2pkvmJpfo=";
-  } // import ./fix-gqlgen-trimpath.nix { inherit unzip; });
+    vendorHash = "sha256-wmuM0SxQbohTDaU8zmkw1TQTmqhOy1yAl1jRWk6TKL8=";
+  } // gqlgen);
+in
+buildPythonPackage rec {
+  inherit src version;
+  pname = "hubsrht";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  postPatch = ''
+    substituteInPlace Makefile --replace "all: api" ""
+  '';
 
   nativeBuildInputs = [
     pip

--- a/pkgs/applications/version-management/sourcehut/lists.nix
+++ b/pkgs/applications/version-management/sourcehut/lists.nix
@@ -73,6 +73,6 @@ buildPythonPackage rec {
     homepage = "https://git.sr.ht/~sircmpwn/lists.sr.ht";
     description = "Mailing list service for the sr.ht network";
     license = licenses.agpl3Only;
-    maintainers = with maintainers; [ eadwu ];
+    maintainers = with maintainers; [ eadwu christoph-heiss ];
   };
 }

--- a/pkgs/applications/version-management/sourcehut/lists.nix
+++ b/pkgs/applications/version-management/sourcehut/lists.nix
@@ -14,26 +14,30 @@
 , setuptools
 }:
 
-buildPythonPackage rec {
-  pname = "listssrht";
-  version = "0.57.8";
-  pyproject = true;
-
-  disabled = pythonOlder "3.7";
+let
+  version = "0.57.14";
+  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.36"; };
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "lists.sr.ht";
     rev = version;
-    sha256 = "sha256-nQZRSTAyTWxcPHrRVCZ5TgcrNgrlxBFc1vRds0cQwA0=";
+    hash = "sha256-rzOxlat7Lbgt0Wl6vvnAC+fS3MynFVKFvVdIdxgA5e0=";
   };
 
   listssrht-api = buildGoModule ({
     inherit src version;
     pname = "listssrht-api";
     modRoot = "api";
-    vendorHash = "sha256-E5Zzft9ANJT/nhhCuenZpdo3t9QYLmA+AyDyrbGectE=";
-  } // import ./fix-gqlgen-trimpath.nix { inherit unzip; });
+    vendorHash = "sha256-OWgrPvXVlvJPcoABP0ZxKzoYFhU44j/I44sBBRbd6KY=";
+  } // gqlgen);
+in
+buildPythonPackage rec {
+  inherit src version;
+  pname = "listssrht";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
 
   postPatch = ''
     substituteInPlace Makefile \

--- a/pkgs/applications/version-management/sourcehut/man.nix
+++ b/pkgs/applications/version-management/sourcehut/man.nix
@@ -11,30 +11,34 @@
 , setuptools
 }:
 
-buildPythonPackage rec {
-  pname = "mansrht";
-  version = "0.16.1";
-  pyproject = true;
-
-  disabled = pythonOlder "3.7";
+let
+  version = "0.16.3";
+  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.36"; };
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "man.sr.ht";
     rev = version;
-    sha256 = "sha256-94G9/Kzt1gaQ2CaXtsJYCB6W5OTdn27XhVdpNJ9a5cE=";
+    hash = "sha256-o1A3LmwH6WgpFqjKyL3UTru9q7TgKdOdbKZfJHR6fCA=";
   };
-
-  postPatch = ''
-    substituteInPlace Makefile --replace "all: api" ""
-  '';
 
   mansrht-api = buildGoModule ({
     inherit src version;
     pname = "mansrht-api";
     modRoot = "api";
-    vendorHash = "sha256-K5EmZ4U+xItTR85+SCwhwg5KUGLkKHo9Nr2pkvmJpfo=";
-  } // import ./fix-gqlgen-trimpath.nix { inherit unzip; });
+    vendorHash = "sha256-6AzKWytdyuofCFaDEdeO24mv1mtpnQEJydrjVWGY2eU=";
+  } // gqlgen);
+in
+buildPythonPackage rec {
+  inherit src version;
+  pname = "mansrht";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  postPatch = ''
+    substituteInPlace Makefile --replace "all: api" ""
+  '';
 
   nativeBuildInputs = [
     pip

--- a/pkgs/applications/version-management/sourcehut/man.nix
+++ b/pkgs/applications/version-management/sourcehut/man.nix
@@ -65,6 +65,6 @@ buildPythonPackage rec {
     homepage = "https://git.sr.ht/~sircmpwn/man.sr.ht";
     description = "Wiki service for the sr.ht network";
     license = licenses.agpl3Only;
-    maintainers = with maintainers; [ eadwu ];
+    maintainers = with maintainers; [ eadwu christoph-heiss ];
   };
 }

--- a/pkgs/applications/version-management/sourcehut/meta.nix
+++ b/pkgs/applications/version-management/sourcehut/meta.nix
@@ -80,6 +80,6 @@ buildPythonPackage rec {
     homepage = "https://git.sr.ht/~sircmpwn/meta.sr.ht";
     description = "Account management service for the sr.ht network";
     license = licenses.agpl3Only;
-    maintainers = with maintainers; [ eadwu ];
+    maintainers = with maintainers; [ eadwu christoph-heiss ];
   };
 }

--- a/pkgs/applications/version-management/sourcehut/meta.nix
+++ b/pkgs/applications/version-management/sourcehut/meta.nix
@@ -18,22 +18,22 @@
 , setuptools
 }:
 let
-  version = "0.64.8";
+  version = "0.68.5";
+  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.36"; };
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "meta.sr.ht";
     rev = version;
-    hash = "sha256-eiNvoy68PvjZ3iwdeNPjsXJjxAXb2PMF1/HvJquWa/U=";
+    hash = "sha256-mwUqBzi7nMTZL7uwv7hBjGkO8U3krXXpvfUCaYHgHBU=";
   };
 
   metasrht-api = buildGoModule ({
     inherit src version;
     pname = "metasrht-api";
     modRoot = "api";
-    vendorHash = "sha256-D3stDSb99uXze49kKZgGrAq5Zmg6hkIzIpsQKlnKVtE=";
-  } // import ./fix-gqlgen-trimpath.nix { inherit unzip; });
-
+    vendorHash = "sha256-4T1xnHDjxsIyddA51exNwwz6ZWeuT7N8LBsCJ7c8sRI=";
+  } // gqlgen);
 in
 buildPythonPackage rec {
   pname = "metasrht";

--- a/pkgs/applications/version-management/sourcehut/pages.nix
+++ b/pkgs/applications/version-management/sourcehut/pages.nix
@@ -31,7 +31,7 @@ buildGoModule (rec {
     homepage = "https://git.sr.ht/~sircmpwn/pages.sr.ht";
     description = "Web hosting service for the sr.ht network";
     license = licenses.agpl3Only;
-    maintainers = with maintainers; [ eadwu ];
+    maintainers = with maintainers; [ eadwu christoph-heiss ];
   };
   # There is no ./loaders but this does not cause troubles
   # to go generate

--- a/pkgs/applications/version-management/sourcehut/pages.nix
+++ b/pkgs/applications/version-management/sourcehut/pages.nix
@@ -6,13 +6,13 @@
 
 buildGoModule (rec {
   pname = "pagessrht";
-  version = "0.13.0";
+  version = "0.15.4";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "pages.sr.ht";
     rev = version;
-    sha256 = "sha256-vUN6c6cyhcLI8bKrFYKoxlBQ29VS/bowpSfBRmi47wg=";
+    hash = "sha256-3kdQVIL7xaIPu2elxj1k+4/y75bd+OKP5+VPSniF7w8=";
   };
 
   postPatch = ''
@@ -20,7 +20,7 @@ buildGoModule (rec {
       --replace "all: server" ""
   '';
 
-  vendorHash = "sha256-GKuHkUqSVBLN3k8YsFtxdmdHFkqKo9YZqDk2GBmbfWo=";
+  vendorHash = "sha256-DP+6rxjiXzs0RbSuMD20XwO/+v7QXCNgXj2LxZ96lWE=";
 
   postInstall = ''
     mkdir -p $out/share/sql/

--- a/pkgs/applications/version-management/sourcehut/paste.nix
+++ b/pkgs/applications/version-management/sourcehut/paste.nix
@@ -67,6 +67,6 @@ buildPythonPackage rec {
     homepage = "https://git.sr.ht/~sircmpwn/paste.sr.ht";
     description = "Ad-hoc text file hosting service for the sr.ht network";
     license = licenses.agpl3Only;
-    maintainers = with maintainers; [ eadwu nessdoor ];
+    maintainers = with maintainers; [ eadwu nessdoor christoph-heiss ];
   };
 }

--- a/pkgs/applications/version-management/sourcehut/paste.nix
+++ b/pkgs/applications/version-management/sourcehut/paste.nix
@@ -13,6 +13,7 @@
 
 let
   version = "0.15.2";
+  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.20"; };
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
@@ -26,7 +27,7 @@ let
     pname = "pastesrht-api";
     modRoot = "api";
     vendorHash = "sha256-jiE73PUPSHxtWp7XBdH4mJw95pXmZjCl4tk2wQUf2M4=";
-  } // import ./fix-gqlgen-trimpath.nix { inherit unzip; });
+  } // gqlgen);
 in
 buildPythonPackage rec {
   inherit src version;

--- a/pkgs/applications/version-management/sourcehut/paste.nix
+++ b/pkgs/applications/version-management/sourcehut/paste.nix
@@ -19,7 +19,7 @@ let
     owner = "~sircmpwn";
     repo = "paste.sr.ht";
     rev = version;
-    sha256 = "sha256-ZZzcd14Jbo1MfET7B56X/fl9xWXpCJ8TuKrGVgJwZfQ=";
+    hash = "sha256-ZZzcd14Jbo1MfET7B56X/fl9xWXpCJ8TuKrGVgJwZfQ=";
   };
 
   pastesrht-api = buildGoModule ({

--- a/pkgs/applications/version-management/sourcehut/scm.nix
+++ b/pkgs/applications/version-management/sourcehut/scm.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "~sircmpwn";
     repo = "scm.sr.ht";
     rev = version;
-    sha256 = "sha256-058dOEYJDY3jtxH1VkV1CFq5CZTkauSnTWg57DCnNtw=";
+    hash = "sha256-058dOEYJDY3jtxH1VkV1CFq5CZTkauSnTWg57DCnNtw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/version-management/sourcehut/scm.nix
+++ b/pkgs/applications/version-management/sourcehut/scm.nix
@@ -44,6 +44,6 @@ buildPythonPackage rec {
     homepage = "https://git.sr.ht/~sircmpwn/scm.sr.ht";
     description = "Shared support code for sr.ht source control services.";
     license = licenses.agpl3Only;
-    maintainers = with maintainers; [ eadwu ];
+    maintainers = with maintainers; [ eadwu christoph-heiss ];
   };
 }

--- a/pkgs/applications/version-management/sourcehut/todo.nix
+++ b/pkgs/applications/version-management/sourcehut/todo.nix
@@ -73,6 +73,6 @@ buildPythonPackage rec {
     homepage = "https://todo.sr.ht/~sircmpwn/todo.sr.ht";
     description = "Ticket tracking service for the sr.ht network";
     license = licenses.agpl3Only;
-    maintainers = with maintainers; [ eadwu ];
+    maintainers = with maintainers; [ eadwu christoph-heiss ];
   };
 }

--- a/pkgs/applications/version-management/sourcehut/todo.nix
+++ b/pkgs/applications/version-management/sourcehut/todo.nix
@@ -12,31 +12,35 @@
 , setuptools
 }:
 
-buildPythonPackage rec {
-  pname = "todosrht";
-  version = "0.74.6";
-  pyproject = true;
-
-  disabled = pythonOlder "3.7";
+let
+  version = "0.75.6";
+  gqlgen = import ./fix-gqlgen-trimpath.nix { inherit unzip; gqlgenVersion = "0.17.36"; };
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "todo.sr.ht";
     rev = version;
-    sha256 = "sha256-j12pCGfKf6+9R8NOBIrH2V4OuSMuncU6S1AMWFVoHts=";
+    hash = "sha256-BPJ1M9dX+xNIw++VZ0Si/rjnfI9BY95TE2o+u7JRVAU=";
   };
-
-  postPatch = ''
-    substituteInPlace Makefile \
-      --replace "all: api" ""
-  '';
 
   todosrht-api = buildGoModule ({
     inherit src version;
     pname = "todosrht-api";
     modRoot = "api";
-    vendorHash = "sha256-rvfG5F6ez8UM0dYVhKfzwtb7ZEJlaKMBAfKDbo3Aofc=";
-  } // import ./fix-gqlgen-trimpath.nix { inherit unzip; });
+    vendorHash = "sha256-vTKIJFE8AFR2eZFwG9ba6FWPW02og3ZVcrsqUnOkJIQ=";
+  } // gqlgen);
+in
+buildPythonPackage rec {
+  inherit src version;
+  pname = "todosrht";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace "all: api" ""
+  '';
 
   nativeBuildInputs = [
     setuptools


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is a new round of updates across the sourcehut stack. Keeping close to upstream should help us all around, as big version upgrades can be painful.
Pretty minor version upgrades for most packages, nothing should be broken (or at least; not more than before).

It has also been tested on top of the incoming, much more expansive testsuite in #271324.

Two more things to note:
* I've added myself as maintainer for anything sourcehut, since I already spend way to much time on this.
* Refactored the `todo`, `man`, `lists`, `hub` and `hg` packages, such that they are all now pretty similar. I would then combine them using some common expression and factor out most of the now-common stuff between all of them as a next step.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
