### PR TITLE
git-radar: add coreutils-prefixed to PATH on darwin

### DIFF
--- a/pkgs/applications/version-management/git-radar/default.nix
+++ b/pkgs/applications/version-management/git-radar/default.nix
@@ -1,4 +1,4 @@
-{lib, stdenv, fetchFromGitHub}:
+{ coreutils-prefixed, lib, makeWrapper, stdenv, fetchFromGitHub }:
 
 stdenv.mkDerivation rec {
   pname = "git-radar";
@@ -11,12 +11,17 @@ stdenv.mkDerivation rec {
     sha256 = "0c3zp8s4w7m4s71qgwk1jyfc8yzw34f2hi43x1w437ypgabwg81j";
   };
 
+  nativeBuildInputs = [ makeWrapper ];
+
   dontBuild = true;
 
   installPhase = ''
     mkdir -p $out/bin
     cp git-radar fetch.sh prompt.bash prompt.zsh radar-base.sh $out
     ln -s $out/git-radar $out/bin
+    ${lib.optionalString stdenv.isDarwin ''
+      wrapProgram $out/git-radar --prefix PATH : ${lib.makeBinPath [ coreutils-prefixed ]}
+    ''}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

On Darwin, git-radar assumes that prefixed coreutils `gstat`, `greadlink` etc. are available in PATH, see e.g.:
* https://github.com/michaeldfallen/git-radar/blob/2ac25e3d1047cdf19f15bc894ff39449b83d65d4/git-radar#L7-L11
* https://github.com/michaeldfallen/git-radar/blob/2ac25e3d1047cdf19f15bc894ff39449b83d65d4/radar-base.sh#L144-L151

When they are not available, git-radar will fail with an error message:

```console
$ ./result/bin/git-radar --bash
./result/bin/git-radar: line 13: greadlink: command not found
```

This PR adds a Darwin-only wrapper to add the prefixed coreutils to the script's PATH.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
