### PR TITLE
treewide: use finalAttrs in packages maintained by @fgaz

### DIFF
--- a/pkgs/applications/audio/goattracker/default.nix
+++ b/pkgs/applications/audio/goattracker/default.nix
@@ -22,14 +22,14 @@ let
     keywords = [ "tracker" "music" ];
   };
 
-in stdenv.mkDerivation rec {
+in stdenv.mkDerivation (finalAttrs: {
   inherit pname;
   version = if isStereo
     then "2.77"  # stereo
     else "2.76"; # normal
 
   src = fetchurl {
-    url = "mirror://sourceforge/goattracker2/GoatTracker_${version}${lib.optionalString isStereo "_Stereo"}.zip";
+    url = "mirror://sourceforge/goattracker2/GoatTracker_${finalAttrs.version}${lib.optionalString isStereo "_Stereo"}.zip";
     sha256 = if isStereo
       then "1hiig2d152sv9kazwz33i56x1c54h5sh21ipkqnp6qlnwj8x1ksy"  # stereo
       else "0d7a3han4jw4bwiba3j87racswaajgl3pj4sb5lawdqdxicv3dn1"; # normal
@@ -69,4 +69,4 @@ in stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ fgaz ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/applications/audio/hivelytracker/default.nix
+++ b/pkgs/applications/audio/hivelytracker/default.nix
@@ -8,14 +8,14 @@
 , gtk3
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "hivelytracker";
   version = "1.9";
 
   src = fetchFromGitHub {
     owner = "pete-gordon";
     repo = "hivelytracker";
-    rev = "V${lib.replaceStrings ["."] ["_"] version}";
+    rev = "V${lib.replaceStrings ["."] ["_"] finalAttrs.version}";
     sha256 = "148p320sd8phcpmj4m85ns5zly2dawbp8kgx9ryjfdk24pa88xg6";
   };
 
@@ -65,4 +65,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ fgaz ];
     broken = stdenv.isDarwin; # TODO: try to use xcbuild
   };
-}
+})

--- a/pkgs/applications/audio/littlegptracker/default.nix
+++ b/pkgs/applications/audio/littlegptracker/default.nix
@@ -6,7 +6,7 @@
 , Foundation
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "littlegptracker";
   version = "unstable-2020-11-26";
 

--- a/pkgs/applications/audio/pt2-clone/default.nix
+++ b/pkgs/applications/audio/pt2-clone/default.nix
@@ -6,14 +6,14 @@
 , SDL2
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "pt2-clone";
   version = "1.66.1";
 
   src = fetchFromGitHub {
     owner = "8bitbubsy";
     repo = "pt2-clone";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-j7VPC1sj1Q+wL2TBgv06uYLPqym8F57HG1SRvj0Ggeo=";
   };
 
@@ -40,5 +40,4 @@ stdenv.mkDerivation rec {
     # > This code is NOT big-endian compatible
     platforms = platforms.littleEndian;
   };
-}
-
+})

--- a/pkgs/applications/audio/sfxr/default.nix
+++ b/pkgs/applications/audio/sfxr/default.nix
@@ -8,12 +8,12 @@
 , wrapGAppsHook
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sfxr";
   version = "1.2.1";
 
   src = fetchurl {
-    url = "http://www.drpetter.se/files/sfxr-sdl-${version}.tar.gz";
+    url = "http://www.drpetter.se/files/sfxr-sdl-${finalAttrs.version}.tar.gz";
     sha256 = "0dfqgid6wzzyyhc0ha94prxax59wx79hqr25r6if6by9cj4vx4ya";
   };
 
@@ -53,5 +53,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.unix;
   };
-}
-
+})

--- a/pkgs/applications/audio/soundtracker/default.nix
+++ b/pkgs/applications/audio/soundtracker/default.nix
@@ -12,7 +12,7 @@
 , libsndfile
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "soundtracker";
   version = "1.0.4";
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     # Only the latest release is at the top level.
     # Nonetheless, only the name of the file seems to affect which file is
     # downloaded, so this path should be fine both for old and current releases.
