### PR TITLE
nixos/hardened: fix lower bounds of hardened options

### DIFF
--- a/pkgs/os-specific/linux/kernel/hardened/config.nix
+++ b/pkgs/os-specific/linux/kernel/hardened/config.nix
@@ -60,11 +60,11 @@ assert (versionAtLeast version "4.9");
   PAGE_POISONING_ZERO      = whenOlder "5.11" yes;
 
   # Enable init_on_alloc and init_on_free by default
-  INIT_ON_ALLOC_DEFAULT_ON = yes;
-  INIT_ON_FREE_DEFAULT_ON  = yes;
+  INIT_ON_ALLOC_DEFAULT_ON = whenAtLeast "5.3" yes;
+  INIT_ON_FREE_DEFAULT_ON  = whenAtLeast "5.3" yes;
 
   # Wipe all caller-used registers on exit from a function
-  ZERO_CALL_USED_REGS = yes;
+  ZERO_CALL_USED_REGS = whenAtLeast "5.15" yes;
 
   # Enable the SafeSetId LSM
   SECURITY_SAFESETID = whenAtLeast "5.1" yes;
@@ -86,8 +86,8 @@ assert (versionAtLeast version "4.9");
   # https://www.kernel.org/doc/html/latest/dev-tools/ubsan.html
   # https://developers.redhat.com/blog/2014/10/16/gcc-undefined-behavior-sanitizer-ubsan
   UBSAN      = yes;
-  UBSAN_TRAP = yes;
-  UBSAN_BOUNDS = yes;
+  UBSAN_TRAP = whenAtLeast "5.7" yes;
+  UBSAN_BOUNDS = whenAtLeast "5.7" yes;
   UBSAN_SANITIZE_ALL = yes;
   UBSAN_LOCAL_BOUNDS = option yes; # clang only
   CFI_CLANG = option yes; # clang only Control Flow Integrity since 6.1


### PR DESCRIPTION
Without the change build of `linux-config-4.19.306` fails as https://cache.nixos.org/log/994zy6g5fsb4p6c8jdwham8sp0mqh1w4-linux-config-4.19.306.drv:

    error: unused option: INIT_ON_ALLOC_DEFAULT_ON
    error: unused option: INIT_ON_FREE_DEFAULT_ON
    error: unused option: UBSAN_TRAP
    error: unused option: ZERO_CALL_USED_REGS

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
