### PR TITLE
python311Packages.editorconfig: 0.12.3 -> 0.12.4

### DIFF
--- a/pkgs/development/python-modules/editorconfig/default.nix
+++ b/pkgs/development/python-modules/editorconfig/default.nix
@@ -1,35 +1,26 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, setuptools
 , cmake
 }:
 
-let
-  tests = fetchFromGitHub {
-    owner = "editorconfig";
-    repo = "editorconfig-core-test";
-    rev = "e407c1592df0f8e91664835324dea85146f20189";
-    hash = "sha256-9WSEkMJOewPqJjB6f7J6Ir0L+U712hkaN+GszjnGw7c=";
-  };
-in
 buildPythonPackage rec {
   pname = "editorconfig";
-  version = "0.12.3";
-  format = "setuptools";
+  version = "0.12.4";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "editorconfig";
     repo = "editorconfig-core-py";
     rev = "v${version}";
-    hash = "sha256-ZwoTMgk18+BpPNtXKQUMXGcl2Lp+1RQVyPHgk6gHWh8=";
-    # workaround until https://github.com/editorconfig/editorconfig-core-py/pull/40 is merged
-    # fetchSubmodules = true;
+    hash = "sha256-+m674bLj6xs7MWU+8BMixEwy7/TjyES0lvCLLogTDHQ=";
+    fetchSubmodules = true;
   };
 
-  postUnpack = ''
-    cp -r ${tests}/* source/tests
-    chmod +w -R source/tests
-  '';
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   nativeCheckInputs = [
     cmake
@@ -38,9 +29,12 @@ buildPythonPackage rec {
   dontUseCmakeConfigure = true;
 
   checkPhase = ''
+    runHook preCheck
+
     cmake .
-    # utf_8_char fails with Python 3
-    ctest -E "utf_8_char" .
+    ctest .
+
+    runHook postCheck
   '';
 
   pythonImportsCheck = [ "editorconfig" ];


### PR DESCRIPTION
Diff: https://github.com/editorconfig/editorconfig-core-py/compare/v0.12.3...v0.12.4

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
