### PR TITLE
python312Packages.aws-sam-translator: don't fail when pytest/pluggy, skip slow tests

### DIFF
--- a/pkgs/development/python-modules/aws-sam-translator/default.nix
+++ b/pkgs/development/python-modules/aws-sam-translator/default.nix
@@ -29,8 +29,8 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    substituteInPlace pytest.ini \
-      --replace " --cov samtranslator --cov-report term-missing --cov-fail-under 95" ""
+    # don't try to use --cov or fail on new warnings
+    rm pytest.ini
   '';
 
   propagatedBuildInputs = [
@@ -49,13 +49,14 @@ buildPythonPackage rec {
     pyyaml
   ];
 
-  pythonImportsCheck = [
-    "samtranslator"
-  ];
-
   preCheck = ''
-    sed -i '2ienv =\n\tAWS_DEFAULT_REGION=us-east-1' pytest.ini
+    export AWS_DEFAULT_REGION=us-east-1
   '';
+
+  pytestFlagsArray = [
+    "tests"
+    ''-m "not slow"''
+  ];
 
   disabledTests = [
     # urllib3 2.0 compat
@@ -78,6 +79,10 @@ buildPythonPackage rec {
   ];
 
   __darwinAllowLocalNetworking = true;
+
+  pythonImportsCheck = [
+    "samtranslator"
+  ];
 
   meta = with lib; {
     description = "Python library to transform SAM templates into AWS CloudFormation templates";


### PR DESCRIPTION
## Description of changes

for example this failure was triggered because warnings are filtered in pytest.ini:
```
python3.12-aws-sam-translator>   File "/nix/store/jzba2jjz0l3222pry5mf6nyflbwgpd32-python3.12-python-dateutil-2.8.2/lib/python3.12/site-packages/dateutil/tz/__init__.py", line 2, in <module>
python3.12-aws-sam-translator>     from .tz import *
python3.12-aws-sam-translator>   File "/nix/store/jzba2jjz0l3222pry5mf6nyflbwgpd32-python3.12-python-dateutil-2.8.2/lib/python3.12/site-packages/dateutil/tz/tz.py", line 37, in <module>
python3.12-aws-sam-translator>     EPOCH = datetime.datetime.utcfromtimestamp(0)
python3.12-aws-sam-translator>             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
python3.12-aws-sam-translator> DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
python3.12-aws-sam-translator>
```
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
