### PR TITLE
libgit2: drop all old versions

### DIFF
--- a/pkgs/applications/file-managers/projectable/default.nix
+++ b/pkgs/applications/file-managers/projectable/default.nix
@@ -2,7 +2,7 @@
 , rustPlatform
 , fetchFromGitHub
 , pkg-config
-, libgit2_1_5
+, libgit2
 , openssl
 , zlib
 , stdenv
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   buildInputs = [
-    libgit2_1_5
+    libgit2
     openssl
     zlib
   ] ++ lib.optionals stdenv.isDarwin [
@@ -35,6 +35,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   env = {
+    LIBGIT2_NO_VENDOR = 1;
     OPENSSL_NO_VENDOR = true;
   };
 

--- a/pkgs/applications/version-management/git-dive/default.nix
+++ b/pkgs/applications/version-management/git-dive/default.nix
@@ -2,8 +2,7 @@
 , rustPlatform
 , fetchFromGitHub
 , pkg-config
-  # libgit2-sys doesn't support libgit2 1.6 yet
-, libgit2_1_5
+, libgit2
 , oniguruma
 , zlib
 , stdenv
@@ -29,7 +28,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   buildInputs = [
-    libgit2_1_5
+    libgit2
     oniguruma
     zlib
   ] ++ lib.optionals stdenv.isDarwin [
@@ -54,7 +53,10 @@ rustPlatform.buildRustPackage rec {
     git config --global user.email nixbld@example.com
   '';
 
-  RUSTONIG_SYSTEM_LIBONIG = true;
+  env = {
+    LIBGIT2_NO_VENDOR = 1;
+    RUSTONIG_SYSTEM_LIBONIG = true;
+  };
 
   meta = with lib; {
     description = "Dive into a file's history to find root cause";

--- a/pkgs/applications/version-management/git-mit/default.nix
+++ b/pkgs/applications/version-management/git-mit/default.nix
@@ -2,7 +2,7 @@
 , rustPlatform
 , fetchFromGitHub
 , pkg-config
-, libgit2_1_5
+, libgit2
 , openssl
 , zlib
 , stdenv
@@ -28,12 +28,16 @@ rustPlatform.buildRustPackage {
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [
-    libgit2_1_5
+    libgit2
     openssl
     zlib
   ] ++ lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.AppKit
   ];
+
+  env = {
+    LIBGIT2_NO_VENDOR = 1;
+  };
 
   meta = with lib; {
     description = "Minimalist set of hooks to aid pairing and link commits to issues";

--- a/pkgs/development/tools/biome/default.nix
+++ b/pkgs/development/tools/biome/default.nix
@@ -2,7 +2,7 @@
 , rustPlatform
 , fetchFromGitHub
 , pkg-config
-, libgit2_1_6
+, libgit2
 , rust-jemalloc-sys
 , zlib
 , stdenv
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   buildInputs = [
-    libgit2_1_6
+    libgit2
     rust-jemalloc-sys
     zlib
   ] ++ lib.optionals stdenv.isDarwin [
@@ -47,6 +47,7 @@ rustPlatform.buildRustPackage rec {
 
   env = {
     BIOME_VERSION = version;
+    LIBGIT2_NO_VENDOR = 1;
   };
 
   preCheck = ''

--- a/pkgs/development/tools/rust/cargo-audit/default.nix
+++ b/pkgs/development/tools/rust/cargo-audit/default.nix
@@ -2,7 +2,6 @@
 , rustPlatform
 , fetchCrate
 , pkg-config
-, libgit2
 , openssl
 , zlib
 , stdenv
@@ -26,7 +25,6 @@ rustPlatform.buildRustPackage rec {
   ];
 
   buildInputs = [
-    libgit2
     openssl
     zlib
   ] ++ lib.optionals stdenv.isDarwin [

--- a/pkgs/development/tools/rust/cargo-codspeed/default.nix
+++ b/pkgs/development/tools/rust/cargo-codspeed/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , curl
 , pkg-config
-, libgit2_1_5
+, libgit2
 , openssl
 , zlib
 , stdenv
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [
     curl
-    libgit2_1_5
+    libgit2
     openssl
     zlib
   ] ++ lib.optionals stdenv.isDarwin [
@@ -39,6 +39,10 @@ rustPlatform.buildRustPackage rec {
 
   cargoBuildFlags = [ "-p=cargo-codspeed" ];
   cargoTestFlags = cargoBuildFlags;
+
+  env = {
+    LIBGIT2_NO_VENDOR = 1;
+  };
 
   meta = with lib; {
     description = "Cargo extension to build & run your codspeed benchmarks";

--- a/pkgs/development/tools/rust/cargo-dephell/default.nix
+++ b/pkgs/development/tools/rust/cargo-dephell/default.nix
@@ -6,7 +6,7 @@
 , curl
 , openssl
 , darwin
-, libgit2_1_3_0
+, libgit2
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -35,13 +35,17 @@ rustPlatform.buildRustPackage rec {
   ] ++ lib.optionals stdenv.isDarwin [
     curl
     darwin.apple_sdk.frameworks.Security
-    libgit2_1_3_0
+    libgit2
   ];
 
   # update Cargo.lock to work with openssl 3
   postPatch = ''
     ln -sf ${./Cargo.lock} Cargo.lock
   '';
+
+  env = {
+    LIBGIT2_NO_VENDOR = 1;
+  };
 
   meta = with lib; {
     description = "A tool to analyze the third-party dependencies imported by a rust crate or rust workspace";

--- a/pkgs/development/tools/rust/cargo-generate/default.nix
+++ b/pkgs/development/tools/rust/cargo-generate/default.nix
@@ -2,7 +2,7 @@
 , rustPlatform
 , fetchFromGitHub
 , pkg-config
-, libgit2_1_6
+, libgit2
 , openssl
 , stdenv
 , darwin
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ libgit2_1_6 openssl ] ++ lib.optionals stdenv.isDarwin [
+  buildInputs = [ libgit2 openssl ] ++ lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.Security
   ];
 
@@ -47,6 +47,10 @@ rustPlatform.buildRustPackage rec {
   ] ++ lib.optionals stdenv.isDarwin [
     "--skip=git::utils::should_canonicalize"
   ];
+
+  env = {
+    LIBGIT2_NO_VENDOR = 1;
+  };
 
   meta = with lib; {
     description = "A tool to generate a new Rust project by leveraging a pre-existing git repository as a template";

--- a/pkgs/development/tools/rust/cargo-ui/default.nix
+++ b/pkgs/development/tools/rust/cargo-ui/default.nix
@@ -2,7 +2,7 @@
 , rustPlatform
 , fetchCrate
 , pkg-config
-, libgit2_1_5
+, libgit2
 , openssl
 , stdenv
 , expat
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   buildInputs = [
-    libgit2_1_5
+    libgit2
     openssl
   ] ++ lib.optionals stdenv.isLinux [
     expat
@@ -47,6 +47,10 @@ rustPlatform.buildRustPackage rec {
     patchelf $out/bin/cargo-ui \
       --add-rpath ${lib.makeLibraryPath [ fontconfig libGL ]}
   '';
+
+  env = {
+    LIBGIT2_NO_VENDOR = 1;
+  };
 
   meta = with lib; {
     description = "A GUI for Cargo";

--- a/pkgs/development/tools/rust/cargo-unused-features/default.nix
+++ b/pkgs/development/tools/rust/cargo-unused-features/default.nix
@@ -3,7 +3,7 @@
 , fetchCrate
 , curl
 , pkg-config
-, libgit2_1_5
+, libgit2
 , openssl
 , stdenv
 , darwin
@@ -27,12 +27,16 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [
     curl
-    libgit2_1_5
+    libgit2
     openssl
   ] ++ lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.CoreFoundation
     darwin.apple_sdk.frameworks.Security
   ];
+
+  env = {
+    LIBGIT2_NO_VENDOR = 1;
+  };
 
   meta = with lib; {
     description = "A tool to find potential unused enabled feature flags and prune them";

--- a/pkgs/development/tools/rust/cargo-update/default.nix
+++ b/pkgs/development/tools/rust/cargo-update/default.nix
@@ -7,7 +7,7 @@
 , ronn
 , stdenv
 , curl
-, libgit2_1_5
+, libgit2
 , libssh2
 , openssl
 , zlib
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   buildInputs = [
-    libgit2_1_5
+    libgit2
     libssh2
     openssl
     zlib
@@ -54,6 +54,10 @@ rustPlatform.buildRustPackage rec {
   postInstall = ''
     installManPage man/*.1
   '';
+
+  env = {
+    LIBGIT2_NO_VENDOR = 1;
+  };
 
   meta = with lib; {
     description = "A cargo subcommand for checking and applying updates to installed executables";

--- a/pkgs/development/tools/rust/cargo-workspaces/default.nix
+++ b/pkgs/development/tools/rust/cargo-workspaces/default.nix
@@ -2,7 +2,6 @@
 , rustPlatform
 , fetchCrate
 , pkg-config
-, libgit2_1_6
 , libssh2
 , openssl
 , zlib
@@ -26,7 +25,6 @@ rustPlatform.buildRustPackage rec {
   ];
 
   buildInputs = [
-    libgit2_1_6
     libssh2
     openssl
     zlib

--- a/pkgs/tools/nix/nix-init/default.nix
+++ b/pkgs/tools/nix/nix-init/default.nix
@@ -6,7 +6,7 @@
 , installShellFiles
 , pkg-config
 , bzip2
-, libgit2_1_6
+, libgit2
 , openssl
 , zlib
 , zstd
@@ -45,7 +45,7 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [
     bzip2
     curl
-    libgit2_1_6
+    libgit2
     openssl
     zlib
     zstd
@@ -80,6 +80,7 @@ rustPlatform.buildRustPackage rec {
 
   env = {
     GEN_ARTIFACTS = "artifacts";
+    LIBGIT2_NO_VENDOR = 1;
     NIX = lib.getExe nix;
     NURL = lib.getExe nurl;
     ZSTD_SYS_USE_PKG_CONFIG = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21371,17 +21371,6 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
-  libgit2_1_3_0 = libgit2.overrideAttrs rec {
-    version = "1.3.0";
-    src = pkgs.fetchFromGitHub {
-      owner = "libgit2";
-      repo = "libgit2";
-      rev = "v${version}";
-      hash = "sha256-7atNkOBzX+nU1gtFQEaE+EF1L+eex+Ajhq2ocoJY920=";
-    };
-    patches = [];
-  };
-
   libgit2_1_5 = libgit2.overrideAttrs rec {
     version = "1.5.1";
     src = pkgs.fetchFromGitHub {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20133,7 +20133,22 @@ with pkgs;
   ttyd = callPackage ../servers/ttyd { };
 
   turbogit = callPackage ../development/tools/turbogit {
-    libgit2 = libgit2_1_3_0;
+    libgit2 = libgit2.overrideAttrs rec {
+      version = "1.3.0";
+      src = pkgs.fetchFromGitHub {
+        owner = "libgit2";
+        repo = "libgit2";
+        rev = "v${version}";
+        hash = "sha256-7atNkOBzX+nU1gtFQEaE+EF1L+eex+Ajhq2ocoJY920=";
+      };
+      patches = [];
+      # tests fail on old version
+      doCheck = false;
+      meta = libgit2.meta // {
+        maintainers = [];
+        knownVulnerabilities = [ "CVE-2024-24575" "CVE-2024-24577" "CVE-2022-29187" "CVE 2022-24765" ];
+      };
+    };
   };
 
   tweak = callPackage ../applications/editors/tweak { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21371,17 +21371,6 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
-  libgit2_1_5 = libgit2.overrideAttrs rec {
-    version = "1.5.1";
-    src = pkgs.fetchFromGitHub {
-      owner = "libgit2";
-      repo = "libgit2";
-      rev = "v${version}";
-      hash = "sha256-KzBMwpqn6wUFhgB3KDclBS0BvZSVcasM5AG/y+L91xM=";
-    };
-    patches = [];
-  };
-
   libgit2-glib = callPackage ../development/libraries/libgit2-glib { };
 
   libhsts = callPackage ../development/libraries/libhsts { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21378,17 +21378,6 @@ with pkgs;
     patches = [];
   };
 
-  libgit2_1_6 = libgit2.overrideAttrs rec {
-    version = "1.6.5";
-    src = fetchFromGitHub {
-      owner = "libgit2";
-      repo = "libgit2";
-      rev = "v${version}";
-      hash = "sha256-2tgXnrB85dEfxu7giETqMuFxfm0RH5MicHZqO3ezGu0=";
-    };
-    patches = [ ];
-  };
-
   libgit2-glib = callPackage ../development/libraries/libgit2-glib { };
 
   libhsts = callPackage ../development/libraries/libhsts { };


### PR DESCRIPTION
## Description of changes

Surprisingly the tools all compile with the newest version right now.

Closes #288064
Resolves the root cause that would be fixed by #289802 which is now draft for something else

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
