### PR TITLE
evtest-qt: 0.2.0 -> 0.2.0-unstable-2023-09-13

### DIFF
--- a/pkgs/applications/misc/evtest-qt/default.nix
+++ b/pkgs/applications/misc/evtest-qt/default.nix
@@ -1,19 +1,32 @@
-{ mkDerivation, lib, qtbase, cmake, fetchFromGitHub }:
+{ mkDerivation, lib, qtbase, cmake, fetchFromGitHub, fetchpatch, unstableGitUpdater }:
 
 mkDerivation rec {
   pname = "evtest-qt";
-  version = "0.2.0";
+  version = "0.2.0-unstable-2023-09-13";
 
   src = fetchFromGitHub {
     owner = "Grumbel";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "1wfzkgq81764qzxgk0y5vvpxcrb3icvrr4dd4mj8njrqgbwmn0mw";
+    rev = "fb087f4d3d51377790f1ff30681c48031bf23145";
+    hash = "sha256-gE47x1J13YZUVyB0b4VRyESIVCm3GbOXp2bX0TP97UU=";
+    fetchSubmodules = true;
   };
+
+  patches = [
+    # Fix build against gcc-13:
+    #   https://github.com/Grumbel/evtest-qt/pull/14
+    (fetchpatch {
+      name = "gcc-13.patch";
+      url = "https://github.com/Grumbel/evtest-qt/commit/975dedcfd60853bd329f34d48ce4740add8866eb.patch";
+      hash = "sha256-gR/9oVhO4G9i7dn+CjvDAQN0KLXoX/fatpE0W3gXDc0=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [ qtbase ];
+
+  passthru.updateScript = unstableGitUpdater {};
 
   meta = with lib; {
     description = "Simple input device tester for linux with Qt GUI";


### PR DESCRIPTION
The main change is the build fix against `gcc-13`
https://hydra.nixos.org/build/247729704:

    In file included from /build/source/src/evdev_info.cpp:17:
    /build/source/src/evdev_info.hpp:74:12: error: 'uint16_t' was not declared in this scope
       74 |   std::map<uint16_t, AbsInfo> absinfos;
          |            ^~~~~~~~

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