-    url = "mirror://sourceforge/soundtracker/soundtracker-${version}.tar.xz";
+    url = "mirror://sourceforge/soundtracker/soundtracker-${finalAttrs.version}.tar.xz";
     hash = "sha256-kNt0BSRaEQY+oa1xbuZ1l6nCqXhcktVugxzcC3ZDaX0=";
   };
 
@@ -76,4 +76,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/applications/editors/libresprite/default.nix
+++ b/pkgs/applications/editors/libresprite/default.nix
@@ -27,14 +27,14 @@
 , nixosTests
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libresprite";
   version = "1.0";
 
   src = fetchFromGitHub {
     owner = "LibreSprite";
     repo = "LibreSprite";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
     sha256 = "sha256-d8GmVHYomDb74iSeEhJEVTHvbiVXggXg7xSqIKCUSzY=";
   };
@@ -118,4 +118,4 @@ stdenv.mkDerivation rec {
     # https://github.com/LibreSprite/LibreSprite/issues/308
     broken = stdenv.isDarwin;
   };
-}
+})

--- a/pkgs/applications/graphics/evilpixie/default.nix
+++ b/pkgs/applications/graphics/evilpixie/default.nix
@@ -12,14 +12,14 @@
 , impy
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "evilpixie";
   version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "bcampbell";
     repo = "evilpixie";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-+DdAN+xDOYxLgLHUlr75piTEPrWpuOyXvxckhBEl7yU=";
   };
 
@@ -51,5 +51,4 @@ stdenv.mkDerivation rec {
     # https://github.com/bcampbell/evilpixie/issues/28
       stdenv.isAarch64;
   };
-}
-
+})

--- a/pkgs/applications/graphics/gnome-obfuscate/default.nix
+++ b/pkgs/applications/graphics/gnome-obfuscate/default.nix
@@ -18,7 +18,7 @@
 , Foundation
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-obfuscate";
   version = "0.0.9";
 
@@ -26,13 +26,13 @@ stdenv.mkDerivation rec {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "Obfuscate";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-aUhzact437V/bSsG2Ddu2mC03LbyXFg+hJiuGy5NQfQ=";
   };
 
   cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit src;
-    name = "${pname}-${version}";
+    inherit (finalAttrs) src;
+    name = "${finalAttrs.pname}-${finalAttrs.version}";
     hash = "sha256-HUQvdCmzjdmuJGDLtC/86yzbRimLzx+XbW29f+Ua48w=";
   };
 
@@ -66,4 +66,4 @@ stdenv.mkDerivation rec {
     mainProgram = "obfuscate";
     maintainers = with maintainers; [ fgaz ];
   };
-}
+})

--- a/pkgs/applications/graphics/goxel/default.nix
+++ b/pkgs/applications/graphics/goxel/default.nix
@@ -1,14 +1,14 @@
 { lib, stdenv, fetchFromGitHub, scons, pkg-config, wrapGAppsHook
 , glfw3, gtk3, libpng12 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "goxel";
   version = "0.14.0";
 
   src = fetchFromGitHub {
     owner = "guillaumechereau";
     repo = "goxel";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-ueA0YW2n/DXd9AytDzfPtvtXbvuUm4VDwcdvHWObKxc=";
   };
 
@@ -38,4 +38,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [ tilpner fgaz ];
   };
-}
+})

--- a/pkgs/applications/graphics/vengi-tools/default.nix
+++ b/pkgs/applications/graphics/vengi-tools/default.nix
@@ -27,14 +27,14 @@
 , nixosTests
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "vengi-tools";
   version = "0.0.28";
 
   src = fetchFromGitHub {
     owner = "mgerhardy";
     repo = "vengi";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-UjSm/J/y7MUg3Exmw0P56+bcjiLxXdGS2brocdzgJ+c=";
   };
 
@@ -107,4 +107,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/applications/misc/openrgb-plugins/effects/default.nix
+++ b/pkgs/applications/misc/openrgb-plugins/effects/default.nix
@@ -10,14 +10,14 @@
 , wrapQtAppsHook
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "openrgb-plugin-effects";
   version = "0.9";
 
   src = fetchFromGitLab {
     owner = "OpenRGBDevelopers";
     repo = "OpenRGBEffectsPlugin";
-    rev = "release_${version}";
+    rev = "release_${finalAttrs.version}";
     hash = "sha256-8BnHifcFf7ESJgJi/q3ca38zuIVa++BoGlkWxj7gpog=";
     fetchSubmodules = true;
   };
