### PR TITLE
graphia: 3.2 -> 4.2

### DIFF
--- a/pkgs/applications/science/misc/graphia/default.nix
+++ b/pkgs/applications/science/misc/graphia/default.nix
@@ -1,47 +1,47 @@
 { stdenv
 , lib
 , cmake
+, git
 , fetchFromGitHub
 , fetchpatch
 , wrapQtAppsHook
 , qtbase
-, qtquickcontrols2
-, qtgraphicaleffects
+, qtdeclarative
+, qtsvg
+, qtwebengine
 }:
 
 stdenv.mkDerivation rec {
   pname = "graphia";
-  version = "3.2";
+  version = "4.2";
 
   src = fetchFromGitHub {
     owner = "graphia-app";
     repo = "graphia";
     rev = version;
-    sha256 = "sha256-9kohXLXF4F/qoHm8qmvPM1y9ak0Thb4xvgKJlVuOPTg=";
+    sha256 = "sha256-8+tlQbTr6BGx+/gjviuNrQQWcxC/j6dJ+PxwB4fYmqQ=";
   };
 
   patches = [
-    # Fix for a breakpad incompatibility with glibc>2.33
-    # https://github.com/pytorch/pytorch/issues/70297
-    # https://github.com/google/breakpad/commit/605c51ed96ad44b34c457bbca320e74e194c317e
-    ./breakpad-sigstksz.patch
-
-    # FIXME: backport patch fixing build with Qt 5.15, remove for next release
+    # Fix gcc-13 build:
     (fetchpatch {
-      url = "https://github.com/graphia-app/graphia/commit/4b51bb8d465afa7ed0b2b30cb1c5e1c6af95976f.patch";
-      hash = "sha256-GDJAFLxQlRWKvcOgqqPYV/aVTRM7+KDjW7Zp9l7SuyM=";
+      name = "gcc-13.patch";
+      url = "https://github.com/graphia-app/graphia/commit/78fb55a4d73f96e9a182de433c7da60330bd5b5e.patch";
+      hash = "sha256-waI2ur3gOKMQvqB2Qnyz7oMOMConl3jLMVKKmOmTpJs=";
     })
   ];
 
   nativeBuildInputs = [
     cmake
+    git # needs to define some hash as a version
     wrapQtAppsHook
   ];
 
   buildInputs = [
     qtbase
-    qtquickcontrols2
-    qtgraphicaleffects
+    qtdeclarative
+    qtsvg
+    qtwebengine
   ];
 
   meta = with lib; {
@@ -50,6 +50,7 @@ stdenv.mkDerivation rec {
     description = "A visualisation tool for the creation and analysis of graphs.";
     homepage = "https://graphia.app";
     license = licenses.gpl3Only;
+    mainProgram = "Graphia";
     maintainers = [ maintainers.bgamari ];
     platforms = platforms.all;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21389,7 +21389,7 @@ with pkgs;
     stdenv = if stdenv.isDarwin then darwin.apple_sdk_11_0.stdenv else stdenv;
   };
 
-  graphia = libsForQt5.callPackage ../applications/science/misc/graphia { };
+  graphia = qt6Packages.callPackage ../applications/science/misc/graphia { };
 
   graphinder = callPackage ../tools/security/graphinder { };
 


### PR DESCRIPTION
The main change is the build fis against `gcc-13`
https://hydra.nixos.org/build/247540136:

    /build/source/source/thirdparty/breakpad/src/client/linux/handler/minidump_descriptor.h:115:3: error: 'uintptr_t' does not name a type
      115 |   uintptr_t address_within_principal_mapping() const {
          |   ^~~~~~~~~

Changes:
- https://github.com/graphia-app/graphia/releases/tag/4.0
- https://github.com/graphia-app/graphia/releases/tag/4.1
- https://github.com/graphia-app/graphia/releases/tag/4.2

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
