### PR TITLE
python311Packages.python-idzip init at 0.3.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20098,6 +20098,12 @@
     githubId = 326263;
     name = "Danny Wilson";
   };
+  vizid = {
+    email = "vizid1337@gmail.com";
+    github = "ViZiD";
+    githubId = 7444430;
+    name = "Radik Islamov";
+  };
   vklquevs = {
     email = "vklquevs@gmail.com";
     github = "vklquevs";

--- a/pkgs/development/python-modules/python-idzip/default.nix
+++ b/pkgs/development/python-modules/python-idzip/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+
+, pythonOlder
+
+, setuptools
+
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "python-idzip";
+  version = "0.3.9";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "bauman";
+    repo = "python-idzip";
+    rev = "refs/tags/${version}";
+    hash = "sha256-ChzwC/Afn0qeo5anq4anIu2eI9i6XDnSvB7jAwY7rSw=";
+  };
+
+  patches = [
+    # fix collision
+    # https://github.com/bauman/python-idzip/pull/23
+    (fetchpatch {
+      name = "fix-bin-folder-collisions.patch";
+      url = "https://patch-diff.githubusercontent.com/raw/bauman/python-idzip/pull/23.patch";
+      hash = "sha256-4fPhLdY9MaH1aX6tqMT+NNNNDsyv87G0xBh4MC+5yQE=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # need third-party files
+    # https://github.com/bauman/python-idzip/blob/master/.github/workflows/test.yaml#L2https://github.com/bauman/python-idzip/blob/master/.github/workflows/test.yaml#L288
+    "test/test_compressor.py"
+    "test/test_decompressor.py"
+    "test/test_lucky_cache.py"
+    "test/test_readline.py"
+    "test/test_seek_read_behavior.py"
+    "test/test_zero_cache.py"
+  ];
+
+  disabledTests = [
+    # Terminated
+    # pop_var_context: head of shell_variables not a function context
+    "test_bufferedio_compat"
+  ];
+
+  meta = with lib; {
+    description = "Seekable, gzip compatible, compression format";
+    homepage = "https://github.com/bauman/python-idzip";
+    changelog = "https://github.com/bauman/python-idzip/releases/tag/${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ vizid ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9684,6 +9684,8 @@ self: super: with self; {
 
   python-tado = callPackage ../development/python-modules/python-tado { };
 
+  python-idzip = callPackage ../development/python-modules/python-idzip { };
+
   pythonfinder = callPackage ../development/python-modules/pythonfinder { };
 
   pytomorrowio = callPackage ../development/python-modules/pytomorrowio { };


### PR DESCRIPTION
## Description of changes
Seekable, gzip compatible, compression format

Gzip allows to store extra fields in the gzip header. Idzip stores offsets for the efficient seeking there.

https://github.com/bauman/python-idzip

fix bin folder collisions
https://github.com/bauman/python-idzip/pull/23

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
