### PR TITLE
ocenaudio: fix url

### DIFF
--- a/pkgs/by-name/oc/ocenaudio/package.nix
+++ b/pkgs/by-name/oc/ocenaudio/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   version = "3.13.4";
 
   src = fetchurl {
-    url = "https://www.ocenaudio.com/downloads/index.php/ocenaudio_debian9_64.deb?version=${version}";
+    url = "https://www.ocenaudio.com/downloads/index.php/ocenaudio_debian9_64.deb?version=v${version}";
     hash = "sha256-vE+xwwkBXIksy+6oygLDsrT8mFfHYIGcb6+8KMZe0no=";
   };
 
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     mv $out/usr/share $out/share
     rm -rf $out/usr
     substituteInPlace $out/share/applications/ocenaudio.desktop \
-      --replace "/opt/ocenaudio/bin/ocenaudio" "ocenaudio"
+      --replace-fail "/opt/ocenaudio/bin/ocenaudio" "ocenaudio"
     mkdir -p $out/share/licenses/ocenaudio
     mv $out/bin/ocenaudio_license.txt $out/share/licenses/ocenaudio/LICENSE
 


### PR DESCRIPTION
## Description of changes
The source download url needs a `v` prepending the version number (as per the [Arch packagebuild](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=ocenaudio-bin)) otherwise it ignores the version number and just downloads the latest version. This leads to a hash mismatch when a new version comes out and is what led to the below issue.

Closes https://github.com/NixOS/nixpkgs/issues/287404 (and prevents issue occurring in future).

To confirm / test the above. Lets download 2 different versions without prepending `v`:
```
wget "https://www.ocenaudio.com/downloads/index.php/ocenaudio_debian9_64.deb?version=3.13.3"
wget "https://www.ocenaudio.com/downloads/index.php/ocenaudio_debian9_64.deb?version=3.13.4"
diff "ocenaudio_debian9_64.deb?version=3.13.3" "ocenaudio_debian9_64.deb?version=3.13.4"
```
binary files match despite version difference. So version information is being ignored.

Now download with a prepended `v`:
```
wget "https://www.ocenaudio.com/downloads/index.php/ocenaudio_debian9_64.deb?version=v3.13.3"
wget "https://www.ocenaudio.com/downloads/index.php/ocenaudio_debian9_64.deb?version=v3.13.4"
diff "ocenaudio_debian9_64.deb?version=v3.13.3" "ocenaudio_debian9_64.deb?version=v3.13.4"
```
binary files differ this time. So version string is being recognized.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
