### PR TITLE
haskell.compiler: determine native-bignum GHCs via excludes

### DIFF
--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -9,25 +9,18 @@ let
     "ghc8107"
   ];
 
-  nativeBignumIncludes = [
-    "ghc90"
-    "ghc902"
-    "ghc92"
-    "ghc925"
-    "ghc926"
-    "ghc927"
-    "ghc928"
-    "ghc94"
-    "ghc945"
-    "ghc946"
-    "ghc947"
-    "ghc948"
-    "ghc96"
-    "ghc963"
-    "ghc964"
-    "ghc98"
-    "ghc981"
-    "ghcHEAD"
+  nativeBignumExcludes = integerSimpleIncludes ++ [
+    # haskell.compiler sub groups
+    "integer-simple"
+    "native-bignum"
+    # Binary GHCs
+    "ghc865Binary"
+    "ghc8107Binary"
+    "ghc924Binary"
+    "ghc963Binary"
+    # ghcjs
+    "ghcjs"
+    "ghcjs810"
   ];
 
   haskellLibUncomposable = import ../development/haskell-modules/lib {
@@ -357,7 +350,7 @@ in {
     # with "native" and "gmp" backends.
     native-bignum = let
       nativeBignumGhcNames = pkgs.lib.filter
-        (name: builtins.elem name nativeBignumIncludes)
+        (name: !(builtins.elem name nativeBignumExcludes))
         (pkgs.lib.attrNames compiler);
     in pkgs.recurseIntoAttrs (pkgs.lib.genAttrs
       nativeBignumGhcNames
@@ -502,7 +495,7 @@ in {
     native-bignum =
       let
         nativeBignumGhcNames = pkgs.lib.filter
-          (name: builtins.elem name nativeBignumIncludes)
+          (name: !(builtins.elem name nativeBignumExcludes))
           (pkgs.lib.attrNames compiler);
       in
       pkgs.lib.genAttrs nativeBignumGhcNames


### PR DESCRIPTION
native-bignum has become the norm, so let's convert it to an exclude rather than an include list. This way it's no longer possible to forget to add a newly packaged GHC to the include list.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
