### PR TITLE
phpPackages.composer: apply patch for CVE-2024-24821

### DIFF
--- a/pkgs/development/php-packages/composer/default.nix
+++ b/pkgs/development/php-packages/composer/default.nix
@@ -1,4 +1,4 @@
-{ lib, callPackage, fetchFromGitHub, php, unzip, _7zz, xz, git, curl, cacert, makeBinaryWrapper }:
+{ lib, callPackage, fetchFromGitHub, fetchpatch, php, unzip, _7zz, xz, git, curl, cacert, makeBinaryWrapper }:
 
 php.buildComposerProject (finalAttrs: {
   # Hash used by ../../../build-support/php/pkgs/composer-phar.nix to
@@ -21,6 +21,18 @@ php.buildComposerProject (finalAttrs: {
     rev = finalAttrs.version;
     hash = "sha256-KsTZi7dSlQcAxoen9rpofbptVdLYhK+bZeDSXQY7o5M=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2024-24821.patch";
+      url = "https://github.com/composer/composer/commit/77e3982918bc1d886843dc3d5e575e7e871b27b7.patch";
+      hash = "sha256-Q7gkPLf59+p++DpfJZeOrAOiWePuGkdGYRaS/rK+Nv4=";
+      excludes = [
+        # Skipping test files, they are not included in the source tarball
+        "tests/*"
+      ];
+    })
+  ];
 
   nativeBuildInputs = [ makeBinaryWrapper ];
 


### PR DESCRIPTION
## Description of changes

Upgrade to the 2.7.x branch needs some work (see #288574), let's patch the security issue in the meantime.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

No new build failures.

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>4 packages failed to build:</summary>
  <ul>
    <li>php81Packages.php-parallel-lint</li>
    <li>php83Packages.php-parallel-lint</li>
    <li>phpdocumentor</li>
    <li>robo</li>
  </ul>
</details>
<details>
  <summary>34 packages built:</summary>
  <ul>
    <li>adminer</li>
    <li>bookstack</li>
    <li>composer-require-checker</li>
    <li>librenms</li>
    <li>paratest</li>
    <li>pdepend</li>
    <li>pest</li>
    <li>phel</li>
    <li>php81Packages.box (php82Packages.box ,php83Packages.box)</li>
    <li>php81Packages.castor</li>
    <li>php81Packages.composer</li>
    <li>php81Packages.grumphp</li>
    <li>php81Packages.phpstan</li>
    <li>php81Packages.psalm</li>
    <li>php81Packages.psysh</li>
    <li>php82Packages.castor</li>
    <li>php82Packages.composer</li>
    <li>php82Packages.grumphp</li>
    <li>php82Packages.php-parallel-lint</li>
    <li>php82Packages.phpstan</li>
    <li>php82Packages.psalm</li>
    <li>php82Packages.psysh</li>
    <li>php83Packages.castor</li>
    <li>php83Packages.composer</li>
    <li>php83Packages.grumphp</li>
    <li>php83Packages.phpstan</li>
    <li>php83Packages.psalm</li>
    <li>php83Packages.psysh</li>
    <li>phpactor</li>
    <li>phpunit</li>
    <li>pixelfed</li>
    <li>platformsh</li>
    <li>snipe-it</li>
    <li>vimPlugins.phpactor</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
