### PR TITLE
whitesur-gtk-theme: fix color variant names and add additional options

### DIFF
--- a/pkgs/data/themes/whitesur/default.nix
+++ b/pkgs/data/themes/whitesur/default.nix
@@ -24,7 +24,7 @@ let
 
 in
 lib.checkListOfEnum "${pname}: alt variants" [ "normal" "alt" "all" ] altVariants
-lib.checkListOfEnum "${pname}: color variants" [ "light" "dark" ] colorVariants
+lib.checkListOfEnum "${pname}: color variants" [ "Light" "Dark" ] colorVariants
 lib.checkListOfEnum "${pname}: opacity variants" [ "normal" "solid" ] opacityVariants
 lib.checkListOfEnum "${pname}: theme variants" [ "default" "blue" "purple" "pink" "red" "orange" "yellow" "green" "grey" "all" ] themeVariants
 lib.checkListOfEnum "${pname}: nautilus sidebar minimum width" [ "default" "180" "220" "240" "260" "280" ] (single nautilusSize)

--- a/pkgs/data/themes/whitesur/default.nix
+++ b/pkgs/data/themes/whitesur/default.nix
@@ -13,9 +13,12 @@
 , colorVariants ? [] # default: all
 , opacityVariants ? [] # default: all
 , themeVariants ? [] # default: default (BigSur-like theme)
+, iconVariant ? null # default: standard (Apple logo)
+, nautilusStyle ? null # default: stable (BigSur-like style)
 , nautilusSize ? null # default: 200px
 , panelOpacity ? null # default: 15%
 , panelSize ? null # default: 32px
+, roundedMaxWindow ? false # default: false
 }:
 
 let
@@ -27,6 +30,8 @@ lib.checkListOfEnum "${pname}: alt variants" [ "normal" "alt" "all" ] altVariant
 lib.checkListOfEnum "${pname}: color variants" [ "Light" "Dark" ] colorVariants
 lib.checkListOfEnum "${pname}: opacity variants" [ "normal" "solid" ] opacityVariants
 lib.checkListOfEnum "${pname}: theme variants" [ "default" "blue" "purple" "pink" "red" "orange" "yellow" "green" "grey" "all" ] themeVariants
+lib.checkListOfEnum "${pname}: Activities icon variants" [ "standard" "simple" "gnome" "ubuntu" "tux" "arch" "manjaro" "fedora" "debian" "void" "opensuse" "popos" "mxlinux" "zorin" ] (single iconVariant)
+lib.checkListOfEnum "${pname}: nautilus style" [ "stable" "normal" "mojave" "glassy" ] (single nautilusStyle)
 lib.checkListOfEnum "${pname}: nautilus sidebar minimum width" [ "default" "180" "220" "240" "260" "280" ] (single nautilusSize)
 lib.checkListOfEnum "${pname}: panel opacity" [ "default" "30" "45" "60" "75" ] (single panelOpacity)
 lib.checkListOfEnum "${pname}: panel size" [ "default" "smaller" "bigger" ] (single panelSize)
@@ -79,9 +84,12 @@ stdenv.mkDerivation rec {
       ${toString (map (x: "--color " + x) colorVariants)} \
       ${toString (map (x: "--opacity " + x) opacityVariants)} \
       ${toString (map (x: "--theme " + x) themeVariants)} \
+      ${lib.optionalString (iconVariant != null) ("--icon " + iconVariant)} \
+      ${lib.optionalString (nautilusStyle != null) ("--nautilus-style " + nautilusStyle)} \
       ${lib.optionalString (nautilusSize != null) ("--size " + nautilusSize)} \
       ${lib.optionalString (panelOpacity != null) ("--panel-opacity " + panelOpacity)} \
       ${lib.optionalString (panelSize != null) ("--panel-size " + panelSize)} \
+      ${lib.optionalString (roundedMaxWindow == true) "--roundedmaxwindow"} \
       --dest $out/share/themes
 
     jdupes --quiet --link-soft --recurse $out/share


### PR DESCRIPTION
## Description of changes

This PR contains two changes:

- The color variant names [were capitalized](https://github.com/vinceliuice/WhiteSur-gtk-theme/commit/bef774bd0fe74aa29338ab0757a58e3831138295#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R70). Attempting to use the `colorVariants` option at all thus failed, as the derivation would not accept uppercase variants, yet the script now only recognises uppercase.
- A few new options were surfaced:
    - `iconVariant`: Set the icon used for launching apps
    - `nautilusStyle`: Tweak the CSS of Nautilus to look like BigSur, Mojave, or a 'glassy' look
    - `roundMaxWindow`: Round the corners of windows when maximized.

I have tested this on my local setup with success.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
