### PR TITLE
cargo,rustc: 1.75.0 -> 1.76.0

### DIFF
--- a/pkgs/development/compilers/rust/1_76.nix
+++ b/pkgs/development/compilers/rust/1_76.nix
@@ -19,8 +19,8 @@
 } @ args:
 
 import ./default.nix {
-  rustcVersion = "1.75.0";
-  rustcSha256 = "sha256-W3OfRbydNB4tHFcNZdI3VZHiLC0j71uKN3EaA4arwIg=";
+  rustcVersion = "1.76.0";
+  rustcSha256 = "sha256-nlz/Azp/DSJmgYmCrZDk0+Tvj47hcVd2xuJQc6E2wCE=";
 
   llvmSharedForBuild = pkgsBuildBuild.llvmPackages_17.libllvm.override { enableSharedLibraries = true; };
   llvmSharedForHost = pkgsBuildHost.llvmPackages_17.libllvm.override { enableSharedLibraries = true; };
@@ -34,24 +34,24 @@ import ./default.nix {
 
   # Note: the version MUST be one version prior to the version we're
   # building
-  bootstrapVersion = "1.74.1";
+  bootstrapVersion = "1.75.0";
 
   # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
   bootstrapHashes = {
-    i686-unknown-linux-gnu = "b883b98372c91bc6aa9dc6ebb2b4e02e7dacbbc2ac1ebe55923dc37134df70a4";
-    x86_64-unknown-linux-gnu = "d206888a2a9d55113940151ba16117ce2456d7de021bab18cfcb06dc48d3157c";
-    x86_64-unknown-linux-musl = "5af3115a1f16431630f288821bd7f3be8cf7e08a7611b3c3bce3976774aa6cd2";
-    arm-unknown-linux-gnueabihf = "1dd7d835af4afe9adb7f785046c907090ace66f1c975cfe9e8886847310d8ec9";
-    armv7-unknown-linux-gnueabihf = "a5038ae004bf86eed64ef67329f7ba047bb4d188663bfd260320d53a2fed33c4";
-    aarch64-unknown-linux-gnu = "0dbdfce647f3c7d9ff00a7aa5d6dbbd7010486f803a9749cff46189f5ecb438c";
-    aarch64-unknown-linux-musl = "02674b8e4311780464313c5773d43606fbf6880d5c4512930d59b6d5d369f0de";
-    x86_64-apple-darwin = "54e1ef01d73f6031fbee36bbecd9af4209eb682dea478696e8282ca64d5792e5";
-    aarch64-apple-darwin = "af6a982cbed85807fb8e5c4ba85b8a76162b58945f4787e0a7dec32e901e8b3b";
-    powerpc64le-unknown-linux-gnu = "bb1c9f0ab1016a2817afe8f72c03f8f1787fe44d0f9999669e0c1957a08e6213";
-    riscv64gc-unknown-linux-gnu = "86561a8d630f634fdd7cb5899d40027103c907d9763a32770b7e2fd57dbd8473";
+    i686-unknown-linux-gnu = "107b8d8825deab338f338b15f047829da6225bb34644790847e96f0957c6678f";
+    x86_64-unknown-linux-gnu = "473978b6f8ff216389f9e89315211c6b683cf95a966196e7914b46e8cf0d74f6";
+    x86_64-unknown-linux-musl = "cc6ef41aa811ab34f946fe2b4338d1107daf08642125fd566386bf45563597de";
+    arm-unknown-linux-gnueabihf = "985454b6c385cb461cc8a39d2d7d55dcf6c50495033fe5d28edcc717729d8ae9";
+    armv7-unknown-linux-gnueabihf = "bd876a75f72040d96be2fb882770b16b482ac0ab15d7e3ad24e6d25b7c74bcf7";
+    aarch64-unknown-linux-gnu = "30828cd904fcfb47f1ac43627c7033c903889ea4aca538f53dcafbb3744a9a73";
+    aarch64-unknown-linux-musl = "26b5989525b7cf623f3868a37549736e0efe1142a08f191a97e29758cc640ac4";
+    x86_64-apple-darwin = "ad066e4dec7ae5948c4e7afe68e250c336a5ab3d655570bb119b3eba9cf22851";
+    aarch64-apple-darwin = "878ecf81e059507dd2ab256f59629a4fb00171035d2a2f5638cb582d999373b1";
+    powerpc64le-unknown-linux-gnu = "2599cdfea5860b4efbceb7bca69845a96ac1c96aa50cf8261151e82280b397a0";
+    riscv64gc-unknown-linux-gnu = "7f7b73d8924d7dd24dcb2ef0da257eb48d9aed658b00fe68e8f1ade0b1ce4511";
   };
 
-  selectRustPackage = pkgs: pkgs.rust_1_75;
+  selectRustPackage = pkgs: pkgs.rust_1_76;
 
   rustcPatches = [ ];
 }

--- a/pkgs/os-specific/linux/kernel/patches.nix
+++ b/pkgs/os-specific/linux/kernel/patches.nix
@@ -79,4 +79,13 @@
     name = "rust-1.75.patch";
     patch = ./rust-1.75.patch;
   };
+
+  rust_1_76 = {
+    name = "rust-1.76.patch";
+    patch = fetchurl {
+      name = "rust-1.76.patch";
+      url = "https://lore.kernel.org/rust-for-linux/20240217002638.57373-2-ojeda@kernel.org/raw";
+      hash = "sha256-q3iNBo8t4b1Rn5k5lau2myqOAqdA/9V9A+ok2jGkLdY=";
+    };
+  };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16819,11 +16819,11 @@ with pkgs;
   wrapRustcWith = { rustc-unwrapped, ... } @ args: callPackage ../build-support/rust/rustc-wrapper args;
   wrapRustc = rustc-unwrapped: wrapRustcWith { inherit rustc-unwrapped; };
 
-  rust_1_75 = callPackage ../development/compilers/rust/1_75.nix {
+  rust_1_76 = callPackage ../development/compilers/rust/1_76.nix {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
     llvm_17 = llvmPackages_17.libllvm;
   };
-  rust = rust_1_75;
+  rust = rust_1_76;
 
   mrustc = callPackage ../development/compilers/mrustc { };
   mrustc-minicargo = callPackage ../development/compilers/mrustc/minicargo.nix { };
@@ -16831,8 +16831,8 @@ with pkgs;
     openssl = openssl_1_1;
   };
 
-  rustPackages_1_75 = rust_1_75.packages.stable;
-  rustPackages = rustPackages_1_75;
+  rustPackages_1_76 = rust_1_76.packages.stable;
+  rustPackages = rustPackages_1_76;
 
   inherit (rustPackages) cargo cargo-auditable cargo-auditable-cargo-wrapper clippy rustc rustPlatform;
 

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -192,6 +192,7 @@ in {
         kernelPatches.request_key_helper
         kernelPatches.rust_1_74
         kernelPatches.rust_1_75
+        kernelPatches.rust_1_76
       ];
     };
 
@@ -204,6 +205,7 @@ in {
           kernelPatches.bridge_stp_helper
           kernelPatches.request_key_helper
           kernelPatches.rust_1_75
+          kernelPatches.rust_1_76
         ];
       };
       latest = packageAliases.linux_latest.kernel;


### PR DESCRIPTION
## Description of changes

Built:

- [x] fd aarch64-linux
- [x] fd x86_64-linux
- [x] fd x86_64-darwin (help wanted!)
- [x] thunderbird x86_64-linux
- [x] firefox x86_64-linux
- [x] rust-out-of-tree-module (both 6.7 and 6.8-rc4; cross aarch64-linux → x86_64-linux) 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
