### PR TITLE
opensoundmeter: init at 1.3

### DIFF
--- a/pkgs/by-name/op/opensoundmeter/build.patch
+++ b/pkgs/by-name/op/opensoundmeter/build.patch
@@ -1,0 +1,13 @@
+--- a/OpenSoundMeter.desktop
++++ b/OpenSoundMeter.desktop
+@@ -6 +6 @@
+-Icon=white
++Icon=OpenSoundMeter
+--- a/OpenSoundMeter.pro
++++ b/OpenSoundMeter.pro
+@@ -261 +261 @@
+-APP_GIT_VERSION = $$system(git --git-dir $$_PRO_FILE_PWD_/.git --work-tree $$_PRO_FILE_PWD_ describe --tags $$system(git --git-dir $$_PRO_FILE_PWD_/.git --work-tree $$_PRO_FILE_PWD_ rev-list --tags --max-count=1))
++APP_GIT_VERSION = ?
+@@ -486 +486 @@
+-unix:!macx:!ios:CONFIG(release, debug|release) {
++unix:!linux:!macx:!ios:CONFIG(release, debug|release) {

--- a/pkgs/by-name/op/opensoundmeter/package.nix
+++ b/pkgs/by-name/op/opensoundmeter/package.nix
@@ -1,0 +1,45 @@
+{ lib, stdenv, fetchFromGitHub, alsa-lib, qt5 }:
+
+let
+  inherit (qt5) qmake wrapQtAppsHook qtgraphicaleffects qtquickcontrols2;
+in stdenv.mkDerivation rec {
+  pname = "opensoundmeter";
+  version = "1.3";
+
+  src = fetchFromGitHub {
+    owner = "psmokotnin";
+    repo = "osm";
+    rev = "v${version}";
+    hash = "sha256-nRibcEtG6UUTgn7PhSg4IyahMYi5aSPvaEOrAdx6u3o=";
+  };
+
+  patches = [ ./build.patch ];
+
+  postPatch = ''
+    substituteInPlace OpenSoundMeter.pro \
+      --replace 'APP_GIT_VERSION = ?' 'APP_GIT_VERSION = ${src.rev}'
+  '';
+
+  nativeBuildInputs = [ qmake wrapQtAppsHook ];
+
+  buildInputs = [ alsa-lib qtgraphicaleffects qtquickcontrols2 ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install OpenSoundMeter -Dt $out/bin
+    install OpenSoundMeter.desktop -m444 -Dt $out/share/applications
+    install icons/white.png -m444 -D $out/share/icons/OpenSoundMeter.png
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Sound measurement application for tuning audio systems in real-time";
+    homepage = "https://opensoundmeter.com/";
+    license = licenses.gpl3Plus;
+    mainProgram = "OpenSoundMeter";
+    maintainers = with maintainers; [ orivej ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Add Open Sound Meter: https://opensoundmeter.com/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
