### PR TITLE
ptouch-driver: init at 1.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16821,6 +16821,15 @@
     githubId = 178904;
     name = "Daniel Ehlers";
   };
+  sascha8a = {
+    email = "sascha@localhost.systems";
+    github = "sascha8a";
+    githubId = 6937965;
+    name = "Alexander Lampalzer";
+    keys = [{
+      fingerprint = "0350 3136 E22C C561 30E3 A4AE 2087 9CCA CD5C D670";
+    }];
+  };
   saschagrunert = {
     email = "mail@saschagrunert.de";
     github = "saschagrunert";

--- a/pkgs/by-name/pt/ptouch-driver/package.nix
+++ b/pkgs/by-name/pt/ptouch-driver/package.nix
@@ -1,0 +1,82 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cups
+, cups-filters
+, foomatic-db-engine
+, fetchpatch
+, ghostscript
+, libpng
+, libxml2
+, autoreconfHook
+, perl
+, patchPpdFilesHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ptouch-driver";
+  version = "1.7";
+
+  src = fetchFromGitHub {
+    owner = "philpem";
+    repo = "printer-driver-ptouch";
+    rev = "v${version}";
+    hash = "sha256-3ZotSHn7lERp53hAzx47Ct/k565rEoensCcltwX/Xls=";
+  };
+
+  patches = [
+    # Fixes some invalid XML file that otherwise causes a build failure
+    (fetchpatch {
+      name = "fix-brother-ql-600.patch";
+      url = "https://github.com/philpem/printer-driver-ptouch/commit/b3c53b3bc4dd98ed172f2c79405c7c09b3b3836a.patch";
+      hash = "sha256-y5bHKFeRXx8Wdl1++l4QNGgiY41LY5uzrRdOlaZyF9I=";
+    })
+  ];
+
+  buildInputs = [ cups cups-filters ghostscript libpng libxml2 ];
+  nativeBuildInputs = [
+    autoreconfHook
+    foomatic-db-engine
+    patchPpdFilesHook
+    (perl.withPackages (pp: with pp; [ XMLLibXML ]))
+  ];
+
+  postPatch = ''
+    patchShebangs ./foomaticalize
+  '';
+
+  postInstall = ''
+    export FOOMATICDB="${placeholder "out"}/share/foomatic"
+    mkdir -p "${placeholder "out"}/share/cups/model"
+    foomatic-compiledb -j "$NIX_BUILD_CORES" -d "${placeholder "out"}/share/cups/model/ptouch-driver"
+  '';
+
+  # compress ppd files
+  postFixup = ''
+    echo 'compressing ppd files'
+    find -H "${placeholder "out"}/share/cups/model/ptouch-driver" -type f -iname '*.ppd' -print0  \
+      | xargs -0r -n 4 -P "$NIX_BUILD_CORES" gzip -9n
+  '';
+
+  # Comments indicate the respective
+  # package the command is contained in.
+  ppdFileCommands = [
+    "rastertoptch" # ptouch-driver
+    "gs" # ghostscript
+    "foomatic-rip" # cups-filters
+  ];
+
+  meta = with lib; {
+    changelog = "https://github.com/philpem/printer-driver-ptouch/releases/tag/v${version}";
+    description = "Printer Driver for Brother P-touch and QL Label Printers";
+    downloadPage = "https://github.com/philpem/printer-driver-ptouch";
+    homepage = "https://github.com/philpem/printer-driver-ptouch";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ sascha8a ];
+    platforms = platforms.linux;
+    longDescription = ''
+      This is ptouch-driver, a printer driver based on CUPS and foomatic,
+      for the Brother P-touch and QL label printer families.
+    '';
+  };
+}


### PR DESCRIPTION
## Description of changes

This package provides a printer driver for the Brother PT- and QT- printers. It is based upon the open source repository [https://github.com/philpem/printer-driver-ptouch](https://github.com/philpem/printer-driver-ptouch).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).