### PR TITLE
thumbsup: init at 2.18.0

### DIFF
--- a/pkgs/by-name/th/thumbsup/package.nix
+++ b/pkgs/by-name/th/thumbsup/package.nix
@@ -1,0 +1,40 @@
+{ buildNpmPackage
+, fetchFromGitHub
+, lib
+, nodejs
+, imagemagick
+, graphicsmagick
+, exiftool
+}:
+
+buildNpmPackage rec {
+  pname = "thumbsup";
+  version = "2.18.0";
+
+  src = fetchFromGitHub {
+    owner = "thumbsup";
+    repo = "thumbsup";
+    rev = "v${version}";
+    hash = "sha256-q3zeIdGGrv9thJiTjaNFbq3bTEq2i91KR6yXIzHLQ24=";
+  };
+
+  npmDepsHash = "sha256-dyA0cmO6yCn5ZFhTEQXTuQyr8UrrW6WasrA9kqqUlC8=";
+
+  buildInputs = [
+    nodejs
+    imagemagick
+    graphicsmagick
+    exiftool
+  ];
+
+  dontNpmBuild = true;
+
+  meta = with lib; {
+    description = "Static web galleries for all your photos and videos";
+    homepage = "https://thumbsup.github.io/";
+    changelog = "https://github.com/thumbsup/thumbsup/releases/tag/v${version}";
+    license = licenses.mit;
+    mainProgram = "thumbsup";
+    maintainers = [ maintainers.presto8 ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Package thumbsup, a static web gallery generator.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
