### PR TITLE
cmake: fix patch for darwin

### DIFF
--- a/pkgs/by-name/cm/cmake/005-remove-systemconfiguration-dep.diff
+++ b/pkgs/by-name/cm/cmake/005-remove-systemconfiguration-dep.diff
@@ -1,6 +1,6 @@
-diff -ru cmake-3.28.2/Utilities/cmcurl/CMakeLists.txt cmake-3.28.2-patched/Utilities/cmcurl/CMakeLists.txt
---- cmake-3.28.2/Utilities/cmcurl/CMakeLists.txt	2024-01-29 21:01:32
-+++ cmake-3.28.2-patched/Utilities/cmcurl/CMakeLists.txt	2024-01-31 21:20:02
+diff -Naur cmake-3.28.2/Utilities/cmcurl/CMakeLists.txt cmake-3.28.2-new/Utilities/cmcurl/CMakeLists.txt
+--- cmake-3.28.2/Utilities/cmcurl/CMakeLists.txt	2024-01-29 23:01:32.000000000 +0300
++++ cmake-3.28.2-new/Utilities/cmcurl/CMakeLists.txt	2024-02-16 13:09:40.805479195 +0300
 @@ -470,13 +470,6 @@
  
    if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT ENABLE_ARES)
@@ -15,15 +15,15 @@ diff -ru cmake-3.28.2/Utilities/cmcurl/CMakeLists.txt cmake-3.28.2-patched/Utili
    endif()
  endif()
  
-diff -ru cmake-3.28.2/Utilities/cmcurl/lib/curl_setup.h cmake-3.28.2-patched/Utilities/cmcurl/lib/curl_setup.h
---- cmake-3.28.2/Utilities/cmcurl/lib/curl_setup.h	2024-01-29 21:01:32
-+++ cmake-3.28.2-patched/Utilities/cmcurl/lib/curl_setup.h	2024-01-31 21:20:50
-@@ -255,12 +255,7 @@
+diff -Naur cmake-3.28.2/Utilities/cmcurl/lib/curl_setup.h cmake-3.28.2-new/Utilities/cmcurl/lib/curl_setup.h
+--- cmake-3.28.2/Utilities/cmcurl/lib/curl_setup.h	2024-01-29 23:01:32.000000000 +0300
++++ cmake-3.28.2-new/Utilities/cmcurl/lib/curl_setup.h	2024-02-16 13:10:38.822445566 +0300
+@@ -255,12 +255,6 @@
   * performing this task will result in a synthesized IPv6 address.
   */
  #if defined(__APPLE__) && !defined(USE_ARES)
 -#include <TargetConditionals.h>
-- #define USE_RESOLVE_ON_IPS 1
+-#define USE_RESOLVE_ON_IPS 1
 -#  if TARGET_OS_MAC && !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE) && \
 -     defined(ENABLE_IPV6)
 -#    define CURL_MACOS_CALL_COPYPROXIES 1


### PR DESCRIPTION
## Description of changes
The patch was malformed and did not apply before. Looks like it was broken during #285472.

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
