### PR TITLE
pandas, numpy, numba, llvmlite updates

### DIFF
--- a/pkgs/development/python-modules/llvmlite/default.nix
+++ b/pkgs/development/python-modules/llvmlite/default.nix
@@ -15,17 +15,16 @@
 
 buildPythonPackage rec {
   pname = "llvmlite";
-  version = "0.41.1";
+  version = "0.42.0";
   pyproject = true;
 
-  # uses distutils in setup.py
-  disabled = isPyPy || pythonAtLeast "3.12";
+  disabled = isPyPy || pythonAtLeast "3.13";
 
   src = fetchFromGitHub {
     owner = "numba";
     repo = "llvmlite";
     rev = "refs/tags/v${version}";
-    hash = "sha256-RBgs8L5kOJ8BhEDLB8r8/iVhwuVIPT/rUSmwmBWm4D0=";
+    hash = "sha256-vN2npyAyN6C340l69YSRtRJrAe4EHSqh4SCgWfeSQaQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -28,11 +28,11 @@ let
 in buildPythonPackage rec {
   # Using an untagged version, with numpy 1.25 support, when it's released
   # also drop the versioneer patch in postPatch
-  version = "0.58.1";
+  version = "0.59.0";
   pname = "numba";
   pyproject = true;
 
-  disabled = pythonOlder "3.8" || pythonAtLeast "3.12";
+  disabled = pythonOlder "3.8" || pythonAtLeast "3.13";
 
   src = fetchFromGitHub {
     owner = "numba";
@@ -50,7 +50,7 @@ in buildPythonPackage rec {
     # use `forceFetchGit = true;`.` If in the future we'll observe the hash
     # changes too often, we can always use forceFetchGit, and inject the
     # relevant strings ourselves, using `sed` commands, in extraPostFetch.
-    hash = "sha256-1Tj2GFoUwRRCWBFxhreF+0Mr+Tjyb7+X4peO+T0qGNs=";
+    hash = "sha256-wd4TujPhV2Jy/HUUXLHAlcbVFm4gfQNWxWFXD+jeZC4=";
   };
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.isDarwin "-I${lib.getDev libcxx}/include/c++/v1";
 
@@ -77,6 +77,10 @@ in buildPythonPackage rec {
       cuda_toolkit_path = cudatoolkit;
       cuda_toolkit_lib_path = cudatoolkit.lib;
     })
+  ] ++ lib.optionals (stdenv.isLinux && stdenv.isAarch64) [
+    # segfaults the interpreter on aarch64-linux on 0.59.0
+    # https://github.com/numba/numba/issues/9442
+    ./gh-issue-9442.patch
   ];
 
   postFixup = lib.optionalString cudaSupport ''

--- a/pkgs/development/python-modules/numba/gh-issue-9442.patch
+++ b/pkgs/development/python-modules/numba/gh-issue-9442.patch
@@ -1,0 +1,22 @@
+diff --git a/numba/tests/test_usecases.py b/numba/tests/test_usecases.py
+index bf58dabe9..ecd1f5f28 100644
+--- a/numba/tests/test_usecases.py
++++ b/numba/tests/test_usecases.py
+@@ -35,17 +35,6 @@ class TestUsecases(TestCase):
+         for args in itertools.product(ss, es):
+             self.assertEqual(pyfunc(*args), cfunc(*args), args)
+ 
+-    @TestCase.run_test_in_subprocess
+-    def test_sum1d_pyobj(self):
+-        pyfunc = usecases.sum1d
+-        cfunc = jit((types.int32, types.int32), forceobj=True)(pyfunc)
+-
+-        ss = -1, 0, 1, 100, 200
+-        es = -1, 0, 1, 100, 200
+-
+-        for args in itertools.product(ss, es):
+-            self.assertEqual(pyfunc(*args), cfunc(*args), args)
+-
+     @TestCase.run_test_in_subprocess
+     def test_sum2d(self):
+         pyfunc = usecases.sum2d

--- a/pkgs/development/python-modules/numpy/default.nix
+++ b/pkgs/development/python-modules/numpy/default.nix
@@ -53,20 +53,17 @@ let
   };
 in buildPythonPackage rec {
   pname = "numpy";
-  version = "1.26.2";
+  version = "1.26.4";
   pyproject = true;
   disabled = pythonOlder "3.9" || pythonAtLeast "3.13";
 
   src = fetchPypi {
     inherit pname version;
     extension = "tar.gz";
-    hash = "sha256-9lc4RHZ2q1d38R5ru9uM4Rt4XhBfaQvEWWZXSBa20+o=";
+    hash = "sha256-KgKrqe0S5KxOs+qUIcQgMBoMZGDZgw10qd+H76SRIBA=";
   };
 
   patches = [
-    # Remove last usage of distutils to enable numpy on Python 3.12
-    ./0001-BLD-remove-last-usage-of-distutils-in-_core-code_gen.patch
-
     # Disable `numpy/core/tests/test_umath.py::TestComplexFunctions::test_loss_of_precision[complex256]`
     # on x86_64-darwin because it fails under Rosetta 2 due to issues with trig functions and
     # 80-bit long double complex numbers.

--- a/pkgs/development/python-modules/pandas/default.nix
+++ b/pkgs/development/python-modules/pandas/default.nix
@@ -6,7 +6,6 @@
 , pythonOlder
 
 # build-system
-, cython
 , cython_3
 , meson-python
 , meson
@@ -65,7 +64,7 @@
 
 let pandas = buildPythonPackage rec {
   pname = "pandas";
-  version = "2.1.3";
+  version = "2.2.0";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -74,19 +73,18 @@ let pandas = buildPythonPackage rec {
     owner = "pandas-dev";
     repo = "pandas";
     rev = "refs/tags/v${version}";
-    hash = "sha256-okGYzPJC3mpG+Sq4atjWwLlocUDnpjgGRPmQ+4ehQX0=";
+    hash = "sha256-PMrqniyyFYRnAeFBruPrTrGKzX2dRxMRct8AHeghstA=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace "Cython>=0.29.33,<3" "Cython" \
-      --replace "meson-python==0.13.1" "meson-python>=0.13.1" \
-      --replace "meson==1.2.1" "meson>=1.2.1"
+      --replace-fail "Cython==3.0.5" "Cython>=3.0.5" \
+      --replace-fail "meson-python==0.13.1" "meson-python>=0.13.1" \
+      --replace-fail "meson==1.2.1" "meson>=1.2.1"
   '';
 
   nativeBuildInputs = [
-    # TODO: hack to support pandas on python3.12, remove with pandas 2.2.0
-    (if pythonAtLeast "3.12" then cython_3 else cython)
+    cython_3
     meson-python
     meson
     numpy

--- a/pkgs/development/python-modules/tqdm/default.nix
+++ b/pkgs/development/python-modules/tqdm/default.nix
@@ -48,6 +48,7 @@ buildPythonPackage rec {
 
   pytestFlagsArray = [
     "-W" "ignore::FutureWarning"
+    "-W" "ignore::DeprecationWarning"
   ];
 
   # Remove performance testing.


### PR DESCRIPTION
https://pandas.pydata.org/docs/whatsnew/v2.2.0.html
https://github.com/numpy/numpy/releases/tag/v1.26.3
https://github.com/numpy/numpy/releases/tag/v1.26.4
https://github.com/numba/numba/compare/refs/tags/0.58.1...0.59.0

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [X] aarch64-linux
  - [x] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
