### PR TITLE
wxSVG: fix build failure against `gcc-13`

### DIFF
--- a/pkgs/development/libraries/wxSVG/default.nix
+++ b/pkgs/development/libraries/wxSVG/default.nix
@@ -23,6 +23,12 @@ stdenv.mkDerivation rec {
     hash = "sha256-rkcykfjQpf6voGzScMgmxr6tS86yud1vzs8tt8JeJII=";
   };
 
+  postPatch = ''
+    # Apply upstream patch for gcc-13 support:
+    #   https://sourceforge.net/p/wxsvg/git/ci/7b17fe365fb522618fb3520d7c5c1109b138358f/
+    sed -i src/cairo/SVGCanvasCairo.cpp -e '1i #include <cstdint>'
+  '';
+
   nativeBuildInputs = [
     pkg-config
   ];

--- a/pkgs/development/libraries/wxSVG/default.nix
+++ b/pkgs/development/libraries/wxSVG/default.nix
@@ -42,6 +42,8 @@ stdenv.mkDerivation rec {
     wxGTK
   ] ++ lib.optional stdenv.isDarwin Cocoa;
 
+  enableParallelBuilding = true;
+
   meta = with lib; {
     homepage = "https://wxsvg.sourceforge.net/";
     description = "A SVG manipulation library built with wxWidgets";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25506,7 +25506,6 @@ with pkgs;
 
   wxSVG = callPackage ../development/libraries/wxSVG {
     wxGTK = wxGTK32;
-    stdenv = gcc12Stdenv;
   };
 
   wtk = callPackage ../development/libraries/wtk { };


### PR DESCRIPTION
## Description of changes

Without the change `wxSVG` fails the build in `master` as
https://hydra.nixos.org/build/248172755:

    libwx_gtk3u_xrc-3.2.so: undefined reference to `std::ios_base_library_init()@GLIBCXX_3.4.32'
    collect2: error: ld returned 1 exit status
    make[1]: *** [Makefile:416: svgview] Error 1

This happens due to mix of `gcc-12` / `gcc-13` `libstdc++` libraries.

The fix just applies upstream fix for `wxSVG` for `gcc-13`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
