### PR TITLE
foomatic-db-engine: unstable-2022-05-03 -> unstable-2024-02-10

### DIFF
--- a/pkgs/misc/cups/drivers/foomatic-db-engine/default.nix
+++ b/pkgs/misc/cups/drivers/foomatic-db-engine/default.nix
@@ -17,15 +17,15 @@
 
 perlPackages.buildPerlPackage rec {
   pname = "foomatic-db-engine";
-  version = "unstable-2022-05-03";
+  version = "unstable-2024-02-10";
 
   src = fetchFromGitHub {
     # there is also a daily snapshot at the `downloadPage`,
     # but it gets deleted quickly and would provoke 404 errors
     owner = "OpenPrinting";
     repo = "foomatic-db-engine";
-    rev = "2e6f14b54748fa121a4d2e3d480010e10b070c5a";
-    hash = "sha256-m7FQTxWmawbtm24h8UqznGKXgX41JhOtyyFMRwEhm5k=";
+    rev = "fa91bdfd87da9005591ac2ef2c9c7b8ecdd19511";
+    hash = "sha256-Ufy9BtYMD7sUUVfraTmO5e8+nZ4C4up5a5GXeGTtejg=";
   };
 
   outputs = [ "out" ];


### PR DESCRIPTION
## Description of changes

Update to newest version.  This adds just one commit that improves the content of PPD file's `1284DeviceID` field.

The package at hand is used to generate ppd files in the package `foomatic-db-ppds`.  However, many ppd files in that package are not affected by this change at all.

The ppd file `${pkgs.foomatic-db-ppds}/share/cups/model/foomatic-db-ppds/Xerox-WorkCentre_7345-Postscript.ppd` *is* affected.  To verify that `foomatic-db-engine` still generated good ppd files, I generated that file with the pull request at hand, and used the file to print some pages on a Xerox WorkCentre printer.  It still prints flawlessly (also two-sided, also colored).
I can't test other printers, but I expect no problems with this update.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


## Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>3 packages built:</summary>
  <ul>
    <li>foomatic-db-engine</li>
    <li>foomatic-db-ppds</li>
    <li>foomatic-db-ppds-withNonfreeDb</li>
  </ul>
</details>


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
