### PR TITLE
phpPackages.composer: 2.6.6 -> 2.7.1

### DIFF
--- a/pkgs/build-support/php/hooks/composer-install-hook.sh
+++ b/pkgs/build-support/php/hooks/composer-install-hook.sh
@@ -91,26 +91,7 @@ composerInstallBuildHook() {
 composerInstallCheckHook() {
     echo "Executing composerInstallCheckHook"
 
-    if ! composer validate --strict --no-ansi --no-interaction --quiet; then
-        if [ ! -z "${composerStrictValidation-}" ]; then
-            echo
-            echo -e "\e[31mERROR: composer files validation failed\e[0m"
-            echo
-            echo -e '\e[31mThe validation of the composer.json and composer.lock failed.\e[0m'
-            echo -e '\e[31mMake sure that the file composer.lock is consistent with composer.json.\e[0m'
-            echo
-            exit 1
-        else
-            echo
-            echo -e "\e[33mWARNING: composer files validation failed\e[0m"
-            echo
-            echo -e '\e[33mThe validation of the composer.json and composer.lock failed.\e[0m'
-            echo -e '\e[33mMake sure that the file composer.lock is consistent with composer.json.\e[0m'
-            echo
-            echo -e '\e[33mThis check is not blocking, but it is recommended to fix the issue.\e[0m'
-            echo
-        fi
-    fi
+    checkComposerValidate
 
     echo "Finished composerInstallCheckHook"
 }

--- a/pkgs/build-support/php/hooks/composer-install-hook.sh
+++ b/pkgs/build-support/php/hooks/composer-install-hook.sh
@@ -83,28 +83,7 @@ composerInstallBuildHook() {
 
     # Since this file cannot be generated in the composer-repository-hook.sh
     # because the file contains hardcoded nix store paths, we generate it here.
-    composer-local-repo-plugin --no-ansi build-local-repo -m "${composerRepository}" .
-
-    # Remove all the repositories of type "composer" and "vcs"
-    # from the composer.json file.
-    jq -r -c 'del(try .repositories[] | select(.type == "composer" or .type == "vcs"))' composer.json | sponge composer.json
-
-    # Configure composer to disable packagist and avoid using the network.
-    composer config repo.packagist false
-    # Configure composer to use the local repository.
-    composer config repo.composer composer file://"$PWD"/packages.json
-
-    # Since the composer.json file has been modified in the previous step, the
-    # composer.lock file needs to be updated.
-    composer \
-      --lock \
-      --no-ansi \
-      --no-install \
-      --no-interaction \
-      ${composerNoDev:+--no-dev} \
-      ${composerNoPlugins:+--no-plugins} \
-      ${composerNoScripts:+--no-scripts} \
-      update
+    composer-local-repo-plugin --no-ansi build-local-repo-lock -m "${composerRepository}" .
 
     echo "Finished composerInstallBuildHook"
 }
@@ -150,9 +129,6 @@ composerInstallInstallHook() {
       ${composerNoPlugins:+--no-plugins} \
       ${composerNoScripts:+--no-scripts} \
       install
-
-    # Remove packages.json, we don't need it in the store.
-    rm packages.json
 
     # Copy the relevant files only in the store.
     mkdir -p "$out"/share/php/"${pname}"

--- a/pkgs/build-support/php/hooks/composer-repository-hook.sh
+++ b/pkgs/build-support/php/hooks/composer-repository-hook.sh
@@ -63,7 +63,7 @@ composerRepositoryBuildHook() {
     # Build the local composer repository
     # The command 'build-local-repo' is provided by the Composer plugin
     # nix-community/composer-local-repo-plugin.
-    composer-local-repo-plugin --no-ansi build-local-repo ${composerNoDev:+--no-dev} -r repository
+    composer-local-repo-plugin --no-ansi build-local-repo-lock ${composerNoDev:+--no-dev} -r repository
 
     echo "Finished composerRepositoryBuildHook"
 }

--- a/pkgs/build-support/php/hooks/composer-repository-hook.sh
+++ b/pkgs/build-support/php/hooks/composer-repository-hook.sh
@@ -71,26 +71,7 @@ composerRepositoryBuildHook() {
 composerRepositoryCheckHook() {
     echo "Executing composerRepositoryCheckHook"
 
-    if ! composer validate --strict --no-ansi --no-interaction --quiet; then
-        if [ ! -z "${composerStrictValidation-}" ]; then
-            echo
-            echo -e "\e[31mERROR: composer files validation failed\e[0m"
-            echo
-            echo -e '\e[31mThe validation of the composer.json and composer.lock failed.\e[0m'
-            echo -e '\e[31mMake sure that the file composer.lock is consistent with composer.json.\e[0m'
-            echo
-            exit 1
-        else
-            echo
-            echo -e "\e[33mWARNING: composer files validation failed\e[0m"
-            echo
-            echo -e '\e[33mThe validation of the composer.json and composer.lock failed.\e[0m'
-            echo -e '\e[33mMake sure that the file composer.lock is consistent with composer.json.\e[0m'
-            echo
-            echo -e '\e[33mThis check is not blocking, but it is recommended to fix the issue.\e[0m'
-            echo
-        fi
-    fi
+    checkComposerValidate
 
     echo "Finished composerRepositoryCheckHook"
 }

--- a/pkgs/build-support/php/hooks/php-script-utils.bash
+++ b/pkgs/build-support/php/hooks/php-script-utils.bash
@@ -1,4 +1,5 @@
 declare version
+declare composerStrictValidation
 
 setComposeRootVersion() {
     set +e # Disable exit on error
@@ -9,4 +10,27 @@ setComposeRootVersion() {
     fi
 
     set -e
+}
+
+checkComposerValidate() {
+    if ! composer validate --strict --no-ansi --no-interaction; then
+        if [ "1" == "${composerStrictValidation-}" ]; then
+            echo
+            echo -e "\e[31mERROR: composer files validation failed\e[0m"
+            echo
+            echo -e '\e[31mThe validation of the composer.json and composer.lock failed.\e[0m'
+            echo -e '\e[31mMake sure that the file composer.lock is consistent with composer.json.\e[0m'
+            echo
+            exit 1
+        else
+            echo
+            echo -e "\e[33mWARNING: composer files validation failed\e[0m"
+            echo
+            echo -e '\e[33mThe validation of the composer.json and composer.lock failed.\e[0m'
+            echo -e '\e[33mMake sure that the file composer.lock is consistent with composer.json.\e[0m'
+            echo
+            echo -e '\e[33mThis check is not blocking, but it is recommended to fix the issue.\e[0m'
+            echo
+        fi
+    fi
 }

--- a/pkgs/build-support/php/pkgs/composer-local-repo-plugin.nix
+++ b/pkgs/build-support/php/pkgs/composer-local-repo-plugin.nix
@@ -29,13 +29,13 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "composer-local-repo-plugin";
-  version = "1.0.3";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "composer-local-repo-plugin";
     rev = finalAttrs.version;
-    hash = "sha256-fLJlxcAQ7X28GDK8PVYKxJgTzbspfWxvgRmRK4NZRIA=";
+    hash = "sha256-edbn07r/Uc1g0qOuVBZBs6N1bMN5kIfA1b4FCufdw5M=";
   };
 
   COMPOSER_CACHE_DIR = "/dev/null";

--- a/pkgs/development/php-packages/composer/default.nix
+++ b/pkgs/development/php-packages/composer/default.nix
@@ -1,11 +1,22 @@
-{ lib, callPackage, fetchFromGitHub, fetchpatch, php, unzip, _7zz, xz, git, curl, cacert, makeBinaryWrapper }:
+{ lib
+, callPackage
+, fetchFromGitHub
+, php
+, unzip
+, _7zz
+, xz
+, git
+, curl
+, cacert
+, makeBinaryWrapper
+}:
 
 php.buildComposerProject (finalAttrs: {
   # Hash used by ../../../build-support/php/pkgs/composer-phar.nix to
   # use together with the version from this package to keep the
   # bootstrap phar file up-to-date together with the end user composer
   # package.
-  passthru.pharHash = "sha256-cmACAcc8fEshjxwFEbNthTeWPjaq+iRHV/UjCfiFsxQ=";
+  passthru.pharHash = "sha256-H/0L4/J+I3sa5H+ejyn5asf1CgvZ7vT4jNvpTdBL//A=";
 
   composer = callPackage ../../../build-support/php/pkgs/composer-phar.nix {
     inherit (finalAttrs) version;
@@ -13,26 +24,14 @@ php.buildComposerProject (finalAttrs: {
   };
 
   pname = "composer";
-  version = "2.6.6";
+  version = "2.7.1";
 
   src = fetchFromGitHub {
     owner = "composer";
     repo = "composer";
     rev = finalAttrs.version;
-    hash = "sha256-KsTZi7dSlQcAxoen9rpofbptVdLYhK+bZeDSXQY7o5M=";
+    hash = "sha256-OThWqY3m/pIas4qvR/kiYgc/2QrAbnsYEOxpHxKhDfM=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "CVE-2024-24821.patch";
-      url = "https://github.com/composer/composer/commit/77e3982918bc1d886843dc3d5e575e7e871b27b7.patch";
-      hash = "sha256-Q7gkPLf59+p++DpfJZeOrAOiWePuGkdGYRaS/rK+Nv4=";
-      excludes = [
-        # Skipping test files, they are not included in the source tarball
-        "tests/*"
-      ];
-    })
-  ];
 
   nativeBuildInputs = [ makeBinaryWrapper ];
 
@@ -41,7 +40,7 @@ php.buildComposerProject (finalAttrs: {
       --prefix PATH : ${lib.makeBinPath [ _7zz cacert curl git unzip xz ]}
   '';
 
-  vendorHash = "sha256-50M1yeAKl9KRsjs34cdb5ZTBFgbukgg0cMtHTYGJ/EM=";
+  vendorHash = "sha256-NJa6nu60HQeBJr7dd79ATptjcekgY35Jq9V40SrN9Ds";
 
   meta = {
     changelog = "https://github.com/composer/composer/releases/tag/${finalAttrs.version}";


### PR DESCRIPTION
Diff: https://github.com/composer/composer/compare/2.6.6..2.7.1
Changelog: https://github.com/composer/composer/releases/tag/2.7.1

Encountering issues with the Composer plugin (https://github.com/nix-community/composer-local-repo-plugin, version 1.0.3) while using Composer 2.7, I opened an issue at https://github.com/composer/composer/pull/11850. Today, I had a meeting with @seldaek, he proposed a better idea for the plugin's functionality. Rather than generating a `packages.json` file, the suggestion was to create an updated `composer.lock` file.

And indeed, this approach has proven to be highly effective, streamlining the Composer builder's process and enhancing its comprehensibility.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
