### PR TITLE
filebrowser: 2.23.0 -> 2.28.0, add service module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14394,12 +14394,6 @@
       fingerprint = "E576 BFB2 CF6E B13D F571  33B9 E315 A758 4613 1564";
     }];
   };
-  nielsegberts = {
-    email = "nix@nielsegberts.nl";
-    github = "nielsegberts";
-    githubId = 368712;
-    name = "Niels Egberts";
-  };
   nigelgbanks = {
     name = "Nigel Banks";
     email = "nigel.g.banks@gmail.com";

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -181,6 +181,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - [systemd-lock-handler](https://git.sr.ht/~whynothugo/systemd-lock-handler/), a bridge between logind D-Bus events and systemd targets. Available as [services.systemd-lock-handler.enable](#opt-services.systemd-lock-handler.enable).
 
+- [filebrowser](https://github.com/filebrowser/filebrowser), a web application for managing files and directories. Available as [services.filebrowser.enable](#opt-services.filebrowser.enable).
+
 - [wastebin](https://github.com/matze/wastebin), a pastebin server written in rust. Available as [services.wastebin](#opt-services.wastebin.enable).
 
 - [Mealie](https://nightly.mealie.io/), a self-hosted recipe manager and meal planner with a RestAPI backend and a reactive frontend application built in NuxtJS for a pleasant user experience for the whole family. Available as [services.mealie](#opt-services.mealie.enable)

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1338,6 +1338,7 @@
   ./services/web-apps/engelsystem.nix
   ./services/web-apps/ethercalc.nix
   ./services/web-apps/firefly-iii.nix
+  ./services/web-apps/filebrowser.nix
   ./services/web-apps/fluidd.nix
   ./services/web-apps/freshrss.nix
   ./services/web-apps/galene.nix

--- a/nixos/modules/services/web-apps/filebrowser.nix
+++ b/nixos/modules/services/web-apps/filebrowser.nix
@@ -1,0 +1,181 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) generators types hasPrefix literalExpression mkEnableOption mkIf
+                mkOption mkPackageOption optional optionalAttrs;
+
+  cfg = config.services.filebrowser;
+  enableDynamicUser =
+    assert cfg.user != "filebrowser" -> cfg.group != "filebrowser";
+    cfg.user == "filebrowser";
+  enableTls =
+    assert cfg.tlsCertificate != null -> cfg.tlsCertificateKey != null;
+    cfg.tlsCertificate != null;
+
+  configFile = pkgs.writeText "filebrowser-config.json" (generators.toJSON {} ({
+      database = "/var/lib/filebrowser/filebrowser.db";
+      root = cfg.rootDir;
+      inherit (cfg) address port;
+    } // (optionalAttrs enableTls {
+      cert = cfg.tlsCertificate;
+      key = cfg.tlsCertificateKey;
+    })
+    // (optionalAttrs (cfg.baseUrl != null) { baseurl = cfg.baseUrl; })
+    // (optionalAttrs (cfg.cacheDir != null) { cache-dir = cfg.cacheDir; })
+    // (optionalAttrs cfg.disableThumbnails { disable-thumbnails = true; })
+    // (optionalAttrs cfg.disablePreviewResize { disable-preview-resize = true; })
+    // (optionalAttrs cfg.disableCommandRunner { disable-exec = true; })
+    // (optionalAttrs cfg.disableTypeDetectionByHeader { disable-type-detection-by-header = true; })
+  ));
+in
+{
+  options.services.filebrowser = {
+    enable = mkEnableOption
+      "File Browser is a web application for managing files and directories";
+
+    package = mkPackageOption pkgs "filebrowser" { };
+
+    # https://github.com/filebrowser/filebrowser/blob/bd3c1941ff8289a5dae877e08f7e25fa9b2a92c5/cmd/root.go#L56
+    address = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      example = literalExpression "0.0.0.0";
+      description = ''
+        Address the service should listen on.
+      '';
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 8080;
+      description = "Port the service should listen on.";
+    };
+
+    tlsCertificate = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = "Optional TLS certificate";
+    };
+
+    tlsCertificateKey = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        Key for TLS certificate. Must be set if `services.filebrowser.tlsCertficate`
+        is used.
+      '';
+    };
+
+    rootDir = mkOption {
+      type = types.path;
+      default = "/var/lib/filebrowser/files";
+      description = ''
+        Path to the directory that should be exposed by File Browser.
+      '';
+    };
+
+    baseUrl = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "/files";
+      description = ''
+        Subpath to serve the web interface at. Useful in combination with a
+        reverse proxy.
+      '';
+    };
+
+    cacheDir = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = literalExpression "/var/cache/filebrowser";
+      description = "File cache directory. Disabled by default.";
+    };
+
+    tokenExpirationTime = mkOption {
+      type = types.str;
+      default = "2h";
+      example = "12h";
+      description = "User session timeout";
+    };
+
+    imageProcessors = mkOption {
+      type = types.int;
+      default = 4;
+      example = 2;
+      description = "Number of image processes.";
+    };
+
+    disableThumbnails = mkEnableOption "Disable image thumbnails.";
+    disablePreviewResize = mkEnableOption "Disable resize of image previews.";
+    disableCommandRunner = mkEnableOption "Disable the Command Runner feature.";
+    disableTypeDetectionByHeader = mkEnableOption
+      "Disable file type detection by reading file headers.";
+
+    user = mkOption {
+      type = types.str;
+      default = "filebrowser";
+      description = ''
+        If `services.filebrowser.group` is set, this must be set as well. Must
+        already exist.
+      '';
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "filebrowser";
+      description = ''
+        If `services.filebrowser.user` is set, this must be set as well. Must
+        already exist.
+      '';
+    };
+
+    openFirewall = mkEnableOption "Open the port in the firewall.";
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.filebrowser = {
+      description = "File Browser service";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      environment.HOME = "/var/lib/filebrowser";
+
+      serviceConfig = {
+        Type = "simple";
+        Restart = "on-failure";
+        User = cfg.user;
+        Group = cfg.group;
+        StateDirectory = "filebrowser";
+        BindPaths = optional (!(hasPrefix "/var/lib/filebrowser" cfg.rootDir)) cfg.rootDir;
+
+        DynamicUser = enableDynamicUser;
+
+        # Basic hardening
+        NoNewPrivileges = "yes";
+        PrivateTmp = "yes";
+        PrivateDevices = "yes";
+        DevicePolicy = "closed";
+        ProtectSystem = "strict";
+        ProtectHome = "tmpfs";
+        ProtectControlGroups = "yes";
+        ProtectKernelModules = "yes";
+        ProtectKernelTunables = "yes";
+        RestrictAddressFamilies = "AF_UNIX AF_INET AF_INET6";
+        RestrictNamespaces = "yes";
+        RestrictRealtime = "yes";
+        RestrictSUIDSGID = "yes";
+        MemoryDenyWriteExecute = "yes";
+        LockPersonality = "yes";
+
+        ExecStartPre = ''
+          ${pkgs.coreutils}/bin/mkdir -p ${toString cfg.rootDir}
+        '';
+
+        ExecStart = "${cfg.package}/bin/filebrowser --config ${configFile}";
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.port ];
+  };
+
+  meta.maintainers = with lib.maintainers; [ christoph-heiss ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -307,6 +307,7 @@ in {
   fenics = handleTest ./fenics.nix {};
   ferm = handleTest ./ferm.nix {};
   ferretdb = handleTest ./ferretdb.nix {};
+  filebrowser = handleTest ./filebrowser.nix { };
   filesystems-overlayfs = runTest ./filesystems-overlayfs.nix;
   firefly-iii = handleTest ./firefly-iii.nix {};
   firefox = handleTest ./firefox.nix { firefoxPackage = pkgs.firefox; };

--- a/nixos/tests/filebrowser.nix
+++ b/nixos/tests/filebrowser.nix
@@ -1,0 +1,46 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }:
+  let
+    tls-cert = pkgs.runCommand "selfSignedCerts" {
+      buildInputs = [ pkgs.openssl ];
+    } ''
+      mkdir -p $out
+      openssl req -x509 \
+        -subj '/CN=localhost/' -days 365 \
+        -addext 'subjectAltName = DNS:localhost' \
+        -keyout "$out/cert.key" -newkey ed25519 \
+        -out "$out/cert.pem" -noenc
+    '';
+  in {
+    name = "filebrowser";
+    meta.maintainers = with lib.maintainers; [ christoph-heiss ];
+
+    nodes = {
+      http = {
+        services.filebrowser = {
+          enable = true;
+        };
+      };
+      https  = {
+        security.pki.certificateFiles = [ "${tls-cert}/cert.pem" ];
+        services.filebrowser = {
+          enable = true;
+          tlsCertificate = "${tls-cert}/cert.pem";
+          tlsCertificateKey = "${tls-cert}/cert.key";
+        };
+      };
+    };
+
+    testScript = ''
+      start_all()
+
+      with subtest("check if http works"):
+        http.wait_for_unit("filebrowser.service")
+        http.wait_for_open_port(8080)
+        http.succeed("curl -sSf http://localhost:8080 | grep '<!doctype html>'")
+
+      with subtest("check if https works"):
+        https.wait_for_unit("filebrowser.service")
+        https.wait_for_open_port(8080)
+        https.succeed("curl -sSf https://localhost:8080 | grep '<!doctype html>'")
+    '';
+  })

