### PR TITLE
fishPlugins.plugin-git: 0.1 -> 0.2

### DIFF
--- a/pkgs/shells/fish/plugins/plugin-git.nix
+++ b/pkgs/shells/fish/plugins/plugin-git.nix
@@ -16,6 +16,6 @@ buildFishPlugin rec {
     homepage = "https://github.com/jhillyerd/plugin-git";
     changelog = "https://github.com/jhillyerd/plugin-git/releases/tag/v${version}";
     license = licenses.mit;
-    maintainers = with maintainers; [ unsolvedcypher ];
+    maintainers = with maintainers; [ GaetanLepage unsolvedcypher ];
   };
 }

--- a/pkgs/shells/fish/plugins/plugin-git.nix
+++ b/pkgs/shells/fish/plugins/plugin-git.nix
@@ -2,18 +2,19 @@
 
 buildFishPlugin rec {
   pname = "plugin-git";
-  version = "0.1";
+  version = "0.2";
 
   src = fetchFromGitHub {
     owner = "jhillyerd";
     repo = "plugin-git";
-    rev = "v0.1";
-    sha256 = "sha256-MfrRQdcj7UtIUgtqKjt4lqFLpA6YZgKjE03VaaypNzE";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-MfrRQdcj7UtIUgtqKjt4lqFLpA6YZgKjE03VaaypNzE";
   };
 
   meta = with lib; {
     description = "Git plugin for fish (similar to oh-my-zsh git)";
     homepage = "https://github.com/jhillyerd/plugin-git";
+    changelog = "https://github.com/jhillyerd/plugin-git/releases/tag/v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ unsolvedcypher ];
   };


### PR DESCRIPTION
## Description of changes

Update the plugin to get [this fix](https://github.com/jhillyerd/plugin-git/pull/103).

Changelog: https://github.com/jhillyerd/plugin-git/releases/tag/v0.2

cc @UnsolvedCypher 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
