### PR TITLE
javaPackages: assert stdenv.isLinux in mkOpenjdkLinuxOnly

### DIFF
--- a/pkgs/top-level/java-packages.nix
+++ b/pkgs/top-level/java-packages.nix
@@ -62,7 +62,7 @@ in {
 
     mkOpenjdkLinuxOnly = path-linux: args: let
       openjdk = callPackage path-linux  (gnomeArgs // args);
-    in openjdk // {
+    in assert stdenv.isLinux; openjdk // {
       headless = openjdk.override { headless = true; };
     };
 


### PR DESCRIPTION
## Description of changes

This PR fixes an eval error that is never detected by ofborg, since there is no use of `openjdk15` in Nixpkgs. The failure comes from the fact that `openjdk15` specifically overrides `gtkSupport` in `openjdk15-bootstrap`, but that argument only exists on Linux.

Before:

```bash
$ NIXPKGS_ALLOW_BROKEN=1 NIXPKGS_ALLOW_INSECURE=1 NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1 nix-build -A javaPackages.compiler.openjdk15 --argstr system x86_64-darwin
error:
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'openjdk-15.0.1-ga'
         whose name attribute is located at /Users/weijiawang/Projects/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:352:7

       … while evaluating attribute 'buildInputs' of derivation 'openjdk-15.0.1-ga'

         at /Users/weijiawang/Projects/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:399:7:

          398|       depsHostHost                = elemAt (elemAt dependencies 1) 0;
          399|       buildInputs                 = elemAt (elemAt dependencies 1) 1;
             |       ^
          400|       depsTargetTarget            = elemAt (elemAt dependencies 2) 0;

       error: function 'anonymous lambda' called with unexpected argument 'gtkSupport'

       at /Users/weijiawang/Projects/nixpkgs/pkgs/development/compilers/adoptopenjdk-bin/jdk-darwin-base.nix:3:1:

            2|
            3| { swingSupport ? true # not used for now
             | ^
            4| , lib, stdenv
```

After:

```bash
$ NIXPKGS_ALLOW_BROKEN=1 NIXPKGS_ALLOW_INSECURE=1 NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1 nix-build -A javaPackages.compiler.openjdk15 --argstr system x86_64-darwin
error: assertion '(stdenv).isLinux' failed

       at /Users/weijiawang/Projects/nixpkgs/pkgs/top-level/java-packages.nix:65:8:

           64|       openjdk = callPackage path-linux  (gnomeArgs // args);
           65|     in assert stdenv.isLinux; openjdk // {
             |        ^
           66|       headless = openjdk.override { headless = true; };
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
