### PR TITLE
formats.envvars: init

### DIFF
--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -473,4 +473,56 @@ rec {
     '') {};
   };
 
+  envvars = {
+    export ? false
+  , listToStringSep ? ","
+  , listToStringFn ? lib.concatStringsSep listToStringSep
+  , boolToStringFn ? lib.boolToString
+  }: {
+    type = with lib.types; let
+      unescapedType = addCheck (attrsOf str) (attrs: (lib.attrNames attrs) == [ "_type" "value" ] && attrs._type == "unescaped");
+      valueType = nullOr (oneOf [
+        bool
+        float
+        int
+        path
+        str
+        unescapedType
+      ]);
+      valueType' = (either valueType (listOf valueType)) // {
+        description = "Environment variable";
+      };
+    in attrsOf valueType';
+
+    lib = {
+      mkUnescaped = value: {
+        _type = "unescaped";
+        inherit value;
+      };
+    };
+
+    generate = name: value: let
+      valueToString = v: let
+        innerListValues = replaceChar: v':
+          if lib.isAttrs v'
+            then v'.value
+          else lib.replaceStrings [ replaceChar ] [ "\\${replaceChar}" ] (
+            if lib.isBool v'
+              then boolToStringFn v'
+            else toString v');
+      in if lib.isList v
+        then if lib.any lib.isAttrs v
+          then ''"${listToStringFn (map (innerListValues "\"") v)}"''
+        else "'${listToStringFn (map (innerListValues "\'") v)}'"
+      else if lib.isAttrs v
+        then ''"${v.value}"''
+      else "'${if lib.isBool v then boolToStringFn v else toString v}'";
+    in pkgs.writeText name (lib.pipe value [
+      (lib.filterAttrs (_: v: v != null))
+      (lib.mapAttrsToList (n: v: "${n}=${valueToString v}"))
+      (xs: if export then (map (s: "export " + s)) xs else xs)
+      (map (s: s + "\n"))
+      lib.concatStrings
+    ]);
+  };
 }

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -250,4 +250,56 @@ in runBuildTests {
       \u0627\u0644\u062c\u0628\u0631 = \u0623\u0643\u062b\u0631 \u0645\u0646 \u0645\u062c\u0631\u062f \u0623\u0631\u0642\u0627\u0645
     '';
   };
+
+  testEnvvars = {
+    drv = evalFormat formats.envvars {} {
+      A = 1;
+      B = "two";
+      C = 3.14;
+      D = [ "a" "b" "c" ];
+      E = null;
+      F = true;
+      G = false;
+      H = (formats.envvars {}).lib.mkUnescaped "$(\"ls\")";
+      I = [ "a" 2 ((formats.envvars {}).lib.mkUnescaped "$(\"ls\")") ];
+    };
+    expected = ''
+      A='1'
+      B='two'
+      C='3.140000'
+      D='a,b,c'
+      F='true'
+      G='false'
+      H="$("ls")"
+      I="a,2,$("ls")"
+    '';
+  };
+
+  testEnvvarsAlternative = {
+    drv = evalFormat formats.envvars {
+      export = true;
+      listToStringSep = ":";
+      boolToStringFn = b: if b then "1" else "0";
+    } {
+      A = 1;
+      B = "two";
+      C = 3.14;
+      D = [ "a" "b" "c" ];
+      E = null;
+      F = true;
+      G = false;
+      H = (formats.envvars {}).lib.mkUnescaped "$(\"ls\")";
+      I = [ "a" 2 ((formats.envvars {}).lib.mkUnescaped "$(\"ls\")") ];
+    };
+    expected = ''
+      export A='1'
+      export B='two'
+      export C='3.140000'
+      export D='a:b:c'
+      export F='1'
+      export G='0'
+      export H="$("ls")"
+      export I="a:2:$("ls")"
+    '';
+  };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is a format specifically targeting software that use environment variables for configuration. A lot of modules modeled for these pieces of software can be seen hardcoding the arguments in a pre-RFC42 style. The aim is for this to act as a freeform for these modules.

I think there might be a discussion to be had about the name of the format. To me, `envvars` seemed reasonably short and easy to use, but maybe `environment` or `environmentVariables` is better?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