@@ -47,4 +47,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/applications/misc/openrgb-plugins/hardwaresync/default.nix
+++ b/pkgs/applications/misc/openrgb-plugins/hardwaresync/default.nix
@@ -11,14 +11,14 @@
 , wrapQtAppsHook
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "openrgb-plugin-hardwaresync";
   version = "0.9";
 
   src = fetchFromGitLab {
     owner = "OpenRGBDevelopers";
     repo = "OpenRGBHardwareSyncPlugin";
-    rev = "release_${version}";
+    rev = "release_${finalAttrs.version}";
     hash = "sha256-3sQFiqmXhuavce/6v3XBpp6PAduY7t440nXfbfCX9a0=";
   };
 
@@ -50,4 +50,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/applications/networking/sync/openrsync/default.nix
+++ b/pkgs/applications/networking/sync/openrsync/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "openrsync";
   version = "unstable-2022-05-08";
 

--- a/pkgs/applications/networking/upnp-router-control/default.nix
+++ b/pkgs/applications/networking/upnp-router-control/default.nix
@@ -12,12 +12,12 @@
 , gupnp_1_6
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "upnp-router-control";
   version = "0.3.4";
 
   src = fetchzip {
-    url = "https://launchpad.net/upnp-router-control/trunk/${version}/+download/upnp-router-control-${version}.tar.xz";
+    url = "https://launchpad.net/upnp-router-control/trunk/${finalAttrs.version}/+download/upnp-router-control-${finalAttrs.version}.tar.xz";
     hash = "sha256-28F/OB2fHemn7HLVFEDmefRA5AsEaQKy+Qbcv75z9w0=";
   };
 
@@ -50,4 +50,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     mainProgram = "upnp-router-control";
   };
-}
+})

--- a/pkgs/applications/networking/yaup/default.nix
+++ b/pkgs/applications/networking/yaup/default.nix
@@ -8,7 +8,7 @@
 , miniupnpc
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "yaup";
   version = "unstable-2019-10-16";
 

--- a/pkgs/data/fonts/twemoji-color-font/default.nix
+++ b/pkgs/data/fonts/twemoji-color-font/default.nix
@@ -3,14 +3,14 @@
 , fetchurl
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "twemoji-color-font";
   version = "14.0.2";
 
   # We fetch the prebuilt font because building it takes 1.5 hours on hydra.
   # Relevant issue: https://github.com/NixOS/nixpkgs/issues/97871
   src = fetchurl {
-    url = "https://github.com/eosrei/twemoji-color-font/releases/download/v${version}/TwitterColorEmoji-SVGinOT-Linux-${version}.tar.gz";
+    url = "https://github.com/eosrei/twemoji-color-font/releases/download/v${finalAttrs.version}/TwitterColorEmoji-SVGinOT-Linux-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-aCbiHqCNxd8myIeuTlYEaYfg9JCd+MAsc94FcUoDU8E=";
   };
 
@@ -39,4 +39,4 @@ stdenv.mkDerivation rec {
     license = with licenses; [ cc-by-40 mit ];
     maintainers = [ maintainers.fgaz ];
   };
-}
+})

--- a/pkgs/development/compilers/lobster/default.nix
+++ b/pkgs/development/compilers/lobster/default.nix
@@ -16,14 +16,14 @@
 , ForceFeedback
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lobster";
   version = "2023.13";
 
   src = fetchFromGitHub {
     owner = "aardappel";
     repo = "lobster";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-7lMIIJ3iduyxZKwK65tle3c+az2G2Mpi4JwAeCCsTxw=";
   };
 
