### PR TITLE
 ruff: 0.1.15 -> 0.2.1

### DIFF
--- a/pkgs/development/tools/ruff/default.nix
+++ b/pkgs/development/tools/ruff/default.nix
@@ -1,6 +1,7 @@
 { lib
 , rustPlatform
 , fetchFromGitHub
+, fetchpatch
 , installShellFiles
 , stdenv
 , darwin
@@ -10,14 +11,23 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "ruff";
-  version = "0.1.15";
+  version = "0.2.1";
 
   src = fetchFromGitHub {
     owner = "astral-sh";
     repo = "ruff";
     rev = "refs/tags/v${version}";
-    hash = "sha256-DzdzMO9PEwf4HmpG8SxRJTmdrmkXuQ8RsIchvsKstH8=";
+    hash = "sha256-VcDDGi6fPGZ75+J7aOSr7S6Gt5bpr0vM2Sk/Utlmf4k=";
   };
+
+  patches = [
+    # TODO: remove at next release
+    (fetchpatch {
+      name = "filter-out-test-rules-in-ruleselector-json-schema";
+      url = "https://github.com/astral-sh/ruff/commit/49c5e715f9c85aa8d0412b2ec9b1dd6f7ae24c5c.patch";
+      hash = "sha256-s0Nv5uW3TKfKgro3V3E8Q0c8uOTgOKZQx9CxXge4YWE=";
+    })
+  ];
 
   # The following specific substitution is not working as the current directory is `/build/source` and thus has no mention of `ruff` in it.
   # https://github.com/astral-sh/ruff/blob/866bea60a5de3c59d2537b0f3a634ae0ac9afd94/crates/ruff/tests/show_settings.rs#L12
@@ -27,7 +37,7 @@ rustPlatform.buildRustPackage rec {
       --replace '"[BASEPATH]"' '"'$PWD'"'
   '';
 
-  cargoHash = "sha256-MpiWdNUs66OGYfOJo1kJQTCqjrk/DAYecaLf6GUUKew=";
+  cargoHash = "sha256-B7AiDNWEN4i/Lz9yczlRNXczQph52SMa3pcxK2AtO2A=";
 
   nativeBuildInputs = [
     installShellFiles


### PR DESCRIPTION
## Description of changes

Update:
- ruff: https://github.com/astral-sh/ruff/releases/tag/v0.2.1
cc @figsoda 
 ~~- python311Packages.python-lsp-ruff: https://github.com/python-lsp/python-lsp-ruff/releases/tag/v2.1.0
cc @linsui~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
