### PR TITLE
git-filter-repo: fix broken --help option

### DIFF
--- a/pkgs/development/python-modules/git-filter-repo/default.nix
+++ b/pkgs/development/python-modules/git-filter-repo/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   docs = fetchFromGitHub {
     owner = "newren";
-    repo = pname;
+    repo = "git-filter-repo";
     rev = docs_version;
     hash = "sha256-Z/3w3Rguo8sfuc/OQ25eFbMfiOHjxQqPY6S32zuvoY4=";
   };

--- a/pkgs/development/python-modules/git-filter-repo/default.nix
+++ b/pkgs/development/python-modules/git-filter-repo/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   pname = "git-filter-repo";
   version = "2.38.0";
   docs_version = "01ead411966a83dfcfb35f9d2e8a9f7f215eaa65";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.5";
 

--- a/pkgs/development/python-modules/git-filter-repo/default.nix
+++ b/pkgs/development/python-modules/git-filter-repo/default.nix
@@ -1,7 +1,9 @@
 { lib
 , buildPythonPackage
-, fetchpatch
+, fetchFromGitHub
 , fetchPypi
+, fetchpatch
+, installShellFiles
 , pythonOlder
 , setuptools-scm
 }:
@@ -9,6 +11,7 @@
 buildPythonPackage rec {
   pname = "git-filter-repo";
   version = "2.38.0";
+  docs_version = "01ead411966a83dfcfb35f9d2e8a9f7f215eaa65";
   format = "setuptools";
 
   disabled = pythonOlder "3.5";
@@ -16,6 +19,13 @@ buildPythonPackage rec {
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-/hdT4Y8L1tPJtXhoyAEa59BWpuurcGcGOWoV71MScl4=";
+  };
+
+  docs = fetchFromGitHub {
+    owner = "newren";
+    repo = pname;
+    rev = docs_version;
+    hash = "sha256-Z/3w3Rguo8sfuc/OQ25eFbMfiOHjxQqPY6S32zuvoY4=";
   };
 
   patches = [
@@ -28,8 +38,13 @@ buildPythonPackage rec {
     })
   ];
 
+  postInstall = ''
+    installManPage ${docs}/man1/git-filter-repo.1
+  '';
+
   nativeBuildInputs = [
     setuptools-scm
+    installShellFiles
   ];
 
   # Project has no tests

--- a/pkgs/development/python-modules/git-filter-repo/default.nix
+++ b/pkgs/development/python-modules/git-filter-repo/default.nix
@@ -59,7 +59,7 @@ buildPythonPackage rec {
     description = "Quickly rewrite git repository history";
     homepage = "https://github.com/newren/git-filter-repo";
     license = with licenses; [ mit /* or */ gpl2Plus ];
-    maintainers = with maintainers; [ fab ];
+    maintainers = with maintainers; [ aiotter fab ];
   };
 
   passthru.updateScript = writeScript "update-${pname}" ''

--- a/pkgs/development/python-modules/git-filter-repo/default.nix
+++ b/pkgs/development/python-modules/git-filter-repo/default.nix
@@ -6,6 +6,7 @@
 , installShellFiles
 , pythonOlder
 , setuptools-scm
+, writeScript
 }:
 
 buildPythonPackage rec {
@@ -60,4 +61,18 @@ buildPythonPackage rec {
     license = with licenses; [ mit /* or */ gpl2Plus ];
     maintainers = with maintainers; [ fab ];
   };
+
+  passthru.updateScript = writeScript "update-${pname}" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p common-updater-scripts curl jq nix-update
+
+    set -eu -o pipefail
+
+    # Update program
+    nix-update ${pname}
+
+    # Update docs
+    docs_latest=$(curl -s https://api.github.com/repos/newren/git-filter-repo/commits/heads/docs/status | jq -r '.sha')
+    [[ "${docs_version}" = "$docs_latest" ]] || update-source-version ${pname} "$docs_latest" --version-key=docs_version --source-key=docs
+  '';
 }


### PR DESCRIPTION
## Description of changes
`git filter-repo --help` is broken because man page is not installed.
This PR adds man page.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