@@ -62,4 +62,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/development/interpreters/duktape/default.nix
+++ b/pkgs/development/interpreters/duktape/default.nix
@@ -1,10 +1,10 @@
 { lib, stdenv, fetchurl, validatePkgConfig }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "duktape";
   version = "2.7.0";
   src = fetchurl {
-    url = "http://duktape.org/duktape-${version}.tar.xz";
+    url = "http://duktape.org/duktape-${finalAttrs.version}.tar.xz";
     sha256 = "sha256-kPjS+otVZ8aJmDDd7ywD88J5YLEayiIvoXqnrGE8KJA=";
   };
 
@@ -38,4 +38,4 @@ stdenv.mkDerivation rec {
     mainProgram = "duk";
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/development/interpreters/jimtcl/default.nix
+++ b/pkgs/development/interpreters/jimtcl/default.nix
@@ -16,14 +16,14 @@
 , SDLSupport ? true
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "jimtcl";
   version = "0.82";
 
   src = fetchFromGitHub {
     owner = "msteveb";
     repo = "jimtcl";
-    rev = version;
+    rev = finalAttrs.version;
     sha256 = "sha256-CDjjrxpoTbLESAbCiCjQ8+E/oJP87gDv9SedQOzH3QY=";
   };
 
@@ -77,4 +77,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ dbohdan fgaz vrthra ];
   };
-}
+})

--- a/pkgs/development/libraries/audiality2/default.nix
+++ b/pkgs/development/libraries/audiality2/default.nix
@@ -7,14 +7,14 @@
 , jack2
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "audiality2";
   version = "1.9.4";
 
   src = fetchFromGitHub {
     owner = "olofson";
     repo = "audiality2";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "0ipqna7a9mxqm0fl9ggwhbc7i9yxz3jfyi0w3dymjp40v7jw1n20";
   };
 
@@ -35,5 +35,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     maintainers = with maintainers; [ fgaz ];
   };
-}
-
+})

--- a/pkgs/development/libraries/impy/default.nix
+++ b/pkgs/development/libraries/impy/default.nix
@@ -9,14 +9,14 @@
 , libjpeg
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "impy";
   version = "0.2";
 
   src = fetchFromGitHub {
     owner = "bcampbell";
     repo = "impy";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-0bHm3jawYgcIeF2COALWlypX7kvPw1hifB/W+TKcC4M=";
   };
 
@@ -40,5 +40,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.all;
   };
-}
-
+})

--- a/pkgs/development/libraries/litehtml/default.nix
+++ b/pkgs/development/libraries/litehtml/default.nix
@@ -5,14 +5,14 @@
 , gumbo
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "litehtml";
   version = "0.6";
 
   src = fetchFromGitHub {
     owner = "litehtml";
     repo = "litehtml";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-9571d3k8RkzEpMWPuIejZ7njLmYstSwFUaSqT3sk6uQ=";
   };
 
@@ -43,4 +43,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     maintainers = with maintainers; [ fgaz ];
   };
-}
+})

--- a/pkgs/development/libraries/lmdbxx/default.nix
+++ b/pkgs/development/libraries/lmdbxx/default.nix
@@ -2,14 +2,14 @@
 , fetchFromGitHub
 , lmdb }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lmdbxx";
   version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "hoytech";
     repo = "lmdbxx";
-    rev = version;
+    rev = finalAttrs.version;
     sha256 = "sha256-7CxQZdgHVvmof6wVR9Mzic6tg89XJT3Z1ICGRs7PZYo=";
   };
 
@@ -22,5 +22,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.unlicense;
     maintainers = with lib.maintainers; [ fgaz ];
   };
-}
-
+})

--- a/pkgs/development/libraries/termbox/default.nix
+++ b/pkgs/development/libraries/termbox/default.nix
@@ -1,12 +1,12 @@
 { lib, stdenv, fetchFromGitHub }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "termbox";
   version = "1.1.4";
   src = fetchFromGitHub {
     owner = "termbox";
     repo = "termbox";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "075swv6ajx8m424dbmgbf6fs6nd5q004gjpvx48gkxmnf9spvykl";
   };
 
@@ -19,4 +19,4 @@ stdenv.mkDerivation rec {
     downloadPage = "https://github.com/termbox/termbox/releases";
     maintainers = with maintainers; [ fgaz ];
   };
-}
+})

