### PR TITLE
osc-cli: init at 1.11.0

### DIFF
--- a/pkgs/by-name/os/osc-cli/package.nix
+++ b/pkgs/by-name/os/osc-cli/package.nix
@@ -1,0 +1,41 @@
+{
+  lib
+  , python3
+  , fetchFromGitHub
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "osc-cli";
+  version = "1.11.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "outscale";
+    repo = "osc-cli";
+    rev = "v${version}";
+    hash = "sha256-7WXy+1NHwFvYmyi5xGfWpq/mbVGJ3WkgP5WQd5pvcC0=";
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    defusedxml
+    fire
+    requests
+    typing-extensions
+    xmltodict
+  ];
+
+  # Skipping tests as they require working access and secret keys
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Official Outscale CLI providing connectors to Outscale API";
+    homepage = "https://github.com/outscale/osc-cli";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ nicolas-goudry ];
+    mainProgram = "osc-cli";
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is the official [Outscale](https://outscale.com) CLI providing connectors to Outscale API.

Please note that meanwhile this CLI is currently in maintenance mode, it has been in such state for 5 months only. I’m currently trying to package its replacement ([oapi-cli](https://github.com/outscale/oapi-cli)) but since this is still a WIP, I’m adding this one in the meantime, which I know is still heavily being used by users.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
