### PR TITLE
nixos: drop scripted initrd networking

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -12,6 +12,9 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - `linuxPackages_testing_bcachefs` is now fully deprecated by `linuxPackages_latest`, and is therefore no longer available.
 
+- `boot.initrd.network` does not work anymore with the scripted NixOS initrd as part of our efforts to transition fully to
+  a systemd NixOS initrd.
+
 - NixOS now installs a stub ELF loader that prints an informative error message when users attempt to run binaries not made for NixOS.
    - This can be disabled through the `environment.stub-ld.enable` option.
    - If you use `programs.nix-ld.enable`, no changes are needed. The stub will be disabled automatically.

--- a/nixos/modules/system/boot/initrd-network.nix
+++ b/nixos/modules/system/boot/initrd-network.nix
@@ -3,46 +3,8 @@
 with lib;
 
 let
-
   cfg = config.boot.initrd.network;
-
-  dhcpInterfaces = lib.attrNames (lib.filterAttrs (iface: v: v.useDHCP == true) (config.networking.interfaces or {}));
-  doDhcp = cfg.udhcpc.enable || dhcpInterfaces != [];
-  dhcpIfShellExpr = if config.networking.useDHCP || cfg.udhcpc.enable
-                      then "$(ls /sys/class/net/ | grep -v ^lo$)"
-                      else lib.concatMapStringsSep " " lib.escapeShellArg dhcpInterfaces;
-
-  udhcpcScript = pkgs.writeScript "udhcp-script"
-    ''
-      #! /bin/sh
-      if [ "$1" = bound ]; then
-        ip address add "$ip/$mask" dev "$interface"
-        if [ -n "$mtu" ]; then
-          ip link set mtu "$mtu" dev "$interface"
-        fi
-        if [ -n "$staticroutes" ]; then
-          echo "$staticroutes" \
-            | sed -r "s@(\S+) (\S+)@ ip route add \"\1\" via \"\2\" dev \"$interface\" ; @g" \
-            | sed -r "s@ via \"0\.0\.0\.0\"@@g" \
-            | /bin/sh
-        fi
-        if [ -n "$router" ]; then
-          ip route add "$router" dev "$interface" # just in case if "$router" is not within "$ip/$mask" (e.g. Hetzner Cloud)
-          ip route add default via "$router" dev "$interface"
-        fi
-        if [ -n "$dns" ]; then
-          rm -f /etc/resolv.conf
-          for server in $dns; do
-            echo "nameserver $server" >> /etc/resolv.conf
-          done
-        fi
-      fi
-    '';
-
-  udhcpcArgs = toString cfg.udhcpc.extraArgs;
-
 in
