### PR TITLE
pixelfed: 0.11.8 -> 0.11.11

### DIFF
--- a/pkgs/servers/web-apps/pixelfed/default.nix
+++ b/pkgs/servers/web-apps/pixelfed/default.nix
@@ -28,13 +28,13 @@ let
   });
 in package.override rec {
   pname = "pixelfed";
-  version = "0.11.8";
+  version = "0.11.11";
 
   src = fetchFromGitHub {
     owner = "pixelfed";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-du+xwSrMqt4KIzQRUos6EmVBRp+39gHuoLSRsgLe1CQ=";
+    hash = "sha256-ytE1ZCKQvoigC8jKPfQ/17jYA0XYOzospq7wY18o2Nk=";
   };
 
   passthru = {

--- a/pkgs/servers/web-apps/pixelfed/php-packages.nix
+++ b/pkgs/servers/web-apps/pixelfed/php-packages.nix
@@ -5,20 +5,20 @@ let
     "aws/aws-crt-php" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "aws-aws-crt-php-1926277fc71d253dfa820271ac5987bdb193ccf5";
+        name = "aws-aws-crt-php-eb0c6e4e142224a10b08f49ebf87f32611d162b2";
         src = fetchurl {
-          url = "https://api.github.com/repos/awslabs/aws-crt-php/zipball/1926277fc71d253dfa820271ac5987bdb193ccf5";
-          sha256 = "037rdpys895vmk80zgb6r2c77ss2l545qsfma7q55kx9jm39habl";
+          url = "https://api.github.com/repos/awslabs/aws-crt-php/zipball/eb0c6e4e142224a10b08f49ebf87f32611d162b2";
+          sha256 = "10fnazz3gv51i6dngrc6hbcmzwrvl6mmd2z44rrdbzz3ry8v3vc9";
         };
       };
     };
     "aws/aws-sdk-php" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "aws-aws-sdk-php-f481134d37b8303fa2e82ca7fe2a3124144057f6";
+        name = "aws-aws-sdk-php-1d3e952ea2f45bb0d42d7f873d1b4957bb6362c4";
         src = fetchurl {
-          url = "https://api.github.com/repos/aws/aws-sdk-php/zipball/f481134d37b8303fa2e82ca7fe2a3124144057f6";
-          sha256 = "0ym593x000cm7yjsav0i53sq36np8d4r1j1zhbhfc06765s0x05q";
+          url = "https://api.github.com/repos/aws/aws-sdk-php/zipball/1d3e952ea2f45bb0d42d7f873d1b4957bb6362c4";
+          sha256 = "1yymdd50m30qjd6pclph8g4mrl40j0qg9hi3z72i1lb3chacz93c";
         };
       };
     };
@@ -35,10 +35,10 @@ let
     "beyondcode/laravel-websockets" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "beyondcode-laravel-websockets-9ab87be1d96340979e67b462ea5fd6a8b06e6a02";
+        name = "beyondcode-laravel-websockets-fee9a81e42a096d2aaca216ce91acf6e25d8c06d";
         src = fetchurl {
-          url = "https://api.github.com/repos/beyondcode/laravel-websockets/zipball/9ab87be1d96340979e67b462ea5fd6a8b06e6a02";
-          sha256 = "08iz2v882v0nhh23w92nv8yb66kbp03f2nqhz4y5nik04l3kyhrs";
+          url = "https://api.github.com/repos/beyondcode/laravel-websockets/zipball/fee9a81e42a096d2aaca216ce91acf6e25d8c06d";
+          sha256 = "1sxszc0q41wj9a04waap1sjpmz4sp0ji7dndlslaym4ml3x8mjf5";
         };
       };
     };
@@ -62,6 +62,16 @@ let
         };
       };
     };
+    "carbonphp/carbon-doctrine-types" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "carbonphp-carbon-doctrine-types-67a77972b9f398ae7068dabacc39c08aeee170d5";
+        src = fetchurl {
+          url = "https://api.github.com/repos/CarbonPHP/carbon-doctrine-types/zipball/67a77972b9f398ae7068dabacc39c08aeee170d5";
+          sha256 = "1li7qzj2cb0l6m41l8fya1p3izc8g23y3gpm4dy006pz07pmhr20";
+        };
+      };
+    };
     "cboden/ratchet" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
@@ -75,20 +85,20 @@ let
     "dasprid/enum" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "dasprid-enum-8e6b6ea76eabbf19ea2bf5b67b98e1860474012f";
+        name = "dasprid-enum-6faf451159fb8ba4126b925ed2d78acfce0dc016";
         src = fetchurl {
-          url = "https://api.github.com/repos/DASPRiD/Enum/zipball/8e6b6ea76eabbf19ea2bf5b67b98e1860474012f";
-          sha256 = "0cckq42c9iyjfv7xmy6rl4xj3dn80v9k8qzc3ppdjm4wgj43rrkz";
+          url = "https://api.github.com/repos/DASPRiD/Enum/zipball/6faf451159fb8ba4126b925ed2d78acfce0dc016";
+          sha256 = "1c3c7zdmpd5j1pw9am0k3mj8n17vy6xjhsh2qa7c0azz0f21jk4j";
         };
       };
     };
     "defuse/php-encryption" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "defuse-php-encryption-77880488b9954b7884c25555c2a0ea9e7053f9d2";
+        name = "defuse-php-encryption-f53396c2d34225064647a05ca76c1da9d99e5828";
         src = fetchurl {
-          url = "https://api.github.com/repos/defuse/php-encryption/zipball/77880488b9954b7884c25555c2a0ea9e7053f9d2";
-          sha256 = "1lcvpg56nw72cxyh6sga7fx94qw9l0l1y78z7y7ny3hgdniwhihx";
+          url = "https://api.github.com/repos/defuse/php-encryption/zipball/f53396c2d34225064647a05ca76c1da9d99e5828";
+          sha256 = "1g4mnnw9nmg1v8zq04d56v5n4m6vr3rsjbqdbny9d2f4c8xd4pqz";
         };
       };
     };
@@ -115,20 +125,20 @@ let
     "doctrine/dbal" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "doctrine-dbal-b4bd1cfbd2b916951696d82e57d054394d84864c";
+        name = "doctrine-dbal-0ac3c270590e54910715e9a1a044cc368df282b2";
         src = fetchurl {
-          url = "https://api.github.com/repos/doctrine/dbal/zipball/b4bd1cfbd2b916951696d82e57d054394d84864c";
-          sha256 = "04qiilphjk1zx4j5pwjh0svi90ad7vrb94h3x02wscfracxbwhjz";
+          url = "https://api.github.com/repos/doctrine/dbal/zipball/0ac3c270590e54910715e9a1a044cc368df282b2";
+          sha256 = "1qf6nhrrn7hdxqvym9l3mxj1sb0fmx2h1s3yi4mjkkb4ri5hcmm8";
         };
       };
     };
     "doctrine/deprecations" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "doctrine-deprecations-0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de";
+        name = "doctrine-deprecations-4f2d4f2836e7ec4e7a8625e75c6aa916004db931";
         src = fetchurl {
-          url = "https://api.github.com/repos/doctrine/deprecations/zipball/0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de";
-          sha256 = "1sk1f020n0w7p7r4rsi7wnww85vljrim1i5h9wb0qiz2c4l8jj09";
+          url = "https://api.github.com/repos/doctrine/deprecations/zipball/4f2d4f2836e7ec4e7a8625e75c6aa916004db931";
+          sha256 = "1kxy6s4v9prkfvsnggm10kk0yyqsyd2vk238zhvv3c9il300h8sk";
         };
       };
     };
@@ -145,10 +155,10 @@ let
     "doctrine/inflector" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "doctrine-inflector-d9d313a36c872fd6ee06d9a6cbcf713eaa40f024";
+        name = "doctrine-inflector-f9301a5b2fb1216b2b08f02ba04dc45423db6bff";
         src = fetchurl {
-          url = "https://api.github.com/repos/doctrine/inflector/zipball/d9d313a36c872fd6ee06d9a6cbcf713eaa40f024";
-          sha256 = "1z6y0mxqadarw76whppcl0h0cj7p5n6k7mxihggavq46i2wf7nhj";
+          url = "https://api.github.com/repos/doctrine/inflector/zipball/f9301a5b2fb1216b2b08f02ba04dc45423db6bff";
+          sha256 = "1kdq3sbwrzwprxr36cdw9m1zlwn15c0nz6i7mw0sq9mhnd2sgbrb";
         };
       };
     };
@@ -165,40 +175,40 @@ let
     "dragonmantank/cron-expression" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "dragonmantank-cron-expression-782ca5968ab8b954773518e9e49a6f892a34b2a8";
+        name = "dragonmantank-cron-expression-adfb1f505deb6384dc8b39804c5065dd3c8c8c0a";
         src = fetchurl {
-          url = "https://api.github.com/repos/dragonmantank/cron-expression/zipball/782ca5968ab8b954773518e9e49a6f892a34b2a8";
-          sha256 = "18pxn1v3b2yhwzky22p4wn520h89rcrihl7l6hd0p769vk1b2qg9";
+          url = "https://api.github.com/repos/dragonmantank/cron-expression/zipball/adfb1f505deb6384dc8b39804c5065dd3c8c8c0a";
+          sha256 = "1gw2bnsh8ca5plfpyyyz1idnx7zxssg6fbwl7niszck773zrm5ca";
         };
       };
     };
     "egulias/email-validator" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "egulias-email-validator-3a85486b709bc384dae8eb78fb2eec649bdb64ff";
+        name = "egulias-email-validator-ebaaf5be6c0286928352e054f2d5125608e5405e";
         src = fetchurl {
-          url = "https://api.github.com/repos/egulias/EmailValidator/zipball/3a85486b709bc384dae8eb78fb2eec649bdb64ff";
-          sha256 = "1vbwd4fgg6910pfy0dpzkaf5djwzpx5nqr43hy2qpmkp11mkbbxw";
+          url = "https://api.github.com/repos/egulias/EmailValidator/zipball/ebaaf5be6c0286928352e054f2d5125608e5405e";
+          sha256 = "02n4sh0gywqzsl46n9q8hqqgiyva2gj4lxdz9fw4pvhkm1s27wd6";
         };
       };
     };
     "evenement/evenement" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "evenement-evenement-531bfb9d15f8aa57454f5f0285b18bec903b8fb7";
+        name = "evenement-evenement-0a16b0d71ab13284339abb99d9d2bd813640efbc";
         src = fetchurl {
-          url = "https://api.github.com/repos/igorw/evenement/zipball/531bfb9d15f8aa57454f5f0285b18bec903b8fb7";
-          sha256 = "02mi1lrga41caa25whr6sj9hmmlfjp10l0d0fq8kc3d4483pm9rr";
+          url = "https://api.github.com/repos/igorw/evenement/zipball/0a16b0d71ab13284339abb99d9d2bd813640efbc";
+          sha256 = "1gbm1nha3h8hhqlqxdrgmrwh35xld0by1si7qg2944g5wggfxpad";
         };
       };
     };
     "ezyang/htmlpurifier" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "ezyang-htmlpurifier-523407fb06eb9e5f3d59889b3978d5bfe94299c8";
+        name = "ezyang-htmlpurifier-bbc513d79acf6691fa9cf10f192c90dd2957f18c";
         src = fetchurl {
-          url = "https://api.github.com/repos/ezyang/htmlpurifier/zipball/523407fb06eb9e5f3d59889b3978d5bfe94299c8";
-          sha256 = "1g65bndiwd2dmq5p6f29lh66x8lwxhpp1pmd619qbm8bnsy7hvki";
+          url = "https://api.github.com/repos/ezyang/htmlpurifier/zipball/bbc513d79acf6691fa9cf10f192c90dd2957f18c";
+          sha256 = "0jg5aw2x872hlxnvz9ck8z322rfdxs86rhzj5lh0q9j7cm377v4a";
         };
       };
     };
@@ -209,6 +219,16 @@ let
         src = fetchurl {
           url = "https://api.github.com/repos/facade/ignition-contracts/zipball/3c921a1cdba35b68a7f0ccffc6dffc1995b18267";
           sha256 = "1nsjwd1k9q8qmfvh7m50rs42yxzxyq4f56r6dq205gwcmqsjb2j0";
+        };
+      };
+    };
+    "fgrosse/phpasn1" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "fgrosse-phpasn1-42060ed45344789fb9f21f9f1864fc47b9e3507b";
+        src = fetchurl {
+          url = "https://api.github.com/repos/fgrosse/PHPASN1/zipball/42060ed45344789fb9f21f9f1864fc47b9e3507b";
+          sha256 = "0ps35qg86v4khkz14dj9z2qny0irwba3n0z26nqn24p41zrcv8xl";
         };
       };
     };
