### PR TITLE
deltatouch: init at 1.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11403,6 +11403,13 @@
       fingerprint = "80EE AAD8 43F9 3097 24B5  3D7E 27E9 7B91 E63A 7FF8";
     }];
   };
+  link2xt = {
+    email = "link2xt@testrun.org";
+    githubId = 18373967;
+    github = "link2xt";
+    matrix = "@link2xt:matrix.org";
+    name = "link2xt";
+  };
   linquize = {
     email = "linquize@yahoo.com.hk";
     github = "linquize";

--- a/pkgs/by-name/de/deltatouch/package.nix
+++ b/pkgs/by-name/de/deltatouch/package.nix
@@ -1,0 +1,91 @@
+{ lib
+, stdenv
+, fetchFromGitea
+, fetchpatch
+, cmake
+, intltool
+, libdeltachat
+, lomiri
+, qt5
+, quirc
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "deltatouch";
+  version = "1.4.0";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "lk108";
+    repo = "deltatouch";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-tqcQmFmF8Z9smVMfaXOmXQ3Uw41bUcU4iUi8fxBlg8U=";
+    fetchSubmodules = true;
+  };
+
+
+  patches = [
+    (fetchpatch {
+      name = "0001-deltatouch-Fix-localisation.patch";
+      url = "https://codeberg.org/lk108/deltatouch/commit/dcfdd8a0fca5fff10d0383f77f4c0cbea302de00.patch";
+      hash = "sha256-RRjHG/xKtj757ZP2SY0GtWwh66kkTWoICV1vDkFAw3k=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    qt5.wrapQtAppsHook
+    intltool
+    cmake
+  ];
+
+  buildInputs = [
+    qt5.qtbase
+    qt5.qtwebengine
+    qt5.qtquickcontrols2
+    lomiri.lomiri-ui-toolkit
+    lomiri.lomiri-ui-extras
+    lomiri.lomiri-api
+    lomiri.lomiri-indicator-network # Lomiri.Connectivity module
+    lomiri.qqc2-suru-style
+  ];
+
+  postPatch = ''
+    # Fix all sorts of install locations
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'set(DATA_DIR /)' 'set(DATA_DIR ''${CMAKE_INSTALL_DATAROOTDIR})' \
+      --replace-fail 'RUNTIME DESTINATION ''${CMAKE_INSTALL_PREFIX}' 'RUNTIME DESTINATION ''${CMAKE_INSTALL_BINDIR}' \
+      --replace-fail 'assets/logo.svg DESTINATION assets' 'assets/logo.svg DESTINATION ''${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps RENAME deltatouch.svg' \
+      --replace-fail "\''${DESKTOP_FILE_NAME} DESTINATION \''${DATA_DIR}" "\''${DESKTOP_FILE_NAME} DESTINATION \''${CMAKE_INSTALL_DATAROOTDIR}/applications"
+
+    substituteInPlace plugins/DeltaHandler/CMakeLists.txt plugins/DTWebEngineProfile/CMakeLists.txt \
+      --replace-fail 'set(QT_IMPORTS_DIR "/lib/''${ARCH_TRIPLET}")' 'set(QT_IMPORTS_DIR "${placeholder "out"}/${qt5.qtbase.qtQmlPrefix}")'
+
+    # Fix import of library dependencies
+    substituteInPlace plugins/DeltaHandler/CMakeLists.txt \
+      --replace-fail 'IMPORTED_LOCATION "''${CMAKE_CURRENT_BINARY_DIR}/libdeltachat.so"' 'IMPORTED_LOCATION "${lib.getLib libdeltachat}/lib/libdeltachat.so"' \
+      --replace-fail 'IMPORTED_LOCATION "''${CMAKE_CURRENT_BINARY_DIR}/libquirc.so.1.2"' 'IMPORTED_LOCATION "${lib.getLib quirc}/lib/libquirc.so"'
+
+    # Fix icon reference in desktop file
+    substituteInPlace deltatouch.desktop.in \
+      --replace-fail 'Icon=assets/logo.svg' 'Icon=deltatouch'
+  '';
+
+  postInstall = ''
+    # Remove clickable metadata & helpers from out
+    rm $out/{manifest.json,share/push*}
+  '';
+
+  meta = with lib; {
+    changelog = "https://codeberg.org/lk108/deltatouch/src/commit/${finalAttrs.src.rev}/CHANGELOG";
+    description = "Messaging app for Ubuntu Touch, powered by Delta Chat core";
+    longDescription = ''
+      DeltaTouch is a messenger for Ubuntu Touch based on Delta Chat core.
+      Delta Chat works over email.
+    '';
+    homepage = "https://codeberg.org/lk108/deltatouch";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ link2xt ];
+    mainProgram = "deltatouch";
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

This is an initial commit for [DeltaTouch](https://codeberg.org/lk108/deltatouch) Delta Chat client.
It is a [Delta Chat](https://delta.chat) client for Ubuntu Touch, [available at OpenStore](https://open-store.io/app/deltatouch.lotharketterer).  

## Things done

Built on x86_64-linux (Arch Linux with Nix installed via [Determinate Nix Installer](https://github.com/DeterminateSystems/nix-installer)).

Having correct icons requires installing qt5ct in the profile and selecting "suru" icon theme.
Tested by running:
```
$ nix profile install nixpkgs#qt5ct nixpkgs#lomiri.suru-icon-theme
$ export QT_QPA_PLATFORMTHEME=qt5ct
$ qt5ct # select Suru icon theme
$ nix run github:guibou/nixGL#nixGLIntel -- nix shell .#deltatouch
```

This is how it looks like:
![1](https://github.com/NixOS/nixpkgs/assets/18373967/0d81e063-0cab-44c5-ab33-60829d1043b5)
It is possible to configure account, send and receive messages. File selection dialog currently does not work outside of Lomiri desktop environment and I am not running the whole Lomiri, but it is usable anyway.
