### PR TITLE
vaults: init at 0.7.1

### DIFF
--- a/pkgs/by-name/va/vaults/package.nix
+++ b/pkgs/by-name/va/vaults/package.nix
@@ -1,0 +1,85 @@
+{ fetchFromGitHub
+, lib
+, stdenv
+, appstream-glib
+, desktop-file-utils
+, meson
+, ninja
+, pkg-config
+, python3
+, rustPlatform
+, rustc
+, cargo
+, wrapGAppsHook
+, glib
+, gtk4
+, libadwaita
+, wayland
+, gocryptfs
+, cryfs
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "vaults";
+  version = "0.7.1";
+
+  src = fetchFromGitHub {
+    owner = "mpobaschnig";
+    repo = "Vaults";
+    rev = version;
+    hash = "sha256-jA7OeyRqc5DxkS4sMx9cIbVlZwd++aCQi09uBQik1oA=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-l9Zer6d6kgjIUNiQ1VdQQ57caVNWfzCkdsMf79X8Ar4=";
+  };
+
+  postPatch = ''
+    patchShebangs build-aux
+  '';
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : "${lib.makeBinPath [ gocryptfs cryfs ]}"
+    )
+  '';
+
+  nativeBuildInputs = [
+    desktop-file-utils
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook
+    cargo
+    rustc
+    rustPlatform.cargoSetupHook
+  ];
+
+  buildInputs = [
+    appstream-glib
+    gtk4
+    python3
+    glib
+    libadwaita
+    wayland
+    gocryptfs
+    cryfs
+  ];
+
+  meta = {
+    description = "GTK frontend for encrypted vaults supporting gocryptfs and CryFS for encryption";
+    homepage = "https://mpobaschnig.github.io/vaults/";
+    changelog = "https://github.com/mpobaschnig/vaults/releases/tag/${version}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ benneti ];
+    mainProgram = "vaults";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

A package that fits in with the gnome design to create and mount encrypted "stores" using encfs or gocryptfs.
Substitutes https://github.com/NixOS/nixpkgs/pull/277746 for the current version.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
