### PR TITLE
python/hooks/setuptools-build-hook.sh: use `--parallel` flag only for…

### DIFF
--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -195,6 +195,8 @@ in {
       propagatedBuildInputs = [ setuptools wheel ];
       substitutions = {
         inherit pythonInterpreter setuppy;
+        # python2.pkgs.setuptools does not support parallelism
+        setuptools_has_parallel = setuptools != null && lib.versionAtLeast setuptools.version "69";
       };
     } ./setuptools-build-hook.sh) {};
 

--- a/pkgs/development/interpreters/python/hooks/setuptools-build-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/setuptools-build-hook.sh
@@ -3,7 +3,7 @@ echo "Sourcing setuptools-build-hook"
 
 setuptoolsBuildPhase() {
     echo "Executing setuptoolsBuildPhase"
-    local args
+    local args setuptools_has_parallel=@setuptools_has_parallel@
     runHook preBuild
 
     cp -f @setuppy@ nix_run_setup
@@ -12,7 +12,9 @@ setuptoolsBuildPhase() {
         args+="$setupPyGlobalFlags"
     fi
     if [ -n "$enableParallelBuilding" ]; then
-        setupPyBuildFlags+=" --parallel $NIX_BUILD_CORES"
+        if [ -n "$setuptools_has_parallel" ]; then
+            setupPyBuildFlags+=" --parallel $NIX_BUILD_CORES"
+        fi
     fi
     if [ -n "$setupPyBuildFlags" ]; then
         args+=" build_ext $setupPyBuildFlags"


### PR DESCRIPTION
… fresh setuptools

Without the change attempt to enable parallelist for `python2` packages fails with unsupported `--parallel` flag for `setuptools`-based packages:

    $ nix build --no-link -f. --arg config '{enableParallelBuildingByDefault = true;}' xdg-utils
    error: builder for '/nix/store/...-python2.7-setuptools-44.0.0.drv' failed with exit code 1;
       last 10 log lines:
       > no configure script, doing nothing
       > Running phase: buildPhase
       > Executing setuptoolsBuildPhase
       > usage: nix_run_setup [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
       >    or: nix_run_setup --help [cmd1 cmd2 ...]
       >    or: nix_run_setup --help-commands
       >    or: nix_run_setup cmd --help
       >
       > error: option --parallel not recognized

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
