### PR TITLE
nixos/logiops: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -113,6 +113,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - [Mealie](https://nightly.mealie.io/), a self-hosted recipe manager and meal planner with a RestAPI backend and a reactive frontend application built in NuxtJS for a pleasant user experience for the whole family. Available as [services.mealie](#opt-services.mealie.enable)
 
+- [logiops](https://github.com/PixlOne/logiops), an unofficial userspace driver for HID++ Logitech devices. Available as [services.logiops](#opt-services.logiops.enable).
+
 ## Backward Incompatibilities {#sec-release-24.05-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -551,6 +551,7 @@
   ./services/hardware/lirc.nix
   ./services/hardware/nvidia-container-toolkit-cdi-generator
   ./services/hardware/monado.nix
+  ./services/hardware/logiops.nix
   ./services/hardware/nvidia-optimus.nix
   ./services/hardware/openrgb.nix
   ./services/hardware/pcscd.nix

--- a/nixos/modules/services/hardware/logiops.nix
+++ b/nixos/modules/services/hardware/logiops.nix
@@ -1,0 +1,113 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkPackageOption mkEnableOption mkIf mkOption types;
+  cfg = config.services.logiops;
+  format = pkgs.formats.libconfig { };
+in {
+  options.services.logiops = {
+    enable = mkEnableOption "logiops, an unofficial userspace driver for HID++ Logitech devices";
+    package = mkPackageOption pkgs "logiops" {
+      example = "logiops_0_2_3";
+    };
+
+    settings = mkOption {
+      type = types.submodule { freeformType = format.type; };
+      description = ''
+        Configuration for logiops.
+
+        See <https://github.com/PixlOne/logiops/wiki/Configuration> for more details.
+        Also see <https://github.com/PixlOne/logiops/blob/main/logid.example.cfg> for an example config.
+      '';
+      default = { };
+      example = {
+        devices = [{
+          name = "Wireless Mouse MX Master";
+          dpi = 1000;
+          buttons = [
+            {
+              cid = "0xc3";
+              action = {
+                type = "Gestures";
+                gestures = [
+                  {
+                    direction = "Up";
+                    mode = "OnRelease";
+                    action = {
+                      type = "Keypress";
+                      keys = [ "KEY_UP" ];
+                    };
+                  }
+                  {
+                    direction = "None";
+                    mode = "NoPress";
+                  }
+                ];
+              };
+            }
+            {
+              cid = "0xc4";
+              action = {
+                type = "Keypress";
+                keys = [ "KEY_A" ];
+              };
+            }
+          ];
+        }];
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.etc."logid.cfg".source = format.generate "logid.cfg" cfg.settings;
+    systemd.services.logiops = {
+      description = "Logitech Configuration Daemon";
+      documentation = [ "https://github.com/PixlOne/logiops" ];
+
+      wantedBy = [ "multi-user.target" ];
+
+      startLimitIntervalSec = 0;
+      after = [ "multi-user.target" ];
+      wants = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/logid";
+        Restart = "always";
+        User = "root";
+
+        RuntimeDirectory = "logiops";
+
+        CapabilityBoundingSet = [ "CAP_SYS_NICE" ];
+        DeviceAllow = [ "/dev/uinput rw" "char-hidraw rw" ];
+        ProtectClock = true;
+        PrivateNetwork = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        PrivateUsers = true;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        RestrictNamespaces = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectControlGroups = true;
+        MemoryDenyWriteExecute = true;
+        RestrictRealtime = true;
+        LockPersonality = true;
+        ProtectProc = "invisible";
+        SystemCallFilter = [ "nice" "@system-service" "~@privileged" ];
+        RestrictAddressFamilies = [ "AF_NETLINK" "AF_UNIX" ];
+        RestrictSUIDSGID = true;
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProcSubset = "pid";
+        UMask = "0077";
+      };
+    };
+
+    # Add a `udev` rule to restart `logiops` when the mouse is connected
+    # https://github.com/PixlOne/logiops/issues/239#issuecomment-1044122412
+    services.udev.extraRules = ''
+      ACTION=="add", SUBSYSTEM=="input", ATTRS{id/vendor}=="046d", RUN{program}="${config.systemd.package}/bin/systemctl --no-block try-restart logiops.service"
+    '';
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -492,6 +492,7 @@ in {
   lldap = handleTest ./lldap.nix {};
   locate = handleTest ./locate.nix {};
   login = handleTest ./login.nix {};
+  logiops = handleTest ./logiops.nix {};
   logrotate = handleTest ./logrotate.nix {};
   loki = handleTest ./loki.nix {};
   luks = handleTest ./luks.nix {};

--- a/nixos/tests/logiops.nix
+++ b/nixos/tests/logiops.nix
@@ -1,0 +1,54 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "logiops";
+  meta = with pkgs.lib.maintainers; { maintainers = [ ckie ]; };
+
+  nodes = {
+    main = { ... }: {
+      services.logiops = {
+        enable = true;
+
+        settings = {
+          devices = [{
+            name = "Wireless Mouse MX Master 3";
+
+            smartshift = {
+              on = true;
+              threshold = 20;
+            };
+
+            hiresscroll = {
+              hires = true;
+              invert = false;
+              target = false;
+            };
+
+            dpi = 1500;
+
+            buttons = [
+              {
+                cid = "0x53";
+                action = {
+                  type = "Keypress";
+                  keys = [ "KEY_FORWARD" ];
+                };
+              }
+              {
+                cid = "0x56";
+                action = {
+                  type = "Keypress";
+                  keys = [ "KEY_BACK" ];
+                };
+              }
+            ];
+          }];
+        };
+      };
+    };
+  };
+
+  testScript = ''
+    start_all()
+    with subtest("main machine should succeed"):
+      main.wait_for_unit("logiops.service")
+  '';
+})


### PR DESCRIPTION
## Description of changes

[`Logiops`](https://github.com/PixlOne/logiops) is third-party software for configuring Logitech mice, e.g remapping buttons or scroll behavior. It is already packaged in `nixpkgs`, but there is no `systemd` service associated with it.

Closes #226575

~~**Note**: I'm not quite sure how to write tests for this service, so any help in that department would be much appreciated!~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
