### PR TITLE
virtualbox: guest additions resize & clipboard fixes

### DIFF
--- a/nixos/modules/services/x11/display-managers/xpra.nix
+++ b/nixos/modules/services/x11/display-managers/xpra.nix
@@ -251,7 +251,6 @@ in
 
     environment.systemPackages = [pkgs.xpra];
 
-    virtualisation.virtualbox.guest.x11 = false;
     hardware.pulseaudio.enable = mkDefault cfg.pulseaudio;
     hardware.pulseaudio.systemWide = mkDefault cfg.pulseaudio;
   };

--- a/nixos/modules/virtualisation/virtualbox-guest.nix
+++ b/nixos/modules/virtualisation/virtualbox-guest.nix
@@ -5,14 +5,32 @@
 with lib;
 
 let
-
   cfg = config.virtualisation.virtualbox.guest;
   kernel = config.boot.kernelPackages;
 
+  mkVirtualBoxUserService = serviceArgs: {
+    description = "VirtualBox Guest User Services ${serviceArgs}";
+
+    wantedBy = [ "graphical-session.target" ];
+    partOf = [ "graphical-session.target" ];
+
+    # The graphical session may not be ready when starting the service
+    # Hence, check if the DISPLAY env var is set, otherwise fail, wait and retry again
+    startLimitBurst = 20;
+
+    unitConfig.ConditionVirtualization = "oracle";
+
+    # Check if the display environment is ready, otherwise fail
+    preStart = "${pkgs.bash}/bin/bash -c \"if [ -z $DISPLAY ]; then exit 1; fi\"";
+    serviceConfig = {
+      ExecStart = "@${kernel.virtualboxGuestAdditions}/bin/VBoxClient --foreground ${serviceArgs}";
+      # Wait after a failure, hoping that the display environment is ready after waiting
+      RestartSec = 2;
+      Restart = "always";
+    };
+  };
 in
