### PR TITLE
findex: 0.7.1 -> 0.8.1

### DIFF
--- a/pkgs/applications/misc/findex/default.nix
+++ b/pkgs/applications/misc/findex/default.nix
@@ -1,26 +1,38 @@
-{ lib, fetchFromGitHub, rustPlatform, pkg-config, keybinder3, gtk3 }:
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, wrapGAppsHook
+, keybinder3
+}:
 
 rustPlatform.buildRustPackage rec {
   pname = "findex";
-  version = "0.7.1";
+  version = "0.8.1";
 
   src = fetchFromGitHub {
     owner = "mdgaziur";
-    repo = pname;
+    repo = "findex";
     rev = "v${version}";
-    hash = "sha256-KaT6lEbrUelv/f9bIBW4bSCuExFu4b7XI7hcrO4mD0M=";
+    hash = "sha256-rxOVrl2Q27z5oo1J6D4ft4fKaOMOadmidflD0jK0+3k=";
   };
 
-  cargoHash = "sha256-7A+EF88DJrgsKPOJt2xaBnWSMkyhpFImyZmnHcyp+Dw=";
+  cargoHash = "sha256-MiD96suB88NZWg7Ay/ACZfOeE66WOe9dLsvtOhCQgGo=";
 
-  nativeBuildInputs = [
-    pkg-config
-  ];
+  postPatch = ''
+    # failing rust documentation tests and faulty quotes "`README.md`"
+    sed -i '/^\/\/\//d' ./crates/findex-plugin/src/lib.rs
+    substituteInPlace ./crates/findex/src/gui/css.rs \
+      --replace-fail '/opt/findex/style.css' "$out/share/findex/style.css"
+  '';
 
-  buildInputs = [
-    gtk3
-    keybinder3
-  ];
+  nativeBuildInputs = [ pkg-config wrapGAppsHook ];
+
+  buildInputs = [ keybinder3 ];
+
+  postInstall = ''
+    install -Dm644 css/style.css $out/share/findex/style.css
+  '';
 
   meta = with lib; {
     description = "Highly customizable application finder written in Rust and uses Gtk3";


### PR DESCRIPTION
## Description of changes

I originally thought this could be used on wayland, but it doesn't seem to work, so still need an xorg user to test it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
