### PR TITLE
[23.11] Revert "[Backport staging-23.11] dnsmasq: 2.89 -> 2.90"

### DIFF
--- a/pkgs/tools/networking/dnsmasq/default.nix
+++ b/pkgs/tools/networking/dnsmasq/default.nix
@@ -18,11 +18,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "dnsmasq";
-  version = "2.90";
+  version = "2.89";
 
   src = fetchurl {
     url = "https://www.thekelleys.org.uk/dnsmasq/${pname}-${version}.tar.xz";
-    hash = "sha256-jlAwm9g3v+yWSagS4GbAm2mItz10m30pPAbFfUahCeQ=";
+    sha256 = "sha256-Ar0jA0bPC51ZCfXhUd8WiycHEDeF62FrVmhYVa3rtgk=";
   };
 
   postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''


### PR DESCRIPTION
Reverts NixOS/nixpkgs#288796

Noticed that this breaks `nixosTests.prometheus-exporters.dnsmasq`:

```
dnsmasq: must succeed: curl -sSf http://localhost:9153/metrics | grep 'dnsmasq_leases 0'
dnsmasq # curl: (22) The requested URL returned error: 500
```

Perhaps we should revert given the CVEs are only DoS via cpu consumption?