### PR TITLE
netopeer2: init at 2.2.13

### DIFF
--- a/pkgs/by-name/li/libnetconf2/package.nix
+++ b/pkgs/by-name/li/libnetconf2/package.nix
@@ -1,0 +1,59 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, openssl
+, libssh
+, curl
+, libyang
+, pcre2
+, libxcrypt
+, validatePkgConfig
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libnetconf2";
+  version = "3.0.8";
+
+  src = fetchFromGitHub {
+    owner = "CESNET";
+    repo = "libnetconf2";
+    rev = "v${version}";
+    hash = "sha256-MEub9bElAm8SIwRDUsAyURKeEF7cau/ZtmRNvlB3wn4=";
+  };
+
+  postPatch = ''
+    substituteInPlace libnetconf2.pc.in \
+      --replace "\''${prefix}/@CMAKE_INSTALL_LIBDIR@" "\''${prefix}/lib" \
+      --replace "\''${prefix}/@CMAKE_INSTALL_INCLUDEDIR@" "\''${prefix}/include"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    validatePkgConfig
+  ];
+
+  buildInputs = [
+    openssl
+    libssh
+    curl
+    libyang
+    # Hidden dependencies but necessary ones
+    pcre2
+    libxcrypt
+  ];
+
+  meta = with lib; {
+    description = "C NETCONF library";
+    longDescription = ''
+      libnetconf2 is a NETCONF library in C intended for building NETCONF clients and
+      servers. NETCONF is the NETwork CONFiguration protocol introduced by
+      IETF in RFC 4741 and RFC 6241.
+    '';
+    homepage = "https://github.com/CESNET/libnetconf2";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ raitobezarius ];
+    mainProgram = "libnetconf2";
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/by-name/ne/netopeer2/package.nix
+++ b/pkgs/by-name/ne/netopeer2/package.nix
@@ -1,0 +1,65 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, libnetconf2
+, sysrepo
+, systemdMinimal
+, libyang
+, openssl
+, libssh
+, pcre2
+, cmocka
+}:
+
+stdenv.mkDerivation rec {
+  pname = "netopeer2";
+  version = "2.2.13";
+
+  src = fetchFromGitHub {
+    owner = "CESNET";
+    repo = "Netopeer2";
+    rev = "v${version}";
+    hash = "sha256-eStuZT+EGfEH5VC0GicIM71N26ZGhj0SK+40fTW1cZw=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    libnetconf2
+    sysrepo
+    systemdMinimal
+    libyang
+    openssl
+    libssh
+    pcre2
+    # For tests
+    cmocka
+  ];
+
+  cmakeFlags = [
+    # This will break cross compilation otherwise
+    # and try to manipulate a global state (to install sysrepo modules).
+    "-DSYSREPO_SETUP=OFF"
+  ];
+
+  meta = with lib; {
+    description = "NETCONF toolset";
+    longDescription = ''
+      Netopeer2 is a server for implementing network configuration management
+      based on the NETCONF Protocol. This is the second generation, originally
+      available as the Netopeer project.
+
+      It contains also the command-line tool `netopeer2-cli`.
+    '';
+    homepage = "https://github.com/CESNET/Netopeer2";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ raitobezarius ];
+    mainProgram = "netopeer2";
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/by-name/sy/sysrepo/package.nix
+++ b/pkgs/by-name/sy/sysrepo/package.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, pkg-config
+, libyang
+, pcre2
+, validatePkgConfig
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sysrepo";
+  version = "2.2.150";
+
+  src = fetchFromGitHub {
+    owner = "sysrepo";
+    repo = "sysrepo";
+    rev = "v${version}";
+    hash = "sha256-4De10Lp4XCnphypzw1K+jY3LHbDd1FdP3cnu28BIFJg=";
+  };
+
+  postPatch = ''
+    substituteInPlace sysrepo.pc.in \
+      --replace "\''${prefix}/@CMAKE_INSTALL_LIBDIR@" "\''${prefix}/lib" \
+      --replace "\''${prefix}/@CMAKE_INSTALL_INCLUDEDIR@" "\''${prefix}/include"
+  '';
+
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    validatePkgConfig
+  ];
+
+  buildInputs = [
+    libyang
+    pcre2
+  ];
+
+  meta = with lib; {
+    description = "YANG-based configuration and operational state data store for Unix/Linux applications";
+    homepage = "https://github.com/sysrepo/sysrepo";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ raitobezarius ];
+    mainProgram = "sysrepo";
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/libraries/libyang/default.nix
+++ b/pkgs/development/libraries/libyang/default.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libyang";
-  version = "2.1.128";
+  version = "2.1.148";
 
   src = fetchFromGitHub {
     owner = "CESNET";
     repo = "libyang";
     rev = "v${version}";
-    sha256 = "sha256-qwEHGUizjsWQZSwQkh7Clevd1OQfj1mse7Q8YiRCMyQ=";
+    sha256 = "sha256-uYZJo8lUv6tq0MRRJvbTS/8t1eZNGqcMb5k5sVCwMJM=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

This enables CLI and server for NETCONF ecosystems using CESNET software.

netconf-cli is impossible to package because it relies on C++ bindings and those are mutually incompatible with the current set of packages. We will have to do with the Netopeer2 CLI.

Personal TODO:

- add automatic gitUpdater to new components
- ensure that libraries run their tests if they can run them.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
