### PR TITLE
flatter: init at 0-unstable-2023-08-10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9282,6 +9282,12 @@
     github = "josephst";
     githubId = 1269177;
   };
+  josephsurin = {
+    name = "Joseph Surin";
+    email = "nix@jsur.in";
+    github = "josephsurin";
+    githubId = 14977484;
+  };
   joshniemela = {
     name = "Joshua Niemelä";
     email = "josh@jniemela.dk";

--- a/pkgs/by-name/fl/flatter/package.nix
+++ b/pkgs/by-name/fl/flatter/package.nix
@@ -1,0 +1,51 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, unstableGitUpdater
+, cmake
+, blas
+, gmp
+, mpfr
+, fplll
+, eigen
+, llvmPackages
+}:
+
+stdenv.mkDerivation {
+  pname = "flatter";
+  version = "0-unstable-2023-08-10";
+
+  src = fetchFromGitHub {
+    owner = "keeganryan";
+    repo = "flatter";
+    rev = "500e31df6b7308e8101b2a4a9cc816bf8f483417";
+    hash = "sha256-STYx7cXvkcF+KqrG32pN16HWfEScc0zxkmOmfv43zIw=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    blas
+    gmp
+    mpfr
+    fplll
+    eigen
+  ] ++ lib.optionals stdenv.isDarwin [
+    llvmPackages.openmp
+  ];
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = with lib; {
+    description = "(F)ast (lat)tice (r)eduction of integer lattice bases";
+    homepage = "https://github.com/keeganryan/flatter";
+    license = licenses.lgpl3Only;
+    mainProgram = "flatter";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ josephsurin ];
+  };
+}


### PR DESCRIPTION
## Description of changes

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
