### PR TITLE
[23.11] ansible_2_15: 2.15.5 -> 2.15.9

### DIFF
--- a/pkgs/development/python-modules/ansible/core.nix
+++ b/pkgs/development/python-modules/ansible/core.nix
@@ -28,11 +28,11 @@
 
 buildPythonPackage rec {
   pname = "ansible-core";
-  version = "2.15.5";
+  version = "2.15.9";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-jMU5y41DSa8//ZAccHIvenogOuZCfdrJX/31RqbkFgI=";
+    hash = "sha256-JfmxtaWvPAmGvTko7QhurduGdSf7XIOv7xoDz60080U=";
   };
 
   # ansible_connection is already wrapped, so don't pass it through


### PR DESCRIPTION
## Description of changes

Fixes CVE-2023-5764.

https://github.com/ansible/ansible/blob/v2.15.9/changelogs/CHANGELOG-v2.15.rst
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Result of `nixpkgs-review pr 287886` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>38 packages built:</summary>
  <ul>
    <li>ansible (python311Packages.ansible-core)</li>
    <li>ansible-later</li>
    <li>ansible-later.dist</li>
    <li>ansible-lint</li>
    <li>ansible-lint.dist</li>
    <li>ansible.dist (python311Packages.ansible-core.dist)</li>
    <li>kargo</li>
    <li>kargo.dist</li>
    <li>molecule (python311Packages.molecule)</li>
    <li>molecule.dist (python311Packages.molecule.dist)</li>
    <li>python310Packages.ansible-compat</li>
    <li>python310Packages.ansible-compat.dist</li>
    <li>python310Packages.ansible-core</li>
    <li>python310Packages.ansible-core.dist</li>
    <li>python310Packages.ansible-kernel</li>
    <li>python310Packages.ansible-kernel.dist</li>
    <li>python310Packages.ansible-runner</li>
    <li>python310Packages.ansible-runner.dist</li>
    <li>python310Packages.ansible-vault-rw</li>
    <li>python310Packages.ansible-vault-rw.dist</li>
    <li>python310Packages.molecule</li>
    <li>python310Packages.molecule.dist</li>
    <li>python310Packages.pytest-ansible</li>
    <li>python310Packages.pytest-ansible.dist</li>
    <li>python310Packages.pytest-testinfra</li>
    <li>python310Packages.pytest-testinfra.dist</li>
    <li>python311Packages.ansible-compat</li>
    <li>python311Packages.ansible-compat.dist</li>
    <li>python311Packages.ansible-kernel</li>
    <li>python311Packages.ansible-kernel.dist</li>
    <li>python311Packages.ansible-runner</li>
    <li>python311Packages.ansible-runner.dist</li>
    <li>python311Packages.ansible-vault-rw</li>
    <li>python311Packages.ansible-vault-rw.dist</li>
    <li>python311Packages.pytest-ansible</li>
    <li>python311Packages.pytest-ansible.dist</li>
    <li>python311Packages.pytest-testinfra</li>
    <li>python311Packages.pytest-testinfra.dist</li>
  </ul>
</details>
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
