### PR TITLE
[23.11] liquidctl: fix test for pillow ≥ 10.2.0

### DIFF
--- a/pkgs/development/python-modules/liquidctl/default.nix
+++ b/pkgs/development/python-modules/liquidctl/default.nix
@@ -15,6 +15,7 @@
 , colorlog
 , crcmod
 , pillow
+, fetchpatch
 }:
 
 buildPythonPackage rec {
@@ -32,6 +33,14 @@ buildPythonPackage rec {
   };
 
   env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  patches = [
+    (fetchpatch {
+      name = "tests-pillow-10.2.0-compat.patch";
+      url = "https://github.com/liquidctl/liquidctl/commit/c50afa4e610bd2e268e85c347e2644794c817a78.diff";
+      hash = "sha256-1cKk3drl3RybHmnPXdlJoeYK6UDz25jHSS2YS/XLHIY=";
+    })
+  ];
 
   nativeBuildInputs = [
     installShellFiles


### PR DESCRIPTION
issue described upstream in
  https://github.com/liquidctl/liquidctl/issues/661

## Description of changes

added patch linked in upstream issue
(https://github.com/liquidctl/liquidctl/commit/c50afa4e610bd2e268e85c347e2644794c817a78)

## Things done

manual backport of #288085
verified this does not break liquidctl before #284251 gets to 23.11

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  nixpkgs-review failed to automatically merge ¯\\\_(ツ)_/¯
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
