### PR TITLE
k3s_1_29: 1.29.0+k3s1 -> 1.29.1+k3s2

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/1_28/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_28/versions.nix
@@ -1,8 +1,8 @@
 {
-  k3sVersion = "1.28.6+k3s1";
-  k3sCommit = "39a0001575780fffa6aae0271f4cb4ce7413aac8";
-  k3sRepoSha256 = "1bhbpbgs02gh5y7pgn6vmanacrz3p0b2gq3w2kqpb11bijp2alld";
-  k3sVendorHash = "sha256-Mo+gZ+NOZqd3CP/Z02LfO4dHyEuRhabZVAU60GofOMo=";
+  k3sVersion = "1.28.6+k3s2";
+  k3sCommit = "c9f49a3b06cd7ebe793f8cc1dcd0293168e743d9";
+  k3sRepoSha256 = "0vz5976q58v9x6g1qz6kz3xksgf8gm1f727ccckmpbyxbhw75zsa";
+  k3sVendorHash = "sha256-HG4x3N/F5qCFpLxGrUWPkBHHqY7WBRDWN7DNyAcJwyI=";
   chartVersions = import ./chart-versions.nix;
   k3sRootVersion = "0.12.2";
   k3sRootSha256 = "1gjynvr350qni5mskgm7pcc7alss4gms4jmkiv453vs8mmma9c9k";

--- a/pkgs/applications/networking/cluster/k3s/1_29/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_29/versions.nix
@@ -1,8 +1,8 @@
 {
-  k3sVersion = "1.29.0+k3s1";
-  k3sCommit = "3190a5faa28d7a0d428c756d67adcab7eb11e6a5";
-  k3sRepoSha256 = "1g75a7kz9nnv0vagzhggkw0zqigykimdwsmibgssa8vyjpg7idda";
-  k3sVendorHash = "sha256-iHmPVjYR/ZLH9UZ5yNEApyuGQsEwtxVbQw7Pu7WrpaQ=";
+  k3sVersion = "1.29.1+k3s2";
+  k3sCommit = "57482a1c1bb9c67b5f893418a114edca1004258e";
+  k3sRepoSha256 = "0pvab3dd6dzgk1zgra4jmdwba5b8xssfjr3mihwq1h0c5bxf1cza";
+  k3sVendorHash = "sha256-EkRbdUoYpK7M+Wbc2Cf37bOwdwPB6/xLxULO7Bkpt5c=";
   chartVersions = import ./chart-versions.nix;
   k3sRootVersion = "0.12.2";
   k3sRootSha256 = "1gjynvr350qni5mskgm7pcc7alss4gms4jmkiv453vs8mmma9c9k";

--- a/pkgs/applications/networking/cluster/k3s/builder.nix
+++ b/pkgs/applications/networking/cluster/k3s/builder.nix
@@ -187,7 +187,7 @@ let
 
     patches =
       # Disable: Add runtime checking of golang version
-      lib.optional (lib.versionAtLeast k3sVersion "1.29")
+      lib.optional (lib.versionAtLeast k3sVersion "1.28")
         (fetchpatch {
           # https://github.com/k3s-io/k3s/pull/9054
           url = "https://github.com/k3s-io/k3s/commit/b297996b9252b02e56e9425f55f6becbf6bb7832.patch";

--- a/pkgs/applications/networking/cluster/k3s/builder.nix
+++ b/pkgs/applications/networking/cluster/k3s/builder.nix
@@ -30,6 +30,7 @@ lib:
 # It is likely we will have to split out additional builders for additional
 # versions in the future, or customize this one further.
 { lib
+, fetchpatch
 , makeWrapper
 , socat
 , iptables
@@ -183,6 +184,16 @@ let
 
     src = k3sRepo;
     vendorHash = k3sVendorHash;
+
+    patches =
+      # Disable: Add runtime checking of golang version
+      lib.optional (lib.versionAtLeast k3sVersion "1.29")
+        (fetchpatch {
+          # https://github.com/k3s-io/k3s/pull/9054
+          url = "https://github.com/k3s-io/k3s/commit/b297996b9252b02e56e9425f55f6becbf6bb7832.patch";
+          hash = "sha256-xBOY2jnLhT9dtVKtq26V9QUnuX1q6E/9UcO9IaU719U=";
+          revert = true;
+        });
 
     nativeBuildInputs = [ pkg-config ];
     buildInputs = [ libseccomp sqlite.dev ];


### PR DESCRIPTION
k3s_1_29: 1.29.0+k3s1 -> 1.29.1+k3s2

  - Release: https://github.com/k3s-io/k3s/releases/tag/v1.29.1%2Bk3s2

  - Fixes #286072

k3s_1_28: 1.28.6+k3s1 -> 1.28.6+k3s2

  - Fixes #287834

Noteworthy change:
- K3s now has a runtime check for Kubernetes's Go version:
  >    -X ${PKG}/pkg/version.UpstreamGolang=${VERSION_GOLANG}
  References:
  - https://github.com/k3s-io/k3s/pull/9054
  - https://github.com/k3s-io/k3s/blob/de825845b2f1eca82c19892c327ed274abfa8901/pkg/cli/cmds/golang.go#L15
  - https://github.com/kubernetes/kubernetes/blob/v1.29.1/build/dependencies.yaml#L121

  I have disabled this runtime check by removing the patch that introduced it.
  Being locked to a specific (as in `minor.patch`) go compiler version is undesirable. Considering when it gets out of sync with Nixpkgs, it would be necessary to build a Go compiler exclusively for K3s/K8s. I think this is dumb. Alternatively if we just fake a Go compiler version, then it serves no purpose.

  Checking version in our case should be for `major` version (and never patch). The thing we still need is different. K3s update script still needs a mechanism to pick the correct go builder version major version wise. And we have been doing that manually (and it has always worked fine).

CC @euank @Mic92 @yajo @wrmilling