### PR TITLE
darwin.d3dmetal: init at 1.1

### DIFF
--- a/pkgs/os-specific/darwin/d3dmetal/default.nix
+++ b/pkgs/os-specific/darwin/d3dmetal/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenvNoCC
+, requireFile
+, undmg
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "d3dmetal";
+  version = "1.1";
+
+  src = requireFile {
+    name = "Game_Porting_Toolkit_${finalAttrs.version}.dmg";
+    hash = "sha256-KoZRjX/OicMEJmZUp2EH05Wpp1VyJQlrc6g0iTSCt/E=";
+    url = "https://developer.apple.com/download/all/?q=game%20porting%20toolkit";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ undmg ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p "$out/lib/wine/x86_64-"{unix,windows}
+
+    cp -r lib/external "$out/lib"
+
+    for dll_so in atidxx64 d3d9 d3d10 d3d11 d3d12 dxgi; do
+      ln -s "$out/lib/external/libd3dshared.dylib" "$out/lib/wine/x86_64-unix/$dll_so.so"
+    done
+    cp -r lib/wine/x86_64-windows "$out/lib/wine"
+  '';
+
+  meta = with lib; {
+    description = "The D3D Metal component of Apple’s Gaming Porting Toolkit for use with Wine.";
+    license = licenses.unfree;
+    maintainers = [ maintainers.reckenrode ];
+    platforms = [ "x86_64-darwin" ];
+  };
+})

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -129,6 +129,8 @@ impure-cmds // appleSourcePackages // chooseLibs // {
   # TODO(@connorbaker): See https://github.com/NixOS/nixpkgs/issues/229389.
   cf-private = self.apple_sdk.frameworks.CoreFoundation;
 
+  d3dmetal = callPackage ../os-specific/darwin/d3dmetal { };
+
   DarwinTools = callPackage ../os-specific/darwin/DarwinTools { };
 
   darwin-stubs = callPackage ../os-specific/darwin/darwin-stubs { };


### PR DESCRIPTION
## Description of changes

Package D3DMetal for use with Wine. Part of implementing https://github.com/NixOS/nixpkgs/issues/236414. Patches to Wine will follow once https://github.com/NixOS/nixpkgs/pull/287609 is merged.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
