### PR TITLE
sptk: fix `gcc-13` build failure

### DIFF
--- a/pkgs/development/libraries/sptk/default.nix
+++ b/pkgs/development/libraries/sptk/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , cmake
 , fetchFromGitHub
+, fetchpatch
 }:
 
 stdenv.mkDerivation rec {
@@ -14,6 +15,16 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     hash = "sha256-lIyOcN2AR3ilUZ9stpicjbwlredbwgGPwmMICxZEijU=";
   };
+
+  patches = [
+    # Fix gcc-13 build failure:
+    #   https://github.com/sp-nitech/SPTK/pull/57
+    (fetchpatch {
+      name = "gcc-13.patch";
+      url = "https://github.com/sp-nitech/SPTK/commit/060bc2ad7a753c1f9f9114a70d4c4337b91cb7e0.patch";
+      hash = "sha256-QfzpIS63LZyTHAaMGUZh974XLRNZLQG3om7ZJJ4RlgE=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Without the change build fails on` master` as
https://hydra.nixos.org/build/247569562:

    /build/source/src/conversion/autocorrelation_to_composite_sinusoidal_modeling.cc:25:1: error: 'uint64_t' does not name a type
       25 | uint64_t CalculateBinomialCoefficient(int n, int k) {
          | ^~~~~~~~
    /build/source/src/conversion/autocorrelation_to_composite_sinusoidal_modeling.cc:21:1: note: 'uint64_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
       20 | #include <cmath>      // std::acos, std::fabs, std::pow
      +++ |+#include <cstdint>
       21 | #include <cstddef>    // std::size_t

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
