### PR TITLE
stereotool: init at 10.21

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16659,6 +16659,12 @@
     githubId = 6445619;
     name = "Ruben Cano Diaz";
   };
+  RudiOnTheAir = {
+    name = "Rüdiger Schwoon";
+    email = "wolf@schwoon.info";
+    github = "RudiOnTheAir";
+    githubId = 47517341;
+  };
   rudolfvesely = {
     name = "Rudolf Vesely";
     email = "i@rudolfvesely.com";

--- a/pkgs/by-name/st/stereotool/package.nix
+++ b/pkgs/by-name/st/stereotool/package.nix
@@ -1,0 +1,171 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, libX11
+, libXpm
+, alsa-lib
+, bzip2
+, zlib
+, libsForQt5
+, libgcc
+, makeWrapper
+, copyDesktopItems
+, makeDesktopItem
+}:
+
+stdenv.mkDerivation rec {
+  pname = "stereotool";
+  version = "10.21";
+
+  srcs =
+    let
+      versionNoPoint = lib.replaceStrings [ "." ] [ "" ] version;
+    in
+    [
+      (fetchurl {
+        name = "stereo-tool-icon.png";
+        url = "https://download.thimeo.com/stereo_tool_icon_${versionNoPoint}.png";
+        hash = "sha256-dcivH6Cc7pdQ99m80vS4E5mp/SHtTlNu1EHc+0ALIGM=";
+      })
+    ] ++ (
+      {
+        # Alsa version for 64bits.
+        x86_64-linux = [
+          (fetchurl {
+            name = "alsa";
+            url = "https://download.thimeo.com/stereo_tool_gui_64_${versionNoPoint}";
+            hash = "sha256-ByRguhZ29ertQM3q+TPUUT1BMnAJGbwNe8WbNxLhcmk=";
+          })
+          # Jack version for 64bits.
+          (fetchurl {
+            name = "jack";
+            url = "https://download.thimeo.com/stereo_tool_gui_jack_64_${versionNoPoint}";
+            hash = "sha256-ByRguhZ29ertQM3q+TPUUT1BMnAJGbwNe8WbNxLhcmk=";
+          })
+          # Cmd version for 64bits
+          (fetchurl {
+            name = "cmd";
+            url = "https://download.thimeo.com/stereo_tool_cmd_64_${versionNoPoint}";
+            hash = "sha256-PGheJfOQJzI1gs05qW9vcAMoVnCPIHR2qS0GIg5V6vw=";
+          })
+        ];
+        # Sources if the system is aarch64-linux
+        aarch64-linux = [
+          (fetchurl {
+            name = "alsa";
+            url = "https://download.thimeo.com/stereo_tool_gui_pi2_64_${versionNoPoint}";
+            hash = "sha256-iwoc6c+ox+2DSqmiz8mpDotDjqki7iL0jgqc7Z1htNI=";
+          })
+          (fetchurl {
+            name = "jack";
+            url = "https://download.thimeo.com/stereo_tool_gui_jack_pi2_64_${versionNoPoint}";
+            hash = "sha256-iwoc6c+ox+2DSqmiz8mpDotDjqki7iL0jgqc7Z1htNI==";
+          })
+          (fetchurl {
+            name = "cmd";
+            url = "https://download.thimeo.com/stereo_tool_pi2_64_${versionNoPoint}";
+            hash = "sha256-bIFnQkJB9XoEKo7IG+MSMvx/ia1C8i97Cw7EX4EDizk=";
+          })
+        ];
+        # Sources if the system is aarch32-linux
+        aarch32-linux = [
+          (fetchurl {
+            name = "alsa";
+            url = "https://download.thimeo.com/stereo_tool_gui_pi2_${versionNoPoint}";
+            hash = "sha256-922yqmis5acvASU2rEi5YzFLAUuDO7BiEiW49RKfcoU=";
+          })
+          (fetchurl {
+            name = "jack";
+            url = "https://download.thimeo.com/stereo_tool_gui_jack_pi2_${versionNoPoint}";
+            hash = "sha256-922yqmis5acvASU2rEi5YzFLAUuDO7BiEiW49RKfcoU=";
+          })
+          (fetchurl {
+            name = "cmd";
+            url = "https://download.thimeo.com/stereo_tool_pi2_${versionNoPoint}";
+            hash = "sha256-xKM5Mg6gEAvbp63rd81ssnx2Bj1hUylCo36mQBYwIvg=";
+          })
+        ];
+        # Sources if the system is 32bits i686
+        i686-linux = [
+          (fetchurl {
+            # The name is the name of this source in the build directory
+            name = "alsa";
+            url = "https://download.thimeo.com/stereo_tool_gui_${versionNoPoint}";
+            hash = "sha256-iEPqJvmXKXD4AVbM+1QZeUOwpMjMT7ROYNQpmhRVZyw=";
+          })
+          (fetchurl {
+            name = "jack";
+            url = "https://download.thimeo.com/stereo_tool_gui_jack_${versionNoPoint}";
+            hash = "sha256-iEPqJvmXKXD4AVbM+1QZeUOwpMjMT7ROYNQpmhRVZyw=";
+          })
+          (fetchurl {
+            name = "cmd";
+            url = "https://download.thimeo.com/stereo_tool_cmd_${versionNoPoint}";
+            hash = "sha256-sk13wj7XvuwTDWWW6tMYHdTV9XjPeHe6hHv2JPBxBLA=";
+          })
+        ];
+      }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}"));
+
+  unpackPhase = ''
+    for srcFile in $srcs; do
+      cp $srcFile $(stripHash $srcFile)
+    done
+  '';
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "stereotool-alsa";
+      desktopName = "Stereotool-Alsa";
+      exec = "stereo_tool_gui";
+      icon = "stereo-tool-icon";
+      comment = "Broadcast Audio Processing";
+      categories = [ "AudioVideo" "Audio" "AudioVideoEditing" ];
+    })
+    (makeDesktopItem {
+      name = "stereotool-jack";
+      desktopName = "Stereotool-Jack";
+      exec = "stereo_tool_gui_jack";
+      icon = "stereo-tool-icon";
+      comment = "Broadcast Audio Processing";
+      categories = [ "AudioVideo" "Audio" "AudioVideoEditing" ];
+    })
+  ];
+
+  buildInputs = [
+    libX11
+    alsa-lib
+    bzip2
+    zlib
+    libXpm
+    libgcc
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 alsa $out/bin/stereo_tool_gui
+    wrapProgram $out/bin/stereo_tool_gui --prefix PATH : ${lib.makeBinPath [ libsForQt5.kdialog ]}
+    install -Dm755 jack $out/bin/stereo_tool_gui_jack
+    wrapProgram $out/bin/stereo_tool_gui_jack --prefix PATH : ${lib.makeBinPath [ libsForQt5.kdialog ]}
+    install -Dm755 cmd $out/bin/stereo_tool_cmd
+    mkdir -p $out/share/icons/hicolor/48x48/apps
+    cp stereo-tool-icon.png $out/share/icons/hicolor/48x48/apps/stereo-tool-icon.png
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.thimeo.com/stereo-tool/";
+    description = "Stereo Tool is a software-based audio processor which offers outstanding audio quality and comes with many unique features.";
+    license = licenses.unfree;
+    mainProgram = "stereo_tool_gui";
+    platforms = [ "aarch64-linux" "aarch32-linux" "x86_64-linux" "i686-linux" ];
+    maintainers = with maintainers; [ RudiOnTheAir ];
+  };
+
+}


### PR DESCRIPTION
## Description

Stereo Tool is a software-based audio processor which offers outstanding audio quality and comes with many unique features. It is used by over 3000 FM stations ranging from small local stations to 50-100 kW stations and nation-wide networks with dozens of transmitters, thousands of streaming stations and many DAB+, HD, AM and TV stations. It can be used for both live and file based processing.

Beside performing traditional audio processing, Stereo Tool can also repair many common audio problems on the fly, and optimize outgoing audio for better FM reception. A full list of features can be found below on this page.

[https://www.thimeo.com/stereo-tool/](url)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] x686-linux
  - [x] aarch64-linux
  - [x] aarch32-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
