### PR TITLE
Add mingw32 support libtheora

### DIFF
--- a/pkgs/development/libraries/libtheora/default.nix
+++ b/pkgs/development/libraries/libtheora/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchurl, libogg, libvorbis, pkg-config, autoreconfHook, fetchpatch }:
+{ lib, stdenv, fetchurl, libogg, libvorbis, pkg-config, autoreconfHook, fetchpatch }:
 
 stdenv.mkDerivation rec {
   pname = "libtheora";

--- a/pkgs/development/libraries/libtheora/default.nix
+++ b/pkgs/development/libraries/libtheora/default.nix
@@ -15,6 +15,8 @@ stdenv.mkDerivation rec {
       url = "https://github.com/xiph/theora/commit/28cc6dbd9b2a141df94f60993256a5fca368fa54.diff";
       sha256 = "16jqrq4h1b3krj609vbpzd5845cvkbh3mwmjrcdg35m490p19x9k";
     })
+  ] ++ lib.optionals stdenv.hostPlatform.isMinGW [
+    ./mingw-remove-export.patch
   ];
 
   configureFlags = [ "--disable-examples" ];
@@ -30,6 +32,6 @@ stdenv.mkDerivation rec {
     description = "Library for Theora, a free and open video compression format";
     license = licenses.bsd3;
     maintainers = with maintainers; [ ];
-    platforms = platforms.unix;
+    platforms = platforms.unix ++ platforms.windows;
   };
 }

--- a/pkgs/development/libraries/libtheora/mingw-remove-export.patch
+++ b/pkgs/development/libraries/libtheora/mingw-remove-export.patch
@@ -1,0 +1,18 @@
+diff --git a/win32/xmingw32/libtheoradec-all.def b/win32/xmingw32/libtheoradec-all.def
+index 566eeb3..4a2e766 100644
+--- a/win32/xmingw32/libtheoradec-all.def
++++ b/win32/xmingw32/libtheoradec-all.def
+@@ -1,4 +1,3 @@
+-EXPORTS
+ ; Old alpha API
+ 	theora_version_string @ 1
+ 	theora_version_number @ 2
+diff --git a/win32/xmingw32/libtheoraenc-all.def b/win32/xmingw32/libtheoraenc-all.def
+index 36d2dad..d1da2f4 100644
+--- a/win32/xmingw32/libtheoraenc-all.def
++++ b/win32/xmingw32/libtheoraenc-all.def
+@@ -1,4 +1,3 @@
+-EXPORTS
+ ; Old alpha API
+ 	theora_encode_init @ 1
+ 	theora_encode_YUVin @ 2


### PR DESCRIPTION
## Description of changes
Add mingw support for libthoera

Part of a larger effort to provide mingw support for qtmultimedia

Relevant for https://github.com/NixOS/nixpkgs/issues/274274

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
