### PR TITLE
pdf-sign: fix version name, simplify installPhase, move to pkgs/by-name

### DIFF
--- a/pkgs/by-name/pd/pdf-sign/package.nix
+++ b/pkgs/by-name/pd/pdf-sign/package.nix
@@ -10,12 +10,12 @@
 }:
 
 let
-  python-env = python3.withPackages (ps: with ps; [ tkinter ]);
+  python = python3.withPackages (ps: with ps; [ tkinter ]);
   binPath = lib.makeBinPath [ ghostscript pdftk poppler_utils ];
 in
 stdenv.mkDerivation {
   pname = "pdf-sign";
-  version = "unstable-2023-08-08";
+  version = "0-unstable-2023-08-08";
 
   src = fetchFromGitHub {
     owner = "svenssonaxel";
@@ -26,18 +26,14 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ makeBinaryWrapper ];
 
+  buildInputs = [ python ];
+
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out
-    cp pdf-sign pdf-create-empty $out
-
-    makeWrapper ${python-env}/bin/python $out/bin/pdf-sign \
-          --add-flags $out/pdf-sign \
-          --prefix PATH : ${binPath}
-    makeWrapper ${python-env}/bin/python $out/bin/pdf-create-empty \
-          --add-flags $out/pdf-create-empty \
-          --prefix PATH : ${binPath}
+    install -Dm755 pdf-sign pdf-create-empty -t $out/bin
+    wrapProgram $out/bin/pdf-sign --prefix PATH : ${binPath}
+    wrapProgram $out/bin/pdf-create-empty --prefix PATH : ${binPath}
 
     runHook postInstall
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11970,8 +11970,6 @@ with pkgs;
 
   pdf-quench = callPackage ../applications/misc/pdf-quench { };
 
-  pdf-sign = callPackage ../tools/graphics/pdf-sign { };
-
   pdfarranger = callPackage ../applications/misc/pdfarranger { };
 
   briss = callPackage ../tools/graphics/briss { };


### PR DESCRIPTION
## Description of changes

This PR fixes the version name to be according to the naming guidelines. (`version` must start with a number)

I also cleaned up the `installPhase`, as it didn't look very nice.
I was pretty new to nixpkgs, when I initially packaged this, so I overcomplicated the `installPhase` a bit.

I also moved the package to `pkgs/by-name`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
