### PR TITLE
pythonCatchConflictsHook: scan $out, not sys.path (2)

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -469,7 +469,7 @@ are used in [`buildPythonPackage`](#buildpythonpackage-function).
   be added as `nativeBuildInput`.
 - `pipInstallHook` to install wheels.
 - `pytestCheckHook` to run tests with `pytest`. See [example usage](#using-pytestcheckhook).
-- `pythonCatchConflictsHook` to check whether a Python package is not already existing.
+- `pythonCatchConflictsHook` to fail if the package depends on two different versions of the same dependency.
 - `pythonImportsCheckHook` to check whether importing the listed modules works.
 - `pythonRelaxDepsHook` will relax Python dependencies restrictions for the package.
   See [example usage](#using-pythonrelaxdepshook).

--- a/pkgs/development/interpreters/python/catch_conflicts/catch_conflicts.py
+++ b/pkgs/development/interpreters/python/catch_conflicts/catch_conflicts.py
@@ -5,39 +5,71 @@ import sys
 import os
 
 
-do_abort = False
-packages = collections.defaultdict(list)
-out_path = Path(os.getenv("out"))
-version = sys.version_info
-site_packages_path = f'lib/python{version[0]}.{version[1]}/site-packages'
+do_abort: bool = False
+packages: dict[str, dict[str, list[dict[str, list[str]]]]] = collections.defaultdict(list)
+out_path: Path = Path(os.getenv("out"))
+version: tuple[int, int] = sys.version_info
+site_packages_path: str = f'lib/python{version[0]}.{version[1]}/site-packages'
 
 
-def find_packages(store_path, site_packages_path):
-    site_packages = (store_path / site_packages_path)
-    propagated_build_inputs = (store_path / "nix-support/propagated-build-inputs")
+# pretty print a package
+def describe_package(dist: PathDistribution) -> str:
+    return f"{dist._normalized_name} {dist.version} ({dist._path})"
+
+
+# pretty print a list of parents (dependency chain)
+def describe_parents(parents: list[str]) -> str:
+    if not parents:
+        return ""
+    return \
+        f"    dependency chain:\n      " \
+        + str(f"\n      ...depending on: ".join(parents))
+
+
+# inserts an entry into 'packages'
+def add_entry(name: str, version: str, store_path: str, parents: list[str]) -> None:
+    if name not in packages:
+        packages[name] = {}
+    if store_path not in packages[name]:
+        packages[name][store_path] = []
+    packages[name][store_path].append(dict(
+        version=version,
+        parents=parents,
+    ))
+
+
+# transitively discover python dependencies and store them in 'packages'
+def find_packages(store_path: Path, site_packages_path: str, parents: list[str]) -> None:
+    site_packages: Path = (store_path / site_packages_path)
+    propagated_build_inputs: Path = (store_path / "nix-support/propagated-build-inputs")
+
+    # add the current package to the list
     if site_packages.exists():
         for dist_info in site_packages.glob("*.dist-info"):
-            dist = PathDistribution(dist_info)
-            packages[dist._normalized_name].append(
-                f"{dist._normalized_name} {dist.version} ({dist._path})"
-            )
+            dist: PathDistribution = PathDistribution(dist_info)
+            add_entry(dist._normalized_name, dist.version, store_path, parents)
 
+    # recursively add dependencies
     if propagated_build_inputs.exists():
         with open(propagated_build_inputs, "r") as f:
-            build_inputs = f.read().strip().split(" ")
+            build_inputs: list[str] = f.read().strip().split(" ")
             for build_input in build_inputs:
-                find_packages(Path(build_input), site_packages_path)
+                find_packages(Path(build_input), site_packages_path, parents + [build_input])
 
 
-find_packages(out_path, site_packages_path)
+find_packages(out_path, site_packages_path, [f"this derivation: {out_path}"])
 
-for name, duplicates in packages.items():
-    if len(duplicates) > 1:
+# print all duplicates
+for name, store_paths in packages.items():
+    if len(store_paths) > 1:
         do_abort = True
         print("Found duplicated packages in closure for dependency '{}': ".format(name))
-        for duplicate in duplicates:
-            print(f"\t{duplicate}")
+        for store_path, candidates in store_paths.items():
+            for candidate in candidates:
+                print(f"  {name} {candidate['version']} ({store_path})")
+                print(describe_parents(candidate['parents']))
 
+# fail if duplicates were found
 if do_abort:
     print("")
     print(

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -118,6 +118,10 @@ in {
       } // lib.optionalAttrs useLegacyHook {
         inherit setuptools;
       };
+      passthru.tests = import ./python-catch-conflicts-hook-tests.nix {
+        inherit pythonOnBuildForHost runCommand;
+        inherit (pkgs) coreutils gnugrep writeShellScript;
+      };
     } ./python-catch-conflicts-hook.sh) {};
 
   pythonImportsCheckHook = callPackage ({ makePythonHook }:

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -108,7 +108,7 @@ in {
     makePythonHook {
       name = "python-catch-conflicts-hook";
       substitutions = let
-        useLegacyHook = lib.versionOlder python.pythonVersion "3.10";
+        useLegacyHook = lib.versionOlder python.pythonVersion "3";
       in {
         inherit pythonInterpreter pythonSitePackages;
         catchConflicts = if useLegacyHook then

--- a/pkgs/development/interpreters/python/hooks/python-catch-conflicts-hook-tests.nix
+++ b/pkgs/development/interpreters/python/hooks/python-catch-conflicts-hook-tests.nix
@@ -1,0 +1,137 @@
+{ pythonOnBuildForHost, runCommand, writeShellScript, coreutils, gnugrep }: let
+
+  pythonPkgs = pythonOnBuildForHost.pkgs;
+
+  ### UTILITIES
+
+  # customize a package so that its store paths differs
+  customize = pkg: pkg.overrideAttrs { some_modification = true; };
+
+  # generates minimal pyproject.toml
+  pyprojectToml = pname: builtins.toFile "pyproject.toml" ''
+    [project]
+    name = "${pname}"
+    version = "1.0.0"
+  '';
+
+  # generates source for a python project
+  projectSource = pname: runCommand "my-project-source" {} ''
+    mkdir -p $out/src
+    cp ${pyprojectToml pname} $out/pyproject.toml
+    touch $out/src/__init__.py
+  '';
+
+  # helper to reduce boilerplate
+  generatePythonPackage = args: pythonPkgs.buildPythonPackage (
+    {
+      version = "1.0.0";
+      src = runCommand "my-project-source" {} ''
+        mkdir -p $out/src
+        cp ${pyprojectToml args.pname} $out/pyproject.toml
+        touch $out/src/__init__.py
+      '';
+      pyproject = true;
+      catchConflicts = true;
+      buildInputs = [ pythonPkgs.setuptools ];
+    }
+    // args
+  );
+
+  # in order to test for a failing build, wrap it in a shell script
+  expectFailure = build: errorMsg: build.overrideDerivation (old: {
+    builder = writeShellScript "test-for-failure" ''
+      export PATH=${coreutils}/bin:${gnugrep}/bin:$PATH
+      ${old.builder} "$@" > ./log 2>&1
+      status=$?
+      cat ./log
+      if [ $status -eq 0 ] || ! grep -q "${errorMsg}" ./log; then
+        echo "The build should have failed with '${errorMsg}', but it didn't"
+        exit 1
+      else
+        echo "The build failed as expected with: ${errorMsg}"
+        mkdir -p $out
+      fi
+    '';
+  });
+in {
+
+  ### TEST CASES
+
+  # Test case which must not trigger any conflicts.
+  # This derivation has runtime dependencies on custom versions of multiple build tools.
+  # This scenario is relevant for lang2nix tools which do not override the nixpkgs fix-point.
+  # see https://github.com/NixOS/nixpkgs/issues/283695
+  ignores-build-time-deps =
+    generatePythonPackage {
+      pname = "ignores-build-time-deps";
+      buildInputs = [
+        pythonPkgs.build
+        pythonPkgs.packaging
+        pythonPkgs.setuptools
+        pythonPkgs.wheel
+      ];
+      propagatedBuildInputs = [
+        # Add customized versions of build tools as runtime deps
+        (customize pythonPkgs.packaging)
+        (customize pythonPkgs.setuptools)
+        (customize pythonPkgs.wheel)
+      ];
+    };
+
+  # Simplest test case that should trigger a conflict
+  catches-simple-conflict = let
+    # this build must fail due to conflicts
+    package = pythonPkgs.buildPythonPackage rec {
+      pname = "catches-simple-conflict";
+      version = "0.0.0";
+      src = projectSource pname;
+      pyproject = true;
+      catchConflicts = true;
+      buildInputs = [
+        pythonPkgs.setuptools
+      ];
+      # depend on two different versions of packaging
+      # (an actual runtime dependency conflict)
+      propagatedBuildInputs = [
+        pythonPkgs.packaging
+        (customize pythonPkgs.packaging)
+      ];
+    };
+  in
+    expectFailure package "Found duplicated packages in closure for dependency 'packaging'";
+
+
+  /*
+    More complex test case with a transitive conflict
+
+    Test sets up this dependency tree:
+
+      toplevel
+      ├── dep1
+      │   └── leaf
+      └── dep2
+          └── leaf (customized version -> conflicting)
+  */
+  catches-transitive-conflict = let
+    # package depending on both dependency1 and dependency2
+    toplevel = generatePythonPackage {
+      pname = "catches-transitive-conflict";
+      propagatedBuildInputs = [ dep1 dep2 ];
+    };
+    # dep1 package depending on leaf
+    dep1 = generatePythonPackage {
+      pname = "dependency1";
+      propagatedBuildInputs = [ leaf ];
+    };
+    # dep2 package depending on conflicting version of leaf
+    dep2 = generatePythonPackage {
+      pname = "dependency2";
+      propagatedBuildInputs = [ (customize leaf) ];
+    };
+    # some leaf package
+    leaf = generatePythonPackage {
+      pname = "leaf";
+    };
+  in
+    expectFailure toplevel "Found duplicated packages in closure for dependency 'leaf'";
+}


### PR DESCRIPTION
Based on #284067
Fixes https://github.com/NixOS/nixpkgs/issues/283695

- pythonCatchConflictsHook: scan only $out for conflicts instead of $PYTHONPATH (see #283695 on why this is better)
- improve error message: print part of the dependency tree that leads to the conflict
- add test cases for the hook testing 3 important scenarios
  - ensure hook ignores build time packages
  - ensure hook catches simple conflict
  - ensure hook catches transitive conflict
  
cc @mweinelt @phaer @FRidh 

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
