### PR TITLE
biboumi: add package option

### DIFF
--- a/nixos/modules/services/networking/biboumi.nix
+++ b/nixos/modules/services/networking/biboumi.nix
@@ -17,6 +17,13 @@ in
     services.biboumi = {
       enable = mkEnableOption (lib.mdDoc "the Biboumi XMPP gateway to IRC");
 
+      package = mkOption {
+        description = lib.mdDoc "The Biboumi package to use";
+        default = pkgs.biboumi;
+        defaultText = literalExpression "pkgs.biboumi";
+        type = types.package;
+      };
+
       settings = mkOption {
         description = lib.mdDoc ''
           See [biboumi 8.5](https://lab.louiz.org/louiz/biboumi/blob/8.5/doc/biboumi.1.rst)
@@ -105,8 +112,8 @@ in
           };
           options.policy_directory = mkOption {
             type = types.path;
-            default = "${pkgs.biboumi}/etc/biboumi";
-            defaultText = literalExpression ''"''${pkgs.biboumi}/etc/biboumi"'';
+            default = "${cfg.package}/etc/biboumi";
+            defaultText = literalExpression ''"''${services.biboumi.package}/etc/biboumi"'';
             description = lib.mdDoc ''
               A directory that should contain the policy files,
               used to customize Botan’s behaviour
@@ -189,7 +196,7 @@ in
           cat ${settingsFile} '${cfg.credentialsFile}' |
           install -m 644 /dev/stdin /run/biboumi/biboumi.cfg
         '')];
-        ExecStart = "${pkgs.biboumi}/bin/biboumi /run/biboumi/biboumi.cfg";
+        ExecStart = "${cfg.package}/bin/biboumi /run/biboumi/biboumi.cfg";
         ExecReload = "${pkgs.coreutils}/bin/kill -USR1 $MAINPID";
         # Firewalls needing opening for output connections can still do that
         # selectively for biboumi with:


### PR DESCRIPTION
## Description of changes

Add a package option for Biboumi.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).