### PR TITLE
haskellPackages.gi-gtk_4: Build fixes

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2220,6 +2220,17 @@ self: super: {
   gi-gtk-declarative = doJailbreak super.gi-gtk-declarative;
   gi-gtk-declarative-app-simple = doJailbreak super.gi-gtk-declarative-app-simple;
 
+  gi-gtk_4 = self.gi-gtk_4_0_8;
+  gi-gtk_4_0_8 = doDistribute (super.gi-gtk_4_0_8.override {
+    gi-gdk = self.gi-gdk_4;
+  });
+  gi-gdk_4 = self.gi-gdk_4_0_7;
+  gi-gdk_4_0_7 = doDistribute super.gi-gdk_4_0_7;
+  # GSK is only used for GTK 4.
+  gi-gsk = super.gi-gsk.override {
+    gi-gdk = self.gi-gdk_4;
+  };
+
   # Missing dependency on gi-cairo
   # https://github.com/haskell-gi/haskell-gi/pull/420
   gi-vte =

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2230,6 +2230,10 @@ self: super: {
   gi-gsk = super.gi-gsk.override {
     gi-gdk = self.gi-gdk_4;
   };
+  gi-adwaita = super.gi-adwaita.override {
+    gi-gdk = self.gi-gdk_4;
+    gi-gtk = self.gi-gtk_4;
+  };
 
   # Missing dependency on gi-cairo
   # https://github.com/haskell-gi/haskell-gi/pull/420

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -1862,7 +1862,6 @@ broken-packages:
   - ghc-time-alloc-prof # failure in job https://hydra.nixos.org/build/233242289 at 2023-09-02
   - ghc-usage # failure in job https://hydra.nixos.org/build/233199565 at 2023-09-02
   - gh-labeler # failure in job https://hydra.nixos.org/build/233233139 at 2023-09-02
-  - gi-adwaita # failure in compileBuildDriverPhase in job https://hydra.nixos.org/build/239685049 at 2023-11-10
   - giak # failure in job https://hydra.nixos.org/build/233242229 at 2023-09-02
   - gi-clutter # failure in job https://hydra.nixos.org/build/233252753 at 2023-09-02
   - gi-coglpango # failure in job https://hydra.nixos.org/build/233194401 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -1868,7 +1868,6 @@ broken-packages:
   - gi-coglpango # failure in job https://hydra.nixos.org/build/233194401 at 2023-09-02
   - Gifcurry # failure in job https://hydra.nixos.org/build/233200204 at 2023-09-02
   - gi-gio-hs-list-model # failure in job https://hydra.nixos.org/build/233241640 at 2023-09-02
-  - gi-gsk # failure in compileBuildDriverPhase in job https://hydra.nixos.org/build/239849990 at 2023-11-10
   - gi-gsttag # failure in job https://hydra.nixos.org/build/233197576 at 2023-09-02
   - gi-gtk-declarative # failure in job https://hydra.nixos.org/build/233217494 at 2023-09-02
   - gi-gtksheet # failure in job https://hydra.nixos.org/build/233211386 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -1479,7 +1479,6 @@ dont-distribute-packages:
  - gi-ges
  - gi-gstpbutils
  - gi-gtk-declarative-app-simple
- - gi-gtk_4_0_8
  - git-config
  - git-fmt
  - git-gpush
@@ -4002,7 +4001,6 @@ dont-distribute-packages:
  - wahsp
  - wai-devel
  - wai-dispatch
- - wai-handler-hal
  - wai-handler-snap
  - wai-hastache
  - wai-middleware-brotli

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1358,6 +1358,9 @@ self: super: builtins.intersectAttrs super {
       webkit2gtk3-javascriptcore
       gi-webkit2
       gi-webkit2webextension
+      gi-gtk_4_0_8
+      gi-gdk_4_0_7
+      gi-gsk
       ;
 
   # Makes the mpi-hs package respect the choice of mpi implementation in Nixpkgs.

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1361,6 +1361,7 @@ self: super: builtins.intersectAttrs super {
       gi-gtk_4_0_8
       gi-gdk_4_0_7
       gi-gsk
+      gi-adwaita
       ;
 
   # Makes the mpi-hs package respect the choice of mpi implementation in Nixpkgs.


### PR DESCRIPTION
This is for merging into the `haskell-updates` branch (PR #279413).

The dependencies for `gi-gtk-4.0.8` are fixed with overrides and a workaround is added for the command-line length limit being exceeded due to an enormous list of pkg-config dependencies.

The `__onlyPropagateKnownPkgConfigModules` workaround used here depends on PR #285125 being completed and merged to master. Without the relevant `meta.pkgConfigModules` changes, this PR fails to build.

Tested with:
```
nix build .#haskellPackages.gi-adwaita
```
