### PR TITLE
linux/generic: take a `kernelTarget` argument

### DIFF
--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -1,3 +1,12 @@
+let
+  # Map of images representations to legacy Makefile targets.
+  defaultMapImageToTargets = {
+    "uImage" = "uinstall";
+    "zImage" = "zinstall";
+    "Image.gz" = "zinstall";
+    "vmlinux" = "install";
+  };
+in
 { buildPackages
 , callPackage
 , perl
@@ -64,6 +73,11 @@
 # easy overrides to stdenv.hostPlatform.linux-kernel members
 , autoModules ? stdenv.hostPlatform.linux-kernel.autoModules
 , preferBuiltin ? stdenv.hostPlatform.linux-kernel.preferBuiltin or false
+, kernelTarget ? null
+# FIXME: this should go whenever we can rely on KBUILD_IMAGE to install
+# our kernel targets, MIPS is probably the only recent kernel in-tree
+# which does not support that yet.
+, installTargets ? [ ]
 , kernelArch ? stdenv.hostPlatform.linuxArch
 , kernelTests ? []
 , nixosTests

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -31,6 +31,16 @@ in lib.makeOverridable ({
   src,
   # a list of { name=..., patch=..., extraConfig=...} patches
   kernelPatches ? [],
+  # KBUILD_IMAGE
+  kernelTarget ? null,
+  # a list of install targets, e.g. :
+  # - uinstall for uImage, U-Boot wrapped image
+  # - zinstall for zImage, self-extracting images
+  # - install, the generic binary image
+  # those targets are legacy and are present
+  # only for compatibility with old kernels or MIPS for now.
+  # prefer KBUILD_IMAGE instead.
+  installTargets ? [],
   # The kernel .config file
   configfile,
   # Manually specified nixexpr representing the config
@@ -267,12 +277,7 @@ let
       '';
 
       # Some image types need special install targets (e.g. uImage is installed with make uinstall)
-      installTargets = [
-        (kernelConf.installTarget or (
-          /**/ if kernelConf.target == "uImage" then "uinstall"
-          else if kernelConf.target == "zImage" || kernelConf.target == "Image.gz" then "zinstall"
-          else "install"))
-      ];
+      installTargets = if installTargets == [ ] then [ "install" ] else installTargets;
 
       postInstall = optionalString isModular ''
         mkdir -p $dev


### PR DESCRIPTION
## Description of changes

Deprecates the legacy targets too.

Nowadays, most architectures supports `KBUILD_IMAGE` which is
set by the architecture-specific Makefile or can be overriden by the user
Before that, we were using Makefile "install targets" such as "uinstall" for uImage,
"zinstall" for zImage, etc.

We move them into a "legacy" list which is used by default if `kernelTarget` is null.

This is a retake of #244706 containing the old amjoseph comments.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
