### PR TITLE
timeloop: unstable-2022-11-29 -> 3.0.3, fix `gcc-13` build failure

### DIFF
--- a/pkgs/applications/science/computer-architecture/timeloop/default.nix
+++ b/pkgs/applications/science/computer-architecture/timeloop/default.nix
@@ -46,6 +46,10 @@ stdenv.mkDerivation rec {
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-fno-lto";
 
   postPatch = ''
+    # Fix gcc-13 build failure due to missing includes:
+    sed -e '1i #include <cstdint>' -i \
+      include/compound-config/compound-config.hpp
+
     # use nix ar/ranlib
     substituteInPlace ./SConstruct \
       --replace "env.Replace(AR = \"gcc-ar\")" "" \

--- a/pkgs/applications/science/computer-architecture/timeloop/default.nix
+++ b/pkgs/applications/science/computer-architecture/timeloop/default.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation rec {
   pname = "timeloop";
-  version = "unstable-2022-11-29";
+  version = "3.0.3";
 
   src = fetchFromGitHub {
     owner = "NVlabs";
     repo = "timeloop";
-    rev = "905ba953432c812772de935d57fd0a674a89d3c1";
-    hash = "sha256-EXiWXf8hdX4vFRNk9wbFSOsix/zVkwrafGUtFrsoAN0=";
+    rev = "v${version}";
+    hash = "sha256-CGPhrBNzFdERAA/Eym2v0+FvFUe+VkBLnwYEqEMHE9k=";
   };
 
   nativeBuildInputs = [ scons ];
@@ -52,8 +52,8 @@ stdenv.mkDerivation rec {
 
     # use nix ar/ranlib
     substituteInPlace ./SConstruct \
-      --replace "env.Replace(AR = \"gcc-ar\")" "" \
-      --replace "env.Replace(RANLIB = \"gcc-ranlib\")" ""
+      --replace-fail "env.Replace(AR = \"gcc-ar\")" "pass" \
+      --replace-fail "env.Replace(RANLIB = \"gcc-ranlib\")" "pass"
     '' + lib.optionalString stdenv.isDarwin ''
     # prevent clang from dying on errors that gcc is fine with
     substituteInPlace ./src/SConscript --replace "-Werror" "-Wno-inconsistent-missing-override"


### PR DESCRIPTION
Without the change build fails on `master` as
https://hydra.nixos.org/build/248973743:

    include/compound-config/compound-config.hpp:149:8: error: ‘uint64_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
      149 |   std::uint64_t parseElementSize(std::string name);
          |        ^~~~~~~~
          |        wint_t

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
