### PR TITLE
remote-exec: 1.13.2 -> 1.13.3

### DIFF
--- a/pkgs/tools/misc/remote-exec/default.nix
+++ b/pkgs/tools/misc/remote-exec/default.nix
@@ -1,9 +1,10 @@
 { lib
 , stdenv
+, fetchpatch
 , fetchFromGitHub
 , buildPythonApplication
 , click
-, pydantic_1
+, pydantic
 , toml
 , watchdog
 , pytestCheckHook
@@ -12,14 +13,23 @@
 
 buildPythonApplication rec {
   pname = "remote-exec";
-  version = "1.13.2";
+  version = "1.13.3";
 
   src = fetchFromGitHub {
     owner = "remote-cli";
     repo = "remote";
     rev = "refs/tags/v${version}";
-    hash = "sha256-xaxkN6XukV9HiLYehwVTBZB8bUyjgpfg+pPfAGrOkgo=";
+    hash = "sha256-rsboHJLOHXnpXtsVsvsfKsav8mSbloaq2lzZnU2pw6c=";
   };
+
+  patches = [
+    # relax install requirements
+    # https://github.com/remote-cli/remote/pull/60.patch
+    (fetchpatch {
+      url = "https://github.com/remote-cli/remote/commit/a2073c30c7f576ad7ceb46e39f996de8d06bf186.patch";
+      hash = "sha256-As0j+yY6LamhOCGFzvjUQoXFv46BN/tRBpvIS7r6DaI=";
+    })
+  ];
 
   # remove legacy endpoints, we use --multi now
   postPatch = ''
@@ -29,7 +39,7 @@ buildPythonApplication rec {
 
   propagatedBuildInputs = [
     click
-    pydantic_1
+    pydantic
     toml
     watchdog
   ];
@@ -58,6 +68,7 @@ buildPythonApplication rec {
   meta = with lib; {
     description = "Work with remote hosts seamlessly via rsync and ssh";
     homepage = "https://github.com/remote-cli/remote";
+    changelog = "https://github.com/remote-cli/remote/releases/tag/v${version}";
     license = licenses.bsd2;
     maintainers = with maintainers; [ pbsds ];
   };


### PR DESCRIPTION
## Description of changes

release: https://github.com/remote-cli/remote/releases/tag/v1.13.3

diff: https://github.com/remote-cli/remote/compare/v1.13.2...v1.13.3

The current set of pinned install requirements actually does work in nixpkgs at the time of writing, but will become problematic in the future, hence the patch from https://github.com/remote-cli/remote/pull/60


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
