### PR TITLE
performous: 1.3.0 -> 1.3.1

### DIFF
--- a/pkgs/games/performous/default.nix
+++ b/pkgs/games/performous/default.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation rec {
   pname = "performous";
-  version = "1.3.0";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
     owner = "performous";
     repo = "performous";
     rev = "refs/tags/${version}";
-    hash = "sha256-y7kxLht15vULN9NxM0wzj9+7Uq4/3D5j9oBEnrTIwQ8=";
+    hash = "sha256-f70IHA8LqIlkMRwJqSmszx3keStSx50nKcEWLGEjc3g=";
   };
 
   cedSrc = fetchFromGitHub {

--- a/pkgs/games/performous/performous-cmake.patch
+++ b/pkgs/games/performous/performous-cmake.patch
@@ -1,17 +1,18 @@
 diff --git a/cmake/Modules/FindCed.cmake b/cmake/Modules/FindCed.cmake
-index d6e2aca..3085adb 100644
+index 5794bc84..08d6b49d 100644
 --- a/cmake/Modules/FindCed.cmake
 +++ b/cmake/Modules/FindCed.cmake
-@@ -1,11 +1 @@
--include(LibFetchMacros)
--
--set(Ced_GIT_VERSION "master")
--
--libfetch_git_pkg(Ced
--	REPOSITORY ${SELF_BUILT_GIT_BASE}/compact_enc_det.git
--	#https://github.com/google/compact_enc_det.git
--	REFERENCE  ${Ced_GIT_VERSION}
--	FIND_PATH  compact_enc_det/compact_enc_det.h
--)
--message(STATUS "Found Google CED ${Ced_VERSION}")
-+add_subdirectory(../ced-src ced-src)
+@@ -22,12 +22,7 @@ elseif(SELF_BUILT_CED STREQUAL "AUTO")
+ 	pkg_check_modules(CED IMPORTED_TARGET GLOBAL CED)
+ 	if(NOT CED_FOUND)
+ 		message(STATUS "ced build from source because not found on system")
+-		libfetch_git_pkg(Ced
+-			REPOSITORY ${SELF_BUILT_GIT_BASE}/compact_enc_det.git
+-			#https://github.com/google/compact_enc_det.git
+-			REFERENCE  ${Ced_GIT_VERSION}
+-			FIND_PATH  compact_enc_det/compact_enc_det.h
+-		)
++		add_subdirectory(../ced-src ced-src)
+ 	else()
+ 		add_library(ced ALIAS PkgConfig::CED)
+ 		set(Ced_VERSION ${CED_VERSION})


### PR DESCRIPTION
## Description of changes

https://github.com/performous/performous/releases/tag/1.3.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