--- a/pkgs/games/brogue-ce/default.nix
+++ b/pkgs/games/brogue-ce/default.nix
@@ -7,14 +7,14 @@
 , SDL2_image
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "brogue-ce";
   version = "1.13";
 
   src = fetchFromGitHub {
     owner = "tmewett";
     repo = "BrogueCE";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-FUIdi1Ytn+INeD9550MW41qXtLb6in0QS3Snt8QaXUA=";
   };
 
@@ -60,4 +60,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ AndersonTorres fgaz ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/games/brogue/default.nix
+++ b/pkgs/games/brogue/default.nix
@@ -1,11 +1,11 @@
 { lib, stdenv, fetchurl, fetchpatch, SDL, ncurses, libtcod, makeDesktopItem }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "brogue";
   version = "1.7.5";
 
   src = fetchurl {
-    url = "https://sites.google.com/site/broguegame/brogue-${version}-linux-amd64.tbz2";
+    url = "https://sites.google.com/site/broguegame/brogue-${finalAttrs.version}-linux-amd64.tbz2";
     sha256 = "0i042zb3axjf0cpgpdh8hvfn66dbfizidyvw0iymjk2n760z2kx7";
   };
   patches = [
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     install -m 555 -D bin/brogue $out/bin/brogue
-    install -m 444 -D ${desktopItem}/share/applications/brogue.desktop $out/share/applications/brogue.desktop
+    install -m 444 -D ${finalAttrs.desktopItem}/share/applications/brogue.desktop $out/share/applications/brogue.desktop
     install -m 444 -D bin/brogue-icon.png $out/share/icons/hicolor/256x256/apps/brogue.png
     mkdir -p $out/share/brogue
     cp -r bin/fonts $out/share/brogue/
@@ -56,4 +56,4 @@ stdenv.mkDerivation rec {
     maintainers =  with maintainers; [ AndersonTorres fgaz ];
     platforms = [ "x86_64-linux" ];
   };
-}
+})

--- a/pkgs/games/curseofwar/default.nix
+++ b/pkgs/games/curseofwar/default.nix
@@ -4,14 +4,14 @@
 , SDL
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "curseofwar";
   version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "a-nikolaev";
-    repo = pname;
-    rev = "v${version}";
+    repo = "curseofwar";
+    rev = "v${finalAttrs.version}";
     sha256 = "1wd71wdnj9izg5d95m81yx3684g4zdi7fsy0j5wwnbd9j34ilz1i";
   };
 
@@ -33,5 +33,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.all;
   };
-}
-
+})

--- a/pkgs/games/gnonograms/default.nix
+++ b/pkgs/games/gnonograms/default.nix
@@ -16,14 +16,14 @@
 , libhandy
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gnonograms";
   version = "2.1.2";
 
   src = fetchFromGitHub {
     owner = "jeremypw";
     repo = "gnonograms";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-TkEVjrwlr4Q5FsfcdY+9fxwaMq+DFs0RwGI2E+GT5Mk=";
   };
 
@@ -63,4 +63,4 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/jeremypw/gnonograms";
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/games/gnujump/default.nix
+++ b/pkgs/games/gnujump/default.nix
@@ -1,10 +1,10 @@
 { lib, stdenv, makeDesktopItem, copyDesktopItems, fetchurl, SDL, SDL_image, SDL_mixer }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gnujump";
   version = "1.0.8";
   src = fetchurl {
-    url = "mirror://gnu/gnujump/${pname}-${version}.tar.gz";
+    url = "mirror://gnu/gnujump/gnujump-${finalAttrs.version}.tar.gz";
     sha256 = "05syy9mzbyqcfnm0hrswlmhwlwx54f0l6zhcaq8c1c0f8dgzxhqk";
   };
 
@@ -39,4 +39,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/games/hikounomizu/default.nix
+++ b/pkgs/games/hikounomizu/default.nix
@@ -22,12 +22,12 @@
 , bc
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "hikounomizu";
   version = "1.0.1";
 
   src = fetchurl {
-    url = "http://download.tuxfamily.org/hnm/${version}/hikounomizu-${version}-src.tar.bz2";
+    url = "http://download.tuxfamily.org/hnm/${finalAttrs.version}/hikounomizu-${finalAttrs.version}-src.tar.bz2";
     hash = "sha256-3wRhe6CDq1dD0SObAygfqslYJx+EM3LM3rj6HI0whYU=";
   };
 
