### PR TITLE
linuxPackages_latest.perf: add `-O1` workaround for `gcc-13`

### DIFF
--- a/pkgs/os-specific/linux/kernel/perf/default.nix
+++ b/pkgs/os-specific/linux/kernel/perf/default.nix
@@ -129,12 +129,17 @@ stdenv.mkDerivation {
   ++ lib.optional (lib.versionAtLeast kernel.version "5.8") libpfm
   ++ lib.optional (lib.versionAtLeast kernel.version "6.0") python3.pkgs.setuptools;
 
-  env.NIX_CFLAGS_COMPILE = toString [
+  env.NIX_CFLAGS_COMPILE = toString ([
     "-Wno-error=cpp"
     "-Wno-error=bool-compare"
     "-Wno-error=deprecated-declarations"
     "-Wno-error=stringop-truncation"
-  ];
+  ] ++ lib.optionals (stdenv.cc.isGNU && lib.versions.major stdenv.cc.version == "13") [
+    # Workaround gcc bug that causes enev simplest `perf top` runs to
+    # crash: https://gcc.gnu.org/PR111009.
+    # Can be removed once gcc-13 is updated past 13.2.0.
+    "-O1"
+  ]);
 
   doCheck = false; # requires "sparse"
 


### PR DESCRIPTION
Without the change `perf top` just crashes early as:

    $ perf top
    perf: Segmentation fault
    -------- backtrace --------
    /<<NIX>>/perf-linux-6.7.4/bin/perf[0x627382]
    /<<NIX>>/glibc-2.38-27/lib/libc.so.6(+0x3deb0)[0x7f423a054eb0]
    /<<NIX>>/perf-linux-6.7.4/bin/perf(__dsos__findnew_link_by_longname_id+0x34b)[0x53655b]
    /<<NIX>>/perf-linux-6.7.4/bin/perf(map__new+0x35f)[0x55884f]
    /<<NIX>>/perf-linux-6.7.4/bin/perf(machine__process_mmap2_event+0xb7)[0x557b27]
    /<<NIX>>/perf-linux-6.7.4/bin/perf(perf_tool__process_synth_event+0x7e)[0x59e86e]
    /<<NIX>>/perf-linux-6.7.4/bin/perf(perf_event__synthesize_mmap_events+0x370)[0x59f0e0]
    /<<NIX>>/perf-linux-6.7.4/bin/perf[0x59fd5c]
    /<<NIX>>/perf-linux-6.7.4/bin/perf[0x59ffcc]
    /<<NIX>>/perf-linux-6.7.4/bin/perf[0x5a0093]
    /<<NIX>>/glibc-2.38-27/lib/libc.so.6(+0x8b333)[0x7f423a0a2333]
    /<<NIX>>/glibc-2.38-27/lib/libc.so.6(+0x10defc)[0x7f423a124efc]

It's a known `gcc-12+` bug not yet fixed in `gcc-13`: https://gcc.gnu.org/PR111009

Let's demote optimizations from `-O2` down to `-O1` to disable any VRP-related effects for affected `gcc-13`.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
