### PR TITLE
7zz: add setup hook script to unpack DMG files

### DIFF
--- a/pkgs/tools/archivers/7zz/default.nix
+++ b/pkgs/tools/archivers/7zz/default.nix
@@ -99,6 +99,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = lib.optionals useUasm [ uasm ];
 
+  setupHook = ./setup-hook.sh;
+
   enableParallelBuilding = true;
 
   preBuild = "cd CPP/7zip/Bundles/Alone2";

--- a/pkgs/tools/archivers/7zz/setup-hook.sh
+++ b/pkgs/tools/archivers/7zz/setup-hook.sh
@@ -1,0 +1,5 @@
+unpackCmdHooks+=(_tryUnpackDmg)
+_tryUnpackDmg() {
+    if ! [[ "$curSrc" =~ \.dmg$ ]]; then return 1; fi
+    7zz x "$curSrc"
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add support to unpack DMGs containing an APFS filesystem.

Kudos [@wegank's comment on discourse](https://discourse.nixos.org/t/help-with-error-only-hfs-file-systems-are-supported-on-ventura/25873/9)

~~❓ Are nixpkgs folks onboard for `_tryUnpackDmg` to use the external `/usr/bin/hdiutil` program?
Could this be improved by creating an out-of-tree reference to `hdiutil` or somehow including/referencing it in nix by other means?~~

~~Kudos to @ldeck for the [post on discourse](https://discourse.nixos.org/t/help-with-error-only-hfs-file-systems-are-supported-on-ventura/25873/8) and [`ldeck/nix-home/…/app.nix`](https://github.com/ldeck/nix-home/blob/master/lib/defaults/apps/macOS/lib/app.nix#L47-L57) which this PR borrows heavily from. IANAL, yet the [`ldeck/nix-home`](https://github.com/ldeck/nix-home) is [licensed CC0](https://github.com/ldeck/nix-home/tree/master?tab=CC0-1.0-1-ov-file#readme) and appears to be suitable for use here. @ldeck do you and nixpkgs maintainers agree?~~

✅  Are the changes in this PR eligible to be merged into `master` instead of `staging`?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
