### PR TITLE
[release-23.11] python3Packages.gevent: Cherry-pick fixes to events.py for Python < 3.10

### DIFF
--- a/pkgs/development/python-modules/gevent/default.nix
+++ b/pkgs/development/python-modules/gevent/default.nix
@@ -42,6 +42,17 @@ buildPythonPackage rec {
       hash = "sha256-Y+cxIScuEgAVYmmxBJ8OI+JuJ4G+iiROTcRdWglo3l0=";
       includes = [ "src/gevent/events.py" ];
     })
+  ] ++ lib.optionals (pythonOlder "3.10") [
+    (fetchpatch {
+      url = "https://github.com/gevent/gevent/commit/07035b7e0ccf35abea20d774827423e959429df1.patch";
+      hash = "sha256-w4Lw9kFALkg4QDUXLvWVmlyiOYGKE0W7kJIMd1jpGHI=";
+      includes = [ "src/gevent/events.py" ];
+    })
+    (fetchpatch {
+      url = "https://github.com/gevent/gevent/commit/d9e2479b83da1a8b2e75720d9bfa771bb97d7c94.patch";
+      hash = "sha256-j6AtVCYpwPXBz8HUJHSD0VfvkBsKuZBrmHh9WRgoEl4=";
+      includes = [ "src/gevent/events.py" ];
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

In 61dac96af51b77aebb664e18daadd471dbec604f we backported upstream patch gevent/gevent@bd96d8e14dc99f757de22ab4bb98439f912dab1e to support Python 3.11, however that patch was not fully tested and broke compatibility with Python 3.9. In particular, on [line 126 of events.py](https://github.com/gevent/gevent/blob/bd96d8e14dc99f757de22ab4bb98439f912dab1e/src/gevent/events.py#L126), `entry_points` is not defined.

There were two subsequent commits after that one (and from the same date) which fix the issues in Python < 3.10 branch:
- gevent/gevent@07035b7e0ccf35abea20d774827423e959429df1
- gevent/gevent@d9e2479b83da1a8b2e75720d9bfa771bb97d7c94

Each of them is just one line when limited to events.py. They both together are equivalent to the following diff (all of which is in Python < 3.10 code path):
```diff
--- a/src/gevent/events.py
+++ b/src/gevent/events.py
@@ -123,14 +123,14 @@ def notify_and_call_entry_points(event):
         # Prior to 3.9, there is no ``.module`` attribute, so if we
         # needed that we'd have to look at the complete ``.value``
         # attribute.
-        ep_dict = entry_points()
+        ep_dict = metadata.entry_points()
         __traceback_info__ = ep_dict
         # On Python 3.8, we can get duplicate EntryPoint objects; it is unclear
         # why. Drop them into a set to make sure we only get one.
         entry_points = set(
             ep
             for ep
-            in ep_dict.get(event.ENTRY_POINT_NAME)
+            in ep_dict.get(event.ENTRY_POINT_NAME, ())
         )
 
     for plugin in entry_points:
```

This fixes build of python39.pkgs.geventhttpclient in nixos-23.11 branch, which was previously failing with:
```
_________ ERROR collecting src/geventhttpclient/tests/test_headers.py __________
...
src/geventhttpclient/tests/test_headers.py:5: in <module>
    gevent.monkey.patch_all()
/nix/store/9r8ngl5757karzhxhjl29l13850nf7i5-python3.9-gevent-22.10.2/lib/python3.9/site-packages/gevent/monkey.py:1255: in patch_all
    _notify_patch(events.GeventWillPatchAllEvent(modules_to_patch, kwargs), _warnings)
/nix/store/9r8ngl5757karzhxhjl29l13850nf7i5-python3.9-gevent-22.10.2/lib/python3.9/site-packages/gevent/monkey.py:190: in _notify_patch
    notify_and_call_entry_points(event)
/nix/store/9r8ngl5757karzhxhjl29l13850nf7i5-python3.9-gevent-22.10.2/lib/python3.9/site-packages/gevent/events.py:126: in notify_and_call_entry_points
    ep_dict = entry_points()
E   UnboundLocalError: local variable 'entry_points' referenced before assignment
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).