@@ -225,70 +245,70 @@ let
     "firebase/php-jwt" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "firebase-php-jwt-e94e7353302b0c11ec3cfff7180cd0b1743975d2";
+        name = "firebase-php-jwt-a49db6f0a5033aef5143295342f1c95521b075ff";
         src = fetchurl {
-          url = "https://api.github.com/repos/firebase/php-jwt/zipball/e94e7353302b0c11ec3cfff7180cd0b1743975d2";
-          sha256 = "1iv1252x141m7nhhxzg2bawfyzsvaprhlclhlyhacra9pd5ng61y";
+          url = "https://api.github.com/repos/firebase/php-jwt/zipball/a49db6f0a5033aef5143295342f1c95521b075ff";
+          sha256 = "0rgr90jbp1469pwib3n1yd2by2y3xsc0c5acpzs9iskfcn132swk";
         };
       };
     };
     "fruitcake/php-cors" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "fruitcake-php-cors-58571acbaa5f9f462c9c77e911700ac66f446d4e";
+        name = "fruitcake-php-cors-3d158f36e7875e2f040f37bc0573956240a5a38b";
         src = fetchurl {
-          url = "https://api.github.com/repos/fruitcake/php-cors/zipball/58571acbaa5f9f462c9c77e911700ac66f446d4e";
-          sha256 = "18xm69q4dk9zqfwgp938y2byhlyy9lr5x5qln4k2mg8cq8xr2sm1";
+          url = "https://api.github.com/repos/fruitcake/php-cors/zipball/3d158f36e7875e2f040f37bc0573956240a5a38b";
+          sha256 = "1pdq0dxrmh4yj48y9azrld10qmz1w3vbb9q81r85fvgl62l2kiww";
         };
       };
     };
     "graham-campbell/result-type" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "graham-campbell-result-type-672eff8cf1d6fe1ef09ca0f89c4b287d6a3eb831";
+        name = "graham-campbell-result-type-fbd48bce38f73f8a4ec8583362e732e4095e5862";
         src = fetchurl {
-          url = "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/672eff8cf1d6fe1ef09ca0f89c4b287d6a3eb831";
-          sha256 = "156zbfs19r9g543phlpjwhqin3k2x4dsvr5p0wk7rk4j0wwp8l2v";
+          url = "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/fbd48bce38f73f8a4ec8583362e732e4095e5862";
+          sha256 = "1mzahy4df8d45qm716crs45rp5j7k31r0jhkmbrrvqsvapnmj9ip";
         };
       };
     };
     "guzzlehttp/guzzle" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "guzzlehttp-guzzle-fb7566caccf22d74d1ab270de3551f72a58399f5";
+        name = "guzzlehttp-guzzle-41042bc7ab002487b876a0683fc8dce04ddce104";
         src = fetchurl {
-          url = "https://api.github.com/repos/guzzle/guzzle/zipball/fb7566caccf22d74d1ab270de3551f72a58399f5";
-          sha256 = "0cmpq50s5xi9sg1dygllrhwj5dz5bxxj83xkvjspz63751xr51cs";
+          url = "https://api.github.com/repos/guzzle/guzzle/zipball/41042bc7ab002487b876a0683fc8dce04ddce104";
+          sha256 = "0awhhka285kk0apv92n0a0yfbihi2ddnx3qr1c7s97asgxfnwxsv";
         };
       };
     };
     "guzzlehttp/promises" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "guzzlehttp-promises-67ab6e18aaa14d753cc148911d273f6e6cb6721e";
+        name = "guzzlehttp-promises-bbff78d96034045e58e13dedd6ad91b5d1253223";
         src = fetchurl {
-          url = "https://api.github.com/repos/guzzle/promises/zipball/67ab6e18aaa14d753cc148911d273f6e6cb6721e";
-          sha256 = "0y3md6lkpk60kvmi607mgj29cfjg2bljc5nhfh3qf9hzk6c1b2j6";
+          url = "https://api.github.com/repos/guzzle/promises/zipball/bbff78d96034045e58e13dedd6ad91b5d1253223";
+          sha256 = "1p0bry118c3lichkz8lag37ndvvhbd2nf0k9kzwi8gz1bzf9d45f";
         };
       };
     };
     "guzzlehttp/psr7" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "guzzlehttp-psr7-b635f279edd83fc275f822a1188157ffea568ff6";
+        name = "guzzlehttp-psr7-45b30f99ac27b5ca93cb4831afe16285f57b8221";
         src = fetchurl {
-          url = "https://api.github.com/repos/guzzle/psr7/zipball/b635f279edd83fc275f822a1188157ffea568ff6";
-          sha256 = "0734h3r8db06hcffagr8s7bxhjkvlfzvqg1klwmqidflwdwk7yj1";
+          url = "https://api.github.com/repos/guzzle/psr7/zipball/45b30f99ac27b5ca93cb4831afe16285f57b8221";
+          sha256 = "0k60pzfpxd6q1rhr9gbf53j0hm9wj5p5spkc0zfyia4b8f8pgmdm";
         };
       };
     };
     "guzzlehttp/uri-template" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "guzzlehttp-uri-template-b945d74a55a25a949158444f09ec0d3c120d69e2";
+        name = "guzzlehttp-uri-template-ecea8feef63bd4fef1f037ecb288386999ecc11c";
         src = fetchurl {
-          url = "https://api.github.com/repos/guzzle/uri-template/zipball/b945d74a55a25a949158444f09ec0d3c120d69e2";
-          sha256 = "02vd4r2di8xh9n5awfjy1lyb7vn5gkaynbiiqilm8did0r89qdhf";
+          url = "https://api.github.com/repos/guzzle/uri-template/zipball/ecea8feef63bd4fef1f037ecb288386999ecc11c";
+          sha256 = "0r3cbb2pgsy4nawbylc0nbski2r9dkl335ay5m4i82yglspl9zz4";
         };
       };
     };
@@ -305,10 +325,10 @@ let
     "jaybizzle/crawler-detect" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "jaybizzle-crawler-detect-62d0e6b38f6715c673e156ffb0fc894791de3452";
+        name = "jaybizzle-crawler-detect-97e9fe30219e60092e107651abb379a38b342921";
         src = fetchurl {
-          url = "https://api.github.com/repos/JayBizzle/Crawler-Detect/zipball/62d0e6b38f6715c673e156ffb0fc894791de3452";
-          sha256 = "19wqayfrb38609hn90bb3y7zkr9rmpk17w7a430gxg6408hrpfm7";
+          url = "https://api.github.com/repos/JayBizzle/Crawler-Detect/zipball/97e9fe30219e60092e107651abb379a38b342921";
+          sha256 = "0ywqamhyilrlb1sli00i2gnaw2hyjpbb9pkxb8nxx7dr1a4v8x7q";
         };
       };
     };
@@ -322,13 +342,23 @@ let
         };
       };
     };
+    "laravel-notification-channels/webpush" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "laravel-notification-channels-webpush-b31f7d807d30c80e7391063291ebfe9683bb7de5";
+        src = fetchurl {
+          url = "https://api.github.com/repos/laravel-notification-channels/webpush/zipball/b31f7d807d30c80e7391063291ebfe9683bb7de5";
+          sha256 = "1vdalwjcncf3xz44j85bkb709c9mlnjqsxrhsvjmlkabwn2zi4aj";
+        };
+      };
+    };
     "laravel/framework" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "laravel-framework-9e6dcff23ab1d4b522bef56074c31625cf077576";
+        name = "laravel-framework-c581caa233e380610b34cc491490bfa147a3b62b";
         src = fetchurl {
-          url = "https://api.github.com/repos/laravel/framework/zipball/9e6dcff23ab1d4b522bef56074c31625cf077576";
-          sha256 = "0nw3isfjmwqs1a4n3qvw0kvsg6jsrx5wcapkxdbcfp2lha0sbmld";
+          url = "https://api.github.com/repos/laravel/framework/zipball/c581caa233e380610b34cc491490bfa147a3b62b";
+          sha256 = "1np37vczzj08vfkx413b247w3y8cmfbgj6a1fmpyaannfjp97m9k";
         };
       };
     };
@@ -345,50 +375,60 @@ let
     "laravel/horizon" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "laravel-horizon-4f762b1bd47b51f0557da84873a208410de9eece";
+        name = "laravel-horizon-bdf58c84b592b83f62262cc6ca98b0debbbc308b";
         src = fetchurl {
-          url = "https://api.github.com/repos/laravel/horizon/zipball/4f762b1bd47b51f0557da84873a208410de9eece";
-          sha256 = "0f9bxc63kqf1ljs1hv5g8h7j337wdy1xs0bcv45dwmh49f1fzkwm";
+          url = "https://api.github.com/repos/laravel/horizon/zipball/bdf58c84b592b83f62262cc6ca98b0debbbc308b";
+          sha256 = "0r2qyqsz27jnfr43i1qxfl57hqv5wn0jf8b95xjc0k8izz7p0z2k";
         };
       };
     };
     "laravel/passport" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "laravel-passport-48a03ffbfce7217b7ceba2c8e685ae8caa68db10";
+        name = "laravel-passport-966bc8e477d08c86a11dc4c5a86f85fa0abdb89b";
         src = fetchurl {
-          url = "https://api.github.com/repos/laravel/passport/zipball/48a03ffbfce7217b7ceba2c8e685ae8caa68db10";
-          sha256 = "1lnz22l2jxixbhk0833kvx04xh97q0vz5rqc8dzggim22mdrpd0c";
+          url = "https://api.github.com/repos/laravel/passport/zipball/966bc8e477d08c86a11dc4c5a86f85fa0abdb89b";
+          sha256 = "1y7i9ahjgj575bvywqr7ikm9kfaa3s9bkp4x0s2cjrvcra4fpwnx";
+        };
+      };
+    };
+    "laravel/prompts" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "laravel-prompts-e1379d8ead15edd6cc4369c22274345982edc95a";
+        src = fetchurl {
+          url = "https://api.github.com/repos/laravel/prompts/zipball/e1379d8ead15edd6cc4369c22274345982edc95a";
+          sha256 = "16nb9i939sgfwm11dhi9n1dgwldh4ylhr4p8qdp5f05crvmybc02";
         };
       };
     };
     "laravel/serializable-closure" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "laravel-serializable-closure-f23fe9d4e95255dacee1bf3525e0810d1a1b0f37";
+        name = "laravel-serializable-closure-3dbf8a8e914634c48d389c1234552666b3d43754";
         src = fetchurl {
-          url = "https://api.github.com/repos/laravel/serializable-closure/zipball/f23fe9d4e95255dacee1bf3525e0810d1a1b0f37";
-          sha256 = "0dyvqph5q1lb6gl6ga4b1xkziqzj6s2ia5pbd7h40anm4sh3z8dl";
+          url = "https://api.github.com/repos/laravel/serializable-closure/zipball/3dbf8a8e914634c48d389c1234552666b3d43754";
+          sha256 = "1vvayh1bzbw16xj8ash4flibkgn5afwn64nfwmjdi7lcr48cw65q";
         };
       };
     };
     "laravel/tinker" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "laravel-tinker-04a2d3bd0d650c0764f70bf49d1ee39393e4eb10";
+        name = "laravel-tinker-b936d415b252b499e8c3b1f795cd4fc20f57e1f3";
         src = fetchurl {
-          url = "https://api.github.com/repos/laravel/tinker/zipball/04a2d3bd0d650c0764f70bf49d1ee39393e4eb10";
-          sha256 = "06rivrmcf8m8hm4vn9s7wwpfmgl89p73b78dm0qx26rs0lpr36p0";
+          url = "https://api.github.com/repos/laravel/tinker/zipball/b936d415b252b499e8c3b1f795cd4fc20f57e1f3";
+          sha256 = "1vggdik2nby6a9avwgylgihhwyglm0mdwm703bwv7ilwx0dsx1i7";
         };
       };
     };
     "laravel/ui" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "laravel-ui-a58ec468db4a340b33f3426c778784717a2c144b";
