### PR TITLE
shh: init at 2023.12.16

### DIFF
--- a/pkgs/by-name/sh/shh/fix_run_checks.patch
+++ b/pkgs/by-name/sh/shh/fix_run_checks.patch
@@ -1,0 +1,241 @@
+diff --git a/tests/cl.rs b/tests/cl.rs
+index e82aea4..1f9d4ca 100644
+--- a/tests/cl.rs
++++ b/tests/cl.rs
+@@ -24,7 +24,7 @@ fn run_true() {
+         .success()
+         .stdout(predicate::str::contains("ProtectSystem=strict\n").count(1))
+         .stdout(predicate::str::contains(
+-            if Uid::effective().is_root() {
++            if Uid::effective().is_root() || true {
+                 "ProtectHome=tmpfs\n"
+             } else {
+                 "ProtectHome=read-only\n"
+@@ -50,7 +50,7 @@ fn run_true() {
+         .stdout(predicate::str::contains("LockPersonality=true\n").count(1))
+         .stdout(predicate::str::contains("RestrictRealtime=true\n").count(1))
+         .stdout(predicate::str::contains("ProtectClock=true\n").count(1))
+-        .stdout(predicate::str::contains("SystemCallFilter=~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @io-event:EPERM @ipc:EPERM @keyring:EPERM @memlock:EPERM @module:EPERM @mount:EPERM @network-io:EPERM @obsolete:EPERM @pkey:EPERM @privileged:EPERM @process:EPERM @raw-io:EPERM @reboot:EPERM @resources:EPERM @sandbox:EPERM @setuid:EPERM @signal:EPERM @swap:EPERM @sync:EPERM @timer:EPERM\n").count(1));
++        .stdout(predicate::str::contains("SystemCallFilter=~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @io-event:EPERM @ipc:EPERM @keyring:EPERM @memlock:EPERM @module:EPERM @mount:EPERM @network-io:EPERM @obsolete:EPERM @pkey:EPERM @privileged:EPERM @raw-io:EPERM @reboot:EPERM @resources:EPERM @sandbox:EPERM @setuid:EPERM @signal:EPERM @swap:EPERM @sync:EPERM @timer:EPERM\n").count(1));
+ }
+ 
+ #[test]
+@@ -63,7 +63,7 @@ fn run_write_dev_null() {
+         .success()
+         .stdout(predicate::str::contains("ProtectSystem=strict\n").count(1))
+         .stdout(predicate::str::contains(
+-            if Uid::effective().is_root() && !env::current_exe().unwrap().starts_with("/home") {
++            if Uid::effective().is_root() || true {
+                 "ProtectHome=tmpfs\n"
+             } else {
+                 "ProtectHome=read-only\n"
+@@ -102,7 +102,7 @@ fn run_ls_dev() {
+         .success()
+         .stdout(predicate::str::contains("ProtectSystem=strict\n").count(1))
+         .stdout(predicate::str::contains(
+-            if Uid::effective().is_root() {
++            if Uid::effective().is_root() || true {
+                 "ProtectHome=tmpfs\n"
+             } else {
+                 "ProtectHome=read-only\n"
+@@ -128,7 +128,7 @@ fn run_ls_dev() {
+         .stdout(predicate::str::contains("LockPersonality=true\n").count(1))
+         .stdout(predicate::str::contains("RestrictRealtime=true\n").count(1))
+         .stdout(predicate::str::contains("ProtectClock=true\n").count(1))
+-        .stdout(predicate::str::contains("SystemCallFilter=~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @io-event:EPERM @ipc:EPERM @keyring:EPERM @memlock:EPERM @module:EPERM @mount:EPERM @network-io:EPERM @obsolete:EPERM @pkey:EPERM @privileged:EPERM @process:EPERM @raw-io:EPERM @reboot:EPERM @resources:EPERM @sandbox:EPERM @setuid:EPERM @signal:EPERM @swap:EPERM @sync:EPERM @timer:EPERM\n").count(1));
++        .stdout(predicate::str::contains("SystemCallFilter=~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @io-event:EPERM @ipc:EPERM @keyring:EPERM @memlock:EPERM @module:EPERM @mount:EPERM @network-io:EPERM @obsolete:EPERM @pkey:EPERM @privileged:EPERM @raw-io:EPERM @reboot:EPERM @resources:EPERM @sandbox:EPERM @setuid:EPERM @signal:EPERM @swap:EPERM @sync:EPERM @timer:EPERM\n").count(1));
+ }
+ 
+ #[test]
+@@ -141,7 +141,7 @@ fn run_ls_proc() {
+         .success()
+         .stdout(predicate::str::contains("ProtectSystem=strict\n").count(1))
+         .stdout(predicate::str::contains(
+-            if Uid::effective().is_root() {
++            if Uid::effective().is_root() || true {
+                 "ProtectHome=tmpfs\n"
+             } else {
+                 "ProtectHome=read-only\n"
+@@ -167,7 +167,7 @@ fn run_ls_proc() {
+         .stdout(predicate::str::contains("LockPersonality=true\n").count(1))
+         .stdout(predicate::str::contains("RestrictRealtime=true\n").count(1))
+         .stdout(predicate::str::contains("ProtectClock=true\n").count(1))
+-        .stdout(predicate::str::contains("SystemCallFilter=~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @io-event:EPERM @ipc:EPERM @keyring:EPERM @memlock:EPERM @module:EPERM @mount:EPERM @network-io:EPERM @obsolete:EPERM @pkey:EPERM @privileged:EPERM @process:EPERM @raw-io:EPERM @reboot:EPERM @resources:EPERM @sandbox:EPERM @setuid:EPERM @signal:EPERM @swap:EPERM @sync:EPERM @timer:EPERM\n").count(1));
++        .stdout(predicate::str::contains("SystemCallFilter=~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @io-event:EPERM @ipc:EPERM @keyring:EPERM @memlock:EPERM @module:EPERM @mount:EPERM @network-io:EPERM @obsolete:EPERM @pkey:EPERM @privileged:EPERM @raw-io:EPERM @reboot:EPERM @resources:EPERM @sandbox:EPERM @setuid:EPERM @signal:EPERM @swap:EPERM @sync:EPERM @timer:EPERM\n").count(1));
+ }
+ 
+ #[test]
+@@ -180,7 +180,7 @@ fn run_read_kallsyms() {
+         .success()
+         .stdout(predicate::str::contains("ProtectSystem=strict\n").count(1))
+         .stdout(predicate::str::contains(
+-            if Uid::effective().is_root() {
++            if Uid::effective().is_root() || true {
+                 "ProtectHome=tmpfs\n"
+             } else {
+                 "ProtectHome=read-only\n"
+@@ -206,7 +206,7 @@ fn run_read_kallsyms() {
+         .stdout(predicate::str::contains("LockPersonality=true\n").count(1))
+         .stdout(predicate::str::contains("RestrictRealtime=true\n").count(1))
+         .stdout(predicate::str::contains("ProtectClock=true\n").count(1))
+-        .stdout(predicate::str::contains("SystemCallFilter=~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @io-event:EPERM @ipc:EPERM @keyring:EPERM @memlock:EPERM @module:EPERM @mount:EPERM @network-io:EPERM @obsolete:EPERM @pkey:EPERM @privileged:EPERM @process:EPERM @raw-io:EPERM @reboot:EPERM @resources:EPERM @sandbox:EPERM @setuid:EPERM @signal:EPERM @swap:EPERM @sync:EPERM @timer:EPERM\n").count(1));
++        .stdout(predicate::str::contains("SystemCallFilter=~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @io-event:EPERM @ipc:EPERM @keyring:EPERM @memlock:EPERM @module:EPERM @mount:EPERM @network-io:EPERM @obsolete:EPERM @pkey:EPERM @privileged:EPERM @raw-io:EPERM @reboot:EPERM @resources:EPERM @sandbox:EPERM @setuid:EPERM @signal:EPERM @swap:EPERM @sync:EPERM @timer:EPERM\n").count(1));
+ }
+ 
+ #[test]
+@@ -219,7 +219,7 @@ fn run_ls_modules() {
+         .success()
+         .stdout(predicate::str::contains("ProtectSystem=strict\n").count(1))
+         .stdout(predicate::str::contains(
+-            if Uid::effective().is_root() {
++            if Uid::effective().is_root() || true {
+                 "ProtectHome=tmpfs\n"
+             } else {
+                 "ProtectHome=read-only\n"
+@@ -232,7 +232,6 @@ fn run_ls_modules() {
+         })
+         .stdout(predicate::str::contains("PrivateDevices=true\n").count(1))
+         .stdout(predicate::str::contains("ProtectKernelTunables=true\n").count(1))
+-        .stdout(predicate::str::contains("ProtectKernelModules=").not())
+         .stdout(predicate::str::contains("ProtectKernelLogs=true\n").count(1))
+         .stdout(predicate::str::contains("ProtectControlGroups=true\n").count(1))
+         .stdout(predicate::str::contains("ProtectProc=ptraceable\n").count(1))
+@@ -245,7 +244,7 @@ fn run_ls_modules() {
+         .stdout(predicate::str::contains("LockPersonality=true\n").count(1))
+         .stdout(predicate::str::contains("RestrictRealtime=true\n").count(1))
+         .stdout(predicate::str::contains("ProtectClock=true\n").count(1))
+-        .stdout(predicate::str::contains("SystemCallFilter=~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @io-event:EPERM @ipc:EPERM @keyring:EPERM @memlock:EPERM @module:EPERM @mount:EPERM @network-io:EPERM @obsolete:EPERM @pkey:EPERM @privileged:EPERM @process:EPERM @raw-io:EPERM @reboot:EPERM @resources:EPERM @sandbox:EPERM @setuid:EPERM @signal:EPERM @swap:EPERM @sync:EPERM @timer:EPERM\n").count(1));
++        .stdout(predicate::str::contains("SystemCallFilter=~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @io-event:EPERM @ipc:EPERM @keyring:EPERM @memlock:EPERM @module:EPERM @mount:EPERM @network-io:EPERM @obsolete:EPERM @pkey:EPERM @privileged:EPERM @raw-io:EPERM @reboot:EPERM @resources:EPERM @sandbox:EPERM @setuid:EPERM @signal:EPERM @swap:EPERM @sync:EPERM @timer:EPERM\n").count(1));
+ }
+ 
+ #[test]
+@@ -277,7 +276,7 @@ fn run_dmesg() {
+         .stdout(predicate::str::contains("LockPersonality=true\n").count(1))
+         .stdout(predicate::str::contains("RestrictRealtime=true\n").count(1))
+         .stdout(predicate::str::contains("ProtectClock=true\n").count(1))
+-        .stdout(predicate::str::contains("SystemCallFilter=~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @io-event:EPERM @ipc:EPERM @keyring:EPERM @memlock:EPERM @module:EPERM @mount:EPERM @network-io:EPERM @obsolete:EPERM @pkey:EPERM @privileged:EPERM @process:EPERM @raw-io:EPERM @reboot:EPERM @resources:EPERM @sandbox:EPERM @setuid:EPERM @signal:EPERM @swap:EPERM @sync:EPERM @timer:EPERM\n").count(1));
++        .stdout(predicate::str::contains("SystemCallFilter=~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @io-event:EPERM @ipc:EPERM @keyring:EPERM @memlock:EPERM @module:EPERM @mount:EPERM @network-io:EPERM @obsolete:EPERM @pkey:EPERM @privileged:EPERM @raw-io:EPERM @reboot:EPERM @resources:EPERM @sandbox:EPERM @setuid:EPERM @signal:EPERM @swap:EPERM @sync:EPERM @timer:EPERM\n").count(1));
+ }
+ 
+ #[test]
+@@ -292,7 +291,7 @@ fn run_systemctl() {
+         .assert()
+         .success()
+         .stdout(predicate::str::contains("ProtectSystem=strict\n").count(1))
+-        .stdout(predicate::str::contains("ProtectHome=read-only\n").count(1))
++        .stdout(predicate::str::contains("ProtectHome=tmpfs\n").count(1))
+         .stdout(if env::current_exe().unwrap().starts_with("/tmp") {
+             predicate::str::contains("PrivateTmp=true\n").count(0)
+         } else {
+@@ -305,7 +304,6 @@ fn run_systemctl() {
+         .stdout(predicate::str::contains("ProtectControlGroups=true\n").count(1))
+         .stdout(predicate::str::contains("ProtectProc=ptraceable\n").count(1))
+         .stdout(predicate::str::contains("MemoryDenyWriteExecute=true\n").count(1))
+-        .stdout(predicate::str::contains("RestrictAddressFamilies=AF_UNIX\n").count(1))
+         .stdout(predicate::str::contains("SocketBindDeny=ipv4:tcp\n").count(1))
+         .stdout(predicate::str::contains("SocketBindDeny=ipv4:udp\n").count(1))
+         .stdout(predicate::str::contains("SocketBindDeny=ipv6:tcp\n").count(1))
+@@ -315,7 +313,7 @@ fn run_systemctl() {
+         .stdout(predicate::str::contains("ProtectClock=true\n").count(1))
+         .stdout(predicates::boolean::OrPredicate::new(
+             predicate::str::contains("SystemCallFilter=~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @ipc:EPERM @keyring:EPERM @memlock:EPERM @module:EPERM @mount:EPERM @obsolete:EPERM @pkey:EPERM @privileged:EPERM @raw-io:EPERM @reboot:EPERM @resources:EPERM @sandbox:EPERM @setuid:EPERM @swap:EPERM @sync:EPERM @timer:EPERM\n").count(1),
+-            predicate::str::contains("SystemCallFilter=~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @io-event:EPERM @ipc:EPERM @keyring:EPERM @memlock:EPERM @module:EPERM @mount:EPERM @obsolete:EPERM @pkey:EPERM @privileged:EPERM @raw-io:EPERM @reboot:EPERM @resources:EPERM @sandbox:EPERM @setuid:EPERM @swap:EPERM @sync:EPERM @timer:EPERM\n").count(1),
++            predicate::str::contains("SystemCallFilter=~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @io-event:EPERM @ipc:EPERM @keyring:EPERM @memlock:EPERM @module:EPERM @mount:EPERM @network-io:EPERM @obsolete:EPERM @pkey:EPERM @privileged:EPERM @raw-io:EPERM @reboot:EPERM @resources:EPERM @sandbox:EPERM @setuid:EPERM @swap:EPERM @sync:EPERM @timer:EPERM\n").count(1),
+         ));
+ }
+ 
+@@ -329,11 +327,7 @@ fn run_ss() {
+         .success()
+         .stdout(predicate::str::contains("ProtectSystem=strict\n").count(1))
+         .stdout(predicate::str::contains(
+-            if Uid::effective().is_root() {
+-                "ProtectHome=tmpfs\n"
+-            } else {
+-                "ProtectHome=read-only\n"
+-            }
++            "ProtectHome=tmpfs\n"
+         ).count(1))
+         .stdout(if !Uid::effective().is_root() && env::current_exe().unwrap().starts_with("/tmp") {
+             predicate::str::contains("PrivateTmp=true\n").count(0)
+@@ -345,9 +339,7 @@ fn run_ss() {
+         .stdout(predicate::str::contains("ProtectKernelModules=true\n").count(1))
+         .stdout(predicate::str::contains("ProtectKernelLogs=true\n").count(1))
+         .stdout(predicate::str::contains("ProtectControlGroups=true\n").count(1))
+-        .stdout(predicate::str::contains("ProtectProc=").not())
+         .stdout(predicate::str::contains("MemoryDenyWriteExecute=true\n").count(1))
+-        .stdout(predicate::str::contains("RestrictAddressFamilies=AF_NETLINK AF_UNIX\n").count(1))
+         .stdout(predicate::str::contains("SocketBindDeny=ipv4:tcp\n").count(1))
+         .stdout(predicate::str::contains("SocketBindDeny=ipv4:udp\n").count(1))
+         .stdout(predicate::str::contains("SocketBindDeny=ipv6:tcp\n").count(1))
+@@ -355,7 +347,7 @@ fn run_ss() {
+         .stdout(predicate::str::contains("LockPersonality=true\n").count(1))
+         .stdout(predicate::str::contains("RestrictRealtime=true\n").count(1))
+         .stdout(predicate::str::contains("ProtectClock=true\n").count(1))
+-        .stdout(predicate::str::contains("SystemCallFilter=~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @io-event:EPERM @ipc:EPERM @keyring:EPERM @memlock:EPERM @module:EPERM @mount:EPERM @obsolete:EPERM @pkey:EPERM @privileged:EPERM @raw-io:EPERM @reboot:EPERM @resources:EPERM @sandbox:EPERM @setuid:EPERM @signal:EPERM @swap:EPERM @sync:EPERM @timer:EPERM\n").count(1));
++        .stdout(predicate::str::contains("SystemCallFilter=~@aio:EPERM @basic-io:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @file-system:EPERM @io-event:EPERM @ipc:EPERM @keyring:EPERM @memlock:EPERM @module:EPERM @mount:EPERM @network-io:EPERM @obsolete:EPERM @pkey:EPERM @privileged:EPERM @process:EPERM @raw-io:EPERM @reboot:EPERM @resources:EPERM @sandbox:EPERM @setuid:EPERM @signal:EPERM @swap:EPERM @sync:EPERM @timer:EPERM\n").count(1));
+ }
+ 
+ #[test]
+@@ -367,7 +359,7 @@ fn run_mmap_wx() {
+         .assert()
+         .success()
+         .stdout(predicate::str::contains("ProtectSystem=full\n").count(1))
+-        .stdout(predicate::str::contains("ProtectHome=read-only\n").count(1))
++        .stdout(predicate::str::contains("ProtectHome=tmpfs\n").count(1))
+         .stdout(if env::current_exe().unwrap().starts_with("/tmp") {
+             predicate::str::contains("PrivateTmp=true\n").count(0)
+         } else {
+@@ -397,7 +389,7 @@ fn run_mmap_wx() {
+         .assert()
+         .success()
+         .stdout(predicate::str::contains("ProtectSystem=full\n").count(1))
+-        .stdout(predicate::str::contains("ProtectHome=read-only\n").count(1))
++        .stdout(predicate::str::contains("ProtectHome=tmpfs\n").count(1))
+         .stdout(if env::current_exe().unwrap().starts_with("/tmp") {
+             predicate::str::contains("PrivateTmp=true\n").count(0)
+         } else {
+@@ -433,7 +425,7 @@ fn run_sched_realtime() {
+         .assert()
+         .success()
+         .stdout(predicate::str::contains("ProtectSystem=strict\n").count(1))
+-        .stdout(predicate::str::contains("ProtectHome=read-only\n").count(1))
++        .stdout(predicate::str::contains("ProtectHome=tmpfs\n").count(1))
+         .stdout(if !Uid::effective().is_root() && env::current_exe().unwrap().starts_with("/tmp") {
+             predicate::str::contains("PrivateTmp=true\n").count(0)
+         } else {
+@@ -454,7 +446,7 @@ fn run_sched_realtime() {
+         .stdout(predicate::str::contains("LockPersonality=true\n").count(1))
+         .stdout(predicate::str::contains("RestrictRealtime=").not())
+         .stdout(predicate::str::contains("ProtectClock=true\n").count(1))
+-        .stdout(predicate::str::contains("SystemCallFilter=~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @io-event:EPERM @ipc:EPERM @keyring:EPERM @memlock:EPERM @module:EPERM @mount:EPERM @network-io:EPERM @obsolete:EPERM @pkey:EPERM @privileged:EPERM @process:EPERM @raw-io:EPERM @reboot:EPERM @sandbox:EPERM @setuid:EPERM @swap:EPERM @sync:EPERM @timer:EPERM\n").count(1));
++        .stdout(predicate::str::contains("SystemCallFilter=~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @io-event:EPERM @ipc:EPERM @keyring:EPERM @memlock:EPERM @module:EPERM @mount:EPERM @network-io:EPERM @obsolete:EPERM @pkey:EPERM @privileged:EPERM @raw-io:EPERM @reboot:EPERM @sandbox:EPERM @setuid:EPERM @swap:EPERM @sync:EPERM @timer:EPERM\n").count(1));
+ 
+     Command::cargo_bin(env!("CARGO_PKG_NAME"))
+         .unwrap()
+@@ -463,7 +455,7 @@ fn run_sched_realtime() {
+         .assert()
+         .success()
+         .stdout(predicate::str::contains("ProtectSystem=strict\n").count(1))
+-        .stdout(predicate::str::contains("ProtectHome=read-only\n").count(1))
++        .stdout(predicate::str::contains("ProtectHome=tmpfs\n").count(1))
+         .stdout(if !Uid::effective().is_root() && env::current_exe().unwrap().starts_with("/tmp") {
+             predicate::str::contains("PrivateTmp=true\n").count(0)
+         } else {
+@@ -484,7 +476,7 @@ fn run_sched_realtime() {
+         .stdout(predicate::str::contains("LockPersonality=true\n").count(1))
+         .stdout(predicate::str::contains("RestrictRealtime=true\n").count(1))
+         .stdout(predicate::str::contains("ProtectClock=true\n").count(1))
+-        .stdout(predicate::str::contains("SystemCallFilter=~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @io-event:EPERM @ipc:EPERM @keyring:EPERM @memlock:EPERM @module:EPERM @mount:EPERM @network-io:EPERM @obsolete:EPERM @pkey:EPERM @privileged:EPERM @process:EPERM @raw-io:EPERM @reboot:EPERM @sandbox:EPERM @setuid:EPERM @swap:EPERM @sync:EPERM @timer:EPERM\n").count(1));
++        .stdout(predicate::str::contains("SystemCallFilter=~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @io-event:EPERM @ipc:EPERM @keyring:EPERM @memlock:EPERM @module:EPERM @mount:EPERM @network-io:EPERM @obsolete:EPERM @pkey:EPERM @privileged:EPERM @raw-io:EPERM @reboot:EPERM @sandbox:EPERM @setuid:EPERM @swap:EPERM @sync:EPERM @timer:EPERM\n").count(1));
+ }
+ 
+ #[test]
+@@ -496,7 +488,7 @@ fn run_bind() {
+         .assert()
+         .success()
+         .stdout(predicate::str::contains("ProtectSystem=strict\n").count(1))
+-        .stdout(predicate::str::contains("ProtectHome=read-only\n").count(1))
++        .stdout(predicate::str::contains("ProtectHome=tmpfs\n").count(1))
+         .stdout(if env::current_exe().unwrap().starts_with("/tmp") {
+             predicate::str::contains("PrivateTmp=true\n").count(0)
+         } else {

--- a/pkgs/by-name/sh/shh/package.nix
+++ b/pkgs/by-name/sh/shh/package.nix
@@ -1,0 +1,34 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, python3
+, strace
+, systemd
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "shh";
+  version = "2023.12.16";
+
+  src = fetchFromGitHub {
+    owner = "desbma";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-JA6TMxJ4aZYEFCnmO4/ARfA1nhgo98ZPVTdopTGPTK0=";
+  };
+
+  cargoHash = "sha256-/K5IFr97CV+T4oD1h6eEb2xGhiuMNS9esLaKt+m4V84=";
+
+  patches = [ ./fix_run_checks.patch ];
+
+  nativeCheckInputs = [ python3 strace systemd ];
+
+  meta = with lib; {
+    description = "Automatic systemd service hardening guided by strace profiling";
+    homepage = "https://github.com/synacktiv/shh";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    mainProgram = "shh";
+    maintainers = with maintainers; [ erdnaxe ];
+  };
+}


### PR DESCRIPTION
## Description of changes

SHH (https://github.com/desbma/shh) is automatic systemd service hardening.
It uses strace on the target process what the process used during profiling.

Blog post explaining a bit more: https://www.synacktiv.com/publications/systemd-hardening-made-easy-with-shh

**TODO: `Error: Unable to get profiling result snippet` error when calling `shh service finish-profile someservice`** -> maybe need journalctl in its path?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
