### PR TITLE
phpExtensions.ioncube-loader: init at 13.0.2

### DIFF
--- a/pkgs/development/php-packages/ioncube-loader/default.nix
+++ b/pkgs/development/php-packages/ioncube-loader/default.nix
@@ -1,0 +1,57 @@
+{ stdenv
+, lib
+, fetchzip
+, php
+}:
+
+let
+  phpVersion = lib.versions.majorMinor php.version;
+
+  variant = {
+    "aarch64-darwin" = {
+      url = "https://web.archive.org/web/20240209234707/https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_arm64.tar.gz";
+      sha256 = "sha256-J6+bOXX9uRdrGouMAxt7nROjjfH4P2txb1hmPoHUmdM=";
+      prefix = "dar";
+    };
+    "aarch64-linux" = {
+      url = "https://web.archive.org/web/20240209234617/https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_aarch64.tar.gz";
+      sha256 = "sha256-oOO4zr0CssxVGIUIfmAujILqOfQf8dJPADkr03a8HAs=";
+      prefix = "lin";
+    };
+    "x86_64-linux" = {
+      url = "https://web.archive.org/web/20240209052345if_/https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz";
+      sha256 = "sha256-rsXKgxKHldBKDjJTsOdJP4SxfxLmMPDY+GizBpuDeyw=";
+      prefix = "lin";
+    };
+    "x86_64-darwin" = {
+      url = "https://web.archive.org/web/20240209234406/https://downloads.ioncube.com/loader_downloads/ioncube_loaders_mac_x86-64.tar.gz";
+      sha256 = "sha256-bz2hQOaFbXePa8MhAZHESpZMRjjBH51IgvbR2EfBYMg=";
+      prefix = "mac";
+    };
+  };
+in
+stdenv.mkDerivation {
+  version = "13.0.2";
+  pname = "ioncube-loader";
+  extensionName = "ioncube-loader";
+
+  src = fetchzip {
+    url = variant.${stdenv.hostPlatform.system}.url;
+    sha256 = variant.${stdenv.hostPlatform.system}.sha256;
+  };
+
+  installPhase = ''
+    mkdir -p $out/lib/php/extensions
+    cp $src/ioncube_loader_${variant.${stdenv.hostPlatform.system}.prefix}_${phpVersion}.so $out/lib/php/extensions/ioncube-loader.so
+  '';
+
+  meta = with lib; {
+    description = "Use ionCube-encoded files on a web server";
+    changelog = "https://www.ioncube.com/loaders.php";
+    homepage = "https://www.ioncube.com";
+    sourceProvenance = [ sourceTypes.binaryNativeCode ];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ neverbehave ];
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+  };
+}

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -260,6 +260,8 @@ lib.makeScope pkgs.newScope (self: with self; {
 
     inotify = callPackage ../development/php-packages/inotify { };
 
+    ioncube-loader = callPackage ../development/php-packages/ioncube-loader { };
+
     mailparse = callPackage ../development/php-packages/mailparse { };
 
     maxminddb = callPackage ../development/php-packages/maxminddb { };


### PR DESCRIPTION
## Description of changes

ioncube-loader is an extension to use ionCube-encoded files on a web server.

I am not entirely sure if ts(thread safety) version should be controlled by a parameter and right now they are ignored (file ends with `_ts`).

This PR has not yet built: I do a simple drv locally to test it but not against the whole nixpkgs. Any docs to test extension I could take a look? Thanks!

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
