### PR TITLE
gogdl: 0.7.3 -> unstable-2024-02-15

### DIFF
--- a/pkgs/games/gogdl/default.nix
+++ b/pkgs/games/gogdl/default.nix
@@ -7,18 +7,19 @@
 , setuptools
 , requests
 , cacert
+, unstableGitUpdater
 }:
 
 buildPythonApplication rec {
   pname = "gogdl";
-  version = "1.0.0";
+  version = "unstable-2024-02-15";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "Heroic-Games-Launcher";
     repo = "heroic-gogdl";
-    rev = "e1c3e5b98feda53ea88f54f9aa5c614ae9424ef0";
-    hash = "sha256-MGxpWfDGchZruVmSiea5s1JQV23F9QvQLWrxPmIsBEo=";
+    rev = "18f651931d4098cba66f4c2a2f9dc6e1351f9460";
+    hash = "sha256-wGytOzMencWZIku5lM6gEFaFyqUtfurjZVSHAY5mI7g=";
   };
 
   disabled = pythonOlder "3.8";
@@ -39,28 +40,5 @@ buildPythonApplication rec {
 
   # Upstream no longer create git tags when bumping the version, so we have to
   # extract it from the source code on the main branch.
-  passthru.updateScript = writeScript "gogdl-update-script" ''
-    #!/usr/bin/env nix-shell
-    #!nix-shell -i bash -p curl gnused jq common-updater-scripts
-    set -eou pipefail;
-
-    owner=Heroic-Games-Launcher
-    repo=heroic-gogdl
-    path='gogdl/__init__.py'
-
-    version=$(
-      curl --cacert "${cacert}/etc/ssl/certs/ca-bundle.crt" \
-      https://raw.githubusercontent.com/$owner/$repo/main/$path |
-      sed -n 's/^\s*version\s*=\s*"\([0-9]\.[0-9]\.[0-9]\)"\s*$/\1/p')
-
-    commit=$(curl --cacert "${cacert}/etc/ssl/certs/ca-bundle.crt" \
-      https://api.github.com/repos/$owner/$repo/commits?path=$path |
-      jq -r '.[0].sha')
-
-    update-source-version \
-      ${pname} \
-      "$version" \
-      --file=./pkgs/games/gogdl/default.nix \
-      --rev=$commit
-  '';
+  passthru.updateScript = unstableGitUpdater { };
 }


### PR DESCRIPTION
## Description of changes
Upstream has some bug fixes on the main branch without a version number bump.  Also switch the update script to unstableGitUpdater, because this has happened before (upstream fixes without a version bump).

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
