### PR TITLE
zulu11: 11.0.20 -> 11.0.22

### DIFF
--- a/pkgs/development/compilers/zulu/11.nix
+++ b/pkgs/development/compilers/zulu/11.nix
@@ -8,35 +8,35 @@ callPackage ./common.nix ({
   # Note that the latest build may differ by platform
   dists = {
     x86_64-linux = {
-      zuluVersion = "11.66.15";
-      jdkVersion = "11.0.20";
+      zuluVersion = "11.70.15";
+      jdkVersion = "11.0.22";
       hash =
-        if enableJavaFX then "sha256-CjWtqnirEDrpF61WXm/Yi372IzhpTpi+/AfEqirlZnc="
-        else "sha256-o0tAT4egimEUizjhQW2DcYnh33oEDZSedDYz2vRpWjw=";
+        if enableJavaFX then "sha256-FxTHgng7/oDY3n3qy8j1ztbpBQeoGcEBJbEXqaE4Zr4="
+        else "sha256-V41ZRrJtkle3joKhwoID5bvWkN5I4gFjmbEnTD7no8U=";
     };
 
     aarch64-linux = {
-      zuluVersion = "11.66.15";
-      jdkVersion = "11.0.20";
+      zuluVersion = "11.70.15";
+      jdkVersion = "11.0.22";
       hash =
         if enableJavaFX then throw "JavaFX is not available for aarch64-linux"
-        else "sha256-VBdEOfKz/d0R8QSMOX/nu0XUydZtRS1oibAT0E0hxN4=";
+        else "sha256-u6XWMXAArUhMMb6j3KFOhkIxpVYR1oYLF0Wde7/tI0k=";
     };
 
     x86_64-darwin = {
-      zuluVersion = "11.66.15";
-      jdkVersion = "11.0.20";
+      zuluVersion = "11.70.15";
+      jdkVersion = "11.0.22";
       hash =
-        if enableJavaFX then "sha256-pVgCJkgYTlFeL7nkkMWLeJ/J8ELhgvWb7gzf3erZP7Y="
-        else "sha256-vKqxHP5Yb651g8bZ0xHGQ4Q1T7JjjrmgEuykw/Gh2f0=";
+        if enableJavaFX then "sha256-JkJZwk+D28wHWqwUoLo7WW5ypwTrT5biSoP+70YI3eQ="
+        else "sha256-ca/ttkPe2tbcm1ruguDgPsxKWbEdKcICsKCDXaup9N4=";
     };
 
     aarch64-darwin = {
-      zuluVersion = "11.66.15";
-      jdkVersion = "11.0.20";
+      zuluVersion = "11.70.15";
+      jdkVersion = "11.0.22";
       hash =
-        if enableJavaFX then "sha256-VoZo34SCUU+HHnTl6iLe0QBC+4VDkPP14N98oqSg9EQ="
-        else "sha256-djK8Kfikt9SSuT87x1p7YWMIlNuF0TZFYDWrKiTTiIU=";
+        if enableJavaFX then "sha256-bAgH4lCxPvvFOeif5gI2aoLt1aC4EXPzb2YmiS9bQsU="
+        else "sha256-PWQOF+P9djZarjAJaE3I0tuI1E4H/9584VN04BMzmvM=";
     };
   };
 } // builtins.removeAttrs args [ "callPackage" ])


### PR DESCRIPTION
## Description of changes

https://www.azul.com/downloads/?version=java-11-lts&package=jdk

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
