### PR TITLE
stdenv: log build hooks as they run

### DIFF
--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -432,7 +432,7 @@ The propagated equivalent of `depsTargetTarget`. This is prefixed for the same r
 
 #### `NIX_DEBUG` {#var-stdenv-NIX_DEBUG}
 
-A number between 0 and 7 indicating how much information to log. If set to 1 or higher, `stdenv` will print moderate debugging information during the build. In particular, the `gcc` and `ld` wrapper scripts will print out the complete command line passed to the wrapped tools. If set to 6 or higher, the `stdenv` setup script will be run with `set -x` tracing. If set to 7 or higher, the `gcc` and `ld` wrapper scripts will also be run with `set -x` tracing.
+A number between 0 and 7 indicating how much information to log. If set to 1 or higher, `stdenv` will print moderate debugging information during the build. In particular, the `gcc` and `ld` wrapper scripts will print out the complete command line passed to the wrapped tools. If set to 2 or higher, multiline build hooks will be printed literally. If set to 6 or higher, the `stdenv` setup script will be run with `set -x` tracing. If set to 7 or higher, the `gcc` and `ld` wrapper scripts will also be run with `set -x` tracing.
 
 ### Attributes affecting build properties {#attributes-affecting-build-properties}
 

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -50,6 +50,42 @@ getAllOutputNames() {
 ######################################################################
 # Hook handling.
 
+# Log a hook, to be run before the hook is actually called.
+# logging for "implicit" hooks -- the ones specified directly
+# in derivation's arguments -- is done in _callImplicitHook instead.
+_logHook() {
+    local hookKind="$1"
+    local hookExpr="$2"
+    shift 2
+
+    if declare -F "$hookExpr" > /dev/null 2>&1; then
+        echo "calling '$hookKind' function hook '$hookExpr'" "$@"
+    elif type -p "$hookExpr" > /dev/null; then
+        echo "sourcing '$hookKind' script hook '$hookExpr'"
+    elif [[ "$hookExpr" != "_callImplicitHook"* ]]; then
+        # Here we have a string hook to eval.
+        # Join lines onto one with literal \n characters unless NIX_DEBUG >= 2.
+        local exprToOutput
+        if (( "${NIX_DEBUG:-0}" >= 2 )); then
+            exprToOutput="$hookExpr"
+        else
+            while IFS= read -r hookExprLine; do
+                # These lines often have indentation,
+                # so let's removing leading whitespace.
+                hookExprLine="${hookExprLine#"${hookExprLine%%[![:space:]]*}"}"
+                # If this line wasn't entirely whitespace,
+                # then add it to our output.
+                 if [[ -n "$hookExprLine" ]]; then
+                     exprToOutput+="$hookExprLine\\n "
+                 fi
+            done <<< "$hookExpr"
+
+            # And then remove the final, unnecessary, \n
+            exprToOutput="${exprToOutput%%\\n }"
+        fi
+        echo "evaling '$hookKind' string hook '$exprToOutput'"
+    fi
+}
 
 # Run all hooks with the specified name in the order in which they
 # were added, stopping if any fails (returns a non-zero exit
@@ -64,6 +100,7 @@ runHook() {
     # Hack around old bash being bad and thinking empty arrays are
     # undefined.
     for hook in "_callImplicitHook 0 $hookName" ${!hooksSlice+"${!hooksSlice}"}; do
+        _logHook "$hookName" "$hook" "$@"
         _eval "$hook" "$@"
     done
 
@@ -81,6 +118,7 @@ runOneHook() {
     local hook ret=1
     # Hack around old bash like above
     for hook in "_callImplicitHook 1 $hookName" ${!hooksSlice+"${!hooksSlice}"}; do
+        _logHook "$hookName" "$hook" "$@"
         if _eval "$hook" "$@"; then
             ret=0
             break
@@ -100,10 +138,13 @@ _callImplicitHook() {
     local def="$1"
     local hookName="$2"
     if declare -F "$hookName" > /dev/null; then
+        echo "calling implicit '$hookName' function hook"
         "$hookName"
     elif type -p "$hookName" > /dev/null; then
+        echo "sourcing implicit '$hookName' script hook"
         source "$hookName"
     elif [ -n "${!hookName:-}" ]; then
+        echo "evaling implicit '$hookName' string hook"
         eval "${!hookName}"
     else
         return "$def"
@@ -644,6 +685,7 @@ activatePackage() {
     (( hostOffset <= targetOffset )) || exit 1
 
     if [ -f "$pkg" ]; then
+        echo "sourcing setup hook '$pkg'"
         source "$pkg"
     fi
 
@@ -667,6 +709,7 @@ activatePackage() {
     fi
 
     if [[ -f "$pkg/nix-support/setup-hook" ]]; then
+        echo "sourcing setup hook '$pkg/nix-support/setuphook'"
         source "$pkg/nix-support/setup-hook"
     fi
 }

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -51,8 +51,8 @@ getAllOutputNames() {
 # Hook handling.
 
 # Log a hook, to be run before the hook is actually called.
-# logging for "implicit" hooks -- the ones specified directly
-# in derivation's arguments -- is done in _callImplicitHook instead.
+# This only logs explicit hooks; "implicit" hooks, those specified directly
+# in a derivation's arguments, are logged in `_callImplicitHook` instead.
 _logHook() {
     local hookKind="$1"
     local hookExpr="$2"

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -71,13 +71,13 @@ _logHook() {
         else
             while IFS= read -r hookExprLine; do
                 # These lines often have indentation,
-                # so let's removing leading whitespace.
+                # so let's remove leading whitespace.
                 hookExprLine="${hookExprLine#"${hookExprLine%%[![:space:]]*}"}"
                 # If this line wasn't entirely whitespace,
                 # then add it to our output.
-                 if [[ -n "$hookExprLine" ]]; then
-                     exprToOutput+="$hookExprLine\\n "
-                 fi
+                if [[ -n "$hookExprLine" ]]; then
+                    exprToOutput+="$hookExprLine\\n "
+                fi
             done <<< "$hookExpr"
 
             # And then remove the final, unnecessary, \n


### PR DESCRIPTION
## Description of changes

Hooks are vital to Nixpkgs, and are often the "magic" to make things Just Work, but they're also extremely opaque. Adding something like `undmg` to a derivation's `nativeBuildInputs` adds a hook to the unpackPhase to automatically extract DMG sources — this is fantastic, but a beginner would have *no* way of knowing that adding something as a build input could have such a major effect (`undmg` gets only a [single passing mention](https://nixos.org/manual/nixpkgs/unstable/#unzip) in the Nixpkgs manual), and even to Nixpkgs veterans it's *far* from obvious what the final array of hooks for a build might be, or what order they even run in (a source of confusion if one causes an error!).

This PR changes stdenv's setup.sh to log hooks to stdout as they run, as it does currently with phases. Setup hook files are logged just before they're sourced, and individual build hooks like `patchShebangsAuto` are also logged just before they're run.

With this PR, now anyone building with `--print-build-logs` will have transparency into one of the most important aspects of Nixpkgs, to aid heavily in both debugging and learning.


<details>
<summary>For example, here what it now looks like when building Curlie:</summary>
<code><pre>
sourcing setup hook '/nix/store/33jvc2jsv20lsx8dp0pwf0rr7xhwwpq9-patchelf-0.15.0/nix-support/setuphook'
sourcing setup hook '/nix/store/qmavq4i2rh012ggwb5fxlvp3pzhxmbkl-update-autotools-gnu-config-scripts-hook/nix-support/setuphook'
sourcing setup hook '/nix/store/h9lc1dpi14z7is86ffhl3ld569138595-audit-tmpdir.sh'
sourcing setup hook '/nix/store/m54bmrhj6fqz8nds5zcj97w9s9bckc9v-compress-man-pages.sh'
sourcing setup hook '/nix/store/wgrbkkaldkrlrni33ccvm3b6vbxzb656-make-symlinks-relative.sh'
sourcing setup hook '/nix/store/5yzw0vhkyszf2d179m0qfkgxmp5wjjx4-move-docs.sh'
sourcing setup hook '/nix/store/fyaryjvghbkpfnsyw97hb3lyb37s1pd6-move-lib64.sh'
sourcing setup hook '/nix/store/kd4xwxjpjxi71jkm6ka0np72if9rm3y0-move-sbin.sh'
sourcing setup hook '/nix/store/pag6l61paj1dc9sv15l7bm5c17xn5kyk-move-systemd-user-units.sh'
sourcing setup hook '/nix/store/jivxp510zxakaaic7qkrb7v1dd2rdbw9-multiple-outputs.sh'
sourcing setup hook '/nix/store/wzdsbnv2ba3nj91aql8jjdddfmkkdh7h-patch-shebangs.sh'
sourcing setup hook '/nix/store/cickvswrvann041nqxb0rxilc46svw1n-prune-libtool-files.sh'
sourcing setup hook '/nix/store/xyff06pkhki3qy1ls77w10s0v79c9il0-reproducible-builds.sh'
sourcing setup hook '/nix/store/ngg1cv31c8c7bcm2n8ww4g06nq7s4zhm-set-source-date-epoch-to-latest.sh'
sourcing setup hook '/nix/store/wmknncrif06fqxa16hpdldhixk95nds0-strip.sh'
sourcing setup hook '/nix/store/w0x01w0vcdzvaj90axjxq6w2p290cp5m-gcc-wrapper-13.2.0/nix-support/setuphook'
sourcing setup hook '/nix/store/1byi00pspg4j6jpvaj4xn2mfkyh28g9g-binutils-wrapper-2.40/nix-support/setuphook'
@nix { "action": "setPhase", "phase": "unpackPhase" }
Running phase: unpackPhase
unpacking source archive /nix/store/1mmyk26f86cg3cvs9djg0l4cf95hwl7q-source
calling 'unpackCmd' function hook '_defaultUnpack' /nix/store/1mmyk26f86cg3cvs9djg0l4cf95hwl7q-source
source root is source
calling 'postUnpack' function hook '_updateSourceDateEpochFromSourceRoot'
@nix { "action": "setPhase", "phase": "patchPhase" }
Running phase: patchPhase
applying patch /nix/store/2q6i5q3jin7d357dm53hdkancj5wzpaq-bump-golang-x-sys.patch
patching file go.mod
patching file go.sum
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "configurePhase" }
Running phase: configurePhase
calling 'preConfigure' function hook '_multioutConfig'
@nix { "action": "setPhase", "phase": "buildPhase" }
Running phase: buildPhase
Building subPackage .
Building subPackage ./args
Building subPackage ./formatter
@nix { "action": "setPhase", "phase": "checkPhase" }
Running phase: checkPhase
ok  	github.com/rs/curlie/args	0.001s
@nix { "action": "setPhase", "phase": "installPhase" }
Running phase: installPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
Running phase: fixupPhase
calling 'preFixup' function hook '_moveToShare'
calling 'preFixup' function hook '_multioutDocs'
calling 'preFixup' function hook '_multioutDevs'
evaling 'fixupOutput' string hook 'if [ -z "${dontPatchELF-}" ]; then patchELF "$prefix"; fi'
shrinking RPATHs of ELF executables and libraries in /nix/store/crnvz72hxrp3cc0wrfcdaivyymqiy55q-curlie-1.7.2
shrinking /nix/store/crnvz72hxrp3cc0wrfcdaivyymqiy55q-curlie-1.7.2/bin/curlie
patchelf: cannot find section '.dynamic'. The input file is most likely statically linked
evaling 'fixupOutput' string hook 'if [[ -z "${noAuditTmpdir-}" && -e "$prefix" ]]; then auditTmpdir "$prefix"; fi'
checking for references to /build/ in /nix/store/crnvz72hxrp3cc0wrfcdaivyymqiy55q-curlie-1.7.2...
patchelf: cannot find section '.dynamic'. The input file is most likely statically linked
evaling 'fixupOutput' string hook 'if [ -z "${dontGzipMan-}" ]; then compressManPages "$prefix"; fi'
calling 'fixupOutput' function hook '_moveLib64'
calling 'fixupOutput' function hook '_moveSbin'
calling 'fixupOutput' function hook '_moveSystemdUserUnits'
calling 'fixupOutput' function hook 'patchShebangsAuto'
patching script interpreter paths in /nix/store/crnvz72hxrp3cc0wrfcdaivyymqiy55q-curlie-1.7.2
calling 'fixupOutput' function hook '_pruneLibtoolFiles'
calling 'fixupOutput' function hook '_doStrip'
stripping (with command strip and flags -S -p) in  /nix/store/crnvz72hxrp3cc0wrfcdaivyymqiy55q-curlie-1.7.2/bin
calling 'postFixup' function hook '_makeSymlinksRelativeInAllOutputs'
calling 'postFixup' function hook '_multioutPropagateDev'
</pre></code>
</details>

There are more example output diffs at https://github.com/Qyriad/nixpkgs/compare/before/diag/log-hooks...Qyriad:nixpkgs:after/diag/log-hooks?diff=split&w=.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
	- This is a mass rebuild and I don't particularly want to turn my computer into a space heater, but I did test all the packages listed in the above diff
- [ ] (N/A) Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
	- Other major stdenv PRs don't seem to have done this, so I haven't, but can if desired
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
