### PR TITLE
saxon-he: 11.5 -> 12.4

### DIFF
--- a/pkgs/development/libraries/java/saxon/default.nix
+++ b/pkgs/development/libraries/java/saxon/default.nix
@@ -1,46 +1,92 @@
-{ lib, stdenv, fetchurl, unzip, jre, jre8 }:
+{ lib
+, stdenv
+, fetchurl
+, unzip
+, jre
+, jre8
+, genericUpdater
+, writeShellScript
+, common-updater-scripts
+, gnused
+}:
 
 let
+  inherit (lib.versions) major majorMinor splitVersion;
+  inherit (lib.strings) concatStringsSep versionAtLeast;
+
   common = { pname, version, src, description, java ? jre
-           , prog ? null, jar ? null, license ? lib.licenses.mpl20 }:
-    stdenv.mkDerivation {
-      name = "${pname}-${version}";
+           , prog ? null, jar ? null, license ? lib.licenses.mpl20
+           , updateScript ? null }:
+    stdenv.mkDerivation (finalAttrs: let
+      mainProgram = if prog == null then pname else prog;
+      jar' = if jar == null then pname else jar;
+    in {
       inherit pname version src;
 
       nativeBuildInputs = [ unzip ];
 
-      buildCommand = let
-        prog' = if prog == null then pname else prog;
-        jar' = if jar == null then pname else jar;
-      in ''
+      buildCommand = ''
         unzip $src -d $out
         mkdir -p $out/bin $out/share $out/share/java
         cp -s "$out"/*.jar "$out/share/java/"  # */
         rm -rf $out/notices
         mv $out/doc $out/share
-        cat > $out/bin/${prog'} <<EOF
+        cat > $out/bin/${mainProgram} <<EOF
         #! $shell
         export JAVA_HOME=${jre}
         exec ${jre}/bin/java -jar $out/${jar'}.jar "\$@"
         EOF
-        chmod a+x $out/bin/${prog'}
+        chmod a+x $out/bin/${mainProgram}
       '';
 
+      passthru = lib.optionalAttrs (updateScript != null) {
+        inherit updateScript;
+      };
+
       meta = with lib; {
-        inherit description license;
-        homepage = "https://saxon.sourceforge.net/";
+        inherit description license mainProgram;
+        homepage = if versionAtLeast finalAttrs.version "11"
+          then "https://www.saxonica.com/products/latest.xml"
+          else "https://www.saxonica.com/products/archive.xml";
         sourceProvenance = with sourceTypes; [ binaryBytecode ];
         maintainers = with maintainers; [ rvl ];
         platforms = platforms.all;
       };
-    };
+    });
+
+  # Saxon release zipfiles and tags often use dashes instead of dots.
+  dashify = version: concatStringsSep "-" (splitVersion version);
+
+  # SaxonJ-HE release files are pushed to the Saxon-HE GitHub repository.
+  # They are also available from Maven.
+  #
+  # Older releases were uploaded to SourceForge. They are also
+  # available from the Saxon-Archive GitHub repository.
+  github = {
+    updateScript = version: genericUpdater {
+      versionLister = writeShellScript "saxon-he-versionLister" ''
+        export PATH="${lib.makeBinPath [ common-updater-scripts gnused ]}:$PATH"
+        major_ver="${major version}"
+        list-git-tags --url="https://github.com/Saxonica/Saxon-HE.git" \
+          | sed -En \
+            -e "s/SaxonHE([0-9]+)-([0-9]+)/\1.\2/" \
+            -e "/^''${major_ver:-[0-9]+}\./p"
+        '';
+      };
+
+    downloadUrl = version: let
+      tag = "SaxonHE${dashify version}";
+      filename = "${major version}/Java/${tag}J.zip";
+    in
+      "https://raw.githubusercontent.com/Saxonica/Saxon-HE/${tag}/${filename}";
+  };
 
 in {
-  saxon = common {
+  saxon = common rec {
     pname = "saxon";
     version = "6.5.3";
     src = fetchurl {
-      url = "mirror://sourceforge/saxon/saxon6_5_3.zip";
+      url = "mirror://sourceforge/saxon/saxon${dashify version}.zip";
       sha256 = "0l5y3y2z4wqgh80f26dwwxwncs8v3nkz3nidv14z024lmk730vs3";
     };
     description = "XSLT 1.0 processor";
@@ -49,50 +95,63 @@ in {
     java = jre8;
   };
 
-  saxonb_8_8 = common {
+  saxonb_8_8 = common rec {
     pname = "saxonb";
     version = "8.8";
     jar = "saxon8";
     src = fetchurl {
-      url = "mirror://sourceforge/saxon/saxonb8-8j.zip";
+      url = "mirror://sourceforge/saxon/saxonb${dashify version}j.zip";
       sha256 = "15bzrfyd2f1045rsp9dp4znyhmizh1pm97q8ji2bc0b43q23xsb8";
     };
     description = "Complete and conformant processor of XSLT 2.0, XQuery 1.0, and XPath 2.0";
     java = jre8;
   };
 
-  saxonb_9_1 = common {
+  saxonb_9_1 = common rec {
     pname = "saxonb";
     version = "9.1.0.8";
     jar = "saxon9";
     src = fetchurl {
-      url = "mirror://sourceforge/saxon/Saxon-B/9.1.0.8/saxonb9-1-0-8j.zip";
+      url = "mirror://sourceforge/saxon/Saxon-B/${version}/saxonb${dashify version}j.zip";
       sha256 = "1d39jdnwr3v3pzswm81zry6yikqlqy9dp2l2wmpqdiw00r5drg4j";
     };
     description = "Complete and conformant processor of XSLT 2.0, XQuery 1.0, and XPath 2.0";
   };
 
-  saxon_9-he = common {
+  # Saxon-HE (home edition) replaces Saxon-B as the open source
+  # version of the Saxon XSLT and XQuery processor.
+  saxon_9-he = common rec {
     pname = "saxon-he";
     version = "9.9.0.1";
-    prog = "saxon-he";
     jar = "saxon9he";
     src = fetchurl {
-      url = "mirror://sourceforge/saxon/Saxon-HE/9.9/SaxonHE9-9-0-1J.zip";
+      url = "mirror://sourceforge/saxon/Saxon-HE/${majorMinor version}/SaxonHE${dashify version}J.zip";
       sha256 = "1inxd7ia7rl9fxfrw8dy9sb7rqv76ipblaki5262688wf2dscs60";
     };
     description = "Processor for XSLT 3.0, XPath 2.0 and 3.1, and XQuery 3.1";
   };
 
-  saxon-he = common {
+  saxon_11-he = common rec {
     pname = "saxon-he";
-    version = "11.5";
-    prog = "saxon-he";
-    jar = "saxon-he-11.5";
+    version = "11.6";
+    jar = "saxon-he-${version}";
     src = fetchurl {
-      url = "https://github.com/Saxonica/Saxon-HE/raw/a6d11dec3853326b661e9aff283e30b43c02e163/11/Java/SaxonHE11-5J.zip";
-      sha256 = "2Nwh6dG3YAjc/OTr8DMOfbnRvdCWB0YsVP3ZLRbM9U0=";
+      url = github.downloadUrl version;
+      sha256 = "/AVX5mtZSO6Is19t3+FlEvtIBsnwB3MIWAPCht8Aqnw=";
     };
+    updateScript = github.updateScript version;
     description = "Processor for XSLT 3.0, XPath 2.0 and 3.1, and XQuery 3.1";
+  };
+
+  saxon_12-he = common rec {
+    pname = "saxon-he";
+    version = "12.4";
+    jar = "saxon-he-${version}";
+    src = fetchurl {
+      url = github.downloadUrl version;
+      hash = "sha256-RKso6pRQkJgxlvC2R5WWon/VejQehGW223/C7KjD3c4=";
+    };
+    updateScript = github.updateScript version;
+    description = "Processor for XSLT 3.0, XPath 3.1, and XQuery 3.1";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25761,6 +25761,7 @@ with pkgs;
   mockobjects = callPackage ../development/libraries/java/mockobjects { };
 
   saxonb = saxonb_8_8;
+  saxon-he = saxon_12-he;
 
   inherit (callPackages ../development/libraries/java/saxon {
     jre = jre_headless;
@@ -25770,7 +25771,8 @@ with pkgs;
     saxonb_8_8
     saxonb_9_1
     saxon_9-he
-    saxon-he;
+    saxon_11-he
+    saxon_12-he;
 
   smack = callPackage ../development/libraries/java/smack { };
 


### PR DESCRIPTION
## Description of changes

Updates to the latest release of SaxonJ-HE.

Adds `saxon_11-he` and `saxon_12-he` attributes for specific versions, and sets `saxon-he = saxon_12-he`.

Adds an `updateScript` for the latest versions of Saxon-HE.

cc @avi-jois

## Things done

- [x] Built on platform: `x86_64-linux`
- [x] Tested compilation of all packages that depend on this change - no reverse dependencies
- [x] Tested basic functionality of  `./result/bin/saxon-he`.
- [x] [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes) N/A
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
