### PR TITLE
More Python 3.12 enablement (home-assistant edition)

### DIFF
--- a/pkgs/development/python-modules/aiocoap/default.nix
+++ b/pkgs/development/python-modules/aiocoap/default.nix
@@ -65,6 +65,23 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  pytestFlagsArray = lib.optionals (pythonAtLeast "3.12") [
+    # https://github.com/chrysn/aiocoap/issues/339
+    "--deselect=tests/test_server.py::TestServerTCP::test_big_resource"
+    "--deselect=tests/test_server.py::TestServerTCP::test_empty_accept"
+    "--deselect=tests/test_server.py::TestServerTCP::test_error_resources"
+    "--deselect=tests/test_server.py::TestServerTCP::test_fast_resource"
+    "--deselect=tests/test_server.py::TestServerTCP::test_js_accept"
+    "--deselect=tests/test_server.py::TestServerTCP::test_manualbig_resource"
+    "--deselect=tests/test_server.py::TestServerTCP::test_nonexisting_resource"
+    "--deselect=tests/test_server.py::TestServerTCP::test_replacing_resource"
+    "--deselect=tests/test_server.py::TestServerTCP::test_root_resource"
+    "--deselect=tests/test_server.py::TestServerTCP::test_slow_resource"
+    "--deselect=tests/test_server.py::TestServerTCP::test_slowbig_resource"
+    "--deselect=tests/test_server.py::TestServerTCP::test_spurious_resource"
+    "--deselect=tests/test_server.py::TestServerTCP::test_unacceptable_accept"
+  ];
+
   disabledTestPaths = [
     # Don't test the plugins
     "tests/test_tls.py"

--- a/pkgs/development/python-modules/aiocoap/default.nix
+++ b/pkgs/development/python-modules/aiocoap/default.nix
@@ -1,15 +1,31 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
-, pytestCheckHook
-, pygments
+, pythonAtLeast
 , pythonOlder
+
+# build-system
+, setuptools
+
+# optionals
+, cbor2
+, cbor-diag
+, cryptography
+, filelock
+, ge25519
+, dtlssocket
+, websockets
+, termcolor
+, pygments
+
+# tests
+, pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "aiocoap";
   version = "0.4.7";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -20,9 +36,30 @@ buildPythonPackage rec {
     hash = "sha256-4iwoPfmIwk+PlWUp60aqA5qZgzyj34pnZHf9uH5UhnY=";
   };
 
-  propagatedBuildInputs = [
-    pygments
+  nativeBuildInputs = [
+    setuptools
   ];
+
+  passthru.optional-dependencies = {
+    oscore = [
+      cbor2
+      cryptography
+      filelock
+      ge25519
+    ];
+    tinydtls = [
+      dtlssocket
+    ];
+    ws = [
+      websockets
+    ];
+    prettyprint = [
+      termcolor
+      cbor2
+      pygments
+      cbor-diag
+    ];
+  };
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/airly/default.nix
+++ b/pkgs/development/python-modules/airly/default.nix
@@ -5,6 +5,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , pytestCheckHook
+, pythonOlder
 }:
 
 buildPythonPackage rec {
@@ -20,6 +21,9 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ aiohttp ];
+
+  # aiounittest is not supported on 3.12
+  doCheck = pythonOlder "3.12";
 
   nativeCheckInputs = [
     aioresponses

--- a/pkgs/development/python-modules/alarmdecoder/default.nix
+++ b/pkgs/development/python-modules/alarmdecoder/default.nix
@@ -23,6 +23,11 @@ buildPythonPackage rec {
     hash = "sha256-q2s+wngDKtWm5mxGHNAc63Ed6tiQD9gLHVoQZNWFB0w=";
   };
 
+  postPatch = ''
+    substituteInPlace test/test_{ad2,devices,messages}.py \
+      --replace-fail assertEquals assertEqual
+  '';
+
   propagatedBuildInputs = [
     pyftdi
     pyopenssl

--- a/pkgs/development/python-modules/bidict/default.nix
+++ b/pkgs/development/python-modules/bidict/default.nix
@@ -10,13 +10,14 @@
 , pytest-benchmark
 , sortedcollections
 , sortedcontainers
+, typing-extensions
 , pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "bidict";
-  version = "0.22.1";
-  format = "pyproject";
+  version = "0.23.1";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -24,7 +25,7 @@ buildPythonPackage rec {
     owner = "jab";
     repo = "bidict";
     rev = "refs/tags/v${version}";
-    hash = "sha256-mPBruasjQwErl5M91OBf71hArztdRVONOCnqos180DY=";
+    hash = "sha256-WE0YaRT4a/byvU2pzcByuf1DfMlOpYA9i0PPrKXsS+M=";
   };
 
   nativeBuildInputs = [
@@ -43,6 +44,7 @@ buildPythonPackage rec {
     pytest-benchmark
     sortedcollections
     sortedcontainers
+    typing-extensions
   ];
 
   pythonImportsCheck = [ "bidict" ];

--- a/pkgs/development/python-modules/django/4.nix
+++ b/pkgs/development/python-modules/django/4.nix
@@ -2,6 +2,7 @@
 , stdenv
 , buildPythonPackage
 , fetchPypi
+, fetchpatch2
 , pythonOlder
 , substituteAll
 
@@ -60,6 +61,12 @@ buildPythonPackage rec {
     # make sure the tests don't remove packages from our pythonpath
     # and disable failing tests
     ./django_4_tests.patch
+
+    (fetchpatch2 {
+      # fix test on 3.12; https://github.com/django/django/pull/17843
+      url = "https://github.com/django/django/commit/bc8471f0aac8f0c215b9471b594d159783bac19b.patch";
+      hash = "sha256-g1T9b73rmQ0uk1lB+iQy1XwK3Qin3mf5wpRsyYISJaw=";
+    })
   ] ++ lib.optionals withGdal [
     (substituteAll {
       src = ./django_4_set_geos_gdal_lib.patch;

--- a/pkgs/development/python-modules/django/5.nix
+++ b/pkgs/development/python-modules/django/5.nix
@@ -2,6 +2,7 @@
 , stdenv
 , buildPythonPackage
 , fetchPypi
+, fetchpatch2
 , pythonOlder
 , substituteAll
 
@@ -61,6 +62,12 @@ buildPythonPackage rec {
     ./django_5_tests_pythonpath.patch
     # disable test that excpects timezone issues
     ./django_5_disable_failing_tests.patch
+
+    (fetchpatch2 {
+      # fix test on 3.12; https://github.com/django/django/pull/17843
+      url = "https://github.com/django/django/commit/bc8471f0aac8f0c215b9471b594d159783bac19b.patch";
+      hash = "sha256-g1T9b73rmQ0uk1lB+iQy1XwK3Qin3mf5wpRsyYISJaw=";
+    })
   ] ++ lib.optionals withGdal [
     (substituteAll {
       src = ./django_5_set_geos_gdal_lib.patch;

--- a/pkgs/development/python-modules/enocean/default.nix
+++ b/pkgs/development/python-modules/enocean/default.nix
@@ -4,7 +4,7 @@
 , beautifulsoup4
 , enum-compat
 , pyserial
-, nose
+, pynose
 }:
 
 buildPythonPackage rec {
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    nose
+    pynose
   ];
 
   checkPhase = ''

--- a/pkgs/development/python-modules/fitbit/default.nix
+++ b/pkgs/development/python-modules/fitbit/default.nix
@@ -24,6 +24,11 @@ buildPythonPackage rec {
     hash = "sha256-1u3h47lRBrJ7EUWBl5+RLGW4KHHqXqqrXbboZdy7VPA=";
   };
 
+  postPatch = ''
+    substituteInPlace fitbit_tests/test_api.py \
+      --replace-fail assertRaisesRegexp assertRaisesRegex
+  '';
+
   propagatedBuildInputs = [
     python-dateutil
     requests-oauthlib

--- a/pkgs/development/python-modules/gpiozero/default.nix
+++ b/pkgs/development/python-modules/gpiozero/default.nix
@@ -1,17 +1,26 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, pythonOlder
+
+# build-system
+, setuptools
+
+# docs
 , sphinx-rtd-theme
 , sphinxHook
+
+# dependencies
 , colorzero
-, pythonOlder
+
+# tests
 , pytestCheckHook
 }:
 
 buildPythonPackage rec {
   pname = "gpiozero";
-  version = "2.0";
-  format = "setuptools";
+  version = "2.0.1";
+  pyproject = true;
 
   disabled = pythonOlder "3.9";
 
@@ -19,7 +28,7 @@ buildPythonPackage rec {
     owner = "gpiozero";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-6qSB9RMypNXNj+Ds1nyzB7iaeHXvF0swSubrJSn2L34=";
+    hash = "sha256-ifdCFcMH6SrhKQK/TJJ5lJafSfAUzd6ZT5ANUzJGwxI=";
   };
 
   postPatch = ''
@@ -33,6 +42,7 @@ buildPythonPackage rec {
   ];
 
   nativeBuildInputs = [
+    setuptools
     sphinx-rtd-theme
     sphinxHook
   ];

--- a/pkgs/development/python-modules/habitipy/default.nix
+++ b/pkgs/development/python-modules/habitipy/default.nix
@@ -5,7 +5,7 @@
 , requests
 , setuptools
 , hypothesis
-, nose
+, pynose
 , responses
 }:
 
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     hypothesis
-    nose
+    pynose
     responses
   ];
 

--- a/pkgs/development/python-modules/http-ece/default.nix
+++ b/pkgs/development/python-modules/http-ece/default.nix
@@ -1,20 +1,30 @@
-{ lib, fetchPypi, buildPythonPackage, pythonOlder
-, coverage, flake8, mock, nose, importlib-metadata
-, cryptography }:
+{ lib
+, buildPythonPackage
+, cryptography
+, fetchPypi
+, mock
+, pynose
+}:
 
 buildPythonPackage rec {
-  pname = "http_ece";
+  pname = "http-ece";
   version = "1.2.0";
 
   src = fetchPypi {
-    inherit pname version;
+    pname = "http_ece";
+    inherit version;
     sha256 = "sha256-tZIPjvuOG1+wJXE+Ozb9pUM2JiAQY0sm3B+Y+F0es94=";
   };
 
-  propagatedBuildInputs = [ cryptography ]
-    ++ lib.optionals (pythonOlder "3.8") [ importlib-metadata ];
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail '"nose",' "" \
+      --replace-fail '"coverage",' ""
+  '';
 
-  nativeCheckInputs = [ coverage flake8 mock nose ];
+  propagatedBuildInputs = [ cryptography ];
+
+  nativeCheckInputs = [ mock pynose ];
 
   meta = with lib; {
     description = "Encipher HTTP Messages";

--- a/pkgs/development/python-modules/influxdb/default.nix
+++ b/pkgs/development/python-modules/influxdb/default.nix
@@ -4,7 +4,7 @@
 , fetchPypi
 , mock
 , msgpack
-, nose
+, pynose
 , pandas
 , pytestCheckHook
 , pytz
@@ -26,7 +26,12 @@ buildPythonPackage rec {
   postPatch = ''
     for f in influxdb/tests/dataframe_client_test.py influxdb/tests/influxdb08/dataframe_client_test.py; do
       substituteInPlace "$f" \
-        --replace "pandas.util.testing" "pandas.testing"
+        --replace-fail "pandas.util.testing" "pandas.testing"
+    done
+
+    for f in influxdb/tests/influxdb08/client_test.py influxdb/tests/client_test.py; do
+      substituteInPlace "$f" \
+        --replace-fail "assertRaisesRegexp" "assertRaisesRegex"
     done
   '';
 
@@ -44,7 +49,7 @@ buildPythonPackage rec {
     pytestCheckHook
     requests-mock
     mock
-    nose
+    pynose
     pandas
   ];
 
@@ -62,6 +67,10 @@ buildPythonPackage rec {
     # Pandas API changes cause it to no longer infer datetimes in the expected manner
     "test_multiquery_into_dataframe"
     "test_multiquery_into_dataframe_dropna"
+    # FutureWarning: 'H' is deprecated and will be removed in a future version, please use 'h' instead.
+    "test_write_points_from_dataframe_with_tag_escaped"
+    # AssertionError: 2 != 1 : <class 'influxdb.tests.helper_test.TestSeriesHelper.testWarnBulkSizeNoEffect.<locals>.WarnBulkSizeNoEffect'> call should have generated one warning.
+    "testWarnBulkSizeNoEffect"
   ];
 
   pythonImportsCheck = [ "influxdb" ];

--- a/pkgs/development/python-modules/lark/default.nix
+++ b/pkgs/development/python-modules/lark/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , regex
 , pytestCheckHook
+, pythonOlder
 , js2py
 , setuptools
 }:
@@ -32,6 +33,9 @@ buildPythonPackage rec {
     "lark.tools"
     "lark.grammars"
   ];
+
+  # Js2py is not supported on 3.12
+  doCheck = pythonOlder "3.12";
 
   nativeCheckInputs = [
     js2py

--- a/pkgs/development/python-modules/lingua/default.nix
+++ b/pkgs/development/python-modules/lingua/default.nix
@@ -15,6 +15,11 @@ buildPythonPackage rec {
     hash = "sha256-DhqUZ0HbKIpANhrQT/OP4EvwgZg0uKu4TEtTX+2bpO8=";
   };
 
+  postPatch = ''
+    substituteInPlace src/lingua/extract.py \
+      --replace-fail SafeConfigParser ConfigParser
+  '';
+
   nativeBuildInputs = [
     flit-core
   ];

--- a/pkgs/development/python-modules/lomond/default.nix
+++ b/pkgs/development/python-modules/lomond/default.nix
@@ -47,6 +47,9 @@ buildPythonPackage rec {
     # Makes HTTP requests
     "test_proxy"
     "test_live"
+  ] ++ lib.optionals (pythonAtLeast "3.12") [
+    # https://github.com/wildfoundry/dataplicity-lomond/issues/91
+    "test_that_on_ping_responds_with_pong"
   ];
 
   disabledTestPaths = lib.optionals (pythonAtLeast "3.10") [

--- a/pkgs/development/python-modules/minio/default.nix
+++ b/pkgs/development/python-modules/minio/default.nix
@@ -11,6 +11,7 @@
 , certifi
 , urllib3
 , pycryptodome
+, typing-extensions
 
 # test
 , faker
@@ -20,7 +21,7 @@
 
 buildPythonPackage rec {
   pname = "minio";
-  version = "7.2.0";
+  version = "7.2.4";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -29,7 +30,7 @@ buildPythonPackage rec {
     owner = "minio";
     repo = "minio-py";
     rev = "refs/tags/${version}";
-    hash = "sha256-hZn1T75JbnJ5lIyWnX3f8r6OET/d6ZltuRr6jjYOp2o=";
+    hash = "sha256-26naoSccz/LEf56iQIePrNKllq6XkEQD9Peld7VeGqY=";
   };
 
   nativeBuildInputs = [
@@ -41,6 +42,7 @@ buildPythonPackage rec {
     certifi
     urllib3
     pycryptodome
+    typing-extensions
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/odp-amsterdam/default.nix
+++ b/pkgs/development/python-modules/odp-amsterdam/default.nix
@@ -4,6 +4,7 @@
 , buildPythonPackage
 , fetchFromGitHub
 , poetry-core
+, pythonRelaxDepsHook
 , pythonOlder
 , pytest-asyncio
 , pytestCheckHook
@@ -26,12 +27,17 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace '"0.0.0"' '"${version}"'
+      --replace-fail '"0.0.0"' '"${version}"'
     sed -i '/addopts/d' pyproject.toml
   '';
 
   nativeBuildInputs = [
     poetry-core
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [
+    "pytz"
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pushbullet-py/default.nix
+++ b/pkgs/development/python-modules/pushbullet-py/default.nix
@@ -1,33 +1,52 @@
 { lib
 , buildPythonPackage
 , fetchPypi
+, setuptools
 , requests
 , websocket-client
 , python-magic
 , cryptography
 , pytestCheckHook
+, pythonAtLeast
 }:
 
 buildPythonPackage rec {
   pname = "pushbullet-py";
   version = "0.12.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "917883e1af4a0c979ce46076b391e0243eb8fe0a81c086544bcfa10f53e5ae64";
   };
 
-  propagatedBuildInputs = [ cryptography requests websocket-client python-magic ];
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    cryptography
+    python-magic
+    requests
+    websocket-client
+  ];
 
   preCheck = ''
     export PUSHBULLET_API_KEY=""
   '';
-  nativeCheckInputs = [ pytestCheckHook ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
   disabledTests = [
     "test_auth_fail"
     "test_auth_success"
     "test_decryption"
+  ] ++ lib.optionals (pythonAtLeast "3.12") [
+    # AttributeError: 'called_once_with' is not a valid assertion. Use a spec for the mock if 'called_once_with' is meant to be an attribute.. Did you mean: 'assert_called_once_with'?
+    "test_new_device_ok"
+    "test_new_chat_ok"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/py-vapid/default.nix
+++ b/pkgs/development/python-modules/py-vapid/default.nix
@@ -1,10 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, flake8
 , mock
-, nose
-, pytest
+, pytestCheckHook
 , cryptography
 , pythonOlder
 }:
@@ -26,10 +24,8 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    flake8
     mock
-    nose
-    pytest
+    pytestCheckHook
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/pydiscovergy/default.nix
+++ b/pkgs/development/python-modules/pydiscovergy/default.nix
@@ -9,6 +9,7 @@
 , poetry-core
 , pytestCheckHook
 , pythonOlder
+, pythonRelaxDepsHook
 , pytz
 , respx
 }:
@@ -29,6 +30,11 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     poetry-core
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [
+    "pytz"
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pyicloud/default.nix
+++ b/pkgs/development/python-modules/pyicloud/default.nix
@@ -1,6 +1,8 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, pythonAtLeast
+, setuptools
 , certifi
 , click
 , keyring
@@ -17,7 +19,7 @@
 buildPythonPackage rec {
   pname = "pyicloud";
   version = "1.0.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "picklepete";
@@ -25,6 +27,10 @@ buildPythonPackage rec {
     rev = version;
     hash = "sha256-2E1pdHHt8o7CGpdG+u4xy5OyNCueUGVw5CY8oicYd5w=";
   };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   propagatedBuildInputs = [
     certifi
@@ -43,14 +49,10 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  postPatch = ''
-    sed -i \
-      -e 's!click>=.*!click!' \
-      -e 's!keyring>=.*!keyring!' \
-      -e 's!keyrings.alt>=.*!keyrings.alt!' \
-      -e 's!tzlocal==.*!tzlocal!' \
-      requirements.txt
-  '';
+  disabledTests = lib.optionals (pythonAtLeast "3.12") [
+    # https://github.com/picklepete/pyicloud/issues/446
+    "test_storage"
+  ];
 
   meta = with lib; {
     description = "PyiCloud is a module which allows pythonistas to interact with iCloud webservices";

--- a/pkgs/development/python-modules/pysqueezebox/default.nix
+++ b/pkgs/development/python-modules/pysqueezebox/default.nix
@@ -4,6 +4,7 @@
 , fetchFromGitHub
 , pytest-asyncio
 , pytestCheckHook
+, pythonAtLeast
 , pythonOlder
 }:
 
@@ -32,6 +33,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [
     "pysqueezebox"
+  ];
+
+  disabledTests = lib.optionals (pythonAtLeast "3.12") [
+    # AttributeError: 'has_calls' is not a valid assertion. Use a spec for the mock if 'has_calls' is meant to be an attribute.
+    "test_verified_pause"
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/smmap/default.nix
+++ b/pkgs/development/python-modules/smmap/default.nix
@@ -3,6 +3,7 @@
 , buildPythonPackage
 , setuptools
 , nosexcover
+, pythonOlder
 }:
 
 buildPythonPackage rec {
@@ -18,6 +19,8 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     setuptools
   ];
+
+  doCheck = pythonOlder "3.12";
 
   nativeCheckInputs = [
     nosexcover

--- a/pkgs/development/python-modules/snitun/default.nix
+++ b/pkgs/development/python-modules/snitun/default.nix
@@ -1,5 +1,6 @@
 { lib
 , stdenv
+, setuptools
 , async-timeout
 , attrs
 , buildPythonPackage
@@ -14,16 +15,20 @@
 buildPythonPackage rec {
   pname = "snitun";
   version = "0.36.2";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "NabuCasa";
-    repo = pname;
+    repo = "snitun";
     rev = "refs/tags/${version}";
     hash = "sha256-ViNsmTq1iLxNujA71b9JZB5AZ79ZbiqdTyDeBGd4gUA=";
   };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   propagatedBuildInputs = [
     async-timeout
@@ -36,19 +41,30 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  disabledTests = [
-    # broke after aiohttp 3.8.5 upgrade
-    "test_client_stop_no_wait"
-  ] ++ lib.optionals stdenv.isDarwin [
+  disabledTests = lib.optionals stdenv.isDarwin [
     "test_multiplexer_data_channel_abort_full" # https://github.com/NabuCasa/snitun/issues/61
     # port binding conflicts
     "test_snitun_single_runner_timeout"
     "test_snitun_single_runner_throttling"
     # ConnectionResetError: [Errno 54] Connection reset by peer
     "test_peer_listener_timeout"
-  ] ++ lib.optionals (pythonAtLeast "3.11") [
-    # TypeError: Passing coroutines is forbidden, use tasks explicitly.
-    "test_snitun_runner_updown"
+  ] ++ lib.optionals (pythonAtLeast "3.12") [
+    # blocking
+    "test_flow_client_peer"
+    "test_close_client_peer"
+    "test_init_connector"
+    "test_flow_connector"
+    "test_close_connector_remote"
+    "test_init_connector_whitelist"
+    "test_init_multiplexer_server"
+    "test_init_multiplexer_client"
+    "test_init_multiplexer_server_throttling"
+    "test_init_multiplexer_client_throttling"
+    "test_multiplexer_ping"
+    "test_multiplexer_ping_error"
+    "test_multiplexer_init_channel_full"
+    "test_multiplexer_close_channel_full"
+    "test_init_dual_peer_with_multiplexer"
   ];
 
   pythonImportsCheck = [ "snitun" ];

--- a/pkgs/development/python-modules/statsd/default.nix
+++ b/pkgs/development/python-modules/statsd/default.nix
@@ -2,7 +2,7 @@
 , buildPythonPackage
 , fetchPypi
 , setuptools
-, nose
+, pynose
 , mock
 }:
 
@@ -20,13 +20,10 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  nativeCheckInputs = [ nose mock ];
+  nativeCheckInputs = [ pynose mock ];
 
-  patchPhase = ''
-    # Failing test: ERROR: statsd.tests.test_ipv6_resolution_udp
-    sed -i 's/test_ipv6_resolution_udp/noop/' statsd/tests.py
-    # well this is a noop, but so it was before
-    sed -i 's/assert_called_once()/called/' statsd/tests.py
+  checkPhase = ''
+    nosetests -sv
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/twilio/default.nix
+++ b/pkgs/development/python-modules/twilio/default.nix
@@ -44,6 +44,9 @@ buildPythonPackage rec {
     requests
   ];
 
+  # aiounittest is not supported on 3.12
+  doCheck = pythonOlder "3.12";
+
   nativeCheckInputs = [
     aiounittest
     cryptography

--- a/pkgs/development/python-modules/uncertainties/default.nix
+++ b/pkgs/development/python-modules/uncertainties/default.nix
@@ -1,5 +1,6 @@
 { lib, fetchPypi, buildPythonPackage
 , nose, numpy, future
+, pythonOlder
 }:
 
 buildPythonPackage rec {
@@ -13,6 +14,10 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ future ];
+
+  # uses removed lib2to3.tests
+  doCheck = pythonOlder "3.12";
+
   nativeCheckInputs = [ nose numpy ];
 
   checkPhase = ''

--- a/pkgs/development/python-modules/uvcclient/default.nix
+++ b/pkgs/development/python-modules/uvcclient/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub, nose, mock }:
+{ lib, buildPythonPackage, fetchFromGitHub, pythonOlder, pynose, mock }:
 
 buildPythonPackage rec {
   pname = "uvcclient";
@@ -12,8 +12,13 @@ buildPythonPackage rec {
     sha256 = "0k8aswrk1n08w6pi6dg0zdzsmk23cafihkrss9ywg3i85w7q43x2";
   };
 
+  postPatch = ''
+    substituteInPlace tests/test_camera.py \
+      --replace-fail "assertEquals" "assertEqual"
+  '';
+
   nativeCheckInputs = [
-    nose
+    pynose
     mock
   ];
 

--- a/pkgs/development/python-modules/xknx/default.nix
+++ b/pkgs/development/python-modules/xknx/default.nix
@@ -8,7 +8,6 @@
 , pytestCheckHook
 , pythonOlder
 , setuptools
-, wheel
 }:
 
 buildPythonPackage rec {
@@ -25,15 +24,19 @@ buildPythonPackage rec {
     hash = "sha256-Fwo76tvkLLx8QJeokuGohhnt83eGBMyWIUSHJGuQWJ4=";
   };
 
+  patches = [
+    ./pytest-asyncio-0.22-compat.patch
+  ];
+
   nativeBuildInputs = [
     setuptools
-    wheel
   ];
 
   propagatedBuildInputs = [
-    async-timeout
     cryptography
     ifaddr
+  ] ++ lib.optionals (pythonOlder "3.11") [
+    async-timeout
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/xknx/pytest-asyncio-0.22-compat.patch
+++ b/pkgs/development/python-modules/xknx/pytest-asyncio-0.22-compat.patch
@@ -1,0 +1,28 @@
+diff --git a/test/devices_tests/datetime_test.py b/test/devices_tests/datetime_test.py
+index af06abc6..2145fcc1 100644
+--- a/test/devices_tests/datetime_test.py
++++ b/test/devices_tests/datetime_test.py
+@@ -12,11 +12,6 @@ from xknx.telegram.apci import GroupValueRead, GroupValueResponse, GroupValueWri
+ class TestDateTime:
+     """Test class for DateTime object."""
+ 
+-    # pylint: disable=attribute-defined-outside-init
+-    def teardown_method(self):
+-        """Cancel broadcast_task."""
+-        self.datetime.__del__()
+-
+     #
+     # SET Time
+     #
+diff --git a/test/io_tests/secure_session_test.py b/test/io_tests/secure_session_test.py
+index cd2dc1d0..ca90e2d9 100644
+--- a/test/io_tests/secure_session_test.py
++++ b/test/io_tests/secure_session_test.py
+@@ -65,7 +65,6 @@ class TestSecureSession:
+ 
+     def teardown_method(self):
+         """Cancel keepalive task."""
+-        self.session.stop()
+         self.patch_serial_number.stop()
+         self.patch_message_tag.stop()
+ 

--- a/pkgs/development/python-modules/yalexs/default.nix
+++ b/pkgs/development/python-modules/yalexs/default.nix
@@ -39,6 +39,9 @@ buildPythonPackage rec {
     requests
   ];
 
+  # aiounittest is not supported on 3.12
+  doCheck = pythonOlder "3.12";
+
   nativeCheckInputs = [
     aioresponses
     aiounittest

--- a/pkgs/development/python-modules/youless-api/default.nix
+++ b/pkgs/development/python-modules/youless-api/default.nix
@@ -5,7 +5,7 @@
 , certifi
 , chardet
 , idna
-, nose
+, pynose
 , requests
 , urllib3
 }:
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    nose
+    pynose
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
## Description of changes

Reverting the pbr disable for 3.12 unblocks lots of packages, which of course need lots of attention. :shrug: 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
