### PR TITLE
stp: fix build failure

### DIFF
--- a/pkgs/applications/science/logic/stp/default.nix
+++ b/pkgs/applications/science/logic/stp/default.nix
@@ -11,6 +11,12 @@ stdenv.mkDerivation rec {
     rev    = version;
     sha256 = "1yg2v4wmswh1sigk47drwsxyayr472mf4i47lqmlcgn9hhbx1q87";
   };
+  patches = [
+    # Fix missing type declaration
+    # due to undeterminisitic compilation
+    # of circularly dependent headers
+    ./stdint.patch
+  ];
 
   buildInputs = [ boost zlib minisat cryptominisat python3 ];
   nativeBuildInputs = [ cmake bison flex perl ];
@@ -26,7 +32,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Simple Theorem Prover";
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ McSinyx ];
     platforms = platforms.linux;
     license = licenses.mit;
   };

--- a/pkgs/applications/science/logic/stp/stdint.patch
+++ b/pkgs/applications/science/logic/stp/stdint.patch
@@ -1,0 +1,16 @@
+diff --git a/include/stp/AST/ASTNode.h b/include/stp/AST/ASTNode.h
+index 91acd726182c..0a17db23ffbf 100644
+--- a/include/stp/AST/ASTNode.h
++++ b/include/stp/AST/ASTNode.h
+@@ -24,9 +24,10 @@ THE SOFTWARE.
+ #ifndef ASTNODE_H
+ #define ASTNODE_H
+ 
++#include "stp/AST/ASTInternal.h"
+ #include "stp/AST/NodeFactory/HashingNodeFactory.h"
++#include "stp/AST/UsefulDefs.h"
+ #include "stp/Util/Attributes.h"
+-#include "ASTInternal.h"
+ #include "stp/Globals/Globals.h"
+ 
+ namespace stp


### PR DESCRIPTION
## Description of changes

Fix stp's build failure caused by incorrect assumption of processing order of circular headers.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).