### PR TITLE
octoprint: init plugins

### DIFF
--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -289,6 +289,24 @@ in
     };
   };
 
+  navbartemp = buildPlugin rec {
+    pname = "navbartemp";
+    version = "0.15";
+
+    src = fetchFromGitHub {
+      owner = "imrahil";
+      repo = "OctoPrint-NavbarTemp";
+      rev = version;
+      sha256 = "sha256-ZPpTx+AadRffUb53sZbMUbCZa7xYGQW/5si7UB8mnVI=";
+    };
+
+    meta = with lib; {
+      description = "Displays temperatures on navbar";
+      homepage = "https://github.com/imrahil/OctoPrint-NavbarTemp";
+      license = licenses.agpl3;
+    };
+  };
+
   printtimegenius = buildPlugin rec {
     pname = "printtimegenius";
     version = "2.3.1";

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -411,6 +411,28 @@ in
     };
   };
 
+  resource-monitor = buildPlugin rec {
+    pname = "resource-monitor";
+    version = "0.3.15";
+
+    src = fetchFromGitHub {
+      owner = "Renaud11232";
+      repo = "OctoPrint-Resource-Monitor";
+      rev = version;
+      sha256 = "sha256-7/xYcWiGTF089JshybYTF6cViFAkR59939FCZ4gPh7w=";
+    };
+
+    propagatedBuildInputs = with super; [
+      psutil
+    ];
+
+    meta = with lib; {
+      description = "A plugin to view the current CPU and RAM usage on your system";
+      homepage = "https://github.com/Renaud11232/OctoPrint-Resource-Monitor";
+      license = licenses.mit;
+    };
+  };
+
   simpleemergencystop = buildPlugin rec {
     pname = "simpleemergencystop";
     version = "1.0.5";

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -511,6 +511,24 @@ in
     };
   };
 
+  timelapsepurger = buildPlugin rec {
+    pname = "timelapsepurger";
+    version = "0.1.4";
+
+    src = fetchFromGitHub {
+      owner = "jneilliii";
+      repo = "OctoPrint-TimelapsePurger";
+      rev = version;
+      sha256 = "sha256-XS4m4KByScGTPfVE4kuRLw829gNE2CdM0RyhRqGGxyw=";
+    };
+
+    meta = with lib; {
+      description = "Automatically deletes timelapses that are older than configured timeframe.";
+      homepage = "https://github.com/jneilliii/OctoPrint-TimelapsePurger";
+      license = licenses.agpl3;
+    };
+  };
+
   titlestatus = buildPlugin rec {
     pname = "titlestatus";
     version = "0.0.5";

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -194,6 +194,24 @@ in
     };
   };
 
+  fullscreen = buildPlugin {
+    pname = "fullscreen";
+    version = "0.0.6";
+
+    src = fetchFromGitHub {
+      owner = "BillyBlaze";
+      repo = "OctoPrint-FullScreen";
+      rev = version;
+      sha256 = "sha256-Z8twpj+gqgbiWWxNd9I9qflEAln5Obpb3cn34KwSc5A=";
+    };
+
+    meta = with lib; {
+      description = "Open webcam in fullscreen mode";
+      homepage = "https://github.com/BillyBlaze/OctoPrint-FullScreen";
+      license = licenses.agpl3;
+    };
+  };
+
   gcodeeditor = buildPlugin rec {
     pname = "gcodeeditor";
     version = "0.2.12";

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -271,6 +271,24 @@ in
     };
   };
 
+  mqttchambertemperature = buildPlugin rec {
+    pname = "mqttchambertemperature";
+    version = "0.0.2";
+
+    src = fetchFromGitHub {
+      owner = "synman";
+      repo = "OctoPrint-MqttChamberTemperature";
+      rev = version;
+      sha256 = "sha256-dI0wv5MAyREDYFRnCbMgNrfJEOvRPwLNubHZFtTGnQU=";
+    };
+
+    meta = with lib; {
+      description = "Enables Chamber temperature reporting via subscribing to an MQTT topic";
+      homepage = "https://github.com/synman/OctoPrint-MqttChamberTemperature";
+      license = licenses.wtfpl;
+    };
+  };
+
   printtimegenius = buildPlugin rec {
     pname = "printtimegenius";
     version = "2.3.1";

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -307,6 +307,30 @@ in
     };
   };
 
