### PR TITLE
buildLuarocksPackage: accept structured luarocks config

### DIFF
--- a/doc/languages-frameworks/lua.section.md
+++ b/doc/languages-frameworks/lua.section.md
@@ -215,6 +215,11 @@ install the package
   environment variable and add dependent libraries to script's `LUA_PATH` and
   `LUA_CPATH`.
 
+It accepts as arguments:
+
+* 'luarocksConfig': a nix value that directly maps to the luarocks config used during
+  the installation
+
 By default `meta.platforms` is set to the same value as the interpreter unless overridden otherwise.
 
 #### `buildLuaApplication` function {#buildluaapplication-function}

--- a/pkgs/development/interpreters/lua-5/build-luarocks-package.nix
+++ b/pkgs/development/interpreters/lua-5/build-luarocks-package.nix
@@ -51,9 +51,10 @@
 
 # Appended to the generated luarocks config
 , extraConfig ? ""
-# Inserted into the generated luarocks config in the "variables" table
-, extraVariables ? {}
-# The two above arguments have access to builder variables -- e.g. to $out
+
+# transparent mapping nix <-> lua used as LUAROCKS_CONFIG
+# Refer to https://github.com/luarocks/luarocks/wiki/Config-file-format for specs
+, luarocksConfig ? {}
 
 # relative to srcRoot, path to the rockspec to use when using rocks
 , rockspecFilename ? null
@@ -92,7 +93,7 @@ let
     luarocks
   ];
 
-  inherit doCheck extraConfig extraVariables rockspecFilename knownRockspec externalDeps nativeCheckInputs;
+  inherit doCheck extraConfig rockspecFilename knownRockspec externalDeps nativeCheckInputs;
 
   buildInputs = let
     # example externalDeps': [ { name = "CRYPTO"; dep = pkgs.openssl; } ]
@@ -116,9 +117,18 @@ let
     text = self.luarocks_content;
   };
 
-  luarocks_content = let
-      externalDepsGenerated = lib.filter (drv: !drv ? luaModule)
-        (self.nativeBuildInputs ++ self.propagatedBuildInputs ++ self.buildInputs);
+  luarocks_content =
+      (lib.generators.toLua { asBindings = true; } self.luarocksConfig) +
+      ''
+
+      ${self.extraConfig}
+      '';
+
+  # TODO make it the default variable
+  luarocksConfig = let
+    externalDepsGenerated = lib.filter (drv: !drv ? luaModule)
+      (self.nativeBuildInputs ++ self.propagatedBuildInputs ++ self.buildInputs);
+
     generatedConfig = luaLib.generateLuarocksConfig {
       externalDeps = lib.unique (self.externalDeps ++ externalDepsGenerated);
       # Filter out the lua derivation itself from the Lua module dependency
@@ -126,13 +136,17 @@ let
       # luaLib.hasLuaModule
       requiredLuaRocks = lib.filter luaLib.hasLuaModule
         (lua.pkgs.requiredLuaModules (self.nativeBuildInputs ++ self.propagatedBuildInputs));
-      inherit (self) extraVariables rocksSubdir;
+      inherit (self) rocksSubdir;
     };
-    in
-      ''
-      ${generatedConfig}
-      ${self.extraConfig}
-      '';
+
+    luarocksConfig' = lib.recursiveUpdate luarocksConfig
+      (lib.optionalAttrs (attrs ? extraVariables) (lib.warn "extraVariables in buildLuarocksPackage is deprecated, use luarocksConfig instead"
+      {
+        variables = attrs.extraVariables;
+      }))
+    ;
+  in lib.recursiveUpdate generatedConfig luarocksConfig';
+
 
   configurePhase = ''
     runHook preConfigure

--- a/pkgs/development/lua-modules/nfd/default.nix
+++ b/pkgs/development/lua-modules/nfd/default.nix
@@ -22,7 +22,7 @@ buildLuarocksPackage {
   ];
   knownRockspec = "lua/nfd-scm-1.rockspec";
 
-  extraVariables.LUA_LIBDIR = "${lua}/lib";
+  luarocksConfig.LUA_LIBDIR = "${lua}/lib";
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = lib.optionals stdenv.isDarwin [ AppKit ];

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -164,7 +164,7 @@ with prev;
   });
 
   ldbus = prev.ldbus.overrideAttrs (oa: {
-    extraVariables = {
+    luarocksConfig.variables = {
       DBUS_DIR = "${dbus.lib}";
       DBUS_ARCH_INCDIR = "${dbus.lib}/lib/dbus-1.0/include";
       DBUS_INCDIR = "${dbus.dev}/include/dbus-1.0";
@@ -309,7 +309,7 @@ with prev;
   });
 
   luadbi-mysql = prev.luadbi-mysql.overrideAttrs (oa: {
-    extraVariables = {
+    luarocksConfig.variables = {
       # Can't just be /include and /lib, unfortunately needs the trailing 'mysql'
       MYSQL_INCDIR = "${libmysqlclient.dev}/include/mysql";
       MYSQL_LIBDIR = "${libmysqlclient}/lib/mysql";
@@ -520,7 +520,7 @@ with prev;
     buildInputs = [ libuv ];
 
     # Use system libuv instead of building local and statically linking
-    extraVariables = {
+    luarocksConfig.variables = {
       WITH_SHARED_LIBUV = "ON";
     };
 
@@ -573,6 +573,7 @@ with prev;
     '';
   });
 
+  # upstream broken, can't be generated, so moved out from the generated set
   readline = final.callPackage({ buildLuarocksPackage, fetchurl, luaAtLeast, luaOlder, lua, luaposix }:
   buildLuarocksPackage ({
     pname = "readline";
@@ -588,7 +589,7 @@ with prev;
       sha256 = "1mk9algpsvyqwhnq7jlw4cgmfzj30l7n2r6ak4qxgdxgc39f48k4";
     };
 
-    extraVariables = rec {
+    luarocksConfig.variables = rec {
       READLINE_INCDIR = "${readline.dev}/include";
       HISTORY_INCDIR = READLINE_INCDIR;
     };
@@ -597,7 +598,6 @@ with prev;
       tar xf *.tar.gz
     '';
 
-    disabled = (luaOlder "5.1") || (luaAtLeast "5.5");
     propagatedBuildInputs = [ lua luaposix
       readline.out
     ];
@@ -606,6 +606,7 @@ with prev;
       homepage = "http://pjb.com.au/comp/lua/readline.html";
       description = "Interface to the readline library";
       license.fullName = "MIT/X11";
+      broken = (luaOlder "5.1") || (luaAtLeast "5.5");
     };
   })) {};
 


### PR DESCRIPTION
There is an arbitrary mapping being done right now between nixpkgs lua infrastructre and luarocks config schema. This is confusing if you use lua so let's make it possible to use the lua names in the nixpkgs, thanks to the lib.generators.toLua convertor.

The only nixpkgs thing to remember should be to put the config into `luarocksConfig`

`buildLuarocksPackage.extraVariables` should become `buildLuarocksPackage.luarocksConfig.variables`


## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
