### PR TITLE
emulationstation-de: add retroarch cores for local nix profile

### DIFF
--- a/pkgs/by-name/em/emulationstation-de/001-add-nixpkgs-retroarch-cores.patch
+++ b/pkgs/by-name/em/emulationstation-de/001-add-nixpkgs-retroarch-cores.patch
@@ -6,6 +6,7 @@
              <entry>/usr/pkg/lib/libretro</entry>
 +            <!-- NixOS / Nixpkgs -->
 +            <entry>/run/current-system/sw/lib/retroarch/cores</entry>
++            <entry>~/.nix-profile/lib/retroarch/cores/</entry>
          </rule>
      </core>
      <emulator name="3DSEN-WINDOWS">


### PR DESCRIPTION
## Description of changes

Adds retroarch cores that are installed via `home-manager` or `nix profile` to the search path.
