### PR TITLE
nixos/prometheus-fastly-exporter: fix runtime environment, refactor, make things prettier

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters/fastly.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/fastly.nix
@@ -1,41 +1,54 @@
-{ config, lib, pkgs, options }:
+{ config
+, lib
+, pkgs
+, options
+}:
 
-with lib;
+let
+  inherit (lib)
+    escapeShellArgs
+    mkOption
+    optionals
+    types
+  ;
 
-let cfg = config.services.prometheus.exporters.fastly;
+  cfg = config.services.prometheus.exporters.fastly;
 in
 {
   port = 9118;
-  extraOpts = {
-    debug = mkEnableOption (lib.mdDoc "Debug logging mode for fastly-exporter");
-
+  extraOpts = with types; {
     configFile = mkOption {
-      type = types.nullOr types.path;
+      type = nullOr path;
       default = null;
-      description = lib.mdDoc ''
+      example = "./fastly-exporter-config.txt";
+      description = ''
         Path to a fastly-exporter configuration file.
         Example one can be generated with `fastly-exporter --config-file-example`.
       '';
-      example = "./fastly-exporter-config.txt";
     };
 
     tokenPath = mkOption {
-      type = types.nullOr types.path;
-      apply = final: if final == null then null else toString final;
-      description = lib.mdDoc ''
+      type = path;
+      description = ''
         A run-time path to the token file, which is supposed to be provisioned
         outside of Nix store.
       '';
     };
   };
   serviceOpts = {
-    script = ''
-      ${optionalString (cfg.tokenPath != null)
-      "export FASTLY_API_TOKEN=$(cat ${toString cfg.tokenPath})"}
-      ${pkgs.prometheus-fastly-exporter}/bin/fastly-exporter \
-        -listen http://${cfg.listenAddress}:${toString cfg.port}
-        ${optionalString cfg.debug "-debug true"} \
-        ${optionalString (cfg.configFile != null) "-config-file ${cfg.configFile}"}
+    serviceConfig = {
+      LoadCredential = "fastly-api-token:${cfg.tokenPath}";
+    };
+    script = let
+      call = escapeShellArgs ([
+        "${pkgs.prometheus-fastly-exporter}/bin/fastly-exporter"
+        "-listen" "${cfg.listenAddress}:${toString cfg.port}"
+      ] ++ optionals (cfg.configFile != null) [
+        "--config-file" cfg.configFile
+      ] ++ cfg.extraFlags);
+    in ''
+      export FASTLY_API_TOKEN="$(cat $CREDENTIALS_DIRECTORY/fastly-api-token)"
+      ${call}
     '';
   };
 }

--- a/pkgs/servers/monitoring/prometheus/fastly-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/fastly-exporter.nix
@@ -1,22 +1,31 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, nixosTests
+}:
 
 buildGoModule rec {
   pname = "fastly-exporter";
   version = "7.6.1";
 
   src = fetchFromGitHub {
-    owner = "peterbourgon";
-    repo = pname;
+    owner = "fastly";
+    repo = "fastly-exporter";
     rev = "v${version}";
-    sha256 = "sha256-JUbjWAJ70iq0RCr6U2thbtZ3nmCic9wGtSf2ArRy4uA=";
+    hash = "sha256-JUbjWAJ70iq0RCr6U2thbtZ3nmCic9wGtSf2ArRy4uA=";
   };
 
   vendorHash = "sha256-lEaMhJL/sKNOXx0W+QHMG4QUUE6Pc4AqulhgyCMQQNY=";
 
+  passthru.tests = {
+    inherit (nixosTests.prometheus-exporters) fastly;
+  };
+
   meta = with lib; {
     description = "Prometheus exporter for the Fastly Real-time Analytics API";
-    homepage = "https://github.com/peterbourgon/fastly-exporter";
+    homepage = "https://github.com/fastly/fastly-exporter";
     license = licenses.asl20;
     maintainers = teams.deshaw.members;
+    mainProgram = "fastly-exporter";
   };
 }


### PR DESCRIPTION
Unbreak the exporter. The argparser changed, so we need a backport to 23.11 to get this fixed.

module
- Make the token a required option
- Drop the proto from the listen parameter
- Use systemd credentials to pass the token file
- Drop debug flag, use extraArgs instead
- Actually hook up extraArgs
- Escape shell arguments
- Drop overly broad `with lib` statement

pkg
- Update source repo, it was migrated to fastly
- Hook up the NixOS test
- Add meta.mainProgram

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
