### PR TITLE
python3Packages.osc: Enable keyring support

### DIFF
--- a/pkgs/development/python-modules/osc/default.nix
+++ b/pkgs/development/python-modules/osc/default.nix
@@ -7,6 +7,7 @@
 , lib
 , rpm
 , urllib3
+, keyring
 }:
 
 buildPythonPackage rec {
@@ -23,7 +24,7 @@ buildPythonPackage rec {
 
   buildInputs = [ bashInteractive ]; # needed for bash-completion helper
   nativeCheckInputs = [ rpm diffstat ];
-  propagatedBuildInputs = [ urllib3 cryptography ];
+  propagatedBuildInputs = [ urllib3 cryptography keyring ];
 
   postInstall = ''
     install -D -m444 contrib/osc.fish $out/etc/fish/completions/osc.fish


### PR DESCRIPTION
## Description of changes

Enables support for storing passwords in keyring. For details see openSUSE Wiki: https://en.opensuse.org/openSUSE:OSC#Authentication

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Tested manually
- [x] that option for storing in keyring is now an option and that
- [x] storing in gnome-keyring works.

Before

```console
$ osc ls /
The apiurl 'https://obs.local' does not exist in the config file. Please enter
your credentials for this apiurl.

Username [obs.local]: username
Password [username@obs.local]: 
To use keyrings please install python3-keyring.

NUM NAME              DESCRIPTION
1   Transient         Do not store the password and always ask for it [secure, in-memory]
2   Obfuscated config Store the password in obfuscated form in the osc config file [insecure, persistent]
3   Config            Store the password in plain text in the osc config file [insecure, persistent]
Select credentials manager [default=1]:
```

After:

```console
$ osc ls /
The apiurl 'https://obs.local' does not exist in the config file. Please enter
your credentials for this apiurl.

Username [obs.local]: username
Password [username@obs.local]: 

NUM NAME              DESCRIPTION
1   Secret Service    Store password in Secret Service (GNOME Keyring backend) [secure, persistent]
2   Transient         Do not store the password and always ask for it [secure, in-memory]
3   Obfuscated config Store the password in obfuscated form in the osc config file [insecure, persistent]
4   Config            Store the password in plain text in the osc config file [insecure, persistent]
Select credentials manager [default=1]:
```
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
