### PR TITLE
rcu: init at 2024.001n

### DIFF
--- a/pkgs/by-name/rc/rcu/Port-to-paramiko-3.x.patch
+++ b/pkgs/by-name/rc/rcu/Port-to-paramiko-3.x.patch
@@ -1,0 +1,104 @@
+From aad61b320d65953fddec10b019a186fc67f57a5d Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Sat, 10 Feb 2024 12:20:29 +0100
+Subject: [PATCH] src/model/transport.py: Port to paramiko 3.x
+
+---
+ src/model/transport.py | 19 +++++++++----------
+ 1 file changed, 9 insertions(+), 10 deletions(-)
+
+diff --git a/src/model/transport.py b/src/model/transport.py
+index 0c2ee16..5a2bd22 100644
+--- a/src/model/transport.py
++++ b/src/model/transport.py
+@@ -117,7 +117,6 @@ from paramiko.kex_gss import KexGSSGex, KexGSSGroup1, KexGSSGroup14
+ from paramiko.message import Message
+ from paramiko.packet import Packetizer, NeedRekeyException
+ from paramiko.primes import ModulusPack
+-from paramiko.py3compat import string_types, long, byte_ord, b, input, PY2
+ from paramiko.rsakey import RSAKey
+ from paramiko.ecdsakey import ECDSAKey
+ from paramiko.server import ServerInterface
+@@ -128,7 +127,7 @@ from paramiko.ssh_exception import (
+     ChannelException,
+     ProxyCommandFailure,
+ )
+-from paramiko.util import retry_on_signal, ClosingContextManager, clamp_value
++from paramiko.util import ClosingContextManager, clamp_value
+ 
+ 
+ # for thread cleanup
+@@ -396,7 +395,7 @@ class Transport(threading.Thread, ClosingContextManager):
+         self.active = False
+         self.hostname = None
+ 
+-        if isinstance(sock, string_types):
++        if isinstance(sock, str):
+             # convert "host:port" into (host, port)
+             hl = sock.split(":", 1)
+             self.hostname = hl[0]
+@@ -419,7 +418,7 @@ class Transport(threading.Thread, ClosingContextManager):
+                     sock = socket.socket(af, socket.SOCK_STREAM)
+                     sock.settimeout(1)
+                     try:
+-                        retry_on_signal(lambda: sock.connect((hostname, port)))
++                        sock.connect((hostname, port))
+                     except socket.error as e:
+                         reason = str(e)
+                     else:
+@@ -542,7 +541,7 @@ class Transport(threading.Thread, ClosingContextManager):
+         """
+         Returns a string representation of this object, for debugging.
+         """
+-        id_ = hex(long(id(self)) & xffffffff)
++        id_ = hex(int(id(self)) & xffffffff)
+         out = "<paramiko.Transport at {}".format(id_)
+         if not self.active:
+             out += " (unconnected)"
+@@ -1123,7 +1122,7 @@ class Transport(threading.Thread, ClosingContextManager):
+         m = Message()
+         m.add_byte(cMSG_IGNORE)
+         if byte_count is None:
+-            byte_count = (byte_ord(os.urandom(1)) % 32) + 10
++            byte_count = (os.urandom(1) % 32) + 10
+         m.add_bytes(os.urandom(byte_count))
+         self._send_user_message(m)
+ 
+@@ -1802,7 +1801,7 @@ class Transport(threading.Thread, ClosingContextManager):
+     def stop_thread(self):
+         self.active = False
+         self.packetizer.close()
+-        if PY2:
++        if False:
+             # Original join logic; #520 doesn't appear commonly present under
+             # Python 2.
+             while self.is_alive() and self is not threading.current_thread():
+@@ -1909,7 +1908,7 @@ class Transport(threading.Thread, ClosingContextManager):
+         m = Message()
+         m.add_mpint(self.K)
+         m.add_bytes(self.H)
+-        m.add_byte(b(id))
++        m.add_byte(id.encode("utf8"))
+         m.add_bytes(self.session_id)
+         # Fallback to SHA1 for kex engines that fail to specify a hex
+         # algorithm, or for e.g. transport tests that don't run kexinit.
+@@ -2037,14 +2036,14 @@ class Transport(threading.Thread, ClosingContextManager):
+ 
+         # active=True occurs before the thread is launched, to avoid a race
+         _active_threads.append(self)
+-        tid = hex(long(id(self)) & xffffffff)
++        tid = hex(int(id(self)) & xffffffff)
+         if self.server_mode:
+             self._log(DEBUG, "starting thread (server mode): {}".format(tid))
+         else:
+             self._log(DEBUG, "starting thread (client mode): {}".format(tid))
+         try:
+             try:
+-                self.packetizer.write_all(b(self.local_version + "\r\n"))
++                self.packetizer.write_all((self.local_version + "\r\n").encode("utf8"))
+                 self._log(
+                     DEBUG,
+                     "Local version/idstring: {}".format(self.local_version),
+-- 
+2.42.0
+

--- a/pkgs/by-name/rc/rcu/package.nix
+++ b/pkgs/by-name/rc/rcu/package.nix
@@ -1,0 +1,152 @@
+{ stdenv
+, lib
+, requireFile
+, fetchpatch
+, runCommand
+, rcu
+, testers
+, copyDesktopItems
+, desktopToDarwinBundle
+, libsForQt5
+, makeDesktopItem
+, python3Packages
+, system-config-printer
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "rcu";
+  version = "2024.001n";
+
+  format = "other";
+
+  src = let
+    src-tarball = requireFile {
+      name = "rcu-d${version}-source.tar.gz";
+      sha256 = "1snmf2cr242k946q6fh5b5fqdyafdbs8gbbdzchjhm7n9r1kxyca";
+      url = "http://www.davisr.me/projects/rcu/";
+    };
+  in runCommand "${src-tarball.name}-unpacked" {} ''
+    gunzip -ck ${src-tarball} | tar -xvf-
+    mv rcu $out
+  '';
+
+  patches = [
+    ./Port-to-paramiko-3.x.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace src/main.py \
+      --replace-fail "ui_basepath = '.'" "ui_basepath = '$out/share/rcu'"
+
+    substituteInPlace package_support/gnulinux/50-remarkable.rules \
+      --replace-fail 'GROUP="yourgroup"' 'GROUP="users"'
+  '';
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    libsForQt5.wrapQtAppsHook
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    desktopToDarwinBundle
+  ];
+
+  buildInputs = [
+    libsForQt5.qtbase
+    libsForQt5.qtwayland
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    certifi
+    packaging
+    paramiko
+    pdfminer-six
+    pikepdf
+    pillow
+    protobuf
+    pyside2
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "rcu";
+      desktopName = "reMarkable Connection Utility";
+      comment = "All-in-one offline/local management software for reMarkable e-paper tablets";
+      icon = "rcu";
+      exec = "rcu";
+    })
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  # No tests
+  doCheck = false;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share}
+    cp -r src $out/share/rcu
+
+  '' + lib.optionalString stdenv.hostPlatform.isLinux ''
+    install -Dm644 package_support/gnulinux/50-remarkable.rules $out/etc/udev/rules.d/50-remarkable.rules
+  '' + ''
+
+    # Keep source from being GC'd by linking into it
+
+    for icondir in $(find icons -type d -name '[0-9]*x[0-9]*'); do
+      iconsize=$(basename $icondir)
+      mkdir -p $out/share/icons/hicolor/$iconsize/apps
+      ln -s ${src}/icons/$iconsize/rcu-icon-$iconsize.png $out/share/icons/hicolor/$iconsize/apps/rcu.png
+    done
+
+    mkdir -p $out/share/icons/hicolor/scalable/apps
+    ln -s ${src}/icons/64x64/rcu-icon-64x64.svg $out/share/icons/hicolor/scalable/apps/rcu.svg
+
+    mkdir -p $out/share/doc/rcu
+    for docfile in {COPYING,manual.pdf}; do
+      ln -s ${src}/manual/$docfile $out/share/doc/rcu/$docfile
+    done
+
+    mkdir -p $out/share/licenses/rcu
+    ln -s ${src}/COPYING $out/share/licenses/rcu/COPYING
+
+    runHook postInstall
+  '';
+
+  # Manually creating wrapper, hook struggles with lack of shebang & symlink
+  dontWrapPythonPrograms = true;
+
+  preFixup = ''
+    makeWrapperArgs+=(
+      "''${qtWrapperArgs[@]}"
+  '' + lib.optionalString stdenv.hostPlatform.isLinux ''
+      --prefix PATH : ${lib.makeBinPath [ system-config-printer ]}
+  '' + ''
+    )
+  '';
+
+  postFixup = ''
+    makeWrapper ${lib.getExe python3Packages.python} $out/bin/rcu \
+      ''${makeWrapperArgs[@]} \
+      --prefix PYTHONPATH : ${python3Packages.makePythonPath (propagatedBuildInputs ++ [(placeholder "out")])} \
+      --add-flags $out/share/rcu/main.py
+  '';
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = rcu;
+      version = let
+        versionSuffixPos = (lib.strings.stringLength rcu.version) - 1;
+      in
+        "d${lib.strings.substring 0 versionSuffixPos rcu.version}(${lib.strings.substring versionSuffixPos 1 rcu.version})";
+    };
+  };
+
+  meta = with lib; {
+    mainProgram = "rcu";
+    description = "All-in-one offline/local management software for reMarkable e-paper tablets";
+    homepage = "http://www.davisr.me/projects/rcu/";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ OPNA2608 ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds a package for the development version of [reMarkable Connection Utility (RCU)](http://www.davisr.me/projects/rcu/). It's FLOSS software, but not gratis, so purchased & downloaded source code must be provided by the user.

![Bildschirmfoto_2024-02-10_12-30-06](https://github.com/NixOS/nixpkgs/assets/23431373/534e2404-8fed-4efb-bd72-498c4d2bcc15)

- The intended way of building it seems incompatible with how we package python applications (Makefile constructs a venv & runs `pyinstaller` to bundle everything into a single binary), so I'm just patching & moving the code to a separate directory. Seems to work fine.

- A patch is needed to make it compatible with our packaged version of paramiko (3.x), due to the following upstream changes:
  - https://github.com/paramiko/paramiko/commit/5c4b311b6951dbfcca1206d10bcbdef1a8dda219
  - https://github.com/paramiko/paramiko/commit/8367147e883583bba71cd660d1bae880a66eb27c

- I'm symlinking several non-code data files from the unpacked source into the final derivation, in an attempt to keep the src from being GC'd between system rebuilds: The download is quite slow, so I'd like to avoid redownloads as conveniently as possible.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
