### PR TITLE
nfs-ganesha: add tools output for mount.9P helper

### DIFF
--- a/pkgs/servers/nfs-ganesha/default.nix
+++ b/pkgs/servers/nfs-ganesha/default.nix
@@ -6,6 +6,7 @@
 stdenv.mkDerivation rec {
   pname = "nfs-ganesha";
   version = "5.7";
+  outputs = [ "out" "tools" ];
 
   src = fetchFromGitHub {
     owner = "nfs-ganesha";
@@ -43,8 +44,16 @@ stdenv.mkDerivation rec {
     nfs-utils
   ];
 
+  postPatch = ''
+    substituteInPlace src/tools/mount.9P --replace "/bin/mount" "/usr/bin/env mount"
+  '';
+
   postFixup = ''
     patchelf --add-rpath $out/lib $out/bin/ganesha.nfsd
+  '';
+
+  postInstall = ''
+    install -Dm755 $src/src/tools/mount.9P $tools/bin/mount.9P
   '';
 
   meta = with lib; {
@@ -54,5 +63,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     license = licenses.lgpl3Plus;
     mainProgram = "ganesha.nfsd";
+    outputsToInstall = [ "out" "tools" ];
   };
 }


### PR DESCRIPTION
## Description of changes

The nfs-ganesha mount.9P helper is a standalone shell script that makes
some aspects of mounting a 9P filesystem easier, e.g. instead of:
```
  mount -t 9p 192.168.10.2 /mnt -oaname=/home
```
it allows the familiar syntax:
```
  mount -t 9P 192.168.10.2:/home /mnt
```
As the mount helper is independent of the server, it's added here
separately from it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
