### PR TITLE
python311Packages.pylibjpeg: 1.4.0 -> 2.02

### DIFF
--- a/pkgs/development/python-modules/pylibjpeg-libjpeg/default.nix
+++ b/pkgs/development/python-modules/pylibjpeg-libjpeg/default.nix
@@ -3,14 +3,16 @@
 , fetchFromGitHub
 , pythonOlder
 , pytestCheckHook
-, cython
+, cython_3
+, poetry-core
+, setuptools
 , numpy
 }:
 
 buildPythonPackage rec {
   pname = "pylibjpeg-libjpeg";
-  version = "1.3.4";
-  format = "setuptools";
+  version = "2.02";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -18,12 +20,14 @@ buildPythonPackage rec {
     owner = "pydicom";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-VmqeoMU8riLpWyC+yKqq56TkruxOie6pjbg+ozivpBk=";
+    hash = "sha256-mGwku19Xe605fF3UU59712rYp+s/pP79lBRl79fhhTI=";
     fetchSubmodules = true;
   };
 
   nativeBuildInputs = [
-    cython
+    cython_3
+    poetry-core
+    setuptools
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pylibjpeg/default.nix
+++ b/pkgs/development/python-modules/pylibjpeg/default.nix
@@ -4,6 +4,7 @@
 , fetchFromGitHub
 , pythonOlder
 , pytestCheckHook
+, flit-core
 , setuptools
 , numpy
 , pydicom
@@ -31,7 +32,7 @@ in
 
 buildPythonPackage rec {
   pname = "pylibjpeg";
-  version = "1.4.0";
+  version = "2.0.0";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -40,10 +41,10 @@ buildPythonPackage rec {
     owner = "pydicom";
     repo = "pylibjpeg";
     rev = "refs/tags/v${version}";
-    hash = "sha256-Px1DyYDkKAUdYo+ZxZ1w7TkPzWN++styiFl02iQOvyQ=";
+    hash = "sha256-qGtrphsBBVieGS/8rdymbsjLMU/QEd7zFNAANN8bD+k=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  nativeBuildInputs = [ flit-core ];
 
   propagatedBuildInputs = [ numpy ];
 


### PR DESCRIPTION
python311Packages.pylibjpeg-libjpeg: 1.3.4 -> 2.02

## Description of changes

Routine update.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
