### PR TITLE
linux: mitigate broken ASLR on >=2MB libraries

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -239,6 +239,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
   - The `erlang_node_short_name`, `erlang_node_name`, `port` and `options` configuration parameters are gone, and have been replaced with an `environment` parameter.
     Use the appropriate [environment variables](https://hexdocs.pm/livebook/readme.html#environment-variables) inside `environment` to configure the service instead.
 
+- Default `CONFIG_ARCH_MMAP_RND_BITS` are set to the maximum to mitigate [kernel >=5.18 ASLR regression](https://zolutal.github.io/aslrnt/).  This may lead to programs breaking, specially the ones running on limited virtual address space. To get the previous behavior, check the minimum value with `zcat /proc/config.gz | grep "ARCH_MMAP_RND_BITS_MIN"` and set `boot.kernel.sysctl."vm.mmap_rnd_bits"` to the minimum.
+
 ## Other Notable Changes {#sec-release-24.05-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -590,6 +590,15 @@ let
       CRYPTO_DRBG_HASH                 = yes;
       CRYPTO_DRBG_CTR                  = yes;
 
+      # Set ARCH_MMAP_RND_{COMPAT_,}BITS to the maximum to regain ASLR entropy
+      # https://zolutal.github.io/aslrnt/
+      # https://git.launchpad.net/~ubuntu-kernel/ubuntu/+source/linux/+git/noble/commit/?h=master-next&id=760c2b1fa1f5e95be1117bc7b80afb8441d4b002
+      ARCH_MMAP_RND_BITS = whenAtLeast "5.18" (mkMerge (with stdenv.hostPlatform; [
+        (mkIf isAarch64 (freeform "33"))
+        (mkIf isPower64 (freeform "32"))
+        (mkIf isRiscV64 (freeform "24"))
+        (mkIf isx86_64 (freeform "32"))
+      ]));
     } // optionalAttrs stdenv.hostPlatform.isx86_64 {
       # Enable Intel SGX
       X86_SGX     = whenAtLeast "5.11" yes;


### PR DESCRIPTION
## Description of changes

This mitigates broken ASLR on >=2MB libraries.

from [ASLRn’t: How memory alignment broke library ASLR](https://zolutal.github.io/aslrnt/):
> As it turns out, on recent Ubuntu, Arch, Fedora, and likely other distro’s releases, with kernel versions >=5.18, library ASLR is literally broken for 32-bit libraries of at least 2MB in size, on certain filesystems. Also, ASLR’s entropy on 64-bit libraries that are at least 2MB is significantly reduced, 28 bits -> 19 bits, on certain filesystems.
> 
> Then what are these “certain filesystems”? Those would be: ext4, ext2, btrfs, xfs, and fuse. So, some of the most widely used filesystems.

This also affects NixOS.

 * [ASLRn’t: How memory alignment broke library ASLR](https://zolutal.github.io/aslrnt/)
 * [Ubuntu's patch](https://bugs.launchpad.net/ubuntu-kernel-tests/+bug/1983357)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] armv7l-linux
  - [X] powerpc64le-linux
  - [X] riscv64-linux
  - [X] riscv32-linux
  - [X] i686-linux
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
    - tested with `nixosTests.login` on x86_64-linux
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [X] (Package updates) Added a release notes entry if the change is major or breaking
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
