### PR TITLE
opencv4: 4.7.0 -> 4.9.0

### DIFF
--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -2,14 +2,14 @@
 , stdenv
 , fetchurl
 , fetchFromGitHub
-, fetchpatch
 , cmake
 , pkg-config
 , unzip
 , zlib
-, pcre
+, pcre2
 , hdf5
 , boost
+, glib
 , gflags
 , protobuf_21
 , config
@@ -35,6 +35,8 @@
 , eigen
 , enableBlas ? true
 , blas
+, enableVA ? !stdenv.isDarwin
+, libva
 , enableContrib ? true
 
 , enableCuda ? config.cudaSupport
@@ -58,7 +60,11 @@
 , enableFfmpeg ? true
 , ffmpeg
 , enableGStreamer ? true
+, elfutils
 , gst_all_1
+, orc
+, libunwind
+, zstd
 , enableTesseract ? false
 , tesseract
 , leptonica
@@ -85,7 +91,7 @@
 }@inputs:
 
 let
-  version = "4.7.0";
+  version = "4.9.0";
 
   # It's necessary to consistently use backendStdenv when building with CUDA
   # support, otherwise we get libstdc++ errors downstream
@@ -96,21 +102,21 @@ let
     owner = "opencv";
     repo = "opencv";
     rev = version;
-    sha256 = "sha256-jUeGsu8+jzzCnIFbVMCW8DcUeGv/t1yCY/WXyW+uGDI=";
+    hash = "sha256-3qqu4xlRyMbPKHHTIT+iRRGtpFlcv0NU8GNZpgjdi6k=";
   };
 
   contribSrc = fetchFromGitHub {
     owner = "opencv";
     repo = "opencv_contrib";
     rev = version;
-    sha256 = "sha256-meya0J3RdOIeMM46e/6IOVwrKn3t/c0rhwP2WQaybkE=";
+    hash = "sha256-K74Ghk4uDqj4OWEzDxT2R3ERi+jkAWZszzezRenfuZ8=";
   };
 
   testDataSrc = fetchFromGitHub {
     owner = "opencv";
     repo = "opencv_extra";
     rev = version;
-    sha256 = "sha256-6hAdJdaUgtRGQanQKuY/q6fcXWXFZ3K/oLbGxvksry0=";
+    hash = "sha256-pActKi7aN5EOZq2Fpf5mALnZq71c037/R3Q6wJ4uCfQ=";
   };
 
   # Contrib must be built in order to enable Tesseract support:
@@ -121,16 +127,16 @@ let
     src = fetchFromGitHub {
       owner = "opencv";
       repo = "opencv_3rdparty";
-      rev = "a56b6ac6f030c312b2dce17430eef13aed9af274";
-      sha256 = "1msbkc3zixx61rcg6a04i1bcfhw1phgsrh93glq1n80hgsk3nbjq";
+      rev = "0cc4aa06bf2bef4b05d237c69a5a96b9cd0cb85a";
+      hash = "sha256-/kHivOgCkY9YdcRRaVgytXal3ChE9xFfGAB0CfFO5ec=";
     } + "/ippicv";
-    files = let name = platform: "ippicv_2019_${platform}_general_20180723.tgz"; in
+    files = let name = platform: "ippicv_2021.10.0_${platform}_20230919_general.tgz"; in
       if effectiveStdenv.hostPlatform.system == "x86_64-linux" then
-        { ${name "lnx_intel64"} = "c0bd78adb4156bbf552c1dfe90599607"; }
+        { ${name "lnx_intel64"} = "606a19b207ebedfe42d59fd916cc4850"; }
       else if effectiveStdenv.hostPlatform.system == "i686-linux" then
-        { ${name "lnx_ia32"} = "4f38432c30bfd6423164b7a24bbc98a0"; }
+        { ${name "lnx_ia32"} = "ea08487b810baad2f68aca87b74a2db9"; }
       else if effectiveStdenv.hostPlatform.system == "x86_64-darwin" then
-        { ${name "mac_intel64"} = "fe6b2bb75ae0e3f19ad3ae1a31dfa4a2"; }
+        { ${name "mac_intel64"} = "14f01c5a4780bfae9dde9b0aaf5e56fc"; }
       else
         throw "ICV is not available for this platform (or not yet supported by this package)";
     dst = ".cache/ippicv";
@@ -142,7 +148,7 @@ let
       owner = "opencv";
       repo = "opencv_3rdparty";
       rev = "fccf7cd6a4b12079f73bbfb21745f9babcd4eb1d";