--- a/pkgs/applications/networking/filebrowser/default.nix
+++ b/pkgs/applications/networking/filebrowser/default.nix
@@ -1,20 +1,21 @@
 { buildGoModule, buildNpmPackage, fetchFromGitHub, lib }:
 
 let
+  version = "2.28.0";
+  src = fetchFromGitHub {
+    owner = "filebrowser";
+    repo = "filebrowser";
+    rev = "v${version}";
+    hash = "sha256-ubfNGsVClMIq7u0DQVrR4Hdr8NNf76QXqLxnRVJHaCM=";
+  };
+
   frontend = buildNpmPackage rec {
     pname = "filebrowser-frontend";
-    version = "2.23.0";
-
-    src = fetchFromGitHub {
-      owner = "filebrowser";
-      repo = "filebrowser";
-      rev = "v${version}";
-      hash = "sha256-xhBIJcEtxDdMXSgQtLAV0UWzPtrvKEil0WV76K5ycBc=";
-    };
+    inherit version src;
 
     sourceRoot = "${src.name}/frontend";
 
-    npmDepsHash = "sha256-acNIMKHc4q7eiFLPBtKZBNweEsrt+//0VR6dqwXHTvA=";
+    npmDepsHash = "sha256-h2Sqco7NHLnaMNgh9Ykggarv6cS0NrA6M9/2nv2RU28=";
 
     NODE_OPTIONS = "--openssl-legacy-provider";
 
@@ -30,16 +31,9 @@ let
 in
 buildGoModule rec {
   pname = "filebrowser";
-  version = "2.23.0";
+  inherit version src;
 
-  src = fetchFromGitHub {
-    owner = "filebrowser";
-    repo = "filebrowser";
-    rev = "v${version}";
-    hash = "sha256-xhBIJcEtxDdMXSgQtLAV0UWzPtrvKEil0WV76K5ycBc=";
-  };
-
-  vendorHash = "sha256-MR0ju2Nomb3j78Z+1YcJY+jPd40MZpuOTuQJM94AM8A=";
+  vendorHash = "sha256-pDQyJ0F6gCkJtUnaoSe+lWpgNbk/2GDGQ67S3G+VudE=";
 
   excludedPackages = [ "tools" ];
 

--- a/pkgs/applications/networking/filebrowser/default.nix
+++ b/pkgs/applications/networking/filebrowser/default.nix
@@ -49,7 +49,7 @@ buildGoModule rec {
     description = "Filebrowser is a web application for managing files and directories";
     homepage = "https://filebrowser.org";
     license = licenses.asl20;
-    maintainers = with maintainers; [ nielsegberts christoph-heiss ];
+    maintainers = with maintainers; [ christoph-heiss ];
     mainProgram = "filebrowser";
   };
 }

--- a/pkgs/applications/networking/filebrowser/default.nix
+++ b/pkgs/applications/networking/filebrowser/default.nix
@@ -49,7 +49,7 @@ buildGoModule rec {
     description = "Filebrowser is a web application for managing files and directories";
     homepage = "https://filebrowser.org";
     license = licenses.asl20;
-    maintainers = with maintainers; [ nielsegberts ];
+    maintainers = with maintainers; [ nielsegberts christoph-heiss ];
     mainProgram = "filebrowser";
   };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updates the `filebrowser` package from 2.23.0 to 2.28.0 and adds an appropriate service module for it.

Changelog: https://github.com/filebrowser/filebrowser/compare/v2.23.0...v2.28.0

cc @nielsegberts As this package has not been updated in nearly a year, are you still interested?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
