### PR TITLE
flexoptix-app: 5.16.0 -> 5.20.0

### DIFF
--- a/pkgs/tools/misc/flexoptix-app/default.nix
+++ b/pkgs/tools/misc/flexoptix-app/default.nix
@@ -1,11 +1,11 @@
 { lib, appimageTools, fetchurl, asar }: let
   pname = "flexoptix-app";
-  version = "5.16.0-latest";
+  version = "5.20.0-latest";
 
   src = fetchurl {
     name = "${pname}-${version}.AppImage";
     url = "https://flexbox.reconfigure.me/download/electron/linux/x64/FLEXOPTIX%20App.${version}.AppImage";
-    hash = "sha256-A10r8IUB3zWKWmjen90vLXPF7V/Cgo+DhFn/Hsc1Nhg=";
+    hash = "sha256-/4vZaVLpSiufjNwwofPi+YBtTJ4aq7eYgFnYFv89LFY=";
   };
 
   udevRules = fetchurl {
@@ -19,7 +19,7 @@
 
       # Get rid of the autoupdater
       ${asar}/bin/asar extract $out/resources/app.asar app
-      sed -i 's/async isUpdateAvailable.*/async isUpdateAvailable(updateInfo) { return false;/g' app/node_modules/electron-updater/out/AppUpdater.js
+      patch -p0 < ${./disable-autoupdate.patch}
       ${asar}/bin/asar pack app $out/resources/app.asar
     '';
   });

--- a/pkgs/tools/misc/flexoptix-app/disable-autoupdate.patch
+++ b/pkgs/tools/misc/flexoptix-app/disable-autoupdate.patch
@@ -1,0 +1,16 @@
+--- app/electron/jsComponents/mainWindowEvents.js	2024-02-18 12:53:41.115773007 -0500
++++ app/electron/jsComponents/mainWindowEvents.js2	2024-02-18 23:22:20.003280203 -0500
+@@ -128,7 +128,12 @@
+ 
+ 	if (app.isPackaged) {
+ 		global.mainWindow.webContents.once("did-finish-load", function () {
+-			autoUpdater.checkForUpdates();
++			global.mainWindow.loadURL(
++				url.format({
++					...global.APPLICATION_URL_OBJECT,
++					slashes: true,
++				}),
++			);
+ 		});
+ 	} else {
+ 		global.mainWindow.webContents.openDevTools();


### PR DESCRIPTION
## Description of changes

https://www.flexoptix.net/en/flexoptix-app/

Starting with 5.19.0, the appimage would still hang when checking for updates, so just patch out the check directly.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
