### PR TITLE
haskell.compiler: no dynamic way without enableShared

### DIFF
--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -103,7 +103,7 @@ let
     Stage1Only = ${if targetPlatform.system == hostPlatform.system then "NO" else "YES"}
     CrossCompilePrefix = ${targetPrefix}
   '' + lib.optionalString (!enableProfiledLibs) ''
-    GhcLibWays = "v dyn"
+    BUILD_PROF_LIBS = NO
   '' + lib.optionalString enableRelocatedStaticLibs ''
     GhcLibHcOpts += -fPIC
     GhcRtsHcOpts += -fPIC

--- a/pkgs/development/compilers/ghc/9.0.2.nix
+++ b/pkgs/development/compilers/ghc/9.0.2.nix
@@ -105,7 +105,7 @@ let
     Stage1Only = ${if targetPlatform.system == hostPlatform.system then "NO" else "YES"}
     CrossCompilePrefix = ${targetPrefix}
   '' + lib.optionalString (!enableProfiledLibs) ''
-    GhcLibWays = "v dyn"
+    BUILD_PROF_LIBS = NO
   '' +
   # -fexternal-dynamic-refs apparently (because it's not clear from the documentation)
   # makes the GHC RTS able to load static libraries, which may be needed for TemplateHaskell.

--- a/pkgs/development/compilers/ghc/9.2.5.nix
+++ b/pkgs/development/compilers/ghc/9.2.5.nix
@@ -105,7 +105,7 @@ let
     Stage1Only = ${if targetPlatform.system == hostPlatform.system then "NO" else "YES"}
     CrossCompilePrefix = ${targetPrefix}
   '' + lib.optionalString (!enableProfiledLibs) ''
-    GhcLibWays = "v dyn"
+    BUILD_PROF_LIBS = NO
   '' +
   # -fexternal-dynamic-refs apparently (because it's not clear from the documentation)
   # makes the GHC RTS able to load static libraries, which may be needed for TemplateHaskell.

--- a/pkgs/development/compilers/ghc/9.2.6.nix
+++ b/pkgs/development/compilers/ghc/9.2.6.nix
@@ -105,7 +105,7 @@ let
     Stage1Only = ${if targetPlatform.system == hostPlatform.system then "NO" else "YES"}
     CrossCompilePrefix = ${targetPrefix}
   '' + lib.optionalString (!enableProfiledLibs) ''
-    GhcLibWays = "v dyn"
+    BUILD_PROF_LIBS = NO
   '' +
   # -fexternal-dynamic-refs apparently (because it's not clear from the documentation)
   # makes the GHC RTS able to load static libraries, which may be needed for TemplateHaskell.

--- a/pkgs/development/compilers/ghc/9.2.7.nix
+++ b/pkgs/development/compilers/ghc/9.2.7.nix
@@ -105,7 +105,7 @@ let
     Stage1Only = ${if targetPlatform.system == hostPlatform.system then "NO" else "YES"}
     CrossCompilePrefix = ${targetPrefix}
   '' + lib.optionalString (!enableProfiledLibs) ''
-    GhcLibWays = "v dyn"
+    BUILD_PROF_LIBS = NO
   '' +
   # -fexternal-dynamic-refs apparently (because it's not clear from the documentation)
   # makes the GHC RTS able to load static libraries, which may be needed for TemplateHaskell.

--- a/pkgs/development/compilers/ghc/9.2.8.nix
+++ b/pkgs/development/compilers/ghc/9.2.8.nix
@@ -105,7 +105,7 @@ let
     Stage1Only = ${if targetPlatform.system == hostPlatform.system then "NO" else "YES"}
     CrossCompilePrefix = ${targetPrefix}
   '' + lib.optionalString (!enableProfiledLibs) ''
-    GhcLibWays = "v dyn"
+    BUILD_PROF_LIBS = NO
   '' +
   # -fexternal-dynamic-refs apparently (because it's not clear from the documentation)
   # makes the GHC RTS able to load static libraries, which may be needed for TemplateHaskell.

--- a/pkgs/development/compilers/ghc/9.4.5.nix
+++ b/pkgs/development/compilers/ghc/9.4.5.nix
@@ -107,7 +107,7 @@ let
     Stage1Only = ${if targetPlatform.system == hostPlatform.system then "NO" else "YES"}
     CrossCompilePrefix = ${targetPrefix}
   '' + lib.optionalString (!enableProfiledLibs) ''
-    GhcLibWays = "v dyn"
+    BUILD_PROF_LIBS = NO
   '' +
   # -fexternal-dynamic-refs apparently (because it's not clear from the documentation)
   # makes the GHC RTS able to load static libraries, which may be needed for TemplateHaskell.

--- a/pkgs/development/compilers/ghc/9.4.6.nix
+++ b/pkgs/development/compilers/ghc/9.4.6.nix
@@ -107,7 +107,7 @@ let
     Stage1Only = ${if targetPlatform.system == hostPlatform.system then "NO" else "YES"}
     CrossCompilePrefix = ${targetPrefix}
   '' + lib.optionalString (!enableProfiledLibs) ''
-    GhcLibWays = "v dyn"
+    BUILD_PROF_LIBS = NO
   '' +
   # -fexternal-dynamic-refs apparently (because it's not clear from the documentation)
   # makes the GHC RTS able to load static libraries, which may be needed for TemplateHaskell.

--- a/pkgs/development/compilers/ghc/9.4.7.nix
+++ b/pkgs/development/compilers/ghc/9.4.7.nix
@@ -107,7 +107,7 @@ let
     Stage1Only = ${if targetPlatform.system == hostPlatform.system then "NO" else "YES"}
     CrossCompilePrefix = ${targetPrefix}
   '' + lib.optionalString (!enableProfiledLibs) ''
-    GhcLibWays = "v dyn"
+    BUILD_PROF_LIBS = NO
   '' +
   # -fexternal-dynamic-refs apparently (because it's not clear from the documentation)
   # makes the GHC RTS able to load static libraries, which may be needed for TemplateHaskell.

--- a/pkgs/development/compilers/ghc/9.4.8.nix
+++ b/pkgs/development/compilers/ghc/9.4.8.nix
@@ -107,7 +107,7 @@ let
     Stage1Only = ${if targetPlatform.system == hostPlatform.system then "NO" else "YES"}
     CrossCompilePrefix = ${targetPrefix}
   '' + lib.optionalString (!enableProfiledLibs) ''
-    GhcLibWays = "v dyn"
+    BUILD_PROF_LIBS = NO
   '' +
   # -fexternal-dynamic-refs apparently (because it's not clear from the documentation)
   # makes the GHC RTS able to load static libraries, which may be needed for TemplateHaskell.


### PR DESCRIPTION
My use-case is to build a small/minimal GHC in terms of disk space, to have CI jobs run faster by pulling fewer dependencies from cachix. When I used `enableShared = false`, I was surprised to see the dynamic variants of all the ghc provided libraries still being built.

This disables building dynamic libraries for GHC 9.4.x and before, when enableShared is set to false. Previously, this only disabled dynamic linking of GHC itself, but still created dynamic libraries.

The hadrian-based GHC 9.6+ already disable building dynamic libraries via the no_dynamic_libs transformer in this case.

## Things done

To test, I built `haskell.packages.ghc948.th-orphans` and `haskell.packages.ghc981.th-orphans`, making sure template haskell also worked.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
