### PR TITLE
 [Release-23.11] openvswitch: 3.1.1 -> 3.1.4, lts: backport 2.17.6 -> 2.17.9

### DIFF
--- a/pkgs/os-specific/linux/openvswitch/default.nix
+++ b/pkgs/os-specific/linux/openvswitch/default.nix
@@ -1,4 +1,4 @@
 import ./generic.nix {
-  version = "3.1.1";
-  hash = "sha256-YEiRg6RNO5WlUiQHIhfF9tN6oRvhKnV2JRDO25Ok4gQ=";
+  version = "3.1.4";
+  hash = "sha256-jcqr88fLll9+rTS7kTHYZt/XV0YSD8dTZUntYbG3/go=";
 }

--- a/pkgs/os-specific/linux/openvswitch/generic.nix
+++ b/pkgs/os-specific/linux/openvswitch/generic.nix
@@ -94,6 +94,8 @@ in stdenv.mkDerivation rec {
 
   doCheck = true;
   preCheck = ''
+    export TESTSUITEFLAGS="-j$NIX_BUILD_CORES"
+    export RECHECK=yes
     patchShebangs tests/
   '';
 

--- a/pkgs/os-specific/linux/openvswitch/lts.nix
+++ b/pkgs/os-specific/linux/openvswitch/lts.nix
@@ -1,4 +1,4 @@
 import ./generic.nix {
-  version = "2.17.6";
-  hash = "sha256-dNqvK+c0iuXdQBe6RbjaxlNB8Vn0+0paecVC/tQQENk=";
+  version = "2.17.9";
+  hash = "sha256-4bP6RyZ2YmhT8i1j+VnlrQYeG/V+G71ETQ7Yj5R++LE=";
 }


### PR DESCRIPTION
https://www.openvswitch.org/releases/NEWS-2.17.9.txt
https://www.openvswitch.org/releases/NEWS-3.1.4.txt
https://mail.openvswitch.org/pipermail/ovs-announce/2024-February/000340.html
https://mail.openvswitch.org/pipermail/ovs-announce/2024-February/000339.html

Fixes: CVE-2023-3966, https://github.com/advisories/GHSA-f89w-2cg8-8h78

## Description of changes

- openvswitch-lts: 2.17.8 -> 2.17.9 (backport)
- openvswitch: 3.1.1 -> 3.1.4
- openvswitch*: enable parallel tests and rechecking of failures (backport)

I can split out the parallel tests backport if necessary, but it's too beneficial to not send to stable in my opinion.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