+        name = "laravel-ui-eb532ea096ca1c0298c87c19233daf011fda743a";
         src = fetchurl {
-          url = "https://api.github.com/repos/laravel/ui/zipball/a58ec468db4a340b33f3426c778784717a2c144b";
-          sha256 = "0qrfr7rbi5b90inx3xf5yy5p9h38rs9b2567p2vh3711w4kqjmqd";
+          url = "https://api.github.com/repos/laravel/ui/zipball/eb532ea096ca1c0298c87c19233daf011fda743a";
+          sha256 = "0n79mcly7rzka7m50r41nkil4ia5d0x5jihxdn790shqm0mcdxw8";
         };
       };
     };
@@ -405,20 +445,20 @@ let
     "lcobucci/jwt" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "lcobucci-jwt-47bdb0e0b5d00c2f89ebe33e7e384c77e84e7c34";
+        name = "lcobucci-jwt-0ba88aed12c04bd2ed9924f500673f32b67a6211";
         src = fetchurl {
-          url = "https://api.github.com/repos/lcobucci/jwt/zipball/47bdb0e0b5d00c2f89ebe33e7e384c77e84e7c34";
-          sha256 = "0bkkf98iflgdpryxm270wwgzw9id627h2iszjgw7ddkibn14lgq3";
+          url = "https://api.github.com/repos/lcobucci/jwt/zipball/0ba88aed12c04bd2ed9924f500673f32b67a6211";
+          sha256 = "0icvs7glzsb3j63fsa0j6d210hj5vaw3n6crzjdczdhiiz71hs0r";
         };
       };
     };
     "league/commonmark" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "league-commonmark-d44a24690f16b8c1808bf13b1bd54ae4c63ea048";
+        name = "league-commonmark-3669d6d5f7a47a93c08ddff335e6d945481a1dd5";
         src = fetchurl {
-          url = "https://api.github.com/repos/thephpleague/commonmark/zipball/d44a24690f16b8c1808bf13b1bd54ae4c63ea048";
-          sha256 = "1qx99m1qa2g3l6r2fim3rak6qh28zjj8sqjj86nq743dm3yszygw";
+          url = "https://api.github.com/repos/thephpleague/commonmark/zipball/3669d6d5f7a47a93c08ddff335e6d945481a1dd5";
+          sha256 = "1rbaydy1n1c1schskbabzd4nx57nvwpnzqapsfxjm6kyihca1nr3";
         };
       };
     };
@@ -445,150 +485,160 @@ let
     "league/flysystem" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "league-flysystem-a141d430414fcb8bf797a18716b09f759a385bed";
+        name = "league-flysystem-d18526ee587f265f091f47bb83f1d9a001ef6f36";
         src = fetchurl {
-          url = "https://api.github.com/repos/thephpleague/flysystem/zipball/a141d430414fcb8bf797a18716b09f759a385bed";
-          sha256 = "0w476nkv4izdrh8dn4g58lrqnfwrp8ijhj6fj8d8cpvr81kq0wiv";
+          url = "https://api.github.com/repos/thephpleague/flysystem/zipball/d18526ee587f265f091f47bb83f1d9a001ef6f36";
+          sha256 = "1anzfh9fzfnim68dqlyil4c6a61y6dppl4sk1drx4mbms5ds9473";
         };
       };
     };
     "league/flysystem-aws-s3-v3" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "league-flysystem-aws-s3-v3-d8de61ee10b6a607e7996cff388c5a3a663e8c8a";
+        name = "league-flysystem-aws-s3-v3-9808919ee5d819730d9582d4e1673e8d195c38d8";
         src = fetchurl {
-          url = "https://api.github.com/repos/thephpleague/flysystem-aws-s3-v3/zipball/d8de61ee10b6a607e7996cff388c5a3a663e8c8a";
-          sha256 = "0hr11wwn2c2f26w0kj5yanx17ln17plk0si8yajkd470z3ssprwj";
+          url = "https://api.github.com/repos/thephpleague/flysystem-aws-s3-v3/zipball/9808919ee5d819730d9582d4e1673e8d195c38d8";
+          sha256 = "1339ix4nqkk54bfnms18fz853s9ngsgjvkjdln1ff045m7dm4svi";
         };
       };
     };
     "league/flysystem-local" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "league-flysystem-local-543f64c397fefdf9cfeac443ffb6beff602796b3";
+        name = "league-flysystem-local-42dfb4eaafc4accd248180f0dd66f17073b40c4c";
         src = fetchurl {
-          url = "https://api.github.com/repos/thephpleague/flysystem-local/zipball/543f64c397fefdf9cfeac443ffb6beff602796b3";
-          sha256 = "1f44jgjip7pgnjafwlazmbv9jap3xsw3jfzhgakbsa4bkx3aavr2";
+          url = "https://api.github.com/repos/thephpleague/flysystem-local/zipball/42dfb4eaafc4accd248180f0dd66f17073b40c4c";
+          sha256 = "12xf0qnj3nr521is0dxi6b8rs6bn660nsj97dqzrf0givqny5g1q";
         };
       };
     };
     "league/iso3166" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "league-iso3166-74a08ffe08d4e0dd8ab0aac8c34ea5a641d57669";
+        name = "league-iso3166-11703e0313f34920add11c0228f0dd43ebd10f9a";
         src = fetchurl {
-          url = "https://api.github.com/repos/thephpleague/iso3166/zipball/74a08ffe08d4e0dd8ab0aac8c34ea5a641d57669";
-          sha256 = "0mh0rz7imb3zwi7lfhxinwfwqlrn7anp1xhskx6pg19w3jjm5rn4";
+          url = "https://api.github.com/repos/thephpleague/iso3166/zipball/11703e0313f34920add11c0228f0dd43ebd10f9a";
+          sha256 = "1rhvyki2za32k8z23bacq02apbhbk3vdg0d52wvjdvlsr4n402gv";
         };
       };
     };
     "league/mime-type-detection" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "league-mime-type-detection-ff6248ea87a9f116e78edd6002e39e5128a0d4dd";
+        name = "league-mime-type-detection-b6a5854368533df0295c5761a0253656a2e52d9e";
         src = fetchurl {
-          url = "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/ff6248ea87a9f116e78edd6002e39e5128a0d4dd";
-          sha256 = "1a63nvqd6cz3vck3y8vjswn6c3cfwh13p0cn0ci5pqdf0bgjvvfz";
+          url = "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/b6a5854368533df0295c5761a0253656a2e52d9e";
+          sha256 = "0bsqha9c0pyb5l78iiv1klrpqmhki6nh9x73pgnmh7sphh6ilygj";
         };
       };
     };
     "league/oauth2-server" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "league-oauth2-server-43cd4d406906c6be5c8de2cee9bd3ad3753544ef";
+        name = "league-oauth2-server-ab7714d073844497fd222d5d0a217629089936bc";
         src = fetchurl {
-          url = "https://api.github.com/repos/thephpleague/oauth2-server/zipball/43cd4d406906c6be5c8de2cee9bd3ad3753544ef";
-          sha256 = "01amlk9r8srsk3603d56qswbq81hvksyw6jbn3i8f97l7fsdvaa9";
+          url = "https://api.github.com/repos/thephpleague/oauth2-server/zipball/ab7714d073844497fd222d5d0a217629089936bc";
+          sha256 = "1p4lvibdfi458bv778qzbah3b1lkhdvd9hiws040ky8jizfs6c2g";
         };
       };
     };
     "league/uri" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "league-uri-a700b4656e4c54371b799ac61e300ab25a2d1d39";
+        name = "league-uri-bf414ba956d902f5d98bf9385fcf63954f09dce5";
         src = fetchurl {
-          url = "https://api.github.com/repos/thephpleague/uri/zipball/a700b4656e4c54371b799ac61e300ab25a2d1d39";
-          sha256 = "1sjh26mapy1jrlryp6c55s7ghsamwabak1psz5lfs5d7z06vbasy";
+          url = "https://api.github.com/repos/thephpleague/uri/zipball/bf414ba956d902f5d98bf9385fcf63954f09dce5";
+          sha256 = "1rwwf77s2i2jlz7d8ylp695z25lwadp66868b82si151y0mm5qy3";
         };
       };
     };
     "league/uri-interfaces" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "league-uri-interfaces-00e7e2943f76d8cb50c7dfdc2f6dee356e15e383";
+        name = "league-uri-interfaces-bd8c487ec236930f7bbc42b8d374fa882fbba0f3";
         src = fetchurl {
-          url = "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/00e7e2943f76d8cb50c7dfdc2f6dee356e15e383";
-          sha256 = "01jllf6n9fs4yjcf6sjc4ivqp7k7dkqhbpz354bq9mr14njsjv6x";
+          url = "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/bd8c487ec236930f7bbc42b8d374fa882fbba0f3";
+          sha256 = "13zy4pk2rphm5cmv08sksdxwlh3kwflsc13nr8i4nzmnj8m32zpr";
+        };
+      };
+    };
+    "minishlink/web-push" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "minishlink-web-push-ec034f1e287cd1e74235e349bd017d71a61e9d8d";
+        src = fetchurl {
+          url = "https://api.github.com/repos/web-push-libs/web-push-php/zipball/ec034f1e287cd1e74235e349bd017d71a61e9d8d";
+          sha256 = "1v8gr9wkhbqybb7fi8bmyhvp9i8bjpjx63bcsbyqf1aw9nrfnpcv";
         };
       };
     };
     "mobiledetect/mobiledetectlib" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "mobiledetect-mobiledetectlib-fc9cccd4d3706d5a7537b562b59cc18f9e4c0cb1";
+        name = "mobiledetect-mobiledetectlib-96aaebcf4f50d3d2692ab81d2c5132e425bca266";
         src = fetchurl {
-          url = "https://api.github.com/repos/serbanghita/Mobile-Detect/zipball/fc9cccd4d3706d5a7537b562b59cc18f9e4c0cb1";
-          sha256 = "1qmkrbdrfnxgd7lcgw7g30r8qc6yg1c9lkdam54zhgxhcc2ryxqs";
+          url = "https://api.github.com/repos/serbanghita/Mobile-Detect/zipball/96aaebcf4f50d3d2692ab81d2c5132e425bca266";
+          sha256 = "0s4sj600kaiaxnsjxh27jq62b3iwydp0bg5zxjqd2l3rgh8xy879";
         };
       };
     };
     "monolog/monolog" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "monolog-monolog-9b5daeaffce5b926cac47923798bba91059e60e2";
+        name = "monolog-monolog-c915e2634718dbc8a4a15c61b0e62e7a44e14448";
         src = fetchurl {
-          url = "https://api.github.com/repos/Seldaek/monolog/zipball/9b5daeaffce5b926cac47923798bba91059e60e2";
-          sha256 = "18nll4p6fh5zmw2wgzgp4lznkqqr6d598663rrji424dfpv55233";
+          url = "https://api.github.com/repos/Seldaek/monolog/zipball/c915e2634718dbc8a4a15c61b0e62e7a44e14448";
+          sha256 = "1sqqjdg75vc578zrm6xklmk9928l4dc7csjvlpln331b8rnai8hs";
         };
       };
     };
     "mtdowling/jmespath.php" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "mtdowling-jmespath.php-9b87907a81b87bc76d19a7fb2d61e61486ee9edb";
+        name = "mtdowling-jmespath.php-bbb69a935c2cbb0c03d7f481a238027430f6440b";
         src = fetchurl {
-          url = "https://api.github.com/repos/jmespath/jmespath.php/zipball/9b87907a81b87bc76d19a7fb2d61e61486ee9edb";
-          sha256 = "1ig3gi6f8gisagcn876598ps48s86s6m0c82diyksylarg3yn0yd";
+          url = "https://api.github.com/repos/jmespath/jmespath.php/zipball/bbb69a935c2cbb0c03d7f481a238027430f6440b";
+          sha256 = "1ksjdc2icgafkx16j05ir3vk1ryhgdr2l41wpfd6nhzzk42smiwb";
         };
       };
     };
     "nesbot/carbon" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "nesbot-carbon-c1001b3bc75039b07f38a79db5237c4c529e04c8";
