### PR TITLE
qctools: init at 1.3.1

### DIFF
--- a/pkgs/applications/video/qctools/default.nix
+++ b/pkgs/applications/video/qctools/default.nix
@@ -1,0 +1,40 @@
+{ lib, stdenv, fetchurl, qmake, wrapQtAppsHook, ffmpeg, qtmultimedia, qwt }:
+
+stdenv.mkDerivation rec {
+  pname = "qctools";
+  version = "1.3.1";
+
+  src = fetchurl {
+    url = "https://mediaarea.net/download/source/${pname}/${version}/${pname}_${version}.tar.xz";
+    hash = "sha256-ClF8KiVjV2JTCjz/ueioojhiHZf8UW9WONaJrIx4Npo=";
+  };
+
+  sourceRoot = "${pname}/Project/QtCreator";
+
+  nativeBuildInputs = [ qmake wrapQtAppsHook ];
+
+  buildInputs = [ ffmpeg qtmultimedia qwt ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dt $out/bin qctools-cli/qcli qctools-gui/QCTools
+    cd ../GNU/GUI
+    install -Dm644 qctools.desktop $out/share/applications/qctools.desktop
+    install -Dm644 qctools.metainfo.xml $out/share/metainfo/qctools.metainfo.xml
+    cd ../../../Source/Resource
+    install -Dm 0644 Logo.png $out/share/icons/hicolor/256x256/apps/qctools.png
+    install -Dm 0644 Logo.png $out/share/pixmaps/qctools.png
+    cd ../../Project/QtCreator
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Audiovisual analytics and filtering of video files";
+    homepage = "https://mediaarea.net/QCTools";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ orivej ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34690,6 +34690,8 @@ with pkgs;
 
   qcomicbook = libsForQt5.callPackage ../applications/graphics/qcomicbook { };
 
+  qctools = libsForQt5.callPackage ../applications/video/qctools { };
+
   qelectrotech = libsForQt5.callPackage ../applications/misc/qelectrotech { };
 
   eiskaltdcpp = libsForQt5.callPackage ../applications/networking/p2p/eiskaltdcpp { };


### PR DESCRIPTION
## Description of changes

Add QCTools: https://mediaarea.net/QCTools

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
