### PR TITLE
ite-backlight: fix build issues with GCC 13

### DIFF
--- a/pkgs/misc/ite-backlight/default.nix
+++ b/pkgs/misc/ite-backlight/default.nix
@@ -1,6 +1,7 @@
 { lib
 , pkgs
 , stdenv
+, fetchpatch
 , ninja
 , libusb1
 , meson
@@ -31,6 +32,14 @@ stdenv.mkDerivation rec {
   buildInputs = [
     boost
     libusb1
+  ];
+
+  patches = [
+    (fetchpatch {
+      name = "fix-gcc13-build-failure.patch";
+      url = "https://github.com/hexagonal-sun/ite-backlight/commit/dc8c19d4785d80cbe7a82869daee1f723d3f3fb2.patch";
+      hash = "sha256-iTRTVy7qB2z1ip135b8k3RufTBzeJaP1wdrRWN9tPsU=";
+    })
   ];
 
   meta = with lib; {


### PR DESCRIPTION
GCC 13 stopped transitively including some headers (such as `cstdint`) in various scenarios, causing
the build of `ite-backlight` to fail on nixos-unstable.

This change temporarily pulls in a commit from an open upstream PR [^1] that fixes the mentioned build issue via `fetchpatch` until said PR gets merged.

[^1]: https://github.com/hexagonal-sun/ite-backlight/pull/2

Broken Hydra build: https://hydra.nixos.org/build/247432723
Hydra log: https://hydra.nixos.org/build/247432723/nixlog/1

Relevant log excerpt:
```
[1/25] Compiling C++ object ite-mono.p/speed.cpp.o
FAILED: ite-mono.p/speed.cpp.o 
g++ -Iite-mono.p -I. -I.. -I/nix/store/82cq00gwm8zchqaj97kf03h8kc359q54-libusb-1.0.26-dev/include/libusb-1.0 -I/nix/store/x1c6mnx5n7hl85b0r141zp69sw1sd2fg-boost-1.81.0-dev/include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Wpedantic -std=c++17 -DBOOST_ALL_NO_LIB -MD -MQ ite-mono.p/speed.cpp.o -MF ite-mono.p/speed.cpp.o.d -o ite-mono.p/speed.cpp.o -c ../speed.cpp
In file included from ../speed.cpp:4:
../speed.h:24:5: error: 'uint8_t' does not name a type
   24 |     uint8_t getDeviceSpeed() const;
      |     ^~~~~~~
../speed.h:6:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
    5 | #include <iostream>
  +++ |+#include <cstdint>
    6 | 
../speed.cpp:14:43: error: 'uint8_t' was not declared in this scope
   14 | const static std::unordered_map<ITESpeed, uint8_t> speedMap = {
      |                                           ^~~~~~~
../speed.cpp:5:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
    4 | #include "speed.h"
  +++ |+#include <cstdint>
    5 | 
../speed.cpp:14:50: error: template argument 2 is invalid
   14 | const static std::unordered_map<ITESpeed, uint8_t> speedMap = {
      |                                                  ^
../speed.cpp:14:50: error: template argument 5 is invalid
../speed.cpp:14:52: error: scalar object 'speedMap' requires one element in initializer
   14 | const static std::unordered_map<ITESpeed, uint8_t> speedMap = {
      |                                                    ^~~~~~~~
../speed.cpp:32:1: error: 'uint8_t' does not name a type
   32 | uint8_t Speed::getDeviceSpeed() const
      | ^~~~~~~
../speed.cpp:32:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
```

## Description of changes

- Pull in patch from open upstream PR.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
