### PR TITLE
nixos-rebuild: capture the switch output to the journal

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -24,6 +24,9 @@ In addition to numerous new and upgraded packages, this release has the followin
 - A new option `system.etc.overlay.enable` was added. If enabled, `/etc` is
   mounted via an overlayfs instead of being created by a custom perl script.
 
+- `nixos-rebuild` output is now logged to the journal of the target system,
+  allowing finding what was done even if the session crashed.
+
 - It is now possible to have a completely perlless system (i.e. a system
   without perl). Previously, the NixOS activation depended on two perl scripts
   which can now be replaced via an opt-in mechanism. To make your system

--- a/nixos/modules/system/activation/capture-pty-to-journal.sh
+++ b/nixos/modules/system/activation/capture-pty-to-journal.sh
@@ -1,0 +1,21 @@
+#! @runtimeShell@
+# shellcheck shell=bash
+
+if [ -x "@runtimeShell@" ]; then export SHELL="@runtimeShell@"; fi;
+
+# Runs the provided command in script(1) with logging of stdout to the systemd journal.
+# This is necessary to keep the command thinking it is operating against a
+# terminal while still logging the output regardless. This is split into a
+# helper script to cleanly deal with shell quoting.
+#
+# This has been checked by some manual testing that this works fine even if the
+# journal has exploded or does not exist, such as in a container, chroot or
+# such cases.
+
+LABEL=${LABEL:-nixos-rebuild}
+# the cat >/dev/null is load bearing if systemd-cat fails to initialize,
+# because script does not like having its output fd hang up on it, and seems to
+# hang the terminal if that happens.
+#
+# ${*@Q} - the * array (all args as one word), with shell quoting applied (@Q modifier)
+@script@ --quiet --flush --log-out >(systemd-cat -t "$LABEL" >/dev/null 2>&1 || cat >/dev/null) --command "${*@Q}"

--- a/nixos/modules/system/activation/capture-pty-to-journal.sh
+++ b/nixos/modules/system/activation/capture-pty-to-journal.sh
@@ -12,7 +12,7 @@ if [ -x "@runtimeShell@" ]; then export SHELL="@runtimeShell@"; fi;
 # journal has exploded or does not exist, such as in a container, chroot or
 # such cases.
 
-LABEL=${LABEL:-nixos-rebuild}
+LABEL="${LABEL:-nixos-rebuild}"
 # the cat >/dev/null is load bearing if systemd-cat fails to initialize,
 # because script does not like having its output fd hang up on it, and seems to
 # hang the terminal if that happens.

--- a/nixos/modules/system/activation/switchable-system.nix
+++ b/nixos/modules/system/activation/switchable-system.nix
@@ -42,6 +42,14 @@ in
         ;
 
       chmod +x $out/bin/switch-to-configuration
