### PR TITLE
arianna: add missing runtime dependency

### DIFF
--- a/pkgs/applications/kde/arianna.nix
+++ b/pkgs/applications/kde/arianna.nix
@@ -16,6 +16,7 @@
 , kfilemetadata
 , ki18n
 , kirigami-addons
+, kitemmodels
 , kquickcharts
 , kwindowsystem
 , qqc2-desktop-style
@@ -44,6 +45,7 @@ mkDerivation {
     kfilemetadata
     ki18n
     kirigami-addons
+    kitemmodels
     kquickcharts
     kwindowsystem
     qqc2-desktop-style


### PR DESCRIPTION
## Description of changes

Without kitemmodels, arianna does not run:

```
QQmlApplicationEngine failed to load component
qrc:/content/ui/main.qml:273:20: Type TableOfContentDrawer unavailable
qrc:/content/ui/TableOfContentDrawer.qml:49:13: Type Tree.TreeListView unavailable
file:///nix/store/rwd01yryix22rdkcyi5krf2b0jrxa8sl-kirigami-addons-0.11.0/lib/qt-5.15.12/qml/org/kde/kirigamiaddons/treeview/TreeListView.qml:20:1: Type InternalTreeListView unavailable
file:///nix/store/rwd01yryix22rdkcyi5krf2b0jrxa8sl-kirigami-addons-0.11.0/lib/qt-5.15.12/qml/org/kde/kirigamiaddons/treeview/private/InternalTreeListView.qml:11:1: module "org.kde.kitemmodels" is not installed
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
