### PR TITLE
elegant-sddm: init at unstable-2024-02-08

### DIFF
--- a/pkgs/data/themes/elegant-sddm/default.nix
+++ b/pkgs/data/themes/elegant-sddm/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, formats
+, stdenvNoCC
+, fetchFromGitHub
+, qtgraphicaleffects
+  /* An example of how you can override the background with a NixOS wallpaper
+  *
+  *  environment.systemPackages = [
+  *    (pkgs.elegant-sddm.override {
+  *      themeConfig.General = {
+           background = "${pkgs.nixos-artwork.wallpapers.simple-dark-gray-bottom.gnomeFilePath}";
+  *      };
+  *    })
+  *  ];
+  */
+, themeConfig ? null
+}:
+
+let
+  user-cfg = (formats.ini { }).generate "theme.conf.user" themeConfig;
+in
+
+stdenvNoCC.mkDerivation {
+  pname = "elegant-sddm";
+  version = "unstable-2024-02-08";
+
+  src = fetchFromGitHub {
+    owner = "surajmandalcell";
+    repo = "Elegant-sddm";
+    rev = "3102e880f46a1b72c929d13cd0a3fb64f973952a";
+    hash = "sha256-yn0fTYsdZZSOcaYlPCn8BUIWeFIKcTI1oioTWqjYunQ=";
+  };
+
+  propagatedBuildInputs = [
+    qtgraphicaleffects
+  ];
+
+  dontWrapQtApps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/share/sddm/themes"
+    cp -r Elegant/ "$out/share/sddm/themes/Elegant"
+  '' + (lib.optionalString (lib.isAttrs themeConfig) ''
+    ln -sf ${user-cfg} $out/share/sddm/themes/Elegant/theme.conf.user
+  '') + ''
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    mkdir -p $out/nix-support
+
+    echo ${qtgraphicaleffects} >> $out/nix-support/propagated-user-env-packages
+  '';
+
+  meta = with lib; {
+    description = "Sleek and stylish SDDM theme crafted in QML";
+    homepage = "https://github.com/surajmandalcell/Elegant-sddm";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27660,6 +27660,8 @@ with pkgs;
 
   ebtables = callPackage ../os-specific/linux/ebtables { };
 
+  elegant-sddm = libsForQt5.callPackage ../data/themes/elegant-sddm { };
+
   error-inject = callPackages ../os-specific/linux/error-inject { };
 
   extrace = callPackage ../os-specific/linux/extrace { };


### PR DESCRIPTION
## Description of changes

Add support for the [Elegant SDDM](https://github.com/surajmandalcell/Elegant-sddm) theme.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
