### PR TITLE
python311Packages.medpy: init at 0.5.0rc1

### DIFF
--- a/pkgs/development/python-modules/medpy/default.nix
+++ b/pkgs/development/python-modules/medpy/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, buildPythonPackage
+, pythonOlder
+, fetchFromGitHub
+, setuptools
+, unittestCheckHook
+, boost
+, numpy
+, scipy
+, simpleitk
+}:
+
+buildPythonPackage rec {
+  pname = "medpy";
+  version = "0.5.0rc1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "loli";
+    repo = "medpy";
+    rev = "refs/tags/${version}";
+    hash = "sha256-W62LjstH42OzNG+vMkuApUWczTNugJGKuuoeeS5ok4U=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    boost
+    numpy
+    scipy
+    simpleitk
+  ];
+
+  nativeCheckInputs = [
+    unittestCheckHook
+  ];
+  preCheck = ''
+    rm -r medpy/  # prevent importing from build directory at test time
+    rm -r tests/graphcut_  # SIGILL at test time
+  '';
+
+  pythonImportsCheck = [
+    "medpy"
+    "medpy.core"
+    "medpy.features"
+    "medpy.filter"
+    "medpy.graphcut"
+    "medpy.io"
+    "medpy.metric"
+    "medpy.utilities"
+  ];
+
+  meta = with lib; {
+    description = "Medical image processing library";
+    homepage = "https://loli.github.io/medpy";
+    changelog = "https://github.com/loli/medpy/releases/tag/${version}";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6957,6 +6957,8 @@ self: super: with self; {
 
   mediapy = callPackage ../development/python-modules/mediapy { };
 
+  medpy = callPackage ../development/python-modules/medpy { };
+
   meeko = callPackage ../development/python-modules/meeko { };
 
   meep = callPackage ../development/python-modules/meep { };


### PR DESCRIPTION
## Description of changes

Init `medpy`, a Python medical imaging library. (Using a `rc` for now since the previous release is several years old and likely to have various dependency versioning issues with current `nixpkgs`.)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