+        name = "nesbot-carbon-a6885fcbad2ec4360b0e200ee0da7d9b7c90786b";
         src = fetchurl {
-          url = "https://api.github.com/repos/briannesbitt/Carbon/zipball/c1001b3bc75039b07f38a79db5237c4c529e04c8";
-          sha256 = "0w5gk7b05pfsbf091plfr0ag6sx6h90sckz1phr46kd6cnrzk3rh";
+          url = "https://api.github.com/repos/briannesbitt/Carbon/zipball/a6885fcbad2ec4360b0e200ee0da7d9b7c90786b";
+          sha256 = "0j4x43v58jmgmfqcx0sfjh5rc1n9an2wdnmbp4yhbdnb1nhxg9z3";
         };
       };
     };
     "nette/schema" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "nette-schema-abbdbb70e0245d5f3bf77874cea1dfb0c930d06f";
+        name = "nette-schema-0462f0166e823aad657c9224d0f849ecac1ba10a";
         src = fetchurl {
-          url = "https://api.github.com/repos/nette/schema/zipball/abbdbb70e0245d5f3bf77874cea1dfb0c930d06f";
-          sha256 = "16i8gim0jpmmbq0pp4faw8kn2448yvpgsd1zvipbv9xrk37vah5q";
+          url = "https://api.github.com/repos/nette/schema/zipball/0462f0166e823aad657c9224d0f849ecac1ba10a";
+          sha256 = "0x2pz3mjnx78ndxm5532ld3kwzs9p43l4snk4vjbwnqiqgcpqwn7";
         };
       };
     };
     "nette/utils" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "nette-utils-cacdbf5a91a657ede665c541eda28941d4b09c1e";
+        name = "nette-utils-a9d127dd6a203ce6d255b2e2db49759f7506e015";
         src = fetchurl {
-          url = "https://api.github.com/repos/nette/utils/zipball/cacdbf5a91a657ede665c541eda28941d4b09c1e";
-          sha256 = "0v3as5xdmr9j7d4q4ly18f7g8g0sjcy25l4ispsdp60byldi7m8h";
+          url = "https://api.github.com/repos/nette/utils/zipball/a9d127dd6a203ce6d255b2e2db49759f7506e015";
+          sha256 = "0py2072z0rmpzf1ylk7rf2k040lv3asnk2icf97qm384cjw9dzrp";
         };
       };
     };
     "nikic/php-parser" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "nikic-php-parser-11e2663a5bc9db5d714eedb4277ee300403b4a9e";
+        name = "nikic-php-parser-a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d";
         src = fetchurl {
-          url = "https://api.github.com/repos/nikic/PHP-Parser/zipball/11e2663a5bc9db5d714eedb4277ee300403b4a9e";
-          sha256 = "1kkz11dsc11zhflc8wxjxxa8xjww371nwkmjf7ncn0spjf6hx4g5";
+          url = "https://api.github.com/repos/nikic/PHP-Parser/zipball/a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d";
+          sha256 = "0a5a6fzgvcgxn5kc1mxa5grxmm8c1ax91pjr3gxpkji7nyc1zh1y";
         };
       };
     };
@@ -605,10 +655,10 @@ let
     "nyholm/psr7" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "nyholm-psr7-3cb4d163b58589e47b35103e8e5e6a6a475b47be";
+        name = "nyholm-psr7-aa5fc277a4f5508013d571341ade0c3886d4d00e";
         src = fetchurl {
-          url = "https://api.github.com/repos/Nyholm/psr7/zipball/3cb4d163b58589e47b35103e8e5e6a6a475b47be";
-          sha256 = "1wbg5fcqkv8bg1ll0ndxp3jmi353sz6cd6gzdldbh35p1b2mp4jm";
+          url = "https://api.github.com/repos/Nyholm/psr7/zipball/aa5fc277a4f5508013d571341ade0c3886d4d00e";
+          sha256 = "00r9sy7ncrjdc71kqis4vc6q1ksbh97g3fhf97gf5jg9j6pq27lg";
         };
       };
     };
@@ -665,20 +715,20 @@ let
     "phpoption/phpoption" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "phpoption-phpoption-dd3a383e599f49777d8b628dadbb90cae435b87e";
+        name = "phpoption-phpoption-80735db690fe4fc5c76dfa7f9b770634285fa820";
         src = fetchurl {
-          url = "https://api.github.com/repos/schmittjoh/php-option/zipball/dd3a383e599f49777d8b628dadbb90cae435b87e";
-          sha256 = "029gpfa66hwg395jvf7swcvrj085wsw5fw6041nrl5kbc36fvwlb";
+          url = "https://api.github.com/repos/schmittjoh/php-option/zipball/80735db690fe4fc5c76dfa7f9b770634285fa820";
+          sha256 = "1f9hzyjnam157lb7iw9r8f5cnjjsiqam9mnkpqmba73g1668xn9s";
         };
       };
     };
     "phpseclib/phpseclib" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "phpseclib-phpseclib-665d289f59e646a259ebf13f29be7f6f54cab24b";
+        name = "phpseclib-phpseclib-28d8f438a0064c9de80857e3270d071495544640";
         src = fetchurl {
-          url = "https://api.github.com/repos/phpseclib/phpseclib/zipball/665d289f59e646a259ebf13f29be7f6f54cab24b";
-          sha256 = "15l7plmvgq51dly43vsqa66v03m93hcfndapmmjrqywqhb2g4jwv";
+          url = "https://api.github.com/repos/phpseclib/phpseclib/zipball/28d8f438a0064c9de80857e3270d071495544640";
+          sha256 = "0i9275yhwbv9g1bxfy4cp71jy8j8kp1kd6r3zzfp59agkl5hklwv";
         };
       };
     };
@@ -725,10 +775,10 @@ let
     "predis/predis" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "predis-predis-a77a43913a74f9331f637bb12867eb8e274814e5";
+        name = "predis-predis-b1d3255ed9ad4d7254f9f9bba386c99f4bb983d1";
         src = fetchurl {
-          url = "https://api.github.com/repos/predis/predis/zipball/a77a43913a74f9331f637bb12867eb8e274814e5";
-          sha256 = "17xby6nk7nv1gww7hgsd1rzm40ghxx6xg6pfb3zqm40vsg25grrg";
+          url = "https://api.github.com/repos/predis/predis/zipball/b1d3255ed9ad4d7254f9f9bba386c99f4bb983d1";
+          sha256 = "0pylca7in1fm6vyrfdp12pqamp7y09cr5mc8hyr1m22r9f6m82l9";
         };
       };
     };
@@ -775,10 +825,10 @@ let
     "psr/http-client" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "psr-http-client-0955afe48220520692d2d09f7ab7e0f93ffd6a31";
+        name = "psr-http-client-bb5906edc1c324c9a05aa0873d40117941e5fa90";
         src = fetchurl {
-          url = "https://api.github.com/repos/php-fig/http-client/zipball/0955afe48220520692d2d09f7ab7e0f93ffd6a31";
-          sha256 = "09r970lfpwil861gzm47446ck1s6km6ijibkxl13p1ymwdchnv6m";
+          url = "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90";
+          sha256 = "1dfyjqj1bs2n2zddk8402v6rjq93fq26hwr0rjh53m11wy1wagsx";
         };
       };
     };
@@ -825,10 +875,10 @@ let
     "psy/psysh" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "psy-psysh-4f00ee9e236fa6a48f4560d1300b9c961a70a7ec";
+        name = "psy-psysh-128fa1b608be651999ed9789c95e6e2a31b5802b";
         src = fetchurl {
-          url = "https://api.github.com/repos/bobthecow/psysh/zipball/4f00ee9e236fa6a48f4560d1300b9c961a70a7ec";
-          sha256 = "10754cxjwjf818g7i3vyd4jk0sy8r3i36jxpqk38n70ckasdd7w0";
+          url = "https://api.github.com/repos/bobthecow/psysh/zipball/128fa1b608be651999ed9789c95e6e2a31b5802b";
+          sha256 = "0lrmqw53kzgdldxiy2aj0dawdzz5cbsxqz9p47ca3c0ggnszlk1p";
         };
       };
     };
@@ -865,10 +915,10 @@ let
     "ramsey/uuid" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "ramsey-uuid-60a4c63ab724854332900504274f6150ff26d286";
+        name = "ramsey-uuid-5f0df49ae5ad6efb7afa69e6bfab4e5b1e080d8e";
         src = fetchurl {
-          url = "https://api.github.com/repos/ramsey/uuid/zipball/60a4c63ab724854332900504274f6150ff26d286";
-          sha256 = "1w1i50pbd18awmvzqjkbszw79dl09912ibn95qm8lxr4nsjvbb27";
+          url = "https://api.github.com/repos/ramsey/uuid/zipball/5f0df49ae5ad6efb7afa69e6bfab4e5b1e080d8e";
+          sha256 = "0gnpj6jsmwr5azxq8ymp0zpscgxcwld7ps2q9rbkbndr9f9cpkkg";
         };
       };
     };
@@ -895,20 +945,20 @@ let
     "react/dns" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "react-dns-a5427e7dfa47713e438016905605819d101f238c";
+        name = "react-dns-c134600642fa615b46b41237ef243daa65bb64ec";
         src = fetchurl {
-          url = "https://api.github.com/repos/reactphp/dns/zipball/a5427e7dfa47713e438016905605819d101f238c";
-          sha256 = "1dr6hwkxdmkg8pnj497v4x566fyn92h3qrkbfvgsrmhi3cc3gidb";
+          url = "https://api.github.com/repos/reactphp/dns/zipball/c134600642fa615b46b41237ef243daa65bb64ec";
+          sha256 = "0p3slkj1p3gzsv2162y7x5j9ys3b2kslxl3vn2bcq341z1jic0jb";
         };
       };
     };
     "react/event-loop" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "react-event-loop-6e7e587714fff7a83dcc7025aee42ab3b265ae05";
+        name = "react-event-loop-bbe0bd8c51ffc05ee43f1729087ed3bdf7d53354";
         src = fetchurl {
-          url = "https://api.github.com/repos/reactphp/event-loop/zipball/6e7e587714fff7a83dcc7025aee42ab3b265ae05";
-          sha256 = "0f71ahram6w45ksnvscgsgw163m1wylipnpvc4a7gmwzncl9fkw7";
+          url = "https://api.github.com/repos/reactphp/event-loop/zipball/bbe0bd8c51ffc05ee43f1729087ed3bdf7d53354";
+          sha256 = "0g2l68nsmf80wdam602xp1m8w2dvl9qm5rzdvssgn8hq9fil60iv";
         };
       };
     };
@@ -925,40 +975,30 @@ let
     "react/promise" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "react-promise-f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38";
+        name = "react-promise-e563d55d1641de1dea9f5e84f3cccc66d2bfe02c";
         src = fetchurl {
-          url = "https://api.github.com/repos/reactphp/promise/zipball/f913fb8cceba1e6644b7b90c4bfb678ed8a3ef38";
-          sha256 = "1awzjaryj6lyi5wn0rmzwf5wyn1lg5wl3c6jp88i1gc9mp50g0n4";
-        };
-      };
-    };
-    "react/promise-timer" = {
-      targetDir = "";
-      src = composerEnv.buildZipPackage {
-        name = "react-promise-timer-aa7a73c74b8d8c0f622f5982ff7b0351bc29e495";
-        src = fetchurl {
-          url = "https://api.github.com/repos/reactphp/promise-timer/zipball/aa7a73c74b8d8c0f622f5982ff7b0351bc29e495";
-          sha256 = "1a7l9by70ygpp101arn217zvrpaddzsm2fywxd0nzc964jcq5mgd";
+          url = "https://api.github.com/repos/reactphp/promise/zipball/e563d55d1641de1dea9f5e84f3cccc66d2bfe02c";
+          sha256 = "0bwwnpwkf75wybkl22gv88gv9shc1yq45sdd6p2azp6xqjwcrmnr";
         };
       };
     };
     "react/socket" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "react-socket-81e1b4d7f5450ebd8d2e9a95bb008bb15ca95a7b";
+        name = "react-socket-21591111d3ea62e31f2254280ca0656bc2b1bda6";
         src = fetchurl {
-          url = "https://api.github.com/repos/reactphp/socket/zipball/81e1b4d7f5450ebd8d2e9a95bb008bb15ca95a7b";
-          sha256 = "0s22mfcima1plb5i10dy8kd9zz4h0apxk9s8frydc3kd27vl6fvv";
+          url = "https://api.github.com/repos/reactphp/socket/zipball/21591111d3ea62e31f2254280ca0656bc2b1bda6";
+          sha256 = "08wqhxj2zv52df303005m4g1i36j6ypxl26gim1fbvyfnagvb0fw";
         };
       };
     };
     "react/stream" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "react-stream-7a423506ee1903e89f1e08ec5f0ed430ff784ae9";