+  obico = buildPlugin rec {
+    pname = "obico";
+    version = "2.4.10";
+
+    src = fetchFromGitHub {
+      owner = "TheSpaghettiDetective";
+      repo = "OctoPrint-Obico";
+      rev = version;
+      sha256 = "sha256-1i6c8b1sksh8GLiOT5RjCsIwd9aF9u+k4Kuiz+kG/30=";
+    };
+
+    propagatedBuildInputs = with super; [
+      backoff
+      entry-sdk
+      bson
+    ];
+
+    meta = with lib; {
+      description = "Securely monitor and control your OctoPrint-connected printer from anywhere for free with Obico. Get unlimited live webcam streaming, full OctoPrint remote access, printer status notifications, and a free companion mobile app for iOS and Android. The best part? AI-powered failure detection watches your prints so you don’t have to.";
+      homepage = "https://www.obico.io/";
+      license = licenses.agpl3;
+    };
+  };
+
   printtimegenius = buildPlugin rec {
     pname = "printtimegenius";
     version = "2.3.1";

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -383,6 +383,28 @@ in
     };
   };
 
+  prusaslicerthumbnails = buildPlugin rec {
+    pname = "prusaslicerthumbnails";
+    version = "1.0.6";
+
+    src = fetchFromGitHub {
+      owner = "jneilliii";
+      repo = "OctoPrint-PrusaSlicerThumbnails";
+      rev = version;
+      sha256 = "sha256-Qk6VrHau1tLSbrPGM0gYscGa6YAXc0Zp0X9HahXA5gE";
+    };
+
+    propagatedBuildInputs = with super; [
+      psutil
+    ];
+
+    meta = with lib; {
+      description = "Plugin that extracts thumbnails from uploaded gcode files sliced by PrusaSlicer.";
+      homepage = "https://github.com/jneilliii/OctoPrint-PrusaSlicerThumbnails";
+      license = licenses.agpl3;
+    };
+  };
+  
   psucontrol = buildPlugin rec {
     pname = "psucontrol";
     version = "1.0.6";

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -331,6 +331,28 @@ in
     };
   };
 
+  octopod = buildPlugin rec {
+    pname = "octopod";
+    version = "0.3.16";
+
+    src = fetchFromGitHub {
+      owner = "gdombiak";
+      repo = "OctoPrint-OctoPod";
+      rev = version;
+      sha256 = "sha256-9QKC1MsYO3XihOTAijJUv5i20iMSQHOHPfLiYPV5y8s=";
+    };
+
+    propagatedBuildInputs = with super; [
+      pillow
+    ];
+
+    meta = with lib; {
+      description = "OctoPod extension for OctoPrint";
+      homepage = "https://github.com/gdombiak/OctoPrint-OctoPod";
+      license = licenses.asl20;
+    };
+  };
+
   printtimegenius = buildPlugin rec {
     pname = "printtimegenius";
     version = "2.3.1";

--- a/pkgs/applications/misc/octoprint/plugins.nix
+++ b/pkgs/applications/misc/octoprint/plugins.nix
@@ -172,6 +172,28 @@ in
     };
   };
 
+  firmwareupdater = buildPlugin {
+    pname = "firmwareupdater";
+    version = "1.14.0";
+
+    src = fetchFromGitHub {
+      owner = "OctoPrint";
+      repo = "OctoPrint-FirmwareUpdater";
+      rev = version;
+      sha256 = "sha256-CUNjM/IJJS/lqccZ2B0mDOzv3k8AgmDreA/X9wNJ7iY=";
+    };
+
+    propagatedBuildInputs = with super; [
+      pyserial
+    ];
+
+    meta = with lib; {
+      description = "Printer Firmware Updater";
+      homepage = "https://github.com/OctoPrint/OctoPrint-FirmwareUpdater";
+      license = licenses.agpl3;
+    };
+  };
+
   gcodeeditor = buildPlugin rec {
     pname = "gcodeeditor";
     version = "0.2.12";


### PR DESCRIPTION
## Description of changes

- octoprint.python.pkgs.firmwareupdater: init at 1.14.0
- octoprint.python.pkgs.fullscreen: init at 0.0.6
- octoprint.python.pkgs.mqttchambertemperature: init at 0.0.2
- octoprint.python.pkgs.navbartemp: init at 0.15
- octoprint.python.pkgs.obico: init at 2.4.10
- octoprint.python.pkgs.octopod: init at 0.3.16
- octoprint.python.pkgs.resource-monitor: init at 0.3.15
- octoprint.python.pkgs.timelapsepurger: init at 0.1.4
- octoprint.python.pkgs.prusaslicerthumbnails: init at 1.0.6

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
