### PR TITLE
fwupd: 1.9.12 -> 1.9.13

### DIFF
--- a/nixos/tests/installed-tests/fwupd.nix
+++ b/nixos/tests/installed-tests/fwupd.nix
@@ -1,11 +1,12 @@
-{ pkgs, lib, makeInstalledTest, ... }:
+{ pkgs, makeInstalledTest, ... }:
 
 makeInstalledTest {
   tested = pkgs.fwupd;
 
   testConfig = {
-    services.fwupd.enable = true;
-    services.fwupd.daemonSettings.DisabledPlugins = lib.mkForce [ ]; # don't disable test plugin
-    services.fwupd.enableTestRemote = true;
+    services.fwupd = {
+      enable = true;
+      daemonSettings.TestDevices = true;
+    };
   };
 }

--- a/pkgs/by-name/fw/fwupd/add-option-for-installation-sysconfdir.patch
+++ b/pkgs/by-name/fw/fwupd/add-option-for-installation-sysconfdir.patch
@@ -80,7 +80,7 @@ index c20a1a05e..5354bac7f 100644
 @@ -56,12 +56,12 @@ configure_file(
    output: 'vendor.conf',
    configuration: con2,
-   install: true,
+   install: get_option('vendor_metadata'),
 -  install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
 +  install_dir: join_paths(sysconfdir_install, 'fwupd', 'remotes.d'),
  )

--- a/pkgs/by-name/fw/fwupd/installed-tests-path.patch
+++ b/pkgs/by-name/fw/fwupd/installed-tests-path.patch
@@ -6,7 +6,7 @@ index dfce86b1c..5e34c4fa6 100644
    output: 'fwupd-tests.conf',
    configuration: con2,
    install: true,
--  install_dir: join_paths(sysconfdir, 'fwupd', 'remotes.d'),
+-  install_dir: join_paths(datadir, 'fwupd', 'remotes.d'),
 +  install_dir: join_paths(get_option('installed_test_prefix'), 'etc', 'fwupd', 'remotes.d'),
  )
 diff --git a/meson.build b/meson.build

--- a/pkgs/by-name/fw/fwupd/package.nix
+++ b/pkgs/by-name/fw/fwupd/package.nix
@@ -11,7 +11,6 @@
 , libdrm
 , polkit
 , libxmlb
-, glib
 , gusb
 , sqlite
 , libarchive
@@ -121,7 +120,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "fwupd";
-  version = "1.9.12";
+  version = "1.9.13";
 
   # libfwupd goes to lib
   # daemon, plug-ins and libfwupdplugin go to out
@@ -132,7 +131,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "fwupd";
     repo = "fwupd";
     rev = finalAttrs.version;
-    hash = "sha256-hPRp61m/XTXFacYkBOb4SsG4fcFvWrdMfc+sxLk5/sQ=";
+    hash = "sha256-h2e9MFTb777xbNRlzKWXc5GUdu/BHSkJTaogEE5byjo=";
   };
 
   patches = [
@@ -214,6 +213,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dsysconfdir_install=${placeholder "out"}/etc"
     "-Defi_os_dir=nixos"
     "-Dplugin_modem_manager=enabled"
+    "-Dvendor_metadata=true"
     # We do not want to place the daemon into lib (cyclic reference)
     "--libexecdir=${placeholder "out"}/libexec"
   ] ++ lib.optionals (!enablePassim) [
@@ -341,12 +341,6 @@ stdenv.mkDerivation (finalAttrs: {
       "grub.d/35_fwupd"
     ];
 
-    # DisabledPlugins key in fwupd/daemon.conf
-    defaultDisabledPlugins = [
-      "test"
-      "test_ble"
-    ];
-
     # For updating.
     inherit test-firmware;
 
@@ -371,12 +365,6 @@ stdenv.mkDerivation (finalAttrs: {
           passthru_etc = set(${listToPy finalAttrs.passthru.filesInstalledToEtc})
           assert len(package_etc - passthru_etc) == 0, f'fwupd package contains the following paths in /etc that are not listed in passthru.filesInstalledToEtc: {package_etc - passthru_etc}'
           assert len(passthru_etc - package_etc) == 0, f'fwupd package lists the following paths in passthru.filesInstalledToEtc that are not contained in /etc: {passthru_etc - package_etc}'
-
-          config = configparser.RawConfigParser()
-          config.read('${finalAttrs.finalPackage}/etc/fwupd/fwupd.conf')
-          package_disabled_plugins = config.get('fwupd', 'DisabledPlugins').rstrip(';').split(';')
-          passthru_disabled_plugins = ${listToPy finalAttrs.passthru.defaultDisabledPlugins}
-          assert package_disabled_plugins == passthru_disabled_plugins, f'Default disabled plug-ins in the package {package_disabled_plugins} do not match those listed in passthru.defaultDisabledPlugins {passthru_disabled_plugins}'
 
           pathlib.Path(os.getenv('out')).touch()
         '';


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/fwupd/fwupd/releases/tag/1.9.13

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
