### PR TITLE
nixos/v2raya: add more options

### DIFF
--- a/nixos/modules/services/networking/v2raya.nix
+++ b/nixos/modules/services/networking/v2raya.nix
@@ -1,49 +1,117 @@
 { config, pkgs, lib, ... }:
 
-with lib;
-
+let
+  cfg = config.services.v2raya;
+  inherit (lib.options) mkOption mkEnableOption mkPackageOption;
+  inherit (lib) types maintainers mkIf optionals getExe literalExpression;
+in
 {
   options = {
     services.v2raya = {
-      enable = options.mkEnableOption (mdDoc "the v2rayA service");
+      enable = mkEnableOption "the v2rayA service";
+
+      package = mkPackageOption pkgs "v2raya" { };
+
+      listenAddress = mkOption {
+        type = types.str;
+        default = "0.0.0.0";
+        example = "127.0.0.1";
+        description = ''
+          The listening address of v2rayA.
+        '';
+      };
+
+      listenPort = mkOption {
+        type = types.port;
+        default = 2017;
+        description = ''
+          The listening port of v2rayA.
+        '';
+      };
+
+      configPath = mkOption {
+        type = types.path;
+        default = "/etc/v2raya";
+        description = ''
+          The directory containing the configuration file of
+          v2rayA.
+        '';
+      };
+
+      v2rayPath = mkOption {
+        type = with types; nullOr path;
+        default = null;
+        example = literalExpression ''"''${pkgs.xray}/bin/xray"'';
+        description = ''
+          v2ray executable file path. If set to `null`, will
+          use v2ray provided in v2rayA wrapper. It can be
+          modified to the file path of other v2ray branches
+          such as xray.
+        '';
+      };
+
+      logFile = mkOption {
+        type = types.path;
+        default = "/var/log/v2raya/v2raya.log";
+        description = ''
+          The path of v2rayA log file.
+        '';
+      };
+
+      environment = mkOption {
+        type = types.attrsOf lib.types.str;
+        default = { };
+        example = literalExpression ''
+          {
+            V2RAYA_PLUGINLISTENPORT = "32346";
+            V2RAYA_PASSCHECKROOT = "1";
+            V2RAYA_FORCE_IPV6_ON = "1";
+          }
+        '';
+        description = ''
+          Environment variables added to v2raya systemd service.
+        '';
+      };
     };
   };
 
-  config = mkIf config.services.v2raya.enable {
-    environment.systemPackages = [ pkgs.v2raya ];
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
 
-    systemd.services.v2raya =
-      let
-        nftablesEnabled = config.networking.nftables.enable;
-        iptablesServices = [
+    systemd.services.v2raya = {
+      unitConfig = {
+        Description = "v2rayA service";
+        Documentation = "https://github.com/v2rayA/v2rayA/wiki";
+        After = [
+          "network.target"
+          "network-online.target"
+          "nss-lookup.target"
           "iptables.service"
-        ] ++ optional config.networking.enableIPv6 "ip6tables.service";
-        tableServices = if nftablesEnabled then [ "nftables.service" ] else iptablesServices;
-      in
-      {
-        unitConfig = {
-          Description = "v2rayA service";
-          Documentation = "https://github.com/v2rayA/v2rayA/wiki";
-          After = [
-            "network.target"
-            "nss-lookup.target"
-          ] ++ tableServices;
-          Wants = [ "network.target" ];
-        };
-
-        serviceConfig = {
-          User = "root";
-          ExecStart = "${getExe pkgs.v2raya} --log-disable-timestamp";
-          Environment = [ "V2RAYA_LOG_FILE=/var/log/v2raya/v2raya.log" ];
-          LimitNPROC = 500;
-          LimitNOFILE = 1000000;
-          Restart = "on-failure";
-          Type = "simple";
-        };
-
-        wantedBy = [ "multi-user.target" ];
-        path = with pkgs; [ iptables bash iproute2 ]; # required by v2rayA TProxy functionality
+          "ip6tables.service"
+          "nftables.service"
+        ];
+        Wants = [ "network.target" ];
       };
+
+      serviceConfig = {
+        User = "root";
+        ExecStart = "${getExe cfg.package} --log-disable-timestamp";
+        LimitNPROC = 500;
+        LimitNOFILE = 1000000;
+        Restart = "on-failure";
+        Type = "simple";
+      };
+
+      environment = {
+        V2RAYA_ADDRESS = "${cfg.listenAddress}:${toString cfg.listenPort}";
+        V2RAYA_CONFIG = cfg.configPath;
+        V2RAYA_V2RAY_BIN = cfg.v2rayPath;
+        V2RAYA_LOG_FILE = cfg.logFile;
+      } // cfg.environment;
+
+      wantedBy = [ "multi-user.target" ];
+      path = with pkgs; [ iptables bash iproute2 ]; # required by v2rayA TProxy functionality
+    };
   };
 
   meta.maintainers = with maintainers; [ elliot ];


### PR DESCRIPTION
## Description of changes

Added some frequently used configuration options.

Should we consider adding some more attributes to harden this systemd service?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
