### PR TITLE
floorp: 11.9.0 -> 11.10.2

### DIFF
--- a/pkgs/applications/networking/browsers/floorp/default.nix
+++ b/pkgs/applications/networking/browsers/floorp/default.nix
@@ -10,6 +10,7 @@
   packageVersion = "11.9.0";
   applicationName = "Floorp";
   binaryName = "floorp";
+  branding = "browser/branding/official";
 
   # Must match the contents of `browser/config/version.txt` in the source tree
   version = "115.7.0";
@@ -25,7 +26,6 @@
   extraConfigureFlags = [
     "--with-app-name=${pname}"
     "--with-app-basename=${applicationName}"
-    "--with-branding=browser/branding/official"
     "--with-distribution-id=app.floorp.Floorp"
     "--with-unsigned-addon-scopes=app,system"
     "--allow-addon-sideload"

--- a/pkgs/applications/networking/browsers/floorp/default.nix
+++ b/pkgs/applications/networking/browsers/floorp/default.nix
@@ -26,7 +26,7 @@
   extraConfigureFlags = [
     "--with-app-name=${pname}"
     "--with-app-basename=${applicationName}"
-    "--with-distribution-id=app.floorp.Floorp"
+    "--with-distribution-id=one.ablaze.floorp"
     "--with-unsigned-addon-scopes=app,system"
     "--allow-addon-sideload"
   ];
@@ -44,9 +44,15 @@
   };
   tests = [ nixosTests.floorp ];
 }).override {
+  # Upstream build configuration can be found at
+  # .github/workflows/src/linux/shared/mozconfig_linux_base
   privacySupport = true;
   webrtcSupport = true;
   enableOfficialBranding = false;
+  googleAPISupport = true;
+  mlsAPISupport = true;
 }).overrideAttrs (prev: {
+  MOZ_DATA_REPORTING = "";
   MOZ_REQUIRE_SIGNING = "";
+  MOZ_TELEMETRY_REPORTING = "";
 })

--- a/pkgs/applications/networking/browsers/floorp/default.nix
+++ b/pkgs/applications/networking/browsers/floorp/default.nix
@@ -7,20 +7,20 @@
 
 ((buildMozillaMach rec {
   pname = "floorp";
-  packageVersion = "11.9.0";
+  packageVersion = "11.10.2";
   applicationName = "Floorp";
   binaryName = "floorp";
   branding = "browser/branding/official";
 
   # Must match the contents of `browser/config/version.txt` in the source tree
-  version = "115.7.0";
+  version = "115.8.0";
 
   src = fetchFromGitHub {
     owner = "Floorp-Projects";
     repo = "Floorp";
     fetchSubmodules = true;
     rev = "v${packageVersion}";
-    hash = "sha256-Mk/5bkaSLQYFFGhCSjVho8CUilZSYDGarnIt4Wg9/6g=";
+    hash = "sha256-fjLYR59AZaR6S1zcAT+DNpdsCdrW+3NdkRQBoVNdwYw=";
   };
 
   extraConfigureFlags = [

--- a/pkgs/applications/networking/browsers/floorp/default.nix
+++ b/pkgs/applications/networking/browsers/floorp/default.nix
@@ -41,6 +41,7 @@
                                            # not in `badPlatforms` because cross-compilation on 64-bit machine might work.
     maxSilent = 14400; # 4h, double the default of 7200s (c.f. #129212, #129115)
     license = lib.licenses.mpl20;
+    mainProgram = "floorp";
   };
   tests = [ nixosTests.floorp ];
 }).override {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release notes: https://blog.ablaze.one/3992/2024-02-22/
Git changelog: https://github.com/Floorp-Projects/Floorp/compare/v11.9.0...v11.10.2

Also includes some smaller changes, which try to align it more with the upstream build configuration.
One thing I'd like a second look most at is probably the distribution id change - if it could have any adverse side-effects.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
