### PR TITLE
buildLuarocksPackage: ability to self reference extraConfig

### DIFF
--- a/pkgs/applications/editors/neovim/build-neovim-plugin.nix
+++ b/pkgs/applications/editors/neovim/build-neovim-plugin.nix
@@ -19,14 +19,14 @@ in
     let
       originalLuaDrv = lua.pkgs.${luaAttr};
 
-      luaDrv = (lua.pkgs.luaLib.overrideLuarocks originalLuaDrv (drv: {
+      luaDrv = originalLuaDrv.overrideAttrs (oa: {
+        version = attrs.version or oa.version;
+        rockspecVersion = oa.rockspecVersion;
+
         extraConfig = ''
           -- to create a flat hierarchy
           lua_modules_path = "lua"
         '';
-        })).overrideAttrs (drv: {
-        version = attrs.version or drv.version;
-        rockspecVersion = drv.rockspecVersion;
       });
 
       finalDrv = toVimPlugin (luaDrv.overrideAttrs(oa: attrs // {

--- a/pkgs/development/interpreters/lua-5/build-luarocks-package.nix
+++ b/pkgs/development/interpreters/lua-5/build-luarocks-package.nix
@@ -92,7 +92,7 @@ let
     luarocks
   ];
 
-  inherit doCheck extraVariables rockspecFilename knownRockspec externalDeps nativeCheckInputs;
+  inherit doCheck extraConfig extraVariables rockspecFilename knownRockspec externalDeps nativeCheckInputs;
 
   buildInputs = let
     # example externalDeps': [ { name = "CRYPTO"; dep = pkgs.openssl; } ]
@@ -131,7 +131,7 @@ let
     in
       ''
       ${generatedConfig}
-      ${extraConfig}
+      ${self.extraConfig}
       '';
 
   configurePhase = ''


### PR DESCRIPTION
## Description of changes

makes overrideAttrs for lua packages even more powerful, thus simplifying implementation of buildNeovimPlugin

TODO target staging
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
