### PR TITLE
python311Packages.coffea: 2024.1.0 -> 2024.2.1

### DIFF
--- a/pkgs/development/python-modules/coffea/default.nix
+++ b/pkgs/development/python-modules/coffea/default.nix
@@ -1,49 +1,52 @@
 { lib
-, buildPythonPackage
-, fetchFromGitHub
-, hatchling
-, hatch-vcs
 , awkward
-, uproot
+, buildPythonPackage
+, cachetools
+, cloudpickle
+, correctionlib
 , dask
 , dask-awkward
 , dask-histogram
-, correctionlib
-, pyarrow
-, fsspec
+, distributed
+, fetchFromGitHub
+, fsspec-xrootd
+, hatch-vcs
+, hatchling
+, hist
+, lz4
 , matplotlib
+, mplhep
 , numba
 , numpy
-, scipy
-, tqdm
-, lz4
-, cloudpickle
-, toml
-, mplhep
 , packaging
 , pandas
-, hist
-, cachetools
-, distributed
+, pyarrow
 , pyinstrument
 , pytestCheckHook
+, pythonOlder
+, scipy
+, toml
+, tqdm
+, uproot
 }:
 
 buildPythonPackage rec {
   pname = "coffea";
-  version = "2024.1.0";
+  version = "2024.2.1";
   pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "CoffeaTeam";
     repo = "coffea";
     rev = "refs/tags/v${version}";
-    hash = "sha256-jw8ACKXJZhj4fE7oppTxLUR4mhi+gh2ZD7lnUT3pcwc=";
+    hash = "sha256-TQ0aC2iFPWh24ce1WoVRluPvnwvBscLtFl8/wcW/Clg=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace "numba>=0.58.1" "numba"
+      --replace-fail "numba>=0.58.1" "numba"
   '';
 
   nativeBuildInputs = [
@@ -53,28 +56,27 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     awkward
-    uproot
+    cachetools
+    cloudpickle
+    correctionlib
     dask
-    dask.optional-dependencies.array
     dask-awkward
     dask-histogram
-    correctionlib
-    pyarrow
-    fsspec
+    fsspec-xrootd
+    hist
+    lz4
     matplotlib
+    mplhep
     numba
     numpy
-    scipy
-    tqdm
-    lz4
-    cloudpickle
-    toml
-    mplhep
     packaging
     pandas
-    hist
-    cachetools
-  ];
+    pyarrow
+    scipy
+    toml
+    tqdm
+    uproot
+  ] ++ dask.optional-dependencies.array;
 
   nativeCheckInputs = [
     distributed
@@ -89,6 +91,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Basic tools and wrappers for enabling not-too-alien syntax when running columnar Collider HEP analysis";
     homepage = "https://github.com/CoffeaTeam/coffea";
+    changelog = "https://github.com/CoffeaTeam/coffea/releases/tag/v${version}";
     license = with licenses; [ bsd3 ];
     maintainers = with maintainers; [ veprbl ];
   };

--- a/pkgs/development/python-modules/fsspec-xrootd/default.nix
+++ b/pkgs/development/python-modules/fsspec-xrootd/default.nix
@@ -1,0 +1,54 @@
+{ lib
+, bash
+, buildPythonPackage
+, fetchFromGitHub
+, fsspec
+, pkgs
+, pytestCheckHook
+, pythonOlder
+, setuptools
+, setuptools-scm
+, xrootd
+}:
+
+buildPythonPackage rec {
+  pname = "fsspec-xrootd";
+  version = "0.2.4";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "CoffeaTeam";
+    repo = "fsspec-xrootd";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-8TT+49SF/3i2OMIDcDD0AXEn0J9UkNX2q/SBkfoMXso=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    fsspec
+    xrootd
+  ];
+
+  nativeCheckInputs = [
+    pkgs.xrootd
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "fsspec_xrootd"
+  ];
+
+  meta = with lib; {
+    description = "An XRootD implementation for fsspec";
+    homepage = "https://github.com/CoffeaTeam/fsspec-xrootd";
+    changelog = "https://github.com/CoffeaTeam/fsspec-xrootd/releases/tag/v${version}";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4392,6 +4392,8 @@ self: super: with self; {
 
   fsspec = callPackage ../development/python-modules/fsspec { };
 
+  fsspec-xrootd = callPackage ../development/python-modules/fsspec-xrootd { };
+
   fst-pso = callPackage ../development/python-modules/fst-pso { };
 
   ftfy = callPackage ../development/python-modules/ftfy { };


### PR DESCRIPTION
Diff: https://github.com/CoffeaTeam/coffea/compare/refs/tags/v2024.1.0...v2024.2.1

Changelog: https://github.com/CoffeaTeam/coffea/releases/tag/v2024.2.1

## Description of changes
Fix build (https://hydra.nixos.org/build/249527501)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
