### PR TITLE
xdg-user-dirs: fix darwin builds

### DIFF
--- a/pkgs/tools/X11/xdg-user-dirs/default.nix
+++ b/pkgs/tools/X11/xdg-user-dirs/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, libxslt, docbook_xsl, makeWrapper }:
+{ lib, stdenv, fetchurl, libxslt, docbook_xsl, gettext, libiconv, makeWrapper }:
 
 stdenv.mkDerivation rec {
   pname = "xdg-user-dirs";
@@ -9,7 +9,9 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-7G8G10lc26N6cyA5+bXhV4vLKWV2/eDaQO2y9SIg3zw=";
   };
 
-  nativeBuildInputs = [ makeWrapper libxslt docbook_xsl ];
+  buildInputs = lib.optionals stdenv.isDarwin [ libiconv ];
+
+  nativeBuildInputs = [ makeWrapper libxslt docbook_xsl ] ++ lib.optionals stdenv.isDarwin [ gettext ];
 
   preFixup = ''
     # fallback values need to be last
@@ -22,6 +24,6 @@ stdenv.mkDerivation rec {
     description = "A tool to help manage well known user directories like the desktop folder and the music folder";
     license = licenses.gpl2;
     maintainers = with maintainers; [ ];
-    platforms = platforms.linux;
+    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
_Continuing from 288125 after botched retarget_.

A recent update to xdg-utils (https://github.com/NixOS/nixpkgs/pull/285233) added xdg-user-dirs as a dep. Since then we've had a few reports of people running macOS with xdg-utils in their system for one reason or another getting a failure on xdg-user-dirs.

I'm not sure it makes high-level sense to use it on macOS, but it was easy to get it to build...

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
