### PR TITLE
inkcut: add hidden setuptools dependency

### DIFF
--- a/pkgs/applications/misc/inkcut/default.nix
+++ b/pkgs/applications/misc/inkcut/default.nix
@@ -56,6 +56,7 @@ python3.pkgs.buildPythonApplication rec {
     pycups
     qtconsole
     pyqt5
+    setuptools
   ];
 
   # QtApplication.instance() does not work during tests?


### PR DESCRIPTION
## Description of changes

Inkcut requires setuptools to be available.
This is not clearly documented, but is hinted at in the official documentation.

Previously, inkcut started just fine, probably because this dependency was provided by some other python package...
Without this change, inkcut crashes with the following error:

```
Traceback (most recent call last):
  File "/nix/store/xvb2ckb8x0zrz2qkmzv6k002szf69vfv-python3.11-enaml-0.17.0/lib/python3.11/site-packages/enaml/qt/q_deferred_caller.py", line 42, in customEvent
    event.callback(*event.args, **event.kwargs)
  File "/nix/store/i2fxiwv2yiwm9jfcmnq0sqvq7di8mn0x-inkcut-2.1.5/lib/python3.11/site-packages/inkcut/core/plugin.py", line 80, in start_default_workspace
    ui.select_workspace('inkcut.workspace')
  File "/nix/store/xvb2ckb8x0zrz2qkmzv6k002szf69vfv-python3.11-enaml-0.17.0/lib/python3.11/site-packages/enaml/workbench/ui/ui_plugin.py", line 157, in select_workspace
    new_workspace.start()
  File "/nix/store/i2fxiwv2yiwm9jfcmnq0sqvq7di8mn0x-inkcut-2.1.5/lib/python3.11/site-packages/inkcut/ui/workspace.py", line 46, in start
    self.workbench.get_plugin('inkcut.ui')
  File "/nix/store/xvb2ckb8x0zrz2qkmzv6k002szf69vfv-python3.11-enaml-0.17.0/lib/python3.11/site-packages/enaml/workbench/workbench.py", line 144, in get_plugin
    plugin = manifest.factory()
             ^^^^^^^^^^^^^^^^^^
  File "/nix/store/i2fxiwv2yiwm9jfcmnq0sqvq7di8mn0x-inkcut-2.1.5/lib/python3.11/site-packages/inkcut/ui/manifest.enaml", line 30, in plugin_factory
    from inkcut.ui.plugin import InkcutPlugin
  File "/nix/store/i2fxiwv2yiwm9jfcmnq0sqvq7di8mn0x-inkcut-2.1.5/lib/python3.11/site-packages/inkcut/ui/plugin.py", line 14, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
Aborted (core dumped)
```

With the change applied, inkcut starts just fine again.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
