### PR TITLE
FerretDB document defaults, PostgreSQL default URL, disable telemetry

### DIFF
--- a/nixos/modules/services/databases/ferretdb.nix
+++ b/nixos/modules/services/databases/ferretdb.nix
@@ -19,8 +19,22 @@ in
       };
 
       settings = lib.mkOption {
-        type =
-          lib.types.submodule { freeformType = with lib.types; attrsOf str; };
+        type = lib.types.submodule {
+          freeformType = with lib.types; attrsOf str;
+          options = {
+            FERRETDB_HANDLER  = lib.mkOption {
+              type = lib.types.enum [ "sqlite" "pg" ];
+              default = "sqlite";
+              description = "Backend handler";
+            };
+
+            FERRETDB_SQLITE_URL = lib.mkOption {
+              type = lib.types.str;
+              default = "file:/var/lib/ferretdb/";
+              description = "SQLite URI (directory) for 'sqlite' handler";
+            };
+          };
+        };
         example = {
           FERRETDB_LOG_LEVEL = "warn";
           FERRETDB_MODE = "normal";
@@ -36,11 +50,7 @@ in
 
   config = lib.mkIf cfg.enable
     {
-
-      services.ferretdb.settings = {
-        FERRETDB_HANDLER = lib.mkDefault "sqlite";
-        FERRETDB_SQLITE_URL = lib.mkDefault "file:/var/lib/ferretdb/";
-      };
+      services.ferretdb.settings = { };
 
       systemd.services.ferretdb = {
         description = "FerretDB";

--- a/nixos/modules/services/databases/ferretdb.nix
+++ b/nixos/modules/services/databases/ferretdb.nix
@@ -33,6 +33,12 @@ in
               default = "file:/var/lib/ferretdb/";
               description = "SQLite URI (directory) for 'sqlite' handler";
             };
+
+            FERRETDB_POSTGRESQL_URL = lib.mkOption {
+              type = lib.types.str;
+              default = "postgres://ferretdb@localhost/ferretdb?host=/run/postgresql";
+              description = "PostgreSQL URL for 'pg' handler";
+            };
           };
         };
         example = {

--- a/nixos/modules/services/databases/ferretdb.nix
+++ b/nixos/modules/services/databases/ferretdb.nix
@@ -39,6 +39,16 @@ in
               default = "postgres://ferretdb@localhost/ferretdb?host=/run/postgresql";
               description = "PostgreSQL URL for 'pg' handler";
             };
+
+            FERRETDB_TELEMETRY = lib.mkOption {
+              type = lib.types.enum [ "enable" "disable" ];
+              default = "disable";
+              description = ''
+                Enable or disable basic telemetry.
+
+                See <https://docs.ferretdb.io/telemetry/> for more information.
+              '';
+            };
           };
         };
         example = {

--- a/nixos/tests/ferretdb.nix
+++ b/nixos/tests/ferretdb.nix
@@ -26,7 +26,6 @@ with import ../lib/testing-python.nix { inherit system; };
           services.ferretdb = {
             enable = true;
             settings.FERRETDB_HANDLER = "pg";
-            settings.FERRETDB_POSTGRESQL_URL = "postgres://ferretdb@localhost/ferretdb?host=/run/postgresql";
           };
 
           systemd.services.ferretdb.serviceConfig = {


### PR DESCRIPTION
## Description of changes

- Move the default settings into options, so that they are documented in the options list
- set a default value for the PostgreSQL URL, to provide a nice default if the end user wants to use the PostgreSQL backend
- Disable telemetry by default

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

cc @JulienMalka @camillemndn 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
