### PR TITLE
python3Packages.jishaku: init at 2.5.2

### DIFF
--- a/pkgs/development/python-modules/import-expression/default.nix
+++ b/pkgs/development/python-modules/import-expression/default.nix
@@ -1,0 +1,45 @@
+{ lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchpatch,
+  pytestCheckHook,
+  astunparse,
+  setuptools
+}:
+buildPythonPackage rec {
+  pname = "import-expression";
+  version = "1.1.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ioistired";
+    repo = "import-expression-parser";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-mll2NePB7fthzltLOk6D9BgaDpH6GaW4psqcGun/0qM=";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/ioistired/import-expression-parser/commit/3daf968c3163b64685aa529740e132f0df5ab262.patch";
+      hash = "sha256-2Ubv3onor2D26udZbDDMb3iNLopEIRnIcO/X6WUVmJU=";
+    })
+  ];
+
+  nativeBuildInputs = [ setuptools ];
+  propagatedBuildInputs = [ astunparse ];
+  nativeCheckInputs = [ pytestCheckHook ];
+  pytestFlagsArray = [ "tests.py" ];
+
+  pythonImportsCheck = [
+    "import_expression"
+    "import_expression._codec"
+  ];
+
+  meta = {
+    description = "Transpiles a superset of python to allow easy inline imports";
+    homepage = "https://github.com/ioistired/import-expression-parser";
+    license = with lib.licenses; [ mit psfl ];
+    mainProgram = "import-expression";
+    maintainers = with lib.maintainers; [ lychee ];
+  };
+}

--- a/pkgs/development/python-modules/jishaku/default.nix
+++ b/pkgs/development/python-modules/jishaku/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchpatch,
+  setuptools,
+  discordpy,
+  click,
+  braceexpand,
+  import-expression,
+  tabulate,
+  pytestCheckHook,
+  pytest-asyncio,
+  youtube-dl
+}:
+buildPythonPackage rec {
+  pname = "jishaku";
+  version = "2.5.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Gorialis";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-BWnuk6h80cKwRECyTuRvnYnTC78219oraeTNoqWDd1c=";
+  };
+
+  patches = [
+    (fetchpatch {
+      # add entrypoint for install script
+      url = "https://github.com/Gorialis/jishaku/commit/b96cd55a1c2fd154c548f08019ccd6f7be9c7f90.patch";
+      hash = "sha256-laPoupwCC1Zthib8G+c1BXqTwZK0Z6up1DKVkhFicJ0=";
+    })
+  ];
+
+  nativeBuildInputs = [ setuptools ];
+
+  propagatedBuildInputs = [
+    discordpy
+    click
+    braceexpand
+    tabulate
+    import-expression
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    youtube-dl
+  ];
+
+  pythonImportsCheck = [
+    "jishaku"
+    "jishaku.repl"
+    "jishaku.features"
+  ];
+
+  meta = {
+    description = "A debugging and testing cog for discord.py bots";
+    homepage = "https://jishaku.readthedocs.io/en/latest";
+    changelog = "https://github.com/Gorialis/jishaku/releases/tag/${version}";
+    maintainers = with lib.maintainers; [ lychee ];
+    mainProgram = "jishaku";
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5861,6 +5861,8 @@ self: super: with self; {
 
   jira = callPackage ../development/python-modules/jira { };
 
+  jishaku = callPackage ../development/python-modules/jishaku { };
+
   jiwer = callPackage ../development/python-modules/jiwer { };
 
   jmespath = callPackage ../development/python-modules/jmespath { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5526,6 +5526,8 @@ self: super: with self; {
 
   impacket = callPackage ../development/python-modules/impacket { };
 
+  import-expression = callPackage ../development/python-modules/import-expression { };
+
   importlab = callPackage ../development/python-modules/importlab { };
 
   importlib-metadata = callPackage ../development/python-modules/importlib-metadata { };


### PR DESCRIPTION
## Description of changes

This PR adds [`jishaku`](https://github.com/Gorialis/jishaku) as a python module, and due to `import-expression` being a missing module in nixpkgs as well, I also packaged it in a different commit.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
