### PR TITLE
flameshot: add withWaylandClipboard argument

### DIFF
--- a/pkgs/tools/misc/flameshot/default.nix
+++ b/pkgs/tools/misc/flameshot/default.nix
@@ -7,6 +7,7 @@
 , qtsvg
 , nix-update-script
 , fetchpatch
+, kguiaddons
 }:
 
 mkDerivation rec {
@@ -33,8 +34,12 @@ mkDerivation rec {
     updateScript = nix-update-script { };
   };
 
+  cmakeFlags = [
+    (lib.cmakeBool "USE_WAYLAND_CLIPBOARD" true)
+  ];
+
   nativeBuildInputs = [ cmake qttools qtsvg ];
-  buildInputs = [ qtbase ];
+  buildInputs = [ qtbase kguiaddons ];
 
   meta = with lib; {
     description = "Powerful yet simple to use screenshot software";


### PR DESCRIPTION
## Description of changes

Currently flameshot will not copy images to clipboard on wayland. It works in all other ways correctly. See https://github.com/flameshot-org/flameshot/issues/2848#issuecomment-1199400532

Building the package with cmake option `USE_WAYLAND_CLIPBOARD` fixes the issue.

Adding this options allows people to more easily fix this issue if their system is running wayland.

In my home-manager configuration I can now define:

```nix
services.flameshot = {
  enable = true;
  package = pkgs.flameshot.override {
    withWaylandClipboard = true;
  };
};
```

Instead of:

```nix
services.flameshot = {
  enable = true;
  package = pkgs.flameshot.overrideAttrs (oldAttrs: {
    buildInputs = oldAttrs.buildInputs ++ [ pkgs.libsForQt5.kguiaddons ];
    cmakeFlags = [
      "-DUSE_WAYLAND_CLIPBOARD=true"
    ];
  });
};
```

I've considered having a `flameshot-wayland`, but since everything else, apart from the clipboard, is working out-of-the-box on wayland I'd thought it might give a false sense of `flameshot` (non-wayland) not being compatible with wayland.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
