### PR TITLE
nixos/navidrome: add user/group options, ensure dirs exist/are valid & format changes

### DIFF
--- a/nixos/modules/services/audio/navidrome.nix
+++ b/nixos/modules/services/audio/navidrome.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  inherit (lib) mkEnableOption mkPackageOption mkOption;
+  inherit (lib) mkEnableOption mkPackageOption mkOption maintainers;
   inherit (lib.types) bool str;
   cfg = config.services.navidrome;
   settingsFormat = pkgs.formats.json { };
@@ -134,4 +134,5 @@ in
 
       networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.settings.Port ];
     };
+    meta.maintainers = with maintainers; [ nu-nu-ko ];
 }

--- a/nixos/modules/services/audio/navidrome.nix
+++ b/nixos/modules/services/audio/navidrome.nix
@@ -1,11 +1,22 @@
-{ config, lib, pkgs, ... }:
-
-with lib;
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    recursiveUpdate
+    ;
+  inherit (lib.types) bool;
   cfg = config.services.navidrome;
-  settingsFormat = pkgs.formats.json {};
-in {
+  settingsFormat = pkgs.formats.json { };
+in
+{
   options = {
     services.navidrome = {
 
@@ -23,62 +34,72 @@ in {
         example = {
           MusicFolder = "/mnt/music";
         };
-        description = ''
-          Configuration for Navidrome, see <https://www.navidrome.org/docs/usage/configuration-options/> for supported values.
-        '';
+        description = "Configuration for Navidrome, see <https://www.navidrome.org/docs/usage/configuration-options/> for supported values.";
       };
 
       openFirewall = mkOption {
-        type = types.bool;
+        type = bool;
         default = false;
         description = "Whether to open the TCP port in the firewall";
       };
     };
   };
 
-  config = mkIf cfg.enable {
-    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [cfg.settings.Port];
-
-    systemd.services.navidrome = {
-      description = "Navidrome Media Server";
-      after = [ "network.target" ];
-      wantedBy = [ "multi-user.target" ];
-      serviceConfig = {
-        ExecStart = ''
-          ${cfg.package}/bin/navidrome --configfile ${settingsFormat.generate "navidrome.json" cfg.settings}
-        '';
-        DynamicUser = true;
-        StateDirectory = "navidrome";
-        WorkingDirectory = "/var/lib/navidrome";
-        RuntimeDirectory = "navidrome";
-        RootDirectory = "/run/navidrome";
-        ReadWritePaths = "";
-        BindPaths = lib.optional (cfg.settings ? DataFolder) cfg.settings.DataFolder;
-        BindReadOnlyPaths = [
-          # navidrome uses online services to download additional album metadata / covers
-          "${config.environment.etc."ssl/certs/ca-certificates.crt".source}:/etc/ssl/certs/ca-certificates.crt"
-          builtins.storeDir
-          "/etc"
-        ] ++ lib.optional (cfg.settings ? MusicFolder) cfg.settings.MusicFolder;
-        CapabilityBoundingSet = "";
-        RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" ];
-        RestrictNamespaces = true;
-        PrivateDevices = true;
-        PrivateUsers = true;
-        ProtectClock = true;
-        ProtectControlGroups = true;
-        ProtectHome = true;
-        ProtectKernelLogs = true;
-        ProtectKernelModules = true;
-        ProtectKernelTunables = true;
-        SystemCallArchitectures = "native";
-        SystemCallFilter = [ "@system-service" "~@privileged" ];
-        RestrictRealtime = true;
-        LockPersonality = true;
-        MemoryDenyWriteExecute = true;
-        UMask = "0066";
-        ProtectHostname = true;
+  config =
+    let
+      inherit (lib) mkIf optional;
+    in
+    mkIf cfg.enable {
+      systemd.services.navidrome = {
+        description = "Navidrome Media Server";
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          ExecStart = ''
+            ${cfg.package}/bin/navidrome --configfile ${settingsFormat.generate "navidrome.json" cfg.settings}
+          '';
+          DynamicUser = true;
+          StateDirectory = "navidrome";
+          WorkingDirectory = "/var/lib/navidrome";
+          RuntimeDirectory = "navidrome";
+          RootDirectory = "/run/navidrome";
+          ReadWritePaths = "";
+          BindPaths = optional (cfg.settings ? DataFolder) cfg.settings.DataFolder;
+          BindReadOnlyPaths = [
+            # navidrome uses online services to download additional album metadata / covers
+            "${
+              config.environment.etc."ssl/certs/ca-certificates.crt".source
+            }:/etc/ssl/certs/ca-certificates.crt"
+            builtins.storeDir
+            "/etc"
+          ] ++ optional (cfg.settings ? MusicFolder) cfg.settings.MusicFolder;
+          CapabilityBoundingSet = "";
+          RestrictAddressFamilies = [
+            "AF_UNIX"
+            "AF_INET"
+            "AF_INET6"
+          ];
+          RestrictNamespaces = true;
+          PrivateDevices = true;
+          PrivateUsers = true;
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          SystemCallArchitectures = "native";
+          SystemCallFilter = [
+            "@system-service"
+            "~@privileged"
+          ];
+          RestrictRealtime = true;
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          UMask = "0066";
+          ProtectHostname = true;
+        };
       };
+      networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.settings.Port ];
     };
-  };
 }

