### PR TITLE
WIP: cog: 0.8.1 -> 0.18.2

### DIFF
--- a/pkgs/development/web/cog/default.nix
+++ b/pkgs/development/web/cog/default.nix
@@ -1,7 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, cmake
+, meson
 , pkg-config
 , wayland
 , wayland-protocols
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cog";
-  version = "0.8.1";
+  version = "0.18.2";
 
   src = fetchFromGitHub {
     owner = "igalia";
     repo = "cog";
-    rev = "v${version}";
-    sha256 = "sha256-eF7rvOjZntcMmn622342yqfp4ksZ6R/FFBT36bYCViE=";
+    rev = version;
+    sha256 = "sha256-Ss1wZREE56BzLf/2ec7Qv/tc7HiMfXJKaNpP7WJa9xg=";
   };
 
   buildInputs = [
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
-    cmake
+    meson
     pkg-config
     wayland
     makeWrapper
@@ -48,22 +48,6 @@ stdenv.mkDerivation rec {
   depsBuildsBuild = [
     pkg-config
   ];
-
-  cmakeFlags = [
-    "-DCOG_USE_WEBKITGTK=ON"
-  ];
-
-  # https://github.com/Igalia/cog/issues/438
-  postPatch = ''
-    substituteInPlace core/cogcore.pc.in \
-      --replace '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@
-  '';
-
-  # not ideal, see https://github.com/WebPlatformForEmbedded/libwpe/issues/59
-  preFixup = ''
-    wrapProgram $out/bin/cog \
-      --prefix LD_LIBRARY_PATH : ${libwpe-fdo}/lib
-  '';
 
   meta = with lib; {
     description = "A small single “window” launcher for the WebKit WPE port";


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

```
error: builder for '/nix/store/mb3cd0nhbhhkkjzz3s2l24rxx050waah-cog-0.18.2.drv' failed with exit code 1;
       last 25 log lines:
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > mesonConfigurePhase flags: --prefix=/nix/store/kfg4w9n7yrwc38jih0malgz20hpng3y0-cog-0.18.2 --libdir=/nix/store/kfg4w9n7yrwc38jih0malgz20hpng3y0-cog-0.18.2/lib --libexecdir=/nix/store/kfg4w9n7yrwc38jih0malgz20hpng3y0-cog-0.18.2/libexec --bindir=/nix/store/kfg4w9n7yrwc38jih0malgz20hpng3y0-cog-0.18.2/bin --sbindir=/nix/store/kfg4w9n7yrwc38jih0malgz20hpng3y0-cog-0.18.2/sbin --includedir=/nix/store/kfg4w9n7yrwc38jih0malgz20hpng3y0-cog-0.18.2/include --mandir=/nix/store/kfg4w9n7yrwc38jih0malgz20hpng3y0-cog-0.18.2/share/man --infodir=/nix/store/kfg4w9n7yrwc38jih0malgz20hpng3y0-cog-0.18.2/share/info --localedir=/nix/store/kfg4w9n7yrwc38jih0malgz20hpng3y0-cog-0.18.2/share/locale -Dauto_features=enabled -Dwrap_mode=nodownload --buildtype=plain
       > The Meson build system
       > Version: 1.3.1
       > Source dir: /build/source
       > Build dir: /build/source/build
       > Build type: native build
       > Project name: cog
       > Project version: 0.18.2
       > C compiler for the host machine: gcc (gcc 13.2.0 "gcc (GCC) 13.2.0")
       > C linker for the host machine: gcc ld.bfd 2.40
       > Host machine cpu family: x86_64
       > Host machine cpu: x86_64
       > Found pkg-config: YES (/nix/store/knxv5h4hsh86c649rabd6dqfd97kwp5d-pkg-config-wrapper-0.29.2/bin/pkg-config) 0.29.2
       > Did not find CMake 'cmake'
       > Found CMake: NO
       > Run-time dependency wpe-webkit-2.0 found: NO (tried pkgconfig and cmake)
       > Run-time dependency wpe-webkit-1.1 found: NO (tried pkgconfig and cmake)
       > Run-time dependency wpe-webkit-1.0 found: NO (tried pkgconfig and cmake)
       >
       > meson.build:110:4: ERROR: Problem encountered: WPE WebKit not found
       >
       > A full log can be found at /build/source/build/meson-logs/meson-log.txt
       For full logs, run 'nix log /nix/store/mb3cd0nhbhhkkjzz3s2l24rxx050waah-cog-0.18.2.drv'.
```

@matthewbauer do you know by chance if we need to package wpe-webkit or if it should be included in libwpe?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
