### PR TITLE
wps-fonts: add new font package for WPS Office

### DIFF
--- a/pkgs/by-name/wp/wps-fonts/package.nix
+++ b/pkgs/by-name/wp/wps-fonts/package.nix
@@ -1,0 +1,43 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "wps-fonts";
+  version = "2017-08-16";
+
+  src = fetchFromGitHub {
+    owner = "dv-anomaly";
+    repo = "wps-fonts";
+    rev = "b3e935355afcfb5240bac5a99707ffecc35772a2";
+    hash = "sha256-oRVREnE3qsk4gl1W0yFC11bHr+cmuOJe9Ah+0Csplq8=";
+  };
+
+
+  installPhase = ''
+    FONT_PATH="$out/share/fonts/wps-fonts"
+    echo -e "\nFonts will be installed in: "$FONT_PATH
+
+    if [ ! -d "$FONT_PATH" ]; then
+      echo "Creating Font Directory..."
+      mkdir -p $FONT_PATH
+    fi
+
+    echo "Installing Fonts..."
+    cp *.ttf $FONT_PATH
+    cp *.TTF $FONT_PATH
+
+    echo "Fixing Permissions..."
+    chmod 644 $FONT_PATH/*
+
+    echo "Installation Finished."
+  '';
+
+  meta = {
+    homepage = "https://github.com/dv-anomaly/wps-fonts";
+    description = "Fonts required by WPS Office";
+    maintainers = with lib.maintainers; [ cdunster ];
+  };
+}
+


### PR DESCRIPTION
## Description of changes

Add the fonts that are required by the WPS Office suite. It uses the repo: https://github.com/dv-anomaly/ttf-wps-fonts to download the required fonts.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I have built it locally on my NixOS machine and used the package with `nixos-rebuild` and it seems to work correctly.

P.S. This is my first time adding a new package so any suggestions are very welcome. I'm also not sure if the name is descriptive enough or if I should instead use `wps-office-fonts` or something.

Thanks.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
