### PR TITLE
gmni: disable `fortify3` to fix `gcc-13` build

### DIFF
--- a/pkgs/applications/networking/browsers/gmni/default.nix
+++ b/pkgs/applications/networking/browsers/gmni/default.nix
@@ -14,6 +14,14 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ scdoc ];
   buildInputs = [ bearssl ];
 
+  # Fix build on `gcc-13`:
+  #       inlined from 'xt_end_chain' at src/tofu.c:82:3,
+  #   ...-glibc-2.38-27-dev/include/bits/stdio2.h:54:10: error: '__builtin___snprintf_chk' specified bound 4 exceeds destination size 3 [-Werror=stringop-overflow]
+  #
+  # The overflow will not happen in practice, but `snprintf()` gets
+  # passed one more byte than available.
+  hardeningDisable = [ "fortify3" ];
+
   meta = with lib; {
     description = "A Gemini client";
     homepage = "https://git.sr.ht/~sircmpwn/gmni";


### PR DESCRIPTION
It's not masking a real overflow, but inhibits invalid `snprintf()` buffer size bassed. Without the change build fails on `master` as:

    In function 'snprintf',
        inlined from 'xt_end_chain' at src/tofu.c:82:3,
        inlined from 'xt_end_chain' at src/tofu.c:70:1:
    ...-glibc-2.38-27-dev/include/bits/stdio2.h:54:10: error: '__builtin___snprintf_chk' specified bound 4 exceeds destination size 3 [-Werror=stringop-overflow]
       54 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       55 |                                    __glibc_objsize (__s), __fmt,
          |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       56 |                                    __va_arg_pack ());
          |                                    ~~~~~~~~~~~~~~~~~

As the project is not maintained anymore let's just disable the `fortify3` that puts an extra check into `snprintf()` buffer.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
