### PR TITLE
GNOME updates 2024-02-13

### DIFF
--- a/pkgs/desktops/gnome/apps/gnome-music/default.nix
+++ b/pkgs/desktops/gnome/apps/gnome-music/default.nix
@@ -30,13 +30,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "gnome-music";
-  version = "45.0";
+  version = "45.1";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "M+dwFmImp0U31MELFTjvqIQklP/pvyyQoWyrmKuZe98=";
+    sha256 = "lZWc24AkRASNUKGpHELbiyUWWgpoUzvAOJXrNyxN3gs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/desktops/gnome/core/gnome-control-center/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-control-center/default.nix
@@ -68,11 +68,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-control-center";
-  version = "45.2";
+  version = "45.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-control-center/${lib.versions.major finalAttrs.version}/gnome-control-center-${finalAttrs.version}.tar.xz";
-    sha256 = "sha256-DPo8My1u2stz0GxrJv/KEHjob/WerIGbKTHglndT33A=";
+    sha256 = "sha256-selJxOhsBiTsam7Q3wnJ+uKyKYPB3KYO2GrsjvCyQAQ=";
   };
 
   patches = [

--- a/pkgs/desktops/gnome/core/gnome-initial-setup/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-initial-setup/default.nix
@@ -39,11 +39,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnome-initial-setup";
-  version = "45.0";
+  version = "45.4.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "sa/nZHmPiUi+25XHqzG9eFKaxctIHEH3p3d/Jk3lS9g=";
+    sha256 = "Nj4JqjMI5/QHTgZiU6AYKzIqtgN2dD3heLu0AOVLqO4=";
   };
 
   patches = [

--- a/pkgs/desktops/gnome/core/gnome-shell/default.nix
+++ b/pkgs/desktops/gnome/core/gnome-shell/default.nix
@@ -67,13 +67,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-shell";
-  version = "45.3";
+  version = "45.4";
 
   outputs = [ "out" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell/${lib.versions.major finalAttrs.version}/gnome-shell-${finalAttrs.version}.tar.xz";
-    sha256 = "OhlyRyDYJ03GvO1o4N1fx2aKBM15l4y7uCI0dMzdqas=";
+    sha256 = "W/6jeeEgscfyN/PsNprSfvXC9ZMMffFjs5J4LYWCCQ0=";
   };
 
   patches = [

--- a/pkgs/desktops/gnome/core/mutter/default.nix
+++ b/pkgs/desktops/gnome/core/mutter/default.nix
@@ -67,13 +67,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mutter";
-  version = "45.3";
+  version = "45.4";
 
   outputs = [ "out" "dev" "man" "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/mutter/${lib.versions.major finalAttrs.version}/mutter-${finalAttrs.version}.tar.xz";
-    sha256 = "t4rqfz4r7IMioq8EBHFr4iaZBcfVDASwsqcaOIFPzQE=";
+    sha256 = "kRQIN74VWC8sdTvmYauOQtrVXUobDwZQvQssk/Ar16s=";
   };
 
   mesonFlags = [

--- a/pkgs/desktops/gnome/misc/gnome-tweaks/default.nix
+++ b/pkgs/desktops/gnome/misc/gnome-tweaks/default.nix
@@ -20,12 +20,12 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "gnome-tweaks";
-  version = "45.0";
+  version = "45.1";
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    sha256 = "JTmUZYroYXlNDG4OD0dd/hyvJ342dLh5J5AjjzTP1u4=";
+    sha256 = "lf+n842bHf1eTOvvt1JBn+ohzUBwITla3J8RKFRBbU8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/libdex/default.nix
+++ b/pkgs/development/libraries/libdex/default.nix
@@ -53,6 +53,7 @@ stdenv.mkDerivation rec {
 
   passthru.updateScript = gnome.updateScript {
     packageName = "libdex";
+    versionPolicy = "odd-unstable";
   };
 
   meta = with lib; {


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
