### PR TITLE
avogadro2: 1.98.1 -> 1.99.0

### DIFF
--- a/pkgs/applications/editors/molsketch/default.nix
+++ b/pkgs/applications/editors/molsketch/default.nix
@@ -38,7 +38,7 @@ mkDerivation rec {
   '';
 
   postFixup = ''
-    mv $out/lib/molsketch/* $out/lib
+    ln -s $out/lib/molsketch/* $out/lib/.
   '';
 
   nativeBuildInputs = [ cmake pkg-config qttools wrapQtAppsHook ];

--- a/pkgs/applications/editors/molsketch/default.nix
+++ b/pkgs/applications/editors/molsketch/default.nix
@@ -19,6 +19,10 @@ mkDerivation rec {
     hash = "sha256-Mpx4fHktxqBAkmdwqg2pXvEgvvGUQPbgqxKwXKjhJuQ=";
   };
 
+  patches = [
+    ./openbabel.patch
+  ];
+
   # uses C++17 APIs like std::transform_reduce
   postPatch = ''
     substituteInPlace molsketch/CMakeLists.txt \

--- a/pkgs/applications/editors/molsketch/openbabel.patch
+++ b/pkgs/applications/editors/molsketch/openbabel.patch
@@ -1,0 +1,12 @@
+diff --git a/obabeliface/obabeliface.cpp b/obabeliface/obabeliface.cpp
+index 98a9020..a168803 100644
+--- a/obabeliface/obabeliface.cpp
++++ b/obabeliface/obabeliface.cpp
+@@ -196,6 +196,7 @@ namespace Molsketch
+ 
+   // TODO should be const, but OpenBabel iterator methods do not support const
+   bool hasCoordinates(OpenBabel::OBMol &molecule) {
++    using namespace OpenBabel;
+     FOR_ATOMS_OF_MOL(obatom, molecule) {
+       if (obatom->GetVector() != OpenBabel::VZero)
+         return true;

--- a/pkgs/applications/science/chemistry/avogadro2/default.nix
+++ b/pkgs/applications/science/chemistry/avogadro2/default.nix
@@ -12,13 +12,13 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "avogadro2";
-  version = "1.98.1";
+  version = "1.99.0";
 
   src = fetchFromGitHub {
     owner = "OpenChemistry";
     repo = "avogadroapp";
     rev = version;
-    hash = "sha256-N35WGYZbgfjKnorzGKCnbBvlrlt9Vr04YIG2R3k+b8A=";
+    hash = "sha256-m8kX4WzOmPE/BZQRePOoUAdMPdWb6pmcqtPvDdEIIao=";
   };
 
   postUnpack = ''
@@ -37,7 +37,7 @@ in stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ openbabel ];
 
-  qtWrapperArgs = [ "--prefix PATH : ${openbabel}/bin" ];
+  qtWrapperArgs = [ "--prefix PATH : ${lib.getBin openbabel}/bin" ];
 
   meta = with lib; {
     description = "Molecule editor and visualizer";

--- a/pkgs/development/libraries/openbabel/default.nix
+++ b/pkgs/development/libraries/openbabel/default.nix
@@ -1,21 +1,21 @@
-{ stdenv, lib, fetchFromGitHub, cmake, zlib, libxml2, eigen, python, cairo, pcre, pkg-config, swig, rapidjson }:
+{ stdenv, lib, fetchFromGitHub, cmake, perl, zlib, libxml2, eigen, python, cairo, pcre, pkg-config, swig, rapidjson }:
 
 stdenv.mkDerivation rec {
   pname = "openbabel";
-  version = "3.1.1";
+  version = "unstable-06-12-23";
 
   src = fetchFromGitHub {
     owner = "openbabel";
-    repo = "openbabel";
-    rev = "openbabel-${lib.replaceStrings ["."] ["-"] version}";
-    sha256 = "sha256-wQpgdfCyBAoh4pmj9j7wPTlMtraJ62w/EShxi/olVMY=";
+    repo = pname;
+    rev = "32cf131444c1555c749b356dab44fb9fe275271f";
+    hash = "sha256-V0wrZVrojCZ9Knc5H6cPzPoYWVosRZ6Sn4PX+UFEfHY=";
   };
 
   postPatch = ''
     sed '1i#include <ctime>' -i include/openbabel/obutil.h # gcc12
   '';
 
-  buildInputs = [ zlib libxml2 eigen python cairo pcre swig rapidjson ];
+  buildInputs = [ perl zlib libxml2 eigen python cairo pcre swig rapidjson ];
 
   nativeBuildInputs = [ cmake pkg-config ];
 
@@ -26,13 +26,15 @@ stdenv.mkDerivation rec {
     "-DPYTHON_BINDINGS=ON"
   ];
 
+  # Setuptools only accepts PEP 440 version strings. The "unstable" identifier
+  # can not be used. Instead we pretend to be the 3.2 beta release.
   postFixup = ''
     cat <<EOF > $out/lib/python$pythonMajorMinor/site-packages/setup.py
     from distutils.core import setup
 
     setup(
         name = 'pyopenbabel',
-        version = '${version}',
+        version = '3.2b1',
         packages = ['openbabel'],
         package_data = {'openbabel' : ['_openbabel.so']}
     )

--- a/pkgs/development/libraries/science/chemistry/avogadrolibs/default.nix
+++ b/pkgs/development/libraries/science/chemistry/avogadrolibs/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, zlib, eigen, libGL, doxygen, spglib
+{ lib, stdenv, fetchFromGitHub, fetchpatch, cmake, zlib, eigen, libGL, doxygen, spglib
 , mmtf-cpp, glew, python3, libarchive, libmsym, msgpack, qttools, wrapQtAppsHook
 }:
 
@@ -18,26 +18,43 @@ let
     rev = "1.0.1";
     sha256 = "sH/WuvLaYu6akOc3ssAKhnxD8KNoDxuafDSozHqJZC4=";
   };
+  fragmentsRepo = fetchFromGitHub {
+    owner = "OpenChemistry";
+    repo = "fragments";
+    rev = "8dc711a59d016604b3e9b6d59dec178b8e6ccd36";
+    hash = "sha256-Valc5zwlaZ//eDupFouCfWCeID7/4ObU1SDLFJ/mo/g=";
+  };
 
 in stdenv.mkDerivation rec {
   pname = "avogadrolibs";
-  version = "1.98.1";
+  version = "1.99.0";
 
   src = fetchFromGitHub {
     owner = "OpenChemistry";
     repo = pname;
     rev = version;
-    hash = "sha256-BuBMWW7N5Cu9tw5Vpwk+aoIaMWwHViRzLtIG7XDWjN4=";
+    hash = "sha256-3jUbzEd7tUeHlVFAO9KJ+LOQlkLzJQvwmHp8gOriZRI=";
   };
 
   postUnpack = ''
     cp -r ${moleculesRepo} molecules
     cp -r ${crystalsRepo} crystals
+    cp -r ${fragmentsRepo} fragments
   '';
+
+  patches = [
+    # Fix a Cmake error when searching the fragments directory.
+    # Can be removed upon next release
+    (fetchpatch {
+      url = "https://github.com/OpenChemistry/avogadrolibs/commit/6e2e84dbb088a40d69117c1836f4306792f57acd.patch";
+      hash = "sha256-0tY9kHh6e5IDZQ8cWPgTpwIBhfZQlgUEZbPHOmtOVUQ=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake
     wrapQtAppsHook
+    pythonWP
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/science/chemistry/avogadrolibs/fragments.patch
+++ b/pkgs/development/libraries/science/chemistry/avogadrolibs/fragments.patch
@@ -1,0 +1,13 @@
+diff --git a/avogadro/qtplugins/templatetool/CMakeLists.txt b/avogadro/qtplugins/templatetool/CMakeLists.txt
+index 3f68e6dd..822de4e5 100644
+--- a/avogadro/qtplugins/templatetool/CMakeLists.txt
++++ b/avogadro/qtplugins/templatetool/CMakeLists.txt
+@@ -24,7 +24,7 @@ avogadro_plugin(TemplateTool
+ )
+ 
+ # Install the fragments
+-set(_fragments "${AvogadroLibs_SOURCE_DIR}/../fragments")
++set(_fragments "${AvogadroLibs_SOURCE_DIR}/fragments")
+ 
+ # Look in parallel directory for the molecule fragment repository
+ if(NOT EXISTS "${_fragments}")

--- a/pkgs/development/python-modules/openbabel-bindings/default.nix
+++ b/pkgs/development/python-modules/openbabel-bindings/default.nix
@@ -1,8 +1,7 @@
 { lib, openbabel, python, buildPythonPackage }:
 
 buildPythonPackage rec {
-  pname = "openbabel";
-  version = "3.1.1";
+  inherit (openbabel) pname version;
 
   src = "${openbabel}/lib/python${python.sourceVersion.major}.${python.sourceVersion.minor}/site-packages";
 


### PR DESCRIPTION
## Description of changes

Updates to the latest avogadrolibs and avogadroapp versions:
https://github.com/OpenChemistry/avogadrolibs/releases/tag/1.99.0
https://github.com/OpenChemistry/avogadroapp/releases/tag/1.99.0

This release should include fixes for Avogadro on Wayland.

I've also added `openbabel-unstable` and `python3Packages.openbabel-bindings-unstable`. The last OpenBabel release is nearly 4 years old but OpenBabel has been under steady development since then. Consumers like avogadro startet using new features, most importantly chemical JSON and are not working properly anymore with the latest stable release (e.g. can not export molecules to any helpful file format with old OpenBabel versions).
I'm not sure if this is the best approach, but it's the best I came up with :)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
