### PR TITLE
vscode-extensions.quarto.quarto: init at v1.110.1

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -3007,6 +3007,21 @@ let
         };
       };
 
+      quarto.quarto = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "quarto";
+          publisher = "quarto";
+          version = "1.110.1";
+          sha256 = "sha256-9k0ynU7dFc64LTND50R5C98qGkdek8BzWXZKs0sqRWA=";
+        };
+        meta = {
+          description = "Extension for the Quarto scientific and technical publishing system.";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=quarto.quarto";
+          homepage = "https://quarto.org/";
+          license = lib.licenses.agpl3;
+        };
+      };
+
       quicktype.quicktype = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "quicktype";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -3368,6 +3368,22 @@ let
         };
       };
 
+      snakemake.snakemake-lang = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "snakemake-lang";
+          publisher = "snakemake";
+          version = "0.1.8";
+          sha256 = "sha256-ZJa/QWeS3E7XOFAE7FfVykHMax6tMbGyEZTPJwwXe1s=";
+        };
+        meta =  {
+          changelog = "https://github.com/snakemake/snakemake-lang-vscode-plugin/blob/master/CHANGELOG.md";
+          description = "Language support and snippets for Snakemake workflows (Snakefile, *.smk).";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=snakemake.snakemake-lang";
+          homepage = "https://github.com/snakemake/snakemake-lang-vscode-plugin";
+          license = lib.licenses.mit;
+        };
+      };
+
       sonarsource.sonarlint-vscode = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "sonarlint-vscode";


### PR DESCRIPTION
## Description of changes

Adding [Quarto](https://quarto.org/) extension for VSCode.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
