### PR TITLE
Point to official TA-Lib github repo

### DIFF
--- a/pkgs/development/libraries/ta-lib/default.nix
+++ b/pkgs/development/libraries/ta-lib/default.nix
@@ -4,10 +4,10 @@ stdenv.mkDerivation rec {
   pname = "ta-lib";
   version = "0.4.0";
   src = fetchFromGitHub {
-    owner = "rafa-dot-el";
-    repo = "talib";
+    owner = "TA-Lib";
+    repo = "ta-lib";
     rev = version;
-    sha256 = "sha256-bIzN8f9ZiOLaVzGAXcZUHUh/v9z1U+zY+MnyjJr1lSw=";
+    sha256 = "";
   };
 
   nativeBuildInputs = [ pkg-config autoreconfHook ];


### PR DESCRIPTION
## Description of changes

Build from the offical TA-Lib github repo instead of an outdated svn mirror.

## Things done

- Built on platform(s)
  - [ x] x86_64-linux
