### PR TITLE
namespaced-openvpn: init at 0.6.0

### DIFF
--- a/pkgs/tools/networking/namespaced-openvpn/default.nix
+++ b/pkgs/tools/networking/namespaced-openvpn/default.nix
@@ -1,0 +1,52 @@
+{ lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  openvpn,
+  iproute2,
+  iptables,
+  util-linux
+}:
+
+buildPythonPackage rec {
+  pname = "namespaced-openvpn";
+  version = "0.6.0";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "slingamn";
+    repo = pname;
+    rev = "a3fa42b2d8645272cbeb6856e26a7ea9547cb7d1";
+    sha256 = "+Fdaw9EGyFGH9/DSeVJczS8gPzAOv+qn+1U20zQBBqQ=";
+  };
+
+  buildInputs = [ openvpn iproute2 util-linux ];
+
+  postPatch = ''
+    substituteInPlace namespaced-openvpn \
+      --replace-fail "/usr/sbin/openvpn" "${openvpn}/bin/openvpn" \
+      --replace-fail "/sbin/ip" "${iproute2}/bin/ip" \
+      --replace-fail "/usr/bin/nsenter" "${util-linux}/bin/nsenter" \
+      --replace-fail "/bin/mount" "${util-linux}/bin/mount" \
+      --replace-fail "/bin/umount" "${util-linux}/bin/umount"
+
+    substituteInPlace seal-unseal-gateway \
+      --replace-fail "/sbin/iptables" "${iptables}/bin/iptables"
+  '';
+
+  dontBuild = true;
+  doCheck = false;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp namespaced-openvpn seal-unseal-gateway $out/bin
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/slingamn/namespaced-openvpn";
+    description = "Network namespace isolation for OpenVPN tunnels.";
+    license = licenses.mit;
+    maintainers = [ maintainers.lodi ];
+    platforms = platforms.linux;
+    mainProgram = "namespaced-openvpn";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11648,6 +11648,8 @@ with pkgs;
     stdenv = clangStdenv;
   };
 
+  namespaced-openvpn = python3Packages.callPackage ../tools/networking/namespaced-openvpn { };
+
   oq = callPackage ../development/tools/oq { };
 
   out-of-tree = callPackage ../development/tools/out-of-tree { };


### PR DESCRIPTION
## Description of changes

`namespaced-openvpn` is a python script to automate the setup of isolated OpenVPN tunnels using Linux Network Namespaces.  This allows secure per-application control of what data travels over the VPN while leaving the rest of the system unaffected.

https://github.com/slingamn/namespaced-openvpn

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).