@@ -78,4 +78,4 @@ stdenv.mkDerivation rec {
     license = [ licenses.gpl3Plus licenses.lal13 ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/games/powermanga/default.nix
+++ b/pkgs/games/powermanga/default.nix
@@ -8,12 +8,12 @@
 , libpng
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "powermanga";
   version = "0.93.1";
 
   src = fetchurl {
-    url = "https://linux.tlk.fr/games/Powermanga/download/powermanga-${version}.tgz";
+    url = "https://linux.tlk.fr/games/Powermanga/download/powermanga-${finalAttrs.version}.tgz";
     sha256 = "sha256-2nU/zoOQWm2z/Y6mXHDFfWYjYshsQp1saVRBcUT5Q+g=";
   };
 
@@ -56,4 +56,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     broken = stdenv.isDarwin;
   };
-}
+})

--- a/pkgs/games/tecnoballz/default.nix
+++ b/pkgs/games/tecnoballz/default.nix
@@ -10,12 +10,12 @@
 , tinyxml
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tecnoballz";
   version = "0.93.1";
 
   src = fetchurl {
-    url = "https://linux.tlk.fr/games/TecnoballZ/download/tecnoballz-${version}.tgz";
+    url = "https://linux.tlk.fr/games/TecnoballZ/download/tecnoballz-${finalAttrs.version}.tgz";
     sha256 = "sha256-WRW76e+/eXE/KwuyOjzTPFQnKwNznbIrUrz14fnvgug=";
   };
 
@@ -66,4 +66,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     broken = stdenv.isDarwin;
   };
-}
+})

--- a/pkgs/games/titanion/default.nix
+++ b/pkgs/games/titanion/default.nix
@@ -16,12 +16,12 @@ debianPatch = patchname: hash: fetchpatch {
   sha256 = hash;
 };
 