-
 {
 
   options = {
@@ -54,9 +16,6 @@ in
         Add network connectivity support to initrd. The network may be
         configured using the `ip` kernel parameter,
         as described in [the kernel documentation](https://www.kernel.org/doc/Documentation/filesystems/nfs/nfsroot.txt).
-        Otherwise, if
-        {option}`networking.useDHCP` is enabled, an IP address
-        is acquired using DHCP.
 
         You should add the module(s) required for your network card to
         boot.initrd.availableKernelModules.
@@ -78,85 +37,9 @@ in
         because the systemd-networkd documentation suggests it.
       '';
     };
-
-    boot.initrd.network.udhcpc.enable = mkOption {
-      default = config.networking.useDHCP && !config.boot.initrd.systemd.enable;
-      defaultText = "networking.useDHCP";
-      type = types.bool;
-      description = lib.mdDoc ''
-        Enables the udhcpc service during stage 1 of the boot process. This
-        defaults to {option}`networking.useDHCP`. Therefore, this useful if
-        useDHCP is off but the initramfs should do dhcp.
-      '';
-    };
-
-    boot.initrd.network.udhcpc.extraArgs = mkOption {
-      default = [];
-      type = types.listOf types.str;
-      description = lib.mdDoc ''
-        Additional command-line arguments passed verbatim to
-        udhcpc if {option}`boot.initrd.network.enable` and
-        {option}`boot.initrd.network.udhcpc.enable` are enabled.
-      '';
-    };
-
-    boot.initrd.network.postCommands = mkOption {
-      default = "";
-      type = types.lines;
-      description = lib.mdDoc ''
-        Shell commands to be executed after stage 1 of the
-        boot has initialised the network.
-      '';
-    };
-
-
   };
 
   config = mkIf cfg.enable {
-
     boot.initrd.kernelModules = [ "af_packet" ];
-
-    boot.initrd.extraUtilsCommands = mkIf (!config.boot.initrd.systemd.enable) ''
-      copy_bin_and_libs ${pkgs.klibc}/lib/klibc/bin.static/ipconfig
-    '';
-
-    boot.initrd.preLVMCommands = mkIf (!config.boot.initrd.systemd.enable) (mkBefore (
-      # Search for interface definitions in command line.
-      ''
-        ifaces=""
-        for o in $(cat /proc/cmdline); do
-          case $o in
-            ip=*)
-              ipconfig $o && ifaces="$ifaces $(echo $o | cut -d: -f6)"
-              ;;
-          esac
-        done
-      ''
-
-      # Otherwise, use DHCP.
-      + optionalString doDhcp ''
-        # Bring up all interfaces.
-        for iface in ${dhcpIfShellExpr}; do
-          echo "bringing up network interface $iface..."
-          ip link set dev "$iface" up && ifaces="$ifaces $iface"
-        done
-
-        # Acquire DHCP leases.
-        for iface in ${dhcpIfShellExpr}; do
-          echo "acquiring IP address via DHCP on $iface..."
-          udhcpc --quit --now -i $iface -O staticroutes --script ${udhcpcScript} ${udhcpcArgs}
-        done
-      ''
-
-      + cfg.postCommands));
-
-    boot.initrd.postMountCommands = mkIf (cfg.flushBeforeStage2 && !config.boot.initrd.systemd.enable) ''
-      for iface in $ifaces; do
-        ip address flush dev "$iface"
-        ip link set dev "$iface" down
-      done
-    '';
-
   };
-
 }

--- a/nixos/modules/system/boot/initrd-openvpn.nix
+++ b/nixos/modules/system/boot/initrd-openvpn.nix
@@ -38,7 +38,7 @@ in
 
   };
 
