### PR TITLE
nixos/seafile: add persistent user, configurable storage path, and gc service

### DIFF
--- a/nixos/modules/services/networking/seafile.nix
+++ b/nixos/modules/services/networking/seafile.nix
@@ -29,8 +29,8 @@ let
 
   seafRoot = "/var/lib/seafile"; # hardcode it due to dynamicuser
   ccnetDir = "${seafRoot}/ccnet";
-  dataDir = "${seafRoot}/data";
   seahubDir = "${seafRoot}/seahub";
+  defaultUser = "seafile";
 
 in
 {
@@ -118,11 +118,39 @@ in
       type = types.str;
       description = ''
         Seafile Seahub Admin Account initial password.
-        Should be change via Seahub web front-end.
+        Should be changed via Seahub web front-end.
       '';
     };
 
     seafilePackage = mkPackageOption pkgs "seafile-server" { };
+
+    user = mkOption {
+      type = types.str;
+      default = defaultUser;
+      description = "User account under which seafile runs.";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = defaultUser;
+      description = "Group under which seafile runs.";
+    };
+
+    dataDir = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      defaultText = "${seafRoot}/data";
+      description = "Path in which to store user data";
+    };
+
+    gcDates = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "Sun 03:00:00" ];
+      description = ''
+        When to run garbage collection on stored data blocks.
+      '';
+    };
 
     seahubExtraConf = mkOption {
       default = "";
@@ -143,6 +171,17 @@ in
     environment.etc."seafile/seafile.conf".source = seafileConf;
     environment.etc."seafile/seahub_settings.py".source = seahubSettings;
 
+    users.users = lib.optionalAttrs (cfg.user == defaultUser) {
+      "${defaultUser}" = {
+        group = cfg.group;
+        isSystemUser = true;
+      };
+    };
+
+    users.groups = lib.optionalAttrs (cfg.group == defaultUser) {
+      "${defaultUser}" = {};
+    };
+
     systemd.targets.seafile = {
       wantedBy = [ "multi-user.target" ];
       description = "Seafile components";
@@ -154,6 +193,8 @@ in
           ProtectHome = true;
           PrivateUsers = true;
           PrivateDevices = true;
+          PrivateTmp = true;
+          ProtectSystem = "strict";
           ProtectClock = true;
           ProtectHostname = true;
           ProtectProc = "invisible";
@@ -162,30 +203,35 @@ in
           ProtectKernelLogs = true;
           ProtectControlGroups = true;
           RestrictNamespaces = true;
+          RemoveIPC = true;
           LockPersonality = true;
           RestrictRealtime = true;
           RestrictSUIDSGID = true;
+          NoNewPrivileges = true;
           MemoryDenyWriteExecute = true;
           SystemCallArchitectures = "native";
           RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" ];
         };
+        dataDir = if (!builtins.isNull cfg.dataDir) then cfg.dataDir else "${seafRoot}/ccnet";
+        optionalDataDir = lib.lists.optional (!builtins.isNull cfg.dataDir) cfg.dataDir;
       in
       {
         seaf-server = {
           description = "Seafile server";
           partOf = [ "seafile.target" ];
           after = [ "network.target" ];
+          unitConfig.RequiresMountsFor = optionalDataDir;
           wantedBy = [ "seafile.target" ];
           restartTriggers = [ ccnetConf seafileConf ];
           path = [ pkgs.sqlite ];
           serviceConfig = securityOptions // {
-            User = "seafile";
-            Group = "seafile";
-            DynamicUser = true;
+            User = cfg.user;
+            Group = cfg.group;
             StateDirectory = "seafile";
             RuntimeDirectory = "seafile";
             LogsDirectory = "seafile";
             ConfigurationDirectory = "seafile";
+            ReadWritePaths = optionalDataDir;
             ExecStart = ''
               ${cfg.seafilePackage}/bin/seaf-server \
               --foreground \
@@ -237,6 +283,7 @@ in
           partOf = [ "seafile.target" ];
           after = [ "network.target" "seaf-server.service" ];
           requires = [ "seaf-server.service" ];
+          unitConfig.RequiresMountsFor = optionalDataDir;
           restartTriggers = [ seahubSettings ];
           environment = {
             PYTHONPATH = "${pkgs.seahub.pythonPath}:${pkgs.seahub}/thirdpart:${pkgs.seahub}";
@@ -248,13 +295,13 @@ in
             SEAHUB_LOG_DIR = "/var/log/seafile";
           };
           serviceConfig = securityOptions // {
-            User = "seafile";
-            Group = "seafile";
-            DynamicUser = true;
+            User = cfg.user;
+            Group = cfg.group;
             RuntimeDirectory = "seahub";
             StateDirectory = "seafile";
             LogsDirectory = "seafile";
             ConfigurationDirectory = "seafile";
+            ReadWritePaths = optionalDataDir;
             ExecStart = ''
               ${pkgs.seahub.python.pkgs.gunicorn}/bin/gunicorn seahub.wsgi:application \
               --name seahub \
@@ -293,6 +340,54 @@ in
             fi
           '';
         };
+
+        seaf-gc = {
+          description = "Seafile storage garbage collection";
+          conflicts = [ "seaf-server.service" "seahub.service" ];
+          after = [ "seaf-server.service" "seahub.service" ];
+          unitConfig.RequiresMountsFor = optionalDataDir;
+          onSuccess = [ "seaf-server.service" "seahub.service" ];
+          onFailure = [ "seaf-server.service" "seahub.service" ];
+          startAt = cfg.gcDates;
+          serviceConfig = securityOptions // {
+            User = cfg.user;
+            Group = cfg.group;
+            StateDirectory = "seafile";
+            RuntimeDirectory = "seafile";
+            LogsDirectory = "seafile";
+            ConfigurationDirectory = "seafile";
+            ReadWritePaths = optionalDataDir;
+            Type = "oneshot";
+          };
+          script = ''
+            if [ ! -f "${seafRoot}/server-setup" ]; then
+                echo "Server not setup yet, GC not needed" >&2
+                exit
+            fi
+
+            # checking for pending upgrades
+            installedMajor=$(cat "${seafRoot}/server-setup" | cut -d"-" -f1 | cut -d"." -f1)
+            installedMinor=$(cat "${seafRoot}/server-setup" | cut -d"-" -f1 | cut -d"." -f2)
+            pkgMajor=$(echo "${cfg.seafilePackage.version}" | cut -d"." -f1)
+            pkgMinor=$(echo "${cfg.seafilePackage.version}" | cut -d"." -f2)
+
+            if [[ $installedMajor == $pkgMajor && $installedMinor == $pkgMinor ]]; then
+               :
+            else
+                echo "Server not upgraded yet" >&2
+                exit
+            fi
+
+            # Remove deleted blocks and libraries
+            ${cfg.seafilePackage}/bin/seafserv-gc \
+              -F /etc/seafile \
+              -c ${ccnetDir} \
+              -d ${dataDir} \
+              --rm-fs
+          '';
+        };
       };
   };
+
+  meta.maintainers = with maintainers; [ greizgh schmittlauch ];
 }


### PR DESCRIPTION
## Description of changes
Disable `DynamicUser` for seafile in favor of a persistent configurable service user and group. This allows moving the storage directory out of the systemd-managed `StateDirectory` (previously, external paths could be bind-mounted or symlinked into the state directory, but UID reassignments meant having to manually and slowly `chown` the entire storage). 

This also allows access by other services, such as by a garbage-collection timer also added here.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
