### PR TITLE
kodiPackages.mediathekview: init at 1.0.9

### DIFF
--- a/pkgs/applications/video/kodi/addons/mediathekview/default.nix
+++ b/pkgs/applications/video/kodi/addons/mediathekview/default.nix
@@ -1,0 +1,29 @@
+{ lib, buildKodiAddon, fetchFromGitHub, addonUpdateScript, myconnpy }:
+
+buildKodiAddon rec {
+  pname = "mediathekview";
+  namespace = "plugin.video.mediathekview";
+  version = "1.0.9";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = namespace;
+    rev = "release-${version}";
+    hash = "sha256-XYyocXFTiYO7Ar0TtxjpCAy2Ywtnwb8BTxdKxwDWm4Y=";
+  };
+
+  propagatedBuildInputs = [
+    myconnpy
+  ];
+
+  passthru.updateScript = addonUpdateScript {
+    attrPath = "kodi.packages.mediathekview";
+  };
+
+  meta = with lib; {
+    homepage = "https://github.com/mediathekview/plugin.video.mediathekview";
+    description = "Access media libraries of German speaking broadcasting stations";
+    license = licenses.mit;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -83,6 +83,8 @@ let self = rec {
 
   mediacccde = callPackage ../applications/video/kodi/addons/mediacccde { };
 
+  mediathekview = callPackage ../applications/video/kodi/addons/mediathekview { };
+
   netflix = callPackage ../applications/video/kodi/addons/netflix { };
 
   orftvthek = callPackage ../applications/video/kodi/addons/orftvthek { };


### PR DESCRIPTION
## Description of changes
Add [MediathekView (for Kodi)](https://mediathekview.de/download/), which allows
access to media libraries of German speaking broadcasting stations.

I tested this on my home server. However, I do not know if the automatic updates
work (never tried this functionality).

I am looking forward to your comments!

@NixOS/kodi

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
