### PR TITLE
nanosaur: unstable-2021-12-03 -> 1.4.4-unstable-2023-05-21

### DIFF
--- a/pkgs/games/nanosaur/default.nix
+++ b/pkgs/games/nanosaur/default.nix
@@ -1,14 +1,14 @@
-{ lib, stdenv, fetchFromGitHub, SDL2, cmake, makeWrapper }:
+{ lib, stdenv, fetchFromGitHub, SDL2, cmake, makeWrapper, unstableGitUpdater }:
 
 stdenv.mkDerivation rec {
   pname = "nanosaur";
-  version = "unstable-2021-12-03";
+  version = "1.4.4-unstable-2023-05-21";
 
   src = fetchFromGitHub {
     owner = "jorio";
     repo = pname;
-    rev = "b567a3e6d7fd1cbc43800cfaa1bd82f31c6d9fae";
-    sha256 = "sha256-P/o6uSwUV6O8u8XNXN9YyA8XlgEUkqGj3SC+oD2/GKQ=";
+    rev = "c9753648996b09a17c8bd526d8309b73fb14c435";
+    sha256 = "sha256-0xG/HSUF65eV+fSJ2geDv5VUxTeso9dulrLgE1KNDhc=";
     fetchSubmodules = true;
   };
 
@@ -27,10 +27,12 @@ stdenv.mkDerivation rec {
     mv Data ReadMe.txt "$out/share/Nanosaur/"
     install -Dm755 {.,$out/bin}/Nanosaur
     wrapProgram $out/bin/Nanosaur --chdir "$out/share/Nanosaur"
-    install -Dm644 $src/packaging/nanosaur.desktop $out/share/applications/nanosaur.desktop
-    install -Dm644 $src/packaging/nanosaur-desktopicon.png $out/share/pixmaps/nanosaur-desktopicon.png
+    install -Dm644 $src/packaging/io.jor.nanosaur.desktop $out/share/applications/nanosaur.desktop
+    install -Dm644 $src/packaging/io.jor.nanosaur.png $out/share/pixmaps/nanosaur-desktopicon.png
     runHook postInstall
   '';
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = with lib; {
     description = "A port of Nanosaur, a 1998 Macintosh game by Pangea Software, for modern operating systems";
@@ -41,6 +43,7 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/jorio/Nanosaur";
     license = licenses.cc-by-sa-40;
+    mainProgram = "Nanosaur";
     maintainers = with maintainers; [ lux ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
Fixes build failure against `gcc-13` as
https://hydra.nixos.org/build/247659575:

    /build/source/extern/Pomme/src/PommeDebug.h:21:34: error: 'uint32_t' was not declared in this scope
       21 |         std::string FourCCString(uint32_t t, char filler = '?');
          |                                  ^~~~~~~~

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
