### PR TITLE
Fix #287288

### DIFF
--- a/pkgs/tools/security/nmap/default.nix
+++ b/pkgs/tools/security/nmap/default.nix
@@ -37,8 +37,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     pkg-config
-    gobject-introspection
-    (python3.withPackages(pypkgs: [
+    pkgs.gobject-introspection
+    pkgs.(python3.withPackages(pypkgs: [
       pypkgs.pygobject3
     ]))
     wrapGAppsHook

--- a/pkgs/tools/security/nmap/default.nix
+++ b/pkgs/tools/security/nmap/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, fetchurl, libpcap, pkg-config, openssl, lua5_4
 , pcre, libssh2
 , withLua ? true
+, pkgs ? import <nixpkgs>
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/tools/security/nmap/default.nix
+++ b/pkgs/tools/security/nmap/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, libpcap, pkg-config, openssl, lua5_4, gtk3, gobject-introspection, python3
+{ lib, stdenv, fetchurl, libpcap, pkg-config, openssl, lua5_4, gtk3, gobject-introspection, python3, wrapGAppsHook
 , pcre, libssh2
 , withLua ? true
 }:

--- a/pkgs/tools/security/nmap/default.nix
+++ b/pkgs/tools/security/nmap/default.nix
@@ -1,7 +1,6 @@
-{ lib, stdenv, fetchurl, libpcap, pkg-config, openssl, lua5_4
+{ lib, stdenv, fetchurl, libpcap, pkg-config, openssl, lua5_4, gtk3, gobject-introspection, python3
 , pcre, libssh2
 , withLua ? true
-, pkgs ? import <nixpkgs>
 }:
 
 stdenv.mkDerivation rec {
@@ -38,8 +37,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     pkg-config
-    pkgs.gobject-introspection
-    (pkgs.python3.withPackages(pypkgs: [
+    gobject-introspection
+    (python3.withPackages(pypkgs: [
       pypkgs.pygobject3
     ]))
     wrapGAppsHook

--- a/pkgs/tools/security/nmap/default.nix
+++ b/pkgs/tools/security/nmap/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
     pkgs.gobject-introspection
-    pkgs.(python3.withPackages(pypkgs: [
+    (pkgs.python3.withPackages(pypkgs: [
       pypkgs.pygobject3
     ]))
     wrapGAppsHook


### PR DESCRIPTION
Incorporate changes to the nmap package that result in zenmap working properly

## Description of changes

Getting zenmap to work properly involves the following:
1. Remove the `--without-zenmap` configure flag
2. Add `gobject-introspection`, PyGObject, and `wrapGAppsHook` to the `nativeBuildInputs` since these are all dependencies of zenmap
3. Add `gtk3` to the `buildInputs` to ensure that the `wrapGAppsHook` works properly
4. Update the install phase to add the Python packages installed along with zenmap to the Python module search path to avoid import errors

It took me a day and a half, but I got it working and am now ready to share the fix with the world.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
