### PR TITLE
pmbootstrap 2.1.0 -> 2.2.0

### DIFF
--- a/pkgs/tools/misc/pmbootstrap/default.nix
+++ b/pkgs/tools/misc/pmbootstrap/default.nix
@@ -1,23 +1,18 @@
 { stdenv, lib, git, openssl, buildPythonApplication, pytestCheckHook, ps
-, fetchPypi, fetchFromSourcehut, sudo }:
+, fetchPypi, fetchFromGitLab, sudo }:
 
 buildPythonApplication rec {
   pname = "pmbootstrap";
-  version = "2.1.0";
+  version = "2.2.0";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-buCfQsi10LezDzYeplArmFRSc3vbjtl+FuTm/VUS2us=";
-  };
-
-  repo = fetchFromSourcehut {
-    owner = "~postmarketos";
+  src = fetchFromGitLab {
+    owner = "postmarketos";
     repo = pname;
     rev = version;
-    hash = "sha256-3GZ4PeMnG/a46WwvWPQFeYbJPp+NGU7A98QasnlMIL0=";
+    hash = "sha256-wRJvvABIUPh79QfS8VcwRueB/vO9oGcqyE/OugfTsd8=";
   };
 
-  pmb_test = "${repo}/test";
+  pmb_test = "${src}/test";
 
   # Tests depend on sudo
   doCheck = stdenv.isLinux;
@@ -33,14 +28,17 @@ buildPythonApplication rec {
     "test_aportgen"
     "test_aportgen_device_wizard"
     "test_bootimg"
+    "test_build_abuild_leftovers"
     "test_build_depends_binary_outdated"
     "test_build_depends_high_level"
     "test_build_depends_no_binary_error"
     "test_build_is_necessary"
     "test_build_local_source_high_level"
     "test_build_src_invalid_path"
+    "test_check"
     "test_can_fast_forward"
     "test_check_build_for_arch"
+    "test_check_config"
     "test_chroot_arguments"
     "test_chroot_interactive_shell"
     "test_chroot_interactive_shell_user"
@@ -49,6 +47,8 @@ buildPythonApplication rec {
     "test_config_user"
     "test_cross_compile_distcc"
     "test_crossdirect"
+    "test_extract_arch"
+    "test_extract_version"
     "test_file"
     "test_filter_aport_packages"
     "test_filter_missing_packages_binary_exists"
@@ -56,6 +56,7 @@ buildPythonApplication rec {
     "test_filter_missing_packages_pmaports"
     "test_finish"
     "test_folder_size"
+    "test_get_all_component_names"
     "test_get_apkbuild"
     "test_get_depends"
     "test_get_upstream_remote"
@@ -72,6 +73,7 @@ buildPythonApplication rec {
     "test_pkgrel_bump"
     "test_pmbootstrap_status"
     "test_print_checks_git_repo"
+    "test_proxy"
     "test_pull"
     "test_qemu_running_processes"
     "test_questions_additional_options"
@@ -87,18 +89,13 @@ buildPythonApplication rec {
     "test_skip_already_built"
     "test_switch_to_channel_branch"
     "test_version"
-    "test_build_abuild_leftovers"
-    "test_get_all_component_names"
-    "test_check_config"
-    "test_extract_arch"
-    "test_extract_version"
-    "test_check"
   ];
 
   makeWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ git openssl ]}" ];
 
   meta = with lib; {
-    description = "Sophisticated chroot/build/flash tool to develop and install postmarketOS";
+    description =
+      "Sophisticated chroot/build/flash tool to develop and install postmarketOS";
     homepage = "https://gitlab.com/postmarketOS/pmbootstrap";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ onny ];


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
* Release notes: https://gitlab.com/postmarketOS/pmbootstrap/-/tags/2.2.0
* According to the postmarketOS blog, development has moved back to
gitlab: https://postmarketos.org/blog/2024/01/17/moving-pmbootstrap/
* Ordered test names and added new impure test case to be skipped.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
