### PR TITLE
sysdig: 0.34.1 -> 0.35.1

### DIFF
--- a/pkgs/os-specific/linux/sysdig/default.nix
+++ b/pkgs/os-specific/linux/sysdig/default.nix
@@ -16,13 +16,6 @@ let
     hash = "sha256-ZD19Q2MxMQd3yEKbY90GFCrerie5/jzgO8do4JQDoKM=";
   };
 
-  tinydir = fetchFromGitHub {
-    owner = "cxong";
-    repo = "tinydir";
-    rev = "1.2.5";
-    hash = "sha256-qQhvLzpCYMAafBNRWlY5yklHrILM8BYD+xxF0l17+do=";
-  };
-
   # https://github.com/draios/sysdig/blob/0.35.1/cmake/modules/driver.cmake
   driver = fetchFromGitHub {
     owner = "falcosecurity";
@@ -94,7 +87,6 @@ stdenv.mkDerivation rec {
     "-DUSE_BUNDLED_JSONCPP=OFF"
     "-DCREATE_TEST_TARGETS=OFF"
     "-DVALIJSON_INCLUDE=${valijson}/include"
-    "-DTINYDIR_INCLUDE=${tinydir}"
     "-DUTHASH_INCLUDE=${uthash}/include"
   ] ++ lib.optional (kernel == null) "-DBUILD_DRIVER=OFF";
 

--- a/pkgs/os-specific/linux/sysdig/default.nix
+++ b/pkgs/os-specific/linux/sysdig/default.nix
@@ -4,11 +4,11 @@
 }:
 
 let
-  # Compare with https://github.com/draios/sysdig/blob/dev/cmake/modules/falcosecurity-libs.cmake
-  libsRev = "0.13.1";
-  libsHash = "sha256-UNoXIkFr64Nr0XVAtV4+BMNpCk4w8Dn4waZek/ok4Uk=";
+  # Compare with https://github.com/draios/sysdig/blob/0.35.1/cmake/modules/falcosecurity-libs.cmake
+  libsRev = "0.14.2";
+  libsHash = "sha256-sWrniRB/vQd1BZnsiz+wLHugrF3LhuAr9e9gDMavLoo=";
 
-  # Compare with https://github.com/falcosecurity/libs/blob/master/cmake/modules/valijson.cmake#L17
+  # Compare with https://github.com/falcosecurity/libs/blob/0.14.2/cmake/modules/valijson.cmake
   valijson = fetchFromGitHub {
     owner = "tristanpenman";
     repo = "valijson";
@@ -23,35 +23,23 @@ let
     hash = "sha256-qQhvLzpCYMAafBNRWlY5yklHrILM8BYD+xxF0l17+do=";
   };
 
-  # https://github.com/draios/sysdig/blob/0.31.5/cmake/modules/driver.cmake
+  # https://github.com/draios/sysdig/blob/0.35.1/cmake/modules/driver.cmake
   driver = fetchFromGitHub {
     owner = "falcosecurity";
     repo = "libs";
-    rev = "6.0.1+driver";
-    hash = "sha256-e9TJl/IahrUc4Yq2/KssTz3IBjOZwXeLt1jOkZ94EiE=";
-  };
-
-  # can be dropped in next release
-  uthashDevendorPatch = fetchpatch {
-    url = "https://github.com/falcosecurity/libs/commit/0d58f798ab72e21a16ee6965c775cba2932e5100.patch";
-    hash = "sha256-5Y79M9u5rXZiKllJcXzDDw/3JKt0k/CgvWx+MZepkpw=";
-  };
-
-  # https://github.com/falcosecurity/libs/blob/master/cmake/modules/b64.cmake
-  base64 = fetchurl {
-    url = "https://raw.githubusercontent.com/istio/proxy/1.18.2/extensions/common/wasm/base64.h";
-    hash = "sha256-WvHRHp5caMBDvH+2pMrU4ZptX6WvPcPaeVGtVBBCw64=";
+    rev = "7.0.0+driver";
+    hash = "sha256-kXqvfM7HbGh2wEGaO4KBkFDW+m5gpOShJZKJLu9McKk=";
   };
 in
 stdenv.mkDerivation rec {
   pname = "sysdig";
-  version = "0.34.1";
+  version = "0.35.1";
 
   src = fetchFromGitHub {
     owner = "draios";
     repo = "sysdig";
     rev = version;
-    hash = "sha256-G1yr1wHiaGvLMtBZgh4eoiRNJiH0cghHqWFOjKYXXsw=";
+    hash = "sha256-nSCkKwhdEduepyvcyWEKMQtQ6TfhF3GnTSreRVoarsw=";
   };
 
   nativeBuildInputs = [ cmake perl installShellFiles pkg-config ];
@@ -84,15 +72,13 @@ stdenv.mkDerivation rec {
       hash = libsHash;
     }} libs
     chmod -R +w libs
-    pushd libs
-    patch -p1 < ${uthashDevendorPatch}
-    popd
+
+    substituteInPlace libs/userspace/libscap/libscap.pc.in libs/userspace/libsinsp/libsinsp.pc.in \
+      --replace-fail "\''${prefix}/@CMAKE_INSTALL_LIBDIR@" "@CMAKE_INSTALL_FULL_LIBDIR@" \
+      --replace-fail "\''${prefix}/@CMAKE_INSTALL_INCLUDEDIR@" "@CMAKE_INSTALL_FULL_INCLUDEDIR@"
 
     cp -r ${driver} driver-src
     chmod -R +w driver-src
-    pushd driver-src
-    patch -p1 < ${uthashDevendorPatch}
-    popd
     cmakeFlagsArray+=(
       "-DFALCOSECURITY_LIBS_SOURCE_DIR=$(pwd)/libs"
       "-DDRIVER_SOURCE_DIR=$(pwd)/driver-src/driver"
@@ -124,7 +110,6 @@ stdenv.mkDerivation rec {
       exit 1
     fi
     cmakeFlagsArray+=(-DCMAKE_EXE_LINKER_FLAGS="-ltbb -lcurl -lzstd -labsl_synchronization")
-    install -D ${base64} build/b64/base64.h
   '' + lib.optionalString (kernel != null) ''
     export INSTALL_MOD_PATH="$out"
     export KERNELDIR="${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"


### PR DESCRIPTION
## Description of changes
Updated to latest release, support 6.7-kernel

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
