### PR TITLE
flottbot: init at 0.13.0

### DIFF
--- a/pkgs/by-name/fl/flottbot/package.nix
+++ b/pkgs/by-name/fl/flottbot/package.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, nix-update-script
+, substituteAll
+}:
+buildGoModule rec {
+  pname = "flottbot";
+  version = "0.13.0";
+
+  src = fetchFromGitHub {
+    owner = "target";
+    repo = "flottbot";
+    rev = version;
+    hash = "sha256-ldWE5QcLHyIqap5Qe6OTTIJZ1sshI+CVoJoRUxWHfxM=";
+  };
+
+  patches = [
+    # patch out debug.ReadBuidlInfo since version information is not available with buildGoModule
+    (substituteAll {
+      src = ./version.patch;
+      version = version;
+      vcsHash = version; # Maybe there is a way to get the git ref from src? idk.
+    })
+  ];
+
+  vendorHash = "sha256-XRcTp3ZnoPupzI1kjoM4oF5+VlNJFV0Bu+WAwfRWl7g=";
+
+  subPackages = [ "cmd/flottbot" ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = with lib; {
+    description = "A chatbot framework written in Go";
+    homepage = "https://github.com/target/flottbot";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bryanhonof ];
+    sourceProvenance = [ sourceTypes.fromSource ];
+    mainProgram = "flottbot";
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/by-name/fl/flottbot/version.patch
+++ b/pkgs/by-name/fl/flottbot/version.patch
@@ -1,0 +1,37 @@
+diff --git a/version/version.go b/version/version.go
+index 9ca8aba..d9bd968 100644
+--- a/version/version.go
++++ b/version/version.go
+@@ -4,9 +4,6 @@ package version
+ 
+ import (
+ 	"fmt"
+-	"runtime/debug"
+-
+-	"github.com/Masterminds/semver/v3"
+ )
+ 
+ // Version supplies the semantic version.
+@@ -14,20 +11,8 @@ var Version string
+ 
+ // String prints the build information for the bot.
+ func String() string {
+-	hash := "unknown"
+-
+-	_, err := semver.NewVersion(Version)
+-	if err != nil {
+-		Version = "dev"
+-	}
+-
+-	if info, ok := debug.ReadBuildInfo(); ok {
+-		for _, s := range info.Settings {
+-			if s.Key == "vcs.revision" {
+-				hash = s.Value
+-			}
+-		}
+-	}
++	Version = "@version@"
++	hash := "@vcsHash@"
+ 
+ 	return fmt.Sprintf("Version : %s\nGit Hash: %s\n", Version, hash)
+ }


### PR DESCRIPTION
## Description of changes

cc: @Janik-Haag 

Initialize [flottbot](https://github.com/target/flottbot) at version 0.13.0.
Continuation of https://github.com/NixOS/nixpkgs/pull/229444

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
