### PR TITLE
minikube: use correct paths for firmware in case of qemu driver

### DIFF
--- a/pkgs/applications/networking/cluster/minikube/default.nix
+++ b/pkgs/applications/networking/cluster/minikube/default.nix
@@ -7,7 +7,10 @@
 , which
 , libvirt
 , vmnet
+, withQemu ? false
+, qemu
 , makeWrapper
+, OVMF
 }:
 
 buildGoModule rec {
@@ -24,6 +27,22 @@ buildGoModule rec {
     rev = "v${version}";
     sha256 = "sha256-2EWaMpcr4F1wRzIP1rPg1a/Sjd1x+oo2ee90k4Ie8cU=";
   };
+  postPatch =
+    (
+      lib.optionalString (withQemu && stdenv.isDarwin) ''
+        substituteInPlace \
+          pkg/minikube/registry/drvs/qemu2/qemu2.go \
+          --replace "/usr/local/opt/qemu/share/qemu" "${qemu}/share/qemu" \
+          --replace "/opt/homebrew/opt/qemu/share/qemu" "${qemu}/share/qemu"
+      ''
+    ) + (
+      lib.optionalString (withQemu && stdenv.isLinux) ''
+        substituteInPlace \
+          pkg/minikube/registry/drvs/qemu2/qemu2.go \
+          --replace "/usr/share/OVMF/OVMF_CODE.fd" "${OVMF.firmware}" \
+          --replace "/usr/share/AAVMF/AAVMF_CODE.fd" "${OVMF.firmware}"
+      ''
+    );
 
   nativeBuildInputs = [ installShellFiles pkg-config which makeWrapper ];
 


### PR DESCRIPTION
## Description of changes

minikube uses hardcoded paths for edk2 (in case of darwin host system) or OVMF (for linux) to launch VM:
https://github.com/kubernetes/minikube/blob/ed5eb170335d85d06c921ce6ac70c3a26a6bd18f/pkg/minikube/registry/drvs/qemu2/qemu2.go#L84-L96

This prevents launching minikube with qemu2 driver if qemu system binaries is installed by nix-env not by brew.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
