### PR TITLE
openttd-ttf: init at 0.5

### DIFF
--- a/pkgs/by-name/op/openttd-ttf/package.nix
+++ b/pkgs/by-name/op/openttd-ttf/package.nix
@@ -1,0 +1,51 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, python3
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "openttd-ttf";
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner = "zephyris";
+    repo = "openttd-ttf";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-GjtfwM268i3bUAX8Pw5/Og9029AuD1OZuJ2VIlFTogY=";
+  };
+
+  nativeBuildInputs = [
+    (python3.withPackages (pp: with pp; [
+      fontforge
+      pillow
+      setuptools
+    ]))
+  ];
+
+  postPatch = ''
+    chmod a+x build.sh
+    patchShebangs --build build.sh
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    ./build.sh
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -m444 -Dt $out/share/fonts/truetype */*.ttf
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/zephyris/openttd-ttf";
+    changelog = "https://github.com/zephyris/openttd-ttf/releases/tag/${finalAttrs.version}";
+    description = "TrueType typefaces for text in a pixel art style, designed for use in OpenTTD";
+    license = [ licenses.gpl2 ];
+    platforms = platforms.all;
+    maintainers = [ maintainers.sfrijters ];
+  };
+})


### PR DESCRIPTION
## Description of changes

https://www.openttd.org/news/2024/02/17/openttd-truetype-fonts

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
