### PR TITLE
libretro: improve update_cores.py script

### DIFF
--- a/pkgs/applications/emulators/retroarch/hashes.json
+++ b/pkgs/applications/emulators/retroarch/hashes.json
@@ -1,626 +1,891 @@
 {
+    "!comment": "Generated with update_cores.py script, do not edit!",
     "2048": {
-        "owner": "libretro",
-        "repo": "libretro-2048",
-        "rev": "331c1de588ed8f8c370dcbc488e5434a3c09f0f2",
-        "hash": "sha256-gPrAmoBnfuTnW6t699pqS43vE6t0ca3jZcqTNRaJipA=",
-        "date": "unstable-2023-02-20"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "libretro-2048",
+            "rev": "331c1de588ed8f8c370dcbc488e5434a3c09f0f2",
+            "hash": "sha256-gPrAmoBnfuTnW6t699pqS43vE6t0ca3jZcqTNRaJipA="
+        },
+        "version": "unstable-2023-02-20"
     },
     "atari800": {
-        "owner": "libretro",
-        "repo": "libretro-atari800",
-        "rev": "410d7bf0c215f3444793a9cec51c129e7b67c400",
-        "hash": "sha256-mUhAraZrmElB6rxQziQG6I2sCdkiX5wYBJhkZgpMSa0=",
-        "date": "unstable-2023-11-14"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "libretro-atari800",
+            "rev": "410d7bf0c215f3444793a9cec51c129e7b67c400",
+            "hash": "sha256-mUhAraZrmElB6rxQziQG6I2sCdkiX5wYBJhkZgpMSa0="
+        },
+        "version": "unstable-2023-11-14"
     },
     "beetle-gba": {
-        "owner": "libretro",
-        "repo": "beetle-gba-libretro",
-        "rev": "38182572571a48cb58057cde64b915237c4e2d58",
-        "hash": "sha256-4xnXWswozlcXBNI1lbGSNW/gAdIeLLO9Bf1SxOFLhSo=",
-        "date": "unstable-2021-09-18"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "beetle-gba-libretro",
+            "rev": "38182572571a48cb58057cde64b915237c4e2d58",
+            "hash": "sha256-4xnXWswozlcXBNI1lbGSNW/gAdIeLLO9Bf1SxOFLhSo="
+        },
+        "version": "unstable-2021-09-18"
     },
     "beetle-lynx": {
-        "owner": "libretro",
-        "repo": "beetle-lynx-libretro",
-        "rev": "48909ddd1aba4de034d9c1da70c460b1724daa3b",
-        "hash": "sha256-aAS9N54kA2st1+3BodiXDR4sbUDSvoFHpa28D9sohx4=",
-        "date": "unstable-2023-11-01"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "beetle-lynx-libretro",
+            "rev": "48909ddd1aba4de034d9c1da70c460b1724daa3b",
+            "hash": "sha256-aAS9N54kA2st1+3BodiXDR4sbUDSvoFHpa28D9sohx4="
+        },
+        "version": "unstable-2023-11-01"
     },
     "beetle-ngp": {
-        "owner": "libretro",
-        "repo": "beetle-ngp-libretro",
-        "rev": "673c3d924ff33d71c6a342b170eff5359244df1f",
-        "hash": "sha256-V3zcbEwqay3eXwXzXZkmHj3+rx9KY4r0WkzAYFZXlgY=",
-        "date": "unstable-2023-11-01"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "beetle-ngp-libretro",
+            "rev": "673c3d924ff33d71c6a342b170eff5359244df1f",
+            "hash": "sha256-V3zcbEwqay3eXwXzXZkmHj3+rx9KY4r0WkzAYFZXlgY="
+        },
+        "version": "unstable-2023-11-01"
     },
     "beetle-pce": {
-        "owner": "libretro",
-        "repo": "beetle-pce-libretro",
-        "rev": "753f067738e55a6325d3ca5206151a9acd9127f0",
-        "hash": "sha256-OWvoIi0DS3YhxK1S6PAbCNZwKKXti6brZlWVCJELfKY=",
-        "date": "unstable-2024-02-09"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "beetle-pce-libretro",
+            "rev": "753f067738e55a6325d3ca5206151a9acd9127f0",
+            "hash": "sha256-OWvoIi0DS3YhxK1S6PAbCNZwKKXti6brZlWVCJELfKY="
+        },
+        "version": "unstable-2024-02-09"
     },
     "beetle-pce-fast": {
-        "owner": "libretro",
-        "repo": "beetle-pce-fast-libretro",
-        "rev": "86a80e1ba551f9a4627b8394901db0ee365c1442",
-        "hash": "sha256-aIDc4jzliVLpI2Xetcd5tG74/xvIlqRdVEb72yHrsCo=",
-        "date": "unstable-2024-02-09"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "beetle-pce-fast-libretro",
+            "rev": "86a80e1ba551f9a4627b8394901db0ee365c1442",
+            "hash": "sha256-aIDc4jzliVLpI2Xetcd5tG74/xvIlqRdVEb72yHrsCo="
+        },
+        "version": "unstable-2024-02-09"
     },
     "beetle-pcfx": {
-        "owner": "libretro",
-        "repo": "beetle-pcfx-libretro",
-        "rev": "47c355b6a515aef6dc57f57df1535570108a0e21",
-        "hash": "sha256-ylFo/wmLQpQGYSrv9PF2DBmr/8rklmHF9R+3y8v93Rs=",
-        "date": "unstable-2023-05-28"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "beetle-pcfx-libretro",
+            "rev": "47c355b6a515aef6dc57f57df1535570108a0e21",
+            "hash": "sha256-ylFo/wmLQpQGYSrv9PF2DBmr/8rklmHF9R+3y8v93Rs="
+        },
+        "version": "unstable-2023-05-28"
     },
     "beetle-psx": {
-        "owner": "libretro",
-        "repo": "beetle-psx-libretro",
-        "rev": "3adff889b9b8251526ca7dae963be46bf8401e2e",
-        "hash": "sha256-DaDzoAQJLuer/c+V1bJGbejnyGYB2RYdebZ1YIoVRKw=",
-        "date": "unstable-2024-02-09"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "beetle-psx-libretro",
+            "rev": "3adff889b9b8251526ca7dae963be46bf8401e2e",
+            "hash": "sha256-DaDzoAQJLuer/c+V1bJGbejnyGYB2RYdebZ1YIoVRKw="
+        },
+        "version": "unstable-2024-02-09"
     },
     "beetle-saturn": {
-        "owner": "libretro",
-        "repo": "beetle-saturn-libretro",
-        "rev": "cd395e9e3ee407608450ebc565e871b24e7ffed6",
-        "hash": "sha256-EIZRv1EydfLWFoBb8TzvAY3kkL9Qr2OrwrljOnnM92A=",
-        "date": "unstable-2023-05-28"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "beetle-saturn-libretro",
+            "rev": "cd395e9e3ee407608450ebc565e871b24e7ffed6",
+            "hash": "sha256-EIZRv1EydfLWFoBb8TzvAY3kkL9Qr2OrwrljOnnM92A="
+        },
+        "version": "unstable-2023-05-28"
     },
     "beetle-supafaust": {
-        "owner": "libretro",
-        "repo": "supafaust",
-        "rev": "6b639c98372d1c9bac885c55d772c812d2a9d525",
-        "hash": "sha256-EVXwjrxooZm1JqG4HswUe8zwN81Rm7SPB5Fr4WfpTnc=",
-        "date": "unstable-2023-06-19"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "supafaust",
+            "rev": "6b639c98372d1c9bac885c55d772c812d2a9d525",
+            "hash": "sha256-EVXwjrxooZm1JqG4HswUe8zwN81Rm7SPB5Fr4WfpTnc="
+        },
+        "version": "unstable-2023-06-19"
     },
     "beetle-supergrafx": {
-        "owner": "libretro",
-        "repo": "beetle-supergrafx-libretro",
-        "rev": "32070ffd0082fd5127519bb6e92a2daecc359408",
-        "hash": "sha256-ZBZtDMP2inarEuLE76Zw1/qZ2YfyTJy+2eN10hhpn64=",
-        "date": "unstable-2024-02-09"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "beetle-supergrafx-libretro",
+            "rev": "32070ffd0082fd5127519bb6e92a2daecc359408",
+            "hash": "sha256-ZBZtDMP2inarEuLE76Zw1/qZ2YfyTJy+2eN10hhpn64="
+        },
+        "version": "unstable-2024-02-09"
     },
     "beetle-vb": {
-        "owner": "libretro",
-        "repo": "beetle-vb-libretro",
-        "rev": "9d1bd03f21dac7897f65269e1095496331efce8b",
-        "hash": "sha256-CT6CfRe8TOgXuJoUA0TKl71m10XeocUCTUjh88eCenU=",
-        "date": "unstable-2023-11-01"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "beetle-vb-libretro",
+            "rev": "9d1bd03f21dac7897f65269e1095496331efce8b",
+            "hash": "sha256-CT6CfRe8TOgXuJoUA0TKl71m10XeocUCTUjh88eCenU="
+        },
+        "version": "unstable-2023-11-01"
     },
     "beetle-wswan": {
-        "owner": "libretro",
-        "repo": "beetle-wswan-libretro",
-        "rev": "32bf70a3032a138baa969c22445f4b7821632c30",
-        "hash": "sha256-dDph7LNlvzVMVTzkUfGErMEb/tALpCADgTjnzjUHYJU=",
-        "date": "unstable-2023-11-01"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "beetle-wswan-libretro",
+            "rev": "32bf70a3032a138baa969c22445f4b7821632c30",
+            "hash": "sha256-dDph7LNlvzVMVTzkUfGErMEb/tALpCADgTjnzjUHYJU="
+        },
+        "version": "unstable-2023-11-01"
     },
     "blastem": {
-        "owner": "libretro",
-        "repo": "blastem",
-        "rev": "277e4a62668597d4f59cadda1cbafb844f981d45",
-        "hash": "sha256-EHvKElPw8V5Z6LnMaQXBCdM4niLIlF3aBm8dRbeYXHs=",
-        "date": "unstable-2022-07-26"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "blastem",
+            "rev": "277e4a62668597d4f59cadda1cbafb844f981d45",
+            "hash": "sha256-EHvKElPw8V5Z6LnMaQXBCdM4niLIlF3aBm8dRbeYXHs="
+        },
+        "version": "unstable-2022-07-26"
     },
     "bluemsx": {
-        "owner": "libretro",
-        "repo": "bluemsx-libretro",
-        "rev": "e8a4280bcbd149d1e020adcd9469ad9d8bd67412",
-        "hash": "sha256-uh4lMOCN1WXKVJybFkkGxIRWAlde74yPH5eaB1/1qsk=",
-        "date": "unstable-2023-11-10"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "bluemsx-libretro",
+            "rev": "e8a4280bcbd149d1e020adcd9469ad9d8bd67412",
+            "hash": "sha256-uh4lMOCN1WXKVJybFkkGxIRWAlde74yPH5eaB1/1qsk="
+        },
+        "version": "unstable-2023-11-10"
     },
     "bsnes": {
-        "owner": "libretro",
-        "repo": "bsnes-libretro",
-        "rev": "d230353616ab4c7dc01a2f2a63865011bd5c7ffd",
-        "hash": "sha256-TiOdptWOb13UQ8jKDbIlZQQ3mY3h/lPHr/GskPVAkwA=",
-        "date": "unstable-2024-02-09"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "bsnes-libretro",
+            "rev": "d230353616ab4c7dc01a2f2a63865011bd5c7ffd",
+            "hash": "sha256-TiOdptWOb13UQ8jKDbIlZQQ3mY3h/lPHr/GskPVAkwA="
+        },
+        "version": "unstable-2024-02-09"
     },
     "bsnes-hd": {
-        "owner": "DerKoun",
-        "repo": "bsnes-hd",
-        "rev": "f46b6d6368ea93943a30b5d4e79e8ed51c2da5e8",
-        "hash": "sha256-Y3FhGtcz7BzwUSBy1SGMuylJdZti/JB8qQnabIkG/dI=",
-        "date": "unstable-2023-04-26"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "DerKoun",
+            "repo": "bsnes-hd",
+            "rev": "f46b6d6368ea93943a30b5d4e79e8ed51c2da5e8",
+            "hash": "sha256-Y3FhGtcz7BzwUSBy1SGMuylJdZti/JB8qQnabIkG/dI="
+        },
+        "version": "unstable-2023-04-26"
     },
     "bsnes-mercury": {
-        "owner": "libretro",
-        "repo": "bsnes-mercury",
-        "rev": "60c204ca17941704110885a815a65c740572326f",
-        "hash": "sha256-eJ0lac1I7E4YdsVVrIuXx31UL9w3OR6QTVHq5YBgnJU=",
-        "date": "unstable-2023-11-01"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "bsnes-mercury",
+            "rev": "60c204ca17941704110885a815a65c740572326f",
+            "hash": "sha256-eJ0lac1I7E4YdsVVrIuXx31UL9w3OR6QTVHq5YBgnJU="
+        },
+        "version": "unstable-2023-11-01"
     },
     "citra": {
-        "owner": "libretro",
-        "repo": "citra",
-        "rev": "2d67658e85de4767c0eefeb2829d710401c5c802",
-        "hash": "sha256-u2XwAudFgI7j/k6Bq5fk874aI6KpZawlBoIs2+M+eZY=",
-        "fetchSubmodules": true,
-        "date": "unstable-2024-01-24"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "citra",
+            "rev": "2d67658e85de4767c0eefeb2829d710401c5c802",
+            "hash": "sha256-u2XwAudFgI7j/k6Bq5fk874aI6KpZawlBoIs2+M+eZY=",
+            "fetchSubmodules": true
+        },
+        "version": "unstable-2024-01-24"
     },
     "desmume": {
-        "owner": "libretro",
-        "repo": "desmume",
-        "rev": "b518fec54b79f2f71a7536715efcdcd7f60638a8",
-        "hash": "sha256-X6ZL+XdsrdPoOU5zqNsUraMrlPU/HmKWUolrWjFcbDQ=",
-        "date": "unstable-2024-01-11"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "desmume",
+            "rev": "b518fec54b79f2f71a7536715efcdcd7f60638a8",
+            "hash": "sha256-X6ZL+XdsrdPoOU5zqNsUraMrlPU/HmKWUolrWjFcbDQ="
+        },
+        "version": "unstable-2024-01-11"
     },
     "desmume2015": {
-        "owner": "libretro",
-        "repo": "desmume2015",
-        "rev": "af397ff3d1f208c27f3922cc8f2b8e08884ba893",
-        "hash": "sha256-kEb+og4g7rJvCinBZKcb42geZO6W8ynGsTG9yqYgI+U=",
-        "date": "unstable-2022-04-05"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "desmume2015",
+            "rev": "af397ff3d1f208c27f3922cc8f2b8e08884ba893",
+            "hash": "sha256-kEb+og4g7rJvCinBZKcb42geZO6W8ynGsTG9yqYgI+U="
+        },
+        "version": "unstable-2022-04-05"
     },
     "dolphin": {
-        "owner": "libretro",
-        "repo": "dolphin",
-        "rev": "2f4b0f7902257d40a054f60b2c670d6e314f2a04",
-        "hash": "sha256-9WYWbLehExYbPmGJpguhVFXqFJ9aR6VxzFVChd4QOEg=",
-        "date": "unstable-2022-12-17"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "dolphin",
+            "rev": "2f4b0f7902257d40a054f60b2c670d6e314f2a04",
+            "hash": "sha256-9WYWbLehExYbPmGJpguhVFXqFJ9aR6VxzFVChd4QOEg="
+        },
+        "version": "unstable-2022-12-17"
     },
     "dosbox": {
-        "owner": "libretro",
-        "repo": "dosbox-libretro",
-        "rev": "b7b24262c282c0caef2368c87323ff8c381b3102",
-        "hash": "sha256-PG2eElenlEpu0U/NIh53p0uLqewnEdaq6Aoak5E1P3I=",
-        "date": "unstable-2022-07-18"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "dosbox-libretro",
+            "rev": "b7b24262c282c0caef2368c87323ff8c381b3102",
+            "hash": "sha256-PG2eElenlEpu0U/NIh53p0uLqewnEdaq6Aoak5E1P3I="
+        },
+        "version": "unstable-2022-07-18"
     },
     "dosbox-pure": {
-        "owner": "schellingb",
-        "repo": "dosbox-pure",
-        "rev": "87bf6365158325b76ff238c1ad8daf16a859bbe8",
-        "hash": "sha256-IU5AnOEuwZm/bJ9NuxhTQ8Tb5ngmjysLj/om/6P730s=",
-        "date": "unstable-2023-12-29"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "schellingb",
+            "repo": "dosbox-pure",
+            "rev": "87bf6365158325b76ff238c1ad8daf16a859bbe8",
+            "hash": "sha256-IU5AnOEuwZm/bJ9NuxhTQ8Tb5ngmjysLj/om/6P730s="
+        },
+        "version": "unstable-2023-12-29"
     },
     "eightyone": {
-        "owner": "libretro",
-        "repo": "81-libretro",
-        "rev": "525d5c18f1ff3fc54c37e083a475225d9179d59d",
-        "hash": "sha256-H0w9hcAUVOGr0PtNLVdFQScxd3ildZZ68w+TL7vG4jk=",
-        "date": "unstable-2023-11-01"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "81-libretro",
+            "rev": "525d5c18f1ff3fc54c37e083a475225d9179d59d",
+            "hash": "sha256-H0w9hcAUVOGr0PtNLVdFQScxd3ildZZ68w+TL7vG4jk="
+        },
+        "version": "unstable-2023-11-01"
     },
     "fbalpha2012": {
-        "owner": "libretro",
-        "repo": "fbalpha2012",
-        "rev": "b7ac554c53561d41640372f23dab15cd6fc4f0c4",
-        "hash": "sha256-BaeMLej2MLc4uipqTD2z2sHUeOsc50Q1c+PEiPD1cks=",
-        "date": "unstable-2023-11-01"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "fbalpha2012",
+            "rev": "b7ac554c53561d41640372f23dab15cd6fc4f0c4",
+            "hash": "sha256-BaeMLej2MLc4uipqTD2z2sHUeOsc50Q1c+PEiPD1cks="
+        },
+        "version": "unstable-2023-11-01"
     },
     "fbneo": {
-        "owner": "libretro",
-        "repo": "fbneo",
-        "rev": "bb7aa7ea1e3a9a293fcf4e2b15994afde2e52899",
-        "hash": "sha256-XTOZGKq02obnzbtUEAEs99Kxhd8hFqLjI/smwtNAU8Q=",
-        "date": "unstable-2024-02-08"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "fbneo",
+            "rev": "dacb63782bda34d6ac3cb8dd0e071695b8092483",
+            "hash": "sha256-Jnp9QmXAz/q31baJ5jCi0ZH/B2a4ErtDe+e2P1iYLeU="
+        },
+        "version": "unstable-2024-02-14"
     },
     "fceumm": {
-        "owner": "libretro",
-        "repo": "libretro-fceumm",
-        "rev": "63643ba02c8eaea15dbe167ef907f3da7a3e6fd7",
-        "hash": "sha256-xy8hzZ7nt2hHjRJmsty/w/cPzEtdlSkmNAsog3+h5YU=",
-        "date": "unstable-2024-01-25"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "libretro-fceumm",
+            "rev": "63643ba02c8eaea15dbe167ef907f3da7a3e6fd7",
+            "hash": "sha256-xy8hzZ7nt2hHjRJmsty/w/cPzEtdlSkmNAsog3+h5YU="
+        },
+        "version": "unstable-2024-01-25"
     },
     "flycast": {
-        "owner": "flyinghead",
-        "repo": "flycast",
-        "rev": "44fa364f36c43bed19b055096600f075c656f78c",
-        "hash": "sha256-UfASq8OXtsfubMUfke7P6HTygM/9fP421IoLQeJvPgY=",
-        "fetchSubmodules": true,
-        "date": "unstable-2024-02-09"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "flyinghead",
+            "repo": "flycast",
+            "rev": "44fa364f36c43bed19b055096600f075c656f78c",
+            "hash": "sha256-UfASq8OXtsfubMUfke7P6HTygM/9fP421IoLQeJvPgY=",
+            "fetchSubmodules": true
+        },
+        "version": "unstable-2024-02-09"
     },
     "fmsx": {
-        "owner": "libretro",
-        "repo": "fmsx-libretro",
-        "rev": "9b5cf868825a629cc4c7086768338165d3bbf706",
-        "hash": "sha256-zDDAMzV+pfu+AwjgXwduPfHyW1rQnvaDpFvz++QBBkA=",
-        "date": "unstable-2024-02-08"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "fmsx-libretro",
+            "rev": "9b5cf868825a629cc4c7086768338165d3bbf706",
+            "hash": "sha256-zDDAMzV+pfu+AwjgXwduPfHyW1rQnvaDpFvz++QBBkA="
+        },
+        "version": "unstable-2024-02-08"
     },
     "freeintv": {
-        "owner": "libretro",
-        "repo": "freeintv",
-        "rev": "85bf25a39a34bbc39fe36677175d87c2b597dbe7",
-        "hash": "sha256-4cU/YRZZb7EWNBJX8M91Lb+bCCIlks6xX2Cf6Iq/g9g=",
-        "date": "unstable-2023-04-17"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "freeintv",
+            "rev": "85bf25a39a34bbc39fe36677175d87c2b597dbe7",
+            "hash": "sha256-4cU/YRZZb7EWNBJX8M91Lb+bCCIlks6xX2Cf6Iq/g9g="
+        },
+        "version": "unstable-2023-04-17"
     },
     "fuse": {
-        "owner": "libretro",
-        "repo": "fuse-libretro",
-        "rev": "847dbbd6f787823ac9a5dfacdd68ab181063374e",
-        "hash": "sha256-jzS7SFALV/YjI77ST+IWHwUsuhT+Zr5w4t6C7O8yzFM=",
-        "date": "unstable-2023-06-23"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "fuse-libretro",
+            "rev": "847dbbd6f787823ac9a5dfacdd68ab181063374e",
+            "hash": "sha256-jzS7SFALV/YjI77ST+IWHwUsuhT+Zr5w4t6C7O8yzFM="
+        },
+        "version": "unstable-2023-06-23"
     },
     "gambatte": {
-        "owner": "libretro",
-        "repo": "gambatte-libretro",
-        "rev": "05c4e10168aa3070b4ea01f7da7ab1c0d4241103",
-        "hash": "sha256-W/s8FWjFOIcclLkbM5s2+2dcvr+X2My5319SvRo5/lU=",
-        "date": "unstable-2024-02-09"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "gambatte-libretro",
+            "rev": "05c4e10168aa3070b4ea01f7da7ab1c0d4241103",
+            "hash": "sha256-W/s8FWjFOIcclLkbM5s2+2dcvr+X2My5319SvRo5/lU="
+        },
+        "version": "unstable-2024-02-09"
     },
     "genesis-plus-gx": {
-        "owner": "libretro",
-        "repo": "Genesis-Plus-GX",
-        "rev": "ecb956d914d6bc4e5deb49384bc929939e9a19e5",
-        "hash": "sha256-Fk+Ldjav+yQl6fkYESR6t1JEOKiCZYCW386QL4ozE68=",
-        "date": "unstable-2024-02-06"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "Genesis-Plus-GX",
+            "rev": "ecb956d914d6bc4e5deb49384bc929939e9a19e5",
+            "hash": "sha256-Fk+Ldjav+yQl6fkYESR6t1JEOKiCZYCW386QL4ozE68="
+        },
+        "version": "unstable-2024-02-06"
     },
     "gpsp": {
-        "owner": "libretro",
-        "repo": "gpsp",
-        "rev": "4caf7a167d159866479ea94d6b2d13c26ceb3e72",
-        "hash": "sha256-1hkxeTjY52YuphQuDMCITn/dIcNx/8w4FkhQjL8DWz8=",
-        "date": "unstable-2024-02-10"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "gpsp",
+            "rev": "4caf7a167d159866479ea94d6b2d13c26ceb3e72",
+            "hash": "sha256-1hkxeTjY52YuphQuDMCITn/dIcNx/8w4FkhQjL8DWz8="
+        },
+        "version": "unstable-2024-02-10"
     },
     "gw": {
-        "owner": "libretro",
-        "repo": "gw-libretro",
-        "rev": "0ecff52b11c327af52b22ea94b268c90472b6732",
-        "hash": "sha256-N/nZoo+duk7XhRtNdV1paWzxYUhv8nLUcnnOs2gbZuQ=",
-        "date": "unstable-2023-05-28"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "gw-libretro",
+            "rev": "0ecff52b11c327af52b22ea94b268c90472b6732",
+            "hash": "sha256-N/nZoo+duk7XhRtNdV1paWzxYUhv8nLUcnnOs2gbZuQ="
+        },
+        "version": "unstable-2023-05-28"
     },
     "handy": {
-        "owner": "libretro",
-        "repo": "libretro-handy",
-        "rev": "65d6b865544cd441ef2bd18cde7bd834c23d0e48",
-        "hash": "sha256-F4WyiZBNTh8hjuCooZXQkzov0vcHNni6d5mbAMgzAiA=",
-        "date": "unstable-2024-01-01"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "libretro-handy",
+            "rev": "65d6b865544cd441ef2bd18cde7bd834c23d0e48",
+            "hash": "sha256-F4WyiZBNTh8hjuCooZXQkzov0vcHNni6d5mbAMgzAiA="
+        },
+        "version": "unstable-2024-01-01"
     },
     "hatari": {
-        "owner": "libretro",
-        "repo": "hatari",
-        "rev": "a4c9eb0bb79e47a2870c12b04566c1f8d25e4bf3",
-        "hash": "sha256-mHz2nB9Vr/PVifd6w+kz7ZCH+N8igmcS8InvevZoSpE=",
-        "date": "unstable-2023-09-29"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "hatari",
+            "rev": "a4c9eb0bb79e47a2870c12b04566c1f8d25e4bf3",
+            "hash": "sha256-mHz2nB9Vr/PVifd6w+kz7ZCH+N8igmcS8InvevZoSpE="
+        },
+        "version": "unstable-2023-09-29"
     },
     "mame": {
-        "owner": "libretro",
-        "repo": "mame",
-        "rev": "8ebaec4073703f5050dac3f6c8da408943e15938",
-        "hash": "sha256-CFCem9MiaHW2flEZyJkcC9JEGzx7Ox/uqrTY3jue+Pk=",
-        "date": "unstable-2024-02-13"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "mame",
+            "rev": "8ebaec4073703f5050dac3f6c8da408943e15938",
+            "hash": "sha256-CFCem9MiaHW2flEZyJkcC9JEGzx7Ox/uqrTY3jue+Pk="
+        },
+        "version": "unstable-2024-02-13"
     },
     "mame2000": {
-        "owner": "libretro",
-        "repo": "mame2000-libretro",
-        "rev": "1472da3a39ab14fff8325b1f51a1dfdb8eabb5c8",
-        "hash": "sha256-Nd5OqkoMJZ8TzEZGqDT0YX6lHK/H3I5EqJ841PteLi8=",
-        "date": "unstable-2023-10-31"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "mame2000-libretro",
+            "rev": "1472da3a39ab14fff8325b1f51a1dfdb8eabb5c8",
+            "hash": "sha256-Nd5OqkoMJZ8TzEZGqDT0YX6lHK/H3I5EqJ841PteLi8="
+        },
+        "version": "unstable-2023-10-31"
     },
     "mame2003": {
-        "owner": "libretro",
-        "repo": "mame2003-libretro",
-        "rev": "838f84f14422529c37bbb9803eb649209c8ba4e8",
-        "hash": "sha256-NiqlA4FjHS0GLypEg6QbhEJlhV0YU7VmMquzqnyr7aA=",
-        "date": "unstable-2024-02-08"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "mame2003-libretro",
+            "rev": "838f84f14422529c37bbb9803eb649209c8ba4e8",
+            "hash": "sha256-NiqlA4FjHS0GLypEg6QbhEJlhV0YU7VmMquzqnyr7aA="
+        },
+        "version": "unstable-2024-02-08"
     },
     "mame2003-plus": {
-        "owner": "libretro",
-        "repo": "mame2003-plus-libretro",
-        "rev": "a4d62997d332acc709c9644641863c5498e01eb0",
-        "hash": "sha256-9+pxx/fhNsvAMYDqalkkdljaR8/XxuMMSrrz7KeJtDU=",
-        "date": "unstable-2024-02-13"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "mame2003-plus-libretro",
+            "rev": "a4d62997d332acc709c9644641863c5498e01eb0",
+            "hash": "sha256-9+pxx/fhNsvAMYDqalkkdljaR8/XxuMMSrrz7KeJtDU="
+        },
+        "version": "unstable-2024-02-13"
     },
     "mame2010": {
-        "owner": "libretro",
-        "repo": "mame2010-libretro",
-        "rev": "5f524dd5fca63ec1dcf5cca63885286109937587",
-        "hash": "sha256-OmJgDdlan/niGQfajv0KNG8NJfEKn7Nfe6GRQD+TZ8M=",
-        "date": "unstable-2022-06-14"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "mame2010-libretro",
+            "rev": "5f524dd5fca63ec1dcf5cca63885286109937587",
+            "hash": "sha256-OmJgDdlan/niGQfajv0KNG8NJfEKn7Nfe6GRQD+TZ8M="
+        },
+        "version": "unstable-2022-06-14"
     },
     "mame2015": {
-        "owner": "libretro",
-        "repo": "mame2015-libretro",
-        "rev": "316cd06349f2b34b4719f04f7c0d07569a74c764",
-        "hash": "sha256-CBN04Jf26SIk8mKWlui5spQGokBvgFUCvFiC8NoBGw0=",
-        "date": "unstable-2023-11-01"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "mame2015-libretro",
+            "rev": "316cd06349f2b34b4719f04f7c0d07569a74c764",
+            "hash": "sha256-CBN04Jf26SIk8mKWlui5spQGokBvgFUCvFiC8NoBGw0="
+        },
+        "version": "unstable-2023-11-01"
     },
     "mame2016": {
-        "owner": "libretro",
-        "repo": "mame2016-libretro",
-        "rev": "01058613a0109424c4e7211e49ed83ac950d3993",
-        "hash": "sha256-IsM7f/zlzvomVOYlinJVqZllUhDfy4NNTeTPtNmdVak=",
-        "date": "unstable-2022-04-06"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "mame2016-libretro",
+            "rev": "01058613a0109424c4e7211e49ed83ac950d3993",
+            "hash": "sha256-IsM7f/zlzvomVOYlinJVqZllUhDfy4NNTeTPtNmdVak="
+        },
+        "version": "unstable-2022-04-06"
     },
     "melonds": {
-        "owner": "libretro",
-        "repo": "melonds",
-        "rev": "c6488c88cb4c7583dbcd61609e0eef441572fae8",
-        "hash": "sha256-kU0xPM6WBqK6UpMNMotHc3jRFTodahPJRrfbcjdCJTI=",
-        "date": "unstable-2023-04-13"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "melonds",
+            "rev": "c6488c88cb4c7583dbcd61609e0eef441572fae8",
+            "hash": "sha256-kU0xPM6WBqK6UpMNMotHc3jRFTodahPJRrfbcjdCJTI="
+        },
+        "version": "unstable-2023-04-13"
     },
     "mesen": {
-        "owner": "libretro",
-        "repo": "mesen",
-        "rev": "d6f2f1797694f87e698c737b068f621889e96fa9",
-        "hash": "sha256-iLX9UvrjYjGjyaLD4sC10gntWUvgZrwiUqTS7S7YDdc=",
-        "date": "unstable-2024-01-30"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "mesen",
+            "rev": "d6f2f1797694f87e698c737b068f621889e96fa9",
+            "hash": "sha256-iLX9UvrjYjGjyaLD4sC10gntWUvgZrwiUqTS7S7YDdc="
+        },
+        "version": "unstable-2024-01-30"
     },
     "mesen-s": {
-        "owner": "libretro",
-        "repo": "mesen-s",
-        "rev": "32a7adfb4edb029324253cb3632dfc6599ad1aa8",
-        "hash": "sha256-/OOMH7kt9Pmkdmy5m+I8FMvog5mqZHyrZvfjHccz8oo=",
-        "date": "unstable-2022-07-25"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "mesen-s",
+            "rev": "32a7adfb4edb029324253cb3632dfc6599ad1aa8",
+            "hash": "sha256-/OOMH7kt9Pmkdmy5m+I8FMvog5mqZHyrZvfjHccz8oo="
+        },
+        "version": "unstable-2022-07-25"
     },
     "meteor": {
-        "owner": "libretro",
-        "repo": "meteor-libretro",
-        "rev": "e533d300d0561564451bde55a2b73119c768453c",
-        "hash": "sha256-zMkgzUz2rk0SD5ojY4AqaDlNM4k4QxuUxVBRBcn6TqQ=",
-        "date": "unstable-2020-12-28"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "meteor-libretro",
+            "rev": "e533d300d0561564451bde55a2b73119c768453c",
+            "hash": "sha256-zMkgzUz2rk0SD5ojY4AqaDlNM4k4QxuUxVBRBcn6TqQ="
+        },
+        "version": "unstable-2020-12-28"
     },
     "mgba": {
-        "owner": "libretro",
-        "repo": "mgba",
-        "rev": "314bf7b676f5b820f396209eb0c7d6fbe8103486",
-        "hash": "sha256-Rk+glDgSa1J1IIe5NrJElX9zr59+LQynfDXuHWyZcEM=",
-        "date": "unstable-2023-05-28"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "mgba",
+            "rev": "314bf7b676f5b820f396209eb0c7d6fbe8103486",
+            "hash": "sha256-Rk+glDgSa1J1IIe5NrJElX9zr59+LQynfDXuHWyZcEM="
+        },
+        "version": "unstable-2023-05-28"
     },
     "mrboom": {
-        "owner": "Javanaise",
-        "repo": "mrboom-libretro",
-        "rev": "f688664f024723e00c0d2926e51b45754a25e2da",
-        "hash": "sha256-t6ArMkyGvHJ9hLc+FFoH2wTk0wRFn5etzdLipTQnGyc=",
-        "fetchSubmodules": true,
-        "date": "unstable-2024-02-09"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "Javanaise",
+            "repo": "mrboom-libretro",
+            "rev": "f688664f024723e00c0d2926e51b45754a25e2da",
+            "hash": "sha256-t6ArMkyGvHJ9hLc+FFoH2wTk0wRFn5etzdLipTQnGyc=",
+            "fetchSubmodules": true
+        },
+        "version": "unstable-2024-02-09"
     },
     "mupen64plus": {
-        "owner": "libretro",
-        "repo": "mupen64plus-libretro-nx",
-        "rev": "fa55ddca926d3c3ad2285911646919def4aa6fa3",
-        "hash": "sha256-Fn/qSQDR8FuHG9eLE0I24wUa0sdosrl6+lhnf9cD+yQ=",
-        "date": "unstable-2024-02-06"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "mupen64plus-libretro-nx",
+            "rev": "fa55ddca926d3c3ad2285911646919def4aa6fa3",
+            "hash": "sha256-Fn/qSQDR8FuHG9eLE0I24wUa0sdosrl6+lhnf9cD+yQ="
+        },
+        "version": "unstable-2024-02-06"
     },
     "neocd": {
-        "owner": "libretro",
-        "repo": "neocd_libretro",
-        "rev": "71ebe5044639b825e5bd1bd590fef3e918133b80",
-        "hash": "sha256-YVxt3bJ54DD91VHkeQyYdo/BEq//lnBKd9Y42Vby3qc=",
-        "date": "unstable-2024-02-01"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "neocd_libretro",
+            "rev": "71ebe5044639b825e5bd1bd590fef3e918133b80",
+            "hash": "sha256-YVxt3bJ54DD91VHkeQyYdo/BEq//lnBKd9Y42Vby3qc="
+        },
+        "version": "unstable-2024-02-01"
     },
     "nestopia": {
-        "owner": "libretro",
-        "repo": "nestopia",
-        "rev": "407df997b65cddbff9b25abae0510e6645205677",
-        "hash": "sha256-Vlz69ZpXwawdE+bfjlKNrQNmFHhB53FOKhfMgq4viE0=",
-        "date": "unstable-2024-02-13"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "nestopia",
+            "rev": "407df997b65cddbff9b25abae0510e6645205677",
+            "hash": "sha256-Vlz69ZpXwawdE+bfjlKNrQNmFHhB53FOKhfMgq4viE0="
+        },
+        "version": "unstable-2024-02-13"
     },
     "np2kai": {
-        "owner": "AZO234",
-        "repo": "NP2kai",
-        "rev": "c2ca4046860264cb307e768f529f180caee5e224",
-        "hash": "sha256-RizN+NpVp0paXvdt7OudX9/5GJms1YvJ+NVe9iV3nnw=",
-        "fetchSubmodules": true,
-        "date": "unstable-2024-01-10"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "AZO234",
+            "repo": "NP2kai",
+            "rev": "c2ca4046860264cb307e768f529f180caee5e224",
+            "hash": "sha256-RizN+NpVp0paXvdt7OudX9/5GJms1YvJ+NVe9iV3nnw=",
+            "fetchSubmodules": true
+        },
+        "version": "unstable-2024-01-10"
     },
     "nxengine": {
-        "owner": "libretro",
-        "repo": "nxengine-libretro",
-        "rev": "1f371e51c7a19049e00f4364cbe9c68ca08b303a",
-        "hash": "sha256-4XBNTzgN8pLyrK9KsVxTRR1I8CQaZCnVR4gMryYpWW0=",
-        "date": "unstable-2023-02-21"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "nxengine-libretro",
+            "rev": "1f371e51c7a19049e00f4364cbe9c68ca08b303a",
+            "hash": "sha256-4XBNTzgN8pLyrK9KsVxTRR1I8CQaZCnVR4gMryYpWW0="
+        },
+        "version": "unstable-2023-02-21"
     },
     "o2em": {
-        "owner": "libretro",
-        "repo": "libretro-o2em",
-        "rev": "44fe5f306033242f7d74144105e19a7d4939477e",
-        "hash": "sha256-zg8wplVTKRzqa47mmWlqribg+JU4Nap4Ar/iR7y87xs=",
-        "date": "unstable-2023-10-19"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "libretro-o2em",
+            "rev": "44fe5f306033242f7d74144105e19a7d4939477e",
+            "hash": "sha256-zg8wplVTKRzqa47mmWlqribg+JU4Nap4Ar/iR7y87xs="
+        },
+        "version": "unstable-2023-10-19"
     },
     "opera": {
-        "owner": "libretro",
-        "repo": "opera-libretro",
-        "rev": "35e16483be900ea8aa20e87d2710b677437f73ce",
-        "hash": "sha256-ZNHSxI8l0KGJ6uAvOsEhNpB0IkBxtb9Imj3tA/LiOto=",
-        "date": "unstable-2024-01-13"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "opera-libretro",
+            "rev": "35e16483be900ea8aa20e87d2710b677437f73ce",
+            "hash": "sha256-ZNHSxI8l0KGJ6uAvOsEhNpB0IkBxtb9Imj3tA/LiOto="
+        },
+        "version": "unstable-2024-01-13"
     },
     "parallel-n64": {
-        "owner": "libretro",
-        "repo": "parallel-n64",
-        "rev": "1b57f9199b1f8a4510f7f89f14afa9cabf9b3bdd",
-        "hash": "sha256-L20RGav0FJfydOICCNhAMGxIuIvPABDtCs5tWzrh768=",
-        "date": "unstable-2024-01-15"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "parallel-n64",
+            "rev": "1b57f9199b1f8a4510f7f89f14afa9cabf9b3bdd",
+            "hash": "sha256-L20RGav0FJfydOICCNhAMGxIuIvPABDtCs5tWzrh768="
+        },
+        "version": "unstable-2024-01-15"
     },
     "pcsx2": {
-        "owner": "libretro",
-        "repo": "lrps2",
-        "rev": "f3c8743d6a42fe429f703b476fecfdb5655a98a9",
-        "hash": "sha256-0piCNWX7QbZ58KyTlWp4h1qLxXpi1z6ML8sBHMTvCY4=",
-        "date": "unstable-2023-01-30"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "lrps2",
+            "rev": "f3c8743d6a42fe429f703b476fecfdb5655a98a9",
+            "hash": "sha256-0piCNWX7QbZ58KyTlWp4h1qLxXpi1z6ML8sBHMTvCY4="
+        },
+        "version": "unstable-2023-01-30"
     },
     "pcsx_rearmed": {
-        "owner": "libretro",
-        "repo": "pcsx_rearmed",
-        "rev": "016c6e93f6db684211f5c8b05433cb500715ba50",
-        "hash": "sha256-uYzL0uuQbxa4N0uQT8YEBiCgwkIcigvjeNU600WqSDQ=",
-        "date": "unstable-2024-02-07"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "pcsx_rearmed",
+            "rev": "016c6e93f6db684211f5c8b05433cb500715ba50",
+            "hash": "sha256-uYzL0uuQbxa4N0uQT8YEBiCgwkIcigvjeNU600WqSDQ="
+        },
+        "version": "unstable-2024-02-07"
     },
     "picodrive": {
-        "owner": "libretro",
-        "repo": "picodrive",
-        "rev": "d907d65692a45e126d0c7d6685cc8792b52bc577",
-        "hash": "sha256-CJJcWVueg3dbBT4r6W1y8Qj7iRwH7PupvFp+CKEII7o=",
-        "fetchSubmodules": true,
-        "date": "unstable-2024-01-23"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "picodrive",
+            "rev": "d907d65692a45e126d0c7d6685cc8792b52bc577",
+            "hash": "sha256-CJJcWVueg3dbBT4r6W1y8Qj7iRwH7PupvFp+CKEII7o=",
+            "fetchSubmodules": true
+        },
+        "version": "unstable-2024-01-23"
     },
     "play": {
-        "owner": "jpd002",
-        "repo": "Play-",
-        "rev": "34c4c74fbd0ca2223c203bffc23f57157769074b",
-        "hash": "sha256-Nn2VsZOuwyBQxFBGGLVfD5BvvqJBI7g8HoShmH0hch8=",
-        "fetchSubmodules": true,
-        "date": "unstable-2024-02-05"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "jpd002",
+            "repo": "Play-",
+            "rev": "691a893400ef3ca515cb39c7552a8f04bb2d55fa",
+            "hash": "sha256-42d++0R+LcFuFT9T1+9/0eot+IdBDbqoA/axeHTWZfk=",
+            "fetchSubmodules": true
+        },
+        "version": "unstable-2024-02-14"
     },
     "ppsspp": {
-        "owner": "hrydgard",
-        "repo": "ppsspp",
-        "rev": "d832f96010fa378ef0a7f7980524a61803110ad7",
-        "hash": "sha256-LkngiwjRoYw+N+DCdbbWnTokDAYXbqOMJX+DQGAUl2g=",
-        "fetchSubmodules": true,
-        "date": "unstable-2024-02-13"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "hrydgard",
+            "repo": "ppsspp",
+            "rev": "d832f96010fa378ef0a7f7980524a61803110ad7",
+            "hash": "sha256-LkngiwjRoYw+N+DCdbbWnTokDAYXbqOMJX+DQGAUl2g=",
+            "fetchSubmodules": true
+        },
+        "version": "unstable-2024-02-13"
     },
     "prboom": {
-        "owner": "libretro",
-        "repo": "libretro-prboom",
-        "rev": "6ec854969fd9dec33bb2cab350f05675d1158969",
-        "hash": "sha256-y0qZwYNwcO4ofWDZ7UXN9ZVMPFxjCnLDDZKBMdZLxEY=",
-        "date": "unstable-2023-05-28"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "libretro-prboom",
+            "rev": "6ec854969fd9dec33bb2cab350f05675d1158969",
+            "hash": "sha256-y0qZwYNwcO4ofWDZ7UXN9ZVMPFxjCnLDDZKBMdZLxEY="
+        },
+        "version": "unstable-2023-05-28"
     },
     "prosystem": {
-        "owner": "libretro",
-        "repo": "prosystem-libretro",
-        "rev": "4202ac5bdb2ce1a21f84efc0e26d75bb5aa7e248",
-        "hash": "sha256-BR0DTWcB5g0rEoNSxBx+OxBmLELjdR2fgsmdPU7cK68=",
-        "date": "unstable-2023-08-17"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "prosystem-libretro",
+            "rev": "4202ac5bdb2ce1a21f84efc0e26d75bb5aa7e248",
+            "hash": "sha256-BR0DTWcB5g0rEoNSxBx+OxBmLELjdR2fgsmdPU7cK68="
+        },
+        "version": "unstable-2023-08-17"
     },
     "puae": {
-        "owner": "libretro",
-        "repo": "libretro-uae",
-        "rev": "2cad13f98aa4df272decf2ab99d95aa582cd4cfb",
-        "hash": "sha256-8iGsQJcImL7hUK14X+u2BSq4W9BkosiLImCmzf63o4Q=",
-        "date": "unstable-2024-02-03"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "libretro-uae",
+            "rev": "2cad13f98aa4df272decf2ab99d95aa582cd4cfb",
+            "hash": "sha256-8iGsQJcImL7hUK14X+u2BSq4W9BkosiLImCmzf63o4Q="
+        },
+        "version": "unstable-2024-02-03"
     },
     "quicknes": {
-        "owner": "libretro",
-        "repo": "QuickNES_Core",
-        "rev": "cd73f021be7dd5b1a21b71155a320364c02de4ac",
-        "hash": "sha256-fmTAK32ASA8M5nxUUUilm/yMNkmqSAG/gauB7fy1Kbc=",
-        "date": "unstable-2024-02-01"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "QuickNES_Core",
+            "rev": "cd73f021be7dd5b1a21b71155a320364c02de4ac",
+            "hash": "sha256-fmTAK32ASA8M5nxUUUilm/yMNkmqSAG/gauB7fy1Kbc="
+        },
+        "version": "unstable-2024-02-01"
     },
     "same_cdi": {
-        "owner": "libretro",
-        "repo": "same_cdi",
-        "rev": "54cf493c2dee4c46666059c452f8aaaa0bd7c8e0",
-        "hash": "sha256-/+4coMzj/o82Q04Z65DQiPaykK6N56W6PRQLtyJOd8E=",
-        "date": "unstable-2023-02-28"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "same_cdi",
+            "rev": "54cf493c2dee4c46666059c452f8aaaa0bd7c8e0",
+            "hash": "sha256-/+4coMzj/o82Q04Z65DQiPaykK6N56W6PRQLtyJOd8E="
+        },
+        "version": "unstable-2023-02-28"
     },
     "sameboy": {
-        "owner": "libretro",
-        "repo": "sameboy",
-        "rev": "09138330990da32362246c7034cf4de2ea0a2a2b",
-        "hash": "sha256-hQWIuNwCykkJR+6naNarR50kUvIFNny+bbZHR6/GA/4=",
-        "date": "unstable-2022-08-19"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "sameboy",
+            "rev": "09138330990da32362246c7034cf4de2ea0a2a2b",
+            "hash": "sha256-hQWIuNwCykkJR+6naNarR50kUvIFNny+bbZHR6/GA/4="
+        },
+        "version": "unstable-2022-08-19"
     },
     "scummvm": {
-        "owner": "libretro-mirrors",
-        "repo": "scummvm",
-        "rev": "2fb2e4c551c9c1510c56f6e890ee0300b7b3fca3",
-        "hash": "sha256-wrlFqu+ONbYH4xMFDByOgySobGrkhVc7kYWI4JzA4ew=",
-        "date": "unstable-2022-04-06"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro-mirrors",
+            "repo": "scummvm",
+            "rev": "2fb2e4c551c9c1510c56f6e890ee0300b7b3fca3",
+            "hash": "sha256-wrlFqu+ONbYH4xMFDByOgySobGrkhVc7kYWI4JzA4ew="
+        },
+        "version": "unstable-2022-04-06"
     },
     "smsplus-gx": {
-        "owner": "libretro",
-        "repo": "smsplus-gx",
-        "rev": "96fa9bc65aa27a5ab2779f9f2ff0439fec7cf513",
-        "hash": "sha256-tlxlI0+5QFgu2IRB4Cpz9XItbhprLNlq1YdCFGXGyIE=",
-        "date": "unstable-2023-10-31"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "smsplus-gx",
+            "rev": "96fa9bc65aa27a5ab2779f9f2ff0439fec7cf513",
+            "hash": "sha256-tlxlI0+5QFgu2IRB4Cpz9XItbhprLNlq1YdCFGXGyIE="
+        },
+        "version": "unstable-2023-10-31"
     },
     "snes9x": {
-        "owner": "snes9xgit",
-        "repo": "snes9x",
-        "rev": "be6372c0345c82a87b880c791703fb1929ecf72c",
-        "hash": "sha256-JzUXxTJZG3LdWC+FCM/3/ynGclQ11rCj7q5fs45r5Bw=",
-        "date": "unstable-2024-02-08"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "snes9xgit",
+            "repo": "snes9x",
+            "rev": "1e1c45be07bf5760e73414d9ed0253d6dedb8605",
+            "hash": "sha256-gGAsKsI5e9jU6Zo2f72TBsHWdR6Bl+3Y1Om1zsbIjqs="
+        },
+        "version": "unstable-2024-02-14"
     },
     "snes9x2002": {
-        "owner": "libretro",
-        "repo": "snes9x2002",
-        "rev": "540baad622d9833bba7e0696193cb06f5f02f564",
-        "hash": "sha256-WJh8Qf1/uFaL9f9d28qXsbpeAZfYGPgjoty3G6XAKSs=",
-        "date": "unstable-2022-08-06"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "snes9x2002",
+            "rev": "540baad622d9833bba7e0696193cb06f5f02f564",
+            "hash": "sha256-WJh8Qf1/uFaL9f9d28qXsbpeAZfYGPgjoty3G6XAKSs="
+        },
+        "version": "unstable-2022-08-06"
     },
     "snes9x2005": {
-        "owner": "libretro",
-        "repo": "snes9x2005",
-        "rev": "fd45b0e055bce6cff3acde77414558784e93e7d0",
-        "hash": "sha256-zjA/G62V38/hj+WjJDGAs48AcTUIiMWL8feCqLsCRnI=",
-        "date": "unstable-2022-07-25"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "snes9x2005",
+            "rev": "fd45b0e055bce6cff3acde77414558784e93e7d0",
+            "hash": "sha256-zjA/G62V38/hj+WjJDGAs48AcTUIiMWL8feCqLsCRnI="
+        },
+        "version": "unstable-2022-07-25"
     },
     "snes9x2010": {
-        "owner": "libretro",
-        "repo": "snes9x2010",
-        "rev": "d8b10c4cd7606ed58f9c562864c986bc960faaaf",
-        "hash": "sha256-7FmteYrAYr+pGNXGg9CBC4NFlijGRf7GdtJfiNjmonU=",
-        "date": "unstable-2023-02-20"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "snes9x2010",
+            "rev": "d8b10c4cd7606ed58f9c562864c986bc960faaaf",
+            "hash": "sha256-7FmteYrAYr+pGNXGg9CBC4NFlijGRf7GdtJfiNjmonU="
+        },
+        "version": "unstable-2023-02-20"
     },
     "stella": {
-        "owner": "stella-emu",
-        "repo": "stella",
-        "rev": "4557099e5d7a0c0b02424ea85d2a4b093911e048",
-        "hash": "sha256-wyJExpIIScgLTALgvqW5f/QgIsMC19JU8Meh3mV4d2c=",
-        "date": "unstable-2024-02-02"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "stella-emu",
+            "repo": "stella",
+            "rev": "4557099e5d7a0c0b02424ea85d2a4b093911e048",
+            "hash": "sha256-wyJExpIIScgLTALgvqW5f/QgIsMC19JU8Meh3mV4d2c="
+        },
+        "version": "unstable-2024-02-02"
     },
     "stella2014": {
-        "owner": "libretro",
-        "repo": "stella2014-libretro",
-        "rev": "8ab051edd4816f33a5631d230d54059eeed52c5f",
-        "hash": "sha256-wqssB8WXXF2Lu9heII8nWLLOvI38cIfHSMA7OOd6jx0=",
-        "date": "unstable-2023-02-20"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "stella2014-libretro",
+            "rev": "8ab051edd4816f33a5631d230d54059eeed52c5f",
+            "hash": "sha256-wqssB8WXXF2Lu9heII8nWLLOvI38cIfHSMA7OOd6jx0="
+        },
+        "version": "unstable-2023-02-20"
     },
     "swanstation": {
-        "owner": "libretro",
-        "repo": "swanstation",
-        "rev": "77aeeea58a45cccae7a8be37645f8f5a27ff101b",
-        "hash": "sha256-z+9Y9hoQ832caip5U+siQXh9GFxLMnX0HcmLa93B/lc=",
-        "date": "unstable-2024-01-26"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "swanstation",
+            "rev": "77aeeea58a45cccae7a8be37645f8f5a27ff101b",
+            "hash": "sha256-z+9Y9hoQ832caip5U+siQXh9GFxLMnX0HcmLa93B/lc="
+        },
+        "version": "unstable-2024-01-26"
     },
     "tgbdual": {
-        "owner": "libretro",
-        "repo": "tgbdual-libretro",
-        "rev": "a6f3018e6a23030afc1873845ee54d4b2d8ec9d3",
-        "hash": "sha256-MBUgYXX/Pc+TkwoS7OwbXSPssKUf6lwWx/bKhvwDkHs=",
-        "date": "unstable-2022-08-06"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "tgbdual-libretro",
+            "rev": "a6f3018e6a23030afc1873845ee54d4b2d8ec9d3",
+            "hash": "sha256-MBUgYXX/Pc+TkwoS7OwbXSPssKUf6lwWx/bKhvwDkHs="
+        },
+        "version": "unstable-2022-08-06"
     },
     "thepowdertoy": {
-        "owner": "libretro",
-        "repo": "ThePowderToy",
-        "rev": "f644498193c4c8be689d8a1d2a70e37e4eff4243",
-        "hash": "sha256-aPUqrrrH2Ia56A3Kx6ClMcZO9nbHGJIcEQ6nFyIMamo=",
-        "date": "unstable-2023-01-17"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "ThePowderToy",
+            "rev": "f644498193c4c8be689d8a1d2a70e37e4eff4243",
+            "hash": "sha256-aPUqrrrH2Ia56A3Kx6ClMcZO9nbHGJIcEQ6nFyIMamo="
+        },
+        "version": "unstable-2023-01-17"
     },
     "tic80": {
-        "owner": "libretro",
-        "repo": "tic-80",
-        "rev": "bd6ce86174fc7c9d7d3a86263acf3a7de1b62c11",
-        "hash": "sha256-RFp8sTSRwD+cgW3EYk3nBeY+zVKgZVQI5mjtfe2a64Q=",
-        "fetchSubmodules": true,
-        "date": "unstable-2022-06-11"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "tic-80",
+            "rev": "bd6ce86174fc7c9d7d3a86263acf3a7de1b62c11",
+            "hash": "sha256-RFp8sTSRwD+cgW3EYk3nBeY+zVKgZVQI5mjtfe2a64Q=",
+            "fetchSubmodules": true
+        },
+        "version": "unstable-2022-06-11"
     },
     "vba-m": {
-        "owner": "libretro",
-        "repo": "vbam-libretro",
-        "rev": "a2378f05f600a5a9cf450c60a87976b80d6a895a",
-        "hash": "sha256-vWm28cSEGex5h7JkJjzNPqEGtQWHK0dpK2gVDlQ3NbM=",
-        "date": "unstable-2023-08-18"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "vbam-libretro",
+            "rev": "a2378f05f600a5a9cf450c60a87976b80d6a895a",
+            "hash": "sha256-vWm28cSEGex5h7JkJjzNPqEGtQWHK0dpK2gVDlQ3NbM="
+        },
+        "version": "unstable-2023-08-18"
     },
     "vba-next": {
-        "owner": "libretro",
-        "repo": "vba-next",
-        "rev": "ee92625d2f1666496be4f5662508a2430e846b00",
-        "hash": "sha256-r3FKBD4GUUkobMJ33VceseyTyqxm/Wsa5Er6XcfGL2Q=",
-        "date": "unstable-2023-06-03"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "vba-next",
+            "rev": "ee92625d2f1666496be4f5662508a2430e846b00",
+            "hash": "sha256-r3FKBD4GUUkobMJ33VceseyTyqxm/Wsa5Er6XcfGL2Q="
+        },
+        "version": "unstable-2023-06-03"
     },
     "vecx": {
-        "owner": "libretro",
-        "repo": "libretro-vecx",
-        "rev": "56a99fa08a7601b304d752188ca573febf26faeb",
-        "hash": "sha256-9/d6qzsUJZYZewAbFI4LU2FVpv09uby/5mxCZU7rVzo=",
-        "date": "unstable-2024-02-10"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "libretro-vecx",
+            "rev": "56a99fa08a7601b304d752188ca573febf26faeb",
+            "hash": "sha256-9/d6qzsUJZYZewAbFI4LU2FVpv09uby/5mxCZU7rVzo="
+        },
+        "version": "unstable-2024-02-10"
     },
     "virtualjaguar": {
-        "owner": "libretro",
-        "repo": "virtualjaguar-libretro",
-        "rev": "8126e5c504ac7217a638f38e4cd9190822c8abdd",
-        "hash": "sha256-U/qdKApE0OU3jc6ekfgEZ7VCaIqCc2h+Y+IHe7PIRY0=",
-        "date": "unstable-2023-06-01"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "virtualjaguar-libretro",
+            "rev": "8126e5c504ac7217a638f38e4cd9190822c8abdd",
+            "hash": "sha256-U/qdKApE0OU3jc6ekfgEZ7VCaIqCc2h+Y+IHe7PIRY0="
+        },
+        "version": "unstable-2023-06-01"
     },
     "yabause": {
-        "owner": "libretro",
-        "repo": "yabause",
-        "rev": "4c96b96f7fbe07223627c469ff33376b2a634748",
-        "hash": "sha256-7hEpGh2EcrlUoRiUNntaMZEQtStglYAY1MeCub5p8f8=",
-        "date": "unstable-2023-01-03"
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "libretro",
+            "repo": "yabause",
+            "rev": "4c96b96f7fbe07223627c469ff33376b2a634748",
+            "hash": "sha256-7hEpGh2EcrlUoRiUNntaMZEQtStglYAY1MeCub5p8f8="
+        },
+        "version": "unstable-2023-01-03"
     }
 }


### PR DESCRIPTION
## Description of changes

- Add support for multiple fetchers (for now `fetchFromGitHub` is still the only supported one)
- Use `--meta` from `nix-prefetch-github` to extract the date
- Show errors in `nix-prefetch-github` if they occur

This PR will stay in draft until https://github.com/seppeljordan/nix-prefetch-github/pull/64 is released and `nix-prefetch-github` derivation is updated, so we can avoid needing to call GitHub twice for each core CC @seppeljordan.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
