### PR TITLE
freefilesync: fix build with curl 8.6.0

### DIFF
--- a/pkgs/by-name/fr/freefilesync/curl-8.6.0.patch
+++ b/pkgs/by-name/fr/freefilesync/curl-8.6.0.patch
@@ -1,0 +1,16 @@
+diff --git a/libcurl/curl_wrap.cpp b/libcurl/curl_wrap.cpp
+index 11ac9dd..93edd44 100644
+--- a/libcurl/curl_wrap.cpp
++++ b/libcurl/curl_wrap.cpp
+@@ -401,9 +401,10 @@ std::wstring zen::formatCurlStatusCode(CURLcode sc)
+             ZEN_CHECK_CASE_FOR_CONSTANT(CURLE_PROXY);
+             ZEN_CHECK_CASE_FOR_CONSTANT(CURLE_SSL_CLIENTCERT);
+             ZEN_CHECK_CASE_FOR_CONSTANT(CURLE_UNRECOVERABLE_POLL);
++            ZEN_CHECK_CASE_FOR_CONSTANT(CURLE_TOO_LARGE);
+             ZEN_CHECK_CASE_FOR_CONSTANT(CURL_LAST);
+     }
+-    static_assert(CURL_LAST == CURLE_UNRECOVERABLE_POLL + 1);
++    static_assert(CURL_LAST == CURLE_TOO_LARGE + 1);
+ 
+     return replaceCpy<std::wstring>(L"Curl status %x", L"%x", numberTo<std::wstring>(static_cast<int>(sc)));
+ }

--- a/pkgs/by-name/fr/freefilesync/package.nix
+++ b/pkgs/by-name/fr/freefilesync/package.nix
@@ -72,6 +72,8 @@ stdenv.mkDerivation (finalAttrs: {
       patch = "ffs_no_check_updates.patch";
       hash = "sha256-lPyHpxhZz8BSnDI8QfAzKpKwVkp2jiF49RWjKNuZGII=";
     })
+    # Fix build with curl 8.6.0
+    ./curl-8.6.0.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

Closes #288060.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
