### PR TITLE
nixos/tests/etcd: enable aarch64-linux

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -290,8 +290,8 @@ in {
   activation-etc-overlay-mutable = runTest ./activation/etc-overlay-mutable.nix;
   activation-etc-overlay-immutable = runTest ./activation/etc-overlay-immutable.nix;
   activation-perlless = runTest ./activation/perlless.nix;
-  etcd = handleTestOn ["x86_64-linux"] ./etcd.nix {};
-  etcd-cluster = handleTestOn ["x86_64-linux"] ./etcd-cluster.nix {};
+  etcd = handleTestOn [ "aarch64-linux" "x86_64-linux" ] ./etcd/etcd.nix {};
+  etcd-cluster = handleTestOn [ "aarch64-linux" "x86_64-linux" ] ./etcd/etcd-cluster.nix {};
   etebase-server = handleTest ./etebase-server.nix {};
   etesync-dav = handleTest ./etesync-dav.nix {};
   evcc = handleTest ./evcc.nix {};

--- a/nixos/tests/etcd/etcd-cluster.nix
+++ b/nixos/tests/etcd/etcd-cluster.nix
@@ -1,6 +1,6 @@
 # This test runs simple etcd cluster
 
-import ./make-test-python.nix ({ pkgs, ... } : let
+import ../make-test-python.nix ({ pkgs, ... } : let
 
   runWithOpenSSL = file: cmd: pkgs.runCommand file {
     buildInputs = [ pkgs.openssl ];

--- a/nixos/tests/etcd/etcd.nix
+++ b/nixos/tests/etcd/etcd.nix
@@ -1,6 +1,6 @@
 # This test runs simple etcd node
 
-import ./make-test-python.nix ({ pkgs, ... } : {
+import ../make-test-python.nix ({ pkgs, ... } : {
   name = "etcd";
 
   meta = with pkgs.lib.maintainers; {


### PR DESCRIPTION
nixos/tests/etcd: enable aarch64-linux

* move etcd tests to it's own directory

CC @offline @endocrimes