### PR TITLE
rstudio: 2023.9.0+463 -> 2023.12.1+402

### DIFF
--- a/pkgs/applications/editors/rstudio/default.nix
+++ b/pkgs/applications/editors/rstudio/default.nix
@@ -7,7 +7,7 @@
 , makeDesktopItem
 , copyDesktopItems
 , cmake
-, boost
+, boost183
 , zlib
 , openssl
 , R
@@ -40,18 +40,19 @@
 
 let
   pname = "RStudio";
-  version =
-  "${RSTUDIO_VERSION_MAJOR}.${RSTUDIO_VERSION_MINOR}.${RSTUDIO_VERSION_PATCH}${RSTUDIO_VERSION_SUFFIX}";
-  RSTUDIO_VERSION_MAJOR  = "2023";
-  RSTUDIO_VERSION_MINOR  = "09";
-  RSTUDIO_VERSION_PATCH  = "0";
-  RSTUDIO_VERSION_SUFFIX = "+463";
+  version = "2023.12.1+402";
+  RSTUDIO_VERSION_MAJOR = lib.versions.major version;
+  RSTUDIO_VERSION_MINOR = lib.versions.minor version;
+  RSTUDIO_VERSION_PATCH = lib.versions.patch version;
+  RSTUDIO_VERSION_SUFFIX = "+" + toString (
+    lib.tail (lib.splitString "+" version)
+  );
 
   src = fetchFromGitHub {
     owner = "rstudio";
     repo = "rstudio";
-    rev = "v${version}";
-    hash = "sha256-FwNuU2rbE3GEhuwphvZISUMhvSZJ6FjjaZ1oQ9F8NWc=";
+    rev = version;
+    hash = "sha256-ecMzkpHazg8jEBz9wh8hqRX2UdziOC8b6F+3xxdugy0=";
   };
 
   mathJaxSrc = fetchurl {
@@ -62,8 +63,8 @@ let
   rsconnectSrc = fetchFromGitHub {
     owner = "rstudio";
     repo = "rsconnect";
-    rev = "5175a927a41acfd9a21d9fdecb705ea3292109f2";
-    hash = "sha256-c1fFcN6KAfxXv8bv4WnIqQKg1wcNP2AywhEmIbyzaBA=";
+    rev = "v1.2.0";
+    hash = "sha256-ghRz4Frd+I9ShRNNOE/kdk9KjRCj0Z1mPnThueriiUY=";
   };
 
   # Ideally, rev should match the rstudio release name.
@@ -93,7 +94,7 @@ in
     ];
 
     buildInputs = [
-      boost
+      boost183
       zlib
       openssl
       R
@@ -133,6 +134,7 @@ in
       ./fix-resources-path.patch
       ./pandoc-nix-path.patch
       ./use-system-quarto.patch
+      ./ignore-etc-os-release.patch
     ];
 
     postPatch = ''

