### PR TITLE
inochi-creator: init at 0.8.4, inochi-session: init at 0.8.3

### DIFF
--- a/pkgs/applications/misc/inochi2d/creator-dub-lock.json
+++ b/pkgs/applications/misc/inochi2d/creator-dub-lock.json
@@ -1,0 +1,148 @@
+{
+  "dependencies": {
+    "bcaa": {
+      "version": "0.0.8",
+      "sha256": "1v8qy98hjdgfsdx6zg9n09sfpfqsh57nbsn8phw82rssi0gysgsr"
+    },
+    "bindbc-loader": {
+      "version": "1.0.3",
+      "sha256": "0d688cwb2hjhfxc7l00cfh22prybsndk6j1hvlrf9nlzb46i4i1j"
+    },
+    "bindbc-sdl": {
+      "version": "1.1.3",
+      "sha256": "0yi472nv7pg1q1kk749w3mv1l2l6ch20k8kcc4l9jy3m2vwlpd88"
+    },
+    "dcv": {
+      "version": "0.3.0",
+      "sha256": "02fd7wig6i618r7l7alw0hfljbwjvq13fkyhwcpsdd7r5x2f7hyk"
+    },
+    "ddbus": {
+      "version": "3.0.0-beta.2",
+      "sha256": "01dgvlvwbhwz7822gp6z5xn6w3k51q09i6qzns2i4ixmjh45wscs"
+    },
+    "diet-ng": {
+      "version": "1.8.1",
+      "sha256": "0kh8haw712xkd3f07s5x5g12nmmkv0y1lk2cqh66298fc5mgj4sv"
+    },
+    "dportals": {
+      "version": "0.1.0",
+      "sha256": "11wxlp2y7s2mc98bxya7fmg0gc4yqlyg0bjsd1yxzr8fmsvf2zzh"
+    },
+    "dunit": {
+      "version": "1.0.16",
+      "sha256": "0p9g4h5qanbg6281x1068mdl5p7zvqig4zmmi72a2cay6dxnbvxb"
+    },
+    "dxml": {
+      "version": "0.4.4",
+      "sha256": "0p5vmkw29ksh5wdxz1ijms1wblq288pv15vnbl93z7q2vgnq995w"
+    },
+    "eventcore": {
+      "version": "0.9.29",
+      "sha256": "1993mibxqb4v7lbsq3kbfwxfpi0d1gzzmzvx6y01907aqz933isa"
+    },
+    "facetrack-d": {
+      "version": "0.7.8",
+      "sha256": "1414wvh0kn1rps5r16ir92sqfj8a7na1gd71ds81jkq8arkm17j0"
+    },
+    "fghj": {
+      "version": "1.0.2",
+      "sha256": "0c102pfbcb3kpr8hpq3qzlxfw460v202vg6hrfdzw5a8pygy4cxj"
+    },
+    "i18n-d": {
+      "version": "1.0.2",
+      "sha256": "1p33w5wh09ha132fsk0b37rjgzw6z3l0v64dixmkvnhhm1xy3b1g"
+    },
+    "i2d-imgui": {
+      "version": "0.8.0",
+      "sha256": "1xikjz5b9r4gml0j7z5k8x1n8h9qcixzsg8gpjlzr3dwis7m0cfw"
+    },
+    "i2d-opengl": {
+      "version": "1.0.0",
+      "sha256": "0137ifda4z6h7sa7ls9n3rpcd6344qsfpbcc0dl7wzyk0xa73912"
+    },
+    "imagefmt": {
+      "version": "2.1.2",
+      "sha256": "0dl7n4myxp1s3b32v2s975k76gs90wr2nw6ac5jq9hsgzhp1ix0h"
+    },
+    "inmath": {
+      "version": "1.0.6",
+      "sha256": "0kzk55ilbnl6qypjk60zwd5ibys5n47128hbbr0mbc7bpj9ppfg4"
+    },
+    "inochi2d": {
+      "version": "0.8.3",
+      "sha256": "1m9dalm6sb518yi9mbphq1fdax90fc5rmskah19l7slnplbhli4l"
+    },
+    "kra-d": {
+      "version": "0.5.5",
+      "sha256": "0dffmf084ykz19y084v936r3f74613d0jifj0wb3xibfcq9mwxqz"
+    },
+    "libasync": {
+      "version": "0.8.6",
+      "sha256": "0hhk5asfdccby8ky77a25qn7dfmfdmwyzkrg3zk064bicmgdwlnj"
+    },
+    "memutils": {
+      "version": "1.0.10",
+      "sha256": "0hm31birbw59sw1bi9syjhbcdgwwwyyx6r9jg7ar9i6a74cjr52c"
+    },
+    "mir-algorithm": {
+      "version": "3.22.0",
+      "sha256": "0pl1vwyyhr2hrxlj060khzhg33dkgyrzi3f5qqxz6xj3hcp7axxq"
+    },
+    "mir-core": {
+      "version": "1.7.0",
+      "sha256": "14k7y2r06pwzf29shymyjrk7l582bh181rc07bnwgjn3f84ayn62"
+    },
+    "mir-linux-kernel": {
+      "version": "1.0.1",
+      "sha256": "0adyjpcgd65z44iydnrrrpjwbvmrm08a3pkcriqi7npqylfysqn6"
+    },
+    "mir-random": {
+      "version": "2.2.19",
+      "sha256": "0ad9ahvyrv5h38aqwn3zvlrva3ikfq28dfhpg2lwwgm31ymzvqpb"
+    },
+    "openssl": {
+      "version": "3.3.3",
+      "sha256": "1fwhd5fkvgbqf3y8gwmrnd42kzi4k3mibpxijw5j82jxgfp1rzsf"
+    },
+    "openssl-static": {
+      "version": "1.0.3+3.0.8",
+      "sha256": "1z977ghlnczxky2q2gislfi68jnbp2zf4pifv8rzrcs0nx3va2jr"
+    },
+    "psd-d": {
+      "version": "0.6.3",
+      "sha256": "0qbwkvzgrvd6m67p14ari4iiajmhfi2x1id4da971qxiprfm1993"
+    },
+    "silly": {
+      "version": "1.1.1",
+      "sha256": "1l0mpnbz8h3ihjxvk5qwn6p6lwb75g259k7fjqasw0zp0c27bkjb"
+    },
+    "stdx-allocator": {
+      "version": "2.77.5",
+      "sha256": "1g8382wr49sjyar0jay8j7y2if7h1i87dhapkgxphnizp24d7kaj"
+    },
+    "taggedalgebraic": {
+      "version": "0.11.22",
+      "sha256": "1kc39sdnk2ybhrwxiwyw1mqcw0qzjr0vr54yvyp3gkkaad373k4r"
+    },
+    "tinyfiledialogs": {
+      "version": "0.10.1",
+      "sha256": "1k3gq9y7912x5b30h60nvlfdr61as1f187b8rsilkxliizcmbhfi"
+    },
+    "vibe-container": {
+      "version": "1.3.0",
+      "sha256": "02gdw7ma93fdvgx3fngmfjd074jh2rzm9qsxakr3zn81p6qnzair"
+    },
+    "vibe-core": {
+      "version": "2.8.2",
+      "sha256": "1g9l8hmjx4dzzwh7pqasc9s16zzbdfvciswbv0gnrvmjsb0pi9xr"
+    },
+    "vibe-d": {
+      "version": "0.9.8",
+      "sha256": "1gficgfzwswaxj9qlnca28c65gl7xq6q8y47qlf4m1gvkxj4ij2k"
+    },
+    "vmc-d": {
+      "version": "1.1.3",
+      "sha256": "0kkqihhzxdq0n46jk55g4yhhwrnw6b9d931yb5pblxcc342gckvm"
+    }
+  }
+}

