### PR TITLE
arp-scan: 1.9.8 -> 1.10.0

### DIFF
--- a/pkgs/tools/misc/arp-scan/default.nix
+++ b/pkgs/tools/misc/arp-scan/default.nix
@@ -2,19 +2,24 @@
 
 stdenv.mkDerivation rec {
   pname = "arp-scan";
-  version = "1.9.8";
+  version = "1.10.0";
 
   src = fetchFromGitHub {
     owner = "royhills";
     repo = "arp-scan";
     rev = version;
-    sha256 = "sha256-zSihemqGaQ5z6XjA/dALoSJOuAkxF5/nnV6xE+GY7KI=";
+    sha256 = "sha256-BS+ItZd6cSMX92M6XGYrIeAiCB2iBdvbMvKdLfwawLQ=";
   };
+
+  patches = [
+    ./remove-install-exec-hook.patch
+  ];
 
   perlModules = with perlPackages; [
     HTTPDate
     HTTPMessage
     LWP
+    TextCSV
     URI
   ];
 

--- a/pkgs/tools/misc/arp-scan/remove-install-exec-hook.patch
+++ b/pkgs/tools/misc/arp-scan/remove-install-exec-hook.patch
@@ -1,0 +1,24 @@
+diff --git a/Makefile.am b/Makefile.am
+index c02e1cc..0dd6321 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -29,19 +29,3 @@ arp-scan.1: arp-scan.1.dist Makefile
+ 	$(do_subst) < $(srcdir)/arp-scan.1.dist > arp-scan.1
+ get-oui.1: get-oui.1.dist Makefile
+ 	$(do_subst) < $(srcdir)/get-oui.1.dist > get-oui.1
+-# Install arp-scan with cap_net_raw if possible, otherwise SUID root
+-install-exec-hook:
+-	@if command -v setcap > /dev/null; then \
+-	if setcap cap_net_raw+p $(DESTDIR)$(bindir)/arp-scan$(EXEEXT); then \
+-	echo "setcap cap_net_raw+p $(DESTDIR)$(bindir)/arp-scan$(EXEEXT)"; \
+-	chmod u-s $(DESTDIR)$(bindir)/arp-scan$(EXEEXT); \
+-	else \
+-	echo "Setcap failed on $(DESTDIR)$(bindir)/arp-scan$(EXEEXT), falling back to setuid" >&2; \
+-	echo "chmod u+s $(DESTDIR)$(bindir)/arp-scan$(EXEEXT)";  \
+-	chmod u+s $(DESTDIR)$(bindir)/arp-scan$(EXEEXT);  \
+-	fi \
+-	else \
+-	echo "Setcap is not installed, falling back to setuid" >&2 ; \
+-	echo "chmod u+s $(DESTDIR)$(bindir)/arp-scan$(EXEEXT)" ;\
+-	chmod u+s $(DESTDIR)$(bindir)/arp-scan$(EXEEXT) ;\
+-	fi


### PR DESCRIPTION
## Description of changes

[Release Notes](https://github.com/royhills/arp-scan/releases/tag/1.10.0)

`make install` now tries to set the `setuid` on the installed binary, which we don't allow in the Nix store. Developer [suggests](https://github.com/royhills/arp-scan/blob/master/README.md#notes-for-package-maintainers) removing the relevant code in `Makefile.am`, which we do with a patch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
