### PR TITLE
texlive.withPackages: build all outputs

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
@@ -188,7 +188,6 @@ let
 
   passthru = lib.optionalAttrs (! __combine) (splitOutputs // {
     all = builtins.attrValues splitOutputs;
-    outputs = [ "out" ] ++ pkgList.nonEnvOutputs;
   }) // {
     # This is set primarily to help find-tarballs.nix to do its job
     requiredTeXPackages = builtins.filter lib.isDerivation (pkgList.bin ++ pkgList.nonbin
@@ -440,14 +439,11 @@ let
   ;
 }).overrideAttrs (prev:
   { allowSubstitutes = true; }
-  # the outputsToInstall must be built by the main derivation for nix-profile-install to work
   // lib.optionalAttrs (! __combine) ({
-    outputs = pkgList.outputsToInstall;
+    outputs = [ "out" ] ++ pkgList.nonEnvOutputs;
     meta = prev.meta // { inherit (pkgList) outputsToInstall; };
-  } // (lib.mapAttrs'
-    (out: drv: { name = "otherOutput_" + out; value = drv; })
-    (lib.getAttrs (builtins.tail pkgList.outputsToInstall) splitOutputs)
-    )
+  } // builtins.listToAttrs
+    (map (out: { name = "otherOutput_" + out; value = splitOutputs.${out}; }) pkgList.nonEnvOutputs)
   )
 );
 in out)


### PR DESCRIPTION
## Description of changes
Should fix https://github.com/NixOS/infra/issues/309 for good: now `withPackages` builds all possible outputs, no matter if requested or not. In other words, it behaves as a multi-output derivation in every sense of the word. All default schemes now have `outputs = [ "out" "man" "info" ]`.

This makes `texlive.withPackages` marginally wasteful because it downloads (some!) doc containers even if not used (especially when `texlive.withPackages` is used as build input). However, manipulating `passthru.outputs` has proven to be a bad idea, definitely not worth the savings.

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
