### PR TITLE
ocamlPackages.ninja_utils: init at 0.9.0

### DIFF
--- a/pkgs/development/ocaml-modules/ninja_utils/default.nix
+++ b/pkgs/development/ocaml-modules/ninja_utils/default.nix
@@ -1,0 +1,20 @@
+{ lib, fetchurl, buildDunePackage, re }:
+
+buildDunePackage rec {
+  pname = "ninja_utils";
+  version = "0.9.0";
+
+  src = fetchurl {
+    url = "https://github.com/CatalaLang/ninja_utils/archive/refs/tags/${version}.tar.gz";
+    hash = "sha256-ZYxSrTA6BUN3OEDq4sLv9bMAgsL6z97GpGFG5w96OvY=";
+  };
+
+  propagatedBuildInputs = [ re ];
+
+  meta = {
+    description = "Small library used to generate Ninja build files";
+    homepage = "https://github.com/CatalaLang/ninja_utils";
+    license = lib.licenses.asl20;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/development/ocaml-modules/ninja_utils/default.nix
+++ b/pkgs/development/ocaml-modules/ninja_utils/default.nix
@@ -4,6 +4,8 @@ buildDunePackage rec {
   pname = "ninja_utils";
   version = "0.9.0";
 
+  minimalOCamlVersion = "4.12";
+
   src = fetchzip {
     url = "https://github.com/CatalaLang/ninja_utils/archive/refs/tags/${version}.tar.gz";
     hash = "sha256-VSj1IXfczoI3lSAtOqQPIqsxX+HgyxKzlssKd7By/Lo=";

--- a/pkgs/development/ocaml-modules/ninja_utils/default.nix
+++ b/pkgs/development/ocaml-modules/ninja_utils/default.nix
@@ -1,12 +1,12 @@
-{ lib, fetchurl, buildDunePackage, re }:
+{ lib, fetchzip, buildDunePackage, re }:
 
 buildDunePackage rec {
   pname = "ninja_utils";
   version = "0.9.0";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "https://github.com/CatalaLang/ninja_utils/archive/refs/tags/${version}.tar.gz";
-    hash = "sha256-ZYxSrTA6BUN3OEDq4sLv9bMAgsL6z97GpGFG5w96OvY=";
+    hash = "sha256-VSj1IXfczoI3lSAtOqQPIqsxX+HgyxKzlssKd7By/Lo=";
   };
 
   propagatedBuildInputs = [ re ];

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1195,6 +1195,8 @@ let
 
     netchannel = callPackage ../development/ocaml-modules/netchannel { };
 
+    ninja_utils = callPackage ../development/ocaml-modules/ninja_utils { };
+
     nonstd =  callPackage ../development/ocaml-modules/nonstd { };
 
     note = callPackage ../development/ocaml-modules/note { };


### PR DESCRIPTION
## Description of changes

Add the OCaml ninja_utils package, a small OCaml Library used to generate [Ninja](https://ninja-build.org/) build files.

Homepage: https://github.com/CatalaLang/ninja_utils

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
