### PR TITLE
open-scq30: init at 1.10.6

### DIFF
--- a/pkgs/by-name/op/open-scq30/package.nix
+++ b/pkgs/by-name/op/open-scq30/package.nix
@@ -1,0 +1,74 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, protobuf
+, wrapGAppsHook4
+, cairo
+, dbus
+, gdk-pixbuf
+, glib
+, gtk4
+, libadwaita
+, pango
+, stdenv
+, darwin
+, cargo-make
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "open-scq30";
+  version = "1.10.6";
+
+  src = fetchFromGitHub {
+    owner = "Oppzippy";
+    repo = "OpenSCQ30";
+    rev = "v${version}";
+    hash = "sha256-qYWLf0ns4YSq+yAspVTMvKQi861iUMJar2wjqm+BV/0=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    protobuf
+    wrapGAppsHook4
+    cargo-make
+  ];
+
+  buildInputs = [
+    cairo
+    dbus
+    gdk-pixbuf
+    glib
+    gtk4
+    libadwaita
+    pango
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.AppKit
+    darwin.apple_sdk.frameworks.CoreGraphics
+    darwin.apple_sdk.frameworks.Foundation
+  ];
+
+  cargoHash = "sha256-BQLNm+yyimBh7WomrccdQ2lvrQzCNXf4MEa1LlPhck0=";
+
+  INSTALL_PREFIX = placeholder "out";
+
+  # Requires headphones
+  doCheck = false;
+
+  buildPhase = ''
+    cargo make --profile release build
+  '';
+
+  installPhase = ''
+    cargo make --profile release install
+  '';
+
+  meta = with lib; {
+    description = "Cross platform application for controlling settings of Soundcore headphones.";
+    homepage = "https://github.com/Oppzippy/OpenSCQ30";
+    changelog = "https://github.com/Oppzippy/OpenSCQ30/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ mkg20001 ];
+    mainProgram = "open-scq30";
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