+
+      substitute ${./capture-pty-to-journal.sh} $out/bin/capture-pty-to-journal \
+        --subst-var-by runtimeShell "${pkgs.bash}/bin/sh" \
+        --subst-var-by script "${pkgs.util-linux}/bin/script" \
+        ;
+
+      chmod +x $out/bin/capture-pty-to-journal
+
       ${lib.optionalString (pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform) ''
         if ! output=$(${perlWrapped}/bin/perl -c $out/bin/switch-to-configuration 2>&1); then
           echo "switch-to-configuration syntax is not valid:"

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -765,6 +765,9 @@ if [[ "$action" = switch || "$action" = boot || "$action" = test || "$action" = 
         "--service-type=exec"
         "--unit=nixos-rebuild-switch-to-configuration"
         "--wait"
+        # Grabs the output of switching configurations and sends it to the
+        # journal without disturbing the terminal attachment
+        "$pathToConfig/bin/capture-pty-to-journal"
     )
     # Check if we have a working systemd-run. In chroot environments we may have
     # a non-working systemd, so we fallback to not using systemd-run.


### PR DESCRIPTION
Currently nixos-rebuild switch runs switch-to-configuration attached to the user's terminal, but under systemd-run. This is great and helps take the switch to completion if the terminal vanishes, but it does not log the switch output itself to the journal because it is passed straight through to the terminal. We cannot stop using --pty mode, because some users do use stdin in their configuration switch scripts.

A while ago I really screwed up my configuration and it killed my entire desktop session when I switched. There was no log of what it did, besides guessing at which service changes were its fault while looking at the journal afterwards.

Fortunately, there is an ancient Unix utility called script(1) (today, in the util-linux package) which makes digital logs of your teletypewriter printouts as files, so you can `grep` them without having to pore over a large stack of folded paper by hand! What a labour saving!

This is exactly what we want, if the file in question is a pipe to systemd-cat, and it just takes some clever wrapping with a little bash script to shell-quote the command losslessly, so we can stick it in front of the configuration switch.

Arguably logging systemd-run pty mode could be a reasonable feature to include in systemd, but we already depend on util-linux for switch-to-configuration and can compose together something that works today.

Sample log:

```
Feb 11 08:18:16 nixos nixos-rebuild[1199]: Script started on 2024-02-11 08:18:16+00:00 [COMMAND="'/nix/store/q54lbnnnxic7pp2gg1lrs12ym5mgwrfz-nixos-system-nixos-24.05.20240204.>
Feb 11 08:18:16 nixos nixos-rebuild[1199]: Warning: do not know how to make this configuration bootable; please enable a boot loader.
Feb 11 08:18:16 nixos nixos[1200]: switching to system configuration /nix/store/q54lbnnnxic7pp2gg1lrs12ym5mgwrfz-nixos-system-nixos-24.05.20240204.dirty
Feb 11 08:18:16 nixos systemd[1]: Stopped target Local File Systems.
Feb 11 08:18:16 nixos systemd[1]: Stopped target Remote File Systems.
Feb 11 08:18:16 nixos nixos-rebuild[1199]: activating the configuration...
Feb 11 08:18:17 nixos nixos-rebuild[1199]: setting up /etc...
Feb 11 08:18:17 nixos systemd[1]: Reloading requested from client PID 1252 ('systemctl') (unit nixos-rebuild-switch-to-configuration.service)...
Feb 11 08:18:17 nixos systemd[1]: Reloading...
Feb 11 08:18:17 nixos systemd[1]: Reloading finished in 403 ms.
Feb 11 08:18:17 nixos nixos-rebuild[1199]: reloading user units for root...
Feb 11 08:18:17 nixos su[1278]: Successful su for root by root
Feb 11 08:18:17 nixos su[1278]: pam_unix(su:session): session opened for user root(uid=0) by (uid=0)
Feb 11 08:18:17 nixos systemd[1174]: Reexecuting requested from client PID 1280 ('systemctl')...
Feb 11 08:18:17 nixos systemd[1174]: Reexecuting.
Feb 11 08:18:17 nixos systemd[1174]: Run user-specific NixOS activation was skipped because of an unmet condition check (ConditionUser=!@system).
Feb 11 08:18:17 nixos su[1278]: pam_unix(su:session): session closed for user root
Feb 11 08:18:17 nixos nixos-rebuild[1199]: restarting sysinit-reactivation.target
Feb 11 08:18:17 nixos systemd[1]: Stopped target Reactivate sysinit units.
Feb 11 08:18:17 nixos systemd[1]: Stopping Reactivate sysinit units...
Feb 11 08:18:17 nixos systemd[1]: Reached target Reactivate sysinit units.
Feb 11 08:18:17 nixos systemd[1]: Reached target Local File Systems.
Feb 11 08:18:17 nixos systemd[1]: Reached target Remote File Systems.
Feb 11 08:18:18 nixos systemd[1]: Starting Load Kernel Module efi_pstore...
Feb 11 08:18:18 nixos systemd[1]: Starting Create SUID/SGID Wrappers...
Feb 11 08:18:18 nixos systemd[1]: modprobe@efi_pstore.service: Deactivated successfully.
Feb 11 08:18:18 nixos systemd[1]: Finished Load Kernel Module efi_pstore.
Feb 11 08:18:18 nixos systemd[1]: Platform Persistent Storage Archival was skipped because of an unmet condition check (ConditionDirectoryNotEmpty=/sys/fs/pstore).
Feb 11 08:18:18 nixos systemd[1]: suid-sgid-wrappers.service: Deactivated successfully.
Feb 11 08:18:18 nixos systemd[1]: Finished Create SUID/SGID Wrappers.
Feb 11 08:18:18 nixos nixos[1200]: finished switching to system configuration /nix/store/q54lbnnnxic7pp2gg1lrs12ym5mgwrfz-nixos-system-nixos-24.05.20240204.dirty
Feb 11 08:18:18 nixos nixos-rebuild[1199]: Script done on 2024-02-11 08:18:18+00:00 [COMMAND_EXIT_CODE="0"]
```

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I have manually checked this works by putting it in a docker container where systemd-cat would be broken, and cat'ing big files. I found out that way about the load bearing alternative `cat >/dev/null`, which fixes the lockup that happened then. I then stuck it into NixOS and ran a switch on a remote machine. The worst case failure mode of this, in any case, is that nixos-rebuild gives up and runs without systemd-run, which is ultimately harmless.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
