### PR TITLE
nixos/systemd: Support notify-reload service Type

### DIFF
--- a/nixos/lib/systemd-unit-options.nix
+++ b/nixos/lib/systemd-unit-options.nix
@@ -6,7 +6,7 @@ with lib;
 let
   checkService = checkUnitConfig "Service" [
     (assertValueOneOf "Type" [
-      "exec" "simple" "forking" "oneshot" "dbus" "notify" "idle"
+      "exec" "simple" "forking" "oneshot" "dbus" "notify" "notify-reload" "idle"
     ])
     (assertValueOneOf "Restart" [
       "no" "on-success" "on-failure" "on-abnormal" "on-abort" "always"


### PR DESCRIPTION
## Description of changes

Support for this was added in systemd 253:
https://github.com/systemd/systemd/releases/tag/v253

But the NixOS module never started supporting it.

I discovered this in [Nix Hour 62](https://www.youtube.com/watch?v=TKAnQuqXVHo&list=PLyzwHTVJlRc8yjlx4VR4LU5A5O44og9in&index=1&pp=iAQB)

## Things done

Tested that `notify-reload` works correctly:

```nix
{ pkgs, config, ... }:
{

  # This file determines what the service prints,
  # changing the text just requires a reload of the service, not a restart!
  environment.etc.output.source =
    pkgs.writeText "output" "Hello Silvan!";

  systemd.services.myService = {
    serviceConfig.Type = "notify-reload";
    # Not necessary with notify-reload and the systemd-notify below!
    #serviceConfig.ExecReload = "${lib.getBin pkgs.coreutils}/bin/kill -HUP $MAINPID";
    reloadTriggers = [ config.environment.etc.output.source ];
    wantedBy = [ "multi-user.target" ];
    script = ''

      outputFile=$(mktemp)
      loadOutput() {
        echo "Loading output"
        cp -f /etc/output "$outputFile"
      }
      reloadOutput() {
        systemd-notify --reloading
        loadOutput
        systemd-notify --ready
      }
      loadOutput
      trap reloadOutput HUP

      trap 'echo "Stopping"' EXIT
      echo "Starting"

      cat "$outputFile"
      systemd-notify --ready
      while true; do
        sleep 5
        cat "$outputFile"
      done
    '';
  };

}
```

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