--- a/pkgs/applications/editors/rstudio/ignore-etc-os-release.patch
+++ b/pkgs/applications/editors/rstudio/ignore-etc-os-release.patch
@@ -1,0 +1,77 @@
+diff --git a/CMakeGlobals.txt b/CMakeGlobals.txt
+index 5f96ffb..3f15687 100644
+--- a/CMakeGlobals.txt
++++ b/CMakeGlobals.txt
+@@ -29,11 +29,6 @@ endif()
+ get_filename_component(ROOT_SRC_DIR ${CMAKE_CURRENT_LIST_FILE} PATH)
+ set(CMAKE_MODULE_PATH "${ROOT_SRC_DIR}/cmake/modules/")
+ 
+-# read /etc/os-release
+-if(LINUX)
+-   include(OsRelease)
+-endif()
+-
+ # version info
+ if ("$ENV{RSTUDIO_VERSION_MAJOR}" STREQUAL "")
+   string(TIMESTAMP CPACK_PACKAGE_VERSION_MAJOR "%Y")
+diff --git a/cmake/modules/OsRelease.cmake b/cmake/modules/OsRelease.cmake
+deleted file mode 100644
+index 81a9e1f..0000000
+--- a/cmake/modules/OsRelease.cmake
++++ /dev/null
+@@ -1,24 +0,0 @@
+-#
+-# OsRelease.cmake
+-#
+-# Copyright (C) 2022 by Posit Software, PBC
+-#
+-# This program is licensed to you under the terms of version 3 of the
+-# GNU Affero General Public License. This program is distributed WITHOUT
+-# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+-# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+-# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+-#
+-#
+-
+-# reads and parses /etc/os-release into CMake variables
+-file(STRINGS "/etc/os-release" OS_RELEASE)
+-foreach(LINE ${OS_RELEASE})
+-	string(FIND "${LINE}" "=" INDEX)
+-	string(SUBSTRING "${LINE}" 0 "${INDEX}" KEY)
+-	math(EXPR INDEX "${INDEX} + 1")
+-	string(SUBSTRING "${LINE}" "${INDEX}" -1 VALUE)
+-	separate_arguments(VALUE UNIX_COMMAND "${VALUE}")
+-	set("OS_RELEASE_${KEY}" "${VALUE}" CACHE INTERNAL "/etc/os-release: ${KEY}")
+-endforeach()
+-
+diff --git a/package/linux/CMakeLists.txt b/package/linux/CMakeLists.txt
+index 5d5c35e..a94f8fc 100644
+--- a/package/linux/CMakeLists.txt
++++ b/package/linux/CMakeLists.txt
+@@ -16,7 +16,7 @@
+ # configure cpack install location
+ set(CPACK_SET_DESTDIR "ON")
+ set(CPACK_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
+-message(STATUS "Packaging RStudio for ${OS_RELEASE_PRETTY_NAME}")
++message(STATUS "Packaging RStudio for Nix")
+ 
+ # detect architecture (packaging platform specific)
+ find_program(DPKG_EXECUTABLE dpkg)
+@@ -42,17 +42,6 @@ if(EXISTS "/etc/redhat-release")
+    endif()
+ endif()
+ 
+-# set libssl dependency
+-if(OS_RELEASE_ID STREQUAL "ubuntu")
+-  if(OS_RELEASE_VERSION_ID VERSION_GREATER_EQUAL "22.04")
+-    set(RSTUDIO_DEBIAN_DEPENDS_SSL "libssl-dev")
+-  else()
+-    set(RSTUDIO_DEBIAN_DEPENDS_SSL "libssl1.0.0 | libssl1.0.2 | libssl1.1")
+-  endif()
+-else()
+-  set(RSTUDIO_DEBIAN_DEPENDS_SSL "libssl-dev")
+-endif()
+-
+ # configuration specific
+ if(RSTUDIO_SERVER)
+ 

--- a/pkgs/applications/editors/rstudio/use-system-node.patch
+++ b/pkgs/applications/editors/rstudio/use-system-node.patch
@@ -6,7 +6,7 @@ index d18362b..98cdd4c 100644
  external-pandoc-path=${RSTUDIO_DEPENDENCIES_PANDOC_DIR}
  external-quarto-path=${RSTUDIO_DEPENDENCIES_QUARTO_DIR}
  external-libclang-path=${RSTUDIO_DEPENDENCIES_DIR}/common/libclang
--external-node-path=${RSTUDIO_DEPENDENCIES_DIR}/common/node/16.14.0/bin/node
+-external-node-path=${RSTUDIO_DEPENDENCIES_DIR}/common/node/18.18.2/bin/node
 +external-node-path=@node@/bin/node
  
  # enable copilot
@@ -32,7 +32,7 @@ index 033d605..f1ee63d 100644
 +++ b/src/gwt/build.xml
 @@ -87,29 +87,7 @@
     <!-- ensure version matches RSTUDIO_NODE_VERSION -->
-    <property name="node.version" value="16.14.0"/>
+    <property name="node.version" value="18.18.2"/>
     <property name="node.dir" value="../../dependencies/common/node/${node.version}"/>
 -   <!-- use yarn from system but will prefer yarn from dependencies if available -->
 -   <condition property="yarn.bin" value="yarn">
@@ -58,15 +58,18 @@ index 033d605..f1ee63d 100644
 -      value="c:\rstudio-tools\dependencies\common\node\${node.version}\node_modules\yarn\bin\yarn.cmd"
 -      file="c:\rstudio-tools\dependencies\common\node\${node.version}\node_modules\yarn\bin\yarn.cmd"/>
 +   <property name="node.bin" value="@node@/bin/node"/>
- 
+
     <property name="panmirror.dir" value="./lib/quarto/apps/panmirror"/>
     <property name="panmirror.build.dir" value="./www/js/panmirror"/>
-@@ -126,21 +104,11 @@
-       file="c:\rstudio-tools\src\gwt\lib\quarto\apps\panmirror"/>
- 
-    <target name="panmirror" description="Compile panmirror library">
+@@ -133,28 +111,11 @@
+             <isset property="panmirror.minify" />
+          </not>
+       </condition>
+-
 -      <echo message="yarn location: ${yarn.bin}"/>
 -      <echo message="panmirror location: ${panmirror.dir}"/>
+-      <echo message="panmirror minify: ${panmirror.minify}"/>
+-
        <mkdir dir="${panmirror.build.dir}"/>
 -      <exec executable="${yarn.bin}" dir="${panmirror.dir}" resolveexecutable="true" failonerror="true">
 -         <arg value="install"/>
@@ -75,14 +78,19 @@ index 033d605..f1ee63d 100644
 -      </exec>
 -      <exec executable="${yarn.bin}" dir="${panmirror.dir}" resolveexecutable="true" failonerror="true">
 -         <arg value="build"/>
+-         <arg value="--minify"/>
+-         <arg value="${panmirror.minify}"/>
+-         <arg value="--sourcemap"/>
+-         <arg value="true"/>
 -         <env key="PANMIRROR_OUTDIR" value="dist-rstudio"/>
-+      <exec executable="${node.bin}" dir="${panmirror.dir}" spawn="${panmirror.spawn}">
-+         <arg value="fuse"/>
-+         <arg value="${panmirror.target}"/>
++     <exec executable="${node.bin}" dir="${panmirror.dir}" spawn="${panmirror.spawn}">
++          <arg value="fuse"/>
++          <arg value="${panmirror.target}"/>
        </exec>
 -      <copy todir="${panmirror.build.dir}">
 -         <fileset dir="${panmirror.dir}/dist-rstudio"/>
 -      </copy>
     </target>
- 
+
     <target name="javac" description="Compile java source">
+    


### PR DESCRIPTION
Update RStudio. Visual mode is still not functional, but otherwise usable.

## Description of changes

 - Update and add patches
 - Fix boost to 1.83
 - Update to rsconnect 1.2.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

- [x] Tested, as applicable:
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
