### PR TITLE
ruby: replace `rec {}` with `finalAttrs` & make overriding possible

### DIFF
--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -24,7 +24,7 @@ let
     atLeast32 = lib.versionAtLeast ver.majMin "3.2";
     # https://github.com/ruby/ruby/blob/v3_2_2/yjit.h#L21
     yjitSupported = atLeast32 && (stdenv.hostPlatform.isx86_64 || (!stdenv.hostPlatform.isWindows && stdenv.hostPlatform.isAarch64));
-    self = lib.makeOverridable (
+    rubyDrv = lib.makeOverridable (
       { stdenv, buildPackages, lib
       , fetchurl, fetchpatch, fetchFromSavannah, fetchFromGitHub
       , rubygemsSupport ? true
@@ -58,7 +58,7 @@ let
         }
       , useBaseRuby ? stdenv.hostPlatform != stdenv.buildPlatform
       }:
-      stdenv.mkDerivation rec {
+      stdenv.mkDerivation ( finalAttrs: {
         pname = "ruby";
         inherit version;
 
@@ -123,8 +123,8 @@ let
         cargoRoot = opString yjitSupport "yjit";
 
         cargoDeps = if yjitSupport then rustPlatform.fetchCargoTarball {
-          inherit src;
-          sourceRoot = "${pname}-${version}/${cargoRoot}";
+          inherit (finalAttrs) src;
+          sourceRoot = "${finalAttrs.pname}-${version}/${finalAttrs.cargoRoot}";
           hash = cargoHash;
         } else null;
 
@@ -175,8 +175,8 @@ let
 
         preInstall = ''
           # Ruby installs gems here itself now.
-          mkdir -pv "$out/${passthru.gemPath}"
-          export GEM_HOME="$out/${passthru.gemPath}"
+          mkdir -pv "$out/${finalAttrs.passthru.gemPath}"
+          export GEM_HOME="$out/${finalAttrs.passthru.gemPath}"
         '';
 
         installFlags = lib.optional docSupport "install-doc";
@@ -205,16 +205,16 @@ let
           sed -i 's/CONFIG\["CC"\] = "\(.*\)"/CONFIG["CC"] = if ENV["CC"].nil? || ENV["CC"].empty? then "\1" else ENV["CC"] end/'  "$rbConfig"
 
           # Remove unnecessary external intermediate files created by gems
-          extMakefiles=$(find $out/${passthru.gemPath} -name Makefile)
+          extMakefiles=$(find $out/${finalAttrs.passthru.gemPath} -name Makefile)
           for makefile in $extMakefiles; do
             make -C "$(dirname "$makefile")" distclean
           done
-          find "$out/${passthru.gemPath}" \( -name gem_make.out -o -name mkmf.log \) -delete
+          find "$out/${finalAttrs.passthru.gemPath}" \( -name gem_make.out -o -name mkmf.log \) -delete
           # Bundler tries to create this directory
           mkdir -p $out/nix-support
           cat > $out/nix-support/setup-hook <<EOF
           addGemPath() {
-            addToSearchPath GEM_PATH \$1/${passthru.gemPath}
+            addToSearchPath GEM_PATH \$1/${finalAttrs.passthru.gemPath}
           }
           addRubyLibPath() {
             addToSearchPath RUBYLIB \$1/lib/ruby/site_ruby
@@ -274,21 +274,20 @@ let
           gemPath = "lib/${rubyEngine}/gems/${ver.libDir}";
           devEnv = import ./dev.nix {
             inherit buildEnv bundler bundix;
-            ruby = self;
+            ruby = finalAttrs.finalPackage;
           };
 
           inherit rubygems;
           inherit (import ../../ruby-modules/with-packages {
             inherit lib stdenv makeBinaryWrapper buildRubyGem buildEnv;
             gemConfig = defaultGemConfig;
-            ruby = self;
+            ruby = finalAttrs.finalPackage;
           }) withPackages buildGems gems;
-
         } // lib.optionalAttrs useBaseRuby {
           inherit baseRuby;
         };
-      }
-    ) args; in self;
+      } )
+    ) args; in rubyDrv;
 
 in {
   mkRubyVersion = rubyVersion;


### PR DESCRIPTION
## Description of changes

Without this change, use overrideAttrs on Ruby won't change the instance used by Gems, making it very difficult to build a custom Ruby (e.g. add devdoc).

This shouldn't change any outPath at all, but I have no idea whether it leads to breaking changes or not.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