--- a/pkgs/applications/misc/inochi2d/default.nix
+++ b/pkgs/applications/misc/inochi2d/default.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  substituteAll,
+  callPackage,
+}:
+
+# Note for maintainers:
+#
+# These packages are only allowed to be packaged under the the condition that we
+# - patch source/creator/config.d to not point to upstream's bug tracker
+# - use the "barebones" configuration to remove the mascot and logo from the build
+#
+# We have received permission by the owner to go ahead with the packaging, as we have met all the criteria
+# https://github.com/NixOS/nixpkgs/pull/288841#issuecomment-1950247467
+
+let
+  mkGeneric = builderArgs: callPackage ./generic.nix { inherit builderArgs; };
+in
+{
+  inochi-creator = mkGeneric rec {
+    pname = "inochi-creator";
+    appname = "Inochi Creator";
+    version = "0.8.4";
+
+    src = fetchFromGitHub {
+      owner = "Inochi2D";
+      repo = "inochi-creator";
+      rev = "v${version}";
+      hash = "sha256-wsB9KIZyot2Y+6QpQlIXRzv3cPCdwp2Q/ZfDizAKJc4=";
+    };
+
+    dubLock = ./creator-dub-lock.json;
+
+    patches = [
+      # Upstream asks that we change the bug tracker URL to not point to the upsteam bug tracker
+      (substituteAll {
+        src = ./support-url.patch;
+        assignees = "TomaSajt"; # should be a comma separated list of the github usernames of the maintainers
+      })
+      # Change how duplicate locales differentiate themselves (the store paths were too long)
+      ./translations.patch
+    ];
+
+    meta = {
+      # darwin has slightly different build steps
+      broken = stdenv.isDarwin;
+      changelog = "https://github.com/Inochi2D/inochi-creator/releases/tag/${src.rev}";
+      description = "An open source editor for the Inochi2D puppet format";
+    };
+  };
+
+  inochi-session = mkGeneric rec {
+    pname = "inochi-session";
+    appname = "Inochi Session";
+    version = "0.8.3";
+
+    src = fetchFromGitHub {
+      owner = "Inochi2D";
+      repo = "inochi-session";
+      rev = "v${version}";
+      hash = "sha256-yq/uMWEeydZun07/7hgUaAw3IruRqrDuGgbe5NzNYxw=";
+    };
+
+    dubLock = ./session-dub-lock.json;
+
+    preFixup = ''
+      patchelf $out/share/inochi-session/inochi-session --add-needed cimgui.so
+    '';
+
+    dontStrip = true; # symbol lookup error: undefined symbol: , version
+
+    meta = {
+      # darwin has slightly different build steps, aarch fails to build because of some lua related error
+      broken = stdenv.isDarwin || stdenv.isAarch64;
+      changelog = "https://github.com/Inochi2D/inochi-session/releases/tag/${src.rev}";
+      description = "An application that allows streaming with Inochi2D puppets";
+    };
+  };
+}

