### PR TITLE
bip: drop blanket -Werror

### DIFF
--- a/pkgs/applications/networking/irc/bip/default.nix
+++ b/pkgs/applications/networking/irc/bip/default.nix
@@ -1,9 +1,8 @@
 { lib
 , stdenv
 , fetchurl
+, autoreconfHook
 , pkg-config
-, autoconf
-, automake
 , bison
 , flex
 , openssl
@@ -21,12 +20,17 @@ stdenv.mkDerivation {
 
   outputs = [ "out" "man" "doc" ];
 
-  nativeBuildInputs = [ pkg-config autoconf automake ];
+  postPatch = ''
+    # Drop blanket -Werror to avoid build failure on fresh toolchains
+    # and libraries. Without the cnage build fails on gcc-13 and on
+    # openssl-3.
+    substituteInPlace src/Makefile.am --replace-fail ' -Werror ' ' '
+  '';
+
+  nativeBuildInputs = [ autoreconfHook pkg-config ];
   buildInputs = [ bison flex openssl ];
 
-  # FIXME: Openssl3 deprecated PEM_read_DHparams and DH_free
-  # https://projects.duckcorp.org/issues/780
-  env.NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
+  enableParallelBuilding = true;
 
   meta = {
     description = "An IRC proxy (bouncer)";


### PR DESCRIPTION
Without the change the build fails on `master` as
https://hydra.nixos.org/build/249146359:

    In function 'array_count',
        inlined from 'irc_line_free' at line.c:220:18:
    util.h:206:17: error: null pointer dereference [-Werror=null-dereference]
      206 |         return a->elemc;
          |                ~^~~~~~~

Instead of disabling another warning let's drop blanket `-Werror`. While at it enabled parallel builds by default.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
