### PR TITLE
zulu8: 8.0.382 -> 8.0.402

### DIFF
--- a/pkgs/development/compilers/zulu/8.nix
+++ b/pkgs/development/compilers/zulu/8.nix
@@ -8,27 +8,35 @@ callPackage ./common.nix ({
   # Note that the latest build may differ by platform
   dists = {
     x86_64-linux = {
-      zuluVersion = "8.72.0.17";
-      jdkVersion = "8.0.382";
+      zuluVersion = "8.76.0.17";
+      jdkVersion = "8.0.402";
       hash =
-        if enableJavaFX then "sha256-mIPCFESU7hy2naYur2jvFBtVn/LZQRcFiyiG61buCYs="
-        else "sha256-exWlbyrgBb7aD4daJps9qtFP+hKWkwbMdFR4OFslupY=";
+        if enableJavaFX then "sha256-29aDAu8WVYQFSpMUFq4gG64BBz/ei/VDMg72xrpB9w4="
+        else "sha256-34DI6O7T8iqDHsX63S3xk+BKDu8IHRRWNvtxpsnUJEk=";
+    };
+
+    aarch64-linux = {
+      zuluVersion = "8.74.0.17";
+      jdkVersion = "8.0.392";
+      hash =
+        if enableJavaFX then throw "JavaFX is not available for aarch64-linux"
+        else "sha256-xESdKEmfkiE657X/xclwsJR5M+P72BpWErtAcYMcK0Y=";
     };
 
     x86_64-darwin = {
-      zuluVersion = "8.72.0.17";
-      jdkVersion = "8.0.382";
+      zuluVersion = "8.76.0.17";
+      jdkVersion = "8.0.402";
       hash =
-        if enableJavaFX then "sha256-/x8FqygivzddXsOwIV8aj/u+LPXMmokgu97vLAVEv80="
-        else "sha256-3dTPIPGUeT6nb3gncNvEa4VTRyQIBJpp8oZadrT2ToE=";
+        if enableJavaFX then "sha256-oqFpKeWwfiXr3oX78LGvAyDGAAS2GON2gAm6fHGH7Ow="
+        else "sha256-edZqDEsydQCDEwC1ZCDF/MjWVTnuQNWcKR2k/RjaIEI=";
     };
 
     aarch64-darwin = {
-      zuluVersion = "8.72.0.17";
-      jdkVersion = "8.0.382";
+      zuluVersion = "8.76.0.17";
+      jdkVersion = "8.0.402";
       hash =
-        if enableJavaFX then "sha256-FkQ+0MzSZWUzc/HmiDVZEHGOrdKAVCdK5pm9wXXzzaU="
-        else "sha256-rN5AI4xAWppE4kJlzMod0JmGyHdHjTXYtx8/wOW6CFk=";
+        if enableJavaFX then "sha256-UCWRXCz4v381IWzWPDYzwJwbhsmZOYxKPLGJBQGjPmc="
+        else "sha256-0VPlOuNB39gDnU+pK0DGTSUjTHTtYoxaRg3YD2LyLXg=";
     };
   };
 } // builtins.removeAttrs args [ "callPackage" ])


### PR DESCRIPTION
## Description of changes

https://www.azul.com/downloads/?version=java-8-lts&package=jdk

Also added aarch64-linux support, but with an older version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
