### PR TITLE
python313.pkgs.installer: Fix build

### DIFF
--- a/pkgs/development/python-modules/bootstrap/installer/default.nix
+++ b/pkgs/development/python-modules/bootstrap/installer/default.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation {
   pname = "${python.libPrefix}-bootstrap-${installer.pname}";
-  inherit (installer) version src meta;
+  inherit (installer) version src patches meta;
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/development/python-modules/installer/default.nix
+++ b/pkgs/development/python-modules/installer/default.nix
@@ -1,6 +1,6 @@
 { lib
 , buildPythonPackage
-, pythonOlder
+, pythonAtLeast
 , fetchFromGitHub
 , pytestCheckHook
 , flit-core
@@ -19,6 +19,12 @@ buildPythonPackage rec {
     rev = version;
     hash = "sha256-thHghU+1Alpay5r9Dc3v7ATRFfYKV8l9qR0nbGOOX/A=";
   };
+
+  patches = lib.optionals (pythonAtLeast "3.13") [
+    # Fix compatibility with Python 3.13
+    # https://github.com/pypa/installer/pull/201
+    ./python313-compat.patch
+  ];
 
   nativeBuildInputs = [ flit-core ];
 

--- a/pkgs/development/python-modules/installer/python313-compat.patch
+++ b/pkgs/development/python-modules/installer/python313-compat.patch
@@ -1,0 +1,55 @@
+From b23f89b10cf5d179bd6b0bad195ee36f43a5fb9e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Edgar=20Ram=C3=ADrez=20Mondrag=C3=B3n?=
+ <16805946+edgarrmondragon@users.noreply.github.com>
+Date: Tue, 19 Dec 2023 06:09:41 -0600
+Subject: [PATCH] Fix removed `importlib.resources.read_binary` in Python 3.13
+ (#201)
+
+diff --git a/noxfile.py b/noxfile.py
+index a690c59..6a69cce 100644
+--- a/noxfile.py
++++ b/noxfile.py
+@@ -22,7 +22,7 @@ def lint(session):
+     session.run("pre-commit", "run", "--all-files", *args)
+ 
+ 
+-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3"])
++@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3"])
+ def test(session):
+     session.install(".")
+     session.install("-r", "tests/requirements.txt")
+@@ -42,7 +42,7 @@ def test(session):
+     )
+ 
+ 
+-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3"])
++@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3"])
+ def doctest(session):
+     session.install(".")
+     session.install("-r", "docs/requirements.txt")
+diff --git a/src/installer/scripts.py b/src/installer/scripts.py
+index d18060b..c9f96b4 100644
+--- a/src/installer/scripts.py
++++ b/src/installer/scripts.py
+@@ -3,9 +3,19 @@
+ import io
+ import os
+ import shlex
++import sys
+ import zipfile
+-from importlib.resources import read_binary
+-from typing import TYPE_CHECKING, Mapping, Optional, Tuple
++from types import ModuleType
++from typing import TYPE_CHECKING, Mapping, Optional, Tuple, Union
++
++if sys.version_info >= (3, 9):  # pragma: no cover
++    from importlib.resources import files
++
++    def read_binary(package: Union[str, ModuleType], file_path: str) -> bytes:
++        return (files(package) / file_path).read_bytes()
++
++else:  # pragma: no cover
++    from importlib.resources import read_binary
+ 
+ from installer import _scripts
+ 


### PR DESCRIPTION
## Description of changes

Python 3.13 removed `importlib.resources.read_binary` breaking the build of `installer` package.
That is transitive dependency of `pygobject3` among others.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