-in stdenv.mkDerivation rec {
+in stdenv.mkDerivation (finalAttrs: {
   pname = "titanion";
   version = "0.3";
 
   src = fetchurl {
-    url = "http://abagames.sakura.ne.jp/windows/ttn${lib.replaceStrings ["."] ["_"] version}.zip";
+    url = "http://abagames.sakura.ne.jp/windows/ttn${lib.replaceStrings ["."] ["_"] finalAttrs.version}.zip";
     sha256 = "sha256-fR0cufi6dU898wP8KGl/vxbfQJzMmMxlYZ3QNGLajfM=";
   };
 
@@ -88,4 +88,4 @@ in stdenv.mkDerivation rec {
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/games/toppler/default.nix
+++ b/pkgs/games/toppler/default.nix
@@ -15,14 +15,14 @@
 , zlib
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "toppler";
   version = "1.3";
 
   src = fetchFromGitLab {
     owner = "roever";
     repo = "toppler";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-ecEaELu52Nmov/BD9VzcUw6wyWeHJcsKQkEzTnaW330=";
   };
 
@@ -58,4 +58,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/games/torus-trooper/default.nix
+++ b/pkgs/games/torus-trooper/default.nix
@@ -16,12 +16,12 @@ debianPatch = patchname: hash: fetchpatch {
   sha256 = hash;
 };
 
-in stdenv.mkDerivation rec {
+in stdenv.mkDerivation (finalAttrs: {
   pname = "torus-trooper";
   version = "0.22";
 
   src = fetchurl {
-    url = "http://abagames.sakura.ne.jp/windows/tt${lib.replaceStrings ["."] ["_"] version}.zip";
+    url = "http://abagames.sakura.ne.jp/windows/tt${lib.replaceStrings ["."] ["_"] finalAttrs.version}.zip";
     sha256 = "1yhki1fdp3fi4y2iq12vca69f6k38dqjaw9z4lwcxky5kbgb7jvg";
   };
 
@@ -101,4 +101,4 @@ in stdenv.mkDerivation rec {
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/games/tumiki-fighters/default.nix
+++ b/pkgs/games/tumiki-fighters/default.nix
@@ -16,12 +16,12 @@ debianPatch = patchname: hash: fetchpatch {
   sha256 = hash;
 };
 
-in stdenv.mkDerivation rec {
+in stdenv.mkDerivation (finalAttrs: {
   pname = "tumiki-fighters";
   version = "0.21";
 
   src = fetchurl {
-    url = "http://abagames.sakura.ne.jp/windows/tf${lib.replaceStrings ["."] ["_"] version}.zip";
+    url = "http://abagames.sakura.ne.jp/windows/tf${lib.replaceStrings ["."] ["_"] finalAttrs.version}.zip";
     sha256 = "0djykfc1r8ysapklm621h89ana1c4qzc1m5nr9bqw4iccnmvwk3p";
   };
 
@@ -94,4 +94,4 @@ in stdenv.mkDerivation rec {
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/games/warzone2100/default.nix
+++ b/pkgs/games/warzone2100/default.nix
@@ -44,12 +44,12 @@ let
   };
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   inherit pname;
   version  = "4.4.2";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/warzone2100/releases/${version}/warzone2100_src.tar.xz";
+    url = "mirror://sourceforge/project/warzone2100/releases/${finalAttrs.version}/warzone2100_src.tar.xz";
     hash = "sha256-O5Yqxqp1vKYr8uvAZ1SdsI/kocOzg0KRCirCqqvLrN4=";
   };
 
@@ -142,4 +142,4 @@ stdenv.mkDerivation rec {
     # https://github.com/Warzone2100/warzone2100/blob/master/macosx/README.md
     broken = stdenv.isDarwin;
   };
-}
+})

--- a/pkgs/games/zaz/default.nix
+++ b/pkgs/games/zaz/default.nix
@@ -11,12 +11,12 @@
 , freetype
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "zaz";
   version = "1.0.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.gz";
+    url = "mirror://sourceforge/zaz/zaz-${finalAttrs.version}.tar.gz";
     sha256 = "1r3bmwny05zzmdalxm5ah2rray0nnsg1w00r30p47q6x2lpwj8ml";
   };
 
@@ -56,5 +56,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     mainProgram = "zaz";
   };
-}
-
+})

--- a/pkgs/servers/http/merecat/default.nix
+++ b/pkgs/servers/http/merecat/default.nix
@@ -10,15 +10,15 @@
 , nixosTests
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "merecat";
   version = "2.31";
 
-  # Or, already reconf'd: ftp://ftp.troglobit.com/merecat/merecat-${version}.tar.xz
+  # Or, already reconf'd: ftp://ftp.troglobit.com/merecat/merecat-${finalAttrs.version}.tar.xz
   src = fetchFromGitHub {
     owner = "troglobit";
     repo = "merecat";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-oIzOXUnCFqd3HPyKp58r+enRRpaE7f9hqNITtxCCB7I=";
   };
 
@@ -49,4 +49,4 @@ stdenv.mkDerivation rec {
     # Strange header and/or linker errors
     broken = stdenv.isDarwin;
   };
-}
+})

--- a/pkgs/servers/misc/qremotecontrol-server/default.nix
+++ b/pkgs/servers/misc/qremotecontrol-server/default.nix
@@ -7,7 +7,7 @@
 , xorg
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "qremotecontrol-server";
   version = "unstable-2014-11-05"; # basically 2.4.2 + qt5
 

--- a/pkgs/servers/xinetd/default.nix
+++ b/pkgs/servers/xinetd/default.nix
@@ -5,12 +5,12 @@
 , libtirpc
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "xinetd";
   version = "2.3.15.4";
 
   src = fetchurl {
-    url = "https://github.com/openSUSE/xinetd/releases/download/${version}/xinetd-${version}.tar.xz";
+    url = "https://github.com/openSUSE/xinetd/releases/download/${finalAttrs.version}/xinetd-${finalAttrs.version}.tar.xz";
     hash = "sha256-K6pYEBC8cDYavfo38SHpKuucXOZ/mnGRPOvWk1nMllQ=";
   };
 
