### PR TITLE
arftracksat: init at 1.0

### DIFF
--- a/pkgs/by-name/ar/arftracksat/package.nix
+++ b/pkgs/by-name/ar/arftracksat/package.nix
@@ -1,0 +1,63 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  pkgs,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "arftracksat";
+  version = "1.0";
+  src = fetchFromGitHub {
+    owner = "arf20";
+    repo = "arftracksat";
+    rev = "69d3c3b21c5000aa308663bc51eae2dc81b6b885";
+    sha256 = "sha256-RKIT3WOqCHgeeW6gNZxe/JDTVMf5NZnl4QoQqLJUKUs=";
+  };
+
+  nativeBuildInputs = with pkgs; [
+    cmake
+    mesa
+    tree
+  ];
+
+  buildInputs = with pkgs; [
+    curl
+    curlpp
+    nlohmann_json
+    freeglut
+    libGL
+    mesa_glu
+    glm
+  ];
+
+  # Patch share location
+  patchPhase = ''
+    runHook prePatch
+
+    path=${placeholder "out"}
+    sed -i "s,/usr/local,$path," src/main.cpp
+    sed -i "s,/usr/local,$path," config.json
+
+    runHook postPatch
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -m 0555 arftracksat $out/bin/arftracksat
+    install -D ../config.json $out/etc/arftracksat/config.json
+    install -d $out/share/arftracksat/
+    install -D ../assets/* $out/share/arftracksat/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Graphical satellite tracking software for Linux";
+    platforms = lib.platforms.linux;
+    homepage = "https://github.com/arf20/arftracksat";
+    license = lib.licenses.free; # See https://github.com/arf20/arftracksat/issues/40
+    maintainers = with lib.maintainers; [ mabster314 ];
+    mainProgram = "arftracksat";
+  };
+})


### PR DESCRIPTION
## Description of changes

Add arftracksat: a graphical satellite tracking software for linux

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
