### PR TITLE
smb3-foundry: clean up installPhase, move to pkgs/by-name

### DIFF
--- a/pkgs/by-name/sm/smb3-foundry/package.nix
+++ b/pkgs/by-name/sm/smb3-foundry/package.nix
@@ -2,11 +2,10 @@
 , stdenv
 , fetchFromGitHub
 , python3
-, makeWrapper
 }:
 
 let
-  pythonEnv = (python3.withPackages (ps: with ps; [
+  python = (python3.withPackages (ps: with ps; [
     pyside6
     py65
     qdarkstyle
@@ -23,18 +22,16 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-8cf7VhvC372Cqi94n2FSHcoCGblpZoZvBXcXq5jU6CY=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ python ];
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/app
-    cp -R smb3parse foundry scribe data doc VERSION smb3-foundry.py smb3-scribe.py $out/app
+    mkdir -p $out/share/smb3-foundry $out/bin
+    cp -r smb3parse foundry scribe data doc VERSION smb3-foundry.py smb3-scribe.py $out/share/smb3-foundry
 
-    makeWrapper ${pythonEnv}/bin/python $out/bin/smb3-foundry \
-          --add-flags "$out/app/smb3-foundry.py"
-    makeWrapper ${pythonEnv}/bin/python $out/bin/smb3-scribe \
-          --add-flags "$out/app/smb3-scribe.py"
+    ln -s $out/share/smb3-foundry/smb3-foundry.py $out/bin/smb3-foundry
+    ln -s $out/share/smb3-foundry/smb3-scribe.py $out/bin/smb3-scribe
 
     runHook postInstall
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2050,10 +2050,6 @@ with pkgs;
 
   sorted-grep = callPackage ../tools/text/sorted-grep { };
 
-  smb3-foundry = callPackage ../applications/misc/smb3-foundry {
-    python3 = python311;
-  };
-
   smbmap = callPackage ../tools/security/smbmap { };
 
   smbscan = callPackage ../tools/security/smbscan { };


### PR DESCRIPTION
## Description of changes

This PR does some minor cleanup in the `smb3-foundry` package.

Previously the package used `makeWrapper` to make the executables, now it uses the automatic shebang-patching of the builder.

I changed the main directory from `$out/app` to `$out/share/smb3-foundry` as the former was a bit arbitrary.

I also migrated the package to `pkgs/by-name`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
