### PR TITLE
nixos/prometheus: add mqtt-exporter

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -22,6 +22,8 @@
 
 - [agorakit](https://github.com/agorakit/agorakit), an organization tool for citizens' collectives. Available with [services.agorakit](options.html#opt-services.agorakit.enable).
 
+- [mqtt-exporter](https://github.com/kpetremann/mqtt-exporter/), a Prometheus exporter for exposing messages from MQTT. Available as [services.prometheus.exporters.mqtt](#opt-services.prometheus.exporters.mqtt.enable).
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## Backward Incompatibilities {#sec-release-25.05-incompatibilities}

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -58,6 +58,7 @@ let
     "mikrotik"
     "modemmanager"
     "mongodb"
+    "mqtt"
     "mysqld"
     "nats"
     "nextcloud"

--- a/nixos/modules/services/monitoring/prometheus/exporters/mqtt.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/mqtt.nix
@@ -1,0 +1,140 @@
+{
+  config,
+  lib,
+  pkgs,
+  options,
+  utils,
+}:
+
+let
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    mkOption
+    types
+    ;
+  cfg = config.services.prometheus.exporters.mqtt;
+  toConfigBoolean = x: if x then "True" else "False";
+  toConfigList = builtins.concatStringsSep ",";
+in
+{
+  # https://github.com/kpetremann/mqtt-exporter/tree/master?tab=readme-ov-file#configuration
+  port = 9000;
+  extraOpts = {
+    keepFullTopic = mkEnableOption "Keep entire topic instead of the first two elements only. Usecase: Shelly 3EM";
+    logLevel = mkOption {
+      type = types.enum [
+        "CRITICAL"
+        "ERROR"
+        "WARNING"
+        "INFO"
+        "DEBUG"
+      ];
+      default = "INFO";
+      example = "DEBUG";
+      description = "Logging level";
+    };
+    logMqttMessage = mkEnableOption "Log MQTT original message, only if `LOG_LEVEL` is set to DEBUG.";
+    mqttIgnoredTopics = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = "Lists of topics to ignore. Accepts wildcards.";
+    };
+    mqttAddress = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = "IP or hostname of MQTT broker.";
+    };
+    mqttPort = mkOption {
+      type = types.port;
+      default = 1883;
+      description = "TCP port of MQTT broker.";
+    };
+    mqttTopic = mkOption {
+      type = types.str;
+      default = "#";
+      description = "Topic path to subscribe to.";
+    };
+    mqttKeepAlive = mkOption {
+      type = types.int;
+      default = 60;
+      example = 30;
+      description = "Keep alive interval to maintain connection with MQTT broker.";
+    };
+    mqttUsername = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "mqttexporter";
+      description = "Username which should be used to authenticate against the MQTT broker.";
+    };
+    mqttV5Protocol = mkEnableOption "Force to use MQTT protocol v5 instead of 3.1.1.";
+    mqttClientId = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Set client ID manually for MQTT connection";
+    };
+    mqttExposeClientId = mkEnableOption "Expose the client ID as a label in Prometheus metrics.";
+    prometheusPrefix = mkOption {
+      type = types.str;
+      default = "mqtt_";
+      description = "Prefix added to the metric name.";
+    };
+    topicLabel = mkOption {
+      type = types.str;
+      default = "topic";
+      description = "Define the Prometheus label for the topic.";
+    };
+    zigbee2MqttAvailability = mkEnableOption "Normalize sensor name for device availability metric added by Zigbee2MQTT.";
+    zwaveTopicPrefix = mkOption {
+      type = types.str;
+      default = "zwave/";
+      description = "MQTT topic used for Zwavejs2Mqtt messages.";
+    };
+    esphomeTopicPrefixes = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = "MQTT topic used for ESPHome messages.";
+    };
+    hubitatTopicPrefixes = mkOption {
+      type = types.listOf types.str;
+      default = [ "hubitat/" ];
+      description = "MQTT topic used for Hubitat messages.";
+    };
+    environmentFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = [ "/run/secrets/mqtt-exporter" ];
+      description = ''
+        File to load as environment file. Useful for e.g. setting `MQTT_PASSWORD`
+        without putting any secrets into the Nix store.
+      '';
+    };
+  };
+  serviceOpts = {
+    environment = {
+      KEEP_FULL_TOPIC = toConfigBoolean cfg.keepFullTopic;
+      LOG_LEVEL = cfg.logLevel;
+      LOG_MQTT_MESSAGE = toConfigBoolean cfg.logMqttMessage;
+      MQTT_IGNORED_TOPIC = toConfigList cfg.mqttIgnoredTopics;
+      MQTT_ADDRESS = cfg.mqttAddress;
+      MQTT_PORT = toString cfg.mqttPort;
+      MQTT_TOPIC = cfg.mqttTopic;
+      MQTT_KEEPALIVE = toString cfg.mqttKeepAlive;
+      MQTT_USERNAME = cfg.mqttUsername;
+      MQTT_V5_PROTOCOL = toConfigBoolean cfg.mqttV5Protocol;
+      MQTT_CLIENT_ID = mkIf (cfg.mqttClientId != null) cfg.mqttClientId;
+      PROMETHEUS_ADDRESS = cfg.listenAddress;
+      PROMETHEUS_PORT = toString cfg.port;
+      PROMETHEUS_PREFIX = cfg.prometheusPrefix;
+      TOPIC_LABEL = cfg.topicLabel;
+      ZIGBEE2MQTT_AVAILABILITY = toConfigBoolean cfg.zigbee2MqttAvailability;
+      ZWAVE_TOPIC_PREFIX = cfg.zwaveTopicPrefix;
+      ESPHOME_TOPIC_PREFIXES = toConfigList cfg.esphomeTopicPrefixes;
+      HUBITAT_TOPIC_PREFIXES = toConfigList cfg.hubitatTopicPrefixes;
+    };
+    serviceConfig = {
+      EnvironmentFile = mkIf (cfg.environmentFile != null) cfg.environmentFile;
+      ExecStart = lib.getExe pkgs.mqtt-exporter;
+    };
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

~~This adds [mqtt-exporter](https://github.com/kpetremann/mqtt-exporter/), a MQTT exporter for Prometheus, as a package itself.~~
Adds a corresponding `services.prometheus.exporters.mqtt` exporter, such that it can be easily configured & enabled. As well as a test for it, as it should be.  

~~Depends on #288219.~~

<details>
<summary>Obsoleted by 1.4.2</summary>

~~Two patches are unfortunaly (currently) needed, one for providing some basic pyproject properties to allow it to build successfully, as upstream does not have `[project]` defined in their `pyproject.toml`, as well as not have `setup.{cfg,py}`. We could also manually assemble the package I guess, but that seemed like a pretty clean solution to me - or there is some even better solution?~~

~~Second patch addresses the lack of a configuration option to set the port the metrics exporter should listen on, which is an common option pre-defined for all exporters.~~
 
~~I intend to upstream both patches - in fact, I have already sent a PR upstream with both of them, so hopefully they can be dropped soon.~~

~~Both changes have been merged upstream, so they can be dropped with the next release. :rocket:~~
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
