### PR TITLE
nixos/pyload: add user/group options

### DIFF
--- a/nixos/modules/services/networking/pyload.nix
+++ b/nixos/modules/services/networking/pyload.nix
@@ -34,6 +34,18 @@ in
         description = "Directory to store downloads.";
       };
 
+      user = mkOption {
+        type = types.str;
+        default = "pyload";
+        description = "User under which pyLoad runs, and which owns the download directory.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "pyload";
+        description = "Group under which pyLoad runs, and which owns the download directory.";
+      };
+
       credentialsFile = mkOption {
         type = with types; nullOr path;
         default = null;
@@ -52,7 +64,7 @@ in
 
   config = lib.mkIf cfg.enable {
     systemd.tmpfiles.settings.pyload = {
-      ${cfg.downloadDirectory}.d = { };
+      ${cfg.downloadDirectory}.d = { inherit (cfg) user group; };
     };
 
     systemd.services.pyload = {
@@ -80,9 +92,8 @@ in
           cfg.downloadDirectory
         ];
 
-        User = "pyload";
-        Group = "pyload";
-        DynamicUser = true;
+        User = cfg.user;
+        Group = cfg.group;
 
         EnvironmentFile = lib.optional (cfg.credentialsFile != null) cfg.credentialsFile;
 
@@ -143,5 +154,13 @@ in
         ];
       };
     };
+
+    users.users.pyload = lib.mkIf (cfg.user == "pyload") {
+      isSystemUser = true;
+      group = cfg.group;
+      home = stateDir;
+    };
+
+    users.groups.pyload = lib.mkIf (cfg.group == "pyload") { };
   };
 }


### PR DESCRIPTION
## Description of changes

I have a use case which needs to set the group, which is _quite_ annoying to do at the moment. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
