### PR TITLE
discord: fix krisp module

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/fix-krisp.py
+++ b/pkgs/applications/networking/instant-messengers/discord/fix-krisp.py
@@ -1,0 +1,114 @@
+#!@pythonInterpreter@
+# slightly modefied version from the script created by @sersorrel
+# https://github.com/sersorrel/sys/blob/main/hm/discord/krisp-patcher.py
+"""
+This fixes the krisp module not loading.
+"""
+
+
+import subprocess
+import re
+import signal
+import os
+import shutil
+import sys
+
+from pathlib import Path
+from elftools.elf.elffile import ELFFile
+from capstone import *
+from capstone.x86 import *
+
+def getKrisp():
+    process = subprocess.Popen(sys.argv[1], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=False, universal_newlines=True, preexec_fn=os.setsid)
+    print("[Nix] Leting Discord download Krisp")
+    try:
+        for line in iter(process.stdout.readline, ''):
+            print(line, end='')
+            if re.search("installed-module discord_krisp", line):
+                os.killpg(os.getpgid(process.pid), signal.SIGTERM)
+                print("[Nix] Finished downloading Krisp")
+                break
+    finally:
+        process.wait()
+        process.stdout.close()
+
+
+XDG_CONFIG_HOME = os.environ.get("XDG_CONFIG_HOME") or os.path.join(
+    os.path.expanduser("~"), ".config"
+)
+
+executable = f"{XDG_CONFIG_HOME}/@configDirName@/@version@/modules/discord_krisp/discord_krisp.node"
+
+if (not os.path.exists(Path(executable))):
+    print("[Nix] Krisp not found")
+    getKrisp()
+
+elf = ELFFile(open(executable, "rb"))
+symtab = elf.get_section_by_name('.symtab')
+
+krisp_initialize_address = symtab.get_symbol_by_name("_ZN7discord15KrispInitializeEv")[0].entry.st_value
+isSignedByDiscord_address = symtab.get_symbol_by_name("_ZN7discord4util17IsSignedByDiscordERKNSt2Cr12basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE")[0].entry.st_value
+
+text = elf.get_section_by_name('.text')
+text_start = text['sh_addr']
+text_start_file = text['sh_offset']
+# This seems to always be zero (.text starts at the right offset in the file). Do it just in case?
+address_to_file = text_start_file - text_start
+
+# Done with the ELF now.
+# elf.close()
+
+krisp_initialize_offset = krisp_initialize_address - address_to_file
+isSignedByDiscord_offset = krisp_initialize_address - address_to_file
+
+f = open(executable, "rb")
+f.seek(krisp_initialize_offset)
+krisp_initialize = f.read(64)
+f.close()
+
+# States
+found_issigned_by_discord_call = False
+found_issigned_by_discord_test = False
+found_issigned_by_discord_je = False
+found_already_patched = False
+je_location = None
+
+# We are looking for a call to IsSignedByDiscord, followed by a test, followed by a je.
+# Then we patch the je into a two byte nop.
+
+md = Cs(CS_ARCH_X86, CS_MODE_64)
+md.detail = True
+for i in md.disasm(krisp_initialize, krisp_initialize_address):
+    if i.id == X86_INS_CALL:
+        if i.operands[0].type == X86_OP_IMM:
+            if i.operands[0].imm == isSignedByDiscord_address:
+                found_issigned_by_discord_call = True
+
+    if i.id == X86_INS_TEST:
+        if found_issigned_by_discord_call:
+            found_issigned_by_discord_test = True
+
+    if i.id == X86_INS_JE:
+        if found_issigned_by_discord_test:
+            found_issigned_by_discord_je = True
+            je_location = i.address
+            break
+
+    if i.id == X86_INS_NOP:
+        if found_issigned_by_discord_test:
+            found_already_patched = True
+            break
+
+if je_location:
+    print(f"[Nix] Found patch location: 0x{je_location:x}")
+
+    shutil.copyfile(executable, executable + ".orig")
+    f = open(executable, 'rb+')
+    f.seek(je_location - address_to_file)
+    f.write(b'\x66\x90')  # Two byte NOP
+    f.close()
+else:
+    if found_already_patched:
+        print("[Nix] Couldn't find patch location - already patched.")
+    else:
+        print("[Nix] Couldn't find patch location - review manually. Sorry.")

--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -25,6 +25,18 @@ let
     substituteAllInPlace $out/bin/disable-breaking-updates.py
     chmod +x $out/bin/disable-breaking-updates.py
   '';
+  fixKrisp = runCommand "fix-krisp.py"
+    {
+      pythonInterpreter = lib.getExe (python3.withPackages(ps: with ps; [ pyelftools capstone ]));
+      configDirName = lib.toLower binaryName;
+      version = version;
+      meta.mainProgram = "fix-krisp.py";
+    } ''
+    mkdir -p $out/bin
+    cp ${./fix-krisp.py} $out/bin/fix-krisp.py
+    substituteAllInPlace $out/bin/fix-krisp.py
+    chmod +x $out/bin/fix-krisp.py
+  '';
 in
 
 stdenv.mkDerivation rec {
@@ -109,7 +121,8 @@ stdenv.mkDerivation rec {
         ${lib.strings.optionalString withTTS "--add-flags \"--enable-speech-dispatcher\""} \
         --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
         --prefix LD_LIBRARY_PATH : ${libPath}:$out/opt/${binaryName} \
-        --run "${lib.getExe disableBreakingUpdates}"
+        --run "${lib.getExe disableBreakingUpdates}" \
+        --run "${lib.getExe fixKrisp} $out/opt/${binaryName}/.${binaryName}-wrapped"
 
     ln -s $out/opt/${binaryName}/${binaryName} $out/bin/
     # Without || true the install would fail on case-insensitive filesystems


### PR DESCRIPTION
## Description of changes
This includes a modified version of @sersorrel's [krips-patcher.py](https://github.com/sersorrel/sys/blob/main/hm/discord/krisp-patcher.py) to fix krisp not working.

If it's okay with you @sersorrel that we included it in nixpkgs.

Closes #195512

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
