### PR TITLE
geeqie: 2.1 -> 2.2

### DIFF
--- a/pkgs/applications/graphics/geeqie/default.nix
+++ b/pkgs/applications/graphics/geeqie/default.nix
@@ -2,36 +2,32 @@
 , gtk3, lcms2, exiv2, libchamplain, clutter-gtk, ffmpegthumbnailer, fbida
 , libarchive, djvulibre, libheif, openjpeg, libjxl, libraw, lua5_3, poppler
 , gspell, libtiff, libwebp
+, gphoto2, imagemagick, yad, exiftool, gnome, libnotify
 , wrapGAppsHook, fetchpatch, doxygen
 , nix-update-script
 }:
 
 stdenv.mkDerivation rec {
   pname = "geeqie";
-  version = "2.1";
+  version = "2.2";
 
   src = fetchFromGitHub {
     owner = "BestImageViewer";
     repo = "geeqie";
     rev = "v${version}";
-    hash = "sha256-qkM/7auZ9TMF2r8KLnitxmvlyPmIjh7q9Ugh+QKh8hw=";
+    hash = "sha256-13Ayr6r4JhqexaUvwzdc6XHT+j2l2D5YBws6gSAhU3Y=";
   };
 
   patches = [
+    # Remove changelog from menu
     (fetchpatch {
-      name = "exiv2-0.28.0-support-1.patch";
-      url = "https://github.com/BestImageViewer/geeqie/commit/c45cca777aa3477eaf297db99f337e18d9683c61.patch";
-      hash = "sha256-YiFzAj3G3Z2w7p+8zZlDBjWqUqnfSqvaxMkESfPFdzc=";
+      url = "https://salsa.debian.org/debian/geeqie/-/raw/debian/master/debian/patches/Remove-changelog-from-menu-item.patch";
+      hash = "sha256-0awKKTLg/gUZhmwluVbHCOqssog9SneFOaUtG89q0go=";
     })
+    # Fix missing execute permissions for geocode-parametres.awk plugin
     (fetchpatch {
-      name = "exiv2-0.28.0-support-2.patch";
-      url = "https://github.com/BestImageViewer/geeqie/commit/b04f7cd0546976dc4f7ea440648ac0eedd8df3ce.patch";
-      hash = "sha256-V0ZOHbAZOrhLcNN+Al1/kvxvbw0vc/R7r99CegjuBQg=";
-    })
-    (fetchpatch {
-      name = "fix-compilation-with-lua.patch";
-      url = "https://github.com/BestImageViewer/geeqie/commit/a132645ee87e612217ac955b227cad04f21a5722.patch";
-      hash = "sha256-BozarBPoIKxZS3qpjuzHHAWZGIWZAwvJyqsNC8v+TMk=";
+      url = "https://github.com/BestImageViewer/geeqie/commit/4d3ddcf5b9c0668bfdaf1dfe24219ee57c2f0237.patch";
+      hash = "sha256-Na2qiwCTbOv1yt251oaSZiLaOwJCkjWew+us4lQju0I=";
     })
   ];
 
@@ -54,8 +50,29 @@ stdenv.mkDerivation rec {
   postInstall = ''
     # Allow geeqie to find exiv2 and exiftran, necessary to
     # losslessly rotate JPEG images.
+    # Requires exiftran (fbida package) and exiv2.
     sed -i $out/lib/geeqie/geeqie-rotate \
         -e '1 a export PATH=${lib.makeBinPath [ exiv2 fbida ]}:$PATH'
+    # Zenity and yad are used in some scripts for reporting errors.
+    # Allow change quality of image.
+    # Requires imagemagick and yad.
+    sed -i $out/lib/geeqie/geeqie-resize-image \
+        -e '1 a export PATH=${lib.makeBinPath [ imagemagick yad ]}:$PATH'
+    # Allow to crop image.
+    # Requires imagemagick, exiv2 and exiftool.
+    sed -i $out/lib/geeqie/geeqie-image-crop \
+        -e '1 a export PATH=${lib.makeBinPath [ imagemagick exiv2 exiftool gnome.zenity ]}:$PATH'
+    # Requires gphoto2 and libnotify
+    sed -i $out/lib/geeqie/geeqie-tethered-photography \
+        -e '1 a export PATH=${lib.makeBinPath [ gphoto2 gnome.zenity libnotify ]}:$PATH'
+    # Import images from camera.
+    # Requires gphoto2.
+    sed -i $out/lib/geeqie/geeqie-camera-import \
+        -e '1 a export PATH=${lib.makeBinPath [ gphoto2 gnome.zenity ]}:$PATH'
+    # Export jpeg from raw file.
+    # Requires exiv2, exiftool and lcms2.
+    sed -i $out/lib/geeqie/geeqie-export-jpeg \
+        -e '1 a export PATH=${lib.makeBinPath [ gnome.zenity exiv2 exiftool lcms2 ]}:$PATH'
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
## Description of changes

In this version bump i have made several things:
1. Removed 3 old patches, that have been already merged in 2.2;
2. Added additional dependicies for geeqie plugins and have set missing bin path for some another plugins. As a result new dependicies are: gphoto2, imagemagick, yad, exiftool, gnome.zenity, libnotify;
3. Added two new patches: one from Debian (it removes changelog from menu) another for fixing missing execute  persmissions on geocode-parametres.awk plugin. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
