### PR TITLE
[23.11] backport xcbeautify: init at 1.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16574,6 +16574,12 @@
     github = "shymega";
     githubId = 1334592;
   };
+  siddarthkay = {
+    email = "siddarthkay@gmail.com";
+    github = "siddarthkay";
+    githubId = 64726664;
+    name = "Siddarth Kumar";
+  };
   siddharthist = {
     email = "langston.barrett@gmail.com";
     github = "langston-barrett";

--- a/pkgs/by-name/xc/xcbeautify/package.nix
+++ b/pkgs/by-name/xc/xcbeautify/package.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenv
+, fetchurl
+, unzip
+}:
+
+stdenv.mkDerivation rec {
+  pname = "xcbeautify";
+  version = "1.4.0";
+
+  src = fetchurl {
+    url = "https://github.com/cpisciotta/xcbeautify/releases/download/${version}/xcbeautify-${version}-${stdenv.hostPlatform.darwinArch}-apple-macosx.zip";
+    hash = lib.getAttr stdenv.hostPlatform.darwinArch {
+      arm64 = "sha256-4b4mXT5IfNOS8iOrZASDhTrmOehG4mePcoiKxR+IdZk=";
+      x86_64 = "sha256-adEfAK7n3Q/Yd1deyJx7htX7hZaGDztEeBv4z2A0wzg=";
+    };
+  };
+
+  nativeBuildInputs = [ unzip ];
+
+  unpackPhase = ''
+    unzip $src
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D xcbeautify $out/bin/xcbeautify
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Little beautifier tool for xcodebuild";
+    homepage = "https://github.com/cpisciotta/xcbeautify";
+    license = licenses.mit;
+    platforms = platforms.darwin;
+    mainProgram = "xcbeautify";
+    maintainers = with maintainers; [ siddarthkay ];
+  };
+}


### PR DESCRIPTION
## Description of changes

PR to backport https://github.com/NixOS/nixpkgs/pull/286284 to 23.11 release.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
