### PR TITLE
prettier-plugin-sql-cst: init at 0.11.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6032,6 +6032,12 @@
     githubId = 30512529;
     name = "Evils";
   };
+  evolutics = {
+    email = "benjamin.fischer@evolutics.info";
+    github = "evolutics";
+    githubId = 8361681;
+    name = "Benjamin Fischer";
+  };
   ewok = {
     email = "ewok@ewok.ru";
     github = "ewok-old";

--- a/pkgs/by-name/pr/prettier-plugin-sql-cst/package.json
+++ b/pkgs/by-name/pr/prettier-plugin-sql-cst/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "prettier-plugin-sql-cst",
+  "version": "0.11.4",
+  "description": "Prettier plugin for SQL",
+  "author": "Rene Saarsoo <nene@triin.net>",
+  "license": "GPL-3.0-or-later",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nene/prettier-plugin-sql-cst"
+  },
+  "homepage": "https://github.com/nene/prettier-plugin-sql-cst",
+  "bugs": {
+    "url": "https://github.com/nene/prettier-plugin-sql-cst/issues"
+  },
+  "files": [
+    "dist/"
+  ],
+  "scripts": {
+    "prepublishOnly": "yarn analyze-field-access && yarn test && yarn build",
+    "clean": "rm -rf dist",
+    "build": "yarn clean && tsc",
+    "test": "yarn node --experimental-vm-modules $(yarn bin jest)",
+    "pretty": "prettier -w src/ test/",
+    "ts:check": "tsc --noEmit",
+    "analyze-field-access": "ts-node scripts/analyze-field-access.ts src/index.ts"
+  },
+  "keywords": [
+    "prettier",
+    "sql",
+    "plugin"
+  ],
+  "dependencies": {
+    "prettier": "^3.0.3",
+    "sql-parser-cst": "^0.27.1"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.2.5",
+    "chalk": "^4.1.2",
+    "dedent-js": "^1.0.1",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "ts-node": "^10.9.2",
+    "typescript": "^4.9.4"
+  }
+}

--- a/pkgs/by-name/pr/prettier-plugin-sql-cst/package.nix
+++ b/pkgs/by-name/pr/prettier-plugin-sql-cst/package.nix
@@ -1,0 +1,35 @@
+{ lib
+, stdenv
+, mkYarnPackage
+, fetchFromGitHub
+, fetchYarnDeps
+}:
+
+mkYarnPackage rec {
+  pname = "prettier-plugin-sql-cst";
+  version = "0.11.4";
+
+  src = fetchFromGitHub {
+    owner = "nene";
+    repo = "prettier-plugin-sql-cst";
+    rev = "v${version}";
+    hash = "sha256-k6m95FHeJ+iiWSeY++1zds/bo1RtNXbnv2spaY/M+L0="; # TODO: Fix.
+  };
+
+  packageJSON = ./package.json;
+
+  doDist = false;
+
+  offlineCache = fetchYarnDeps {
+    yarnLock = "${src}/yarn.lock";
+    hash = "sha256-Vs8bfkhEbPv33ew//HBeDnpQcyWveByHi1gUsdl2CNI="; # TODO: Fix.
+  };
+
+  meta = with lib; {
+    changelog = "https://github.com/nene/prettier-plugin-sql-cst/releases/tag/${src.rev}";
+    homepage = "https://github.com/nene/prettier-plugin-sql-cst";
+    description = "Prettier SQL plugin that uses sql-parser-cst";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ evolutics ];
+  };
+}


### PR DESCRIPTION
## Description of changes

[Prettier](https://prettier.io/) is a well-known code formatter. While it does not have built-in support for SQL code, there is this plugin SQL-CST ([`prettier-plugin-sql-cst`](https://github.com/nene/prettier-plugin-sql-cst)).

See also [release notes](https://github.com/nene/prettier-plugin-sql-cst/releases).

As for the alternatives, there already exists a NixOS package [`nodePackages.sql-formatter`](https://search.nixos.org/packages?query=nodePackages.sql%2Dformatter) as well as a Node.js package [`prettier-plugin-sql`](https://github.com/un-ts/prettier/tree/master/packages/sql), both of which wrap the same [SQL Formatter](https://github.com/sql-formatter-org/sql-formatter). However, as the author of that SQL Formatter explains, they have started `prettier-plugin-sql-cst` to improve the original tool (see [details](https://github.com/sql-formatter-org/sql-formatter?tab=readme-ov-file#the-future)).

[`pkgs/by-name/po/postlight-parser`](https://github.com/NixOS/nixpkgs/tree/master/pkgs/by-name/po/postlight-parser) has served me as an example for a Yarn package in Nix.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
  - Integration test TODO:
    ```bash
    $ echo 'SELECT a , b FROM c ;' | prettier \
      --plugin ./result/lib/prettier-plugin-sql-cst/dist/index.js \
      --stdin-filepath in.sql
    SELECT a, b FROM c;
    ```
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`) _(there are none)_
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

## See also

- Prettier TOML plugin from PR #129660
- Prettier XML plugin from PR #150346

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
