### PR TITLE
libretro: add EasyRPG core

### DIFF
--- a/pkgs/applications/emulators/retroarch/cores.nix
+++ b/pkgs/applications/emulators/retroarch/cores.nix
@@ -416,8 +416,9 @@ in
     extraNativeBuildInputs = [ cmake pkg-config ];
     extraBuildInputs = [ fmt freetype harfbuzz liblcf libpng libsndfile libvorbis libxmp mpg123 opusfile pcre pixman speexdsp ];
     patches = [
-      # Fixed compatibility with fmt > 9
-      # Remove when version > 0.8
+      # The following patch is shared with easyrpg-player.
+      # Update when new versions of liblcf and easyrpg-player are released.
+      # See pkgs/games/easyrpg-player/default.nix for details.
       (fetchpatch {
         name = "0001-Fix-building-with-fmtlib-10.patch";
         url = "https://github.com/EasyRPG/Player/commit/ab6286f6d01bada649ea52d1f0881dde7db7e0cf.patch";

--- a/pkgs/applications/emulators/retroarch/cores.nix
+++ b/pkgs/applications/emulators/retroarch/cores.nix
@@ -7,10 +7,14 @@
 , cmake
 , curl
 , fetchFromGitHub
+, fetchpatch
 , ffmpeg
 , ffmpeg_4
 , fluidsynth
+, fmt
+, freetype
 , gettext
+, harfbuzz
 , hexdump
 , hidapi
 , icu
@@ -19,21 +23,28 @@
 , libGL
 , libGLU
 , libjpeg
+, liblcf
 , libpcap
 , libpng
+, libsndfile
 , libvorbis
 , libxml2
+, libxmp
 , libzip
 , makeWrapper
+, mpg123
 , nasm
 , openssl
+, opusfile
 , pcre
+, pixman
 , pkg-config
 , portaudio
 , python3
 , retroarch
 , sfml
 , snappy
+, speexdsp
 , udev
 , which
 , xorg
@@ -397,6 +408,31 @@ in
     meta = {
       description = "Port of DOSBox to libretro aiming for simplicity and ease of use.";
       license = lib.licenses.gpl2Only;
+    };
+  };
+
+  easyrpg = mkLibretroCore {
+    core = "easyrpg";
+    extraNativeBuildInputs = [ cmake pkg-config ];
+    extraBuildInputs = [ fmt freetype harfbuzz liblcf libpng libsndfile libvorbis libxmp mpg123 opusfile pcre pixman speexdsp ];
+    patches = [
+      # Fixed compatibility with fmt > 9
+      # Remove when version > 0.8
+      (fetchpatch {
+        name = "0001-Fix-building-with-fmtlib-10.patch";
+        url = "https://github.com/EasyRPG/Player/commit/ab6286f6d01bada649ea52d1f0881dde7db7e0cf.patch";
+        hash = "sha256-GdSdVFEG1OJCdf2ZIzTP+hSrz+ddhTMBvOPjvYQHy54=";
+      })
+    ];
+    cmakeFlags = [
+      "-DBUILD_SHARED_LIBS=ON"
+      "-DPLAYER_TARGET_PLATFORM=libretro"
+      "-DCMAKE_INSTALL_DATADIR=${placeholder "out"}/share"
+    ];
+    makefile = "Makefile";
+    meta = {
+      description = "EasyRPG Player libretro port";
+      license = lib.licenses.gpl3Only;
     };
   };
 

--- a/pkgs/applications/emulators/retroarch/hashes.json
+++ b/pkgs/applications/emulators/retroarch/hashes.json
@@ -251,6 +251,17 @@
         },
         "version": "unstable-2023-12-29"
     },
+    "easyrpg": {
+        "fetcher": "fetchFromGitHub",
+        "src": {
+            "owner": "EasyRPG",
+            "repo": "Player",
+            "rev": "f8e41f43b619413f95847536412b56f85307d378",
+            "hash": "sha256-nvWM4czTv/GxY9raomBEn7dmKBeLtSA9nvjMJxc3Q8s=",
+            "fetchSubmodules": true
+        },
+        "version": "unstable-2023-04-29"
+    },
     "eightyone": {
         "fetcher": "fetchFromGitHub",
         "src": {

--- a/pkgs/applications/emulators/retroarch/update_cores.py
+++ b/pkgs/applications/emulators/retroarch/update_cores.py
@@ -50,6 +50,10 @@ CORES = {
     "dolphin": {"repo": "dolphin"},
     "dosbox": {"repo": "dosbox-libretro"},
     "dosbox-pure": {"repo": "dosbox-pure", "owner": "schellingb"},
+    # The EasyRPG core is pinned to 0.8 since it depends on version 0.8 of liblcf, which
+    # was released in April 2023.
+    # Update the version when a compatible liblcf is available.
+    # See pkgs/games/easyrpg-player/default.nix for details.
     "easyrpg": {"repo": "Player", "owner": "EasyRPG", "fetch_submodules": True, "rev": "0.8"},
     "eightyone": {"repo": "81-libretro"},
     "fbalpha2012": {"repo": "fbalpha2012"},

--- a/pkgs/applications/emulators/retroarch/update_cores.py
+++ b/pkgs/applications/emulators/retroarch/update_cores.py
@@ -50,6 +50,7 @@ CORES = {
     "dolphin": {"repo": "dolphin"},
     "dosbox": {"repo": "dosbox-libretro"},
     "dosbox-pure": {"repo": "dosbox-pure", "owner": "schellingb"},
+    "easyrpg": {"repo": "Player", "owner": "EasyRPG", "fetch_submodules": True, "rev": "0.8"},
     "eightyone": {"repo": "81-libretro"},
     "fbalpha2012": {"repo": "fbalpha2012"},
     "fbneo": {"repo": "fbneo"},


### PR DESCRIPTION
## Description of changes

Adds the EasyRPG core to libretro.

I couldn't run the `update_cores.py` script because `nix-prefetch-github` seems to have been updated very recently, so I added the core metadata into `hashes.json` by hand. However, I loaded the new package into my RetroArch install and it seems to work fine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
