### PR TITLE
buildCrystalPackage: add copyShardDeps flag

### DIFF
--- a/pkgs/development/compilers/crystal/build-package.nix
+++ b/pkgs/development/compilers/crystal/build-package.nix
@@ -26,6 +26,9 @@
   # The default `crystal build` options can be overridden with { foo.options = [ "--optionname" ]; }
 , crystalBinaries ? { }
 , enableParallelBuilding ? true
+  # Copy all shards dependencies instead of symlinking and add write permissions
+  # to make environment more local-like
+, copyShardDeps ? false
 , ...
 }@args:
 
@@ -79,7 +82,8 @@ stdenv.mkDerivation (mkDerivationArgs // {
       ++ lib.optional (lockFile != null) "cp ${lockFile} ./shard.lock"
       ++ lib.optionals (shardsFile != null) [
         "test -e lib || mkdir lib"
-        "for d in ${crystalLib}/*; do ln -s $d lib/; done"
+        (if copyShardDeps then "for d in ${crystalLib}/*; do cp -r $d/ lib/; done; chmod -R +w lib/"
+          else "for d in ${crystalLib}/*; do ln -s $d lib/; done")
         "cp shard.lock lib/.shards.info"
       ]
       ++ [ "runHook postConfigure" ]


### PR DESCRIPTION
## Description of changes
Added the ability to copy dependencies declared in `shards.nix` instead of creating symbolic links to dependencies. By default, the `copyShardDeps` flag is set to `false`, so this change should not break other packages in any way.

This change will have an extremely positive effect on the packaging of crystal packages, since the state of crystal dependencies at the time of download is not final and may change for a number of things:
1) `shards.yml` may contain a `postInstall` script that wants to write to the shard's directory (which will lead to build error, because all shards are in `/nix/store` and they are read only)
2) [gi-crystal](https://github.com/NixOS/nixpkgs/pull/243914) cannot work in `nix`, because it generates bindings in its folder, so by creating a link to `gi-crystal` in `/nix/store`, we actually prohibit `gi-crystal` from working and it becomes useless. I [patched](https://github.com/NixOS/nixpkgs/pull/243914/files#diff-1a3ec3be7dadadd498d82613b7eaba4d02f11f8470913c5cbdb7d54932c63954) it and changed the logic of it, so it works at the moment, however, each new version of `gi-crystal` [breaks](https://hydra.nixos.org/build/248174386/nixlog/2) packages which depends on it, since the version of `gi-crystal` must match the version from `shard.lock`
3) crystal macros can be executed at the time of program compilation and write something to the shard's directory. (I ran into this problem in [blake3.cr](https://github.com/GeopJr/blake3.cr/blob/main/src/compile_blake3.cr) )

With this change, the logic of `buildCrystalPackage` does not change in any way, but an important setting is added, by adding just one flag, you can create an environment closer to the standard environment and simplify packaging.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
