### PR TITLE
browsr: 1.17.0 -> 1.18.0, python311Packages.pytest-textual-snapshot: init at 0.4.0

### DIFF
--- a/pkgs/applications/file-managers/browsr/default.nix
+++ b/pkgs/applications/file-managers/browsr/default.nix
@@ -6,20 +6,19 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "browsr";
-  version = "1.17.1";
-  format = "pyproject";
+  version = "1.18.0";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "juftin";
     repo = "browsr";
-    rev = "v${version}";
-    hash = "sha256-FExDKugFP94C3zMnR1V4QDPWeM2OtRH2ei0LNs3h06c=";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-Ygqoz1rNQwhU1/8NsHwQsSCqQ8gYwHEaAuIaVMCtKKA=";
   };
 
   nativeBuildInputs = with python3.pkgs; [
     hatchling
     pythonRelaxDepsHook
-    pytestCheckHook
   ];
 
   propagatedBuildInputs = with python3.pkgs; [
@@ -48,18 +47,31 @@ python3.pkgs.buildPythonApplication rec {
     ];
   };
 
+  nativeCheckInputs = with python3.pkgs; [
+    pytest-textual-snapshot
+    pytestCheckHook
+  ];
+
   pythonRelaxDeps = [
     "art"
     "pandas"
     "pymupdf"
     "rich-click"
+    "rich-pixels"
+    "rich"
     "textual"
   ];
 
-  pythonImportsCheck = [ "browsr" ];
+  pythonImportsCheck = [
+    "browsr"
+  ];
 
-  # requires internet access
+  pytestFlagsArray = [
+    "--snapshot-update"
+  ];
+
   disabledTests = [
+    # Tests require internet access
     "test_github_screenshot"
     "test_github_screenshot_license"
     "test_textual_app_context_path_github"

--- a/pkgs/development/python-modules/pytest-textual-snapshot/default.nix
+++ b/pkgs/development/python-modules/pytest-textual-snapshot/default.nix
@@ -1,0 +1,56 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, poetry-core
+, jinja2
+, pytest
+, rich
+, pythonOlder
+, syrupy
+, textual
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-textual-snapshot";
+  version = "0.4.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "Textualize";
+    repo = "pytest-textual-snapshot";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-XkXeyodRdwWqCP63Onx82Z3IbNLDDR/Lvaw8xUY7fAg=";
+  };
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  buildInputs = [
+    pytest
+  ];
+
+  propagatedBuildInputs = [
+    jinja2
+    rich
+    syrupy
+    textual
+  ];
+
+  # Module has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "pytest_textual_snapshot"
+  ];
+
+  meta = with lib; {
+    description = "Snapshot testing for Textual applications";
+    homepage = "https://github.com/Textualize/pytest-textual-snapshot";
+    changelog = "https://github.com/Textualize/pytest-textual-snapshot/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11717,6 +11717,8 @@ self: super: with self; {
 
   pytest-testmon = callPackage ../development/python-modules/pytest-testmon { };
 
+  pytest-textual-snapshot = callPackage ../development/python-modules/pytest-textual-snapshot { };
+
   pytest-timeout = callPackage ../development/python-modules/pytest-timeout { };
 
   pytest-tornado = callPackage ../development/python-modules/pytest-tornado { };


### PR DESCRIPTION
Diff: https://github.com/juftin/browsr/compare/refs/tags/v1.17.0...v1.18.0

Changelog: https://github.com/juftin/browsr/releases/tag/refs/tags/v1.18.0

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
