### PR TITLE
octopus-caller: fix `gcc-13` build failure (drop `-Werror`)

### DIFF
--- a/pkgs/applications/science/biology/octopus/default.nix
+++ b/pkgs/applications/science/biology/octopus/default.nix
@@ -19,10 +19,17 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-VaUr63v7mzhh4VBghH7a7qrqOYwl6vucmmKzTi9yAjY=";
   }) ];
 
-  env.NIX_CFLAGS_COMPILE = toString [
-    # Needed with GCC 12
-    "-Wno-error=deprecated-declarations"
-  ];
+  postPatch = ''
+    # Disable -Werror to avoid build failure on fresh toolchains like
+    # gcc-13.
+    substituteInPlace lib/date/CMakeLists.txt --replace-fail ' -Werror ' ' '
+    substituteInPlace lib/ranger/CMakeLists.txt --replace-fail ' -Werror ' ' '
+    substituteInPlace lib/tandem/CMakeLists.txt --replace-fail ' -Werror ' ' '
+    substituteInPlace src/CMakeLists.txt --replace-fail ' -Werror ' ' '
+
+    # Fix gcc-13 build due to missing <cstdint> header.
+    sed -e '1i #include <cstdint>' -i src/core/tools/vargen/utils/assembler.hpp
+  '';
 
   postInstall = ''
     mkdir $out/bin


### PR DESCRIPTION
Without the change the build on `master` fails as
https://hydra.nixos.org/build/249090788:

    /build/source/src/config/option_collation.cpp: In function 'auto octopus::options::make_variant_generator_builder(const OptionMap&, boost::optional<const octopus::ReadSetProfile&>)':
    /build/source/src/config/option_collation.cpp:1298: error: redundant move in initialization [-Werror=redundant-move]
     1298 |                 throw ConflictingSourceVariantFile {std::move(source_path), *output_path};
          |

Blanket `-Werror` frequently causes build failures unless upstream is quick at addressing build failures.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
