### PR TITLE
certificate-ripper: 2.2.0 -> 2.3.0

### DIFF
--- a/pkgs/by-name/ce/certificate-ripper/package.nix
+++ b/pkgs/by-name/ce/certificate-ripper/package.nix
@@ -6,7 +6,7 @@
 
 let
   pname = "certificate-ripper";
-  version = "2.2.0";
+  version = "2.3.0";
 
   jar = maven.buildMavenPackage {
     pname = "${pname}-jar";
@@ -16,15 +16,20 @@ let
       owner = "Hakky54";
       repo = "certificate-ripper";
       rev = version;
-      hash = "sha256-snavZVLY8sHinLnG6k61eSQlR9sb8+k5tRHqu4kzQKM=";
+      hash = "sha256-q/UhKLFAre3YUH2W7e+SH4kRM0GIZAUyNJFDm02eL+8=";
     };
 
     patches = [
-      ./make-deterministic.patch
+      ./pin-default-maven-plguin-versions.patch
       ./fix-test-temp-dir-path.patch
     ];
 
-    mvnHash = "sha256-ahw9VVlvBPlWChcJzXFna55kxqVeJMmdaLtwWcJ+qSA=";
+    mvnHash = "sha256-/iy7DXBAyq8TIpvrd2WAQh+9OApfxCWo1NoGwbzbq7s=";
+
+    mvnParameters = lib.escapeShellArgs [
+      "-Dproject.build.outputTimestamp=1980-01-01T00:00:02Z" # make timestamp deterministic
+      "-Dtest=!PemExportCommandShould#resolveRootCaOnlyWhenEnabled" # disable test using network
+    ];
 
     installPhase = ''
       install -Dm644 target/crip.jar $out

--- a/pkgs/by-name/ce/certificate-ripper/pin-default-maven-plguin-versions.patch
+++ b/pkgs/by-name/ce/certificate-ripper/pin-default-maven-plguin-versions.patch
@@ -2,15 +2,7 @@ diff --git a/pom.xml b/pom.xml
 index dd0075d..46ac184 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -46,6 +46,7 @@
-         <version.license-maven-plugin>4.2.rc3</version.license-maven-plugin>
-         <license.git.copyrightYears>2021</license.git.copyrightYears>
-         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-+        <project.build.outputTimestamp>1980-01-01T00:00:02Z</project.build.outputTimestamp>
-     </properties>
- 
-     <scm>
-@@ -103,6 +104,55 @@
+@@ -103,6 +103,55 @@
  
      <build>
          <plugins>


### PR DESCRIPTION
## Description of changes

This PR bumps the version of `certificate-ripper`

Release notes: https://github.com/Hakky54/certificate-ripper/releases/tag/2.3.0

This release has added some extra tests, one of which was trying to fetch something from `google.com`, so I needed to disable it.

I also renamed the `.patch` file to something more descriptive and moved the timestamp fix from the patch into `mvnParameters`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
