### PR TITLE
python3Packages.requests-gssapi: init at 1.2.3

### DIFF
--- a/pkgs/development/python-modules/requests-gssapi/default.nix
+++ b/pkgs/development/python-modules/requests-gssapi/default.nix
@@ -1,0 +1,41 @@
+{ buildPythonPackage
+, fetchPypi
+, gssapi
+, lib
+, pytestCheckHook
+, pythonOlder
+, requests
+, setuptools
+}:
+buildPythonPackage rec {
+  pname = "requests-gssapi";
+  version = "1.2.3";
+  disabled = pythonOlder "3.8";
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-IHhFCJgUAfcVPJM+7QlTOJM6QIGNplolnb8tgNzLFQ4=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    gssapi
+    requests
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportCheck = [ "requests_gssapi" ];
+
+  meta = with lib; {
+    description = "A GSSAPI authentication handler for python-requests";
+    homepage = "https://github.com/pythongssapi/requests-gssapi";
+    changelog = "https://github.com/pythongssapi/requests-gssapi/blob/v${version}/HISTORY.rst";
+    maintainers = with maintainers; [ javimerino ];
+    license = [ licenses.isc ];
+  };
+}

--- a/pkgs/development/python-modules/requests-gssapi/default.nix
+++ b/pkgs/development/python-modules/requests-gssapi/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "A GSSAPI authentication handler for python-requests";
     homepage = "https://github.com/pythongssapi/requests-gssapi";
-    changelog = "https://github.com/pythongssapi/requests-gssapi/blob/v${version}/HISTORY.rst"
+    changelog = "https://github.com/pythongssapi/requests-gssapi/blob/v${version}/HISTORY.rst";
     license = licenses.isc;
     maintainers = with maintainers; [ javimerino ];
   };

--- a/pkgs/development/python-modules/requests-gssapi/default.nix
+++ b/pkgs/development/python-modules/requests-gssapi/default.nix
@@ -1,26 +1,30 @@
-{ buildPythonPackage
+{ lib
+, buildPythonPackage
 , fetchPypi
 , gssapi
-, lib
 , pytestCheckHook
 , pythonOlder
 , requests
 , setuptools
 }:
+
 buildPythonPackage rec {
   pname = "requests-gssapi";
   version = "1.2.3";
+  pyproject = true;
+
   disabled = pythonOlder "3.8";
+
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-IHhFCJgUAfcVPJM+7QlTOJM6QIGNplolnb8tgNzLFQ4=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     gssapi
     requests
   ];
@@ -29,13 +33,15 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  pythonImportCheck = [ "requests_gssapi" ];
+  pythonImportCheck = [
+    "requests_gssapi"
+  ];
 
   meta = with lib; {
     description = "A GSSAPI authentication handler for python-requests";
     homepage = "https://github.com/pythongssapi/requests-gssapi";
-    changelog = "https://github.com/pythongssapi/requests-gssapi/blob/v${version}/HISTORY.rst";
+    changelog = "https://github.com/pythongssapi/requests-gssapi/blob/v${version}/HISTORY.rst"
+    license = licenses.isc;
     maintainers = with maintainers; [ javimerino ];
-    license = [ licenses.isc ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12700,6 +12700,8 @@ self: super: with self; {
 
   requests-credssp = callPackage ../development/python-modules/requests-credssp { };
 
+  requests-gssapi = callPackage ../development/python-modules/requests-gssapi { };
+
   requests-hawk = callPackage ../development/python-modules/requests-hawk { };
 
   requests = callPackage ../development/python-modules/requests { };


### PR DESCRIPTION
## Description of changes

requests-gssapi lets you use Python Requests authenticated via GSSAPI. This PR adds the module at the latest version (1.2.3).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, in a couple of python applications. One of them is [koji](https://github.com/JaviMerino/nur-packages/blob/koji/pkgs/koji/default.nix)
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] ~~Tested basic functionality of all binary files (usually in `./result/bin/`)~~
  - It's a python module, so tested by using it an application instead.
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] ~~(Package updates) Added a release notes entry if the change is major or breaking~~
    - Not major nor breaking
  - [ ] ~~(Module updates) Added a release notes entry if the change is significant~~
    - Change is not significant
  - [ ] ~~(Module addition) Added a release notes entry if adding a new NixOS module~~
    - Not a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).