### PR TITLE
power-profiles-daemon 0.13 -> 0.20

### DIFF
--- a/pkgs/os-specific/linux/power-profiles-daemon/default.nix
+++ b/pkgs/os-specific/linux/power-profiles-daemon/default.nix
@@ -27,16 +27,16 @@
 
 stdenv.mkDerivation rec {
   pname = "power-profiles-daemon";
-  version = "0.13";
+  version = "0.20";
 
   outputs = [ "out" "devdoc" ];
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
-    owner = "hadess";
+    owner = "upower";
     repo = "power-profiles-daemon";
     rev = version;
-    sha256 = "sha256-ErHy+shxZQ/aCryGhovmJ6KmAMt9OZeQGDbHIkC0vUE=";
+    sha256 = "sha256-8wSRPR/1ELcsZ9K3LvSNlPcJvxRhb/LRjTIxKtdQlCA=";
   };
 
   nativeBuildInputs = [
@@ -52,6 +52,7 @@ stdenv.mkDerivation rec {
     gobject-introspection
     wrapGAppsNoGuiHook
     python3.pkgs.wrapPython
+    argparse-manpage
     # checkInput but cheked for during the configuring
     (python3.pythonOnBuildForHost.withPackages (ps: with ps; [
       pygobject3
@@ -100,6 +101,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     patchShebangs --build \
+      src/powerprofilesctl \
       tests/integration-test.py \
       tests/unittest_inspector.py
   '';


### PR DESCRIPTION
## Description of changes

[Changelog](https://gitlab.freedesktop.org/upower/power-profiles-daemon/-/commit/0d3030b6109156a093b73c66aea2ef3118a79650):

The project has moved under the freedesktop 'Upower' group. The service is
now advertised as 'org.freedesktop.UPower.PowerProfiles' in addition to the
previous 'net.hadess.PowerProfiles' for compatibility reasons.

This release adds support for:

* Multiple power-profiles-daemon drivers to load simultaneously.  This notably
  allows both CPU based control with amd-pstate or intel-pstate as well as
  ACPI platform profile based control.

* amdgpu panel power savings which uses dedicated hardware in systems with
  integrated Radeon graphics to decrease panel power consumption when the
  system is on battery.

This release also enables the test suite by default, so distribution vendors
should update packaging accordingly.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Closes #289019

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
