### PR TITLE
Fix python3Packages.wavefile patch 

### DIFF
--- a/pkgs/development/python-modules/wavefile/libsndfile.py.patch
+++ b/pkgs/development/python-modules/wavefile/libsndfile.py.patch
@@ -1,18 +1,26 @@
 diff --git a/wavefile/libsndfile.py b/wavefile/libsndfile.py
-index 67f0a46..ce066ee 100644
+index 89c670f..fa19e1d 100644
 --- a/wavefile/libsndfile.py
 +++ b/wavefile/libsndfile.py
-@@ -19,11 +19,11 @@ import numpy as np
- if sys.platform == "win32":
-     dllName = 'libsndfile-1'
- elif "linux" in sys.platform:
--    dllName = 'libsndfile.so.1'
-+    dllName = '@libsndfile@'
- elif "cygwin" in sys.platform:
-     dllName = 'libsndfile-1.dll'
- elif "darwin" in sys.platform:
--    dllName = 'libsndfile.dylib'
-+    dllName = '@libsndfile@'
- else:
-     dllName = 'libsndfile'
+@@ -17,20 +17,7 @@ import ctypes as ct
+ import numpy as np
  
+ def _libfilename():
+-    for system, libname in [
+-        ('win32', 'libsndfile-1'),
+-        ('cygwin', 'libsndfile-1.dll'),
+-        ('darwin', 'libsndfile.dylib'),
+-        ('linux', 'libsndfile.so.1'),
+-        ('freebsd', 'libsndfile.so.1'),
+-        ('', 'libsndfile'),
+-    ]:
+-        if system in sys.platform:
+-            return libname
+-    raise Exception(
+-        'No libsndfile dll name mapping for platform {}.'
+-        .format(sys.platform)
+-    )
++    return "@libsndfile@"
+ 
+ dllName = _libfilename()
+ _lib=None


### PR DESCRIPTION
## Description of changes

Changed the patch to build against new source code (v 1.6.2).

## Things done
Patch file

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