-
 {
-
   ###### interface
 
   options.virtualisation.virtualbox.guest = {
@@ -22,32 +40,45 @@ in
       description = lib.mdDoc "Whether to enable the VirtualBox service and other guest additions.";
     };
 
-    x11 = mkOption {
+    clipboard = mkOption {
       default = true;
       type = types.bool;
-      description = lib.mdDoc "Whether to enable x11 graphics";
+      description = lib.mdDoc "Whether to enable clipboard support.";
+    };
+
+    seamless = mkOption {
+      default = true;
+      type = types.bool;
+      description = lib.mdDoc "Whether to enable seamless mode. When activated windows from the guest appear next to the windows of the host.";
+    };
+
+    draganddrop = mkOption {
+      default = true;
+      type = types.bool;
+      description = lib.mdDoc "Whether to enable drag and drop support.";
     };
   };
 
   ###### implementation
 
-  config = mkIf cfg.enable (mkMerge [{
-    assertions = [{
-      assertion = pkgs.stdenv.hostPlatform.isx86;
-      message = "Virtualbox not currently supported on ${pkgs.stdenv.hostPlatform.system}";
-    }];
+  config = mkIf cfg.enable (mkMerge [
+    {
+      assertions = [{
+        assertion = pkgs.stdenv.hostPlatform.isx86;
+        message = "Virtualbox not currently supported on ${pkgs.stdenv.hostPlatform.system}";
+      }];
 
-    environment.systemPackages = [ kernel.virtualboxGuestAdditions ];
+      environment.systemPackages = [ kernel.virtualboxGuestAdditions ];
 
-    boot.extraModulePackages = [ kernel.virtualboxGuestAdditions ];
+      boot.extraModulePackages = [ kernel.virtualboxGuestAdditions ];
 
-    boot.supportedFilesystems = [ "vboxsf" ];
-    boot.initrd.supportedFilesystems = [ "vboxsf" ];
+      boot.supportedFilesystems = [ "vboxsf" ];
+      boot.initrd.supportedFilesystems = [ "vboxsf" ];
 
-    users.groups.vboxsf.gid = config.ids.gids.vboxsf;
+      users.groups.vboxsf.gid = config.ids.gids.vboxsf;
 
-    systemd.services.virtualbox =
-      { description = "VirtualBox Guest Services";
+      systemd.services.virtualbox = {
+        description = "VirtualBox Guest Services";
 
         wantedBy = [ "multi-user.target" ];
         requires = [ "dev-vboxguest.device" ];
@@ -58,36 +89,27 @@ in
         serviceConfig.ExecStart = "@${kernel.virtualboxGuestAdditions}/bin/VBoxService VBoxService --foreground";
       };
 
-    services.udev.extraRules =
-      ''
-        # /dev/vboxuser is necessary for VBoxClient to work.  Maybe we
-        # should restrict this to logged-in users.
-        KERNEL=="vboxuser",  OWNER="root", GROUP="root", MODE="0666"
+      services.udev.extraRules =
+        ''
+          # /dev/vboxuser is necessary for VBoxClient to work.  Maybe we
+          # should restrict this to logged-in users.
+          KERNEL=="vboxuser",  OWNER="root", GROUP="root", MODE="0666"
 
-        # Allow systemd dependencies on vboxguest.
-        SUBSYSTEM=="misc", KERNEL=="vboxguest", TAG+="systemd"
-      '';
-  } (mkIf cfg.x11 {
-    services.xserver.videoDrivers = [ "vmware" "virtualbox" "modesetting" ];
+          # Allow systemd dependencies on vboxguest.
+          SUBSYSTEM=="misc", KERNEL=="vboxguest", TAG+="systemd"
+        '';
 
-    services.xserver.config =
-      ''
-        Section "InputDevice"
-          Identifier "VBoxMouse"
-          Driver "vboxmouse"
-        EndSection
-      '';
-
-    services.xserver.serverLayoutSection =
-      ''
-        InputDevice "VBoxMouse"
-      '';
-
-    services.xserver.displayManager.sessionCommands =
-      ''
-        PATH=${makeBinPath [ pkgs.gnugrep pkgs.which pkgs.xorg.xorgserver.out ]}:$PATH \
-          ${kernel.virtualboxGuestAdditions}/bin/VBoxClient-all
-      '';
-  })]);
-
+      systemd.user.services.virtualboxClientVmsvga = mkVirtualBoxUserService "--vmsvga-session";
+    }
+    (
+      mkIf cfg.clipboard {
+        systemd.user.services.virtualboxClientClipboard = mkVirtualBoxUserService "--clipboard";
+      }
+    )
+    (
+      mkIf cfg.seamless {
+        systemd.user.services.virtualboxClientSeamless = mkVirtualBoxUserService "--seamless";
+      }
+    )
+  ]);
 }

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -1,4 +1,4 @@
-{ config, stdenv, fetchurl, fetchpatch, lib, acpica-tools, dev86, pam, libxslt, libxml2, wrapQtAppsHook
+{ config, stdenv, fetchurl, fetchpatch, callPackage, lib, acpica-tools, dev86, pam, libxslt, libxml2, wrapQtAppsHook
 , libX11, xorgproto, libXext, libXcursor, libXmu, libIDL, SDL2, libcap, libGL, libGLU
 , libpng, glib, lvm2, libXrandr, libXinerama, libopus, libtpms, qtbase, qtx11extras
 , qttools, qtsvg, qtwayland, pkg-config, which, docbook_xsl, docbook_xml_dtd_43
@@ -35,6 +35,8 @@ let
   # The KVM build is not compatible to VirtualBox's kernel modules. So don't export
   # modsrc at all.
   withModsrc = !enableKvm;
+
+  virtualboxGuestAdditionsIso = callPackage guest-additions-iso/default.nix { };
 in stdenv.mkDerivation {
   pname = "virtualbox";
   inherit version;
@@ -249,7 +251,7 @@ in stdenv.mkDerivation {
 
     mkdir -p "$out/share/virtualbox"
     cp -rv src/VBox/Main/UnattendedTemplates "$out/share/virtualbox"
-    ln -s "${linuxPackages.virtualboxGuestAdditions.src}" "$out/share/virtualbox/VBoxGuestAdditions.iso"
+    ln -s "${virtualboxGuestAdditionsIso}/VBoxGuestAdditions_${version}.iso" "$out/share/virtualbox/VBoxGuestAdditions.iso"
   '';
 
   preFixup = optionalString (!headless) ''
@@ -262,7 +264,6 @@ in stdenv.mkDerivation {
   '';
 
   passthru = {
-    inherit version;       # for guest additions
     inherit extensionPack; # for inclusion in profile to prevent gc
     updateScript = ./update.sh;
   };

--- a/pkgs/applications/virtualization/virtualbox/guest-additions-iso/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions-iso/default.nix
@@ -1,0 +1,30 @@
+{ stdenv, fetchurl, lib, virtualbox}:
+
+let
+  inherit (virtualbox) version;
+in
+stdenv.mkDerivation rec {
+  pname = "VirtualBox-GuestAdditions-iso";
+  inherit version;
+
+  src = fetchurl {
+    url = "http://download.virtualbox.org/virtualbox/${version}/VBoxGuestAdditions_${version}.iso";
+    sha256 = "0efbcb9bf4722cb19292ae00eba29587432e918d3b1f70905deb70f7cf78e8ce";
+  };
+
+  buildCommand = ''
+    mkdir -p $out
+    cp $src $out/
+  '';
+
+  meta = {
+    description = "Guest additions ISO for VirtualBox";
+    longDescription = ''
+      ISO containing various add-ons which improves guests inside VirtualBox.
+    '';
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.gpl2;
+    maintainers = [ lib.maintainers.sander lib.maintainers.friedrichaltheide ];
+    platforms = [ "i686-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/builder.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/builder.nix
@@ -1,0 +1,133 @@
+{ config, stdenv, kernel, fetchurl, lib, pam, libxslt
+, libX11, libXext, libXcursor, libXmu
+, glib, alsa-lib, libXrandr, dbus
+, pkg-config, which, zlib, xorg
+, yasm, patchelf, makeWrapper, makeself, nasm
+, linuxHeaders, openssl, libpulseaudio}:
+
+with lib;
+
+let
+  buildType = "release";
+
+in stdenv.mkDerivation (finalAttrs: {
+  pname = "VirtualBox-GuestAdditions-builder-${kernel.version}";
+  version = "7.0.14";
+
+  src = fetchurl {
+    url = "https://download.virtualbox.org/virtualbox/${finalAttrs.version}/VirtualBox-${finalAttrs.version}.tar.bz2";
+    sha256 = "45860d834804a24a163c1bb264a6b1cb802a5bc7ce7e01128072f8d6a4617ca9";
+  };
+
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration";
+
+  nativeBuildInputs = [ patchelf makeWrapper pkg-config which yasm ];
+  buildInputs =  kernel.moduleBuildDependencies ++ [ libxslt libX11 libXext libXcursor
+    glib nasm alsa-lib makeself pam libXmu libXrandr linuxHeaders openssl libpulseaudio xorg.xorgserver ];
+
+  KERN_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+  KERN_INCL = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/source/include";
+
+  prePatch = ''
+    rm -r src/VBox/Additions/x11/x11include/
+    rm -r src/libs/openssl-*/
+    rm -r src/libs/curl-*/
+  '';
+
+  patches = [
+    ../gcc-13.patch
+    # https://www.virtualbox.org/changeset/100258/vbox
+    ./no-legacy-xorg.patch
+    # https://www.virtualbox.org/changeset/102989/vbox
+    ./strlcpy-1.patch
+    # https://www.virtualbox.org/changeset/102990/vbox
+    ./strlcpy-2.patch
+  ];
+
+  postPatch = ''
+    set -x
+    sed -e 's@MKISOFS --version@MKISOFS -version@' \
+        -e 's@CXX_FLAGS="\(.*\)"@CXX_FLAGS="-std=c++17 \1"@' \
+        -i configure
+    ls kBuild/bin/linux.x86/k* tools/linux.x86/bin/* | xargs -n 1 patchelf --set-interpreter ${stdenv.cc.libc}/lib/ld-linux.so.2
+    ls kBuild/bin/linux.amd64/k* tools/linux.amd64/bin/* | xargs -n 1 patchelf --set-interpreter ${stdenv.cc.libc}/lib/ld-linux-x86-64.so.2
+
+    substituteInPlace ./include/VBox/dbus-calls.h --replace-fail libdbus-1.so.3 ${dbus.lib}/lib/libdbus-1.so.3
+
+    substituteInPlace ./src/VBox/Additions/common/VBoxGuest/lib/VBoxGuestR3LibDrmClient.cpp --replace-fail /usr/bin/VBoxDRMClient /run/current-system/sw/bin/VBoxDRMClient
+    substituteInPlace ./src/VBox/Additions/common/VBoxGuest/lib/VBoxGuestR3LibDrmClient.cpp --replace-fail /usr/bin/VBoxClient /run/current-system/sw/bin/VBoxClient
+    substituteInPlace ./src/VBox/Additions/x11/VBoxClient/display.cpp --replace-fail /usr/X11/bin/xrandr ${xorg.xrandr}/bin/xrandr
+    substituteInPlace ./src/VBox/Additions/x11/vboxvideo/Makefile.kmk --replace-fail /usr/include/xorg "${xorg.xorgserver.dev}/include/xorg "
+  '';
+
+  configurePhase = ''
+      NIX_CFLAGS_COMPILE=$(echo "$NIX_CFLAGS_COMPILE" | sed 's,\-isystem ${lib.getDev stdenv.cc.libc}/include,,g')
+
+      cat >> LocalConfig.kmk <<LOCAL_CONFIG
+      VBOX_WITH_TESTCASES            :=
+      VBOX_WITH_TESTSUITE            :=
+      VBOX_WITH_VALIDATIONKIT        :=
+      VBOX_WITH_DOCS                 :=
+      VBOX_WITH_WARNINGS_AS_ERRORS   :=
+
+      VBOX_WITH_ORIGIN               :=
+      VBOX_PATH_APP_PRIVATE_ARCH_TOP := $out/share/virtualbox
+      VBOX_PATH_APP_PRIVATE_ARCH     := $out/libexec/virtualbox
+      VBOX_PATH_SHARED_LIBS          := $out/libexec/virtualbox
+      VBOX_WITH_RUNPATH              := $out/libexec/virtualbox
+      VBOX_PATH_APP_PRIVATE          := $out/share/virtualbox
+      VBOX_PATH_APP_DOCS             := $out/doc
+
+      VBOX_USE_SYSTEM_XORG_HEADERS := 1
+      VBOX_USE_SYSTEM_GL_HEADERS := 1
+      VBOX_NO_LEGACY_XORG_X11 := 1
+
+      SDK_VBoxOpenSslStatic_INCS := ${openssl.dev}/include/ssl
+
+      VBOX_ONLY_ADDITIONS := 1
+      VBOX_WITH_SHARED_CLIPBOARD := 1
+      VBOX_WITH_GUEST_PROPS := 1
+      VBOX_WITH_VMSVGA := 1
+      VBOX_WITH_SHARED_FOLDERS := 1
+      VBOX_WITH_GUEST_CONTROL := 1
+      VBOX_WITHOUT_LINUX_GUEST_PACKAGE := 1
+      VBOX_WITH_PAM :=
+
+      VBOX_BUILD_PUBLISHER := _NixOS
+      LOCAL_CONFIG
+
+      ./configure \
+        --only-additions \
+        --with-linux=${kernel.dev} \
+        --disable-kmods
+
+      sed -e 's@PKG_CONFIG_PATH=.*@PKG_CONFIG_PATH=${glib.dev}/lib/pkgconfig @' \
+        -i AutoConfig.kmk
+      sed -e 's@arch/x86/@@' \
+        -i Config.kmk
+
+      export USER=nix
+      set +x
+    '';
+
+  enableParallelBuilding = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    source env.sh
+    VBOX_ONLY_ADDITIONS=1 VBOX_ONLY_BUILD=1 kmk -j $NIX_BUILD_CORES BUILD_TYPE="${buildType}"
+    VBOX_ONLY_ADDITIONS=1 VBOX_ONLY_BUILD=1 kmk packing
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -rv ./out/linux.${if stdenv.hostPlatform.is32bit then "x86" else "amd64"}/${buildType}/bin/additions/VBoxGuestAdditions-${if stdenv.hostPlatform.is32bit then "x86" else "amd64"}.tar.bz2 $out/
+
+    runHook postInstall
+  '';
+})

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/default.nix
@@ -1,9 +1,12 @@
-{ stdenv, fetchurl, lib, patchelf, cdrkit, kernel, which, makeWrapper
-, zlib, xorg, dbus, virtualbox}:
+{ config, stdenv, kernel, callPackage, lib, dbus
+, libX11, libXext, libXcursor, libXmu, xorg
+, which, zlib, patchelf, makeWrapper
+}:
+
+with lib;
 
 let
-  version = virtualbox.version;
-  xserverVListFunc = builtins.elemAt (lib.splitVersion xorg.xorgserver.version);
+  virtualBoxNixGuestAdditionsBuilder = callPackage ./builder.nix { };
 
   # Forced to 1.18; vboxvideo doesn't seem to provide any newer ABI,
   # and nixpkgs doesn't support older ABIs anymore.
@@ -17,137 +20,94 @@ let
     { name = "libXfixes.so"; pkg = xorg.libXfixes; }
     { name = "libXrandr.so"; pkg = xorg.libXrandr; }
   ];
+in stdenv.mkDerivation {
+    pname = "VirtualBox-GuestAdditions";
+    version = "${virtualBoxNixGuestAdditionsBuilder.version}-${kernel.version}";
 
-in stdenv.mkDerivation rec {
-  name = "VirtualBox-GuestAdditions-${version}-${kernel.version}";
+    src = "${virtualBoxNixGuestAdditionsBuilder}/VBoxGuestAdditions-${if stdenv.hostPlatform.is32bit then "x86" else "amd64"}.tar.bz2";
+    sourceRoot = ".";
 
-  src = fetchurl {
-    url = "http://download.virtualbox.org/virtualbox/${version}/VBoxGuestAdditions_${version}.iso";
-    sha256 = "0efbcb9bf4722cb19292ae00eba29587432e918d3b1f70905deb70f7cf78e8ce";
-  };
+    KERN_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+    KERN_INCL = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/source/include";
 
-  KERN_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
-  KERN_INCL = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/source/include";
+    hardeningDisable = [ "pic" ];
 
-  hardeningDisable = [ "pic" ];
+    env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration";
 
-  env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration";
+    nativeBuildInputs = [ patchelf makeWrapper ];
+    buildInputs = [ virtualBoxNixGuestAdditionsBuilder ] ++ kernel.moduleBuildDependencies;
 
-  nativeBuildInputs = [ patchelf makeWrapper ];
-  buildInputs = [ cdrkit ] ++ kernel.moduleBuildDependencies;
+    buildPhase = ''
+      runHook preBuild
 
+      # Build kernel modules.
+      cd src
+      find . -type f | xargs sed 's/depmod -a/true/' -i
+      cd vboxguest-${virtualBoxNixGuestAdditionsBuilder.version}_NixOS
+      # Run just make first. If we only did make install, we get symbol warnings during build.
+      make
+      cd ../..
 
-  prePatch = ''
-    substituteInPlace src/vboxguest-${version}/vboxvideo/vbox_ttm.c \
-      --replace "<ttm/" "<drm/ttm/"
-  '';
+      # Change the interpreter for various binaries
+      for i in sbin/VBoxService bin/{VBoxClient,VBoxControl,VBoxDRMClient} other/mount.vboxsf; do
+          patchelf --set-interpreter ${stdenv.cc.bintools.dynamicLinker} $i
+          patchelf --set-rpath ${lib.makeLibraryPath [ stdenv.cc.cc stdenv.cc.libc zlib
+            xorg.libX11 xorg.libXt xorg.libXext xorg.libXmu xorg.libXfixes xorg.libXcursor ]} $i
+      done
 
-  patchFlags = [ "-p1" "-d" "src/vboxguest-${version}" ];
-
-  unpackPhase = ''
-    isoinfo -J -i $src -x /VBoxLinuxAdditions.run > ./VBoxLinuxAdditions.run
-    chmod 755 ./VBoxLinuxAdditions.run
-    # An overflow leads the is-there-enough-space check to fail when there's too much space available, so fake how much space there is
-    sed -i 's/\$leftspace/16383/' VBoxLinuxAdditions.run
-    ./VBoxLinuxAdditions.run --noexec --keep
-
-    # Unpack files
-    cd install
-    tar xfvj VBoxGuestAdditions-${if stdenv.hostPlatform.is32bit then "x86" else "amd64"}.tar.bz2
-  '';
-
-  buildPhase = ''
-    # Build kernel modules.
-    cd src
-    find . -type f | xargs sed 's/depmod -a/true/' -i
-    cd vboxguest-${version}
-    # Run just make first. If we only did make install, we get symbol warnings during build.
-    make
-    cd ../..
-
-    # Change the interpreter for various binaries
-    for i in sbin/VBoxService bin/{VBoxClient,VBoxControl} other/mount.vboxsf; do
-        patchelf --set-interpreter ${stdenv.cc.bintools.dynamicLinker} $i
-        patchelf --set-rpath ${lib.makeLibraryPath [ stdenv.cc.cc stdenv.cc.libc zlib
-          xorg.libX11 xorg.libXt xorg.libXext xorg.libXmu xorg.libXfixes xorg.libXrandr xorg.libXcursor ]} $i
-    done
-
-    for i in lib/VBoxOGL*.so
-    do
-        patchelf --set-rpath ${lib.makeLibraryPath [ "$out"
-          xorg.libXcomposite xorg.libXdamage xorg.libXext xorg.libXfixes ]} $i
-    done
-
-    # FIXME: Virtualbox 4.3.22 moved VBoxClient-all (required by Guest Additions
-    # NixOS module) to 98vboxadd-xclient. For now, just work around it:
-    mv other/98vboxadd-xclient bin/VBoxClient-all
-
-    # Remove references to /usr from various scripts and files
-    sed -i -e "s|/usr/bin|$out/bin|" other/vboxclient.desktop
-    sed -i -e "s|/usr/bin|$out/bin|" bin/VBoxClient-all
-  '';
-
-  installPhase = ''
-    # Install kernel modules.
-    cd src/vboxguest-${version}
-    make install INSTALL_MOD_PATH=$out KBUILD_EXTRA_SYMBOLS=$PWD/vboxsf/Module.symvers
-    cd ../..
-
-    # Install binaries
-    install -D -m 755 other/mount.vboxsf $out/bin/mount.vboxsf
-    install -D -m 755 sbin/VBoxService $out/bin/VBoxService
-
-    mkdir -p $out/bin
-    install -m 755 bin/VBoxClient $out/bin
-    install -m 755 bin/VBoxControl $out/bin
-    install -m 755 bin/VBoxClient-all $out/bin
-
-    wrapProgram $out/bin/VBoxClient-all \
-            --prefix PATH : "${which}/bin"
-
-    # Don't install VBoxOGL for now
-    # It seems to be broken upstream too, and fixing it is far down the priority list:
-    # https://www.virtualbox.org/pipermail/vbox-dev/2017-June/014561.html
-    # Additionally, 3d support seems to rely on VBoxOGL.so being symlinked from
-    # libGL.so (which we can't), and Oracle doesn't plan on supporting libglvnd
-    # either. (#18457)
-    ## Install OpenGL libraries
-    #mkdir -p $out/lib
-    #cp -v lib/VBoxOGL*.so $out/lib
-    #mkdir -p $out/lib/dri
-    #ln -s $out/lib/VBoxOGL.so $out/lib/dri/vboxvideo_dri.so
-
-    # Install desktop file
-    mkdir -p $out/etc/xdg/autostart
-    cp -v other/vboxclient.desktop $out/etc/xdg/autostart
-
-    # Install Xorg drivers
-    mkdir -p $out/lib/xorg/modules/{drivers,input}
-    install -m 644 other/vboxvideo_drv_${xserverABI}.so $out/lib/xorg/modules/drivers/vboxvideo_drv.so
-  '';
-
-  # Stripping breaks these binaries for some reason.
-  dontStrip = true;
-
-  # Patch RUNPATH according to dlopenLibs (see the comment there).
-  postFixup = lib.concatMapStrings (library: ''
-    for i in $(grep -F ${lib.escapeShellArg library.name} -l -r $out/{lib,bin}); do
-      origRpath=$(patchelf --print-rpath "$i")
-      patchelf --set-rpath "$origRpath:${lib.makeLibraryPath [ library.pkg ]}" "$i"
-    done
-  '') dlopenLibs;
-
-  meta = {
-    description = "Guest additions for VirtualBox";
-    longDescription = ''
-      Various add-ons which makes NixOS work better as guest OS inside VirtualBox.
-      This add-on provides support for dynamic resizing of the X Display, shared
-      host/guest clipboard support and guest OpenGL support.
+      runHook postBuild
     '';
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    license = "GPL";
-    maintainers = [ lib.maintainers.sander lib.maintainers.friedrichaltheide ];
-    platforms = [ "i686-linux" "x86_64-linux" ];
-    broken = stdenv.hostPlatform.is32bit && (kernel.kernelAtLeast "5.10");
-  };
-}
+
+    installPhase = ''
+      runHook preInstall
+
+      # Install kernel modules.
+      cd src/vboxguest-${virtualBoxNixGuestAdditionsBuilder.version}_NixOS
+      make install INSTALL_MOD_PATH=$out KBUILD_EXTRA_SYMBOLS=$PWD/vboxsf/Module.symvers
+      cd ../..
+
+      # Install binaries
+      install -D -m 755 other/mount.vboxsf $out/bin/mount.vboxsf
+      install -D -m 755 sbin/VBoxService $out/bin/VBoxService
+
+      mkdir -p $out/bin
+      install -m 755 bin/VBoxClient $out/bin
+      install -m 755 bin/VBoxControl $out/bin
+      install -m 755 bin/VBoxDRMClient $out/bin
+
+
+      # Don't install VBoxOGL for now
+      # It seems to be broken upstream too, and fixing it is far down the priority list:
+      # https://www.virtualbox.org/pipermail/vbox-dev/2017-June/014561.html
+      # Additionally, 3d support seems to rely on VBoxOGL.so being symlinked from
+      # libGL.so (which we can't), and Oracle doesn't plan on supporting libglvnd
+      # either. (#18457)
+
+      runHook postInstall
+    '';
+
+    # Stripping breaks these binaries for some reason.
+    dontStrip = true;
+
+    # Patch RUNPATH according to dlopenLibs (see the comment there).
+    postFixup = lib.concatMapStrings (library: ''
+      for i in $(grep -F ${lib.escapeShellArg library.name} -l -r $out/{lib,bin}); do
+        origRpath=$(patchelf --print-rpath "$i")
+        patchelf --set-rpath "$origRpath:${lib.makeLibraryPath [ library.pkg ]}" "$i"
+      done
+    '') dlopenLibs;
+
+    meta = {
+      description = "Guest additions for VirtualBox";
+      longDescription = ''
+        Various add-ons which makes NixOS work better as guest OS inside VirtualBox.
+        This add-on provides support for dynamic resizing of the virtual display, shared
+        host/guest clipboard support.
+      '';
+      sourceProvenance = with lib.sourceTypes; [ fromSource ];
+      license = licenses.gpl2;
+      maintainers = [ lib.maintainers.sander lib.maintainers.friedrichaltheide ];
+      platforms = [ "i686-linux" "x86_64-linux" ];
+      broken = stdenv.hostPlatform.is32bit && (kernel.kernelAtLeast "5.10");
+    };
+  }

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/no-legacy-xorg.patch
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/no-legacy-xorg.patch
@@ -1,0 +1,45 @@
+# https://www.virtualbox.org/changeset/100258/vbox
+diff --git a/src/VBox/Additions/linux/Makefile.kmk b/src/VBox/Additions/linux/Makefile.kmk
+index 0921b3fe619..de9e98b4989 100644
+--- a/src/VBox/Additions/linux/Makefile.kmk
++++ b/src/VBox/Additions/linux/Makefile.kmk
+@@ -136,23 +136,29 @@ VBOX_LNX_ADD_STRIP_SBIN += \
+ 	$(if $(VBOX_WITH_LIGHTDM_GREETER),vbox-greeter)
+ 
+ VBOX_LNX_ADD_STRIP_MOD = \
+-	vboxmouse_drv_70.so \
+-	vboxmouse_drv_71.so \
+-	vboxmouse_drv_13.so \
+-	vboxmouse_drv_14.so \
+-	vboxmouse_drv_15.so \
+-	vboxmouse_drv_16.so \
+-	$(addsuffix .so,$(filter-out %_32,$(filter vboxvideo_drv_%,$(DLLS)))) \
+ 	$(if $(VBOX_WITH_PAM),pam_vbox.so,) \
+ 	mount.vboxsf
+ 
++ifndef VBOX_NO_LEGACY_XORG_X11
++ VBOX_LNX_ADD_STRIP_MOD += \
++ 	vboxmouse_drv_70.so \
++ 	vboxmouse_drv_71.so \
++ 	vboxmouse_drv_13.so \
++ 	vboxmouse_drv_14.so \
++ 	vboxmouse_drv_15.so \
++ 	vboxmouse_drv_16.so \
++ 	$(addsuffix .so,$(filter-out %_32,$(filter vboxvideo_drv_%,$(DLLS))))
++endif
++
+ VBOX_LNX_ADD_MOD = \
+ 	98vboxadd-xclient \
+ 	x11config.sh
+ 
+-VBOX_LNX_ADD_STRIP_OBJ = \
+-	vboxmouse_drv.o \
+-	vboxvideo_drv.o
++ifndef VBOX_NO_LEGACY_XORG_X11
++ VBOX_LNX_ADD_STRIP_OBJ = \
++ 	vboxmouse_drv.o \
++ 	vboxvideo_drv.o
++endif
+ 
+ VBOX_LNX_ADD_INIT = \
+ 	vboxadd \

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/strlcpy-1.patch
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/strlcpy-1.patch
@@ -1,0 +1,29 @@
+# https://www.virtualbox.org/changeset/102989/vbox
+--- a/include/iprt/string.h
++++ b/include/iprt/string.h
+@@ -244,4 +244,26 @@
+ #else  /* !RT_OS_LINUX && !__KERNEL__ */
+ # define RT_BCOPY_UNFORTIFIED(a_pDst, a_pSrc, a_cbToCopy)   memcpy((a_pDst), (a_pSrc), (a_cbToCopy))
++#endif /* !RT_OS_LINUX && !__KERNEL__ */
++
++/** @def RT_STRSCPY
++ * Copy string and NULL-terminate output buffer.
++ *
++ * This macro should mostly be used in Linux kernel code. This is
++ * the replacement for deprecated strlcpy. It was deprecated since 3.16.60
++ * when strscpy was introduced as an alternative. Finally, strlcpy was
++ * completely removed from kernel code in 6.8.0.
++ *
++ * @param   a_pDst          Pointer to the destination string buffer.
++ * @param   a_pSrc          Pointer to the source NULL-terminated string buffer.
++ * @param   a_cbToCopy      Size of destination buffer..
++ */
++#if defined(RT_OS_LINUX) && defined(__KERNEL__)
++# if (RTLNX_VER_MIN(3,16,60))
++#  define RT_STRSCPY(a_pDst, a_pSrc, a_cbToCopy)    strscpy((a_pDst), (a_pSrc), (a_cbToCopy))
++# else /* < 3.16.60 */
++#  define RT_STRSCPY(a_pDst, a_pSrc, a_cbToCopy)    strlcpy((a_pDst), (a_pSrc), (a_cbToCopy))
++# endif
++#else  /* !RT_OS_LINUX && !__KERNEL__ */
++# define RT_STRSCPY(a_pDst, a_pSrc, a_cbToCopy)    strscpy((a_pDst), (a_pSrc), (a_cbToCopy))
+ #endif /* !RT_OS_LINUX && !__KERNEL__ */

--- a/pkgs/applications/virtualization/virtualbox/guest-additions/strlcpy-2.patch
+++ b/pkgs/applications/virtualization/virtualbox/guest-additions/strlcpy-2.patch
@@ -1,0 +1,86 @@
+# https://www.virtualbox.org/changeset/102990/vbox
+--- a/src/VBox/Additions/common/VBoxGuest/VBoxGuest-linux.c
++++ b/src/VBox/Additions/common/VBoxGuest/VBoxGuest-linux.c
+@@ -1411,5 +1411,5 @@
+     }
+     else if (pParam->name[0] != 'd')
+-        strlcpy(&g_szLogGrp[0], pszValue, sizeof(g_szLogGrp));
++        RT_STRSCPY(&g_szLogGrp[0], pszValue, sizeof(g_szLogGrp));
+ 
+     return 0;
+@@ -1437,5 +1437,5 @@
+     }
+     else if (pParam->name[0] != 'd')
+-        strlcpy(&g_szLogFlags[0], pszValue, sizeof(g_szLogFlags));
++        RT_STRSCPY(&g_szLogFlags[0], pszValue, sizeof(g_szLogFlags));
+     return 0;
+ }
+@@ -1462,5 +1462,5 @@
+     }
+     else if (pParam->name[0] != 'd')
+-        strlcpy(&g_szLogDst[0], pszValue, sizeof(g_szLogDst));
++        RT_STRSCPY(&g_szLogDst[0], pszValue, sizeof(g_szLogDst));
+     return 0;
+ }
+
+# https://www.virtualbox.org/changeset/102990/vbox
+--- a/src/VBox/Additions/linux/drm/vbox_drv.h
++++ b/src/VBox/Additions/linux/drm/vbox_drv.h
+@@ -539,7 +539,5 @@
+ void vbox_irq_fini(struct vbox_private *vbox);
+ void vbox_report_hotplug(struct vbox_private *vbox);
+-#if RTLNX_VER_MAX(5,15,0) && !RTLNX_RHEL_MAJ_PREREQ(9,1) && !RTLNX_SUSE_MAJ_PREREQ(15,5)
+ irqreturn_t vbox_irq_handler(int irq, void *arg);
+-#endif
+ 
+ /* vbox_hgsmi.c */
+
+# https://www.virtualbox.org/changeset/102990/vbox
+--- a/src/VBox/Additions/linux/sharedfolders/regops.c
++++ b/src/VBox/Additions/linux/sharedfolders/regops.c
+@@ -3506,5 +3506,5 @@
+ 
+ /** file_operations::mmap wrapper for logging purposes. */
+-extern int vbsf_reg_mmap(struct file *file, struct vm_area_struct *vma)
++static int vbsf_reg_mmap(struct file *file, struct vm_area_struct *vma)
+ {
+     int rc;
+@@ -3787,5 +3787,5 @@
+ 
+ # if RTLNX_VER_MIN(5,19,0) || RTLNX_RHEL_RANGE(9,3, 9,99)
+-int vbsf_write_begin(struct file *file, struct address_space *mapping, loff_t pos,
++static int vbsf_write_begin(struct file *file, struct address_space *mapping, loff_t pos,
+                      unsigned len, struct page **pagep, void **fsdata)
+ {
+@@ -3794,5 +3794,5 @@
+ }
+ # else
+-int vbsf_write_begin(struct file *file, struct address_space *mapping, loff_t pos,
++static int vbsf_write_begin(struct file *file, struct address_space *mapping, loff_t pos,
+                      unsigned len, unsigned flags, struct page **pagep, void **fsdata)
+ {
+
+# https://www.virtualbox.org/changeset/102990/vbox
+--- a/src/VBox/Additions/linux/sharedfolders/vfsmod.c
++++ b/src/VBox/Additions/linux/sharedfolders/vfsmod.c
+@@ -1409,5 +1409,5 @@
+     case Opt_iocharset:
+     case Opt_nls:
+-        strlcpy(info->nls_name, param->string, sizeof(info->nls_name));
++        RT_STRSCPY(info->nls_name, param->string, sizeof(info->nls_name));
+         break;
+     case Opt_uid:
+@@ -1470,5 +1470,5 @@
+         break;
+     case Opt_tag:
+-        strlcpy(info->szTag, param->string, sizeof(info->szTag));
++        RT_STRSCPY(info->szTag, param->string, sizeof(info->szTag));
+         break;
+     default:
+@@ -1529,5 +1529,5 @@
+ 
+     /* fc->source (the shared folder name) is set after vbsf_init_fs_ctx() */
+-    strlcpy(info->name, fc->source, sizeof(info->name));
++    RT_STRSCPY(info->name, fc->source, sizeof(info->name));
+ 
+ # if RTLNX_VER_MAX(5,3,0)

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -543,9 +543,7 @@ in {
       virtualbox = pkgs.virtualboxHardened;
     };
 
-    virtualboxGuestAdditions = callPackage ../applications/virtualization/virtualbox/guest-additions {
-      virtualbox = pkgs.virtualboxHardened;
-    };
+    virtualboxGuestAdditions = callPackage ../applications/virtualization/virtualbox/guest-additions { };
 
     vm-tools = callPackage ../os-specific/linux/vm-tools { };
 


### PR DESCRIPTION
## Description of changes

- Build virtualbox guest additions from source and fix paths (fixes #243671)
- Install VBoxDRMClient to support resizing (fixes #243671)
- Support resizing and clipboard on wayland and x11
- Adding multiple new options
  - conditionVirtualization: On some systems the conditionVirtualization can differ from "oracle"
  - clipboard
  - seamless
  - vmsvga
- Support linux 5.8
 
Patches:
- no-legay-xorg.patch: https://www.virtualbox.org/changeset/100258/vbox
- strlcpy.patch
  - https://www.virtualbox.org//changeset/102989/vbox
  - https://www.virtualbox.org/changeset/102990/vbox
The commit "Fix makeself header path" will removed from the PR once #289436 is merged.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