--- a/nixos/modules/services/audio/navidrome.nix
+++ b/nixos/modules/services/audio/navidrome.nix
@@ -6,11 +6,7 @@
 }:
 
 let
-  inherit (lib)
-    mkEnableOption
-    mkPackageOption
-    mkOption
-    ;
+  inherit (lib) mkEnableOption mkPackageOption mkOption;
   inherit (lib.types) bool str;
   cfg = config.services.navidrome;
   settingsFormat = pkgs.formats.json { };
@@ -58,57 +54,72 @@ in
   config =
     let
       inherit (lib) mkIf optional getExe;
+      WorkingDirectory = "/var/lib/navidrome";
     in
     mkIf cfg.enable {
-      systemd.services.navidrome = {
-        description = "Navidrome Media Server";
-        after = [ "network.target" ];
-        wantedBy = [ "multi-user.target" ];
-        serviceConfig = {
-          ExecStart = ''
-            ${getExe cfg.package} --configfile ${settingsFormat.generate "navidrome.json" cfg.settings}
-          '';
-          User = cfg.user;
-          Group = cfg.group;
-          StateDirectory = "navidrome";
-          WorkingDirectory = "/var/lib/navidrome";
-          RuntimeDirectory = "navidrome";
-          RootDirectory = "/run/navidrome";
-          ReadWritePaths = "";
-          BindPaths = optional (cfg.settings ? DataFolder) cfg.settings.DataFolder;
-          BindReadOnlyPaths = [
-            # navidrome uses online services to download additional album metadata / covers
-            "${
-              config.environment.etc."ssl/certs/ca-certificates.crt".source
-            }:/etc/ssl/certs/ca-certificates.crt"
-            builtins.storeDir
-            "/etc"
-          ] ++ optional (cfg.settings ? MusicFolder) cfg.settings.MusicFolder;
-          CapabilityBoundingSet = "";
-          RestrictAddressFamilies = [
-            "AF_UNIX"
-            "AF_INET"
-            "AF_INET6"
-          ];
-          RestrictNamespaces = true;
-          PrivateDevices = true;
-          PrivateUsers = true;
-          ProtectClock = true;
-          ProtectControlGroups = true;
-          ProtectHome = true;
-          ProtectKernelLogs = true;
-          ProtectKernelModules = true;
-          ProtectKernelTunables = true;
-          SystemCallArchitectures = "native";
-          SystemCallFilter = [
-            "@system-service"
-            "~@privileged"
-          ];
-          RestrictRealtime = true;
-          LockPersonality = true;
-          MemoryDenyWriteExecute = true;
-          UMask = "0066";
-          ProtectHostname = true;
+      systemd = {
+        tmpfiles.settings.navidromeDirs = {
+          "${cfg.settings.DataFolder or WorkingDirectory}"."d" = {
+            mode = "700";
+            inherit (cfg) user group;
+          };
+          "${cfg.settings.CacheFolder or (WorkingDirectory + "/cache")}"."d" = {
+            mode = "700";
+            inherit (cfg) user group;
+          };
+        };
+        services.navidrome = {
+          description = "Navidrome Media Server";
+          after = [ "network.target" ];
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig = {
+            ExecStart = ''
+              ${getExe cfg.package} --configfile ${settingsFormat.generate "navidrome.json" cfg.settings}
+            '';
+            User = cfg.user;
+            Group = cfg.group;
+            StateDirectory = "navidrome";
+            inherit WorkingDirectory;
+            RuntimeDirectory = "navidrome";
+            RootDirectory = "/run/navidrome";
+            ReadWritePaths = "";
+            BindPaths =
+              optional (cfg.settings ? DataFolder) cfg.settings.DataFolder
+              ++ optional (cfg.settings ? CacheFolder) cfg.settings.CacheFolder;
+            BindReadOnlyPaths = [
+              # navidrome uses online services to download additional album metadata / covers
+              "${
+                config.environment.etc."ssl/certs/ca-certificates.crt".source
+              }:/etc/ssl/certs/ca-certificates.crt"
+              builtins.storeDir
+              "/etc"
+            ] ++ optional (cfg.settings ? MusicFolder) cfg.settings.MusicFolder;
+            CapabilityBoundingSet = "";
+            RestrictAddressFamilies = [
+              "AF_UNIX"
+              "AF_INET"
+              "AF_INET6"
+            ];
+            RestrictNamespaces = true;
+            PrivateDevices = true;
+            PrivateUsers = true;
+            ProtectClock = true;
+            ProtectControlGroups = true;
+            ProtectHome = true;
+            ProtectKernelLogs = true;
+            ProtectKernelModules = true;
+            ProtectKernelTunables = true;
+            SystemCallArchitectures = "native";
+            SystemCallFilter = [
+              "@system-service"
+              "~@privileged"
+            ];
+            RestrictRealtime = true;
+            LockPersonality = true;
+            MemoryDenyWriteExecute = true;
+            UMask = "0066";
+            ProtectHostname = true;
+          };
         };
       };
 

--- a/nixos/modules/services/audio/navidrome.nix
+++ b/nixos/modules/services/audio/navidrome.nix
@@ -59,7 +59,7 @@ in
 
   config =
     let
-      inherit (lib) mkIf optional;
+      inherit (lib) mkIf optional getExe;
     in
     mkIf cfg.enable {
       systemd.services.navidrome = {
@@ -68,7 +68,7 @@ in
         wantedBy = [ "multi-user.target" ];
         serviceConfig = {
           ExecStart = ''
-            ${cfg.package}/bin/navidrome --configfile ${settingsFormat.generate "navidrome.json" cfg.settings}
+            ${getExe cfg.package} --configfile ${settingsFormat.generate "navidrome.json" cfg.settings}
           '';
           User = cfg.user;
           Group = cfg.group;

--- a/nixos/modules/services/audio/navidrome.nix
+++ b/nixos/modules/services/audio/navidrome.nix
@@ -10,7 +10,6 @@ let
     mkEnableOption
     mkPackageOption
     mkOption
-    recursiveUpdate
     ;
   inherit (lib.types) bool str;
   cfg = config.services.navidrome;
@@ -24,9 +23,8 @@ in
 
       package = mkPackageOption pkgs "navidrome" { };
 
-      settings = mkOption rec {
+      settings = mkOption {
         type = settingsFormat.type;
-        apply = recursiveUpdate default;
         default = {
           Address = "127.0.0.1";
           Port = 4533;

--- a/pkgs/by-name/na/navidrome/package.nix
+++ b/pkgs/by-name/na/navidrome/package.nix
@@ -10,7 +10,6 @@
 , ffmpeg-headless
 , taglib
 , zlib
-, makeWrapper
 , nixosTests
 , nix-update-script
 , ffmpegSupport ? true

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40958,8 +40958,6 @@ with pkgs;
 
   gpio-utils = callPackage ../os-specific/linux/kernel/gpio-utils.nix { };
 
-  navidrome = callPackage ../servers/misc/navidrome { };
-
   zalgo = callPackage ../tools/misc/zalgo { };
 
   inherit (callPackage ../applications/misc/zettlr { }) zettlr;


### PR DESCRIPTION
## Description of changes
### module
add user and group options
ensure data and cache paths exist with valid permissions
removed `apply` part of the `settings` option.
remove top level `with lib;`
remove `lib.mdDoc`
use `lib.getExe`
added myself to maintainers.
### package
add `meta.mainProgram` as "navidrome"
move from `/pkgs/servers/misc/navidrome/default.nix` to `/pkgs/by-name/na/navidrome/package.nix`

I'd appreciate testing from at least a couple people already using the module before this is merged, thank you.

personally I tested that default dirs and specified dirs were made appropriately, but this was with new data each time so I'm not 100% confident that this wont break existing uses. 


## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
