### PR TITLE
kubeswitch: fix broken package; add nixos module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -214,6 +214,7 @@
   ./programs/kclock.nix
   ./programs/kdeconnect.nix
   ./programs/lazygit.nix
+  ./programs/kubeswitch.nix
   ./programs/less.nix
   ./programs/liboping.nix
   ./programs/light.nix

--- a/nixos/modules/programs/kubeswitch.nix
+++ b/nixos/modules/programs/kubeswitch.nix
@@ -1,0 +1,56 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.programs.kubeswitch;
+in
+{
+  options = {
+    programs.kubeswitch = {
+      enable = lib.mkEnableOption (lib.mdDoc "kubeswitch");
+
+      commandName = lib.mkOption {
+        type = lib.types.str;
+        default = "kswitch";
+        description = "The name of the command to use";
+      };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.kubeswitch;
+        defaultText = lib.literalExpression "pkgs.kubeswitch";
+        description = "The package to install for kubeswitch";
+      };
+    };
+  };
+
+  config =
+    let
+      shell_files = pkgs.stdenv.mkDerivation rec {
+        name = "kubeswitch-shell-files";
+        phases = [ "installPhase" ];
+        installPhase = ''
+          mkdir -p $out/share
+          for shell in bash zsh; do
+            ${cfg.package}/bin/switcher init $shell | sed 's/switch(/${cfg.commandName}(/' > $out/share/${cfg.commandName}_init.$shell
+            ${cfg.package}/bin/switcher --cmd ${cfg.commandName} completion $shell > $out/share/${cfg.commandName}_completion.$shell
+          done
+        '';
+      };
+    in
+    lib.mkIf cfg.enable {
+      environment.systemPackages = [ cfg.package ];
+
+      programs.bash.interactiveShellInit = ''
+        source ${shell_files}/share/${cfg.commandName}_init.bash
+        source ${shell_files}/share/${cfg.commandName}_completion.bash
+      '';
+      programs.zsh.interactiveShellInit = ''
+        source ${shell_files}/share/${cfg.commandName}_init.zsh
+        source ${shell_files}/share/${cfg.commandName}_completion.zsh
+      '';
+    };
+}

--- a/pkgs/development/tools/kubeswitch/default.nix
+++ b/pkgs/development/tools/kubeswitch/default.nix
@@ -1,4 +1,11 @@
-{ lib, buildGoModule, fetchFromGitHub, testers, kubeswitch }:
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  testers,
+  kubeswitch,
+  installShellFiles,
+}:
 
 buildGoModule rec {
   pname = "kubeswitch";
@@ -6,9 +13,9 @@ buildGoModule rec {
 
   src = fetchFromGitHub {
     owner = "danielfoehrKn";
-    repo = pname;
+    repo = "kubeswitch";
     rev = version;
-    sha256 = "sha256-zf7o41YYAppRge0EMXgIN8rI5Kco4/n7BJ90b/X6L1M=";
+    hash = "sha256-zf7o41YYAppRge0EMXgIN8rI5Kco4/n7BJ90b/X6L1M=";
   };
 
   vendorHash = null;
@@ -16,25 +23,30 @@ buildGoModule rec {
   subPackages = [ "cmd/main.go" ];
 
   ldflags = [
-    "-s" "-w"
+    "-s"
+    "-w"
     "-X github.com/danielfoehrkn/kubeswitch/cmd/switcher.version=${version}"
     "-X github.com/danielfoehrkn/kubeswitch/cmd/switcher.buildDate=1970-01-01"
-
   ];
 
-  passthru.tests.version = testers.testVersion {
-    package = kubeswitch;
-  };
+  nativeBuildInputs = [ installShellFiles ];
 
   postInstall = ''
-    mv $out/bin/main $out/bin/switch
+    mv $out/bin/main $out/bin/switcher
+    for shell in bash zsh fish; do
+      $out/bin/switcher --cmd switcher completion $shell > switcher.$shell
+      installShellCompletion --$shell switcher.$shell
+    done
   '';
 
-  meta = with lib; {
-    description = "The kubectx for operators";
-    license = licenses.asl20;
+  passthru.tests.version = testers.testVersion { package = kubeswitch; };
+
+  meta = {
+    changelog = "https://github.com/danielfoehrKn/kubeswitch/releases/tag/${version}";
+    description = "The kubectx for operators, a drop-in replacement for kubectx";
+    license = lib.licenses.asl20;
     homepage = "https://github.com/danielfoehrKn/kubeswitch";
-    maintainers = with maintainers; [ bryanasdev000 ];
-    mainProgram = "switch";
+    maintainers = with lib.maintainers; [ bryanasdev000 ];
+    mainProgram = "switcher";
   };
 }


### PR DESCRIPTION
## Description of changes
Fix the package and add the program to set up the shell to use the kubeswitch properly.
P.S: The command `switch` was a terrible choice by the developer as it has lots of collision with other commands, so I made a program and added a field `commandName` to make it customizable. By default, this field is set to `kswitch`.

closes #237886

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
