### PR TITLE
jupyter related packages updates 2024-02-14

### DIFF
--- a/pkgs/development/python-modules/ipykernel/default.nix
+++ b/pkgs/development/python-modules/ipykernel/default.nix
@@ -22,14 +22,14 @@
 
 buildPythonPackage rec {
   pname = "ipykernel";
-  version = "6.29.0";
+  version = "6.29.2";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-td0wE8q3szDfcSiRyWzRq4aMJ6cVnmBvdiAV6b+M6z8=";
+    hash = "sha256-O63igATj/2JO1Xl0lIEWZwYErF9nbRIzlpPzFCF20/A=";
   };
 
   # debugpy is optional, see https://github.com/ipython/ipykernel/pull/767

--- a/pkgs/development/python-modules/ipywidgets/default.nix
+++ b/pkgs/development/python-modules/ipywidgets/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "IPython HTML widgets for Jupyter";
-    homepage = "https://ipython.org/";
+    homepage = "https://github.com/jupyter-widgets/ipywidgets";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ fridh ];
   };

--- a/pkgs/development/python-modules/ipywidgets/default.nix
+++ b/pkgs/development/python-modules/ipywidgets/default.nix
@@ -1,10 +1,13 @@
 { buildPythonPackage
 , fetchPypi
+, setuptools
+, wheel
+, comm
 , ipykernel
 , ipython
+, jsonschema
 , jupyterlab-widgets
 , lib
-, nbformat
 , pytestCheckHook
 , pytz
 , traitlets
@@ -13,25 +16,33 @@
 
 buildPythonPackage rec {
   pname = "ipywidgets";
-  version = "8.1.1";
-  format = "setuptools";
+  version = "8.1.2";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-QCEe+1Vq3sb6RQzMKnfVnKRKBg9PnxNoM99ZyfU45ug=";
+    hash = "sha256-0Lm0Hkm66SaoZuYTo5sPAJd0XSufHz3UBmQbSlfsQsk=";
   };
 
+  nativeBuildInputs = [
+    setuptools
+    wheel
+  ];
+
   propagatedBuildInputs = [
+    comm
     ipython
-    ipykernel
     jupyterlab-widgets
     traitlets
-    nbformat
-    pytz
     widgetsnbextension
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    ipykernel
+    jsonschema
+    pytestCheckHook
+    pytz
+  ];
 
   meta = {
     description = "IPython HTML widgets for Jupyter";

--- a/pkgs/development/python-modules/jupyter-collaboration/default.nix
+++ b/pkgs/development/python-modules/jupyter-collaboration/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "jupyter-collaboration";
-  version = "2.0.1";
+  version = "2.0.2";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "jupyter_collaboration";
     inherit version;
-    hash = "sha256-Uc57kxhaj/DQi5cX+kjV4PGRcFbxWmzc+B248+1VAYI=";
+    hash = "sha256-EpWFsVWCi/6IOuM/zgPIer3arMDGjPPxhm/tZC4aji4=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/jupyterlab-lsp/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-lsp/default.nix
@@ -8,12 +8,12 @@
 
 buildPythonPackage rec {
   pname = "jupyterlab-lsp";
-  version = "5.0.2";
+  version = "5.0.3";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-JmiGhOkHUPjvikFimgpAUOc26IFVWqFBP7Xah54GNfE=";
+    hash = "sha256-qcijpkZJS+SE1+MXSrHSQV7WD0dzzshHmqW6N+XwS8k=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/jupyterlab-widgets/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-widgets/default.nix
@@ -4,14 +4,20 @@
 
 buildPythonPackage rec {
   pname = "jupyterlab-widgets";
-  version = "3.0.9";
-  format = "setuptools";
+  version = "3.0.10";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "jupyterlab_widgets";
     inherit version;
-    hash = "sha256-YAWk6XTHvu6EBg/fujQaMhhJUEbeiuPsZIiOX+Gf20w=";
+    hash = "sha256-BPKsBJdnJ+T50PqRzcLxq4YPll5QTCnb1qZciCydBMA=";
   };
+
+  # jupyterlab is required to build from source but we use the pre-build package
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace '"jupyterlab~=4.0"' ""
+  '';
 
   nativeBuildInputs = [
     jupyter-packaging

--- a/pkgs/development/python-modules/nbconvert/default.nix
+++ b/pkgs/development/python-modules/nbconvert/default.nix
@@ -20,6 +20,7 @@
 , traitlets
 , importlib-metadata
 , flaky
+, ipykernel
 , ipywidgets
 , pytestCheckHook
 }:
@@ -32,14 +33,14 @@ let
   };
 in buildPythonPackage rec {
   pname = "nbconvert";
-  version = "7.14.2";
+  version = "7.16.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-p/iAj9TggkMWc6xThAAhjdRe/QdvvrB8xuWqWjpOlJ4=";
+    hash = "sha256-gT5lU3ljYkia5XLjm6G/+XhTYZL7UY4QgmsOjK3wPsg=";
   };
 
   # Add $out/share/jupyter to the list of paths that are used to search for
@@ -84,6 +85,7 @@ in buildPythonPackage rec {
 
   nativeCheckInputs = [
     flaky
+    ipykernel
     ipywidgets
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/notebook/default.nix
+++ b/pkgs/development/python-modules/notebook/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "notebook";
-  version = "7.0.7";
+  version = "7.0.8";
   disabled = pythonOlder "3.8";
 
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-O8/wDBezrBQu9fQ21QY32TaydM+gtB9qwBdTY96bTgk=";
+    hash = "sha256-OVfs2VYFawAUZ3r8dtO7RMLS8pZJ+Hsk0TYG/x0Yk48=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/widgetsnbextension/default.nix
+++ b/pkgs/development/python-modules/widgetsnbextension/default.nix
@@ -2,18 +2,17 @@
 , buildPythonPackage
 , fetchPypi
 , jupyter-packaging
-, notebook
 , ipywidgets
 }:
 
 buildPythonPackage rec {
   pname = "widgetsnbextension";
-  version = "4.0.9";
-  format = "setuptools";
+  version = "4.0.10";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-PB9eRtwRZt/UCkLWhealE5b9NP+Hh0Kj5HxvDMSio4U=";
+    hash = "sha256-ZBlsX/O5qRg6jmmaQif7C3AC8lLIFAmOZsTRzQZEaI8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/widgetsnbextension/default.nix
+++ b/pkgs/development/python-modules/widgetsnbextension/default.nix
@@ -19,6 +19,10 @@ buildPythonPackage rec {
     jupyter-packaging
   ];
 
+  pythonImportsCheck = [
+    "widgetsnbextension"
+  ];
+
   # No tests in archive
   doCheck = false;
 


### PR DESCRIPTION
## Description of changes

Update jupyter-related packages at once to avoid building hundreds of packages over and over again.

This PR is based on the commits generated by the following command.

```
nix search nixpkgs#python311Packages 'ipython|jupyter|notebook' --json | jq -r 'keys | .[]' | cut -d . -f 3,4 | xargs -n 1 nix-update --commit
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
