### PR TITLE
xpdf: 4.04 -> 4.05

### DIFF
--- a/pkgs/applications/misc/xpdf/default.nix
+++ b/pkgs/applications/misc/xpdf/default.nix
@@ -12,11 +12,14 @@ assert enablePrinting -> cups != null;
 
 stdenv.mkDerivation rec {
   pname = "xpdf";
-  version = "4.04";
+  version = "4.05";
 
   src = fetchzip {
-    url = "https://dl.xpdfreader.com/xpdf-${version}.tar.gz";
-    hash = "sha256-ujH9KDwFRjPIKwdMg79Mab9BfA2HooY5+2PESUgnGDY=";
+    urls = [
+      "https://dl.xpdfreader.com/xpdf-${version}.tar.gz"
+      "https://dl.xpdfreader.com/old/xpdf-${version}.tar.gz"
+    ];
+    hash = "sha256-LBxKSrXTdoulZDjPiyYMaJr63jFHHI+VCgVJx310i/w=";
   };
 
   # Fix "No known features for CXX compiler", see
@@ -73,8 +76,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     maintainers = with maintainers; [ sikmir ];
     knownVulnerabilities = [
-      "CVE-2018-7453: loop in PDF objects"
-      "CVE-2018-16369: loop in PDF objects"
       "CVE-2019-9587: loop in PDF objects"
       "CVE-2019-9588: loop in PDF objects"
       "CVE-2019-16088: loop in PDF objects"
@@ -82,14 +83,10 @@ stdenv.mkDerivation rec {
       "CVE-2022-38928"
       "CVE-2022-41842"
       "CVE-2022-41843"
-      "CVE-2022-41844"
       "CVE-2022-43071"
       "CVE-2022-43295"
       "CVE-2022-45586"
       "CVE-2022-45587"
-      "CVE-2023-2662"
-      "CVE-2023-2663"
-      "CVE-2023-2664"
       "CVE-2023-26930"
       "CVE-2023-26931"
       "CVE-2023-26934"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36547,7 +36547,9 @@ with pkgs;
 
   apvlv = callPackage ../applications/misc/apvlv { };
 
-  xpdf = libsForQt5.callPackage ../applications/misc/xpdf { };
+  xpdf = libsForQt5.callPackage ../applications/misc/xpdf {
+    stdenv = if stdenv.isDarwin then darwin.apple_sdk_11_0.stdenv else stdenv;
+  };
 
   xplugd = callPackage ../tools/X11/xplugd { };
 


### PR DESCRIPTION
Fixes a bunch of CVEs (but not all of them apparently).

Changes:
https://forum.xpdfreader.com/viewtopic.php?t=43343

```
4.05 (2024-feb-08)
------------------
Added the '-overwrite' option to pdftohtml.
Added the 'ignoreWrongSizeToUnicode' xpdfrc setting.
Added the loadSession and saveSession commands, and the 'Load last
  session' menu item.
Added code to automatically save and restore the xpdf session under
  control of a session manager.  This has not been thoroughly tested
  yet.
Added the zoomScaleFactor xpdfrc setting.
Added the zoomValues xpdfrc setting.
Added a 'smart case' option for search in xpdf.
Added the '-custom' flag to pdfinfo.
Added a color/gray/mono switch to the 'save image' dialog.
Added the separateRotatedText xpdfrc setting.
Added the '-meta' flag to pdftohtml.
Added the allowLinksToChangeZoom xpdfrc setting.
Added the 'uses JavaScript' output to pdfinfo.
Implemented pattern stroking of text.  Also fixed the various
  combinations of filling/stroking with color/pattern + clipping, some
  of which weren't being handled correctly.
Pdftops now (re)compresses any uncompressed or RLE-compressed images.
On an out-of-memory error, the command line tools now exit with an
  "out of memory" message, rather than an exception message.
Add code to pdfimages to extract images from tiling patterns.
Pdftops can now embed external 8-bit OpenType CFF fonts.
Fixed a corner case in the text extractor related to characters drawn
  at extremely large coordinates.  [Thanks to elvadisas for the bug
  report.]
Fixed an integer overflow in the transparency group code.  [Thanks to
  elvadisas for the bug report.]
Modify Annots::Annots() to skip annotations that have been turned into
  AcroFormFields -- invalid Widget-type annots will now be rendered as
  annots.
Added a missing integer overflow check in the JBIG2 decoder.  [Thanks
  to sangjun for the bug report.]
Added some sanity checks to the JBIG2 decoder.  [Thanks to sangjun and
  ycdxsb for the bug reports.]
Tiling patterns that use non-Normal blend modes can't be cached.
Fixed a bitmap size sanity check in the JBIG2 decoder.  [Thanks to Han
  Zheng (NCNIPC of China, Hexhive), for the bug report.]
Fixed a missing bounds check in FoFiType1C::convertToOpenType (used in
  pdftohtml).  [Thanks to cyth for the bug report.]
Fixed a use-after-free bug in pdftohtml.  [Thanks to FeRDNYC for the
  bug report.]
Merged aconf2.h into aconf.h; corrected the cmake config settings for
  paths; added the BASE14_FONT_DIR config option.  [Thanks to FeRDNYC
  for the suggestions.]
Fixed a missing check for a zero-length index in the CFF (Type1C) font
  parser.  [Thanks to Yuhang Huang (NCNIPC of China), Han Zheng

  (NCNIPC of China, Hexhive), Wanying Cao, Jiayu Zhao (NCNIPC of
  China) for the bug report.]
Add an object loop check to Catalog::countPageTree().
The DCT decoder wasn't checking for an SOF before the first SOS.
  [Thanks to cyth for the bug report.]
The inline image decoder was skipping to end-of-stream in the wrong
  stream object.  [Thanks to cyth for the bug report.]
Fixed a bug in the JPEG 2000 decoder when nLayers > 1 and the
  'termination on each coding pass' flag is set.
Removed the #pragma interface/implementation stuff (which is outdated
  and useless at this point).
Fixed a bug in the ICCBased color space parser that was allowing the
  number of components to be zero.  (CVE-2023-2662)  [Thanks to
  huckleberry for the bug report.]
Added checks for PDF object loops in AcroForm::scanField()
  (CVE-2018-7453, CVE-2018-16369, CVE-2022-36561, CVE-2022-41844),
  Catalog::readPageLabelTree2() (CVE-2023-2663), and
  Catalog::readEmbeddedFileTree() (CVE-2023-2664).
The zero-width character problem can also happen if the page size is
  very large -- that needs to be limited too, the same way as
  character position coordinates.  (CVE-2023-3044) [Thanks to jlinliu
  for the bug report.]
Add some missing bounds check code in DCTStream.  [Thanks to Jiahao
  Liu for the bug report.]
Fix a deadlock when an object stream's length field is contained in
  another object stream.  (CVE-2023-3436) [Thanks to Jiahao Liu for
  the bug report.]
Correctly handle tiling patterns with negative step values.
Ignore overprint in soft masks (to match Adobe's behavior).
```

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
