### PR TITLE
python311Packages.courlan: 0.9.5 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/courlan/default.nix
+++ b/pkgs/development/python-modules/courlan/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "courlan";
-  version = "0.9.5";
+  version = "1.0.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-ONw1suO/H11RbQDVGsEuveVD40F8a+b2oic8D8W1s1M=";
+    hash = "sha256-PDVRHDZSXLL5Qc1nCbejp0LtlfC55WyX7sDBb9wDUYM=";
   };
 
   propagatedBuildInputs = [
@@ -35,11 +35,12 @@ buildPythonPackage rec {
     "test_urlcheck"
   ];
 
-  # nixify path to the courlan binary in the test suite
+  # tests try to write to /tmp directly. use $TMPDIR instead.
   postPatch = ''
     substituteInPlace tests/unit_tests.py \
       --replace "\"courlan --help\"" "\"$out/bin/courlan --help\"" \
-      --replace "courlan_bin = \"courlan\"" "courlan_bin = \"$out/bin/courlan\""
+      --replace "courlan_bin = \"courlan\"" "courlan_bin = \"$out/bin/courlan\"" \
+      --replace "/tmp" "$TMPDIR"
   '';
 
   pythonImportsCheck = [ "courlan" ];
@@ -48,7 +49,7 @@ buildPythonPackage rec {
     description = "Clean, filter and sample URLs to optimize data collection";
     homepage = "https://github.com/adbar/courlan";
     changelog = "https://github.com/adbar/courlan/blob/v${version}/HISTORY.md";
-    license = licenses.gpl3Plus;
+    license = licenses.asl20;
     maintainers = with maintainers; [ jokatzke ];
   };
 }


### PR DESCRIPTION
Diff: https://github.com/adbar/courlan/compare/refs/tags/v0.9.5...v1.0.0

Changelog: https://github.com/adbar/courlan/blob/v1.0.0/HISTORY.md

Closes: #287159

## Description of changes

Bump the version of `courlan`. Because its license changed with this update, update it accordingly.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
