### PR TITLE
python3Packages.python-multipart: 0.0.6 -> 0.0.9

### DIFF
--- a/pkgs/development/python-modules/python-multipart/default.nix
+++ b/pkgs/development/python-modules/python-multipart/default.nix
@@ -6,6 +6,13 @@
 , mock
 , pyyaml
 , six
+
+# for passthru.tests
+, asgi-csrf
+, connexion
+, fastapi
+, gradio
+, starlette
 }:
 
 buildPythonPackage rec {
@@ -36,6 +43,16 @@ buildPythonPackage rec {
     mock
     pyyaml
   ];
+
+  passthru.tests = {
+    inherit
+      asgi-csrf
+      connexion
+      fastapi
+      gradio
+      starlette
+    ;
+  };
 
   meta = with lib; {
     description = "A streaming multipart parser for Python";

--- a/pkgs/development/python-modules/python-multipart/default.nix
+++ b/pkgs/development/python-modules/python-multipart/default.nix
@@ -10,13 +10,13 @@
 
 buildPythonPackage rec {
   pname = "python-multipart";
-  version = "0.0.6";
+  version = "0.0.7";
   format = "pyproject";
 
   src = fetchPypi {
     pname = "python_multipart";
     inherit version;
-    hash = "sha256-6ZJagLtmhSnxtnx/2wpdrN18v8b7C/8+pEP+Ir3WITI=";
+    hash = "sha256-KIpsObBllsG5iLtnlMb7yA5sNp415QYmN98la+4Mmvk=";
   };
 
   nativeBuildInputs = [
@@ -31,12 +31,6 @@ buildPythonPackage rec {
     "multipart"
   ];
 
-  preCheck = ''
-    # https://github.com/andrew-d/python-multipart/issues/41
-    substituteInPlace multipart/tests/test_multipart.py \
-      --replace "yaml.load" "yaml.safe_load"
-  '';
-
   nativeCheckInputs = [
     pytestCheckHook
     mock
@@ -47,6 +41,6 @@ buildPythonPackage rec {
     description = "A streaming multipart parser for Python";
     homepage = "https://github.com/andrew-d/python-multipart";
     license = licenses.asl20;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ ris ];
   };
 }

--- a/pkgs/development/python-modules/python-multipart/default.nix
+++ b/pkgs/development/python-modules/python-multipart/default.nix
@@ -17,13 +17,13 @@
 
 buildPythonPackage rec {
   pname = "python-multipart";
-  version = "0.0.7";
-  format = "pyproject";
+  version = "0.0.9";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "python_multipart";
     inherit version;
-    hash = "sha256-KIpsObBllsG5iLtnlMb7yA5sNp415QYmN98la+4Mmvk=";
+    hash = "sha256-A/VGiMZj8beXcQXwIQQ7B5MVHkyxwanUoR/BPWIsQCY=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

This should resolve https://nvd.nist.gov/vuln/detail/CVE-2024-24762 (which incidentally is filed against fastapi, being a user of this :shrug:)

Also took maintainership and added some `passthru.tests` so I can sensibly test it. Of these, `connexion` is currently broken (in staging at least) but I'm confident it will be fixed soon.

Why do this as two separate bumps? Because I want to be able to selectively backport just the 0.0.7 bump as that is what apparently resolves CVE-2024-24762.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
