### PR TITLE
links2: fix darwin build

### DIFF
--- a/pkgs/applications/networking/browsers/links2/default.nix
+++ b/pkgs/applications/networking/browsers/links2/default.nix
@@ -1,23 +1,23 @@
 { lib, stdenv, fetchurl
 , gpm, openssl, pkg-config, libev # Misc.
-, libpng, libjpeg, libtiff, librsvg # graphic formats
+, libpng, libjpeg, libtiff, librsvg, libavif # graphic formats
 , bzip2, zlib, xz # Transfer encodings
-, enableFB ? true
+, enableFB ? (!stdenv.isDarwin)
 , enableDirectFB ? false, directfb
-, enableX11 ? true, libX11, libXt, libXau # GUI support
+, enableX11 ? (!stdenv.isDarwin), libX11, libXt, libXau # GUI support
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "2.29";
   pname = "links2";
 
   src = fetchurl {
-    url = "${meta.homepage}/download/links-${version}.tar.bz2";
-    sha256 = "sha256-IqqWwLOOGm+PftnXpBZ6R/w3JGCXdZ72BZ7Pj56teZg=";
+    url = "${finalAttrs.meta.homepage}/download/links-${finalAttrs.version}.tar.bz2";
+    hash = "sha256-IqqWwLOOGm+PftnXpBZ6R/w3JGCXdZ72BZ7Pj56teZg=";
   };
 
   buildInputs = with lib;
-    [ libev librsvg libpng libjpeg libtiff openssl xz bzip2 zlib ]
+    [ libev librsvg libpng libjpeg libtiff libavif openssl xz bzip2 zlib ]
     ++ optionals stdenv.isLinux [ gpm ]
     ++ optionals enableX11 [ libX11 libXau libXt ]
     ++ optionals enableDirectFB [ directfb ];
@@ -30,6 +30,10 @@ stdenv.mkDerivation rec {
     ++ lib.optional enableFB "--with-fb"
     ++ lib.optional enableDirectFB "--with-directfb";
 
+  env = lib.optionalAttrs stdenv.cc.isClang {
+    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-int";
+  };
+
   meta = with lib; {
     homepage = "http://links.twibright.com/";
     description = "A small browser with some graphics support";
@@ -38,4 +42,4 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* Modernize package by using `finalAttrs` instead of `rec` and `hash` instead of `sha256`
* Disable `implicit-int` warning to fix failing configurePhase thinking compiler is unable to produce binaries due to `implicit int` being disallowed in C99 and above.
* Add `libavif` to `buildInputs` to fix failing configurePhase due to avif.h header not being found
* Disable graphics on Darwin to fix failing configurePhase due to graphics drivers not being found

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
