### PR TITLE
nix-snapshotter: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5612,6 +5612,12 @@
     githubId = 2536303;
     name = "Enno Lohmeier";
   };
+  elpdt852 = {
+    email = "nix@pdtpartners.com";
+    github = "elpdt852";
+    githubId = 122112154;
+    name = "Edgar Lee";
+  };
   elvishjerricco = {
     email = "elvishjerricco@gmail.com";
     matrix = "@elvishjerricco:matrix.org";

--- a/pkgs/by-name/ni/nix-snapshotter/package.nix
+++ b/pkgs/by-name/ni/nix-snapshotter/package.nix
@@ -1,0 +1,32 @@
+{ lib
+, buildGoModule
+, callPackage
+, fetchFromGitHub
+}:
+
+let
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "pdtpartners";
+    repo = "nix-snapshotter";
+    rev = "v${version}";
+    hash = "sha256-hQ2b9Yx8g8okVWGo/iuvY2sR6FWI8iKp74m4gdXeueI=";
+  };
+
+  nix-snapshotter-lib = callPackage "${src}/package.nix" {};
+
+in buildGoModule {
+  pname = "nix-snapshotter";
+  inherit version src;
+  vendorHash = "sha256-QBLePOnfsr6I19ddyZNSFDih6mCaZ/NV2Qz1B1pSHxs=";
+  passthru = { inherit (nix-snapshotter-lib) buildImage; };
+
+  meta = {
+    description = "Brings native understanding of Nix packages to containerd";
+    homepage    = "https://github.com/pdtpartners/nix-snapshotter";
+    license     = lib.licenses.mit;
+    platforms   = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ elpdt852 ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Initializes [nix-snapshotter](https://github.com/pdtpartners/nix-snapshotter) at `v0.2.0`. `nix-snapshotter` is a snapshotter plugin for [containerd](https://github.com/containerd/containerd) that brings native understanding of Nix packages to the popular container runtime.

The repository already includes a `flake.nix` but the hope is to upstream NixOS modules to make it dead-easy to get started with `nix-snapshotter`.

Instead of the existing heuristics based `buildImage` that bundles Nix packages into Docker layers, `nix-snapshotter` builds images that puts store paths into the `annotations` field of a layer in an OCI manifest. By configuring containerd with `nix-snapshotter`, the container rootfs will be prepared in the following manner.

For each Nix store path:
1. Calling `nix build --out-link <containerd-snapshot-dir>/gcroots <nix-store-path>`
2. Returning a Nix store bind mount to container rootfs

`nix-snapshotter` also provides a CRI image service that allows Kubernetes to resolve image references like `nix:0/nix/store/w05rymszja2nnrlh5xr3yxksrwz467cn-nix-image-redis.tar`. Which essentially lets Kubernetes "pull images" from the Nix store, removing the need for a Docker Registry.

This also means, you can now declare fully-declarative Kubernetes resources in pure Nixlang:

```nix
redis = pkgs.nix-snapshotter.buildImage {
  name = "redis";
  resolvedByNix = true; # passthru.image is set to `nix:0/nix/store/...`
  config = {
    entrypoint = [ "${pkgs.redis}/bin/redis-server" ];
  };
};

redisPod = {
  apiVersion = "v1";
  kind = "Pod";
  metadata = {
    name = "redis";
    labels.name = "redis";
  };
  spec.containers = [{
    inherit (redis) name image;
    args = ["--protected-mode" "no"];
    ports = [{
      name = "client";
      containerPort = 6379;
    }];
  }];
};
```

All this is available as NixOS & Home Manager modules in the [nix-snapshotter](https://github.com/pdtpartners/nix-snapshotter?tab=readme-ov-file#installation) repository. This includes modules for running rootless containerd & k3s. The plan is to upstream all these modules.

There is also a QEMU VM with everything setup to play with:

```sh
nix run "github:pdtpartners/nix-snapshotter#vm"
nixos login: root # (Ctrl-a then x to quit)
Password: root

# Running `pkgs.hello` image with nix-snapshotter
nerdctl run ghcr.io/pdtpartners/hello

# Running `pkgs.redis` image with kubernetes & nix-snapshotter
kubectl apply -f /etc/kubernetes/redis/

# Wait a few seconds... 
watch kubectl get pods

# And a kubernetes service will be ready to forward port 30000 to the redis
# pod, so you can test it out with a `ping` command
redis-cli -p 30000 ping
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