@@ -29,4 +29,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.free;
     maintainers = with lib.maintainers; [ fgaz ];
   };
-}
+})

--- a/pkgs/tools/X11/xprintidle/default.nix
+++ b/pkgs/tools/X11/xprintidle/default.nix
@@ -7,14 +7,14 @@
 , xorg
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "xprintidle";
   version = "0.2.5";
 
   src = fetchFromGitHub {
     owner = "g0hl1n";
     repo = "xprintidle";
-    rev = version;
+    rev = finalAttrs.version;
     sha256 = "sha256-bafDUZoSFsJ3g6mtLCRechGizfrWg2qW2vnlfIzj7mQ=";
   };
 
@@ -38,4 +38,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     mainProgram = "xprintidle";
   };
-}
+})

--- a/pkgs/tools/cd-dvd/dvd-vr/default.nix
+++ b/pkgs/tools/cd-dvd/dvd-vr/default.nix
@@ -1,10 +1,10 @@
 { lib, stdenv, fetchurl }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "dvd-vr";
   version = "0.9.7";
   src = fetchurl {
-    url = "https://www.pixelbeat.org/programs/dvd-vr/dvd-vr-${version}.tar.gz";
+    url = "https://www.pixelbeat.org/programs/dvd-vr/dvd-vr-${finalAttrs.version}.tar.gz";
     sha256 = "13wkdia3c0ryda40b2nzpb9vddimasgc4w95hvl0k555k9k8bl0r";
   };
   makeFlags = [ "PREFIX=$(out)" ];
@@ -18,4 +18,4 @@ stdenv.mkDerivation rec {
     mainProgram = "dvd-vr";
   };
 }
-
+)

--- a/pkgs/tools/compression/heatshrink/default.nix
+++ b/pkgs/tools/compression/heatshrink/default.nix
@@ -5,14 +5,14 @@
 , fetchpatch
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "heatshrink";
   version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "atomicobject";
     repo = "heatshrink";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-Nm9/+JFMDXY1N90hmNFGh755V2sXSRQ4VBN9f8TcsGk=";
   };
 
@@ -46,4 +46,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     mainProgram = "heatshrink";
   };
-}
+})

--- a/pkgs/tools/filesystems/davfs2/default.nix
+++ b/pkgs/tools/filesystems/davfs2/default.nix
@@ -8,12 +8,12 @@
 , wrapperDir ? "/run/wrappers/bin"
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "davfs2";
   version = "1.7.0";
 
   src = fetchurl {
-    url = "mirror://savannah/davfs2/davfs2-${version}.tar.gz";
+    url = "mirror://savannah/davfs2/davfs2-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-JR23Wic4DMoTMLG5cXAMXl3MDJDlpHYiKF8BQO3+Oi8=";
   };
 
@@ -59,4 +59,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ fgaz ];
   };
-}
+})

--- a/pkgs/tools/misc/tkman/default.nix
+++ b/pkgs/tools/misc/tkman/default.nix
@@ -10,12 +10,12 @@
 , rman
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tkman";
   version = "2.2";
 
   src = fetchzip {
-    url = "mirror://sourceforge/tkman/tkman-${version}.tar.gz";
+    url = "mirror://sourceforge/tkman/tkman-${finalAttrs.version}.tar.gz";
     hash = "sha256-S4ffz+7zmVy9+isz/8q+FV4wF5Rw2iL1ftY8RsJjRLs=";
   };
 
@@ -84,4 +84,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     maintainers = with maintainers; [ fgaz ];
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Shouldn't change any hash.

I made this change in part to see if it can be automated easily. My findings:

* The majority of packages were updated without problems with a vim macro
* Most of the ones that failed could be fixed by extracting the undefined variables from the instantiation errors
* Apply the change only to packages matching `stdenv.mkDerivation`, filtering out `mkDerivation`s that don't support `finalAttrs` (`qt5.mkDerivation`, `buildPythonApplication`)
* Sometimes `rec` is unused and `finalAttrs` isn't needed
* Checking that the evaluation is the same catches eventual errors

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
