### PR TITLE
jogl: refactor

### DIFF
--- a/pkgs/by-name/jo/jogl/package.nix
+++ b/pkgs/by-name/jo/jogl/package.nix
@@ -38,7 +38,31 @@ stdenv.mkDerivation {
 
   unpackCmd = "cp -r $curSrc \${curSrc##*-}";
 
-  postPatch = lib.optionalString stdenv.isDarwin ''
+  postPatch = ''
+    substituteInPlace gluegen/src/java/com/jogamp/common/util/IOUtil.java \
+      --replace-fail '#!/bin/true' '#!${coreutils}/bin/true'
+  ''
+  # set timestamp of files in jar to a fixed point in time
+  + ''
+    xmlstarlet ed --inplace \
+      --append //jar --type attr -n modificationtime --value 1980-01-01T00:00Z \
+      gluegen/make/{build.xml,gluegen-cpptasks-base.xml} \
+      jogl/make/{build.xml,build-nativewindow.xml,build-jogl.xml}
+  ''
+  # prevent looking for native libraries in /usr/lib
+  + ''
+    substituteInPlace jogl/make/build-*.xml \
+      --replace-warn 'dir="''${TARGET_PLATFORM_USRLIBS}"' ""
+  ''
+  # force way to do disfunctional "ant -Dsetup.addNativeBroadcom=false" and disable dependency on raspberrypi drivers
+  # if arm/aarch64 support will be added, this block might be commented out on those platforms
+  # on x86 compiling with default "setup.addNativeBroadcom=true" leads to unsatisfied import "vc_dispmanx_resource_delete" in libnewt.so
+  + ''
+    xmlstarlet ed --inplace \
+      --delete '//*[@if="setup.addNativeBroadcom"]' \
+      jogl/make/build-newt.xml
+  ''
+  + lib.optionalString stdenv.isDarwin ''
     sed -i '/if="use.macos/d' gluegen/make/gluegen-cpptasks-base.xml
     rm -r jogl/oculusvr-sdk
   '';
@@ -67,46 +91,35 @@ stdenv.mkDerivation {
     darwin.apple_sdk_11_0.frameworks.Cocoa
   ];
 
-  # Workaround build failure on -fno-common toolchains:
-  #   ld: ../obj/Bindingtest1p1Impl_JNI.o:(.bss+0x8): multiple definition of
-  #     `unsigned_size_t_1'; ../obj/TK_Surface_JNI.o:(.bss+0x8): first defined here
-  NIX_CFLAGS_COMPILE = "-fcommon"; # copied from 2.3.2, is this still needed?
+  env = {
+    SOURCE_LEVEL = "1.8";
+    TARGET_LEVEL = "1.8";
+    TARGET_RT_JAR = "null.jar";
+    # error: incompatible pointer to integer conversion returning 'GLhandleARB' (aka 'void *') from a function with result type 'jlong' (aka 'long long')
+    NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-int-conversion";
+  };
 
   buildPhase = ''
-    ( cd gluegen/make
-      substituteInPlace ../src/java/com/jogamp/common/util/IOUtil.java --replace '#!/bin/true' '#!${coreutils}/bin/true'
+    runHook preBuild
 
-      # set timestamp of files in jar to a fixed point in time
-      xmlstarlet ed --inplace \
-         --append //jar --type attr -n modificationtime --value 1980-01-01T00:00Z \
-         build.xml gluegen-cpptasks-base.xml
+    for f in gluegen jogl; do
+      pushd $f/make
+      ant
+      popd
+    done
 
-      ant -Dtarget.sourcelevel=8 -Dtarget.targetlevel=8 -Dtarget.rt.jar='null.jar' )
-
-    ( cd jogl/make
-
-      # prevent looking for native libraries in /usr/lib
-      substituteInPlace build-*.xml \
-        --replace 'dir="''${TARGET_PLATFORM_USRLIBS}"' ""
-
-      # force way to do disfunctional "ant -Dsetup.addNativeBroadcom=false" and disable dependency on raspberrypi drivers
-      # if arm/aarch64 support will be added, this block might be commented out on those platforms
-      # on x86 compiling with default "setup.addNativeBroadcom=true" leads to unsatisfied import "vc_dispmanx_resource_delete" in libnewt.so
-      xmlstarlet ed --inplace --delete '//*[@if="setup.addNativeBroadcom"]' build-newt.xml
-
-      # set timestamp of files in jar to a fixed point in time
-      xmlstarlet ed --inplace \
-         --append //jar --type attr -n modificationtime --value 1980-01-01T00:00Z \
-         build.xml build-nativewindow.xml build-jogl.xml
-
-      ant -Dtarget.sourcelevel=8 -Dtarget.targetlevel=8 -Dtarget.rt.jar='null.jar' )
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/share/java
     cp -v $NIX_BUILD_TOP/gluegen/build/gluegen-rt{,-natives-linux-*}.jar $out/share/java/
     cp -v $NIX_BUILD_TOP/jogl/build/jar/jogl-all{,-natives-linux-*}.jar  $out/share/java/
     cp -v $NIX_BUILD_TOP/jogl/build/nativewindow/nativewindow{,-awt,-natives-linux-*,-os-drm,-os-x11}.jar  $out/share/java/
+
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

The goal of this PR is to establish a clear `patchPhase`/`buildPhase` separation. Also fixes building on darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
