### PR TITLE
djv: Adding OpenEXR Support

### DIFF
--- a/pkgs/applications/graphics/djv/default.nix
+++ b/pkgs/applications/graphics/djv/default.nix
@@ -17,6 +17,7 @@
 , libpng
 , opencolorio_1
 , freetype
+, openexr
 }:
 
 let
@@ -145,11 +146,12 @@ stdenv.mkDerivation rec {
     ilmbase
     glm
     glfw3
-    zlib.dev
+    zlib
     libpng
     freetype
     opencolorio_1
     djv-deps
+    openexr
   ];
 
   postPatch = ''
@@ -162,6 +164,13 @@ stdenv.mkDerivation rec {
     sed -i cmake/Modules/FindOCIO.cmake \
         -e 's/PATH_SUFFIXES static//' \
         -e '/OpenColorIO_STATIC/d'
+
+    # When searching for OpenEXR this looks for Iex.h, which exists in ilmbase,
+    # since it's a secondary inport, to find the correct OpenEXR lib, we search
+    # for something specifically in OpenEXR.
+
+    sed -i cmake/Modules/FindOpenEXR.cmake \
+        -e 's/find_path(OpenEXR_INCLUDE_DIR NAMES Iex.h PATH_SUFFIXES OpenEXR)/find_path(OpenEXR_INCLUDE_DIR NAMES ImfImage.h PATH_SUFFIXES OpenEXR)/'
   '';
 
   # GLFW requires a working X11 session.


### PR DESCRIPTION
## Description of changes

DJV is particularly useful for vfx workflows, where EXRs are common, adding OpenEXR support to the nix buid of djv.

Just adding openexr.dev as an input, and patching FindOpenEXR.cmake to find the correct directory.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

