### PR TITLE
grype: 0.74.5 -> 0.74.6

### DIFF
--- a/pkgs/tools/security/grype/default.nix
+++ b/pkgs/tools/security/grype/default.nix
@@ -1,19 +1,20 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
+, git
 , installShellFiles
 , openssl
 }:
 
 buildGoModule rec {
   pname = "grype";
-  version = "0.74.5";
+  version = "0.74.6";
 
   src = fetchFromGitHub {
     owner = "anchore";
-    repo = pname;
+    repo = "grype";
     rev = "refs/tags/v${version}";
-    hash = "sha256-h68LfKQG5xgFIFkyuK9Z6tw8+xoimnF2d2QgTjwU74U=";
+    hash = "sha256-2KLVIwiSrs+e0srXkfBdk/RxCIvSq/Lixe83th2KvRA=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -28,17 +29,20 @@ buildGoModule rec {
 
   proxyVendor = true;
 
-  vendorHash = "sha256-lnOF3Xvjc20aFPOf9of3n+aBHvPrLTTlH7aPPlYA/RA=";
+  vendorHash = "sha256-wgcbP/VbHOMuc0PxWaOsiYTrr77ztLDVaDMhAD50vuQ=";
 
   nativeBuildInputs = [
     installShellFiles
   ];
 
   nativeCheckInputs = [
+    git
     openssl
   ];
 
-  subPackages = [ "cmd/grype" ];
+  subPackages = [
+    "cmd/grype"
+  ];
 
   excludedPackages = "test/integration";
 
@@ -70,23 +74,25 @@ buildGoModule rec {
 
     # remove tests that depend on docker
     substituteInPlace test/cli/cmd_test.go \
-      --replace "TestCmd" "SkipCmd"
+      --replace-fail "TestCmd" "SkipCmd"
     substituteInPlace grype/pkg/provider_test.go \
-      --replace "TestSyftLocationExcludes" "SkipSyftLocationExcludes"
+      --replace-fail "TestSyftLocationExcludes" "SkipSyftLocationExcludes"
     substituteInPlace test/cli/cmd_test.go \
-      --replace "Test_descriptorNameAndVersionSet" "Skip_descriptorNameAndVersionSet"
+      --replace-fail "Test_descriptorNameAndVersionSet" "Skip_descriptorNameAndVersionSet"
     # remove tests that depend on git
     substituteInPlace test/cli/db_validations_test.go \
-      --replace "TestDBValidations" "SkipDBValidations"
+      --replace-fail "TestDBValidations" "SkipDBValidations"
     substituteInPlace test/cli/registry_auth_test.go \
-      --replace "TestRegistryAuth" "SkipRegistryAuth"
+      --replace-fail "TestRegistryAuth" "SkipRegistryAuth"
     substituteInPlace test/cli/sbom_input_test.go \
-      --replace "TestSBOMInput_FromStdin" "SkipSBOMInput_FromStdin" \
-      --replace "TestSBOMInput_AsArgument" "SkipSBOMInput_AsArgument"
+      --replace-fail "TestSBOMInput_FromStdin" "SkipSBOMInput_FromStdin" \
+      --replace-fail "TestSBOMInput_AsArgument" "SkipSBOMInput_AsArgument"
     substituteInPlace test/cli/subprocess_test.go \
-      --replace "TestSubprocessStdin" "SkipSubprocessStdin"
+      --replace-fail "TestSubprocessStdin" "SkipSubprocessStdin"
     substituteInPlace grype/internal/packagemetadata/names_test.go \
-      --replace "TestAllNames" "SkipAllNames"
+      --replace-fail "TestAllNames" "SkipAllNames"
+    substituteInPlace test/cli/version_cmd_test.go \
+      --replace-fail "TestVersionCmdPrintsToStdout" "SkipVersionCmdPrintsToStdout"
 
     # segfault
     rm grype/db/v5/namespace/cpe/namespace_test.go


### PR DESCRIPTION
Diff: https://github.com/anchore/grype/compare/refs/tags/v0.74.5...v0.74.6

Changelog: https://github.com/anchore/grype/releases/tag/v0.74.6

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
