### PR TITLE
 python3Packages.pynose: init at 1.4.8;  python312Packages.envs: fix build by switching to pynose 

### DIFF
--- a/pkgs/development/python-modules/envs/default.nix
+++ b/pkgs/development/python-modules/envs/default.nix
@@ -4,7 +4,7 @@
 , fetchPypi
 , jinja2
 , mock
-, nose
+, pynose
 , poetry-core
 , pythonOlder
 , terminaltables
@@ -13,7 +13,7 @@
 buildPythonPackage rec {
   pname = "envs";
   version = "1.4";
-  format = "pyproject";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -34,7 +34,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     mock
-    nose
+    pynose
   ];
 
   checkPhase = ''

--- a/pkgs/development/python-modules/pynose/default.nix
+++ b/pkgs/development/python-modules/pynose/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "pynose";
+  version = "1.4.8";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mdmintz";
+    repo = "pynose";
+    rev = "v${version}";
+    hash = "sha256-V6jZBEkEAKzClA/3s+Lyfm9xExgCEJbLCNnIHmZ94E4=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  # has no tests
+  doCheck = false;
+
+  meta = with lib; {
+    description = "pynose fixes nose to extend unittest and make testing easier";
+    homepage = "https://github.com/mdmintz/pynose";
+    license = licenses.mit;
+    maintainers = with maintainers; [ SuperSandro2000 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9542,6 +9542,8 @@ self: super: with self; {
 
   pynobo = callPackage ../development/python-modules/pynobo { };
 
+  pynose = callPackage ../development/python-modules/pynose { };
+
   pynuki = callPackage ../development/python-modules/pynuki { };
 
   pynut2 = callPackage ../development/python-modules/pynut2 { };


### PR DESCRIPTION
## Description of changes

pynose is yet another try to get nose(1) working for newer packages. This time it works for python 3.12, too. I couldn't get envs to work with pytest, so we just use that instead.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
