### PR TITLE
nixos-rebuild: avoid --preserve-env

### DIFF
--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -34,8 +34,7 @@ targetHost=
 remoteSudo=
 verboseScript=
 noFlake=
-# comma separated list of vars to preserve when using sudo
-preservedSudoVars=NIXOS_INSTALL_BOOTLOADER
+installBootloader=
 json=
 
 # log the given argument to stderr
@@ -57,10 +56,10 @@ while [ "$#" -gt 0 ]; do
         ;;
       --install-grub)
         log "$0: --install-grub deprecated, use --install-bootloader instead"
-        export NIXOS_INSTALL_BOOTLOADER=1
+        installBootloader=1
         ;;
       --install-bootloader)
-        export NIXOS_INSTALL_BOOTLOADER=1
+        installBootloader=1
         ;;
       --no-build-nix)
         buildNix=
@@ -157,8 +156,6 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 
-sudoCommand=(sudo --preserve-env="$preservedSudoVars" --)
-
 if [[ -n "$SUDO_USER" ]]; then
     useSudo=1
 fi
@@ -179,7 +176,7 @@ runCmd() {
 buildHostCmd() {
     local c
     if [[ "${useSudo:-x}" = 1 ]]; then
-        c=("${sudoCommand[@]}")
+        c=("sudo")
     else
         c=()
     fi
@@ -196,7 +193,7 @@ buildHostCmd() {
 targetHostCmd() {
     local c
     if [[ "${useSudo:-x}" = 1 ]]; then
-        c=("${sudoCommand[@]}")
+        c=("sudo")
     else
         c=()
     fi
@@ -756,7 +753,7 @@ if [[ "$action" = switch || "$action" = boot || "$action" = test || "$action" = 
     cmd=(
         "systemd-run"
         "-E" "LOCALE_ARCHIVE" # Will be set to new value early in switch-to-configuration script, but interpreter starts out with old value
-        "-E" "NIXOS_INSTALL_BOOTLOADER"
+        "-E" "NIXOS_INSTALL_BOOTLOADER=$installBootloader"
         "--collect"
         "--no-ask-password"
         "--pty"
@@ -774,14 +771,14 @@ if [[ "$action" = switch || "$action" = boot || "$action" = test || "$action" = 
     # may be dangerous in remote access (e.g. SSH).
     if [[ -n "$NIXOS_SWITCH_USE_DIRTY_ENV" ]]; then
         log "warning: skipping systemd-run since NIXOS_SWITCH_USE_DIRTY_ENV is set. This environment variable will be ignored in the future"
-        cmd=()
+        cmd=("env" "NIXOS_INSTALL_BOOTLOADER=$installBootloader")
     elif ! targetHostSudoCmd "${cmd[@]}" true; then
         logVerbose "Skipping systemd-run to switch configuration since it is not working in target host."
         cmd=(
             "env"
             "-i"
             "LOCALE_ARCHIVE=$LOCALE_ARCHIVE"
-            "NIXOS_INSTALL_BOOTLOADER=$NIXOS_INSTALL_BOOTLOADER"
+            "NIXOS_INSTALL_BOOTLOADER=$installBootloader"
         )
     else
         logVerbose "Using systemd-run to switch configuration."


### PR DESCRIPTION
## Description of changes

sudo-rs does not support it, but also it's just spooky action at a distance.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
