### PR TITLE
sweethome3d.*: use fetchzip instead of fetchurl with unzip

### DIFF
--- a/pkgs/applications/misc/sweethome3d/default.nix
+++ b/pkgs/applications/misc/sweethome3d/default.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, fetchzip
 , fetchurl
 , makeWrapper
 , makeDesktopItem
@@ -50,7 +51,7 @@ let
       find . -name '*.so' | xargs strings | { grep '/nix/store' || :; } >> ./.jar-paths
     '';
 
-    nativeBuildInputs = [ makeWrapper unzip autoPatchelfHook ];
+    nativeBuildInputs = [ makeWrapper autoPatchelfHook ];
     buildInputs = [ ant jdk p7zip gtk3 gsettings-desktop-schemas libXxf86vm ];
 
     # upstream targets Java 7 by default
@@ -103,9 +104,6 @@ let
       mainProgram = exec;
     };
   };
-
-  d2u = lib.replaceStrings ["."] ["_"];
-
 in {
 
   application = mkSweetHome3D rec {
@@ -114,9 +112,9 @@ in {
     module = "SweetHome3D";
     description = "Design and visualize your future home";
     license = lib.licenses.gpl2Plus;
-    src = fetchurl {
+    src = fetchzip {
       url = "mirror://sourceforge/sweethome3d/${module}-${version}-src.zip";
-      sha256 = "sha256-Io3HfussfSy6CLHE0JCAk0gjBAla/u+pS1Gan8BxozY=";
+      hash = "sha256-RVuwxL/YATqHoQuc25ZaYgZ+o2rMOqnzU8/LLxb5Ra4=";
     };
     desktopName = "Sweet Home 3D";
     icons = {

--- a/pkgs/applications/misc/sweethome3d/editors.nix
+++ b/pkgs/applications/misc/sweethome3d/editors.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, fetchurl
+, fetchzip
 , makeWrapper
 , makeDesktopItem
 , jdk
@@ -18,14 +18,6 @@ let
     + removeSuffix "libraryeditor" (toLower m)
     + "-editor";
 
-  applicationSrc = stdenv.mkDerivation {
-    name = "application-src";
-    src = sweethome3dApp.src;
-    nativeBuildInputs = [ unzip ];
-    buildPhase = "";
-    installPhase = "cp -r . $out";
-  };
-
   mkEditorProject =
   { pname, module, version, src, license, description, desktopName }:
 
@@ -41,21 +33,21 @@ let
       categories = [ "Graphics" "2DGraphics" "3DGraphics" ];
     };
 
-    nativeBuildInputs = [ makeWrapper unzip ];
+    nativeBuildInputs = [ makeWrapper ];
     buildInputs = [ ant jdk gtk3 gsettings-desktop-schemas ];
 
     # upstream targets Java 7 by default
     env.ANT_ARGS = "-DappletClassSource=8 -DappletClassTarget=8 -DclassSource=8 -DclassTarget=8";
 
     postPatch = ''
-      sed -i -e 's,../SweetHome3D,${applicationSrc},g' build.xml
+      sed -i -e 's,../SweetHome3D,${sweethome3dApp.src},g' build.xml
       sed -i -e 's,lib/macosx/java3d-1.6/jogl-all.jar,lib/java3d-1.6/jogl-all.jar,g' build.xml
     '';
 
     buildPhase = ''
       runHook preBuild
 
-      ant -lib ${applicationSrc}/libtest -lib ${applicationSrc}/lib -lib ${jdk}/lib
+      ant -lib ${sweethome3dApp.src}/libtest -lib ${sweethome3dApp.src}/lib -lib ${jdk}/lib
 
       runHook postBuild
     '';
@@ -93,9 +85,9 @@ in {
     pname = module;
     description = "Easily create SH3T files and edit the properties of the texture images it contain";
     license = lib.licenses.gpl2Plus;
-    src = fetchurl {
+    src = fetchzip {
       url = "mirror://sourceforge/sweethome3d/${module}-${version}-src.zip";
-      sha256 = "03vb9y645qzffxxdhgbjb0d98k3lafxckg2vh2s86j62b6357d0h";
+      hash = "sha256-v8hMEUujTgWvFnBTF8Dnd1iWgoIXBzGMUxBgmjdxx+g=";
     };
     desktopName = "Sweet Home 3D - Textures Library Editor";
   };
@@ -105,10 +97,10 @@ in {
     module = "FurnitureLibraryEditor";
     pname = module;
     description = "Quickly create SH3F files and edit the properties of the 3D models it contain";
-    license = lib.licenses.gpl2;
-    src = fetchurl {
+    license = lib.licenses.gpl2Plus;
+    src = fetchzip {
       url = "mirror://sourceforge/sweethome3d/${module}-${version}-src.zip";
-      sha256 = "sha256-r5xJlUctUdcknJfm8rbz+bdzFhqgHsHpHwxEC4mItws=";
+      hash = "sha256-pqsSxQPzsyx4PS98fgU6UFhPWhpQoepGm0uJtkvV46c=";
     };
     desktopName = "Sweet Home 3D - Furniture Library Editor";
   };


### PR DESCRIPTION
## Description of changes

This PR simplifies the fetching and unwrapping of sources by utilizing `fetchzip`, which auto-unzips the downloaded zip-file.

Other small fixes:
- Fix hashes to use `hash` instead of `sha256`
- Change license from `gpl2` to `gpl2Plus` for the last remaining unchanged license.
- Remove unused `d2u` function.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
