### PR TITLE
home-assistant-custom-lovelace-modules.multiple-entity-row: init at 4.5.0

### DIFF
--- a/pkgs/servers/home-assistant/custom-lovelace-modules/default.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/default.nix
@@ -8,6 +8,8 @@
 
   mini-media-player = callPackage ./mini-media-player {};
 
+  multiple-entity-row = callPackage ./multiple-entity-row { };
+
   mushroom = callPackage ./mushroom { };
 
   zigbee2mqtt-networkmap = callPackage ./zigbee2mqtt-networkmap { };

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/multiple-entity-row/default.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/multiple-entity-row/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, mkYarnPackage
+, fetchFromGitHub
+, fetchYarnDeps
+}:
+
+mkYarnPackage rec {
+  pname = "multiple-entity-row";
+  version = "4.5.0";
+
+  src = fetchFromGitHub {
+    owner = "benct";
+    repo = "lovelace-multiple-entity-row";
+    rev = "v${version}";
+    hash = "sha256-3CkBzxB3bX4jwk71PaRMX1MkAb6UVOBqZCYpTN7VORY=";
+  };
+
+  packageJSON = ./package.json;
+
+  offlineCache = fetchYarnDeps {
+    yarnLock = "${src}/yarn.lock";
+    hash = "sha256-8YIcQhbYf0e2xO620zVHEk/0sssBmzF/jCq+2za+D6E=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    yarn --offline build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    install -m0644 ./deps/multiple-entity-row/multiple-entity-row.js $out
+
+    runHook postInstall
+  '';
+
+  doDist = false;
+
+  meta = with lib; {
+    description = "Show multiple entity states and attributes on entity rows in Home Assistant's Lovelace UI";
+    homepage = "https://github.com/benct/lovelace-multiple-entity-row";
+    changelog = "https://github.com/benct/lovelace-multiple-entity-row/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ hexa ];
+  };
+}

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/multiple-entity-row/package.json
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/multiple-entity-row/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "multiple-entity-row",
+  "version": "4.5.0",
+  "description": "Show multiple entity states, attributes and icons on entity rows in Home Assistant's Lovelace UI",
+  "keywords": [
+    "home-assistant",
+    "homeassistant",
+    "lovelace",
+    "custom-cards",
+    "multiple",
+    "entity",
+    "row"
+  ],
+  "module": "multiple-entity-row.js",
+  "repository": "https://github.com/benct/lovelace-multiple-entity-row.git",
+  "author": "benct <ben@tomlin.no>",
+  "license": "MIT",
+  "dependencies": {
+    "custom-card-helpers": "1.8.0",
+    "lit": "^2.7.4",
+    "memoize-one": "^6.0.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.22.1",
+    "@babel/preset-env": "^7.22.4",
+    "babel-loader": "^9.1.2",
+    "eslint": "^8.41.0",
+    "eslint-config-prettier": "^8.8.0",
+    "eslint-plugin-prettier": "^4.2.1",
+    "prettier": "^2.8.8",
+    "webpack": "^5.84.1",
+    "webpack-cli": "^5.1.1"
+  },
+  "scripts": {
+    "lint": "eslint src/**/*.js",
+    "dev": "webpack -c webpack.config.js",
+    "build": "yarn lint && webpack -c webpack.config.js"
+  }
+}


### PR DESCRIPTION
Show multiple entity states and attributes on entity rows in Home Assistant's Lovelace UI.

https://github.com/benct/lovelace-multiple-entity-row

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
