### PR TITLE
cmake: Fix impurity without sandbox

### DIFF
--- a/pkgs/by-name/cm/cmake/007-fix-impurity-without-sandbox.diff
+++ b/pkgs/by-name/cm/cmake/007-fix-impurity-without-sandbox.diff
@@ -1,0 +1,20 @@
+diff --git a/Modules/GNUInstallDirs.cmake b/Modules/GNUInstallDirs.cmake
+index 97968549dc..55723afc3c 100644
+--- a/Modules/GNUInstallDirs.cmake
++++ b/Modules/GNUInstallDirs.cmake
+@@ -263,15 +263,6 @@ if(NOT DEFINED CMAKE_INSTALL_LIBDIR OR (_libdir_set
+         set(__system_type_for_install "conda")
+       endif()
+     endif()
+-    if(NOT __system_type_for_install)
+-      if (EXISTS "/etc/alpine-release")
+-        set(__system_type_for_install "alpine")
+-      elseif (EXISTS "/etc/arch-release")
+-        set(__system_type_for_install "arch linux")
+-      elseif (EXISTS "/etc/debian_version")
+-        set(__system_type_for_install "debian")
+-      endif()
+-    endif()
+ 
+     if(__system_type_for_install STREQUAL "debian")
+       if(CMAKE_LIBRARY_ARCHITECTURE)

--- a/pkgs/by-name/cm/cmake/package.nix
+++ b/pkgs/by-name/cm/cmake/package.nix
@@ -60,6 +60,8 @@ stdenv.mkDerivation (finalAttrs: {
     ./002-application-services.diff
     # Derived from https://github.com/libuv/libuv/commit/1a5d4f08238dd532c3718e210078de1186a5920d
     ./003-libuv-application-services.diff
+    # Fix impurity without sandbox (CMake thinking we are e.g. on Debian)
+    ./007-fix-impurity-without-sandbox.diff
   ]
   ++ lib.optional stdenv.isCygwin ./004-cygwin.diff
   # Derived from https://github.com/curl/curl/commit/31f631a142d855f069242f3e0c643beec25d1b51


### PR DESCRIPTION
## Description of changes

If a Nix Cmake build occurs without the Nix sandbox on a Debian, Arch, or Alpine system, CMake may probe `/etc`, notice the presence of e.g. `/etc/debian_version`, and decide that it is running on Ubuntu.

Because it uses the result of this probe to configure the default value of the `CMAKE_INSTALL_LIBDIR` variable, this can result in an impurity where such a build will place built library files in a different folder than a properly sandboxed / NixOS build.

Fix this by patching out the corresponding logic.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
