### PR TITLE
nulloy: init at 0.9.8.7

### DIFF
--- a/pkgs/by-name/nu/nulloy/package.nix
+++ b/pkgs/by-name/nu/nulloy/package.nix
@@ -1,0 +1,65 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, which
+, pkg-config
+, zip
+, imagemagick
+, qt5
+, taglib
+, gst_all_1
+}:
+
+stdenv.mkDerivation rec {
+  pname = "nulloy";
+  version = "0.9.8.7";
+
+  src = fetchFromGitHub {
+    owner = "nulloy";
+    repo = "nulloy";
+    rev = version;
+    hash = "sha256-s8DzL7pp3hmD9k8pVqmk7WGq3zZ1tLF9C+jxcRtJOXA=";
+  };
+
+  nativeBuildInputs = [
+    which # used by configure script
+    pkg-config
+    zip
+    imagemagick
+    qt5.qttools
+    qt5.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt5.qtscript
+    qt5.qtsvg
+    taglib
+  ] ++ (with gst_all_1; [
+    gstreamer
+    gst-plugins-base
+    gst-plugins-good
+    gst-plugins-bad
+    gst-plugins-ugly
+  ]);
+
+  prefixKey = "--prefix ";
+
+  enableParallelBuilding = true;
+
+  # FIXME: not added by gstreamer setup hook by default
+  preFixup = ''
+    qtWrapperArgs+=(
+      --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0"
+    )
+  '';
+
+  meta = with lib; {
+    description = "Music player with a waveform progress bar";
+    homepage = "https://nulloy.com";
+    license = licenses.gpl3Only;
+    mainProgram = "nulloy";
+    maintainers = with maintainers; [ aleksana ];
+    platforms = platforms.all;
+    broken = stdenv.isDarwin;
+  };
+}


### PR DESCRIPTION
## Description of changes

Tested

```
./result
├── bin
│   └── nulloy
├── lib
│   └── nulloy
│       └── plugins
│           ├── libplugin_gstreamer.so
│           └── libplugin_taglib.so
└── share
    ├── applications
    │   └── nulloy.desktop
    ├── icons
    │   └── hicolor
    │       └── scalable
    │           └── apps
    │               └── nulloy.svg
    └── nulloy
        ├── i18n
        │   ├── de.qm
        │   ├── es.qm
        │   ├── fr.qm
        │   ├── lt.qm
        │   ├── nl.qm
        │   ├── pl.qm
        │   ├── ru.qm
        │   ├── uk.qm
        │   └── zh_CN.qm
        └── skins
            ├── metro.nzs
            ├── silver.nzs
            └── slim.nzs
```

![image](https://github.com/NixOS/nixpkgs/assets/42209822/2576c8e7-2665-4975-a58e-f95f82cbb1c2)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
