### PR TITLE
ecwolf: add `passthru.updateScript`

### DIFF
--- a/pkgs/games/ecwolf/default.nix
+++ b/pkgs/games/ecwolf/default.nix
@@ -12,6 +12,9 @@
 , SDL2_net
 , SDL2_mixer
 , gtk3
+, writers
+, python3Packages
+, nix-update
 }:
 
 stdenv.mkDerivation rec {
@@ -40,6 +43,33 @@ stdenv.mkDerivation rec {
     cp -R ecwolf.app $out/Applications
     makeWrapper $out/{Applications/ecwolf.app/Contents/MacOS,bin}/ecwolf
   '';
+
+  passthru.updateScript = let
+    updateScriptPkg = writers.writePython3 "ecwolf_update_script" {
+      libraries = with python3Packages; [ debian-inspector requests ];
+    } ''
+      from os import execl
+      from sys import argv
+
+      from debian_inspector.debcon import get_paragraphs_data
+      from requests import get
+
+      # The debian.drdteam.org repo is a primary source of information. It’s
+      # run by Blzut3, the creator and primary developer of ECWolf. It’s also
+      # listed on ECWolf’s download page:
+      # <https://maniacsvault.net/ecwolf/download.php>.
+      url = 'https://debian.drdteam.org/dists/stable/multiverse/binary-amd64/Packages'  # noqa: E501
+      response = get(url)
+      packages = get_paragraphs_data(response.text)
+      for package in packages:
+          if package['package'] == 'ecwolf':
+              latest_version = package['version']
+              break
+      nix_update_path = argv[1]
+
+      execl(nix_update_path, nix_update_path, '--version', latest_version)
+    '';
+  in [ updateScriptPkg (lib.getExe nix-update) ];
 
   meta = with lib; {
     description = "Enhanched SDL-based port of Wolfenstein 3D for various platforms";


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Before this change, [`nixpkgs-update` had to rely on on Repology in order to determine if there was an ECWolf update](https://nixos.org/manual/nixpkgs/stable/#var-passthru-updateScript). When it comes to ECWolf updates, Repology is a tertiary source of information. This change allows `nixpkgs-update` (and any other tools) to use `debian.drdteam.org` to determine if there is an ECWolf update. [When it comes to ECWolf updates, `debian.drdteam.org` is a primary source of information.](https://maniacsvault.net/ecwolf/download.php)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
