### PR TITLE
networkmanager: 1.44.2 → 1.46.0

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -101,7 +101,23 @@ let
     pre-down = "pre-down.d/";
   };
 
-  macAddressOpt = mkOption {
+  macAddressOptWifi = mkOption {
+    type = types.either types.str (types.enum [ "permanent" "preserve" "random" "stable" "stable-ssid" ]);
+    default = "preserve";
+    example = "00:11:22:33:44:55";
+    description = lib.mdDoc ''
+      Set the MAC address of the interface.
+
+      - `"XX:XX:XX:XX:XX:XX"`: MAC address of the interface
+      - `"permanent"`: Use the permanent MAC address of the device
+      - `"preserve"`: Don’t change the MAC address of the device upon activation
+      - `"random"`: Generate a randomized value upon each connect
+      - `"stable"`: Generate a stable, hashed MAC address
+      - `"stable-ssid"`: Generate a stable MAC addressed based on Wi-Fi network
+    '';
+  };
+
+  macAddressOptEth = mkOption {
     type = types.either types.str (types.enum [ "permanent" "preserve" "random" "stable" ]);
     default = "preserve";
     example = "00:11:22:33:44:55";
@@ -258,10 +274,10 @@ in
         '';
       };
 
-      ethernet.macAddress = macAddressOpt;
+      ethernet.macAddress = macAddressOptEth;
 
       wifi = {
-        macAddress = macAddressOpt;
+        macAddress = macAddressOptWifi;
 
         backend = mkOption {
           type = types.enum [ "wpa_supplicant" "iwd" ];

--- a/pkgs/tools/networking/networkmanager/default.nix
+++ b/pkgs/tools/networking/networkmanager/default.nix
@@ -57,11 +57,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "networkmanager";
-  version = "1.44.2";
+  version = "1.46.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/NetworkManager/${lib.versions.majorMinor version}/NetworkManager-${version}.tar.xz";
-    sha256 = "sha256-S1i/OsV+LO+1ZS79CUXrC0vDamPZKmGrRx2LssmkIOE=";
+    hash = "sha256-ciZJ4lNiaTszQ3FHOAKnKbDsnuKDN1CWkF+GiAjnQGg=";
   };
 
   outputs = [ "out" "dev" "devdoc" "man" "doc" ];

--- a/pkgs/tools/networking/networkmanager/fix-install-paths.patch
+++ b/pkgs/tools/networking/networkmanager/fix-install-paths.patch
@@ -1,8 +1,8 @@
 diff --git a/meson.build b/meson.build
-index f71c9fd4aa..deddf28816 100644
+index 61c025b9d7..d2ae60da34 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -1022,9 +1022,9 @@ meson.add_install_script(
+@@ -1025,9 +1025,9 @@ meson.add_install_script(
    join_paths('tools', 'meson-post-install.sh'),
    nm_datadir,
    nm_bindir,

--- a/pkgs/tools/networking/networkmanager/fix-paths.patch
+++ b/pkgs/tools/networking/networkmanager/fix-paths.patch
@@ -24,10 +24,10 @@ index f09ae86ceb..b2ecb405ef 100644
  ExecStart=@sbindir@/NetworkManager --no-daemon
  Restart=on-failure
 diff --git a/src/core/devices/nm-device.c b/src/core/devices/nm-device.c
-index 2038e2f205..90bf9fa28b 100644
+index a9e8c08508..875d6cc2cd 100644
 --- a/src/core/devices/nm-device.c
 +++ b/src/core/devices/nm-device.c
-@@ -14275,14 +14275,14 @@ nm_device_start_ip_check(NMDevice *self)
+@@ -14645,14 +14645,14 @@ nm_device_start_ip_check(NMDevice *self)
              gw = nm_l3_config_data_get_best_default_route(l3cd, AF_INET);
              if (gw) {
                  nm_inet4_ntop(NMP_OBJECT_CAST_IP4_ROUTE(gw)->gateway, buf);
@@ -45,25 +45,25 @@ index 2038e2f205..90bf9fa28b 100644
              }
          }
 diff --git a/src/libnm-client-impl/meson.build b/src/libnm-client-impl/meson.build
-index fb879dca47..13cc2867e1 100644
+index 79ac95598a..83f7ab1373 100644
 --- a/src/libnm-client-impl/meson.build
 +++ b/src/libnm-client-impl/meson.build
-@@ -173,7 +173,6 @@ if enable_introspection
-       input: libnm_core_settings_sources,
-       output: 'nm-propery-infos-' + info + '.xml',
+@@ -191,7 +191,6 @@ if enable_introspection
+       input: [gen_infos_cmd, libnm_gir[0]] + libnm_core_settings_sources,
+       output: 'nm-property-infos-' + name + '.xml',
        command: [
 -        python.path(),
-         join_paths(meson.source_root(), 'tools', 'generate-docs-nm-property-infos.py'),
-         info,
+         gen_infos_cmd,
+         name,
          '@OUTPUT@',
-@@ -230,7 +229,6 @@ if enable_introspection
-       'env',
-       'GI_TYPELIB_PATH=' + gi_typelib_path,
-       'LD_LIBRARY_PATH=' + ld_library_path,
--      python.path(),
-       join_paths(meson.source_root(), 'tools', 'generate-docs-nm-settings-docs-gir.py'),
-       '--lib-path', meson.current_build_dir(),
-       '--gir', '@INPUT@',
+@@ -207,7 +206,6 @@ if enable_introspection
+         'env',
+         'GI_TYPELIB_PATH=' + gi_typelib_path,
+         'LD_LIBRARY_PATH=' + ld_library_path,
+-        python.path(),
+         gen_gir_cmd,
+         '--lib-path', meson.current_build_dir(),
+         '--gir', libnm_gir[0],
 diff --git a/src/libnmc-base/nm-vpn-helpers.c b/src/libnmc-base/nm-vpn-helpers.c
 index cbe76f5f1c..8515f94994 100644
 --- a/src/libnmc-base/nm-vpn-helpers.c
@@ -102,25 +102,25 @@ index cbe76f5f1c..8515f94994 100644
      oc_argv[oc_argc++] = path;
      oc_argv[oc_argc++] = "--authenticate";
 diff --git a/src/libnmc-setting/meson.build b/src/libnmc-setting/meson.build
-index cf8a21fc80..61d8e140e2 100644
+index 7fb460dc33..790a2b75fc 100644
 --- a/src/libnmc-setting/meson.build
 +++ b/src/libnmc-setting/meson.build
-@@ -7,7 +7,6 @@ if enable_docs
-     input: [nm_settings_docs_xml_gir, nm_property_infos_xml['nmcli']],
+@@ -9,7 +9,6 @@ if enable_docs
+     input: [merge_cmd, nm_settings_docs_xml_gir['nmcli'], nm_property_infos_xml['nmcli']],
      output: 'settings-docs-input.xml',
      command: [
 -      python.path(),
-       join_paths(meson.source_root(), 'tools', 'generate-docs-nm-settings-docs-merge.py'),
+       merge_cmd,
        '@OUTPUT@',
        nm_property_infos_xml['nmcli'],
-@@ -20,7 +19,6 @@ if enable_docs
-     input: settings_docs_input_xml,
+@@ -23,7 +22,6 @@ if enable_docs
+     input: [gen_cmd, settings_docs_input_xml],
      output: 'settings-docs.h',
      command: [
 -      python.path(),
-       join_paths(meson.source_root(), 'tools', 'generate-docs-settings-docs.py'),
+       gen_cmd,
        '--output', '@OUTPUT@',
-       '--xml', '@INPUT@'
+       '--xml', settings_docs_input_xml
 diff --git a/src/tests/client/meson.build b/src/tests/client/meson.build
 index 8c36e40559..cfb6649a21 100644
 --- a/src/tests/client/meson.build


### PR DESCRIPTION
## Description of changes

https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/compare/1.44.2...1.46.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
