### PR TITLE
[23.11] starsector: backport multiple fixes

### DIFF
--- a/pkgs/games/starsector/default.nix
+++ b/pkgs/games/starsector/default.nix
@@ -1,6 +1,5 @@
 { lib
 , fetchzip
-, libXxf86vm
 , libGL
 , makeWrapper
 , openal
@@ -48,7 +47,8 @@ stdenv.mkDerivation rec {
     cp -r ./* $out/share/starsector
 
     mkdir -p $out/share/icons/hicolor/64x64/apps
-    ln -s $out/graphics/ui/s_icon64.png $out/share/icons/hicolor/64x64/apps/starsector.png
+    ln -s $out/share/starsector/graphics/ui/s_icon64.png \
+      $out/share/icons/hicolor/64x64/apps/starsector.png
 
     wrapProgram $out/share/starsector/starsector.sh \
       --prefix PATH : ${lib.makeBinPath [ openjdk xorg.xrandr ]} \
@@ -71,14 +71,6 @@ stdenv.mkDerivation rec {
       --replace "-XX:+CompilerThreadHintNoPreempt" "-XX:+UnlockDiagnosticVMOptions -XX:-BytecodeVerificationRemote -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSConcurrentMTEnabled -XX:+DisableExplicitGC"
   '';
 
-  meta = with lib; {
-    description = "Open-world single-player space-combat, roleplaying, exploration, and economic game";
-    homepage = "https://fractalsoftworks.com";
-    sourceProvenance = with sourceTypes; [ binaryBytecode ];
-    license = licenses.unfree;
-    maintainers = with maintainers; [ bbigras rafaelrc ];
-  };
-
   passthru.updateScript = writeScript "starsector-update-script" ''
     #!/usr/bin/env nix-shell
     #!nix-shell -i bash -p curl gnugrep common-updater-scripts
@@ -86,4 +78,12 @@ stdenv.mkDerivation rec {
     version=$(curl -s https://fractalsoftworks.com/preorder/ | grep -oP "https://f005.backblazeb2.com/file/fractalsoftworks/release/starsector_linux-\K.*?(?=\.zip)" | head -1)
     update-source-version ${pname} "$version" --file=./pkgs/games/starsector/default.nix
   '';
+
+  meta = with lib; {
+    description = "Open-world single-player space-combat, roleplaying, exploration, and economic game";
+    homepage = "https://fractalsoftworks.com";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
+    license = licenses.unfree;
+    maintainers = with maintainers; [ bbigras rafaelrc ];
+  };
 }

--- a/pkgs/games/starsector/default.nix
+++ b/pkgs/games/starsector/default.nix
@@ -1,6 +1,7 @@
 { lib
 , fetchzip
 , libXxf86vm
+, libGL
 , makeWrapper
 , openal
 , openjdk
@@ -21,7 +22,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ copyDesktopItems makeWrapper ];
-  buildInputs = [ xorg.libXxf86vm openal ];
+  buildInputs = [ xorg.libXxf86vm openal libGL ];
 
   dontBuild = true;
 

--- a/pkgs/games/starsector/default.nix
+++ b/pkgs/games/starsector/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     ln -s $out/graphics/ui/s_icon64.png $out/share/icons/hicolor/64x64/apps/starsector.png
 
     wrapProgram $out/share/starsector/starsector.sh \
-      --prefix PATH : ${lib.makeBinPath [ openjdk ]} \
+      --prefix PATH : ${lib.makeBinPath [ openjdk xorg.xrandr ]} \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath buildInputs} \
       --run 'mkdir -p ''${XDG_DATA_HOME:-~/.local/share}/starsector' \
       --chdir "$out/share/starsector"

--- a/pkgs/games/starsector/default.nix
+++ b/pkgs/games/starsector/default.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
     homepage = "https://fractalsoftworks.com";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfree;
-    maintainers = with maintainers; [ bbigras ];
+    maintainers = with maintainers; [ bbigras rafaelrc ];
   };
 
   passthru.updateScript = writeScript "starsector-update-script" ''


### PR DESCRIPTION
## Description of changes

This PR is a backport of multiple fixes done in the last few months to starsector:
- Add missing runtime dependency libGL ([d1eb5f6](https://github.com/NixOS/nixpkgs/commit/d1eb5f6a7ec047293d802aec87c0b8e8500e644d) from https://github.com/NixOS/nixpkgs/pull/271829) 
- Add missing runtime dependency xrandr ([0455be6](https://github.com/NixOS/nixpkgs/commit/0455be6eff01920fc47af19b858c252d61b42ac7) from https://github.com/NixOS/nixpkgs/pull/279063)
- Fix game icon ([9854d63](https://github.com/NixOS/nixpkgs/commit/9854d63ff8cb7b978cd4735cf19edd74aa81d988) from https://github.com/NixOS/nixpkgs/pull/216917)

Due to possible merge conflicts, the following commit has also been included:
- Add myself as maintainer ([f4e551f](https://github.com/NixOS/nixpkgs/commit/f4e551f1bedf44d8c51d2b95ed0c14b40bca88bc) from https://github.com/NixOS/nixpkgs/pull/279063)

This is my first backport PR, so if anything is wrong, please point it out.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
