### PR TITLE
alsa-ucm-conf: fix build

### DIFF
--- a/pkgs/by-name/al/alsa-ucm-conf/package.nix
+++ b/pkgs/by-name/al/alsa-ucm-conf/package.nix
@@ -9,16 +9,6 @@ stdenv.mkDerivation rec {
     hash = "sha256-OHwBzzDioWdte49ysmgc8hmrynDdHsKp4zrdW/P+roE=";
   };
 
-  patches = [
-    (fetchpatch {
-      # ToDo: Remove this patch in the next package upgrade
-      # Fixes SplitPCM to make some audio devices work with alsa-ucm-conf v1.2.10 again
-      name = "alsa-ucm-conf-splitpcm-device-argument-fix.patch";
-      url = "https://github.com/alsa-project/alsa-ucm-conf/commit/b68aa52acdd2763fedad5eec0f435fbf43e5ccc6.patch";
-      hash = "sha256-8WE4+uhi4W7cCSZYmL7uFpcHJ9muX09UkGXyZIpEd9I=";
-    })
-  ];
-
   dontBuild = true;
 
   installPhase = ''


### PR DESCRIPTION
## Description of changes

This currently fails to build on staging, since https://github.com/NixOS/nixpkgs/pull/285173, as the now-deleted patch is already applied.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
