### PR TITLE
Revert "nixos/stub-ld: init module"

### DIFF
--- a/nixos/modules/config/ldso.nix
+++ b/nixos/modules/config/ldso.nix
@@ -5,11 +5,11 @@ let
 
   libDir = pkgs.stdenv.hostPlatform.libDir;
   ldsoBasename = builtins.unsafeDiscardStringContext (last (splitString "/" pkgs.stdenv.cc.bintools.dynamicLinker));
-
-  pkgs32 = pkgs.pkgsi686Linux;
-  libDir32 = pkgs32.stdenv.hostPlatform.libDir;
-  ldsoBasename32 = builtins.unsafeDiscardStringContext (last (splitString "/" pkgs32.stdenv.cc.bintools.dynamicLinker));
 in {
+  imports = [
+    (lib.mkRemovedOptionModule ["environment" "ldso32"] "removed as it didn't work on all architectures")
+  ];
+
   options = {
     environment.ldso = mkOption {
       type = types.nullOr types.path;
@@ -18,38 +18,15 @@ in {
         The executable to link into the normal FHS location of the ELF loader.
       '';
     };
-
-    environment.ldso32 = mkOption {
-      type = types.nullOr types.path;
-      default = null;
-      description = mdDoc ''
-        The executable to link into the normal FHS location of the 32-bit ELF loader.
-
-        This currently only works on x86_64 architectures.
-      '';
-    };
   };
 
   config = {
-    assertions = [
-      { assertion = isNull config.environment.ldso32 || pkgs.stdenv.isx86_64;
-        message = "Option environment.ldso32 currently only works on x86_64.";
-      }
-    ];
-
     systemd.tmpfiles.rules = (
       if isNull config.environment.ldso then [
         "r /${libDir}/${ldsoBasename} - - - - -"
       ] else [
         "d /${libDir} 0755 root root - -"
         "L+ /${libDir}/${ldsoBasename} - - - - ${config.environment.ldso}"
-      ]
-    ) ++ optionals pkgs.stdenv.isx86_64 (
-      if isNull config.environment.ldso32 then [
-        "r /${libDir32}/${ldsoBasename32} - - - - -"
-      ] else [
-        "d /${libDir32} 0755 root root - -"
-        "L+ /${libDir32}/${ldsoBasename32} - - - - ${config.environment.ldso32}"
       ]
     );
   };

--- a/nixos/modules/config/stub-ld.nix
+++ b/nixos/modules/config/stub-ld.nix
@@ -27,10 +27,7 @@ let
     $CC -Os main.c -o $out
   '';
 
-  pkgs32 = pkgs.pkgsi686Linux;
-
   stub-ld = stub-ld-for pkgs message;
-  stub-ld32 = stub-ld-for pkgs32 message;
 in {
   options = {
     environment.stub-ld = {
@@ -49,7 +46,6 @@ in {
 
   config = mkIf cfg.enable {
     environment.ldso = mkDefault stub-ld;
-    environment.ldso32 = mkIf pkgs.stdenv.isx86_64 (mkDefault stub-ld32);
   };
 
   meta.maintainers = with lib.maintainers; [ tejing ];

--- a/nixos/tests/stub-ld.nix
+++ b/nixos/tests/stub-ld.nix
@@ -18,12 +18,6 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
     libDir = pkgs.stdenv.hostPlatform.libDir;
     ldsoBasename = lib.last (lib.splitString "/" pkgs.stdenv.cc.bintools.dynamicLinker);
 
-    check32 = pkgs.stdenv.isx86_64;
-    pkgs32 = pkgs.pkgsi686Linux;
-
-    libDir32 = pkgs32.stdenv.hostPlatform.libDir;
-    ldsoBasename32 = lib.last (lib.splitString "/" pkgs32.stdenv.cc.bintools.dynamicLinker);
-
     test-exec = builtins.mapAttrs (n: v: pkgs.runCommand "test-exec-${n}" { src = pkgs.fetchurl v; } "mkdir -p $out;cd $out;tar -xzf $src") {
       x86_64-linux.url = "https://github.com/rustic-rs/rustic/releases/download/v0.6.1/rustic-v0.6.1-x86_64-unknown-linux-gnu.tar.gz";
       x86_64-linux.hash = "sha256-3zySzx8MKFprMOi++yr2ZGASE0aRfXHQuG3SN+kWUCI=";
@@ -33,8 +27,6 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
       aarch64-linux.hash = "sha256-hnldbd2cctQIAhIKoEZLIWY8H3jiFBClkNy2UlyyvAs=";
     };
     exec-name = "rustic";
-
-    if32 = pythonStatement: if check32 then pythonStatement else "pass";
   in
     ''
       machine.start()
@@ -42,32 +34,25 @@ import ./make-test-python.nix ({ lib, pkgs, ... }: {
 
       with subtest("Check for stub (enabled, initial)"):
           machine.succeed('test -L /${libDir}/${ldsoBasename}')
-          ${if32 "machine.succeed('test -L /${libDir32}/${ldsoBasename32}')"}
 
       with subtest("Try FHS executable"):
           machine.copy_from_host('${test-exec.${pkgs.system}}','test-exec')
           machine.succeed('if test-exec/${exec-name} 2>outfile; then false; else [ $? -eq 127 ];fi')
           machine.succeed('grep -qi nixos outfile')
-          ${if32 "machine.copy_from_host('${test-exec.${pkgs32.system}}','test-exec32')"}
-          ${if32 "machine.succeed('if test-exec32/${exec-name} 2>outfile32; then false; else [ $? -eq 127 ];fi')"}
-          ${if32 "machine.succeed('grep -qi nixos outfile32')"}
 
       with subtest("Disable stub"):
           machine.succeed("/run/booted-system/specialisation/nostub/bin/switch-to-configuration test")
 
       with subtest("Check for stub (disabled)"):
           machine.fail('test -e /${libDir}/${ldsoBasename}')
-          ${if32 "machine.fail('test -e /${libDir32}/${ldsoBasename32}')"}
 
       with subtest("Create file in stub location (to be overwritten)"):
           machine.succeed('mkdir -p /${libDir};touch /${libDir}/${ldsoBasename}')
-          ${if32 "machine.succeed('mkdir -p /${libDir32};touch /${libDir32}/${ldsoBasename32}')"}
 
       with subtest("Re-enable stub"):
           machine.succeed("/run/booted-system/bin/switch-to-configuration test")
 
       with subtest("Check for stub (enabled, final)"):
           machine.succeed('test -L /${libDir}/${ldsoBasename}')
-          ${if32 "machine.succeed('test -L /${libDir32}/${ldsoBasename32}')"}
     '';
 })


### PR DESCRIPTION
This reverts commit 0863f6d2da0be5e8d7e3fb316ef58cdfe145220b introduced in #269551.

Fixes:

    error: i686 Linux package set can only be used with the x86 family.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
