### PR TITLE
hh-suite: fix build on GCC 13

### DIFF
--- a/pkgs/applications/science/biology/hh-suite/default.nix
+++ b/pkgs/applications/science/biology/hh-suite/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , cmake
 , xxd
 , enableMpi ? false
@@ -17,6 +18,15 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     hash = "sha256-kjNqJddioCZoh/cZL3YNplweIGopWIGzCYQOnKDqZmw=";
   };
+
+  patches = [
+    # Should be removable as soon as this upstream PR is merged: https://github.com/soedinglab/hh-suite/pull/357
+    (fetchpatch {
+      name = "fix-gcc13-build-issues.patch";
+      url = "https://github.com/soedinglab/hh-suite/commit/cec47cba5dcd580e668b1ee507c9282fbdc8e7d7.patch";
+      hash = "sha256-Msdmj9l8voPYXK0SSwUA6mEbFLBhTjjE/Kjp0VL4Kf4=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake xxd ];
   cmakeFlags = lib.optional stdenv.hostPlatform.isx86 "-DHAVE_SSE2=1"


### PR DESCRIPTION
The build of `hh-suite` stopped working with GCC 13 because GCC stopped transitively including a couple of headers like `cstdint` in various scenarios.

There already is an upstream PR proposed that fixes this issue [^1] but hasn't been merged yet. This change pulls in this correction using `fetchpatch`, fixing the build for now.

[^1]: https://github.com/soedinglab/hh-suite/pull/357

Broken Hydra build: https://hydra.nixos.org/build/247410040
Hydra log: https://hydra.nixos.org/build/247410040/nixlog/1

Relevant log excerpt:
```
[ 13%] Building CXX object src/CMakeFiles/A3M_COMPRESS.dir/a3m_compress.cpp.o
In file included from /build/source/src/a3m_compress.cpp:8:
/build/source/src/a3m_compress.h:37:37: error: 'uint16_t' has not been declared
   37 |   void writeU16(std::ostream& file, uint16_t);
      |                                     ^~~~~~~~
/build/source/src/a3m_compress.h:38:28: error: 'uint16_t' has not been declared
   38 |   void readU16(char** ptr, uint16_t &result);
      |                            ^~~~~~~~
/build/source/src/a3m_compress.h:40:37: error: 'uint32_t' has not been declared
   40 |   void writeU32(std::ostream& file, uint32_t);
      |                                     ^~~~~~~~
/build/source/src/a3m_compress.h:41:27: error: 'uint32_t' has not been declared
   41 |   void readU32(char**ptr, uint32_t &result);
      |                           ^~~~~~~~
```

## Description of changes

- Add upstream patch through `fetchpatch`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
