### PR TITLE
darwin.stdenv: improvements and overrideSDK rewrite

### DIFF
--- a/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
@@ -105,6 +105,8 @@ let
     # conflicting LLVM modules.
     objc4 = stdenv.objc4 or (callPackage ./libobjc.nix { });
 
+    sdkRoot = pkgs.callPackage ../apple-sdk/sdkRoot.nix { sdkVersion = "11.0"; };
+
     # questionable aliases
     configd = pkgs.darwin.apple_sdk.frameworks.SystemConfiguration;
     inherit (pkgs.darwin.apple_sdk.frameworks) IOKit;

--- a/pkgs/os-specific/darwin/apple-sdk/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/default.nix
@@ -352,5 +352,7 @@ in rec {
 
   inherit darwin-stubs;
 
+  inherit (pkgs.darwin) Libsystem;
+
   inherit sdk;
 }

--- a/pkgs/os-specific/darwin/apple-sdk/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/default.nix
@@ -352,6 +352,8 @@ in rec {
 
   inherit darwin-stubs;
 
+  objc4 = pkgs.darwin.libobjc;
+
   inherit (pkgs.darwin) Libsystem;
 
   inherit sdk;

--- a/pkgs/os-specific/darwin/apple-sdk/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/default.nix
@@ -354,6 +354,8 @@ in rec {
 
   objc4 = pkgs.darwin.libobjc;
 
+  sdkRoot = pkgs.callPackage ./sdkRoot.nix { sdkVersion = "10.12"; };
+
   inherit (pkgs.darwin) Libsystem;
 
   inherit sdk;

--- a/pkgs/os-specific/darwin/apple-sdk/sdkRoot.nix
+++ b/pkgs/os-specific/darwin/apple-sdk/sdkRoot.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  runCommand,
+  writeText,
+  sdkVersion,
+}:
+
+let
+  sdkName = "MacOSX${sdkVersion}";
+  toolchainName = "com.apple.dt.toolchain.XcodeDefault";
+  productBuildVer = null;
+
+  inherit (lib.generators) toPlist toJSON;
+
+  SDKSettings = {
+    CanonicalName = "macosx${sdkVersion}";
+    DisplayName = "macOS ${sdkVersion}";
+    Toolchains = [ toolchainName ];
+    Version = sdkVersion;
+    MaximumDeploymentTarget = "${sdkVersion}.99";
+    isBaseSDK = "YES";
+  };
+
+  SystemVersion =
+    lib.optionalAttrs (productBuildVer != null) { ProductBuildVersion = productBuildVer; }
+    // {
+      ProductName = "macOS";
+      ProductVersion = sdkVersion;
+    };
+in
+runCommand "sdkroot-${sdkVersion}" { } ''
+  sdk="$out/${sdkName}.sdk"
+
+  install -D ${writeText "SDKSettings.plist" (toPlist { } SDKSettings)} "$sdk/SDKSettings.plist"
+  install -D ${writeText "SDKSettings.json" (toJSON { } SDKSettings)} "$sdk/SDKSettings.json"
+  install -D ${
+    writeText "SystemVersion.plist" (toPlist { } SystemVersion)
+  } "$sdk/System/Library/CoreServices/SystemVersion.plist"
+
+  ln -s "$sdk" "$sdk/usr"
+
+  install -D '${../../../build-support/setup-hooks/role.bash}' "$out/nix-support/setup-hook"
+  cat >> "$out/nix-support/setup-hook" <<-hook
+  #
+  # See comments in cc-wrapper's setup hook. This works exactly the same way.
+  #
+  [[ -z \''${strictDeps-} ]] || (( "\$hostOffset" < 0 )) || return 0
+
+  sdkRootHook() {
+    # See ../../../build-support/setup-hooks/role.bash
+    local role_post
+    getHostRoleEnvHook
+
+    # Only set the SDK root if one has not been set via this hook or some other means.
+    if [[ ! \$NIX_CFLAGS_COMPILE =~ isysroot ]]; then
+      export NIX_CFLAGS_COMPILE\''${role_post}+=' -isysroot $out/${sdkName}.sdk'
+    fi
+  }
+
+  # See ../../../build-support/setup-hooks/role.bash
+  getTargetRole
+
+  addEnvHooks "\$targetOffset" sdkRootHook
+
+  # No local scope in sourced file
+  unset -v role_post
+  hook
+''

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -500,7 +500,7 @@ in
     assert lib.all isFromBootstrapFiles (with prevStage; [ coreutils gnugrep ]);
 
     assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage; [
-      autoconf automake bash binutils-unwrapped bison brotli cmake cpio curl cyrus_sasl db
+      autoconf automake bash binutils-unwrapped bison brotli cmake cpio cyrus_sasl db
       ed expat flex gettext gmp groff icu libedit libffi libiconv libidn2 libkrb5 libssh2
       libtool libunistring libxml2 m4 ncurses nghttp2 ninja openldap openssh openssl
       patchutils pbzx perl pkg-config.pkg-config python3 python3Minimal scons serf sqlite
@@ -527,7 +527,7 @@ in
     overrides = self: super: {
       inherit (prevStage) ccWrapperStdenv
         autoconf automake bash binutils binutils-unwrapped bison brotli cmake cmakeMinimal
-        coreutils cpio curl cyrus_sasl db ed expat flex gettext gmp gnugrep groff icu
+        coreutils cpio cyrus_sasl db ed expat flex gettext gmp gnugrep groff icu
         libedit libffi libiconv libidn2 libkrb5 libssh2 libtool libunistring libxml2 m4
         ncurses nghttp2 ninja openldap openssh openssl patchutils pbzx perl pkg-config
         python3Minimal scons sed serf sharutils sqlite subversion texinfo unzip which xz
@@ -599,7 +599,7 @@ in
     assert lib.all isFromBootstrapFiles (with prevStage; [ coreutils gnugrep ]);
 
     assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage; [
-      autoconf automake bash binutils-unwrapped bison brotli cmake cpio curl cyrus_sasl db
+      autoconf automake bash binutils-unwrapped bison brotli cmake cpio cyrus_sasl db
       ed expat flex gettext gmp groff icu libedit libffi libiconv libidn2 libkrb5 libssh2
       libtool libunistring libxml2 m4 ncurses nghttp2 ninja openldap openssh openssl
       patchutils pbzx perl pkg-config.pkg-config python3 python3Minimal scons serf sqlite
@@ -627,7 +627,7 @@ in
     overrides = self: super: {
       inherit (prevStage) ccWrapperStdenv
         autoconf automake bash binutils binutils-unwrapped bison brotli cmake cmakeMinimal
-        cpio curl cyrus_sasl db ed expat flex gettext gmp groff icu libedit libffi libiconv
+        cpio cyrus_sasl db ed expat flex gettext gmp groff icu libedit libffi libiconv
         libidn2 libkrb5 libssh2 libtool libunistring libxml2 m4 ncurses nghttp2 ninja
         openldap openssh openssl patchutils pbzx perl pkg-config python3 python3Minimal
         scons sed serf sharutils sqlite subversion sysctl texinfo unzip which xz zlib zstd;
@@ -691,7 +691,7 @@ in
     ]);
 
     assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage; [
-      brotli curl libffi libiconv libidn2 libkrb5 libssh2 libunistring libxml2 ncurses
+      brotli libffi libiconv libidn2 libkrb5 libssh2 libunistring libxml2 ncurses
       nghttp2 openssl zlib zstd
     ]);
 
@@ -719,7 +719,7 @@ in
     overrides = self: super: {
       inherit (prevStage) ccWrapperStdenv
         autoconf automake binutils-unwrapped bison brotli cmake cmakeMinimal coreutils
-        cpio curl cyrus_sasl db ed expat flex gettext gmp gnugrep groff icu libedit libffi
+        cpio cyrus_sasl db ed expat flex gettext gmp gnugrep groff icu libedit libffi
         libiconv libidn2 libkrb5 libssh2 libtool libunistring libxml2 m4 ncurses nghttp2
         ninja openbsm openldap openpam openssh openssl patchutils pbzx perl pkg-config
         python3 python3Minimal scons serf sqlite subversion sysctl texinfo unzip which xz
@@ -782,7 +782,7 @@ in
     # previous stage2-Libsystem stdenv:
     assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage; [
       autoconf automake binutils-unwrapped bison brotli cmake cmakeMinimal coreutils
-      cpio curl cyrus_sasl db ed expat flex gettext gmp gnugrep groff icu libedit libidn2
+      cpio cyrus_sasl db ed expat flex gettext gmp gnugrep groff icu libedit libidn2
       libkrb5 libssh2 libtool libunistring m4 nghttp2 ninja openbsm openldap openpam openssh
       openssl patchutils pbzx perl pkg-config.pkg-config python3 python3Minimal scons serf
       sqlite subversion sysctl.provider texinfo unzip which xz zstd
@@ -818,7 +818,7 @@ in
 
     overrides = self: super: {
       inherit (prevStage) ccWrapperStdenv
-        autoconf automake bash bison brotli cmake cmakeMinimal coreutils cpio curl
+        autoconf automake bash bison brotli cmake cmakeMinimal coreutils cpio
         cyrus_sasl db ed expat flex gettext gmp gnugrep groff libedit libidn2 libkrb5
         libssh2 libtool libunistring m4 ncurses nghttp2 ninja openbsm openldap openpam
         openssh openssl patchutils pbzx perl pkg-config python3 python3Minimal scons serf
@@ -905,7 +905,7 @@ in
   (prevStage:
     # previous stage2-CF stdenv:
     assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage; [
-      autoconf automake bison brotli cmake cmakeMinimal coreutils cpio curl cyrus_sasl
+      autoconf automake bison brotli cmake cmakeMinimal coreutils cpio cyrus_sasl
       db ed expat flex gettext gmp gnugrep groff libedit libidn2 libkrb5 libssh2 libtool
       libunistring m4 ncurses nghttp2 ninja openbsm openldap openpam openssh openssl
       patchutils pbzx perl pkg-config.pkg-config python3 python3Minimal scons serf sqlite
@@ -942,7 +942,7 @@ in
     overrides = self: super: {
       inherit (prevStage) ccWrapperStdenv
         autoconf automake bash binutils binutils-unwrapped bison brotli cmake cmakeMinimal
-        coreutils cpio curl cyrus_sasl db ed expat flex gettext gmp gnugrep groff libedit
+        coreutils cpio cyrus_sasl db ed expat flex gettext gmp gnugrep groff libedit
         libidn2 libkrb5 libssh2 libtool libunistring m4 nghttp2 ninja openbsm openldap
         openpam openssh openssl patchutils pbzx perl pkg-config python3 python3Minimal scons
         sed serf sharutils sqlite subversion sysctl texinfo unzip which xz zstd
@@ -985,7 +985,7 @@ in
   (prevStage:
     # previous stage3 stdenv:
     assert lib.all isBuiltByBootstrapFilesCompiler (with prevStage; [
-      autoconf automake bison brotli cmake cmakeMinimal coreutils cpio curl cyrus_sasl
+      autoconf automake bison brotli cmake cmakeMinimal coreutils cpio cyrus_sasl
       db ed expat flex gettext gmp gnugrep groff libedit libidn2 libkrb5 libssh2 libtool
       libunistring m4 nghttp2 ninja openbsm openldap openpam openssh openssl patchutils pbzx
       perl pkg-config.pkg-config python3 python3Minimal scons serf sqlite subversion
@@ -1153,7 +1153,7 @@ in
   (prevStage:
     # previous stage4 stdenv:
     assert lib.all isBuiltByNixpkgsCompiler (with prevStage; [
-      bash binutils-unwrapped brotli bzip2 cpio curl diffutils ed file findutils gawk
+      bash binutils-unwrapped brotli bzip2 cpio diffutils ed file findutils gawk
       gettext gmp gnugrep gnumake gnused gnutar gzip icu libffi libiconv libidn2 libkrb5
       libssh2 libunistring libxml2 libyaml ncurses nghttp2 openbsm openpam openssl patch
       pbzx pcre python3Minimal xar xz zlib zstd
@@ -1302,7 +1302,7 @@ in
 
       overrides = self: super: {
         inherit (prevStage)
-          bash binutils brotli bzip2 coreutils cpio curl diffutils ed file findutils gawk
+          bash binutils brotli bzip2 coreutils cpio diffutils ed file findutils gawk
           gettext gmp gnugrep gnumake gnused gnutar gzip icu libffi libiconv libidn2 libssh2
           libunistring libxml2 libyaml ncurses nghttp2 openbsm openpam openssl patch pbzx
           pcre python3Minimal xar xz zlib zstd;

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -135,9 +135,11 @@ let
         hostPlatform = localSystem;
         targetPlatform = localSystem;
 
-        inherit config extraNativeBuildInputs;
+        inherit config;
 
         extraBuildInputs = [ prevStage.darwin.CF ];
+        extraNativeBuildInputs = extraNativeBuildInputs
+          ++ [ prevStage.darwin.apple_sdk.sdkRoot ];
 
         preHook = lib.optionalString (!isBuiltByNixpkgsCompiler bash) ''
           # Don't patch #!/interpreter because it leads to retained
@@ -196,6 +198,7 @@ in
     cpio = null;
 
     darwin = {
+      apple_sdk.sdkRoot = null;
       binutils = null;
       binutils-unwrapped = null;
       cctools = null;
@@ -435,6 +438,10 @@ in
       });
 
       darwin = super.darwin.overrideScope (selfDarwin: superDarwin: {
+        apple_sdk = superDarwin.apple_sdk // {
+          inherit (prevStage.darwin.apple_sdk) sdkRoot;
+        };
+
         # Use this stage’s CF to build configd. It’s required but can’t be included in the stdenv.
         configd = superDarwin.configd.overrideAttrs (old: {
           buildInputs = old.buildInputs or [ ] ++ [ self.darwin.CF ];
@@ -558,9 +565,13 @@ in
 
       darwin = super.darwin.overrideScope (_: superDarwin: {
         inherit (prevStage.darwin)
-          CF Libsystem binutils-unwrapped cctools cctools-port configd darwin-stubs dyld
+          CF sdkRoot Libsystem binutils-unwrapped cctools cctools-port configd darwin-stubs dyld
           launchd libclosure libdispatch libobjc locale objc4 postLinkSignHook
           print-reexports rewrite-tbd signingUtils sigtool;
+
+        apple_sdk = superDarwin.apple_sdk // {
+          inherit (prevStage.darwin.apple_sdk) sdkRoot;
+        };
       });
 
       llvmPackages = super.llvmPackages // (
@@ -637,6 +648,10 @@ in
         inherit (prevStage.darwin)
           CF Libsystem configd darwin-stubs dyld launchd libclosure libdispatch libobjc
           locale objc4 postLinkSignHook print-reexports rewrite-tbd signingUtils sigtool;
+
+        apple_sdk = superDarwin.apple_sdk // {
+          inherit (prevStage.darwin.apple_sdk) sdkRoot;
+        };
 
         # Avoid building unnecessary Python dependencies due to building LLVM manpages.
         cctools-llvm = superDarwin.cctools-llvm.override { enableManpages = false; };
@@ -735,6 +750,10 @@ in
         inherit (prevStage.darwin)
           CF binutils-unwrapped cctools configd darwin-stubs launchd libobjc libtapi locale
           objc4 print-reexports rewrite-tbd signingUtils sigtool;
+
+        apple_sdk = superDarwin.apple_sdk // {
+          inherit (prevStage.darwin.apple_sdk) sdkRoot;
+        };
       });
 
       llvmPackages = super.llvmPackages // (
@@ -773,7 +792,7 @@ in
     '';
   })
 
-  # This stage rebuilds CF and compiler-rt.
+  # This stage rebuilds CF, compiler-rt, and the sdkRoot derivation.
   #
   # CF requires:
   # - aarch64-darwin: libobjc (due to being apple_sdk.frameworks.CoreFoundation instead of swift-corefoundation)
@@ -958,6 +977,10 @@ in
           CF Libsystem binutils binutils-unwrapped cctools cctools-llvm cctools-port configd
           darwin-stubs dyld launchd libclosure libdispatch libobjc libtapi locale objc4
           postLinkSignHook print-reexports rewrite-tbd signingUtils sigtool;
+
+        apple_sdk = superDarwin.apple_sdk // {
+          inherit (prevStage.darwin.apple_sdk) sdkRoot;
+        };
       });
 
       llvmPackages = super.llvmPackages // (
@@ -1035,6 +1058,10 @@ in
         inherit (prevStage.darwin) dyld CF Libsystem darwin-stubs
           # CF dependencies - don’t rebuild them.
           libobjc objc4;
+
+        apple_sdk = superDarwin.apple_sdk // {
+          inherit (prevStage.darwin.apple_sdk) sdkRoot;
+        };
 
         signingUtils = superDarwin.signingUtils.override {
           inherit (selfDarwin) sigtool;
@@ -1206,7 +1233,7 @@ in
 
       extraNativeBuildInputs = lib.optionals localSystem.isAarch64 [
         prevStage.updateAutotoolsGnuConfigScriptsHook
-      ];
+      ] ++ [ prevStage.darwin.apple_sdk.sdkRoot ];
 
       extraBuildInputs = [ prevStage.darwin.CF ];
 
@@ -1293,6 +1320,7 @@ in
         dyld
         libtapi
         locale
+        apple_sdk.sdkRoot
       ]
       ++ lib.optional useAppleSDKLibs [ objc4 ]
       ++ lib.optionals doSign [ postLinkSignHook sigtool signingUtils ]);
@@ -1307,9 +1335,13 @@ in
           libunistring libxml2 libyaml ncurses nghttp2 openbsm openpam openssl patch pbzx
           pcre python3Minimal xar xz zlib zstd;
 
-        darwin = super.darwin.overrideScope (_: _: {
+        darwin = super.darwin.overrideScope (_: superDarwin: {
           inherit (prevStage.darwin)
             CF ICU Libsystem darwin-stubs dyld locale libobjc libtapi rewrite-tbd xnu;
+
+          apple_sdk = superDarwin.apple_sdk // {
+            inherit (prevStage.darwin.apple_sdk) sdkRoot;
+          };
         } // lib.optionalAttrs (super.stdenv.targetPlatform == localSystem) {
           inherit (prevStage.darwin) binutils binutils-unwrapped cctools-llvm cctools-port;
         });

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -244,7 +244,7 @@ in
           version = "boot";
         };
 
-        binutils = (import ../../build-support/bintools-wrapper) {
+        binutils = super.wrapBintoolsWith {
           name = "bootstrap-stage0-binutils-wrapper";
 
           nativeTools = false;

--- a/pkgs/stdenv/darwin/override-sdk.nix
+++ b/pkgs/stdenv/darwin/override-sdk.nix
@@ -1,0 +1,437 @@
+# The basic algorithm is to rewrite the propagated inputs of a package and any of its
+# own propagated inputs recursively to replace references from the default SDK with
+# those from the requested SDK version. This is done across all propagated inputs to
+# avoid making assumptions about how those inputs are being used.
+#
+# For example, packages may propagate target-target dependencies with the expectation that
+# they will be just build inputs when the package itself is used as a native build input.
+#
+# To support this use case and operate without regard to the original package set,
+# `overrideSDK` creates a mapping from the default SDK in all package categories to the
+# requested SDK. If the lookup fails, it is assumed the package is not part of the SDK.
+# Non-SDK packages are processed per the algorithm described above.
+{
+  lib,
+  stdenvNoCC,
+  extendMkDerivationArgs,
+  pkgsBuildBuild,
+  pkgsBuildHost,
+  pkgsBuildTarget,
+  pkgsHostHost,
+  pkgsHostTarget,
+  pkgsTargetTarget,
+}@args:
+
+let
+  # Takes a mapping from a package to its replacement and transforms it into a list of
+  # mappings by output (e.g., a package with three outputs produces a list of size 3).
+  expandOutputs =
+    mapping:
+    map (output: {
+      name = builtins.unsafeDiscardStringContext (lib.getOutput output mapping.original);
+      value = lib.getOutput output mapping.replacement;
+    }) mapping.original.outputs;
+
+  # Produces a list of mappings from the default SDK to the new SDK (`sdk`).
+  # `attr` indicates which SDK path to remap (e.g., `libs` remaps `apple_sdk.libs`).
+  #
+  # TODO: Update once the SDKs have been refactored to a common pattern to better handle
+  # frameworks that are not present in both SDKs. Currently, they’re dropped.
+  mkMapping =
+    attr: pkgs: sdk:
+    lib.foldlAttrs (
+      mappings: name: pkg:
+      let
+        # Avoid evaluation failures due to missing or throwing
+        # frameworks (such as QuickTime in the 11.0 SDK).
+        maybeReplacement = builtins.tryEval sdk.${attr}.${name} or { success = false; };
+      in
+      if maybeReplacement.success then
+        mappings
+        ++ expandOutputs {
+          original = pkg;
+          replacement = maybeReplacement.value;
+        }
+      else
+        mappings
+    ) [ ] pkgs.darwin.apple_sdk.${attr};
+
+  # Produces a list of overrides for the given package set, SDK, and version.
+  # If you want to manually specify a mapping, this is where you should do it.
+  mkOverrides =
+    pkgs: sdk: version:
+    lib.concatMap expandOutputs [
+      # Libsystem needs to match the one used by the SDK or weird errors happen.
+      {
+        original = pkgs.darwin.apple_sdk.Libsystem;
+        replacement = sdk.Libsystem;
+      }
+      # Make sure darwin.CF is mapped to the correct version for the SDK.
+      {
+        original = pkgs.darwin.CF;
+        replacement = sdk.frameworks.CoreFoundation;
+      }
+      # libobjc needs to be handled specially because it’s not actually in the SDK.
+      {
+        original = pkgs.darwin.libobjc;
+        replacement = sdk.objc4;
+      }
+      # Unfortunately, this is not consistent between Darwin SDKs in nixpkgs, so
+      # try both versions to map between them.
+      {
+        original = pkgs.darwin.apple_sdk.sdk or pkgs.darwin.apple_sdk.MacOSX-SDK;
+        replacement = sdk.sdk or sdk.MacOSX-SDK;
+      }
+      # Remap the SDK root. This is used by clang to set the SDK version when
+      # linking. This behavior is automatic by clang and can’t be overriden.
+      # Otherwise, without the SDK root set, the SDK version will be inferred to
+      # be the same as the deployment target, which is not usually what you want.
+      {
+        original = pkgs.darwin.apple_sdk.sdkRoot;
+        replacement = sdk.sdkRoot;
+      }
+      # Override xcodebuild because it hardcodes the SDK version.
+      # TODO: Make xcodebuild defer to the SDK root set in the stdenv.
+      {
+        original = pkgs.xcodebuild;
+        replacement = pkgs.xcodebuild.override {
+          # Do the override manually to avoid an infinite recursion.
+          stdenv = pkgs.stdenv.override (old: {
+            buildPlatform = mkPlatform version old.buildPlatform;
+            hostPlatform = mkPlatform version old.hostPlatform;
+            targetPlatform = mkPlatform version old.targetPlatform;
+
+            allowedRequisites = null;
+            cc = mkCC sdk.Libsystem old.cc;
+          });
+        };
+      }
+    ];
+
+  mkBintools =
+    Libsystem: bintools:
+    if bintools ? override then
+      bintools.override { libc = Libsystem; }
+    else
+      let
+        # `override` isn’t available, so bintools has to be rewrapped with the new libc.
+        # Most of the required arguments can be recovered except for `postLinkSignHook`
+        # and `signingUtils`, which have to be scrapped from the original’s `postFixup`.
+        # This isn’t ideal, but it works.
+        postFixup = lib.splitString "\n" bintools.postFixup;
+
+        postLinkSignHook = lib.pipe postFixup [
+          (lib.findFirst (lib.hasPrefix "echo 'source") null)
+          (builtins.match "^echo 'source (.*-post-link-sign-hook)' >> \\$out/nix-support/post-link-hook$")
+          lib.head
+        ];
+
+        signingUtils = lib.pipe postFixup [
+          (lib.findFirst (lib.hasPrefix "export signingUtils") null)
+          (builtins.match "^export signingUtils=(.*)$")
+          lib.head
+        ];
+
+        newBintools = pkgsBuildTarget.wrapBintoolsWith {
+          inherit (bintools) name;
+
+          buildPackages = { };
+          libc = Libsystem;
+
+          inherit lib;
+
+          coreutils = bintools.coreutils_bin;
+          gnugrep = bintools.gnugrep_bin;
+
+          inherit (bintools) bintools;
+
+          inherit postLinkSignHook signingUtils;
+        };
+      in
+      lib.getOutput bintools.outputName newBintools;
+
+  mkCC =
+    Libsystem: cc:
+    if cc ? override then
+      cc.override {
+        bintools = mkBintools Libsystem cc.bintools;
+        libc = Libsystem;
+      }
+    else
+      builtins.throw "CC has no override: ${cc}";
+
+  mkPlatform =
+    version: platform:
+    platform
+    // lib.optionalAttrs platform.isDarwin { inherit (version) darwinMinVersion darwinSdkVersion; };
+
+  # Creates a stub package. Unchanged files from the original package are symlinked
+  # into the package. The contents of `nix-support` are updated to reference any
+  # replaced packages.
+  #
+  # Note: `env` is an attrset containing `outputs` and `dependencies`.
+  # `dependencies` is a regex passed to sed and must be `passAsFile`.
+  mkProxyPackage =
+    name: env:
+    stdenvNoCC.mkDerivation {
+      inherit name;
+
+      inherit (env) outputs replacements sourceOutputs;
+
+      # Take advantage of the fact that replacements and sourceOutputs will be passed
+      # via JSON and parsed into environment variables.
+      __structuredAttrs = true;
+
+      buildCommand = ''
+        # Map over the outputs in the package being replaced to make sure the proxy is
+        # a fully functional replacement. This is like `symlinkJoin` except for
+        # outputs and the contents of `nix-support`, which will be customized.
+        function replacePropagatedInputs() {
+          local sourcePath=$1
+          local targetPath=$2
+
+          mkdir -p "$targetPath"
+
+          local sourceFile
+          for sourceFile in "$sourcePath"/*; do
+            local fileName=$(basename "$sourceFile")
+            local targetFile="$targetPath/$fileName"
+
+            if [ -d "$sourceFile" ]; then
+              replacePropagatedInputs "$sourceFile" "$targetPath/$fileName"
+              # Check to see if any of the files in the folder were replaced.
+              # Otherwise, replace the folder with a symlink if none were changed.
+              if [ "$(find -maxdepth 1 "$targetPath/$fileName" -not -type l)" = "" ]; then
+                rm "$targetPath/$fileName"/*
+                ln -s "$sourceFile" "$targetPath/$fileName"
+              fi
+            else
+              cp "$sourceFile" "$targetFile"
+              local original
+              for original in "''${!replacements[@]}"; do
+                substituteInPlace "$targetFile" \
+                  --replace-quiet "$original" "''${replacements[$original]}"
+              done
+              if cmp -s "$sourceFile" "$targetFile"; then
+                rm "$targetFile"
+                ln -s "$sourceFile" "$targetFile"
+              fi
+            fi
+          done
+        }
+
+        local outputName
+        for outputName in "''${!outputs[@]}"; do
+          local outPath=''${outputs[$outputName]}
+          mkdir -p "$outPath"
+
+          local sourcePath
+          for sourcePath in "''${sourceOutputs[$outputName]}"/*; do
+            sourceName=$(basename "$sourcePath")
+            # `nix-support` is special-cased because any propagated inputs need their
+            # SDK frameworks replaced with those from the requested SDK.
+            if [ "$sourceName" == "nix-support" ]; then
+              replacePropagatedInputs "$sourcePath" "$outPath/nix-support"
+            else
+              ln -s "$sourcePath" "$outPath/$sourceName"
+            fi
+          done
+        done
+      '';
+    };
+
+  # Gets all propagated inputs in a package. This does not recurse.
+  getPropagatedInputs =
+    pkg:
+    lib.optionals (lib.isDerivation pkg) (
+      lib.concatMap (input: pkg.${input} or [ ]) [
+        "depsBuildBuildPropagated"
+        "propagatedNativeBuildInputs"
+        "depsBuildTargetPropagated"
+        "depsHostHostPropagated"
+        "propagatedBuildInputs"
+        "depsTargetTargetPropagated"
+      ]
+    );
+
+  # Looks up the replacement for `pkg` in the `newPackages` mapping. If `pkg` is a
+  # compiler (meaning it has a `libc` attribute), the compiler will be overriden.
+  getReplacement =
+    newPackages: pkg:
+    let
+      pkgOrCC =
+        if pkg.libc or null != null then
+          # Heuristic to determine whether package is a compiler or bintools.
+          if pkg.wrapperName == "CC_WRAPPER" then
+            mkCC (getReplacement newPackages pkg.libc) pkg
+          else
+            mkBintools (getReplacement newPackages pkg.libc) pkg
+        else
+          pkg;
+    in
+    if lib.isDerivation pkg then
+      newPackages.${builtins.unsafeDiscardStringContext pkg} or pkgOrCC
+    else
+      pkg;
+
+  # Replaces all packages propagated by `pkgs` using the `newPackages` mapping.
+  # It is assumed that all possible overrides have already been incorporated into
+  # the mapping. If any propagated packages are replaced, a proxy package will be
+  # created with references to the old packages replaced in `nix-support`.
+  replacePropagatedPackages =
+    newPackages: pkg:
+    let
+      propagatedInputs = getPropagatedInputs pkg;
+      env = {
+        inherit (pkg) outputs;
+
+        replacements = lib.pipe propagatedInputs [
+          (lib.filter (pkg: pkg != null))
+          (map (dep: {
+            name = builtins.unsafeDiscardStringContext dep;
+            value = getReplacement newPackages dep;
+          }))
+          (lib.filter (mapping: mapping.name != mapping.value))
+          lib.listToAttrs
+        ];
+
+        sourceOutputs = lib.genAttrs pkg.outputs (output: lib.getOutput output pkg);
+      };
+    in
+    # Only remap the package’s propagated inputs if there are any and if any of them
+    # had packages remapped (with frameworks or proxy packages).
+    if propagatedInputs != [ ] && env.replacements != { } then mkProxyPackage pkg.name env else pkg;
+
+  # Gets all propagated dependencies in a package in reverse order sorted topologically.
+  # This takes advantage of the fact that items produced by `operator` are pushed to
+  # the end of the working set, ensuring that dependencies always appear after their
+  # parent in the list with leaf nodes at the end.
+  topologicallyOrderedPropagatedDependencies =
+    pkgs:
+    let
+      mapPackageDeps = lib.flip lib.pipe [
+        (lib.filter (pkg: pkg != null))
+        (map (pkg: {
+          key = builtins.unsafeDiscardStringContext pkg;
+          package = pkg;
+          deps = getPropagatedInputs pkg;
+        }))
+      ];
+    in
+    lib.genericClosure {
+      startSet = mapPackageDeps pkgs;
+      operator = { deps, ... }: mapPackageDeps deps;
+    };
+
+  # Returns a package mapping based on remapping all propagated packages.
+  getPackageMapping =
+    baseMapping: input:
+    let
+      dependencies = topologicallyOrderedPropagatedDependencies input;
+    in
+    lib.foldr (
+      pkg: newPackages:
+      let
+        replacement = replacePropagatedPackages newPackages pkg.package;
+        outPath = pkg.key;
+      in
+      if pkg.key == null || newPackages ? ${outPath} then
+        newPackages
+      else
+        newPackages // { ${outPath} = replacement; }
+    ) baseMapping dependencies;
+
+  overrideSDK =
+    stdenv: sdkVersion:
+    let
+      newVersion = {
+        inherit (stdenv.hostPlatform) darwinMinVersion darwinSdkVersion;
+      } // (if lib.isAttrs sdkVersion then sdkVersion else { darwinSdkVersion = sdkVersion; });
+
+      inherit (newVersion) darwinMinVersion darwinSdkVersion;
+
+      # Used to get an SDK version corresponding to the requested `darwinSdkVersion`.
+      # TODO: Treat `darwinSdkVersion` as a constraint rather than as an exact version.
+      resolveSDK = pkgs: pkgs.darwin."apple_sdk_${lib.replaceStrings [ "." ] [ "_" ] darwinSdkVersion}";
+
+      # `newSdkPackages` is constructed based on the assumption that SDK packages only
+      # propagate versioned packages from that SDK -- that they neither propagate
+      # unversioned SDK packages nor propagate non-SDK packages (such as curl).
+      #
+      # Note: `builtins.unsafeDiscardStringContext` is used to allow the path from the
+      # original package output to be mapped to the replacement. This is safe because
+      # the value is not persisted anywhere and necessary because store paths are not
+      # allowed as attrset names otherwise.
+      baseSdkMapping = lib.pipe args [
+        (lib.flip removeAttrs [
+          "lib"
+          "stdenvNoCC"
+          "extendMkDerivationArgs"
+        ])
+        (lib.filterAttrs (_: lib.hasAttr "darwin"))
+        lib.attrValues
+        (lib.concatMap (
+          pkgs:
+          let
+            newSDK = resolveSDK pkgs;
+
+            frameworks = mkMapping "frameworks" pkgs newSDK;
+            libs = mkMapping "libs" pkgs newSDK;
+            overrides = mkOverrides pkgs newSDK newVersion;
+          in
+          frameworks ++ libs ++ overrides
+        ))
+        lib.listToAttrs
+      ];
+
+      # Remaps all inputs given to the requested SDK version. The result is an attrset
+      # that can be passed to `extendMkDerivationArgs`.
+      mapInputsToSDK =
+        inputs: args:
+        lib.pipe inputs [
+          (lib.filter (input: args ? ${input}))
+          (lib.flip lib.genAttrs (
+            inputName:
+            let
+              input = args.${inputName};
+              newPackages = getPackageMapping baseSdkMapping input;
+            in
+            map (getReplacement newPackages) input
+          ))
+        ];
+    in
+    stdenv.override (
+      old:
+      {
+        buildPlatform = mkPlatform newVersion old.buildPlatform;
+        hostPlatform = mkPlatform newVersion old.hostPlatform;
+        targetPlatform = mkPlatform newVersion old.targetPlatform;
+      }
+      # Only perform replacements if the SDK version has changed. Changing only the
+      # deployment target does not require replacing the libc or SDK dependencies.
+      // lib.optionalAttrs (old.hostPlatform.darwinSdkVersion != darwinSdkVersion) {
+        allowedRequisites = null;
+
+        mkDerivationFromStdenv = extendMkDerivationArgs old (mapInputsToSDK [
+          "depsBuildBuild"
+          "nativeBuildInputs"
+          "depsBuildTarget"
+          "depsHostHost"
+          "buildInputs"
+          "depsTargetTarget"
+          "depsBuildBuildPropagated"
+          "propagatedNativeBuildInputs"
+          "depsBuildTargetPropagated"
+          "depsHostHostPropagated"
+          "propagatedBuildInputs"
+          "depsTargetTargetPropagated"
+        ]);
+
+        cc = getReplacement baseSdkMapping old.cc;
+
+        extraBuildInputs = map (getReplacement baseSdkMapping) stdenv.extraBuildInputs;
+        extraNativeBuildInputs = map (getReplacement baseSdkMapping) stdenv.extraNativeBuildInputs;
+      }
+    );
+in
+overrideSDK


### PR DESCRIPTION
## Description of changes

This PR makes several improvements to the Darwin stdenv situation.

### Adds SDK root

It adds the SDK version to the stdenv as a new `darwin.apple_sdk.sdkRoot` package. This is done via a hook that adds `-isysroot` with a path to a stub SDK that just defines version information (based on the `xcbuild.sdk`). This is needed because clang passes `-platform_version <deployment target> <sdk version>` unconditionally to the linker, and the SDK version is inferred to be the same as the deployment target if `-isysroot` or `SDKROOT` do not point to SDK from which it can get the version.
 
macOS implements different behaviors depending on the SDK version. There are two notable examples: dark mode and version checks.

macOS requires the linked SDK to be at least 10.14 for dark mode to work. Currently, x86_64-darwin binaries in nixpkgs do not work with dark mode. With the SDK root specified, clang will pass the correct SDK version, ensuring that binaries linked against the 11.0 SDK work as expected.

For version checks, macOS returns a compatible version when the linked SDK is older than 11.0. I ran into that issue while working on https://github.com/NixOS/nixpkgs/issues/236414. MetalD3D checks the macOS version, but because the load commands in Wine’s binary indicate an older SDK, macOS returns a “compatible” version: 10.20. Since the check is for 14, the check fails, and MetalD3D does not work as expected.

Closes #265139.

### Fleshes out `overrideSDK`

This PR includes a rewrite of `overrideSDK`, addressing most of the issues identified in https://github.com/NixOS/nixpkgs/issues/242666#issuecomment-1803866452. This was necessary to support building Rust applications such as lapce, neovide, and wezterm on x86_64-darwin using the 11.0 SDK. It is also necessary to fix building applications that use `wrapGAppsHook` and the 11.0 SDK.

According to ofborg’s evalulation performance check, the rewritten `overrideSDK` performs about the same as the previous version even though it is more capable: it supports replacing inputs of all types, supports additional SDK-based overrides (libobjc, libs, private frameworks), and should be easier to maintain. It should also work with cross-compilation, but this is untested due to needing https://github.com/NixOS/nixpkgs/pull/256590 to fix cross-compilation support.

I plan to address overriding the SDK for Rust in a separate PR. There are some changes to `rustPlatform` needed to make it work robustly with overriding the SDK. Documentation will also follow in a separate PR.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
