### PR TITLE
dxx-rebirth: unstable-2023-03-23 -> 0-unstable-2024-01-13

### DIFF
--- a/pkgs/games/dxx-rebirth/default.nix
+++ b/pkgs/games/dxx-rebirth/default.nix
@@ -23,7 +23,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "dxx-rebirth";
-  version = "unstable-2024-01-13";
+  version = "0-unstable-2024-01-13";
 
   src = fetchFromGitHub {
     owner = "dxx-rebirth";

--- a/pkgs/games/dxx-rebirth/default.nix
+++ b/pkgs/games/dxx-rebirth/default.nix
@@ -11,6 +11,7 @@
 , libGL
 , libpng
 , physfs
+, unstableGitUpdater
 }:
 
 let
@@ -22,13 +23,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "dxx-rebirth";
-  version = "unstable-2023-03-23";
+  version = "unstable-2024-01-13";
 
   src = fetchFromGitHub {
     owner = "dxx-rebirth";
     repo = "dxx-rebirth";
-    rev = "841ebcc11d249febe48911bc239606ade3bd78b3";
-    hash = "sha256-cr5QdkKO/HNvtc2w4ynJixuLauhPCwtsSC3UEV7+C1A=";
+    rev = "5c710857a9312e1b2f3249c51c12b55f9390a2b1";
+    hash = "sha256-nEPMJiTeePAmourAksUNqyy5whs+8+qy/qrycfNw2lo=";
   };
 
   nativeBuildInputs = [ pkg-config scons ];
@@ -48,6 +49,8 @@ stdenv.mkDerivation rec {
     install -Dm644 ${music} $out/share/games/dxx-rebirth/${music.name}
     install -Dm644 -t $out/share/doc/dxx-rebirth *.txt
   '';
+
+  passthru.updateScript = unstableGitUpdater {};
 
   meta = with lib; {
     description = "Source Port of the Descent 1 and 2 engines";


### PR DESCRIPTION
The main change is the build fix against `gcc-13` https://hydra.nixos.org/build/247695201:

    similar/main/digiobj.cpp: In function ‘void d1x::digi_sync_sounds()’:
    similar/main/digiobj.cpp:625:31:
      error: possibly dangling reference to a temporary [-Werror=dangling-reference]
      625 |                 const object &objp = [&vcobjptr, &s]{
          |                               ^~~~

While at it added the trivial unstable updater.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
