### PR TITLE
unbound: 1.19.2 pkg-config for protobuf-c

### DIFF
--- a/pkgs/tools/networking/unbound/default.nix
+++ b/pkgs/tools/networking/unbound/default.nix
@@ -58,10 +58,35 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-zFYNNFc0ImwbOecadpeX5/3eImXLt3685UJwS7pInlU=";
   };
 
+
+  # Cherry pick some already merged upstream patches for configure
+  patches = [
+    # Search for protobuf-c with pkg-config
+    # https://github.com/NLnetLabs/unbound/pull/999
+    (fetchpatch {
+      url = "https://github.com/NLnetLabs/unbound/commit/59d98b9ef64e597c331c27160715d7a1b40c8638.patch";
+      hash = "sha256-DvYoYBTXOwbR8Z0GRgt724WqX3dbIEOdICU2/VMRSVQ=";
+    })
+    # Fix for previous patch
+    # https://github.com/NLnetLabs/unbound/issues/1006
+    (fetchpatch {
+      url = "https://github.com/NLnetLabs/unbound/commit/93490a0fc1bf9e62e6edcd6b69f1463c7ac410e9.patch";
+      hash = "sha256-mBo63ZlayD3YkOgIoQN0dG+xuFq/BxcjBmSo1vapiYA=";
+      excludes = [ "doc/Changelog" ];
+    })
+    # Fix for previous patch
+    # https://github.com/NLnetLabs/unbound/commit/3f5175584b0bb9ff7d417bc195ec6e4316ae58d3
+    (fetchpatch {
+      url = "https://github.com/NLnetLabs/unbound/commit/3f5175584b0bb9ff7d417bc195ec6e4316ae58d3.patch";
+      hash = "sha256-DcWfvmk+4K3c9Z+4grwzEGIkEBYNpbTK3xuBqRI33fY=";
+    })
+  ];
+
   outputs = [ "out" "lib" "man" ]; # "dev" would only split ~20 kB
 
   nativeBuildInputs =
     lib.optionals withMakeWrapper [ makeWrapper ]
+    ++ lib.optionals withDNSTAP [ protobufc ]
     ++ [ pkg-config ]
     ++ lib.optionals withPythonModule [ swig ];
 
@@ -97,7 +122,6 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-libsodium=${symlinkJoin { name = "libsodium-full"; paths = [ libsodium.dev libsodium.out ]; }}"
   ] ++ lib.optionals withDNSTAP [
     "--enable-dnstap"
-    "--with-protobuf-c=${protobufc}"
   ] ++ lib.optionals withTFO [
     "--enable-tfo-client"
     "--enable-tfo-server"


### PR DESCRIPTION
## Description of changes

Patched configure script with:
https://github.com/NLnetLabs/unbound/commit/59d98b9ef64e597c331c27160715d7a1b40c8638 Credits: @NickCao

Enables multiple outputs for protobuf-c as in https://github.com/NixOS/nixpkgs/pull/283783

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
