### PR TITLE
dotnet: added shell completion scripts

### DIFF
--- a/pkgs/development/compilers/dotnet/common.nix
+++ b/pkgs/development/compilers/dotnet/common.nix
@@ -6,6 +6,7 @@
 , runCommand
 , expect
 , curl
+, installShellFiles
 }: type: args: stdenv.mkDerivation (finalAttrs: args // {
   doInstallCheck = true;
 
@@ -26,6 +27,16 @@
     export DOTNET_CLI_TELEMETRY_OPTOUT=1
     export DOTNET_SKIP_WORKLOAD_INTEGRITY_CHECK=1 # Skip integrity check on first run, which fails due to read-only directory
   '' + args.setupHook or "");
+
+  nativeBuildInputs = (args.nativeBuildInputs or []) ++ [ installShellFiles ];
+
+  postInstall = ''
+    # completions snippets taken from https://learn.microsoft.com/en-us/dotnet/core/tools/enable-tab-autocomplete
+    installShellCompletion --cmd dotnet \
+      --bash ${./completions/dotnet.bash} \
+      --zsh ${./completions/dotnet.zsh} \
+      --fish ${./completions/dotnet.fish}
+  '';
 
 } // lib.optionalAttrs (type == "sdk") {
   passthru = {

--- a/pkgs/development/compilers/dotnet/completions/dotnet.bash
+++ b/pkgs/development/compilers/dotnet/completions/dotnet.bash
@@ -1,0 +1,13 @@
+# bash parameter completion for the dotnet CLI
+
+function _dotnet_bash_complete()
+{
+  local cur="${COMP_WORDS[COMP_CWORD]}" IFS=$'\n' # On Windows you may need to use use IFS=$'\r\n'
+  local candidates
+
+  read -d '' -ra candidates < <(dotnet complete --position "${COMP_POINT}" "${COMP_LINE}" 2>/dev/null)
+
+  read -d '' -ra COMPREPLY < <(compgen -W "${candidates[*]:-}" -- "$cur")
+}
+
+complete -f -F _dotnet_bash_complete dotnet

--- a/pkgs/development/compilers/dotnet/completions/dotnet.fish
+++ b/pkgs/development/compilers/dotnet/completions/dotnet.fish
@@ -1,0 +1,1 @@
+complete -f -c dotnet -a "(dotnet complete (commandline -cp))"

--- a/pkgs/development/compilers/dotnet/completions/dotnet.zsh
+++ b/pkgs/development/compilers/dotnet/completions/dotnet.zsh
@@ -1,0 +1,18 @@
+# zsh parameter completion for the dotnet CLI
+
+_dotnet_zsh_complete()
+{
+  local completions=("$(dotnet complete "$words")")
+
+  # If the completion list is empty, just continue with filename selection
+  if [ -z "$completions" ]
+  then
+    _arguments '*::arguments: _normal'
+    return
+  fi
+
+  # This is not a variable assignment, don't remove spaces!
+  _values = "${(ps:\n:)completions}"
+}
+
+compdef _dotnet_zsh_complete dotnet


### PR DESCRIPTION
## Description of changes

I've added shell completions scripts from official microsoft page to dotnet package

## Things done

I've checked bash and fish shells, completions works fine in there. When I tried to start zsh from `nix-shell -p zsh` it started complaining about missing config and stuff like that and completions didn't work. Would be nice if someone using zsh daily would test this PR. Other options would be to ship it as-is (my choice) or delete zsh completion from PR (if other reviewers decide so).

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
