### PR TITLE
sharedown: unbreak build, sitespeed-io: unbreak build, add `passthru.updateScript`, 27.3.1 -> 33.0.0

### DIFF
--- a/pkgs/tools/misc/sharedown/default.nix
+++ b/pkgs/tools/misc/sharedown/default.nix
@@ -6,7 +6,7 @@
 , libsecret
 , python3
 , pkg-config
-, nodePackages
+, nodejs
 , electron
 , makeWrapper
 , makeDesktopItem
@@ -63,7 +63,6 @@ stdenvNoCC.mkDerivation rec {
             nativeBuildInputs = [
               python3
               pkg-config
-              nodePackages.node-gyp
             ];
             buildInputs = [
               libsecret
@@ -75,6 +74,15 @@ stdenvNoCC.mkDerivation rec {
             '';
           };
         };
+
+        # needed for node-gyp, copied from https://nixos.org/manual/nixpkgs/unstable/#javascript-yarn2nix-pitfalls
+        # permalink: https://github.com/NixOS/nixpkgs/blob/d176767c02cb2a048e766215078c3d231e666091/doc/languages-frameworks/javascript.section.md#pitfalls-javascript-yarn2nix-pitfalls
+        preBuild = ''
+          mkdir -p $HOME/.node-gyp/${nodejs.version}
+          echo 9 > $HOME/.node-gyp/${nodejs.version}/installVersion
+          ln -sfv ${nodejs}/include $HOME/.node-gyp/${nodejs.version}
+          export npm_config_nodedir=${nodejs}
+        '';
 
         packageJSON = "${src}/package.json";
         yarnLock = ./yarn.lock;

--- a/pkgs/tools/networking/sitespeed-io/default.nix
+++ b/pkgs/tools/networking/sitespeed-io/default.nix
@@ -24,13 +24,13 @@
 assert (!withFirefox && !withChromium) -> throw "Either `withFirefox` or `withChromium` must be enabled.";
 buildNpmPackage rec {
   pname = "sitespeed-io";
-  version = "27.3.1";
+  version = "33.0.0";
 
   src = fetchFromGitHub {
     owner = "sitespeedio";
     repo = "sitespeed.io";
     rev = "v${version}";
-    hash = "sha256-Z4U4ZIw5Du/VSHIsGKdgu7wRv/6XVh/nMFDs8aYwkOQ=";
+    hash = "sha256-UmviwcxL67fn8B4ruJH9yKdcYVqmxqKSImQszKhDHZ0=";
   };
 
   nodejs = nodejs_18;
@@ -46,7 +46,7 @@ buildNpmPackage rec {
 
   dontNpmBuild = true;
   npmInstallFlags = [ "--omit=dev" ];
-  npmDepsHash = "sha256-RfZlXE8hnAJKiiWdOGFsAFGcxwgnLNvLrXeIinABFb0=";
+  npmDepsHash = "sha256-FggwOnuQ+azgdLxfc6EUAsbl0+il6/2+p1t7MCrTNgE=";
 
   postInstall = ''
     mv $out/bin/sitespeed{.,-}io

--- a/pkgs/tools/networking/sitespeed-io/default.nix
+++ b/pkgs/tools/networking/sitespeed-io/default.nix
@@ -9,6 +9,7 @@
 , procps
 , python3
 , xorg
+, nix-update-script
 
 # chromedriver is more efficient than geckodriver, but is available on less platforms.
 
@@ -80,6 +81,10 @@ buildNpmPackage rec {
         ${lib.optionalString (!withFirefox && withChromium) "--add-flags '-b chrome'"} \
         ${lib.optionalString (withFirefox && !withChromium) "--add-flags '-b firefox'"}
     '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = with lib; {
     description = "An open source tool that helps you monitor, analyze and optimize your website speed and performance";

--- a/pkgs/tools/networking/sitespeed-io/default.nix
+++ b/pkgs/tools/networking/sitespeed-io/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , buildNpmPackage
-, makeWrapper
+, nodejs_18
 , coreutils
 , ffmpeg-headless
 , imagemagick_light
@@ -32,6 +32,8 @@ buildNpmPackage rec {
     hash = "sha256-Z4U4ZIw5Du/VSHIsGKdgu7wRv/6XVh/nMFDs8aYwkOQ=";
   };
 
+  nodejs = nodejs_18;
+
   postPatch = ''
     ln -s npm-shrinkwrap.json package-lock.json
   '';
@@ -40,8 +42,6 @@ buildNpmPackage rec {
   CHROMEDRIVER_SKIP_DOWNLOAD = true;
   GECKODRIVER_SKIP_DOWNLOAD = true;
   EDGEDRIVER_SKIP_DOWNLOAD = true;
-
-  nativeBuildInputs = [ python3 makeWrapper ];
 
   dontNpmBuild = true;
   npmInstallFlags = [ "--omit=dev" ];


### PR DESCRIPTION
## Description of changes

Those packages taunt me each time I `nixpkgs-review` on `chromium` or `chromium`-related work/PRs.
They have been broken for months.

This PR unbreaks them (in case of `sharedown` again #266866) in hope that they will continue to work from now on.

`sharedown` lacks a maintainer entirely, while `sitespeed-io`'s is @Misterio77.

To make this clear: I do not intend to maintain those packages.
I just hope that it is easier due to those fixes for someone else to pick them up now.

Please see commit messages for details and motivation for each change.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
