### PR TITLE
stalwart-mail: 0.5.2 -> 0.5.3

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -167,6 +167,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - `xxd` has been moved from `vim` default output to its own output to reduce closure size. The canonical way to reference it across all platforms is `unixtools.xxd`.
 
+- The `stalwart-mail` package has been updated to v0.5.3, which includes [breaking changes](https://github.com/stalwartlabs/mail-server/blob/v0.5.3/UPGRADING.md).
+
 - `services.avahi.nssmdns` got split into `services.avahi.nssmdns4` and `services.avahi.nssmdns6` which enable the mDNS NSS switch for IPv4 and IPv6 respectively.
   Since most mDNS responders only register IPv4 addresses, most users want to keep the IPv6 support disabled to avoid long timeouts.
 

--- a/pkgs/servers/mail/stalwart/Cargo.lock
+++ b/pkgs/servers/mail/stalwart/Cargo.lock
@@ -2551,7 +2551,7 @@ checksum = "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284"
 
 [[package]]
 name = "imap"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "ahash 0.8.7",
  "dashmap",
@@ -2728,7 +2728,7 @@ dependencies = [
 
 [[package]]
 name = "jmap"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "mail-server"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "directory",
  "imap",
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "managesieve"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "ahash 0.8.7",
  "bincode",
@@ -3422,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "nlp"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "ahash 0.8.7",
  "bincode",
@@ -5385,7 +5385,7 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "smtp"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "ahash 0.8.7",
  "bincode",
@@ -5507,7 +5507,7 @@ dependencies = [
 
 [[package]]
 name = "stalwart-cli"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "clap",
  "console",
@@ -5531,7 +5531,7 @@ dependencies = [
 
 [[package]]
 name = "stalwart-install"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "base64 0.21.5",
  "clap",
@@ -6414,7 +6414,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "utils"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "ahash 0.8.7",
  "arc-swap",

--- a/pkgs/servers/mail/stalwart/default.nix
+++ b/pkgs/servers/mail/stalwart/default.nix
@@ -14,7 +14,7 @@
 }:
 
 let
-  version = "0.5.2";
+  version = "0.5.3";
 in
 rustPlatform.buildRustPackage {
   pname = "stalwart-mail";
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage {
     owner = "stalwartlabs";
     repo = "mail-server";
     rev = "v${version}";
-    hash = "sha256-U53v123mLD9mGmsNKgHlad8+2vr9lzMXizT4KeOChJY=";
+    hash = "sha256-Fbw2f/Q5ZLnQi8PuxbdIxDIyDayhAzvzdn3LMexnWgA=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
## Description of changes

- https://github.com/stalwartlabs/mail-server/blob/v0.5.3/CHANGELOG.md
- https://github.com/stalwartlabs/mail-server/blob/v0.5.3/UPGRADING.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@happysalada