### PR TITLE
llama-cpp: pull upstream flake changes

### DIFF
--- a/pkgs/by-name/ll/llama-cpp/package.nix
+++ b/pkgs/by-name/ll/llama-cpp/package.nix
@@ -15,12 +15,16 @@
 , openclSupport ? false
 , clblast
 
-, blasSupport ? !rocmSupport && !cudaSupport
-, openblas
+, blasSupport ? builtins.all (x: !x) [ cudaSupport metalSupport openclSupport rocmSupport vulkanSupport ]
 , pkg-config
 , metalSupport ? stdenv.isDarwin && stdenv.isAarch64 && !openclSupport
-, patchelf
-, static ? true # if false will build the shared objects as well
+, vulkanSupport ? false
+, mpiSupport ? false # Increases the runtime closure by ~700M
+, vulkan-headers
+, vulkan-loader
+, ninja
+, git
+, mpi
 }:
 
 let
@@ -28,42 +32,18 @@ let
   # otherwise we get libstdc++ errors downstream.
   # cuda imposes an upper bound on the gcc version, e.g. the latest gcc compatible with cudaPackages_11 is gcc11
   effectiveStdenv = if cudaSupport then cudaPackages.backendStdenv else stdenv;
-in
-effectiveStdenv.mkDerivation (finalAttrs: {
-  pname = "llama-cpp";
-  version = "2249";
+  inherit (lib) cmakeBool cmakeFeature optionals;
 
-  src = fetchFromGitHub {
-    owner = "ggerganov";
-    repo = "llama.cpp";
-    rev = "refs/tags/b${finalAttrs.version}";
-    hash = "sha256-ikJUToUbA60u/8azR6dPmPyodq/nQe5L2aotlYBclaE=";
-  };
-
-  postPatch = ''
-    substituteInPlace ./ggml-metal.m \
-      --replace '[bundle pathForResource:@"ggml-metal" ofType:@"metal"];' "@\"$out/bin/ggml-metal.metal\";"
-  '';
-
-  nativeBuildInputs = [ cmake ] ++ lib.optionals blasSupport [ pkg-config ] ++ lib.optionals cudaSupport [
-    cudaPackages.cuda_nvcc
-
-    # TODO: Replace with autoAddDriverRunpath
-    # once https://github.com/NixOS/nixpkgs/pull/275241 has been merged
-    cudaPackages.autoAddOpenGLRunpathHook
-  ];
-
-  buildInputs = lib.optionals effectiveStdenv.isDarwin
-    (with darwin.apple_sdk.frameworks; [
+  darwinBuildInputs =
+    with darwin.apple_sdk.frameworks;
+    [
       Accelerate
-      CoreGraphics
       CoreVideo
-      Foundation
-    ])
-  ++ lib.optionals metalSupport (with darwin.apple_sdk.frameworks; [
-    MetalKit
-  ])
-  ++ lib.optionals cudaSupport (with cudaPackages; [
+      CoreGraphics
+    ]
+    ++ optionals metalSupport [ MetalKit ];
+
+   cudaBuildInputs = with cudaPackages; [
     cuda_cccl.dev # <nv/target>
 
     # A temporary hack for reducing the closure size, remove once cudaPackages
@@ -74,65 +54,93 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     libcublas.dev
     libcublas.lib
     libcublas.static
-  ]) ++ lib.optionals rocmSupport [
-    rocmPackages.clr
-    rocmPackages.hipblas
-    rocmPackages.rocblas
-  ] ++ lib.optionals openclSupport [
-    clblast
-  ] ++ lib.optionals blasSupport [
-    openblas
   ];
+
+  rocmBuildInputs = with rocmPackages; [
+    clr
+    hipblas
+    rocblas
+  ];
+
+  vulkanBuildInputs = [
+    vulkan-headers
+    vulkan-loader
+  ];
+in
+effectiveStdenv.mkDerivation (finalAttrs: {
+  pname = "llama-cpp";
+  version = "2294";
+
+  src = fetchFromGitHub {
+    owner = "ggerganov";
+    repo = "llama.cpp";
+    rev = "refs/tags/b${finalAttrs.version}";
+    hash = "sha256-uZi4Bj03PgfFV+jS5M+A1sMCWC/GMY5IyyrlR1b4Sh4=";
+  };
+
+  postPatch = ''
+    substituteInPlace ./ggml-metal.m \
+      --replace '[bundle pathForResource:@"ggml-metal" ofType:@"metal"];' "@\"$out/bin/ggml-metal.metal\";"
+  '';
+
+  nativeBuildInputs = [ cmake ninja pkg-config git ]
+    ++ optionals cudaSupport [
+    cudaPackages.cuda_nvcc
+
+    # TODO: Replace with autoAddDriverRunpath
+    # once https://github.com/NixOS/nixpkgs/pull/275241 has been merged
+    cudaPackages.autoAddOpenGLRunpathHook
+  ];
+
+  buildInputs = optionals effectiveStdenv.isDarwin darwinBuildInputs
+    ++ optionals cudaSupport cudaBuildInputs
+    ++ optionals mpiSupport mpi
+    ++ optionals openclSupport [ clblast ]
+    ++ optionals rocmSupport rocmBuildInputs
+    ++ optionals vulkanSupport vulkanBuildInputs;
 
   cmakeFlags = [
-    "-DLLAMA_NATIVE=OFF"
-    "-DLLAMA_BUILD_SERVER=ON"
+    # -march=native is non-deterministic; override with platform-specific flags if needed
+    (cmakeBool "LLAMA_NATIVE" false)
+    (cmakeBool "BUILD_SHARED_SERVER" true)
+    (cmakeBool "BUILD_SHARED_LIBS" true)
+    (cmakeBool "BUILD_SHARED_LIBS" true)
+    (cmakeBool "LLAMA_BLAS" blasSupport)
+    (cmakeBool "LLAMA_CLBLAST" openclSupport)
+    (cmakeBool "LLAMA_CUBLAS" cudaSupport)
+    (cmakeBool "LLAMA_HIPBLAS" rocmSupport)
+    (cmakeBool "LLAMA_METAL" metalSupport)
+    (cmakeBool "LLAMA_MPI" mpiSupport)
+    (cmakeBool "LLAMA_VULKAN" vulkanSupport)
   ]
-  ++ lib.optionals metalSupport [
-    "-DCMAKE_C_FLAGS=-D__ARM_FEATURE_DOTPROD=1"
-    "-DLLAMA_METAL=ON"
-  ]
-  ++ lib.optionals cudaSupport [
-    "-DLLAMA_CUBLAS=ON"
-  ]
-  ++ lib.optionals rocmSupport [
-    "-DLLAMA_HIPBLAS=1"
-    "-DCMAKE_C_COMPILER=hipcc"
-    "-DCMAKE_CXX_COMPILER=hipcc"
-    "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
-  ]
-  ++ lib.optionals openclSupport [
-    "-DLLAMA_CLBLAST=ON"
-  ]
-  ++ lib.optionals blasSupport [
-    "-DLLAMA_BLAS=ON"
-    "-DLLAMA_BLAS_VENDOR=OpenBLAS"
-  ]
-  ++ lib.optionals (!static) [
-    (lib.cmakeBool "BUILD_SHARED_LIBS" true)
-  ];
+      ++ optionals cudaSupport [
+        (
+          with cudaPackages.flags;
+          cmakeFeature "CMAKE_CUDA_ARCHITECTURES" (
+            builtins.concatStringsSep ";" (map dropDot cudaCapabilities)
+          )
+        )
+      ]
+      ++ optionals rocmSupport [
+        (cmakeFeature "CMAKE_C_COMPILER" "hipcc")
+        (cmakeFeature "CMAKE_CXX_COMPILER" "hipcc")
 
-  installPhase = ''
-    runHook preInstall
+        # Build all targets supported by rocBLAS. When updating search for TARGET_LIST_ROCM
+        # in https://github.com/ROCmSoftwarePlatform/rocBLAS/blob/develop/CMakeLists.txt
+        # and select the line that matches the current nixpkgs version of rocBLAS.
+        # Should likely use `rocmPackages.clr.gpuTargets`.
+        "-DAMDGPU_TARGETS=gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack+;gfx90a:xnack-;gfx940;gfx941;gfx942;gfx1010;gfx1012;gfx1030;gfx1100;gfx1101;gfx1102"
+      ]
+      ++ optionals metalSupport [ (cmakeFeature "CMAKE_C_FLAGS" "-D__ARM_FEATURE_DOTPROD=1") ]
+      ++ optionals blasSupport [ (cmakeFeature "LLAMA_BLAS_VENDOR" "OpenBLAS") ];
 
-    mkdir -p $out/bin
-    ${lib.optionalString (!static) ''
-      mkdir $out/lib
-      cp libggml_shared.so $out/lib
-      cp libllama.so $out/lib
-    ''}
-
-    for f in bin/*; do
-      test -x "$f" || continue
-      ${lib.optionalString (!static) ''
-        ${patchelf}/bin/patchelf "$f" --set-rpath "$out/lib"
-      ''}
-      cp "$f" $out/bin/llama-cpp-"$(basename "$f")"
-    done
-
-    ${lib.optionalString metalSupport "cp ./bin/ggml-metal.metal $out/bin/ggml-metal.metal"}
-
-    runHook postInstall
+  # upstream plans on adding targets at the cmakelevel, remove those
+  # additional steps after that
+  postInstall = ''
+    mv $out/bin/main $out/bin/llama
+    mv $out/bin/server $out/bin/llama-server
+    mkdir -p $out/include
+    cp $src/llama.h $out/include/
   '';
 
   passthru.updateScript = nix-update-script {
@@ -144,9 +152,10 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     description = "Port of Facebook's LLaMA model in C/C++";
     homepage = "https://github.com/ggerganov/llama.cpp/";
     license = licenses.mit;
-    mainProgram = "llama-cpp-main";
-    maintainers = with maintainers; [ dit7ya elohmeier ];
-    broken = (effectiveStdenv.isDarwin && effectiveStdenv.isx86_64) || lib.count lib.id [openclSupport blasSupport rocmSupport cudaSupport] == 0;
+    mainProgram = "llama";
+    maintainers = with maintainers; [ dit7ya elohmeier philiptaron ];
     platforms = platforms.unix;
+    badPlatforms = optionals (cudaSupport || openclSupport) lib.platforms.darwin;
+    broken = (metalSupport && !effectiveStdenv.isDarwin);
   };
 })


### PR DESCRIPTION
## Description of changes

I've basically copied the upstream flake.
we had a discussion with @SomeoneSerge about removing the custom install step.
The idea was that using the normal cmake install step uses the upstream file. Whereas using a custom install step, we just loose upstream logic and we just do a worse job at it.

@elohmeier 
I've kept the naming of cudaSupport instead of upstream usecuda since it's the norm in nixpkgs, but I don't feel that strongly about it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
