### PR TITLE
pinecone: init at 0.11.0-unstable-2023-08-10

### DIFF
--- a/pkgs/by-name/pi/pinecone/package.nix
+++ b/pkgs/by-name/pi/pinecone/package.nix
@@ -1,0 +1,23 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule {
+  pname = "pinecone";
+  version = "0.11.0-unstable-2023-08-10";
+
+  src = fetchFromGitHub {
+    owner = "matrix-org";
+    repo = "pinecone";
+    rev = "ea4c33717fd74ef7d6f49490625a0fa10e3f5bbc";
+    hash = "sha256-q4EFWXSkQJ2n+xAWuBxdP7nrtv3eFql9LoavWo10dfs=";
+  };
+
+  vendorHash = "sha256-+P10K7G0UwkbCGEi6sYTQSqO7LzIf/xmaHIr7v110Ao=";
+
+  meta = with lib; {
+    description = "Peer-to-peer overlay routing for the Matrix ecosystem";
+    homepage = "https://matrix-org.github.io/pinecone/";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ networkexception ];
+    mainProgram = "pinecone";
+  };
+}


### PR DESCRIPTION
## Description of changes

This pull request adds a package for https://github.com/matrix-org/pinecone.

Building release 0.11.0 is not possible with any golang version packaged currently, as such we use the latest commit from the main branch (this also fixes several security vulnerabilities).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
