### PR TITLE
tritty: init at 1.0+12

### DIFF
--- a/pkgs/by-name/tr/tritty/package.nix
+++ b/pkgs/by-name/tr/tritty/package.nix
@@ -1,0 +1,43 @@
+{ callPackage, fetchFromGitHub, lib, stdenv }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tritty";
+  # The number after + indicates the number of commits since the release.
+  version = "1.0+12";
+  src = fetchFromGitHub {
+    owner = "sjmulder";
+    repo = "trickle";
+    rev = "57bbf836a232d931404b66938941b2571fdc716f";
+    hash = "sha256-D9UCryE3+rODsP4rXVJrE2gL44EVSQ6fN3doQXJkbJE=";
+  };
+  makeFlags = [ "PREFIX=${builtins.placeholder "out"}" ];
+
+  passthru = {
+    tests = {
+      simple = callPackage ./tests/simple.nix { tritty = finalAttrs.finalPackage; };
+    };
+  };
+
+  meta = {
+    description = "Slow pipe and terminal";
+    license = lib.licenses.bsd2;
+    homepage = "https://github.com/sjmulder/trickle#readme";
+    changelog = "https://github.com/sjmulder/trickle/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    mainProgram = "tritty";
+    longDescription = ''
+      This package provides two programs: trickle and tritty.
+
+      trickle is used as part of a shell pipeline and has very low throughput, hence the name: data trickles through the pipe.
+
+      tritty ("trickle tty") spawns an interactive subterminal with very low throughput. It simulates the experience of using a terminal over a slow connection.
+
+      This is useful for testing the robustness and efficiency of terminal applications. It can uncover problems such as excessive redraws of progress bars, or other inefficient use of the terminal.
+
+      Note that upstream names the package "trickle", but that name was already taken by another package in Nixpkgs.
+    '';
+    # Arguably upstream would pick trickle as the main program, but we can't name it that; see longDescription.
+    # So we pick tritty as the main program instead, for a consistent experience.
+    maintainers = with lib.maintainers; [ roberth ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/tr/tritty/tests/simple.nix
+++ b/pkgs/by-name/tr/tritty/tests/simple.nix
@@ -1,0 +1,47 @@
+{ expect, runCommand, tritty }:
+
+runCommand "tritty-tests-simple" {
+  nativeBuildInputs = [
+    expect
+    tritty
+  ];
+  passAsFile = [ "expectScript" ];
+  expectScript = ''
+    # 200 bytes per second
+    spawn "tritty" "-b" "1600"
+    proc abort_timeout { } { send_user "Timeout!" ; exit 2 }
+    proc abort_eof { } { send_user "End of file!" ; exit 2 }
+    expect_before timeout abort_timeout
+    expect_before eof abort_eof
+    set timeout 60
+
+    expect "\$"
+    # some 1400 bytes worth of output
+    send "for i in 1 2 3 4 5 6 7 8 9 10; do echo 'some output, so that the total number of bytes in this test is a bit more predictable, which helps with the assertion about time at the end'; done\r"
+    expect "\$"
+    send "echo -n he; echo llo\r"
+    expect "hello"
+    send "exit\r"
+    expect "exit"
+
+    # unset eof handler
+    expect_before eof { }
+    expect eof
+  '';
+} ''
+  (
+    set -x
+    [[ hello == "$(echo hello | trickle)" ]]
+  )
+  start=$(date +%s)
+  expect $expectScriptPath
+  end=$(date +%s)
+  echo "Test took $((end - start)) seconds"
+  (
+    set -x
+    # 1400 bytes at 200 bytes per second should take at least 7 seconds,
+    # (given that there's some other output and a bit of input as well)
+    [[ $((end - start)) -ge 7 ]]
+  )
+  touch $out
+''


### PR DESCRIPTION
## Description of changes
To quote `longDescription`:

This package provides two programs: trickle and tritty.
- trickle is used as part of a shell pipeline and has very low throughput, hence the name: data trickles through the pipe.

- tritty ("trickle tty") spawns an interactive subterminal with very low throughput. It simulates the experience of using a terminal over a slow connection.
      This is useful for testing the robustness and efficiency of terminal applications. It can uncover problems such as excessive redraws of progress bars, or other inefficient use of the terminal.
      Note that upstream names the package "trickle", but that name was already taken by another package in Nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
