### PR TITLE
keymapper: 3.0.0 -> 3.5.3, add darwin platform

### DIFF
--- a/pkgs/tools/inputmethods/keymapper/default.nix
+++ b/pkgs/tools/inputmethods/keymapper/default.nix
@@ -2,34 +2,47 @@
 , stdenv
 , fetchFromGitHub
 , cmake
+, asio
 , dbus
 , libX11
 , libusb1
 , pkg-config
 , udev
 , wayland
+, darwin
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "keymapper";
-  version = "3.0.0";
+  version = "3.5.3";
 
   src = fetchFromGitHub {
     owner = "houmain";
     repo = "keymapper";
     rev = finalAttrs.version;
-    hash = "sha256-X2Qk/cAczdkteB+6kyURGjvm1Ryio6WHj3Ga2POosCA=";
+    hash = "sha256-CfZdLeWgeNwy9tEJ3UDRplV0sRcKE4J6d3CxC9gqdmE=";
   };
 
-  # all the following must be in nativeBuildInputs
+  patches = lib.optionals stdenv.isDarwin [
+    # Avoid fetching asio dependency during buildtime, instead use asio from nixpkgs.
+    ./dont-fetch-asio.patch
+  ];
+
+  # all of the following must be in nativeBuildInputs
   nativeBuildInputs = [
     cmake
     pkg-config
+  ] ++ lib.optionals stdenv.isLinux [
     dbus
-    wayland
+    libusb1
     libX11
     udev
-    libusb1
+    wayland
+  ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Carbon
+    asio
   ];
 
   meta = {
@@ -39,6 +52,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Only;
     mainProgram = "keymapper";
     maintainers = with lib.maintainers; [ dit7ya ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })

--- a/pkgs/tools/inputmethods/keymapper/dont-fetch-asio.patch
+++ b/pkgs/tools/inputmethods/keymapper/dont-fetch-asio.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b0daf21..9e13af4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -191,11 +191,6 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+     target_link_libraries(keymapper "-framework Carbon")
+   endif()
+ 
+-  include(FetchContent)
+-  FetchContent_Declare(asio GIT_REPOSITORY "https://github.com/chriskohlhoff/asio")
+-  FetchContent_MakeAvailable(asio)
+-  include_directories(${asio_SOURCE_DIR}/asio/include)
+-
+   include_directories(src/libs/Karabiner-DriverKit-VirtualHIDDevice/include)
+   target_link_libraries(keymapperd "-framework CoreFoundation" "-framework IOKit")
+ endif()


### PR DESCRIPTION
## Description of changes

On darwin requires karabiner-elements `14.13.0` installed. So https://github.com/NixOS/nixpkgs/pull/284830 is relevant, but shouldn't be necessary.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
