### PR TITLE
choose-gui: init 1.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8348,6 +8348,12 @@
       fingerprint = "4304 6B43 8D83 078E 3DF7  10D6 DEB0 E15C 6D2A 5A7C";
     }];
   };
+  heywoodlh = {
+    email = "nixpkgs@heywoodlh.io";
+    github = "heywoodlh";
+    githubId = 18178614;
+    name = "Spencer Heywood";
+  };
   hh = {
     email = "hh@m-labs.hk";
     github = "HarryMakes";

--- a/pkgs/by-name/ch/choose-gui/package.nix
+++ b/pkgs/by-name/ch/choose-gui/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  xcbuild,
+  darwin,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "choose-gui";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "chipsenkbeil";
+    repo = "choose";
+    rev = version;
+    hash = "sha256-oR0GgMinKcBHaZWdE7O+mdbiLKKjkweECKbi80bjW+c=";
+  };
+
+  nativeBuildInputs = [ xcbuild ];
+
+  buildInputs = [ darwin.apple_sdk.frameworks.Cocoa ];
+
+  buildPhase = ''
+    runHook preBuild
+    xcodebuild -arch ${stdenv.hostPlatform.darwinArch} -configuration Release SYMROOT="./output" build
+    cp ./output/Release/choose choose
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp choose $out/bin/choose
+    chmod +x $out/bin/choose
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Fuzzy matcher for OS X that uses both std{in,out} and a native GUI";
+    homepage = "https://github.com/chipsenkbeil/choose";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.darwin;
+    changelog = "https://github.com/chipsenkbeil/choose/blob/${version}/CHANGELOG.md";
+    maintainers = with lib.maintainers; [ heywoodlh ];
+    mainProgram = "choose";
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds [choose](https://github.com/chipsenkbeil/choose), a fuzzy finder for MacOS

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
