### PR TITLE
texlive: add version details based on TLPDB metatada

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -16,7 +16,7 @@
 let
   withSystemLibs = map (libname: "--with-system-${libname}");
 
-  year = toString ((import ./tlpdb.nix)."00texlive.config").year;
+  year = toString tlpdb."00texlive.config".year;
   version = year; # keep names simple for now
 
   # detect and stop redundant rebuilds that may occur when building new fixed hashes

--- a/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
@@ -110,8 +110,10 @@ let
   # and ignoring luatex, perl, and shell scripts (those must be patched using postFixup)
   needsGhostscript = lib.any (p: lib.elem p.pname [ "context" "dvipdfmx" "latex-papersize" "lyluatex" ]) pkgList.bin;
 
-  name = if __combine then "texlive-${__extraName}-${bin.texliveYear}${__extraVersion}" # texlive.combine: old name name
-    else "texlive-${bin.texliveYear}-env";
+  version = if __combine then "${bin.texliveYear}${__extraVersion}" # texlive.combine: old version
+    else bin.texliveYear + "-r" + toString tl."00texlive.config".revision + lib.optionalString tl."00texlive.config".frozen "-final";
+  name = if __combine then "texlive-${__extraName}-${bin.texliveYear}${__extraVersion}" # texlive.combine: old name
+    else "texlive-${version}-env";
 
   texmfdist = (buildEnv {
     name = "${name}-texmfdist";
@@ -194,6 +196,8 @@ let
         (lib.concatMap (n: (pkgList.otherOutputs.${n} or [ ] ++ pkgList.specifiedOutputs.${n} or [ ]))) pkgList.nonEnvOutputs);
     # useful for inclusion in the `fonts.packages` nixos option or for use in devshells
     fonts = "${texmfroot}/texmf-dist/fonts";
+    # keep version available
+    inherit version;
     # support variants attrs, (prev: attrs)
     __overrideTeXConfig = newArgs:
       let appliedArgs = if builtins.isFunction newArgs then newArgs args else newArgs; in

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -103,7 +103,9 @@ let
       # NOTE: the fixed naming scheme must match generate-fixed-hashes.nix
       // { inherit mirrors pname; fixedHashes = fixedHashes."${pname}-${toString revision}${extraRevision}" or { }; }
       // lib.optionalAttrs (args ? deps) { deps = map (n: tl.${n}) (args.deps or [ ]); })
-  ) overriddenTlpdb;
+  ) (removeAttrs overriddenTlpdb [ "00texlive.config" ])
+  # preserve version info
+  // { "00texlive.config" = overriddenTlpdb."00texlive.config"; };
 
   # function for creating a working environment
   buildTeXEnv = import ./build-tex-env.nix {
@@ -142,7 +144,7 @@ let
     (builtins.groupBy (p: p.pname) pkgs);
 
   # export TeX packages as { pkgs = [ ... ]; } in the top attribute set
-  allPkgLists = lib.mapAttrs (n: drv: { pkgs = toTLPkgList drv; }) tl;
+  allPkgLists = lib.mapAttrs (n: drv: { pkgs = toTLPkgList drv; }) (removeAttrs tl [ "00texlive.config" ]);
 
   # function for creating a working environment from a set of TL packages
   # now a legacy wrapper around buildTeXEnv

--- a/pkgs/tools/typesetting/tex/texlive/tlpdb-overrides.nix
+++ b/pkgs/tools/typesetting/tex/texlive/tlpdb-overrides.nix
@@ -20,7 +20,7 @@ let
            in if binNotFormats != [] then attrs // { binfiles = binNotFormats; } else removeAttrs attrs [ "binfiles" ]
       else attrs);
 
-    orig = removeFormatLinks (removeAttrs oldTlpdb [ "00texlive.config" ]);
+    orig = removeFormatLinks oldTlpdb;
 
 in lib.recursiveUpdate orig rec {
   #### overrides of texlive.tlpdb


### PR DESCRIPTION
## Description of changes
Simply add more info to the TeX Live name. Where we previously had `texlive-YYYY-env`, we now get `texlive-YYYY-rNNNNN-env` where `NNNNN` is the SVN revision number included in the texlive.tlpdb.xz file. This becomes `texlive-YYYY-rNNNNNN-final-env`  when TeX Live reaches historic status.

Edit: simplified.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