+        name = "react-stream-6fbc9672905c7d5a885f2da2fc696f65840f4a66";
         src = fetchurl {
-          url = "https://api.github.com/repos/reactphp/stream/zipball/7a423506ee1903e89f1e08ec5f0ed430ff784ae9";
-          sha256 = "1vcn792785hg0991vz3fhdmwl5y47z4g7hvly04y03zmbc0qx0mf";
+          url = "https://api.github.com/repos/reactphp/stream/zipball/6fbc9672905c7d5a885f2da2fc696f65840f4a66";
+          sha256 = "0hgkbjgdl8633w36praw2xjk8y7rib1vawzbvkssclampcg41cxh";
         };
       };
     };
@@ -975,30 +1015,30 @@ let
     "spatie/db-dumper" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "spatie-db-dumper-3b9fd47899bf6a59d3452392121c9ce675d55d34";
+        name = "spatie-db-dumper-bbd5ae0f331d47e6534eb307e256c11a65c8e24a";
         src = fetchurl {
-          url = "https://api.github.com/repos/spatie/db-dumper/zipball/3b9fd47899bf6a59d3452392121c9ce675d55d34";
-          sha256 = "0w9maf9gz8s76whxfq93wm1r795j82l76y0xypqabrr3kngkmzas";
+          url = "https://api.github.com/repos/spatie/db-dumper/zipball/bbd5ae0f331d47e6534eb307e256c11a65c8e24a";
+          sha256 = "0g2r7539wglkggm3mz1mx0lgkxx43icsdr2n76hylannm595dnrx";
         };
       };
     };
     "spatie/image-optimizer" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "spatie-image-optimizer-d997e01ba980b2769ddca2f00badd3b80c2a2512";
+        name = "spatie-image-optimizer-62f7463483d1bd975f6f06025d89d42a29608fe1";
         src = fetchurl {
-          url = "https://api.github.com/repos/spatie/image-optimizer/zipball/d997e01ba980b2769ddca2f00badd3b80c2a2512";
-          sha256 = "0pqyx30ylwsgdh1rz946crjphb0p4qvdvkw4lcbq99g6v36p7ngk";
+          url = "https://api.github.com/repos/spatie/image-optimizer/zipball/62f7463483d1bd975f6f06025d89d42a29608fe1";
+          sha256 = "0fzr4qyk7vzrv2nrwmm5fk3zfbgx0927mnkjq0knjz1qfng1kr4b";
         };
       };
     };
     "spatie/laravel-backup" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "spatie-laravel-backup-a743a8bc21e388e5cc1bceff676859180f018771";
+        name = "spatie-laravel-backup-b79f790cc856e67cce012abf34bf1c9035085dc1";
         src = fetchurl {
-          url = "https://api.github.com/repos/spatie/laravel-backup/zipball/a743a8bc21e388e5cc1bceff676859180f018771";
-          sha256 = "1k7vygfjf784a6wnr5w3qhzgh7vz7hgvrshb4b994yk4f8ggr3hk";
+          url = "https://api.github.com/repos/spatie/laravel-backup/zipball/b79f790cc856e67cce012abf34bf1c9035085dc1";
+          sha256 = "0lyab2cjvz454dbipzxfyvsspz0gq70ywpl5i944f70mn6lbv4dm";
         };
       };
     };
@@ -1015,10 +1055,10 @@ let
     "spatie/laravel-package-tools" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "spatie-laravel-package-tools-efab1844b8826443135201c4443690f032c3d533";
+        name = "spatie-laravel-package-tools-cc7c991555a37f9fa6b814aa03af73f88026a83d";
         src = fetchurl {
-          url = "https://api.github.com/repos/spatie/laravel-package-tools/zipball/efab1844b8826443135201c4443690f032c3d533";
-          sha256 = "1527wh9gyb5k066fmmyngvyy2ldkmc34glqx2dk9swflc1jfjgpb";
+          url = "https://api.github.com/repos/spatie/laravel-package-tools/zipball/cc7c991555a37f9fa6b814aa03af73f88026a83d";
+          sha256 = "1xbyaizfvkcdrlpcs5ci30arnydckdga4a78xsfx8ylia606gcg4";
         };
       };
     };
@@ -1035,360 +1075,380 @@ let
     "spatie/temporary-directory" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "spatie-temporary-directory-0c804873f6b4042aa8836839dca683c7d0f71831";
+        name = "spatie-temporary-directory-efc258c9f4da28f0c7661765b8393e4ccee3d19c";
         src = fetchurl {
-          url = "https://api.github.com/repos/spatie/temporary-directory/zipball/0c804873f6b4042aa8836839dca683c7d0f71831";
-          sha256 = "007vxm2x1anrlnzwhrqyk4nw7yflaicfhr4q9wlp5bhy7d3ixljr";
+          url = "https://api.github.com/repos/spatie/temporary-directory/zipball/efc258c9f4da28f0c7661765b8393e4ccee3d19c";
+          sha256 = "16xb80zhrkrg2p9b1yrcdigkz11z5msvnkac8dd429d5r2r4zfx9";
+        };
+      };
+    };
+    "spomky-labs/base64url" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "spomky-labs-base64url-7752ce931ec285da4ed1f4c5aa27e45e097be61d";
+        src = fetchurl {
+          url = "https://api.github.com/repos/Spomky-Labs/base64url/zipball/7752ce931ec285da4ed1f4c5aa27e45e097be61d";
+          sha256 = "04xjhggcf6zc80ikva0flqis16q9b5lywld73g007m3y8b97q23l";
         };
       };
     };
     "stevebauman/purify" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "stevebauman-purify-7b63762b05db9eadc36d7e8b74cf58fa64bfa527";
+        name = "stevebauman-purify-ce8d10c0dfe804d90470ff819b84d891037cd6bc";
         src = fetchurl {
-          url = "https://api.github.com/repos/stevebauman/purify/zipball/7b63762b05db9eadc36d7e8b74cf58fa64bfa527";
-          sha256 = "08l5qhx7awd64mivxwhim1vm007h5l244g3ssshz56i44qqji673";
+          url = "https://api.github.com/repos/stevebauman/purify/zipball/ce8d10c0dfe804d90470ff819b84d891037cd6bc";
+          sha256 = "0iqbqvvpd23z65ap24arjvppqj5d9rpz7fs3i5sqim0490dj8hav";
         };
       };
     };
     "symfony/cache" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-cache-1ce7ed8e7ca6948892b6a3a52bb60cf2b04f7c94";
+        name = "symfony-cache-ac2d25f97b17eec6e19760b6b9962a4f7c44356a";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/cache/zipball/1ce7ed8e7ca6948892b6a3a52bb60cf2b04f7c94";
-          sha256 = "0n9f8snanv7gxgi7kwjq8z3isjirhjc44ciw2ss3glij63864rwj";
+          url = "https://api.github.com/repos/symfony/cache/zipball/ac2d25f97b17eec6e19760b6b9962a4f7c44356a";
+          sha256 = "0gq6a5z3r2900vnv37wcjk597pqbsz7ib13ykm182l7lwlq4j3z7";
         };
       };
     };
     "symfony/cache-contracts" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-cache-contracts-eeb71f04b6f7f34ca6d15633df82e014528b1632";
+        name = "symfony-cache-contracts-1d74b127da04ffa87aa940abe15446fa89653778";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/cache-contracts/zipball/eeb71f04b6f7f34ca6d15633df82e014528b1632";
-          sha256 = "13dcrpy31arn3v1kns83zndhbyzngwc7ic3vc5c6x7kmv23s5l0x";
+          url = "https://api.github.com/repos/symfony/cache-contracts/zipball/1d74b127da04ffa87aa940abe15446fa89653778";
+          sha256 = "0n8zxm1qqlgzhk3f23s2bjll6il7qkszh1kr9p7hx895vp0rnk9c";
         };
       };
     };
     "symfony/console" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-console-5aa03db8ef0a5457c316ec580e69562d97734c77";
+        name = "symfony-console-a550a7c99daeedef3f9d23fb82e3531525ff11fd";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/console/zipball/5aa03db8ef0a5457c316ec580e69562d97734c77";
-          sha256 = "1dc90j27brsidzp025rz3jkk3ir1qyk9chlp2b6vbg617yyr8ipk";
+          url = "https://api.github.com/repos/symfony/console/zipball/a550a7c99daeedef3f9d23fb82e3531525ff11fd";
+          sha256 = "0fsdnj89ikiaqc3ag6nmkd5iz06659i465qvz62b5lw4zw5zg6d1";
         };
       };
     };
     "symfony/css-selector" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-css-selector-aedf3cb0f5b929ec255d96bbb4909e9932c769e0";
+        name = "symfony-css-selector-d036c6c0d0b09e24a14a35f8292146a658f986e4";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/css-selector/zipball/aedf3cb0f5b929ec255d96bbb4909e9932c769e0";
-          sha256 = "1sr492i55w1shyzp365a2xb50fsb0arkf2idckd8icck54k3zdgf";
+          url = "https://api.github.com/repos/symfony/css-selector/zipball/d036c6c0d0b09e24a14a35f8292146a658f986e4";
+          sha256 = "0pvgk0m2g8n6scwfwwmxj6dyqx2854zrkxizyfhpa8ikhh9a6kwj";
         };
       };
     };
     "symfony/deprecation-contracts" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-deprecation-contracts-e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e";
+        name = "symfony-deprecation-contracts-7c3aff79d10325257a001fcf92d991f24fc967cf";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e";
-          sha256 = "1z7akdycl5ar42vs1kc00ggm5rbqw0lx7i3acbcbfhnwmdxsmcxh";
+          url = "https://api.github.com/repos/symfony/deprecation-contracts/zipball/7c3aff79d10325257a001fcf92d991f24fc967cf";
+          sha256 = "0p0c2942wjq1bb06y9i8gw6qqj7sin5v5xwsvl0zdgspbr7jk1m9";
         };
       };
     };
     "symfony/error-handler" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-error-handler-e847ba47e7a8f9708082990cb40ab4ff0440a11e";
+        name = "symfony-error-handler-c873490a1c97b3a0a4838afc36ff36c112d02788";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/error-handler/zipball/e847ba47e7a8f9708082990cb40ab4ff0440a11e";
-          sha256 = "1ffx7y5pcsxwb95jxdir8kx06p27bkf2bs7c7qbqmlkb6srga1pg";
+          url = "https://api.github.com/repos/symfony/error-handler/zipball/c873490a1c97b3a0a4838afc36ff36c112d02788";
+          sha256 = "0ac4a1zwi1fsisld4rq340y93pimzzlwja3ckx6r7yipb2yzkhib";
         };
       };
     };
     "symfony/event-dispatcher" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-event-dispatcher-04046f35fd7d72f9646e721fc2ecb8f9c67d3339";
+        name = "symfony-event-dispatcher-d76d2632cfc2206eecb5ad2b26cd5934082941b6";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/event-dispatcher/zipball/04046f35fd7d72f9646e721fc2ecb8f9c67d3339";
-          sha256 = "1va0impcvcmbf3v8xpjkwrm0l5w14pb2n2fs2k29xp23xjd7lnil";
+          url = "https://api.github.com/repos/symfony/event-dispatcher/zipball/d76d2632cfc2206eecb5ad2b26cd5934082941b6";
+          sha256 = "0gwi98335dll70dr9g7r5ll9sjx9yy079sdmwsyv82xpg8k72x5i";
         };
       };
     };
     "symfony/event-dispatcher-contracts" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-event-dispatcher-contracts-0ad3b6f1e4e2da5690fefe075cd53a238646d8dd";
+        name = "symfony-event-dispatcher-contracts-a76aed96a42d2b521153fb382d418e30d18b59df";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/0ad3b6f1e4e2da5690fefe075cd53a238646d8dd";
-          sha256 = "0yqg0h2kf4mij39nisshvg5gssn6aqyqphngi05z6jfd0q89a46x";
+          url = "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/a76aed96a42d2b521153fb382d418e30d18b59df";
+          sha256 = "1w49s1q6xhcmkgd3xkyjggiwys0wvyny0p3018anvdi0k86zg678";
         };
       };
     };
     "symfony/finder" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-finder-20808dc6631aecafbe67c186af5dcb370be3a0eb";
