### PR TITLE
power-profiles-daemon: 0.13 -> 0.20

### DIFF
--- a/pkgs/os-specific/linux/power-profiles-daemon/default.nix
+++ b/pkgs/os-specific/linux/power-profiles-daemon/default.nix
@@ -5,7 +5,6 @@
 , mesonEmulatorHook
 , ninja
 , fetchFromGitLab
-, fetchpatch
 , libgudev
 , glib
 , polkit
@@ -21,22 +20,21 @@
 , umockdev
 , systemd
 , python3
-, wrapGAppsNoGuiHook
 , nixosTests
 }:
 
 stdenv.mkDerivation rec {
   pname = "power-profiles-daemon";
-  version = "0.13";
+  version = "0.20";
 
   outputs = [ "out" "devdoc" ];
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
-    owner = "hadess";
+    owner = "upower";
     repo = "power-profiles-daemon";
     rev = version;
-    sha256 = "sha256-ErHy+shxZQ/aCryGhovmJ6KmAMt9OZeQGDbHIkC0vUE=";
+    sha256 = "sha256-8wSRPR/1ELcsZ9K3LvSNlPcJvxRhb/LRjTIxKtdQlCA=";
   };
 
   nativeBuildInputs = [
@@ -50,8 +48,6 @@ stdenv.mkDerivation rec {
     libxml2 # for xmllint for stripping GResources
     libxslt # for xsltproc for building docs
     gobject-introspection
-    wrapGAppsNoGuiHook
-    python3.pkgs.wrapPython
     # checkInput but cheked for during the configuring
     (python3.pythonOnBuildForHost.withPackages (ps: with ps; [
       pygobject3
@@ -68,16 +64,16 @@ stdenv.mkDerivation rec {
     upower
     glib
     polkit
-    python3 # for cli tool
-    # Duplicate from nativeCheckInputs until https://github.com/NixOS/nixpkgs/issues/161570 is solved
-    umockdev
+    # for cli tool
+    (python3.withPackages (ps: [
+      ps.pygobject3
+    ]))
   ];
 
   strictDeps = true;
 
-  # for cli tool
-  pythonPath = [
-    python3.pkgs.pygobject3
+  checkInputs = [
+    umockdev
   ];
 
   nativeCheckInputs = [
@@ -95,26 +91,13 @@ stdenv.mkDerivation rec {
 
   PKG_CONFIG_POLKIT_GOBJECT_1_POLICYDIR = "${placeholder "out"}/share/polkit-1/actions";
 
-  # Avoid double wrapping
-  dontWrapGApps = true;
-
   postPatch = ''
     patchShebangs --build \
       tests/integration-test.py \
       tests/unittest_inspector.py
-  '';
 
-  postCheck = ''
-    # Do not contaminate the wrapper with test dependencies.
-    unset GI_TYPELIB_PATH
-    unset XDG_DATA_DIRS
-  '';
-
-  postFixup = ''
-    # Avoid double wrapping
-    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
-    # Make Python libraries available
-    wrapPythonProgramsIn "$out/bin" "$pythonPath"
+    patchShebangs --host \
+      src/powerprofilesctl
   '';
 
   passthru = {


### PR DESCRIPTION
## Description of changes

```
commit 9998f40bb36ba6fc3b8252cfd7a3ea494b146056 (HEAD -> pic/ppd020, fork/pic/ppd020, master)
Date:   Sun Feb 18 13:46:56 2024 +0100

    nixosTests.power-profiles-daemon: test profilectl CLI
    
    We also take advantage of that change to point to the new dbus
    canonical names.

commit cc557e1055de6e913e1aa0aa312001d206b864c5
Date:   Sun Feb 18 13:43:46 2024 +0100

    power-profiles-daemon: 0.13 -> 0.20
    
    The upstream original maintainer is not paid anymore to maintain the
    project and decided to step down. The project has been taken over by
    the upower team.
    
    This is the first release part of this upower team.
    
    The integration tests are now relying on the powerprofilectl command:
    we need to patch the python path of this dependency before running the
    integration tests instead of doing that during in the fixup phase.
    
    Taking advantage of this to remove the PostFixup phase. Not 100% about
    this move: it's a bit less future proof.

```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
