### PR TITLE
apx-gui: init at 0.1.1

### DIFF
--- a/pkgs/by-name/ap/apx-gui/package.nix
+++ b/pkgs/by-name/ap/apx-gui/package.nix
@@ -1,0 +1,59 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, appstream-glib
+, desktop-file-utils
+, gobject-introspection
+, libadwaita
+, meson
+, ninja
+, pkg-config
+, python3
+, wrapGAppsHook4
+, apx
+, gnome-console
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "apx-gui";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner  = "Vanilla-OS";
+    repo   = "apx-gui";
+    rev    = "v${finalAttrs.version}";
+    hash = "sha256-orP5kAsoXX0zyDskeIPKKHNt5c757eUm9un4Ws6uFYA=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    appstream-glib
+    desktop-file-utils
+    gobject-introspection
+    meson
+    ninja
+    pkg-config
+    (python3.withPackages (ps: [ ps.pygobject3 ]))
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    libadwaita
+  ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : "${lib.makeBinPath [ apx gnome-console ]}"
+    )
+  '';
+
+  meta = {
+    description = "A GUI frontend for Apx in GTK 4 and Libadwaita";
+    homepage    = "https://github.com/Vanilla-OS/apx-gui";
+    license     = lib.licenses.gpl3Only;
+    platforms   = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ chewblacka ];
+    mainProgram = "apx-gui";
+  };
+})


### PR DESCRIPTION
## Description of changes
`apx-gui` is a gtk4 frontend for the `apx` command
https://github.com/Vanilla-OS/apx-gui

Closes https://github.com/NixOS/nixpkgs/issues/289375

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