+        name = "symfony-finder-11d736e97f116ac375a81f96e662911a34cd50ce";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/finder/zipball/20808dc6631aecafbe67c186af5dcb370be3a0eb";
-          sha256 = "113yidfp8sjkv200kx4pi81zn0v0r9gmq8dw7p3zvhc23k1hinh8";
+          url = "https://api.github.com/repos/symfony/finder/zipball/11d736e97f116ac375a81f96e662911a34cd50ce";
+          sha256 = "0p0k05jilm3pfckzilfdpwjvmjppwb2dsg4ym9mxk7520qni8msj";
         };
       };
     };
     "symfony/http-client" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-http-client-39f679c12648cc43bd9f0db12cc69b82041b91a1";
+        name = "symfony-http-client-5c584530b77aa10ae216989ffc48b4bedc9c0b29";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/http-client/zipball/39f679c12648cc43bd9f0db12cc69b82041b91a1";
-          sha256 = "1mn4nf6hwxdgb0x8xmrfmgbayyr1hy613w632ag8rj582bfmag6z";
+          url = "https://api.github.com/repos/symfony/http-client/zipball/5c584530b77aa10ae216989ffc48b4bedc9c0b29";
+          sha256 = "1adz59a11rd6zfp3nxaj4fq275sg0b1hh5rz6b9h93fd0ndx7ng5";
         };
       };
     };
     "symfony/http-client-contracts" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-http-client-contracts-df2ecd6cb70e73c1080e6478aea85f5f4da2c48b";
+        name = "symfony-http-client-contracts-1ee70e699b41909c209a0c930f11034b93578654";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/http-client-contracts/zipball/df2ecd6cb70e73c1080e6478aea85f5f4da2c48b";
-          sha256 = "0ch1kzfxszbaw75rrn9x8f26rx1ikjnygdckhgs8cgn5y1ivp0im";
+          url = "https://api.github.com/repos/symfony/http-client-contracts/zipball/1ee70e699b41909c209a0c930f11034b93578654";
+          sha256 = "181m2alsmj9v8wkzn210g6v41nl2fx519f674p7r9q0m22ivk2ca";
         };
       };
     };
     "symfony/http-foundation" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-http-foundation-df27f4191a4292d01fd062296e09cbc8b657cb57";
+        name = "symfony-http-foundation-44a6d39a9cc11e154547d882d5aac1e014440771";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/http-foundation/zipball/df27f4191a4292d01fd062296e09cbc8b657cb57";
-          sha256 = "1kdzs427q1qxbd3209fpwas3dq40ihjm0skbh6avxarwsyw9vfwk";
+          url = "https://api.github.com/repos/symfony/http-foundation/zipball/44a6d39a9cc11e154547d882d5aac1e014440771";
+          sha256 = "0zabky2ic9rn7mk9dfkwi86amixr1qywfr2hld6n2s0vchw9iv37";
         };
       };
     };
     "symfony/http-kernel" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-http-kernel-954a1a3b178309b216261eedc735c079709e4ab3";
+        name = "symfony-http-kernel-2953274c16a229b3933ef73a6898e18388e12e1b";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/http-kernel/zipball/954a1a3b178309b216261eedc735c079709e4ab3";
-          sha256 = "1iga2bbshrm7d9m90bxmqkh5crzwzziqfyw3g62b6z01iwrp1k42";
+          url = "https://api.github.com/repos/symfony/http-kernel/zipball/2953274c16a229b3933ef73a6898e18388e12e1b";
+          sha256 = "0mbr9g6cr62iyf7r4m12p1v65xf21hc3az0gj400bks3w6gv5gxy";
         };
       };
     };
     "symfony/mailer" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-mailer-bfcfa015c67e19c6fdb7ca6fe70700af1e740a17";
+        name = "symfony-mailer-ca8dcf8892cdc5b4358ecf2528429bb5e706f7ba";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/mailer/zipball/bfcfa015c67e19c6fdb7ca6fe70700af1e740a17";
-          sha256 = "1i6q57w3jhfy69z86jyqvjwx7y50rl8z3y7n6gc1kafw97g1yyn8";
+          url = "https://api.github.com/repos/symfony/mailer/zipball/ca8dcf8892cdc5b4358ecf2528429bb5e706f7ba";
+          sha256 = "16xpdz8gqri3m4xky31581m1gm07ivhxc9krz7f0crc4vpyzv7yp";
         };
       };
     };
     "symfony/mailgun-mailer" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-mailgun-mailer-2c9d47b11cc154d2db3f571030cd965d128de1a8";
+        name = "symfony-mailgun-mailer-72d2f72f2016e559d0152188bef5a5dc9ebf5ec7";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/mailgun-mailer/zipball/2c9d47b11cc154d2db3f571030cd965d128de1a8";
-          sha256 = "0ppsp07mkj382s4h4wh1g5f0w104a4brw6vl3dwr6kjciakxc3hd";
+          url = "https://api.github.com/repos/symfony/mailgun-mailer/zipball/72d2f72f2016e559d0152188bef5a5dc9ebf5ec7";
+          sha256 = "1d5r62pksbdaffg3w89a8rfk5rxzdg1wg9wlqfszfm12kdg3d4gk";
         };
       };
     };
     "symfony/mime" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-mime-b6c137fc53a9f7c4c951cd3f362b3734c7a97723";
+        name = "symfony-mime-ca4f58b2ef4baa8f6cecbeca2573f88cd577d205";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/mime/zipball/b6c137fc53a9f7c4c951cd3f362b3734c7a97723";
-          sha256 = "1cy2xp4hw8lz3d1n5qc5q5afpzk2y7n0kkn0gl68dnn5ffd06xmr";
+          url = "https://api.github.com/repos/symfony/mime/zipball/ca4f58b2ef4baa8f6cecbeca2573f88cd577d205";
+          sha256 = "0lcq2avf9c8r35lhnbp8v5z5pypls4xxhz9pq5grn2x8n57h9fhk";
         };
       };
     };
     "symfony/polyfill-ctype" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-polyfill-ctype-5bbc823adecdae860bb64756d639ecfec17b050a";
+        name = "symfony-polyfill-ctype-ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/polyfill-ctype/zipball/5bbc823adecdae860bb64756d639ecfec17b050a";
-          sha256 = "0vyv70z1yi2is727d1mkb961w5r1pb1v3wy1pvdp30h8ffy15wk6";
+          url = "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb";
+          sha256 = "0ynkrpl3hb448dhab1injwwzfx68l75yn9zgc7lgqwbx60dvhqm3";
         };
       };
     };
     "symfony/polyfill-intl-grapheme" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-polyfill-intl-grapheme-511a08c03c1960e08a883f4cffcacd219b758354";
+        name = "symfony-polyfill-intl-grapheme-875e90aeea2777b6f135677f618529449334a612";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/511a08c03c1960e08a883f4cffcacd219b758354";
-          sha256 = "0ifsgsyxf0z0nkynqvr5259dm5dsmbgdpvyi5zfvy8935mi0ki0i";
+          url = "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/875e90aeea2777b6f135677f618529449334a612";
+          sha256 = "19j8qcbp525q7i61c2lhj6z2diysz45q06d990fvjby15cn0id0i";
         };
       };
     };
     "symfony/polyfill-intl-idn" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-polyfill-intl-idn-639084e360537a19f9ee352433b84ce831f3d2da";
+        name = "symfony-polyfill-intl-idn-ecaafce9f77234a6a449d29e49267ba10499116d";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/639084e360537a19f9ee352433b84ce831f3d2da";
-          sha256 = "1i2wcsbfbwdyrx8545yrrvbdaf4l2393pjvg9266q74611j6pzxj";
+          url = "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/ecaafce9f77234a6a449d29e49267ba10499116d";
+          sha256 = "0f42w4975rakhysnmhsyw6n3rjg6rjg7b7x8gs1n0qfdb6wc8m3q";
         };
       };
     };
     "symfony/polyfill-intl-normalizer" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-polyfill-intl-normalizer-19bd1e4fcd5b91116f14d8533c57831ed00571b6";
+        name = "symfony-polyfill-intl-normalizer-8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/19bd1e4fcd5b91116f14d8533c57831ed00571b6";
-          sha256 = "1d80jph5ykiw6ydv8fwd43s0aglh24qc1yrzds2f3aqanpbk1gr2";
+          url = "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92";
+          sha256 = "0msah2ii2174xh47v5x9vq1b1xn38yyx03sr3pa2rq3a849wi7nh";
         };
       };
     };
     "symfony/polyfill-mbstring" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-polyfill-mbstring-8ad114f6b39e2c98a8b0e3bd907732c207c2b534";
+        name = "symfony-polyfill-mbstring-42292d99c55abe617799667f454222c54c60e229";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/8ad114f6b39e2c98a8b0e3bd907732c207c2b534";
-          sha256 = "1ym84qp609i50lv4vkd4yz99y19kaxd5kmpdnh66mxx1a4a104mi";
+          url = "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/42292d99c55abe617799667f454222c54c60e229";
+          sha256 = "1m3l12y0lid3i0zy3m1jrk0z3zy8wpa7nij85zk2h5vbf924jnwa";
         };
       };
     };
     "symfony/polyfill-php72" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-polyfill-php72-869329b1e9894268a8a61dabb69153029b7a8c97";
+        name = "symfony-polyfill-php72-70f4aebd92afca2f865444d30a4d2151c13c3179";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/polyfill-php72/zipball/869329b1e9894268a8a61dabb69153029b7a8c97";
-          sha256 = "1h0lbh8d41sa4fymmw03yzws3v3z0lz4lv1kgcld7r53i2m3wfwp";
+          url = "https://api.github.com/repos/symfony/polyfill-php72/zipball/70f4aebd92afca2f865444d30a4d2151c13c3179";
+          sha256 = "10j5ipx16p6rybkpawqscpr2wcnby4270rbdj1qchr598wkvi0kb";
         };
       };
     };
     "symfony/polyfill-php80" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-polyfill-php80-7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936";
+        name = "symfony-polyfill-php80-6caa57379c4aec19c0a12a38b59b26487dcfe4b5";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/polyfill-php80/zipball/7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936";
-          sha256 = "16yydk7rsknlasrpn47n4b4js8svvp4rxzw99dkav52wr3cqmcwd";
+          url = "https://api.github.com/repos/symfony/polyfill-php80/zipball/6caa57379c4aec19c0a12a38b59b26487dcfe4b5";
+          sha256 = "05yfindyip9lbfr5apxkz6m0mlljrc9z6qylpxr6k5nkivlrcn9x";
+        };
+      };
+    };
+    "symfony/polyfill-php83" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "symfony-polyfill-php83-b0f46ebbeeeda3e9d2faebdfbf4b4eae9b59fa11";
+        src = fetchurl {
+          url = "https://api.github.com/repos/symfony/polyfill-php83/zipball/b0f46ebbeeeda3e9d2faebdfbf4b4eae9b59fa11";
+          sha256 = "0z0xk1ghssa5qknp7cm3phdam77q4n46bkiwfpc5jkparkq958yb";
         };
       };
     };
     "symfony/polyfill-uuid" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-polyfill-uuid-f3cf1a645c2734236ed1e2e671e273eeb3586166";
+        name = "symfony-polyfill-uuid-9c44518a5aff8da565c8a55dbe85d2769e6f630e";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/polyfill-uuid/zipball/f3cf1a645c2734236ed1e2e671e273eeb3586166";
-          sha256 = "1pjh861iwlf71frm9f9i7acw4bbiq40gkh96a5wd09nfd2c3w7mc";
+          url = "https://api.github.com/repos/symfony/polyfill-uuid/zipball/9c44518a5aff8da565c8a55dbe85d2769e6f630e";
+          sha256 = "0w6mphwcz3n1qz0dc6nld5xqb179dvfcwys6r4nj4gjv5nm2nji0";
         };
       };
     };
     "symfony/process" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-process-97ae9721bead9d1a39b5650e2f4b7834b93b539c";