-  config = mkIf (config.boot.initrd.network.enable && cfg.enable) {
+  config = mkIf (config.boot.initrd.systemd.network.enable && cfg.enable) {
     assertions = [
       {
         assertion = cfg.configuration != null;
@@ -48,16 +48,6 @@ in
 
     # Add kernel modules needed for OpenVPN
     boot.initrd.kernelModules = [ "tun" "tap" ];
-
-    # Add openvpn and ip binaries to the initrd
-    # The shared libraries are required for DNS resolution
-    boot.initrd.extraUtilsCommands = mkIf (!config.boot.initrd.systemd.enable) ''
-      copy_bin_and_libs ${pkgs.openvpn}/bin/openvpn
-      copy_bin_and_libs ${pkgs.iproute2}/bin/ip
-
-      cp -pv ${pkgs.glibc}/lib/libresolv.so.2 $out/lib
-      cp -pv ${pkgs.glibc}/lib/libnss_dns.so.2 $out/lib
-    '';
 
     boot.initrd.systemd.storePaths = [
       "${pkgs.openvpn}/bin/openvpn"
@@ -69,15 +59,6 @@ in
     boot.initrd.secrets = {
       "/etc/initrd.ovpn" = cfg.configuration;
     };
-
-    # openvpn --version would exit with 1 instead of 0
-    boot.initrd.extraUtilsCommandsTest = mkIf (!config.boot.initrd.systemd.enable) ''
-      $out/bin/openvpn --show-gateway
-    '';
-
-    boot.initrd.network.postCommands = mkIf (!config.boot.initrd.systemd.enable) ''
-      openvpn /etc/initrd.ovpn &
-    '';
 
     boot.initrd.systemd.services.openvpn = {
       wantedBy = [ "initrd.target" ];

--- a/nixos/modules/system/boot/initrd-ssh.nix
+++ b/nixos/modules/system/boot/initrd-ssh.nix
@@ -5,10 +5,9 @@ with lib;
 let
 
   cfg = config.boot.initrd.network.ssh;
-  shell = if cfg.shell == null then "/bin/ash" else cfg.shell;
   inherit (config.programs.ssh) package;
 
-  enabled = let initrd = config.boot.initrd; in (initrd.network.enable || initrd.systemd.network.enable) && cfg.enable;
+  enabled = let initrd = config.boot.initrd; in initrd.systemd.network.enable && cfg.enable;
 
 in
 
@@ -164,66 +163,15 @@ in
           for instructions.
         '';
       }
+
+      {
+        assertion = config.boot.initrd.systemd.enable;
+        message = "You cannot use sshd in initrd without the systemd initrd, consider enabling `boot.initrd.systemd.enable`.";
+      }
     ];
 
     warnings = lib.optional (config.boot.initrd.systemd.enable && cfg.shell != null) ''
       Please set 'boot.initrd.systemd.users.root.shell' instead of 'boot.initrd.network.ssh.shell'
-    '';
-
-    boot.initrd.extraUtilsCommands = mkIf (!config.boot.initrd.systemd.enable) ''
-      copy_bin_and_libs ${package}/bin/sshd
-      cp -pv ${pkgs.glibc.out}/lib/libnss_files.so.* $out/lib
-    '';
-
-    boot.initrd.extraUtilsCommandsTest = mkIf (!config.boot.initrd.systemd.enable) ''
-      # sshd requires a host key to check config, so we pass in the test's
-      tmpkey="$(mktemp initrd-ssh-testkey.XXXXXXXXXX)"
-      cp "${../../../tests/initrd-network-ssh/ssh_host_ed25519_key}" "$tmpkey"
-      # keys from Nix store are world-readable, which sshd doesn't like
-      chmod 600 "$tmpkey"
-      echo -n ${escapeShellArg sshdConfig} |
-        $out/bin/sshd -t -f /dev/stdin \
-        -h "$tmpkey"
-      rm "$tmpkey"
-    '';
-
-    boot.initrd.network.postCommands = mkIf (!config.boot.initrd.systemd.enable) ''
-      echo '${shell}' > /etc/shells
-      echo 'root:x:0:0:root:/root:${shell}' > /etc/passwd
-      echo 'sshd:x:1:1:sshd:/var/empty:/bin/nologin' >> /etc/passwd
-      echo 'passwd: files' > /etc/nsswitch.conf
-
-      mkdir -p /var/log /var/empty
-      touch /var/log/lastlog
-
-      mkdir -p /etc/ssh
-      echo -n ${escapeShellArg sshdConfig} > /etc/ssh/sshd_config
-
-      echo "export PATH=$PATH" >> /etc/profile
-      echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> /etc/profile
-
-      mkdir -p /root/.ssh
-      ${concatStrings (map (key: ''
-        echo ${escapeShellArg key} >> /root/.ssh/authorized_keys
-      '') cfg.authorizedKeys)}
-
-      ${flip concatMapStrings cfg.hostKeys (path: ''
-        # keys from Nix store are world-readable, which sshd doesn't like
-        chmod 0600 "${initrdKeyPath path}"
-      '')}
-
-      /bin/sshd -e
-    '';
-
-    boot.initrd.postMountCommands = mkIf (!config.boot.initrd.systemd.enable) ''
-      # Stop sshd cleanly before stage 2.
-      #
-      # If you want to keep it around to debug post-mount SSH issues,
-      # run `touch /.keep_sshd` (either from an SSH session or in
-      # another initrd hook like preDeviceCommands).
-      if ! [ -e /.keep_sshd ]; then
-        pkill -x sshd
-      fi
     '';
 
     boot.initrd.secrets = listToAttrs


### PR DESCRIPTION
## Description of changes

We remove scripted initrd networking as it is:

- very much broken, see https://fem.social/@clerie/111890928880190411
- almost unsalvageable as all boot people are working on the systemd stage 1
- has de-facto no maintainer

Signed-off-by: Raito Bezarius <masterancpp@gmail.com>

TODO:

- [ ] fix all tests
- [ ] sprinkle enough warnings

### I have scripted initrd usecases, what's going to happen to me?

Please consider using the systemd stage 1 setup, if you have troubles, reach out to the support channel. If this is a real showstopper, please chime in this discussion.

**Open to pick up to external contributors** :

- Transform this PR into a warning-only PRs and prepare the drop PR for 24.05 branch-off for a full release cycle of deprecation: I don't suggest it because there's no maintainer and this just cause maintenance churn on the systemd stage 1 side.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
