### PR TITLE
gimx: fix build against `gcc-13`

### DIFF
--- a/pkgs/games/gimx/default.nix
+++ b/pkgs/games/gimx/default.nix
@@ -1,4 +1,5 @@
-{ stdenv, lib, fetchFromGitHub, makeWrapper, curl, libusb1, xorg, libxml2
+{ stdenv, lib, fetchFromGitHub, fetchpatch
+, makeWrapper, curl, libusb1, xorg, libxml2
 , ncurses5, bluez, libmhash, gimxPdpGamepad ? false }:
 
 let
@@ -21,7 +22,23 @@ in stdenv.mkDerivation rec {
     sha256 = "05kdv2qqr311c2p76hdlgvrq7b04vcpps5c80zn8b8l7p831ilgz";
   };
 
-  patches = [ ./conf.patch ];
+  patches = [
+    ./conf.patch
+
+    # gcc-13 build fixes:
+    #   https://github.com/matlo/GIMX/pull/705
+    (fetchpatch {
+      name = "gcc-13-headers.patch";
+      url = "https://github.com/matlo/GIMX/commit/4525dff4d9af672116d8c6c182707f2ad6295b2d.patch";
+      hash = "sha256-LkswnFsxqADooa09yO7Yf0AbxTrGfjBObyv/6FQJvRs=";
+    })
+    (fetchpatch {
+      name = "gcc-13-protos.patch";
+      url = "https://github.com/matlo/GIMX/commit/f11855fcb8bd9d0cb9c94871b4111ddfd5b610df.patch";
+      hash = "sha256-JL67UUsEyPcOuaimJtMviiGLGghuq9665Lg1QuiaWUU=";
+    })
+  ];
+
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [
     curl libusb1 bluez libxml2 ncurses5 libmhash


### PR DESCRIPTION
Without the change the build in `master` fails as
https://hydra.nixos.org/build/247555199:

    gimx.c:195:6: error: implicit declaration of function 'getenv' [-Werror=implicit-function-declaration]
      195 |   if(getenv("GIMXCONF")) { snprintf(file_path, sizeof(file_path), "%s", gimx_params.config_file); }
          |      ^~~~~~

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