+        name = "symfony-process-191703b1566d97a5425dc969e4350d32b8ef17aa";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/process/zipball/97ae9721bead9d1a39b5650e2f4b7834b93b539c";
-          sha256 = "0z5hip2ackw8a97fkf6a5zz7rd8sfv72qj44w4zyw776br0rcviw";
+          url = "https://api.github.com/repos/symfony/process/zipball/191703b1566d97a5425dc969e4350d32b8ef17aa";
+          sha256 = "0z2qbb0l0m1js7vgwmcjmgz479ssbpv9smdc3nymyrwfzbb0m117";
         };
       };
     };
     "symfony/psr-http-message-bridge" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-psr-http-message-bridge-28a732c05bbad801304ad5a5c674cf2970508993";
+        name = "symfony-psr-http-message-bridge-581ca6067eb62640de5ff08ee1ba6850a0ee472e";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/psr-http-message-bridge/zipball/28a732c05bbad801304ad5a5c674cf2970508993";
-          sha256 = "0mbs6d1f05n7ws4nyw3w748q5qp7c28i7d96q9c4lyc6cvxbl12n";
+          url = "https://api.github.com/repos/symfony/psr-http-message-bridge/zipball/581ca6067eb62640de5ff08ee1ba6850a0ee472e";
+          sha256 = "1x9zyp5kmr1vdb457varl32bsr34j8ibcj1hd5kn5601wx6b1hf5";
         };
       };
     };
     "symfony/routing" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-routing-69062e2823f03b82265d73a966999660f0e1e404";
+        name = "symfony-routing-0c95c164fdba18b12523b75e64199ca3503e6d40";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/routing/zipball/69062e2823f03b82265d73a966999660f0e1e404";
-          sha256 = "03nzrw3kvraf3cyn31hmpvnip4aihj84234i5qh5iv59jzpz517p";
+          url = "https://api.github.com/repos/symfony/routing/zipball/0c95c164fdba18b12523b75e64199ca3503e6d40";
+          sha256 = "0vq86glzh42k3m8v3swp4wppbby75q4s098ajm3rqlaj2ky4iv06";
         };
       };
     };
     "symfony/service-contracts" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-service-contracts-a8c9cedf55f314f3a186041d19537303766df09a";
+        name = "symfony-service-contracts-b3313c2dbffaf71c8de2934e2ea56ed2291a3838";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/service-contracts/zipball/a8c9cedf55f314f3a186041d19537303766df09a";
-          sha256 = "0gk4mpvm0v8a98p641wdxdvcinl4366fiqadq0za3w37zrwals53";
+          url = "https://api.github.com/repos/symfony/service-contracts/zipball/b3313c2dbffaf71c8de2934e2ea56ed2291a3838";
+          sha256 = "1blpfzdflh4yl1wqvd94acavlvdn6nrnyssrpsm9286wzh6a6n4k";
         };
       };
     };
     "symfony/string" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-string-193e83bbd6617d6b2151c37fff10fa7168ebddef";
+        name = "symfony-string-b45fcf399ea9c3af543a92edf7172ba21174d809";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/string/zipball/193e83bbd6617d6b2151c37fff10fa7168ebddef";
-          sha256 = "1478grgcbh5vwylwnx89bzjrws5akm8h7kmm7j4h741wvhzv45j6";
+          url = "https://api.github.com/repos/symfony/string/zipball/b45fcf399ea9c3af543a92edf7172ba21174d809";
+          sha256 = "1vwwfm5wwalyrfrs8w68cwjfwglhpmvfpilsrz1hd1ilf5j5dh3d";
         };
       };
     };
     "symfony/translation" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-translation-64113df3e8b009f92fad63014f4ec647e65bc927";
+        name = "symfony-translation-b1035dbc2a344b21f8fa8ac451c7ecec4ea45f37";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/translation/zipball/64113df3e8b009f92fad63014f4ec647e65bc927";
-          sha256 = "18w8yp5l1w0rcrnmm020y4my898ncxldhf7s94875vk7xks69nby";
+          url = "https://api.github.com/repos/symfony/translation/zipball/b1035dbc2a344b21f8fa8ac451c7ecec4ea45f37";
+          sha256 = "1qkyl84pql3b163ldk5w5pv21yqq6frk1bbrgjic7fxji58j6qfv";
         };
       };
     };
     "symfony/translation-contracts" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-translation-contracts-dfec258b9dd17a6b24420d464c43bffe347441c8";
+        name = "symfony-translation-contracts-dee0c6e5b4c07ce851b462530088e64b255ac9c5";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/translation-contracts/zipball/dfec258b9dd17a6b24420d464c43bffe347441c8";
-          sha256 = "1ns37kz4fc2z0kdzhk9kchsxffy5h7ls43z4carv2vzrkgzml8lx";
+          url = "https://api.github.com/repos/symfony/translation-contracts/zipball/dee0c6e5b4c07ce851b462530088e64b255ac9c5";
+          sha256 = "0dwfy3qd1w6pdlcxnxgdjnwpb5zv9wxd488bdss0db6pfr43zqwx";
         };
       };
     };
     "symfony/uid" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-uid-d30c72a63897cfa043e1de4d4dd2ffa9ecefcdc0";
+        name = "symfony-uid-8092dd1b1a41372110d06374f99ee62f7f0b9a92";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/uid/zipball/d30c72a63897cfa043e1de4d4dd2ffa9ecefcdc0";
-          sha256 = "0lg3qxa011mvg41xznm69jqc6l02ysvw9jm48bb63gn1j70zy6ba";
+          url = "https://api.github.com/repos/symfony/uid/zipball/8092dd1b1a41372110d06374f99ee62f7f0b9a92";
+          sha256 = "0wa5ja89lzf4is5393smfxswq1dkyiyrj6qcd32cs9hnrik9rw0q";
         };
       };
     };
     "symfony/var-dumper" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-var-dumper-7d10f2a5a452bda385692fc7d38cd6eccfebe756";
+        name = "symfony-var-dumper-c40f7d17e91d8b407582ed51a2bbf83c52c367f6";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/var-dumper/zipball/7d10f2a5a452bda385692fc7d38cd6eccfebe756";
-          sha256 = "1sb6mjh88rd5ycqkkq0rcx0kplvyvyxf2xa1avyv9f8hjlcyydhv";
+          url = "https://api.github.com/repos/symfony/var-dumper/zipball/c40f7d17e91d8b407582ed51a2bbf83c52c367f6";
+          sha256 = "0idnivgds7w523bf4d6p3frqy21vzqmjpsjrw9grvs5gq7rzlz2x";
         };
       };
     };
     "symfony/var-exporter" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "symfony-var-exporter-9a07920c2058bafee921ce4d90aeef2193837d63";
+        name = "symfony-var-exporter-2d08ca6b9cc704dce525615d1e6d1788734f36d9";
         src = fetchurl {
-          url = "https://api.github.com/repos/symfony/var-exporter/zipball/9a07920c2058bafee921ce4d90aeef2193837d63";
-          sha256 = "1vggk9ya9b2703i0qj70bvqp00c3dbddmcg7sax8c8a0hq308r7m";
+          url = "https://api.github.com/repos/symfony/var-exporter/zipball/2d08ca6b9cc704dce525615d1e6d1788734f36d9";
+          sha256 = "1iw2mg0626pmpk4rdv1c2chyp15h64xvgap6mgnvrhr5sfxg1qrc";
         };
       };
     };
@@ -1415,10 +1475,10 @@ let
     "vlucas/phpdotenv" = {
       targetDir = "";
       src = composerEnv.buildZipPackage {
-        name = "vlucas-phpdotenv-1a7ea2afc49c3ee6d87061f5a233e3a035d0eae7";
+        name = "vlucas-phpdotenv-2cf9fb6054c2bb1d59d1f3817706ecdb9d2934c4";
         src = fetchurl {
-          url = "https://api.github.com/repos/vlucas/phpdotenv/zipball/1a7ea2afc49c3ee6d87061f5a233e3a035d0eae7";
-          sha256 = "13h4xyxhdjn1n7xcxbcdhj20rv5fsaigbsbz61x2i224hj76620a";
+          url = "https://api.github.com/repos/vlucas/phpdotenv/zipball/2cf9fb6054c2bb1d59d1f3817706ecdb9d2934c4";
+          sha256 = "0zb5gm5i6rnmm9zc4mi3wkkhpgciaa76w8jyxnw914xwq1xqzivx";
         };
       };
     };
@@ -1429,6 +1489,56 @@ let
         src = fetchurl {
           url = "https://api.github.com/repos/voku/portable-ascii/zipball/b56450eed252f6801410d810c8e1727224ae0743";
           sha256 = "0gwlv1hr6ycrf8ik1pnvlwaac8cpm8sa1nf4d49s8rp4k2y5anyl";
+        };
+      };
+    };
+    "web-token/jwt-core" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "web-token-jwt-core-4d956e786a4e35d54c74787ebff840a0311c5e83";
+        src = fetchurl {
+          url = "https://api.github.com/repos/web-token/jwt-core/zipball/4d956e786a4e35d54c74787ebff840a0311c5e83";
+          sha256 = "0ldajzhq9s7hwln07sga973yj65g7y9s30x8f3i6yi408zrih4pf";
+        };
+      };
+    };
+    "web-token/jwt-key-mgmt" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "web-token-jwt-key-mgmt-bf6dec304f2a718d70f7316e498c612317c59e08";
+        src = fetchurl {
+          url = "https://api.github.com/repos/web-token/jwt-key-mgmt/zipball/bf6dec304f2a718d70f7316e498c612317c59e08";
+          sha256 = "0n4pfxn6452zpjzvqr50bjfa8fdjmfjv4yfq5ldppa7m5sxnhfcs";
+        };
+      };
+    };
+    "web-token/jwt-signature" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "web-token-jwt-signature-14b71230d9632564e356b785366ad36880964190";
+        src = fetchurl {
+          url = "https://api.github.com/repos/web-token/jwt-signature/zipball/14b71230d9632564e356b785366ad36880964190";
+          sha256 = "1lnnq4iwxrpw3db1pnxasv23pil4lz4p0iipzjzidzr226wa0l8i";
+        };
+      };
+    };
+    "web-token/jwt-signature-algorithm-ecdsa" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "web-token-jwt-signature-algorithm-ecdsa-e09159600f19832cf4a68921e7299e564bc0eaf9";
+        src = fetchurl {
+          url = "https://api.github.com/repos/web-token/jwt-signature-algorithm-ecdsa/zipball/e09159600f19832cf4a68921e7299e564bc0eaf9";
+          sha256 = "0pzvyp0g8r6gh7fij864gmamlavb8skkiby83x91khrdm3ch856y";
+        };
+      };
+    };
+    "web-token/jwt-util-ecc" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "web-token-jwt-util-ecc-b2337052dbee724d710c1fdb0d3609835a5f8609";
+        src = fetchurl {
+          url = "https://api.github.com/repos/web-token/jwt-util-ecc/zipball/b2337052dbee724d710c1fdb0d3609835a5f8609";
+          sha256 = "0pn2qbb016kxvklck271xgl7fjcvvrrk1j9lnx95a3p9mz81lsrs";
         };
       };
     };
@@ -1443,11 +1553,372 @@ let
       };
     };
   };
