### PR TITLE
hoppscotch: init at 23.12.5

### DIFF
--- a/pkgs/by-name/ho/hoppscotch/package.nix
+++ b/pkgs/by-name/ho/hoppscotch/package.nix
@@ -1,0 +1,71 @@
+{ lib
+, stdenv
+, fetchurl
+, appimageTools
+, undmg
+, nix-update-script
+}:
+
+let
+  pname = "hoppscotch";
+  version = "23.12.5";
+
+  src = fetchurl {
+    aarch64-darwin = {
+      url = "https://github.com/hoppscotch/releases/releases/download/v${version}-1/Hoppscotch_mac_aarch64.dmg";
+      hash = "sha256-WUJW38vQ7o5KEmCxhVnJ03/f5tPOTYcczrEcmt6NSCY=";
+    };
+    x86_64-darwin = {
+      url = "https://github.com/hoppscotch/releases/releases/download/v${version}-1/Hoppscotch_mac_x64.dmg";
+      hash = "sha256-bQFD+9IoelinWYUndzbVvPNaRde6ACPvw9ifX9mYdno=";
+    };
+    x86_64-linux = {
+      url = "https://github.com/hoppscotch/releases/releases/download/v${version}-1/Hoppscotch_linux_x64.AppImage";
+      hash = "sha256-MYQ7SRm+CUPIXROZxejbbZ0/wH+U5DQO4YGbE/HQAj8=";
+    };
+  }.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
+
+  meta = {
+    description = "Open source API development ecosystem";
+    homepage = "https://hoppscotch.com";
+    changelog = "https://github.com/hoppscotch/hoppscotch/releases/tag/${version}";
+    platforms = [ "aarch64-darwin" "x86_64-darwin" "x86_64-linux" ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ DataHearth ];
+  };
+in
+if stdenv.isDarwin then stdenv.mkDerivation
+{
+  inherit pname version src meta;
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [ undmg ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications"
+    mv Hoppscotch.app $out/Applications/
+
+    runHook postInstall
+  '';
+}
+else appimageTools.wrapType2 {
+  inherit pname version src meta;
+
+  extraPkgs = pkgs:
+    appimageTools.defaultFhsEnvArgs.multiPkgs pkgs;
+
+  extraInstallCommands =
+    let
+      appimageContents = appimageTools.extractType2 { inherit pname version src; };
+    in
+    ''
+      mv $out/bin/${pname}-${version} $out/bin/${pname}
+
+      # Install .desktop files
+      install -Dm444 ${appimageContents}/hoppscotch.desktop -t $out/share/applications
+      install -Dm444 ${appimageContents}/hoppscotch.png -t $out/share/pixmaps
+    '';
+}


### PR DESCRIPTION
## Description of changes

Git repository: <https://github.com/hoppscotch/hoppscotch>
Hoppscotch is a postman like software to test APIs (rest, graphql, etc) using a web interface.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
