### PR TITLE
shittier: init at unstable-2023-12-22

### DIFF
--- a/pkgs/by-name/sh/shittier/package.nix
+++ b/pkgs/by-name/sh/shittier/package.nix
@@ -1,0 +1,28 @@
+{ lib
+, buildNpmPackage
+, fetchFromGitHub
+}:
+
+buildNpmPackage rec {
+  pname = "shittier";
+  # No tagged release on GitHub yet
+  # Commit corresponds to release tagged as 0.1.1 on [npm](https://www.npmjs.com/package/shittier)
+  # See issue https://github.com/rohitdhas/shittier/issues/7
+  version = "0-unstable-2023-12-22";
+
+  src = fetchFromGitHub {
+    owner = "rohitdhas";
+    repo = "shittier";
+    rev = "c61b443c06dbaa8085a88b16360941cc4ba6baa2";
+    hash = "sha256-qdG1PdIZGWoJI7KgJqM/fayubPbPk+od/SgKfZQADz8=";
+  };
+
+  npmDepsHash = "sha256-oC9eOpoMZLZbyx9XnC4m5zzqORQWP62uRDNVZjyVnBs=";
+
+  meta = {
+    description = "Unconventional code formatting tool for JavaScript";
+    homepage = "https://github.com/rohitdhas/shittier";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ totoroot ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Add package `shittier`.
Shittier is an unconventional code formatting tool for JavaScript.
See https://github.com/rohitdhas/shittier for more information on the project.

It got released with [version 0.1.1 on npm](https://www.npmjs.com/package/shittier/v/0.1.1), but since there is no tagged release on GitHub yet, so I packaged it as unstable for now.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