-  devPackages = {};
+  devPackages = {
+    "brianium/paratest" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "brianium-paratest-8083a421cee7dad847ee7c464529043ba30de380";
+        src = fetchurl {
+          url = "https://api.github.com/repos/paratestphp/paratest/zipball/8083a421cee7dad847ee7c464529043ba30de380";
+          sha256 = "1m8ms7aylxryn2332dv58amnd3x0l1k9nvvd20i4whc1z8sydnsf";
+        };
+      };
+    };
+    "doctrine/instantiator" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "doctrine-instantiator-c6222283fa3f4ac679f8b9ced9a4e23f163e80d0";
+        src = fetchurl {
+          url = "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0";
+          sha256 = "059ahw73z0m24cal4f805j6h1i53f90mrmjr7s4f45yfxgwcqvcn";
+        };
+      };
+    };
+    "fakerphp/faker" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "fakerphp-faker-e3daa170d00fde61ea7719ef47bb09bb8f1d9b01";
+        src = fetchurl {
+          url = "https://api.github.com/repos/FakerPHP/Faker/zipball/e3daa170d00fde61ea7719ef47bb09bb8f1d9b01";
+          sha256 = "1n99cfc737xcyvip3k9j1f5iy91bh1m64xg404xa7gvzlgpdnm7n";
+        };
+      };
+    };
+    "fidry/cpu-core-counter" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "fidry-cpu-core-counter-85193c0b0cb5c47894b5eaec906e946f054e7077";
+        src = fetchurl {
+          url = "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/85193c0b0cb5c47894b5eaec906e946f054e7077";
+          sha256 = "1yc7l1jn509n5k6bxs7zdm6322m71ghwz8q164kprcfmqmlb8i9v";
+        };
+      };
+    };
+    "filp/whoops" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "filp-whoops-a139776fa3f5985a50b509f2a02ff0f709d2a546";
+        src = fetchurl {
+          url = "https://api.github.com/repos/filp/whoops/zipball/a139776fa3f5985a50b509f2a02ff0f709d2a546";
+          sha256 = "18sfx7s3936q7i4hhn08lr5728c6bqyfqji6kzczjzhlyqkbys10";
+        };
+      };
+    };
+    "hamcrest/hamcrest-php" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "hamcrest-hamcrest-php-8c3d0a3f6af734494ad8f6fbbee0ba92422859f3";
+        src = fetchurl {
+          url = "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/8c3d0a3f6af734494ad8f6fbbee0ba92422859f3";
+          sha256 = "1ixmmpplaf1z36f34d9f1342qjbcizvi5ddkjdli6jgrbla6a6hr";
+        };
+      };
+    };
+    "jean85/pretty-package-versions" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "jean85-pretty-package-versions-ae547e455a3d8babd07b96966b17d7fd21d9c6af";
+        src = fetchurl {
+          url = "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/ae547e455a3d8babd07b96966b17d7fd21d9c6af";
+          sha256 = "07s7hl7705vgmyr5m7czja4426rsqrxqh8m362irn29vbc35k6q8";
+        };
+      };
+    };
+    "laravel/telescope" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "laravel-telescope-64da53ee46b99ef328458eaed32202b51e325a11";
+        src = fetchurl {
+          url = "https://api.github.com/repos/laravel/telescope/zipball/64da53ee46b99ef328458eaed32202b51e325a11";
+          sha256 = "1sgsmdnz4k36pqiw4dkynf68r11fcbbjl9r47361p9dgppj1n8wn";
+        };
+      };
+    };
+    "mockery/mockery" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "mockery-mockery-b8e0bb7d8c604046539c1115994632c74dcb361e";
+        src = fetchurl {
+          url = "https://api.github.com/repos/mockery/mockery/zipball/b8e0bb7d8c604046539c1115994632c74dcb361e";
+          sha256 = "1fbz87008ffn35k7wgwsx3g5pdrjsc9pygza71as9bmbkxkryjlr";
+        };
+      };
+    };
+    "myclabs/deep-copy" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "myclabs-deep-copy-7284c22080590fb39f2ffa3e9057f10a4ddd0e0c";
+        src = fetchurl {
+          url = "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c";
+          sha256 = "16k44y94bcr439bsxm5158xvmlyraph2c6n17qa5y29b04jqdw5j";
+        };
+      };
+    };
+    "nunomaduro/collision" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "nunomaduro-collision-f05978827b9343cba381ca05b8c7deee346b6015";
+        src = fetchurl {
+          url = "https://api.github.com/repos/nunomaduro/collision/zipball/f05978827b9343cba381ca05b8c7deee346b6015";
+          sha256 = "09bpw23vq3yyilrkd6k798igrg0ypryxpw2bfbdgjvjwhs4ndf29";
+        };
+      };
+    };
+    "phar-io/manifest" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "phar-io-manifest-97803eca37d319dfa7826cc2437fc020857acb53";
+        src = fetchurl {
+          url = "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53";
+          sha256 = "107dsj04ckswywc84dvw42kdrqd4y6yvb2qwacigyrn05p075c1w";
+        };
+      };
+    };
+    "phar-io/version" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "phar-io-version-4f7fd7836c6f332bb2933569e566a0d6c4cbed74";
+        src = fetchurl {
+          url = "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74";
+          sha256 = "0mdbzh1y0m2vvpf54vw7ckcbcf1yfhivwxgc9j9rbb7yifmlyvsg";
+        };
+      };
+    };
+    "phpunit/php-code-coverage" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "phpunit-php-code-coverage-6a3a87ac2bbe33b25042753df8195ba4aa534c76";
+        src = fetchurl {
+          url = "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6a3a87ac2bbe33b25042753df8195ba4aa534c76";
+          sha256 = "1bh1bxnnvxdjfm0chza9znkn1b5jncvr794xj3npvdm9szbbkyg8";
+        };
+      };
+    };
+    "phpunit/php-file-iterator" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "phpunit-php-file-iterator-cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf";
+        src = fetchurl {
+          url = "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf";
+          sha256 = "1407d8f1h35w4sdikq2n6cz726css2xjvlyr1m4l9a53544zxcnr";
+        };
+      };
+    };
+    "phpunit/php-invoker" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "phpunit-php-invoker-5a10147d0aaf65b58940a0b72f71c9ac0423cc67";
+        src = fetchurl {
+          url = "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67";
+          sha256 = "1vqnnjnw94mzm30n9n5p2bfgd3wd5jah92q6cj3gz1nf0qigr4fh";
+        };
+      };
+    };
+    "phpunit/php-text-template" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "phpunit-php-text-template-5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28";
+        src = fetchurl {
+          url = "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28";
+          sha256 = "0ff87yzywizi6j2ps3w0nalpx16mfyw3imzn6gj9jjsfwc2bb8lq";
+        };
+      };
+    };
+    "phpunit/php-timer" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "phpunit-php-timer-5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2";
+        src = fetchurl {
+          url = "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2";
+          sha256 = "0g1g7yy4zk1bidyh165fsbqx5y8f1c8pxikvcahzlfsr9p2qxk6a";
+        };
+      };
+    };
+    "phpunit/phpunit" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "phpunit-phpunit-05017b80304e0eb3f31d90194a563fd53a6021f1";
+        src = fetchurl {
+          url = "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/05017b80304e0eb3f31d90194a563fd53a6021f1";
+          sha256 = "1027h6phxp8bxjmn8586idpzalyg60i8ihwgjg3pm4za93dz8llk";
+        };
+      };
+    };
+    "sebastian/cli-parser" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "sebastian-cli-parser-442e7c7e687e42adc03470c7b668bc4b2402c0b2";
+        src = fetchurl {
+          url = "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2";
+          sha256 = "074qzdq19k9x4svhq3nak5h348xska56v1sqnhk1aj0jnrx02h37";
+        };
+      };
+    };
+    "sebastian/code-unit" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "sebastian-code-unit-1fc9f64c0927627ef78ba436c9b17d967e68e120";
+        src = fetchurl {
+          url = "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120";
+          sha256 = "04vlx050rrd54mxal7d93pz4119pas17w3gg5h532anfxjw8j7pm";
+        };
+      };
+    };
+    "sebastian/code-unit-reverse-lookup" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "sebastian-code-unit-reverse-lookup-ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5";
+        src = fetchurl {
+          url = "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5";
+          sha256 = "1h1jbzz3zak19qi4mab2yd0ddblpz7p000jfyxfwd2ds0gmrnsja";
+        };
+      };
+    };
+    "sebastian/comparator" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "sebastian-comparator-fa0f136dd2334583309d32b62544682ee972b51a";
+        src = fetchurl {
+          url = "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a";
+          sha256 = "0m8ibkwaxw2q5v84rlvy7ylpkddscsa8hng0cjczy4bqpqavr83w";
+        };
+      };
+    };
+    "sebastian/complexity" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "sebastian-complexity-739b35e53379900cc9ac327b2147867b8b6efd88";
+        src = fetchurl {
+          url = "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88";
+          sha256 = "1y4yz8n8hszbhinf9ipx3pqyvgm7gz0krgyn19z0097yq3bbq8yf";
+        };
+      };
+    };
+    "sebastian/diff" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "sebastian-diff-74be17022044ebaaecfdf0c5cd504fc9cd5a7131";
+        src = fetchurl {
+          url = "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131";
+          sha256 = "0f90471bi8lkmffms3bc2dnggqv8a81y1f4gi7p3r5120328mjm0";
+        };
+      };
+    };
+    "sebastian/environment" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "sebastian-environment-830c43a844f1f8d5b7a1f6d6076b784454d8b7ed";
+        src = fetchurl {
+          url = "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed";
+          sha256 = "02045n3in01zk571v1phyhj0b2mvnvx8qnlqvw4j33r7qdd4clzn";
+        };
+      };
+    };
+    "sebastian/exporter" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "sebastian-exporter-ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d";
+        src = fetchurl {
+          url = "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d";
+          sha256 = "1a6yj8v8rwj3igip8xysdifvbd7gkzmwrj9whdx951pdq7add46j";
+        };
+      };
+    };
+    "sebastian/global-state" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "sebastian-global-state-bde739e7565280bda77be70044ac1047bc007e34";
+        src = fetchurl {
+          url = "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bde739e7565280bda77be70044ac1047bc007e34";
+          sha256 = "0lk9hbvrma0jm4z2nm8dr94w0pinlnp6wzcczcm1cjkm4zx0yabw";
+        };
+      };
+    };
+    "sebastian/lines-of-code" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "sebastian-lines-of-code-c1c2e997aa3146983ed888ad08b15470a2e22ecc";
+        src = fetchurl {
+          url = "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc";
+          sha256 = "0fay9s5cm16gbwr7qjihwrzxn7sikiwba0gvda16xng903argbk0";
+        };
+      };
+    };
+    "sebastian/object-enumerator" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "sebastian-object-enumerator-5c9eeac41b290a3712d88851518825ad78f45c71";
+        src = fetchurl {
+          url = "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71";
+          sha256 = "11853z07w8h1a67wsjy3a6ir5x7khgx6iw5bmrkhjkiyvandqcn1";
+        };
+      };
+    };
+    "sebastian/object-reflector" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "sebastian-object-reflector-b4f479ebdbf63ac605d183ece17d8d7fe49c15c7";
+        src = fetchurl {
+          url = "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7";
+          sha256 = "0g5m1fswy6wlf300x1vcipjdljmd3vh05hjqhqfc91byrjbk4rsg";
+        };
+      };
+    };
+    "sebastian/recursion-context" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "sebastian-recursion-context-e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1";
+        src = fetchurl {
+          url = "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1";
+          sha256 = "1ag6ysxffhxyg7g4rj9xjjlwq853r4x92mmin4f09hn5mqn9f0l1";
+        };
+      };
+    };
+    "sebastian/resource-operations" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "sebastian-resource-operations-0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8";
+        src = fetchurl {
+          url = "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8";
+          sha256 = "0p5s8rp7mrhw20yz5wx1i4k8ywf0h0ximcqan39n9qnma1dlnbyr";
+        };
+      };
+    };
+    "sebastian/type" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "sebastian-type-75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7";
+        src = fetchurl {
+          url = "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7";
+          sha256 = "0bvfvb62qbpy2hzxs4bjzb0xhks6h3cp6qx96z4qlyz6wl2fa1w5";
+        };
+      };
+    };
+    "sebastian/version" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "sebastian-version-c6c1022351a901512170118436c764e473f6de8c";
+        src = fetchurl {
+          url = "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c";
+          sha256 = "1bs7bwa9m0fin1zdk7vqy5lxzlfa9la90lkl27sn0wr00m745ig1";
+        };
+      };
+    };
+    "theseer/tokenizer" = {
+      targetDir = "";
+      src = composerEnv.buildZipPackage {
+        name = "theseer-tokenizer-b2ad5003ca10d4ee50a12da31de12a5774ba6b96";
+        src = fetchurl {
+          url = "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96";
+          sha256 = "03yw81yj8m9dzbifx0zj455jw59fwbiqidaqq2vyh56a6k5sdkgb";
+        };
+      };
+    };
+  };
 in
 composerEnv.buildPackage {
   inherit packages devPackages noDev;
-  name = "pixelfed";
+  name = "pixelfed-pixelfed";
   src = composerEnv.filterSrc ./.;
   executable = false;
   symlinkDependencies = false;


### PR DESCRIPTION
## Description of changes

Fixes CVE-2024-25108.

Changes:
https://github.com/pixelfed/pixelfed/releases/tag/v0.11.11
https://github.com/pixelfed/pixelfed/releases/tag/v0.11.10
https://github.com/pixelfed/pixelfed/releases/tag/v0.11.9

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>pixelfed</li>
  </ul>
</details>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
