### PR TITLE
xv: 4.2.0 -> 5.0.0

### DIFF
--- a/pkgs/applications/graphics/xv/default.nix
+++ b/pkgs/applications/graphics/xv/default.nix
@@ -7,26 +7,25 @@
   libpng,
   libwebp,
   libtiff,
-  libjpeg,
   jasper,
 }:
 
 stdenv.mkDerivation rec {
   pname = "xv";
-  version = "4.2.0";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "jasper-software";
     repo = "xv";
     rev = "v${version}";
-    sha256 = "TXUcdrwtPNiS7z795RbzBXzNYRADeVtF5uz4aovLo/M=";
+    sha256 = "sha256-ATV/LxXQNJB6rjBmurx6a1gRPR8zNuILstvEJoQJhUs=";
   };
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [ xorg.libX11 xorg.libXt libpng libwebp libtiff jasper ];
 
   meta = {
-    description = "Classic image viewer and editor for X.";
+    description = "Classic image viewer and editor for X";
     homepage = "http://www.trilon.com/xv/";
     license = {
       fullName = "XV License";


### PR DESCRIPTION
## Description of changes

Compare  #286926 (which I can't edit so I'm closing in favor of this).  I also removed a redundant dependency.

Release notes: https://github.com/jasper-software/xv/releases/tag/v5.0.0

Changes: https://github.com/jasper-software/xv/compare/v4.2.0...v5.0.0
Mostly removing obsolete code.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).