### PR TITLE
nixos/github-runners: allow removing nix from PATH

### DIFF
--- a/nixos/modules/services/continuous-integration/github-runner/options.nix
+++ b/nixos/modules/services/continuous-integration/github-runner/options.nix
@@ -142,6 +142,14 @@ with lib;
           default = false;
         };
 
+        nixInPath = mkOption {
+          type = types.bool;
+          description = mdDoc ''
+            Add Nix to `PATH` of the service to make it available to workflows.
+          '';
+          default = true;
+        };
+
         replace = mkOption {
           type = types.bool;
           description = mdDoc ''

--- a/nixos/modules/services/continuous-integration/github-runner/service.nix
+++ b/nixos/modules/services/continuous-integration/github-runner/service.nix
@@ -55,9 +55,9 @@ with lib;
         git
         gnutar
         gzip
-      ]) ++ [
-        config.nix.package
-      ] ++ cfg.extraPackages;
+      ])
+      ++ cfg.extraPackages
+      ++ lib.optional cfg.nixInPath config.nix.package;
 
       serviceConfig = mkMerge [
         {
@@ -220,7 +220,7 @@ with lib;
             "-${cfg.tokenFile}"
             # Token file in the state directory
             "${stateDir}/${currentConfigTokenFilename}"
-          ];
+          ] ++ optional (!cfg.nixInPath) "/nix/var/nix/daemon-socket";
 
           KillSignal = "SIGINT";
 


### PR DESCRIPTION
## Description of changes

In order to not break existing users, we still default to having Nix in the path, but users can now optionally remove it.

Nix can be considered a huge attack surface, so runners that don't need it probably shouldn't have it.

In order to realize the added security benefits, the daemon socket is not accessible when Nix is removed from the path.

My original motivation for this change was a desire to wrap the Nix binary exposed to the runners in a script, but since Nix comes first in the path, this wasn't possible. To address this, I put Nix at the end of the path so that any Nix wrappers can take precedence. I then realized that some usecases might not require Nix and it might be useful to add a feature to remove it.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc