### PR TITLE
autobrr: init at 1.57.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2333,6 +2333,12 @@
     githubId = 59499799;
     keys = [ { fingerprint = "A0FF 4F26 6B80 0B86 726D  EA5B 3C23 C7BD 9945 2036"; } ];
   };
+  av-gal = {
+    email = "alex.v.galvin@gmail.com";
+    github = "av-gal";
+    githubId = 32237198;
+    name = "Alex Galvin";
+  };
   avh4 = {
     email = "gruen0aermel@gmail.com";
     github = "avh4";

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -77,6 +77,8 @@
 
 - [Whoogle Search](https://github.com/benbusby/whoogle-search), a self-hosted, ad-free, privacy-respecting metasearch engine. Available as [services.whoogle-search](options.html#opt-services.whoogle-search.enable).
 
+- [autobrr](https://autobrr.com), a modern download automation tool for torrents and usenets. Available as [services.autobrr](#opt-services.autobrr.enable).
+
 - [agorakit](https://github.com/agorakit/agorakit), an organization tool for citizens' collectives. Available with [services.agorakit](options.html#opt-services.agorakit.enable).
 
 - [vivid](https://github.com/sharkdp/vivid), a generator for LS_COLOR. Available as [programs.vivid](#opt-programs.vivid.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -747,6 +747,7 @@
   ./services/misc/anki-sync-server.nix
   ./services/misc/apache-kafka.nix
   ./services/misc/atuin.nix
+  ./services/misc/autobrr.nix
   ./services/misc/autofs.nix
   ./services/misc/autorandr.nix
   ./services/misc/autosuspend.nix

--- a/nixos/modules/services/misc/autobrr.nix
+++ b/nixos/modules/services/misc/autobrr.nix
@@ -1,0 +1,85 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.autobrr;
+  configFormat = pkgs.formats.toml { };
+  configTemplate = configFormat.generate "autobrr.toml" cfg.settings;
+  templaterCmd = "${lib.getExe pkgs.dasel} put -f '${configTemplate}' -v $(cat ${cfg.secretFile}) -o %S/autobrr/config.toml 'sessionSecret'";
+in
+{
+  options = {
+    services.autobrr = {
+      enable = lib.mkEnableOption "Autobrr";
+
+      openFirewall = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Open ports in the firewall for the Autobrr web interface.";
+      };
+
+      secretFile = lib.mkOption {
+        type = lib.types.path;
+        description = "File containing the session secret for the Autobrr web interface.";
+      };
+
+      settings = lib.mkOption {
+        type = lib.types.submodule { freeformType = configFormat.type; };
+        default = {
+          host = "127.0.0.1";
+          port = "7474";
+          checkForUpdates = true;
+        };
+        example = {
+          logLevel = "DEBUG";
+        };
+        description = ''
+          Autobrr configuration options.
+
+          Refer to <https://autobrr.com/configuration/autobrr>
+          for a full list.
+        '';
+      };
+
+      package = lib.mkPackageOption pkgs "autobrr" { };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !(cfg.settings ? sessionSecret);
+        message = ''
+          Session secrets should not be passed via settings, as
+          these are stored in the world-readable nix store.
+
+          Use the secretFile option instead.'';
+      }
+    ];
+
+    systemd.services.autobrr = {
+      description = "Autobrr";
+      after = [
+        "syslog.target"
+        "network-online.target"
+      ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        DynamicUser = true;
+        StateDirectory = "autobrr";
+        ExecStartPre = "${lib.getExe pkgs.bash} -c '${templaterCmd}'";
+        ExecStart = "${lib.getExe pkgs.autobrr} --config %S/autobrr";
+        Restart = "on-failure";
+      };
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall { allowedTCPPorts = [ cfg.settings.port ]; };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -144,6 +144,7 @@ in {
   auth-mysql = handleTest ./auth-mysql.nix {};
   authelia = handleTest ./authelia.nix {};
   auto-cpufreq = handleTest ./auto-cpufreq.nix {};
+  autobrr = handleTest ./autobrr.nix {};
   avahi = handleTest ./avahi.nix {};
   avahi-with-resolved = handleTest ./avahi.nix { networkd = true; };
   ayatana-indicators = runTest ./ayatana-indicators.nix;

--- a/nixos/tests/autobrr.nix
+++ b/nixos/tests/autobrr.nix
@@ -1,0 +1,25 @@
+import ./make-test-python.nix (
+  { lib, ... }:
+
+  {
+    name = "autobrr";
+    meta.maintainers = with lib.maintainers; [ av-gal ];
+
+    nodes.machine =
+      { pkgs, ... }:
+      {
+        services.autobrr = {
+          enable = true;
+          # We create this secret in the Nix store (making it readable by everyone).
+          # DO NOT DO THIS OUTSIDE OF TESTS!!
+          secretFile = pkgs.writeText "session_secret" "not-secret";
+        };
+      };
+
+    testScript = ''
+      machine.wait_for_unit("autobrr.service")
+      machine.wait_for_open_port(7474)
+      machine.succeed("curl --fail http://localhost:7474/")
+    '';
+  }
+)

--- a/pkgs/by-name/au/autobrr/package.nix
+++ b/pkgs/by-name/au/autobrr/package.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  stdenvNoCC,
+  nix-update-script,
+  nodejs,
+  pnpm_9,
+  typescript,
+  versionCheckHook,
+}:
+
+let
+  pname = "autobrr";
+  version = "1.57.0";
+  src = fetchFromGitHub {
+    owner = "autobrr";
+    repo = "autobrr";
+    tag = "v${version}";
+    hash = "sha256-RVkeSrL3ZfEz+oCICi8JFJ6AaOBBumi5mnnQYE5Gjt8=";
+  };
+
+  autobrr-web = stdenvNoCC.mkDerivation {
+    pname = "${pname}-web";
+    inherit src version;
+
+    nativeBuildInputs = [
+      nodejs
+      pnpm_9.configHook
+      typescript
+    ];
+
+    sourceRoot = "${src.name}/web";
+
+    pnpmDeps = pnpm_9.fetchDeps {
+      inherit (autobrr-web)
+        pname
+        version
+        src
+        sourceRoot
+        ;
+      hash = "sha256-mABHRuZfjq9qNanfGGv+xDhs3bSufaWRecJypic8SWo=";
+    };
+
+    postBuild = ''
+      pnpm run build
+    '';
+
+    installPhase = ''
+      cp -r dist $out
+    '';
+  };
+in
+buildGoModule rec {
+  inherit
+    autobrr-web
+    pname
+    version
+    src
+    ;
+
+  vendorHash = "sha256-rCtUE2/IwR6AnXQNgeH0TQ0BL7g6vi9L128xP0PwOXc=";
+
+  preBuild = ''
+    cp -r ${autobrr-web}/* web/dist
+  '';
+
+  ldflags = [
+    "-X main.version=${version}"
+    "-X main.commit=${src.tag}"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgram = "${placeholder "out"}/bin/autobrrctl";
+  versionCheckProgramArg = "version";
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--subpackage"
+      "autobrr-web"
+    ];
+  };
+
+  meta = {
+    description = "Modern, easy to use download automation for torrents and usenet";
+    license = lib.licenses.gpl2Plus;
+    homepage = "https://autobrr.com/";
+    changelog = "https://autobrr.com/release-notes/v${version}";
+    maintainers = with lib.maintainers; [ av-gal ];
+    mainProgram = "autobrr";
+    platforms = with lib.platforms; darwin ++ freebsd ++ linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Reopening #283389. Closes #224560.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
