### PR TITLE
ysfx: init at 0-unstable-2022-07-31

### DIFF
--- a/pkgs/by-name/ys/ysfx/package.nix
+++ b/pkgs/by-name/ys/ysfx/package.nix
@@ -1,0 +1,63 @@
+{ lib, stdenv, fetchFromGitHub, cmake, pkg-config
+, freetype, juce, libX11, libXcursor, libXext, libXinerama, libXrandr, libglvnd
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ysfx";
+  version = "0-unstable-2022-07-31";
+
+  src = fetchFromGitHub {
+    owner = "jpcima";
+    repo = "ysfx";
+    rev = "8077347ccf4115567aed81400281dca57acbb0cc";
+    hash = "sha256-pObuOb/PA9WkKB2FdMDCOd9TKmML+Sj2MybLP0YwT+8=";
+  };
+
+  # Provide latest dr_libs.
+  dr_libs = fetchFromGitHub {
+    owner = "mackron";
+    repo = "dr_libs";
+    rev = "e4a7765e598e9e54dc0f520b7e4416359bee80cc";
+    hash = "sha256-rWabyCP47vd+EfibBWy6iQY/nFN/OXPNhkuOTSboJaU=";
+  };
+
+  prePatch = ''
+    rmdir thirdparty/dr_libs
+    ln -s ${dr_libs} thirdparty/dr_libs
+  '';
+
+  nativeBuildInputs = [ cmake pkg-config ];
+
+  buildInputs = [
+    freetype
+    juce
+    libX11
+    libXcursor
+    libXext
+    libXinerama
+    libXrandr
+    libglvnd
+  ];
+
+  cmakeFlags = [
+    "-DYSFX_PLUGIN_COPY=OFF"
+    "-DYSFX_PLUGIN_USE_SYSTEM_JUCE=ON"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    cp -r ysfx_plugin_artefacts/Release/VST3 $out/lib/vst3
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Hosting library for JSFX";
+    homepage = "https://github.com/jpcima/ysfx";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ orivej ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Add ysfx, Reaper script host for other DAWs: https://github.com/jpcima/ysfx/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
