### PR TITLE
lib.customisation: add makeOverridableGeneric

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -113,7 +113,7 @@ let
       toInt toIntBase10 readPathsFromFile fileContents;
     inherit (self.stringsWithDeps) textClosureList textClosureMap
       noDepEntry fullDepEntry packEntry stringAfter;
-    inherit (self.customisation) overrideDerivation makeOverridable
+    inherit (self.customisation) overrideDerivation makeOverridable makeOverridableGeneric
       callPackageWith callPackagesWith extendDerivation hydraJob
       makeScope makeScopeWithSplicing makeScopeWithSplicing';
     inherit (self.derivations) lazyDerivation optionalDrvAttr;


### PR DESCRIPTION
This is my sketch of a "generic" `lib.makeOverridable` function. It doesn't work yet, but the idea is this could replace functions like `haskell.lib.overrideCabal`, `overridePythonAttrs`, [`overrideRust`](https://github.com/NixOS/nixpkgs/pull/288430), and so on.