### PR TITLE
makeself: fix header path error

### DIFF
--- a/pkgs/applications/misc/makeself/default.nix
+++ b/pkgs/applications/misc/makeself/default.nix
@@ -23,16 +23,18 @@ stdenv.mkDerivation rec {
   checkTarget = "test";
   nativeCheckInputs = [ which zstd pbzip2 ];
 
+  sharePath = "$out/share/${pname}";
+
   installPhase = ''
     runHook preInstall
     installManPage makeself.1
     install -Dm555 makeself.sh $out/bin/makeself
-    install -Dm444 -t $out/share/${pname}/ makeself.lsm README.md makeself-header.sh
+    install -Dm444 -t ${sharePath}/ makeself.lsm README.md makeself-header.sh
     runHook postInstall
   '';
 
   fixupPhase = ''
-    sed -e "s|^HEADER=.*|HEADER=$out/share/${pname}-${version}/makeself-header.sh|" -i $out/bin/makeself
+    sed -e "s|^HEADER=.*|HEADER=${sharePath}/makeself-header.sh|" -i $out/bin/makeself
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

`makeself` is currently broken in master due to a path mismatch when setting the header file. If you try to create an sfx with it, you'll get this error:

```
Unable to open header file: /nix/store/m0ah4yiz9n4wy792n1l94ihpc9nz74vd-makeself-2.4.5/share/makeself-2.4.5/makeself-header.sh
```

This is just because the `$out/share` path specified in the `fixupPhase` call to `sed` used to set the `HEADER` does not match the one used in the `install` command a few lines above. This appears to be a regression introduced in 2e5597d571948911ed00e664752beebea4d5f6dc. So I also extracted this subpath into a shared variable to try to prevent future regressions.

## Things done

I tested `makeself` with this change and was able to create a working sfx directory with it.

Output of nixpkgs-review:

```
3 packages marked as broken and skipped:
linuxKernel.packages.linux_6_5.virtualbox linuxKernel.packages.linux_6_5_hardened.virtualbox linuxPackages_6_5_hardened.virtualbox

30 packages built:
linuxKernel.packages.linux_4_19.virtualbox linuxPackages_4_19_hardened.virtualbox linuxKernel.packages.linux_5_10.virtualbox linuxPackages_5_10_hardened.virtualbox linuxKernel.packages.linux_5_15.virtualbox linuxPackages_5_15_hardened.virtualbox linuxKernel.packages.linux_5_4.virtualbox linuxPackages_5_4_hardened.virtualbox linuxKernel.packages.linux_6_1.virtualbox linuxPackages_6_1_hardened.virtualbox linuxPackages.virtualbox linuxPackages_hardened.virtualbox linuxPackages_latest.virtualbox linuxPackages_6_7_hardened.virtualbox linuxPackages_latest-libre.virtualbox linuxPackages-libre.virtualbox linuxPackages_lqx.virtualbox linuxPackages_xanmod.virtualbox linuxPackages_xanmod_latest.virtualbox linuxPackages_zen.virtualbox makeself veracrypt virtualbox virtualbox.modsrc virtualboxHardened virtualboxHardened.modsrc virtualboxHeadless virtualboxHeadless.modsrc virtualboxWithExtpack virtualboxWithExtpack.modsrc
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
