### PR TITLE
passbolt: init at 4.9.1

### DIFF
--- a/pkgs/by-name/pa/passbolt/package.nix
+++ b/pkgs/by-name/pa/passbolt/package.nix
@@ -1,20 +1,29 @@
-{ lib,
-fetchFromGitHub,
-php,
-bash,
-imagemagick,
-zlib,
-makeWrapper,
-dataDir ? "/var/lib/passbolt",
-runtimeDir ? "/run/passbolt",
+{
+  lib,
+  fetchFromGitHub,
+  php,
+  bash,
+  imagemagick,
+  zlib,
+  makeWrapper,
+  dataDir ? "/var/lib/passbolt",
+  runtimeDir ? "/run/passbolt",
 }:
 
 let
   phpWithExt = php.buildEnv {
-   extensions = ({ all, enabled }: enabled ++ (with all; [
-     gnupg xsl imagick openssl curl
-   ]));
-   };
+    extensions = (
+      { all, enabled }:
+      enabled
+      ++ (with all; [
+        gnupg
+        xsl
+        imagick
+        openssl
+        curl
+      ])
+    );
+  };
 in
 php.buildComposerProject (finalAttrs: {
   pname = "passbolt_api";
@@ -41,7 +50,7 @@ php.buildComposerProject (finalAttrs: {
 
     ## [WIP] Install process requires lot of patching ##
     patchShebangs $out/bin/*
-    substituteInPlace $out/bin/cake --replace-fail "/usr/local/bin/php" "${lib.makeBinPath [phpWithExt]}/php"
+    substituteInPlace $out/bin/cake --replace-fail "/usr/local/bin/php" "${lib.makeBinPath [ phpWithExt ]}/php"
     substituteInPlace $out/bin/cake.php --replace-fail "dirname(__DIR__)" "\"$out\""
     # TODO: Need to patch tmp directory/cache directory to where ??
     # Need to patch logs directory out of nix store to where ??

--- a/pkgs/by-name/pa/passbolt/package.nix
+++ b/pkgs/by-name/pa/passbolt/package.nix
@@ -1,0 +1,69 @@
+{ lib,
+fetchFromGitHub,
+php,
+bash,
+imagemagick,
+zlib,
+makeWrapper,
+dataDir ? "/var/lib/passbolt",
+runtimeDir ? "/run/passbolt",
+}:
+
+let
+  phpWithExt = php.buildEnv {
+   extensions = ({ all, enabled }: enabled ++ (with all; [
+     gnupg xsl imagick openssl curl
+   ]));
+   };
+in
+php.buildComposerProject (finalAttrs: {
+  pname = "passbolt_api";
+  version = "4.9.1";
+
+  src = fetchFromGitHub {
+    owner = "passbolt";
+    repo = "passbolt_api";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-C8vx3a+HFoRPCxK9drgWco6x0sPZzxgGK+dChTRTKUw=";
+  };
+
+  composerStrictValidation = false;
+  composerNoDev = true;
+
+  vendorHash = "sha256-p0yMAwsfWFunPh43YQq+u9JjbWoV12KNjYO49zeqYYY=";
+
+  php = phpWithExt;
+
+  postInstall = ''
+    mv $out/share/php/${finalAttrs.pname}/* $out
+    cp $out/config/passbolt.default.php $out/config/passbolt.php
+    cp $out/config/app.default.php $out/config/app.php
+
+    ## [WIP] Install process requires lot of patching ##
+    patchShebangs $out/bin/*
+    substituteInPlace $out/bin/cake --replace-fail "/usr/local/bin/php" "${lib.makeBinPath [phpWithExt]}/php"
+    substituteInPlace $out/bin/cake.php --replace-fail "dirname(__DIR__)" "\"$out\""
+    # TODO: Need to patch tmp directory/cache directory to where ??
+    # Need to patch logs directory out of nix store to where ??
+
+    # TODO: handle or declare Env variable for initial configuration ?
+    # Any files to clean up/useless ?
+    # tests ?
+    mv $out/webroot $out/webroot-static
+
+    # WIP will require a NixOS module to be written
+    ln -s ${runtimeDir} $out/webroot
+  '';
+  # TODO: Maybe assert that this isn't failing, maybe shouldn't be done here and inside nixos test framework better testing can be done
+  postInstallCheck = ''
+    ${bash}/bin/bash "$out/bin/cake passbolt install"
+  '';
+
+  meta = {
+    changelog = "https://github.com/passbolt/passbolt_api/releases/tag/v${finalAttrs.version}";
+    description = "Password Manager server for Teams";
+    homepage = "https://passbolt.com";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ ];
+  };
+})


### PR DESCRIPTION
## Description of changes

WIP for passbolt server, there is still a lot of structure to move around in order to make this package let's say more immutable friendly
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

Closes #227484
