### PR TITLE
dae: 0.4.0 -> 0.6.0rc2

### DIFF
--- a/pkgs/tools/networking/dae/default.nix
+++ b/pkgs/tools/networking/dae/default.nix
@@ -5,17 +5,17 @@
 }:
 buildGoModule rec {
   pname = "dae";
-  version = "0.4.0";
+  version = "0.6.0rc2";
 
   src = fetchFromGitHub {
     owner = "daeuniverse";
     repo = "dae";
     rev = "v${version}";
-    hash = "sha256-hvAuWCacaWxXwxx5ktj57hnWt8fcnwD6rUuRj1+ZtFA=";
+    hash = "sha256-u+1DkcdXXm/wmKG7yu8nv3OOeG/l5KC+9UcIrYOmsUA=";
     fetchSubmodules = true;
   };
 
-  vendorHash = "sha256-4U6zIxK8K+MGxRboTtsKntDMp8/cQWPqXQ3l03AEtBs=";
+  vendorHash = "sha256-jJbXa3xnQXhEhrhmdi+JqdinLuRrFY5Tb9lsnCancFE=";
 
   proxyVendor = true;
 


### PR DESCRIPTION
## Description of changes
As `0.4.0` is not compilable after kernel > 6.9, I have updated `dae` to `0.6.0rc2` and updated this pr. All descriptions down below is coming from the original `0.5.1` pr. 

Due to the external dns issue: https://github.com/daeuniverse/dae/issues/412, I had temporarily reverted `dae` to `0.4.0` in https://github.com/NixOS/nixpkgs/pull/281740. Now this issue seems to be resolved on [0.5.1](https://github.com/daeuniverse/dae/releases/tag/v0.5.1), tested using `smartdns` as local resolver with following configs (sensitive info were redacted for privacy):

config.dae:
```
global {
  wan_interface: auto

  log_level: info
  allow_insecure: false
  auto_config_kernel_parameter: true
  auto_config_firewall_rule: true

  dial_mode: ip
}

dns {
  upstream {
    global-dns: 'udp://127.0.0.1:53100'
    china-dns: 'udp://127.0.0.1:53101'
  }
  routing {
    request {
      qname(geosite:cn) -> china-dns
      fallback: global-dns
    }
  }
}

node {
  local: [REDACTED]
}

group {
  local {
    policy: min_moving_avg
  }
}

routing {
  pname(smartdns) && dip(geoip:cn) -> direct
  pname(smartdns) -> local
  dip(geoip:private) -> direct
  
  fallback: local
}
```

smartdns:
```
    services.smartdns = {
      enable = true;
      settings = {
        bind = [ ":53100 -group global-dns" ":53101 -group china-dns" ];
        server = "8.8.8.8 -bootstrap-dns";
        user = "nobody";
        force-AAAA-SOA = "yes";
        server-https = [
          "https://8.8.8.8/dns-query -group global-dns -exclude-default-group"
          "https://223.5.5.5/dns-query -group china-dns -exclude-default-group"
        ];
      };
    };
```

Feel free to leave comments here if external dns works for you :)

By the way, I basically just changed ```hash``` and ```vendorHash``` to adapt ```0.5.1```, based on the original `0.5.0` commit from @zzzsyyy: https://github.com/NixOS/nixpkgs/pull/278695. It would not be possible for me to draft this pr so fast without that commit, so big thanks for your kind contribution!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
