### PR TITLE
ocamlPackages.ocaml-lsp: 1.16.2 -> 1.17.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
@@ -8,8 +8,9 @@
 , dot-merlin-reader
 , spawn
 , ocamlc-loc
-, odoc-parser
 , merlin-lib
+, astring
+, camlp-streams
 }:
 
 buildDunePackage rec {
@@ -21,7 +22,7 @@ buildDunePackage rec {
   ++ lib.optional (lib.versionAtLeast version "1.9") spawn
   ++ lib.optionals (lib.versionAtLeast version "1.10") [ fiber xdg ]
   ++ lib.optional (lib.versionAtLeast version "1.14.2") ocamlc-loc
-  ++ lib.optional (lib.versionAtLeast version "1.16.2") [ odoc-parser merlin-lib ];
+  ++ lib.optionals (lib.versionAtLeast version "1.17.0") [ astring camlp-streams merlin-lib ];
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
@@ -9,7 +9,7 @@
 , ocaml
 , version ?
     if lib.versionAtLeast ocaml.version "4.14" then
-      "1.16.2"
+      "1.17.0"
     else if lib.versionAtLeast ocaml.version "4.13" then
       "1.10.5"
     else if lib.versionAtLeast ocaml.version "4.12" then
@@ -19,10 +19,10 @@
 }:
 
 let params = {
-  "1.16.2" = {
+  "1.17.0" = {
     name = "lsp";
     minimalOCamlVersion = "4.14";
-    sha256 = "sha256-FIfVpOLy1PAjNBBYVRvbi6hsIzZ7fFtP3aOqfcAqrsQ=";
+    sha256 = "sha256-j7i71xfu/SYItNg0WBBbZg4N46ETTcj8IWrmWdTRlgA=";
   };
   "1.14.2" = {
     name = "lsp";

--- a/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
@@ -24,7 +24,7 @@
 , ocaml
 , version ?
     if lib.versionAtLeast ocaml.version "4.14" then
-      "1.16.2"
+      "1.17.0"
     else if lib.versionAtLeast ocaml.version "4.13" then
       "1.10.5"
     else if lib.versionAtLeast ocaml.version "4.12" then


### PR DESCRIPTION
Diff: https://github.com/ocaml/ocaml-lsp/compare/1.16.2...1.17.0

Changelog: https://github.com/ocaml/ocaml-lsp/releases/tag/1.17.0

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
