### PR TITLE
byobu: Adopt new upstream and bump to 6.12

### DIFF
--- a/pkgs/tools/misc/byobu/default.nix
+++ b/pkgs/tools/misc/byobu/default.nix
@@ -48,7 +48,7 @@ in stdenv.mkDerivation rec {
     done
 
     # Override the symlinks otherwise they mess with the wrapping
-    cp --remove-destination $out/bin/byobu $out/bin/byobu-screen                   
+    cp --remove-destination $out/bin/byobu $out/bin/byobu-screen
     cp --remove-destination $out/bin/byobu $out/bin/byobu-tmux
 
     for i in $out/bin/byobu*; do

--- a/pkgs/tools/misc/byobu/default.nix
+++ b/pkgs/tools/misc/byobu/default.nix
@@ -1,5 +1,16 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper, python3, perl
-, textual-window-manager, gettext, vim, autoreconfHook, bc, screen }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeWrapper
+, python3
+, perl
+, textual-window-manager
+, gettext
+, vim
+, autoreconfHook
+, bc
+, screen
+}:
 let pythonEnv = python3.withPackages (ps: with ps; [ snack ]);
 in stdenv.mkDerivation rec {
   version = "6.12";
@@ -56,15 +67,15 @@ in stdenv.mkDerivation rec {
     homepage = "https://launchpad.net/byobu/";
     description = "Text-based window manager and terminal multiplexer";
 
-    longDescription =
-      ''Byobu is a GPLv3 open source text-based window manager and terminal multiplexer.
-        It was originally designed to provide elegant enhancements to the otherwise functional,
-        plain, practical GNU Screen, for the Ubuntu server distribution.
-        Byobu now includes an enhanced profiles, convenient keybindings,
-        configuration utilities, and toggle-able system status notifications for both
-        the GNU Screen window manager and the more modern Tmux terminal multiplexer,
-        and works on most Linux, BSD, and Mac distributions.
-      '';
+    longDescription = ''
+      Byobu is a GPLv3 open source text-based window manager and terminal multiplexer.
+      It was originally designed to provide elegant enhancements to the otherwise functional,
+      plain, practical GNU Screen, for the Ubuntu server distribution.
+      Byobu now includes an enhanced profiles, convenient keybindings,
+      configuration utilities, and toggle-able system status notifications for both
+      the GNU Screen window manager and the more modern Tmux terminal multiplexer,
+      and works on most Linux, BSD, and Mac distributions.
+    '';
 
     license = licenses.gpl3;
 

--- a/pkgs/tools/misc/byobu/default.nix
+++ b/pkgs/tools/misc/byobu/default.nix
@@ -1,23 +1,21 @@
-{ lib, stdenv, fetchurl, makeWrapper
-, python3, perl, textual-window-manager
-, gettext, vim, bc, screen }:
-
-let
-  pythonEnv = python3.withPackages (ps: with ps; [ snack ]);
-in
-stdenv.mkDerivation rec {
-  version = "5.133";
+{ lib, stdenv, fetchFromGitHub, makeWrapper, python3, perl
+, textual-window-manager, gettext, vim, autoreconfHook, bc, screen }:
+let pythonEnv = python3.withPackages (ps: with ps; [ snack ]);
+in stdenv.mkDerivation rec {
+  version = "6.12";
   pname = "byobu";
 
-  src = fetchurl {
-    url = "https://launchpad.net/byobu/trunk/${version}/+download/byobu_${version}.orig.tar.gz";
-    sha256 = "0qvmmdnvwqbgbhn5c8asmrmjhclcl029py2d2zvmd7h5ij7s93jd";
+  src = fetchFromGitHub {
+    owner = "dustinkirkland";
+    repo = pname;
+    rev = version;
+    hash = "sha256-NzC9Njsnz14mfKnERGDZw8O3vux0wnfCKwjUeTBQswc=";
   };
 
   doCheck = true;
 
   strictdeps = true;
-  nativeBuildInputs = [ makeWrapper gettext ];
+  nativeBuildInputs = [ makeWrapper gettext autoreconfHook ];
   buildInputs = [ perl ]; # perl is needed for `lib/byobu/include/*` scripts
   propagatedBuildInputs = [ textual-window-manager screen ];
 
@@ -39,7 +37,7 @@ stdenv.mkDerivation rec {
     done
 
     # Override the symlinks otherwise they mess with the wrapping
-    cp --remove-destination $out/bin/byobu $out/bin/byobu-screen
+    cp --remove-destination $out/bin/byobu $out/bin/byobu-screen                   
     cp --remove-destination $out/bin/byobu $out/bin/byobu-tmux
 
     for i in $out/bin/byobu*; do


### PR DESCRIPTION
Adops new upstream and adds support for the autotools based build. It also updates the package from 5.133 to 6.12 because the new upstram doesn't contain the 5.x tags.

Should fix #290168 

## Description of changes

- adds autotool build support
- adopts new upstream, see #290168 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
