### PR TITLE
nixos/appliance-repart-image: enhance reproducibility of VFAT ESP

### DIFF
--- a/nixos/doc/manual/installation/building-images-via-systemd-repart.chapter.md
+++ b/nixos/doc/manual/installation/building-images-via-systemd-repart.chapter.md
@@ -98,12 +98,17 @@ in
       name = "image";
       partitions = {
         "esp" = {
-          contents = {
-            "/EFI/BOOT/BOOT${lib.toUpper efiArch}.EFI".source =
-              "${pkgs.systemd}/lib/systemd/boot/efi/systemd-boot${efiArch}.efi";
+          contents = let
+            espContents = pkgs.runCommand "esp-contents" { } ''
+              mkdir -p $out/EFI/BOOT
+              mkdir -p $out/EFI/Linux
 
-            "/EFI/Linux/${config.system.boot.loader.ukiFile}".source =
-              "${config.system.build.uki}/${config.system.boot.loader.ukiFile}";
+              cp ${pkgs.systemd}/lib/systemd/boot/efi/systemd-boot${efiArch}.efi $out/EFI/BOOT/BOOT${lib.toUpper efiArch}.EFI
+              cp ${config.system.build.uki}/${config.system.boot.loader.ukiFile} $out/EFI/Linux/${config.system.boot.loader.ukiFile}
+            '';
+          in
+          {
+            "/".source = espContents;
           };
           repartConfig = {
             Type = "esp";

--- a/nixos/tests/appliance-repart-image.nix
+++ b/nixos/tests/appliance-repart-image.nix
@@ -47,13 +47,19 @@ in
           contents =
             let
               efiArch = config.nixpkgs.hostPlatform.efiArch;
+              # We build the ESP contents in a separate derivation to have fixed creation timestamps,
+              # as they are mcopied by systemd-repart, which creates the parent directories with undeterministic
+              # timestamps if they don't exist.
+              espContents = pkgs.runCommand "esp-contents" { } ''
+                mkdir -p $out/EFI/BOOT
+                mkdir -p $out/EFI/Linux
+
+                cp ${pkgs.systemd}/lib/systemd/boot/efi/systemd-boot${efiArch}.efi $out/EFI/BOOT/BOOT${lib.toUpper efiArch}.EFI
+                cp ${config.system.build.uki}/${config.system.boot.loader.ukiFile} $out/EFI/Linux/${config.system.boot.loader.ukiFile}
+              '';
             in
             {
-              "/EFI/BOOT/BOOT${lib.toUpper efiArch}.EFI".source =
-                "${pkgs.systemd}/lib/systemd/boot/efi/systemd-boot${efiArch}.efi";
-
-              "/EFI/Linux/${config.system.boot.loader.ukiFile}".source =
-                "${config.system.build.uki}/${config.system.boot.loader.ukiFile}";
+              "/".source = espContents;
             };
           repartConfig = {
             Type = "esp";


### PR DESCRIPTION
## Description of changes
`systemd-repart` uses [`mcopy`](https://github.com/systemd/systemd/blob/e2382ef0053a8bf09d4cd43e30fc90e6d377986e/src/shared/mkfs-util.c#L104) to create VFAT filesystems, which preserves mtimes from the files that are copied into the image. It also creates parent directories in the local tree ad-hoc if they don't exist, causing undeterministic mtimes on these directories. This causes irreproducible VFAT partitions, but can be fixed by creating the files in a separate derivation, allowing Nix to normalise their timestamps. This PR applies this fix for both the NixOS test as well as the corresponding documentation bits.

Related to #286969 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
