### PR TITLE
python311Packages.paho-mqtt: 1.6.1 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/paho-mqtt/default.nix
+++ b/pkgs/development/python-modules/paho-mqtt/default.nix
@@ -1,42 +1,58 @@
 { lib
 , stdenv
 , buildPythonPackage
+, pythonOlder
 , fetchFromGitHub
-, isPy3k
+, hatchling
 , pytestCheckHook
-, mock
-, six
 }:
 
-buildPythonPackage rec {
+let
+  testing = fetchFromGitHub {
+    owner = "eclipse";
+    repo = "paho.mqtt.testing";
+    rev = "9d7bb80bb8b9d9cfc0b52f8cb4c1916401281103";
+    hash = "sha256-3QqCLgV4WMZuG8+3nIa3g9PtzH7cXjw1fWbZkj7H3RU=";
+  };
+in buildPythonPackage rec {
   pname = "paho-mqtt";
-  version = "1.6.1";
-  format = "setuptools";
+  version = "2.0.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "eclipse";
     repo = "paho.mqtt.python";
     rev = "v${version}";
-    hash = "sha256-9nH6xROVpmI+iTKXfwv2Ar1PAmWbEunI3HO0pZyK6Rg=";
+    hash = "sha256-dR/MCz3c9eHai76I17PGD71E5/nZVEo6uRwUULOzKQU=";
   };
+
+  build-system = [
+    hatchling
+  ];
 
   nativeCheckInputs = [
     pytestCheckHook
-    six
-  ] ++ lib.optionals (!isPy3k) [
-    mock
   ];
 
   doCheck = !stdenv.isDarwin;
+
+  preCheck = ''
+    ln -s ${testing} paho.mqtt.testing
+
+    export PYTHONPATH=".:$PYTHONPATH"
+  '';
 
   pythonImportsCheck = [
     "paho.mqtt"
   ];
 
   meta = with lib; {
-    description = "MQTT version 3.1.1 client class";
+    changelog = "https://github.com/eclipse/paho.mqtt.python/blob/${src.rev}/ChangeLog.txt";
+    description = "MQTT version 5.0/3.1.1 client class";
     homepage = "https://eclipse.org/paho";
-    license = licenses.epl10;
+    license = licenses.epl20;
     maintainers = with maintainers; [ mog dotlambda ];
   };
 }

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -304,6 +304,29 @@ let
         };
       });
 
+      # pinned due to API changes in 2.0.0
+      paho-mqtt = super.paho-mqtt.overridePythonAttrs (old: rec {
+        version = "1.6.1";
+
+        src = fetchFromGitHub {
+          owner = "eclipse";
+          repo = "paho.mqtt.python";
+          rev = "v${version}";
+          hash = "sha256-9nH6xROVpmI+iTKXfwv2Ar1PAmWbEunI3HO0pZyK6Rg=";
+        };
+
+        build-system = with self; [
+          setuptools
+        ];
+
+        nativeCheckInputs = with self; [
+          pytestCheckHook
+          six
+        ];
+
+        preCheck = "";
+      });
+
       # Pinned due to API changes in 0.1.0
       poolsense = super.poolsense.overridePythonAttrs (oldAttrs: rec {
         version = "0.0.8";


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/eclipse/paho.mqtt.python/compare/v1.6.1...v2.0.0

Changelog: https://github.com/eclipse/paho.mqtt.python/blob/v2.0.0/ChangeLog.txt



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
