### PR TITLE
openseeface: init at 1.20.4-unstable-2024-09-21

### DIFF
--- a/pkgs/by-name/op/openseeface/package.nix
+++ b/pkgs/by-name/op/openseeface/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenvNoCC,
+  python3,
+  fetchFromGitHub,
+  makeWrapper,
+  enableVisualization ? false,
+}:
+
+let
+  python = python3.withPackages (
+    ps: with ps; [
+      (opencv4.override { enableGtk3 = enableVisualization; })
+      onnxruntime
+      pillow
+      numpy
+    ]
+  );
+in
+stdenvNoCC.mkDerivation {
+  pname = "openseeface";
+  version = "1.20.4-unstable-2024-09-21";
+
+  src = fetchFromGitHub {
+    owner = "emilianavt";
+    repo = "OpenSeeFace";
+    rev = "e6e24efd2038ab778ac094bab21c2c18a7efbeb2";
+    hash = "sha256-pSZXD6UiKPd8sTagdA/I6bI8nWdF1c6SX2Bho+X7pX8=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/openseeface
+    cp -r *.py models $out/share/openseeface
+
+    makeWrapper ${python.interpreter} "$out/bin/facetracker" \
+        --add-flags "$out/share/openseeface/facetracker.py"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Robust realtime face and facial landmark tracking on CPU with Unity integration";
+    homepage = "https://github.com/emilianavt/OpenSeeFace";
+    license = lib.licenses.bsd2;
+    mainProgram = "facetracker";
+    maintainers = with lib.maintainers; [ tomasajt ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This PR adds 1 package: `openseeface`

Homepage: https://github.com/emilianavt/OpenSeeFace
Description: "Robust realtime face and facial landmark tracking on CPU with Unity integration"

At first glance it may look like a poetry project, but it is not. Poetry is just for dependency management.

Now that is merged https://github.com/NixOS/nixpkgs/pull/288841, it would be great to also have this as a facetracker to use it with.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