--- a/pkgs/applications/misc/inochi2d/generic.nix
+++ b/pkgs/applications/misc/inochi2d/generic.nix
@@ -1,0 +1,139 @@
+{
+  lib,
+  buildDubPackage,
+  fetchFromGitHub,
+  writeShellScriptBin,
+
+  cmake,
+  gettext,
+  copyDesktopItems,
+  makeDesktopItem,
+  makeWrapper,
+
+  dbus,
+  freetype,
+  SDL2,
+  gnome,
+
+  builderArgs,
+}:
+
+let
+  cimgui-src = fetchFromGitHub {
+    owner = "Inochi2D";
+    repo = "cimgui";
+    rev = "49bb5ce65f7d5eeab7861d8ffd5aa2a58ca8f08c";
+    hash = "sha256-XcnZbIjwq7vmYBnMAs+cEpJL8HB8wrL098FXGxC+diA=";
+    fetchSubmodules = true;
+  };
+
+  inherit (builderArgs)
+    pname
+    appname
+    version
+    dubLock
+    meta
+    ;
+in
+buildDubPackage (
+  builderArgs
+  // {
+    nativeBuildInputs = [
+      cmake # used for building `i2d-imgui`
+      gettext # used when generating translations
+      copyDesktopItems
+      makeWrapper
+
+      # A fake git implementation to be used by the `gitver` package
+      # It is a dependency of the main packages and the `inochi2d` dub dependency
+      # A side effect of this script is that `inochi2d` will have the same version listed as the main package
+      (writeShellScriptBin "git" "echo v${version}")
+    ];
+
+    buildInputs = [
+      dbus
+      freetype
+      SDL2
+    ];
+
+    dontUseCmakeConfigure = true;
+
+    # these deps are not listed inside `dub.sdl`, so they didn't get auto-generated
+    # these are used for generating version info when building
+    dubLock = lib.recursiveUpdate (lib.importJSON dubLock) {
+      dependencies = {
+        gitver = {
+          version = "1.6.1";
+          sha256 = "sha256-NCyFik4FbD7yMLd5zwf/w4cHwhzLhIRSVw1bWo/CZB4=";
+        };
+        semver = {
+          version = "0.3.2";
+          sha256 = "sha256-l6c9hniUd5xNsJepq8x30e0JTjmXs4pYUmv4ws+Nrn4=";
+        };
+      };
+    };
+
+    postConfigure = ''
+      cimgui_dir=("$DUB_HOME"/packages/i2d-imgui/*/i2d-imgui)
+
+      # `i2d-imgui` isn't able to find SDL2 by default due to it being written in lower case
+      # this is only an issue when compiling statically (session)
+      substituteInPlace "$cimgui_dir/dub.json" \
+          --replace-fail '"sdl2"' '"SDL2"'
+
+      # The `i2d-cimgui` dub dependency fetched inside the auto-generated `*-deps.nix` file
+      # which doesn't know that it's actually a git repo, so it doesn't fetch its submodules.
+      # Upstream uses a cmake script to fetch the `cimgui` submodule anyway, which we can't do
+      # We get around this by manually pre-fetching the submodule and copying it into the right place
+      cp -r --no-preserve=all ${cimgui-src}/* "$cimgui_dir/deps/cimgui"
+
+      # Disable the original cmake fetcher script
+      substituteInPlace "$cimgui_dir/deps/CMakeLists.txt" \
+          --replace-fail "PullSubmodules(" "# PullSubmodules(" \
+          --replace-fail  "\''${cimgui_SUBMOD_DIR}" "cimgui"
+    '';
+
+    preBuild = ''
+      # Generate translations (if possible)
+      . gentl.sh
+
+      # Use the fake git to generate version info
+      dub build --skip-registry=all --compiler=ldc2 --build=release --config=meta
+    '';
+
+    # Use the "barebones" configuration so that we don't include the mascot and icon files in out build
+    dubFlags = [ "--config=barebones" ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/share/${pname}
+      cp -r out/* $out/share/${pname}
+
+      runHook postInstall
+    '';
+
+    desktopItems = [
+      (makeDesktopItem {
+        name = pname;
+        desktopName = appname;
+        exec = pname;
+        comment = meta.description;
+        categories = [ "Utility" ];
+      })
+    ];
+
+    postFixup = ''
+      # Add support for `open file` dialog
+      makeWrapper $out/share/${pname}/${pname} $out/bin/${pname} \
+          --prefix PATH : ${lib.makeBinPath [ gnome.zenity ]}
+    '';
+
+    meta = {
+      homepage = "https://inochi2d.com/";
+      license = lib.licenses.bsd2;
+      mainProgram = pname;
+      maintainers = with lib.maintainers; [ tomasajt ];
+    } // meta;
+  }
+)

--- a/pkgs/applications/misc/inochi2d/session-dub-lock.json
+++ b/pkgs/applications/misc/inochi2d/session-dub-lock.json
@@ -1,0 +1,140 @@
+{
+  "dependencies": {
+    "bindbc-loader": {
+      "version": "1.0.3",
+      "sha256": "0d688cwb2hjhfxc7l00cfh22prybsndk6j1hvlrf9nlzb46i4i1j"
+    },
+    "bindbc-lua": {
+      "version": "0.5.1",
+      "sha256": "116lcplxxl39x6m2sr9zkszdbrm1pa285sjqijnqxqy99jajnhc7"
+    },
+    "bindbc-sdl": {
+      "version": "1.1.3",
+      "sha256": "0yi472nv7pg1q1kk749w3mv1l2l6ch20k8kcc4l9jy3m2vwlpd88"
+    },
+    "bindbc-spout2": {
+      "version": "0.1.1",
+      "sha256": "03r4xsjpwys4nlfhas4hjqygzs764dzsr789b091iczp56pp9w9z"
+    },
+    "ddbus": {
+      "version": "3.0.0-beta.2",
+      "sha256": "01dgvlvwbhwz7822gp6z5xn6w3k51q09i6qzns2i4ixmjh45wscs"
+    },
+    "diet-ng": {
+      "version": "1.8.1",
+      "sha256": "0kh8haw712xkd3f07s5x5g12nmmkv0y1lk2cqh66298fc5mgj4sv"
+    },
+    "dportals": {
+      "version": "0.1.0",
+      "sha256": "11wxlp2y7s2mc98bxya7fmg0gc4yqlyg0bjsd1yxzr8fmsvf2zzh"
+    },
+    "dunit": {
+      "version": "1.0.16",
+      "sha256": "0p9g4h5qanbg6281x1068mdl5p7zvqig4zmmi72a2cay6dxnbvxb"
+    },
+    "eventcore": {
+      "version": "0.9.29",
+      "sha256": "1993mibxqb4v7lbsq3kbfwxfpi0d1gzzmzvx6y01907aqz933isa"
+    },
+    "facetrack-d": {
+      "version": "0.7.8",
+      "sha256": "1414wvh0kn1rps5r16ir92sqfj8a7na1gd71ds81jkq8arkm17j0"
+    },
+    "fghj": {
+      "version": "1.0.2",
+      "sha256": "0c102pfbcb3kpr8hpq3qzlxfw460v202vg6hrfdzw5a8pygy4cxj"
+    },
+    "i18n-d": {
+      "version": "1.0.2",
+      "sha256": "1p33w5wh09ha132fsk0b37rjgzw6z3l0v64dixmkvnhhm1xy3b1g"
+    },
+    "i2d-imgui": {
+      "version": "0.8.0",
+      "sha256": "1xikjz5b9r4gml0j7z5k8x1n8h9qcixzsg8gpjlzr3dwis7m0cfw"
+    },
+    "i2d-opengl": {
+      "version": "1.0.0",
+      "sha256": "0137ifda4z6h7sa7ls9n3rpcd6344qsfpbcc0dl7wzyk0xa73912"
+    },
+    "imagefmt": {
+      "version": "2.1.2",
+      "sha256": "0dl7n4myxp1s3b32v2s975k76gs90wr2nw6ac5jq9hsgzhp1ix0h"
+    },
+    "inmath": {
+      "version": "1.0.6",
+      "sha256": "0kzk55ilbnl6qypjk60zwd5ibys5n47128hbbr0mbc7bpj9ppfg4"
+    },
+    "inochi2d": {
+      "version": "0.8.3",
+      "sha256": "1m9dalm6sb518yi9mbphq1fdax90fc5rmskah19l7slnplbhli4l"
+    },
+    "inui": {
+      "version": "1.2.1",
+      "sha256": "0pygf8jxnbvib5f23qxf6k24wz8mh6fc0zhrkp83gq33k02ab5cx"
+    },
+    "libasync": {
+      "version": "0.8.6",
+      "sha256": "0hhk5asfdccby8ky77a25qn7dfmfdmwyzkrg3zk064bicmgdwlnj"
+    },
+    "lumars": {
+      "version": "1.6.1",
+      "sha256": "1vzdghqwv2gb41rp75456g43yfsndbl0dy6bnn4x6azwwny22br9"
+    },
+    "memutils": {
+      "version": "1.0.10",
+      "sha256": "0hm31birbw59sw1bi9syjhbcdgwwwyyx6r9jg7ar9i6a74cjr52c"
+    },
+    "mir-algorithm": {
+      "version": "3.22.0",
+      "sha256": "0pl1vwyyhr2hrxlj060khzhg33dkgyrzi3f5qqxz6xj3hcp7axxq"
+    },
+    "mir-core": {
+      "version": "1.7.0",
+      "sha256": "14k7y2r06pwzf29shymyjrk7l582bh181rc07bnwgjn3f84ayn62"
+    },
+    "mir-linux-kernel": {
+      "version": "1.0.1",
+      "sha256": "0adyjpcgd65z44iydnrrrpjwbvmrm08a3pkcriqi7npqylfysqn6"
+    },
+    "openssl": {
+      "version": "3.3.3",
+      "sha256": "1fwhd5fkvgbqf3y8gwmrnd42kzi4k3mibpxijw5j82jxgfp1rzsf"
+    },
+    "openssl-static": {
+      "version": "1.0.3+3.0.8",
+      "sha256": "1z977ghlnczxky2q2gislfi68jnbp2zf4pifv8rzrcs0nx3va2jr"
+    },
+    "silly": {
+      "version": "1.1.1",
+      "sha256": "1l0mpnbz8h3ihjxvk5qwn6p6lwb75g259k7fjqasw0zp0c27bkjb"
+    },
+    "stdx-allocator": {
+      "version": "2.77.5",
+      "sha256": "1g8382wr49sjyar0jay8j7y2if7h1i87dhapkgxphnizp24d7kaj"
+    },
+    "taggedalgebraic": {
+      "version": "0.11.22",
+      "sha256": "1kc39sdnk2ybhrwxiwyw1mqcw0qzjr0vr54yvyp3gkkaad373k4r"
+    },
+    "tinyfiledialogs": {
+      "version": "0.10.1",
+      "sha256": "1k3gq9y7912x5b30h60nvlfdr61as1f187b8rsilkxliizcmbhfi"
+    },
+    "vibe-container": {
+      "version": "1.3.0",
+      "sha256": "02gdw7ma93fdvgx3fngmfjd074jh2rzm9qsxakr3zn81p6qnzair"
+    },
+    "vibe-core": {
+      "version": "2.8.2",
+      "sha256": "1g9l8hmjx4dzzwh7pqasc9s16zzbdfvciswbv0gnrvmjsb0pi9xr"
+    },
+    "vibe-d": {
+      "version": "0.9.8",
+      "sha256": "1gficgfzwswaxj9qlnca28c65gl7xq6q8y47qlf4m1gvkxj4ij2k"
+    },
+    "vmc-d": {
+      "version": "1.1.3",
+      "sha256": "0kkqihhzxdq0n46jk55g4yhhwrnw6b9d931yb5pblxcc342gckvm"
+    }
+  }
+}

--- a/pkgs/applications/misc/inochi2d/support-url.patch
+++ b/pkgs/applications/misc/inochi2d/support-url.patch
@@ -1,0 +1,13 @@
+diff --git a/source/creator/config.d b/source/creator/config.d
+index 4289703..d8dea4e 100644
+--- a/source/creator/config.d
++++ b/source/creator/config.d
+@@ -30,7 +30,7 @@ enum INC_BANNER_ARTIST_PAGE = "https://mastodon.art/@nighteden";
+ /**
+     URI for bug reports, for unofficial builds this SHOULD be changed.
+ */
+-enum INC_BUG_REPORT_URI = "https://github.com/Inochi2D/inochi-creator/issues/new?assignees=&labels=bug&template=bug-report.yml&title=%5BBUG%5D";
++enum INC_BUG_REPORT_URI = "https://github.com/NixOS/nixpkgs/issues/new?assignees=@assignees@&labels=0.kind%3A+bug&projects=&template=bug_report.md&title=inochi-creator:";
+ 
+ /**
+     URI for feature requests, for the most part this doesn't need to be changed

--- a/pkgs/applications/misc/inochi2d/translations.patch
+++ b/pkgs/applications/misc/inochi2d/translations.patch
@@ -1,0 +1,22 @@
+diff --git a/source/creator/core/i18n.d b/source/creator/core/i18n.d
+index 38761dd..f276ca1 100644
+--- a/source/creator/core/i18n.d
++++ b/source/creator/core/i18n.d
+@@ -132,7 +132,7 @@ void markDups(TLEntry[] entries) {
+         // If prevEntry has same humanName as entry before prevEntry, or as this entry,
+         // disambiguate with the source folder
+         if (prevIsDup || entryIsDup) {
+-            prevEntry.humanName ~= " (" ~ prevEntry.path ~ ")";
++            prevEntry.humanName ~= " (" ~ prevEntry.code ~ ")";
+             prevEntry.humanNameC = prevEntry.humanName.toStringz;
+         }
+         prevIsDup = entryIsDup;
+@@ -140,7 +140,7 @@ void markDups(TLEntry[] entries) {
+     }
+ 
+     if (prevIsDup) {
+-        prevEntry.humanName ~= " (" ~ prevEntry.path ~ ")";
++        prevEntry.humanName ~= " (" ~ prevEntry.code ~ ")";
+         prevEntry.humanNameC = prevEntry.humanName.toStringz;
+     }
+ }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19100,6 +19100,9 @@ with pkgs;
 
   inotify-tools = callPackage ../development/tools/misc/inotify-tools { };
 
+  inherit (callPackage ../applications/misc/inochi2d { })
+    inochi-creator inochi-session;
+
   intel-gpu-tools = callPackage ../development/tools/misc/intel-gpu-tools { };
 
   insomnia = callPackage ../development/web/insomnia { };


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/288706

This PR adds 2 packages: `inochi-session` `inochi-creator`

I have tested them with a basic setup, they seem to work fine.

---
## Notes

This app uses the D language. It uses the `ldc` compiler with the `dub` package manager and build system.

This PR originally contained the code which adds a generic builder for `dub` based packages, but that part got split off into another PR. This PR uses that builder.

As per the request of the author, I only use the "barebones" configuration, which disables the "InBranding" flag, which makes sure that  `inochi-creator` and `inochi-session` (and `inui`)  don't include the mascot image and the icon in the build.

I had to patch `i2d-imgui`, as that dependency has a git submodule that would be fetched when building.

Interestingly, one of the packages statically links `cimgui` and the other one dynamically links it.
The statically linked one needed some patching (to use capital letters for SDL2).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