-      sha256 = "0r9fam8dplyqqsd3qgpnnfgf9l7lj44di19rxwbm8mxiw0rlcdvy";
+      hash = "sha256-fjdGM+CxV1QX7zmF2AiR9NDknrP2PjyaxtjT21BVLmU=";
     };
     files = {
       "vgg_generated_48.i" = "e8d0dcd54d1bcfdc29203d011a797179";
@@ -179,7 +185,7 @@ let
       owner = "opencv";
       repo = "opencv_3rdparty";
       rev = "8afa57abc8229d611c4937165d20e2a2d9fc5a12";
-      sha256 = "061lsvqdidq9xa2hwrcvwi9ixflr2c2lfpc8drr159g68zi8bp4v";
+      hash = "sha256-m9yF4kfmpRJybohdRwUTmboeU+SbZQ6F6gm32PDWNBg=";
     };
     files = {
       "face_landmark_model.dat" = "7505c44ca4eb54b4ab1e4777cb96ac05";
@@ -191,10 +197,10 @@ let
   ade = rec {
     src = fetchurl {
       url = "https://github.com/opencv/ade/archive/${name}";
-      sha256 = "sha256-TjLRbFbC7MDY9PxIy560ryviBI58cbQwqgc7A7uOHkg=";
+      hash = "sha256-WG/GudVpkO10kOJhoKXFMj672kggvyRYCIpezal3wcE=";
     };
-    name = "v0.1.2a.zip";
-    md5 = "fa4b3e25167319cb0fa9432ef8281945";
+    name = "v0.1.2d.zip";
+    md5 = "dbb095a8bf3008e91edbbf45d8d34885";
     dst = ".cache/ade";
   };
 
@@ -204,7 +210,7 @@ let
       owner = "opencv";
       repo = "opencv_3rdparty";
       rev = "a8b69ccc738421293254aec5ddb38bd523503252";
-      sha256 = "sha256-/n6zHwf0Rdc4v9o4rmETzow/HTv+81DnHP+nL56XiTY=";
+      hash = "sha256-/n6zHwf0Rdc4v9o4rmETzow/HTv+81DnHP+nL56XiTY=";
     };
     files = {
       "detect.caffemodel" = "238e2b2d6f3c18d6c3a30de0c31e23cf";
@@ -260,20 +266,6 @@ effectiveStdenv.mkDerivation {
   patches = [
     ./cmake-don-t-use-OpenCVFindOpenEXR.patch
   ] ++ lib.optionals enableContrib [
-    (fetchpatch {
-      name = "CVE-2023-2617.patch";
-      url = "https://github.com/opencv/opencv_contrib/commit/ccc277247ac1a7aef0a90353edcdec35fbc5903c.patch";
-      stripLen = 2;
-      extraPrefix = [ "opencv_contrib/" ];
-      sha256 = "sha256-drZ+DVn+Pk4zAZJ+LgX5u3Tz7MU0AEI/73EVvxDP3AU=";
-    })
-    (fetchpatch {
-      name = "CVE-2023-2618.patch";
-      url = "https://github.com/opencv/opencv_contrib/commit/ec406fa4748fb4b0630c1b986469e7918d5e8953.patch";
-      stripLen = 2;
-      extraPrefix = [ "opencv_contrib/" ];
-      sha256 = "sha256-cB5Tsh2fDOsc0BNtSzd6U/QoCjkd9yMW1QutUU69JJ0=";
-    })
   ] ++ lib.optional enableCuda ./cuda_opt_flow.patch;
 
   # This prevents cmake from using libraries in impure paths (which
@@ -300,60 +292,104 @@ effectiveStdenv.mkDerivation {
     echo '"(build info elided)"' > modules/core/version_string.inc
   '';
 
-  buildInputs = [ zlib pcre boost gflags protobuf_21 ]
-    ++ lib.optional enablePython pythonPackages.python
-    ++ lib.optional (effectiveStdenv.buildPlatform == effectiveStdenv.hostPlatform) hdf5
-    ++ lib.optional enableGtk2 gtk2
-    ++ lib.optional enableGtk3 gtk3
-    ++ lib.optional enableVtk vtk
-    ++ lib.optional enableJPEG libjpeg
-    ++ lib.optional enablePNG libpng
-    ++ lib.optional enableTIFF libtiff
-    ++ lib.optional enableWebP libwebp
-    ++ lib.optionals enableEXR [ openexr ilmbase ]
-    ++ lib.optional enableJPEG2000 openjpeg
-    ++ lib.optional enableFfmpeg ffmpeg
-    ++ lib.optionals (enableFfmpeg && effectiveStdenv.isDarwin)
-      [ VideoDecodeAcceleration bzip2 ]
-    ++ lib.optionals enableGStreamer (with gst_all_1; [ gstreamer gst-plugins-base gst-plugins-good ])
-    ++ lib.optional enableOvis ogre
-    ++ lib.optional enableGPhoto2 libgphoto2
-    ++ lib.optional enableDC1394 libdc1394
-    ++ lib.optional enableEigen eigen
-    ++ lib.optional enableBlas blas.provider
+  buildInputs = [
+    boost
+    gflags
+    glib
+    pcre2
+    protobuf_21
+    zlib
+  ] ++ lib.optionals enablePython [
+    pythonPackages.python
+  ] ++ lib.optionals (effectiveStdenv.buildPlatform == effectiveStdenv.hostPlatform) [
+    hdf5
+  ] ++ lib.optionals enableGtk2 [
+    gtk2
+  ] ++ lib.optionals enableGtk3 [
+    gtk3
+  ] ++ lib.optionals enableVtk [
+    vtk
+  ] ++ lib.optionals enableJPEG [
+    libjpeg
+  ] ++ lib.optionals enablePNG [
+    libpng
+  ] ++ lib.optionals enableTIFF [
+    libtiff
+  ] ++ lib.optionals enableWebP [
+    libwebp
+  ] ++ lib.optionals enableEXR [
+    openexr
+    ilmbase
+  ] ++ lib.optionals enableJPEG2000 [
+    openjpeg
+  ] ++ lib.optionals enableFfmpeg [
+    ffmpeg
+  ] ++ lib.optionals (enableFfmpeg && effectiveStdenv.isDarwin) [
+    bzip2
+    VideoDecodeAcceleration
+  ] ++ lib.optionals (enableGStreamer && effectiveStdenv.isLinux) (with gst_all_1; [
+    elfutils
+    gst-plugins-base
+    gst-plugins-good
+    gstreamer
+    libunwind
+    orc
+    zstd
+  ]) ++ lib.optionals enableOvis [
+    ogre
+  ] ++ lib.optionals enableGPhoto2 [
+    libgphoto2
+  ] ++ lib.optionals enableDC1394 [
+    libdc1394
+  ] ++ lib.optionals enableEigen [
+    eigen
+  ] ++ lib.optionals enableVA [
+    libva
+  ] ++ lib.optionals enableBlas [
+    blas.provider
+  ] ++ lib.optionals enableTesseract [
     # There is seemingly no compile-time flag for Tesseract.  It's
     # simply enabled automatically if contrib is built, and it detects
     # tesseract & leptonica.
-    ++ lib.optionals enableTesseract [ tesseract leptonica ]
-    ++ lib.optional enableTbb tbb
-    ++ lib.optionals effectiveStdenv.isDarwin [
-      bzip2 AVFoundation Cocoa VideoDecodeAcceleration CoreMedia MediaToolbox Accelerate
-    ]
-    ++ lib.optionals enableDocs [ doxygen graphviz-nox ]
-    ++ lib.optionals enableCuda (with cudaPackages; [
-      cuda_cudart.lib
-      cuda_cudart.dev
-      cuda_cccl.dev # <thrust/*>
-      libnpp.dev # npp.h
-      libnpp.lib
-      libnpp.static
-      nvidia-optical-flow-sdk
-    ] ++ lib.optionals enableCublas [
-      # May start using the default $out instead once
-      # https://github.com/NixOS/nixpkgs/issues/271792
-      # has been addressed
-      libcublas.static
-      libcublas.lib
-      libcublas.dev # cublas_v2.h
-    ] ++ lib.optionals enableCudnn [
-      cudnn.dev # cudnn.h
-      cudnn.lib
-      cudnn.static
-    ] ++ lib.optionals enableCufft [
-      libcufft.dev # cufft.h
-      libcufft.lib
-      libcufft.static
-    ]);
+    tesseract
+    leptonica
+  ] ++ lib.optionals enableTbb [
+    tbb
+  ] ++ lib.optionals effectiveStdenv.isDarwin [
+    bzip2
+    AVFoundation
+    Cocoa
+    VideoDecodeAcceleration
+    CoreMedia
+    MediaToolbox
+    Accelerate
+  ] ++ lib.optionals enableDocs [
+    doxygen
+    graphviz-nox
+  ] ++ lib.optionals enableCuda (with cudaPackages; [
+    cuda_cudart.lib
+    cuda_cudart.dev
+    cuda_cccl.dev # <thrust/*>
+    libnpp.dev # npp.h
+    libnpp.lib
+    libnpp.static
+    nvidia-optical-flow-sdk
+  ] ++ lib.optionals enableCublas [
+    # May start using the default $out instead once
+    # https://github.com/NixOS/nixpkgs/issues/271792
+    # has been addressed
+    libcublas.static
+    libcublas.lib
+    libcublas.dev # cublas_v2.h
+  ] ++ lib.optionals enableCudnn [
+    cudnn.dev # cudnn.h
+    cudnn.lib
+    cudnn.static
+  ] ++ lib.optionals enableCufft [
+    libcufft.dev # cufft.h
+    libcufft.lib
+    libcufft.static
+  ]);
 
   propagatedBuildInputs = lib.optionals enablePython [ pythonPackages.numpy ];
 

--- a/pkgs/development/python-modules/pillow-heif/default.nix
+++ b/pkgs/development/python-modules/pillow-heif/default.nix
@@ -55,6 +55,9 @@ buildPythonPackage rec {
     x265
   ];
 
+  # clang-16: error: argument unused during compilation: '-fno-strict-overflow' [-Werror,-Wunused-command-line-argument]
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-unused-command-line-argument";
+
   propagatedBuildInputs = [
     pillow
   ];


### PR DESCRIPTION
https://github.com/opencv/opencv/wiki/ChangeLog#version490

## Description of changes

- Supprt for Python 3.12
- GStreamer support is now effectively limited by availability of elfutils, so no longer on darwin
- VAAAPI support is now available on !darwin

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
