### PR TITLE
ft: add systemd hardening helpers

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -324,6 +324,7 @@
   ./security/sudo.nix
   ./security/sudo-rs.nix
   ./security/systemd-confinement.nix
+  ./security/systemd-harden.nix
   ./security/tpm2.nix
   ./security/wrappers/default.nix
   ./services/admin/meshcentral.nix

--- a/nixos/modules/security/systemd-harden.nix
+++ b/nixos/modules/security/systemd-harden.nix
@@ -1,0 +1,114 @@
+{config, lib, ...}: let
+  inherit (lib) types;
+in {
+  options.systemd.services = lib.mkOption {
+    type = types.attrsOf (types.submodule ({
+      name,
+      config,
+      ...
+    }: {
+      options.harden = {
+        enable = lib.mkOption {
+          type = types.bool;
+          default = false;
+          description = lib.mdDoc ''
+            Basic restrictions for systemd services
+          '';
+        };
+
+        execOnlyNix = lib.mkOption {
+          type = types.bool;
+          default = true;
+          description = lib.mdDoc ''
+            Mark whole system as non-executable with exception for `/nix/store`.
+          '';
+        };
+
+        protectKernel = lib.mkOption {
+          type = types.bool;
+          default = true;
+          description = lib.mdDoc ''
+            Protect kernel internals from being reachable by the service.
+          '';
+        };
+
+        proc = lib.mkOption {
+          type = types.bool;
+          default = true;
+          description = lib.mdDoc ''
+            Restrict view into `/proc` to only allow access for limited subset.
+          '';
+        };
+
+        onlyLocalhost = lib.mkOption {
+          type = types.bool;
+          default = true;
+          description = lib.mdDoc ''
+            Allow listening sockets only on localhost.
+          '';
+        };
+
+        ipSockets = lib.mkOption {
+          type = types.bool;
+          default = false;
+          description = lib.mdDoc ''
+          Allow using AF_INET and AF_INET6
+          '';
+        };
+      };
+      config.serviceConfig = let
+        cfg = config.harden;
+        inherit (lib) mkDefault;
+      in
+        lib.optionalAttrs cfg.enable ({
+          NoNewPrivileges = mkDefault true;
+          LockPersonality = mkDefault true;
+          RemoveIPC = mkDefault true;
+
+          MemoryDenyWriteExecute = mkDefault true;
+
+          CapabilityBoundingSet = mkDefault [ "" ];
+
+          RestrictNamespaces = mkDefault true;
+          RestrictRealtime = mkDefault true;
+          RestrictSUIDSGID = mkDefault true;
+
+          ProtectHome = mkDefault true;
+          ProtectClock = mkDefault true;
+          ProtectControlGroups = mkDefault true;
+
+          RestrictAddressFamilies = mkDefault (
+            [ "AF_UNIX" ] ++ lib.optionals cfg.ipSockets [ "AF_INET" "AF_INET6" ]
+          );
+
+          PrivateDevices = mkDefault true;
+          PrivateTmp = mkDefault true;
+          PrivateMounts = mkDefault true;
+          PrivateUsers = mkDefault true;
+
+          # By default it does nothing as everything is allowed unless we use
+          # `NoExecPaths`. So this is good default.
+          ExecPaths = mkDefault [ "/nix/store" ];
+
+          ProtectKernelLogs = cfg.protectKernel;
+          ProtectKernelModules = cfg.protectKernel;
+          ProtectKernelTunables = cfg.protectKernel;
+
+          SystemCallFilter = mkDefault [ "@system-service" ];
+          SystemCallArchitectures = [ "native" ];
+          SystemCallErrorNumber = mkDefault "EPERM";
+        }
+        // (lib.optionalAttrs cfg.execOnlyNix {
+          NoExecPaths = [ "/" ];
+        })
+        // (lib.optionalAttrs config.harden.proc {
+          ProtectProc = mkDefault "invisible";
+          ProcSubset = "pid";
+        })
+        // (lib.optionalAttrs config.harden.onlyLocalhost {
+          IPAddressAllow = [ "localhost" ];
+          IPAddressDeny = [ "any" ];
+        }));
+    }));
+  };
+}


### PR DESCRIPTION
## Description of changes

This module adds `systemd.services.<name>.harden` set of options that helps with setting basic systemd units hardening. That should help with making more services hardened and responding with better security analysis grade without too much repetition. Most of the set values are marked with `mkDefault` to allow explicit opt-out for options that aren't needed without resolving to `mkForce` or similar.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
