### PR TITLE
vscode-utils: Set the sourceRoot attribute on vscode extensions

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
+++ b/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
@@ -32,6 +32,10 @@ let
 
     inherit configurePhase buildPhase dontPatchELF dontStrip;
 
+    # Some .vsix files contain other directories (e.g., `package`) that we don't use.
+    # If other directories are present but `sourceRoot` is unset, the unpacker phase fails.
+    sourceRoot = "extension";
+
     installPrefix = "share/vscode/extensions/${vscodeExtUniqueId}";
 
     nativeBuildInputs = [ unzip ] ++ nativeBuildInputs;


### PR DESCRIPTION
Some extensions for VSCode contain directories other than `extension` (e.g., `package`, if the extension has a digital signature). The unpacker phase fails if a .vsix file contains more than one directory at the archive's root and the `sourceRoot` attribute is unset.

I've recently encountered this issue with `ms-vscode.cmake-tools`, which, since 1.17.15, is digitally signed. Others have encountered this issue as well:
* https://github.com/NixOS/nixpkgs/issues/270423
* https://github.com/nix-community/nix-vscode-extensions/issues/31
* https://github.com/nix-community/nix-vscode-extensions/issues/51

In particular, https://github.com/nix-community/nix-vscode-extensions/issues/31 suggests setting `sourceRoot` using `overrideAttrs`. However, since VSCode extensions have a well-defined structure, setting the `sourceRoot` for *all* extensions is valid. `nix-vscode-extensions` uses the functions in `vscode-utils` so it will inherit the fix (which I've verified locally).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
