### PR TITLE
google-amber: unstable-2022-04-21 -> 0-unstable-2023-09-02

### DIFF
--- a/pkgs/tools/graphics/amber/default.nix
+++ b/pkgs/tools/graphics/amber/default.nix
@@ -6,6 +6,7 @@
 , python3
 , vulkan-headers
 , vulkan-loader
+, unstableGitUpdater
 }:
 let
   glslang = fetchFromGitHub {
@@ -46,13 +47,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "amber";
-  version = "unstable-2022-04-21";
+  version = "0-unstable-2023-09-02";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = pname;
-    rev = "8b145a6c89dcdb4ec28173339dd176fb7b6f43ed";
-    hash = "sha256-+xFYlUs13khT6r475eJJ+XS875h2sb+YbJ8ZN4MOSAA=";
+    rev = "8e90b2d2f532bcd4a80069e3f37a9698209a21bc";
+    hash = "sha256-LuNCND/NXoNbbTWv7RYQUkq2QXL1qXR27uHwFIz0DXg=";
   };
 
   buildInputs = [
@@ -88,6 +89,8 @@ stdenv.mkDerivation rec {
   installPhase = ''
     install -Dm755 -t $out/bin amber image_diff
   '';
+
+  passthru.updateScript = unstableGitUpdater {};
 
   meta = with lib; {
     description = "Multi-API shader test framework";


### PR DESCRIPTION
Among other things fixes build failure against `gcc-13` as https://hydra.nixos.org/build/247597876:

    [ 88%] Building CXX object src/CMakeFiles/libamber.dir/executor.cc.o
    In file included from /build/source/src/descriptor_set_and_binding_parser.cc:15:
    /build/source/src/descriptor_set_and_binding_parser.h:43:3: error: 'uint32_t' does not name a type
       43 |   uint32_t GetDescriptorSet() const { return descriptor_set_; }
          |   ^~~~~~~~

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
