### PR TITLE
python312Packages.libpcap: 1.11.0b7 -> 1.11.0b8

### DIFF
--- a/pkgs/development/python-modules/libpcap/default.nix
+++ b/pkgs/development/python-modules/libpcap/default.nix
@@ -7,11 +7,12 @@
 , pkgsLibpcap
 , pkg-about
 , setuptools
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "libpcap";
-  version = "1.11.0b7";
+  version = "1.11.0b8";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -19,7 +20,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
-    hash = "sha256-gEWFqmeOJTVHdjcSOxfVLZtrNSO3CTY1L2VcXOu7q7k=";
+    hash = "sha256-6XhEVOO2Z2rFZiMz4d32tTR+xUu1KdMdDjChmt2wsQo=";
   };
 
   nativeBuildInputs = [
@@ -29,7 +30,7 @@ buildPythonPackage rec {
   # tox is listed in build requirements but not actually used to build
   # keeping it as a requirement breaks the build unnecessarily
   postPatch = ''
-    sed  -i "/requires/s/, 'tox>=3.25.1'//"  pyproject.toml
+    sed -i "/requires/s/, 'tox>=[^']*'//" pyproject.toml
     cat <<EOF >src/libpcap/libpcap.cfg
     [libpcap]
     LIBPCAP = ${pkgsLibpcap}/lib/libpcap${stdenv.hostPlatform.extensions.sharedLibrary}
@@ -42,8 +43,15 @@ buildPythonPackage rec {
     pkg-about
   ];
 
-  # Project has tests, but I can't get them to run even outside of nix
-  doCheck = false;
+  preCheck = ''
+    pushd tests
+  '';
+  postCheck = ''
+    popd
+  '';
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [
     "libpcap"
@@ -61,6 +69,7 @@ buildPythonPackage rec {
       It is fully compliant implementation of the original C libpcap from 1.0.0 up to 1.9.0 API and the WinPcap’s 4.1.3 libpcap (1.0.0rel0b) API by implementing whole its functionality in a clean Python instead of C.
     '';
     homepage = "https://github.com/karpierz/libpcap/";
+    changelog = "https://github.com/karpierz/libpcap/blob/${version}/CHANGES.rst";
     license = licenses.bsd3;
     maintainers = teams.ororatech.members;
   };


### PR DESCRIPTION
~Requires #287746~

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux (cross compiled)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
