### PR TITLE
chia-desktop-bin: init at 2.1.4

### DIFF
--- a/pkgs/by-name/ch/chia-desktop-bin/package.nix
+++ b/pkgs/by-name/ch/chia-desktop-bin/package.nix
@@ -1,0 +1,184 @@
+{ lib
+, stdenv
+, fetchurl
+, dpkg
+, autoPatchelfHook
+, python3
+, glib
+, xorg
+, numactl
+, nss
+, atk
+, at-spi2-atk
+, cups
+, dbus
+, wayland
+, libdrm
+, gtk3
+, pango
+, cairo
+, gdk-pixbuf
+, libXcomposite
+, libXdamage
+, libunity
+, libXfixes
+, libXrandr
+, mesa
+, expat
+, libxkbcommon
+, alsa-lib
+, at-spi2-core
+, fontconfig
+, freetype
+, libcxx
+, libglvnd
+, libnotify
+, libpulseaudio
+, libuuid
+, libX11
+, libXScrnSaver
+, libXcursor
+, libXext
+, libXi
+, libXrender
+, libXtst
+, libxcb
+, libxshmfence
+, nspr
+, systemd
+, libappindicator-gtk3
+, libdbusmenu
+, makeShellWrapper
+}:
+
+stdenv.mkDerivation rec {
+  pname = "chia-desktop-bin";
+  version = "2.1.4";
+
+  src =
+    if stdenv.hostPlatform.system == "aarch64-linux" then
+      fetchurl
+        {
+          url = "https://github.com/Chia-Network/chia-blockchain/releases/download/${version}/chia-blockchain_${version}_arm64.deb";
+          sha256 = "e3c4b3c1c1e088c6a296cd1d531c049694536b0ed57af87509e0b608e61b17db";
+        } else
+      fetchurl {
+        url = "https://github.com/Chia-Network/chia-blockchain/releases/download/${version}/chia-blockchain_${version}_amd64.deb";
+        sha256 = "5b57b1728f063e405d13307a6a54b578c7858572ec92f5d82eaab2bb18c8f0e3";
+      };
+
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    python3
+    glib
+    xorg.libX11
+    xorg.libXext
+    xorg.libxcb
+    numactl
+    nss
+    atk
+    at-spi2-atk
+    cups
+    dbus
+    libdrm
+    gtk3
+    pango
+    cairo
+    gdk-pixbuf
+    libXcomposite
+    libXdamage
+    libXfixes
+    libXrandr
+    mesa
+    expat
+    libxkbcommon
+    alsa-lib
+    at-spi2-core
+    autoPatchelfHook
+    cups
+    libdrm
+    libuuid
+    libXdamage
+    libX11
+    libXScrnSaver
+    libXtst
+    libxcb
+    libxshmfence
+    mesa
+    nss
+    makeShellWrapper
+  ];
+
+  libPath = lib.makeLibraryPath ([
+    libcxx
+    systemd
+    libpulseaudio
+    libdrm
+    mesa
+    stdenv.cc.cc
+    alsa-lib
+    atk
+    at-spi2-atk
+    at-spi2-core
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    gtk3
+    libglvnd
+    libnotify
+    libX11
+    libXcomposite
+    libunity
+    libuuid
+    libXcursor
+    libXdamage
+    libXext
+    libXfixes
+    libXi
+    libXrandr
+    libXrender
+    libXtst
+    nspr
+    libxcb
+    pango
+    libXScrnSaver
+    libappindicator-gtk3
+    libdbusmenu
+    wayland
+  ]);
+
+  unpackPhase = "dpkg-deb -R $src .";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    mv opt $out/opt
+    mv usr/share $out/share
+    chmod +x $out/opt/chia/chia-blockchain
+    patchelf --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
+        $out/opt/chia/chia-blockchain
+    wrapProgramShell $out/opt/chia/chia-blockchain \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-features=WaylandWindowDecorations}}" \
+        --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
+        --prefix LD_LIBRARY_PATH : ${libPath}:$out/opt/chia
+    ln -s $out/opt/chia/chia-blockchain $out/bin/chia-desktop
+    runHook postInstall
+  '';
+
+  outputs = [ "out" ];
+
+  meta = {
+    description = "A blockchain and smart transaction platform that allows users to build decentralized applications.";
+    homepage = "https://www.chia.net/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ abueide ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

#270254 related, chia is difficult to build & maintain from source for nix, so here is a package using the github binaries. Followed the discord package for inspiration. Will follow up soon with a chia-cli-bin & system service module for headless users, this package contains the desktop application. 

@bbjubjub2494 @mfrischknecht @delroth maybe be interested for review / comment

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
