### PR TITLE
stremio: add ffmpeg as runtime dependency to PATH

### DIFF
--- a/pkgs/applications/video/stremio/default.nix
+++ b/pkgs/applications/video/stremio/default.nix
@@ -1,5 +1,13 @@
-{ lib, stdenv, fetchurl, fetchFromGitHub, qmake, wrapQtAppsHook
-, mpv, qtwebengine, qtwebchannel, nodejs
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchurl
+, mpv
+, nodejs
+, qmake
+, qtwebchannel
+, qtwebengine
+, wrapQtAppsHook
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/applications/video/stremio/default.nix
+++ b/pkgs/applications/video/stremio/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , fetchurl
+, ffmpeg
 , mpv
 , nodejs
 , qmake
@@ -38,6 +39,8 @@ stdenv.mkDerivation rec {
     install -Dm 644 images/stremio_window.png $out/share/pixmaps/smartcode-stremio.png
     ln -s ${nodejs}/bin/node $out/opt/stremio/node
     ln -s $server $out/opt/stremio/server.js
+    wrapProgram $out/bin/stremio \
+      --suffix PATH ":" ${lib.makeBinPath [ ffmpeg ]}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Stremio depends on `ffmpeg` for features such as streaming to a chromecast. Without `ffmpeg`, when trying to stream to a chromecast, it never loads, when adding ffmpeg to `PATH` (for example in an ad-hoc nix shell), the feature works fine.

So, this PR wraps the derivation executable with `ffmpeg` binaries added to `PATH`.

This dependency can also be confirmed by seeing some of the official build scripts, that list both the `ffmpeg` and `ffprobe` (the latter is also included in the `ffmpeg` package) binaries:

- [AppImage](https://github.com/Stremio/stremio-shell/blob/b7f862e1fb89744c5c54ae81e5dd87ff81cab967/AppImage.makefile#L19-L20)
- [Windows](https://github.com/Stremio/stremio-shell/blob/b7f862e1fb89744c5c54ae81e5dd87ff81cab967/build_windows.bat#L34-L35)
- [Arch Linux](https://github.com/Stremio/stremio-shell/blob/b7f862e1fb89744c5c54ae81e5dd87ff81cab967/distros/ArchLinux/PKGBUILD#L11)

I also split the derivation arguments into multiple lines, as the list was already pretty long, and I had to add a new dependency.

Another missing dependency seems to be `openssl`. However, when searching the code, it seems only to be used for the autoupdate feature, which will not be useful in the nix package, so I believe it would be fine to not include it.

- [autoupdater.cpp](https://github.com/Stremio/stremio-shell/blob/b7f862e1fb89744c5c54ae81e5dd87ff81cab967/autoupdater.cpp#L9)
- [verifysig.c](https://github.com/Stremio/stremio-shell/blob/b7f862e1fb89744c5c54ae81e5dd87ff81cab967/verifysig.c#L5)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
