### PR TITLE
iomelt: fix broken urls, reformat

### DIFF
--- a/pkgs/os-specific/linux/iomelt/default.nix
+++ b/pkgs/os-specific/linux/iomelt/default.nix
@@ -1,17 +1,19 @@
-{ stdenv, lib, fetchurl }:
+{ fetchurl
+, lib
+, stdenv
+}:
 
 let version = "0.7";
 in stdenv.mkDerivation {
-  pname = "iomelt";
   inherit version;
+  pname = "iomelt";
   src = fetchurl {
-    url = "http://iomelt.com/s/iomelt-${version}.tar.gz";
+    url = "https://web.archive.org/web/20180816072405if_/http://iomelt.com/s/iomelt-${version}.tar.gz";
     sha256 = "1jhrdm5b7f1bcbrdwcc4yzg26790jxl4d2ndqiwd9brl2g5537im";
   };
 
   preBuild = ''
-    mkdir -p $out/bin
-    mkdir -p $out/share/man/man1
+    install -d $out/{bin,share/man/man1}
 
     substituteInPlace Makefile \
       --replace /usr $out
@@ -19,9 +21,9 @@ in stdenv.mkDerivation {
 
   meta = with lib; {
     description = "A simple yet effective way to benchmark disk IO in Linux systems";
-    homepage    = "http://www.iomelt.com";
-    maintainers = with maintainers; [ ];
+    homepage = "https://github.com/camposr/iomelt";
+    maintainers = with maintainers; [ raspher ];
     license = licenses.artistic2;
-    platforms   = platforms.linux;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
## Description of changes
Current state of iomelt:
- http://iomelt.com/ is down
- project is still on github but without versions/releases/tags
- webpage and sources are available through archive.org
- project is old but usable

Changes:
- fixed source ulr to archived via archive.org
- fixed homepage url
- fixed formatting
- added makeBinaryWrapper
- added me as maintainer
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
