### PR TITLE
keepassxc-go: init at 1.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19879,6 +19879,13 @@
     githubId = 31734358;
     name = "Xavier Groleau";
   };
+  xgwq = {
+    name = "XGWQ";
+    email = "nixos@xnee.de";
+    matrix = "@xgwq:nerdberg.de";
+    github = "peterablehmann";
+    githubId = 36541313;
+  };
   xiorcale = {
     email = "quentin.vaucher@pm.me";
     github = "xiorcale";

--- a/pkgs/by-name/ke/keepassxc-go/package.nix
+++ b/pkgs/by-name/ke/keepassxc-go/package.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+}:
+
+buildGoModule rec {
+  pname = "keepassxc-go";
+  version = "1.5.1";
+
+  src = fetchFromGitHub {
+    owner = "MarkusFreitag";
+    repo = "keepassxc-go";
+    rev = "v${version}";
+    hash = "sha256-seCeHNEj5GxAI7BVMPzh+YuoxivmTwvhVCqY5LKHpQk=";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  vendorHash = "sha256-jscyNyVr+RDN1EaxIOc3aYCAVT+1eO/c+dxEsIorDIs=";
+
+  postInstall = ''
+    local INSTALL="$out/bin/keepassxc-go"
+    installShellCompletion --cmd keepassxc-go \
+      --bash <($out/bin/keepassxc-go completion bash) \
+      --fish <($out/bin/keepassxc-go completion fish) \
+      --zsh <($out/bin/keepassxc-go completion zsh)
+  '';
+
+  meta = with lib; {
+    description = "Library and basic CLI tool to interact with KeepassXC via unix socket";
+    homepage = "https://github.com/MarkusFreitag/keepassxc-go";
+    changelog = "https://github.com/MarkusFreitag/keepassxc-go/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ xgwq ];
+    mainProgram = "keepassxc-go";
+  };
+}


### PR DESCRIPTION
## Description of changes
Package keepassxc-go a tool to query KeepassXC from the CLI.
https://github.com/MarkusFreitag/keepassxc-go

## Things done
- Built on platform(s)
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
