### PR TITLE
unbound: 1.19.0 -> 1.19.1

### DIFF
--- a/pkgs/tools/networking/unbound/default.nix
+++ b/pkgs/tools/networking/unbound/default.nix
@@ -51,12 +51,16 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "unbound";
-  version = "1.19.0";
+  version = "1.19.1";
 
   src = fetchurl {
     url = "https://nlnetlabs.nl/downloads/unbound/unbound-${finalAttrs.version}.tar.gz";
-    hash = "sha256-qXUyRohUxhwt5IykFw3oVP07yVyAQ7sM+w/iZgWWZiQ=";
+    hash = "sha256-vB1Xbz3YRqBzmtxB/6pwJATGdn0rYILeufL5fLsko6k=";
   };
+
+  patches = [
+    ./use-pkg-config-protobuf-c.patch
+  ];
 
   outputs = [ "out" "lib" "man" ]; # "dev" would only split ~20 kB
 
@@ -97,7 +101,6 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-libsodium=${symlinkJoin { name = "libsodium-full"; paths = [ libsodium.dev libsodium.out ]; }}"
   ] ++ lib.optionals withDNSTAP [
     "--enable-dnstap"
-    "--with-protobuf-c=${protobufc}"
   ] ++ lib.optionals withTFO [
     "--enable-tfo-client"
     "--enable-tfo-server"

--- a/pkgs/tools/networking/unbound/use-pkg-config-protobuf-c.patch
+++ b/pkgs/tools/networking/unbound/use-pkg-config-protobuf-c.patch
@@ -1,0 +1,44 @@
+commit 59d98b9ef64e597c331c27160715d7a1b40c8638
+Author: Nick Cao <nickcao@nichi.co>
+Date:   Fri Jan 26 17:52:24 2024 -0500
+
+    Search for protobuf-c with pkg-config
+
+diff --git a/dnstap/dnstap.m4 b/dnstap/dnstap.m4
+index be8b40c4..a9202c11 100644
+--- a/dnstap/dnstap.m4
++++ b/dnstap/dnstap.m4
+@@ -30,15 +30,24 @@ AC_DEFUN([dt_DNSTAP],
+ 	  fi
+ 	  LDFLAGS="$LDFLAGS -L$withval/lib"
+ 	], [
+-	  # workaround for protobuf-c includes at old dir before protobuf-c-1.0.0
+-	  if test -f /usr/include/google/protobuf-c/protobuf-c.h; then
+-	    CFLAGS="$CFLAGS -I/usr/include/google"
+-	  else
+-	    if test -f /usr/local/include/google/protobuf-c/protobuf-c.h; then
+-	      CFLAGS="$CFLAGS -I/usr/local/include/google"
+-	      LDFLAGS="$LDFLAGS -L/usr/local/lib"
+-	    fi
+-	  fi
++      ifdef([PKG_CHECK_MODULES], [
++        PKG_CHECK_MODULES([PROTOBUFC], [libprotobuf-c], [
++          CFLAGS="$CFLAGS $PROTOBUFC_CFLAGS"
++          LIBS="$LIBS $PROTOBUFC_LIBS"
++        ], [
++          AC_MSG_ERROR([The protobuf-c package was not found with pkg-config. Please install protobuf-c!])
++        ])
++      ], [
++        # workaround for protobuf-c includes at old dir before protobuf-c-1.0.0
++        if test -f /usr/include/google/protobuf-c/protobuf-c.h; then
++          CFLAGS="$CFLAGS -I/usr/include/google"
++        else
++          if test -f /usr/local/include/google/protobuf-c/protobuf-c.h; then
++            CFLAGS="$CFLAGS -I/usr/local/include/google"
++            LDFLAGS="$LDFLAGS -L/usr/local/lib"
++          fi
++        fi
++      ])
+     ])
+     AC_SEARCH_LIBS([protobuf_c_message_pack], [protobuf-c], [],
+       AC_MSG_ERROR([The protobuf-c library was not found. Please install the development libraries for protobuf-c!]))


### PR DESCRIPTION
## Description of changes

Release Notes:
https://github.com/NLnetLabs/unbound/releases/tag/release-1.19.1

This security release fixes two DNSSEC validation vulnerabilities: CVE-2023-50387 (referred here as the KeyTrap vulnerability) and CVE-2023-50868 (referred here as the NSEC3 vulnerability).

Also patched configure script with:
https://github.com/NLnetLabs/unbound/commit/59d98b9ef64e597c331c27160715d7a1b40c8638 Credits: @NickCao

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
