### PR TITLE
etcd_3_5: add update script

### DIFF
--- a/pkgs/servers/etcd/3.5/default.nix
+++ b/pkgs/servers/etcd/3.5/default.nix
@@ -20,7 +20,7 @@ let
     description = "Distributed reliable key-value store for the most critical data of a distributed system";
     license = licenses.asl20;
     homepage = "https://etcd.io/";
-    maintainers = with maintainers; [ offline endocrimes ];
+    maintainers = with maintainers; [ endocrimes offline superherointj ];
     platforms = platforms.darwin ++ platforms.linux;
   };
 

--- a/pkgs/servers/etcd/3.5/default.nix
+++ b/pkgs/servers/etcd/3.5/default.nix
@@ -2,12 +2,16 @@
 
 let
   version = "3.5.12";
+  etcdSrcHash = "sha256-Z2WXNzFJYfRQCldUspQjUR5NyUzCCINycuEXWaTn4vU=";
+  etcdServerVendorHash = "sha256-S5cEIV4hKRjn9JFEKWBiSEPytHtVacsSnG6T8dofgyk=";
+  etcdUtlVendorHash = "sha256-Vgp44Kg6zUDYVJU6SiYd8ZEcAWqKPPTsqYafcfk89Cc=";
+  etcdCtlVendorHash = "sha256-PZLsekZzwlGzccCirNk9uUj70Ue5LMDs6LMWBI9yivs=";
 
   src = fetchFromGitHub {
     owner = "etcd-io";
     repo = "etcd";
     rev = "v${version}";
-    hash = "sha256-Z2WXNzFJYfRQCldUspQjUR5NyUzCCINycuEXWaTn4vU=";
+    hash = etcdSrcHash;
   };
 
   CGO_ENABLED = 0;
@@ -25,7 +29,7 @@ let
 
     inherit CGO_ENABLED meta src version;
 
-    vendorHash = "sha256-S5cEIV4hKRjn9JFEKWBiSEPytHtVacsSnG6T8dofgyk=";
+    vendorHash = etcdServerVendorHash;
 
     modRoot = "./server";
 
@@ -45,7 +49,7 @@ let
 
     inherit CGO_ENABLED meta src version;
 
-    vendorHash = "sha256-Vgp44Kg6zUDYVJU6SiYd8ZEcAWqKPPTsqYafcfk89Cc=";
+    vendorHash = etcdUtlVendorHash;
 
     modRoot = "./etcdutl";
   };
@@ -55,7 +59,7 @@ let
 
     inherit CGO_ENABLED meta src version;
 
-    vendorHash = "sha256-PZLsekZzwlGzccCirNk9uUj70Ue5LMDs6LMWBI9yivs=";
+    vendorHash = etcdCtlVendorHash;
 
     modRoot = "./etcdctl";
   };
@@ -71,6 +75,7 @@ symlinkJoin {
       inherit (nixosTests) etcd etcd-cluster;
       k3s = k3s.passthru.tests.etcd;
     };
+    updateScript = ./update.sh;
   };
 
   paths = [

--- a/pkgs/servers/etcd/3.5/update.sh
+++ b/pkgs/servers/etcd/3.5/update.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnugrep gnused jq nix-prefetch
+
+set -x -eu -o pipefail
+
+ETCD_VERSION_MAJOR_MINOR=`basename "$PWD"`
+
+ETCD_PKG_NAME=etcd_$(echo $ETCD_VERSION_MAJOR_MINOR | sed 's/[.]/_/g')
+NIXPKGS_PATH="$(git rev-parse --show-toplevel)"
+ETCD_PATH="$(dirname "$0")"
+
+OLD_VERSION="$(nix-instantiate --eval -E "with import $NIXPKGS_PATH {}; \
+    $ETCD_PKG_NAME.version or (builtins.parseDrvName $ETCD_PKG_NAME.name).version" | tr -d '"')"
+
+LATEST_TAG=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} --silent https://api.github.com/repos/etcd-io/etcd/releases \
+    | jq -r 'map(.tag_name)' | grep $ETCD_VERSION_MAJOR_MINOR | sed 's|[", ]||g' | sort -rV | head -n1)
+
+LATEST_VERSION=$(echo ${LATEST_TAG} | sed 's/^v//')
+
+if [ ! "$OLD_VERSION" = "$LATEST_VERSION" ]; then
+    echo "Attempting to update etcd from $OLD_VERSION to $LATEST_VERSION"
+    ETCD_SRC_HASH=$(nix-prefetch-url --quiet --unpack https://github.com/etcd-io/etcd/archive/refs/tags/${LATEST_TAG}.tar.gz)
+    ETCD_SRC_HASH=$(nix hash to-sri --type sha256 $ETCD_SRC_HASH)
+
+    setKV () {
+        sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" "$ETCD_PATH/default.nix"
+    }
+
+    setKV version $LATEST_VERSION
+    setKV etcdSrcHash $ETCD_SRC_HASH
+
+    getAndSetVendorHash () {
+        local EMPTY_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" # Hash from lib.fakeHash
+        local VENDOR_HASH=$EMPTY_HASH
+        local PKG_KEY=$1
+        local INNER_PKG=$2
+
+        setKV $PKG_KEY $EMPTY_HASH
+
+        set +e
+        VENDOR_HASH=$(nix-prefetch -I nixpkgs=$NIXPKGS_PATH "{ sha256 }: \
+            (import $NIXPKGS_PATH/. {}).$ETCD_PKG_NAME.passthru.$INNER_PKG.goModules.overrideAttrs (_: { vendorHash = sha256; })")
+        set -e
+
+        if [ -n "${VENDOR_HASH:-}" ]; then
+            setKV $PKG_KEY $VENDOR_HASH
+        else
+            echo "Update failed. $PKG_KEY is empty."
+            exit 1
+        fi
+    }
+
+    getAndSetVendorHash etcdServerVendorHash etcdserver
+    getAndSetVendorHash etcdUtlVendorHash etcdutl
+    getAndSetVendorHash etcdCtlVendorHash etcdctl
+
+    # `git` flag here is to be used by local maintainers to speed up the bump process
+    if [ $# -eq 1 ] && [ "$1" = "git" ]; then
+        git switch -c "package-$ETCD_PKG_NAME-$LATEST_VERSION"
+        git add "$ETCD_PATH"/default.nix
+        git commit -m "$ETCD_PKG_NAME: $OLD_VERSION -> $LATEST_VERSION
+
+Release: https://github.com/etcd-io/etcd/releases/tag/v$LATEST_VERSION"
+    fi
+
+else
+    echo "etcd is already up-to-date at $OLD_VERSION"
+fi

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25882,7 +25882,7 @@ with pkgs;
 
   etcd = etcd_3_5;
   etcd_3_4 = callPackage ../servers/etcd/3.4.nix { };
-  etcd_3_5 = callPackage ../servers/etcd/3.5.nix { };
+  etcd_3_5 = callPackage ../servers/etcd/3.5 { };
 
   ejabberd = callPackage ../servers/xmpp/ejabberd { erlang = erlang_24; };
 


### PR DESCRIPTION
etcd_3_5: add update script

To test, open `pkgs/servers/etcd/3.5/default.nix` and reset variables:

> version = "3.5.11";
> etcdSrcHash = "";
> etcdServerVendorHash = "";
> etcdUtlVendorHash = "";
> etcdCtlVendorHash = "";

Then, execute:
> pkgs/servers/etcd/3.5/update.sh

It should properly fill fields with latest 3.5.x information.

After merge, watch for logs at:
- https://r.ryantm.com/log/etcd_3_5/

CC @offline @endocrimes