### PR TITLE
openjk: unstable-2022-01-30 -> 0-unstable-2024-02-20

### DIFF
--- a/pkgs/games/openjk/default.nix
+++ b/pkgs/games/openjk/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, fetchFromGitHub, makeDesktopItem, makeWrapper, cmake, libjpeg, zlib, libpng, libGL, SDL2 }:
+{ lib, stdenv, fetchFromGitHub, makeDesktopItem, makeWrapper, cmake, libjpeg, zlib, libpng, libGL, SDL2
+, unstableGitUpdater
+}:
 
 let
   jamp = makeDesktopItem rec {
@@ -30,13 +32,13 @@ let
   };
 in stdenv.mkDerivation {
   pname = "OpenJK";
-  version = "unstable-2022-01-30";
+  version = "0-unstable-2024-02-20";
 
   src = fetchFromGitHub {
     owner = "JACoders";
     repo = "OpenJK";
-    rev = "235fb9e1a9c4537a603b2e54e444327d20d198a3";
-    sha256 = "sha256-DqP6wnu5sE7lQJGEdsEPOc6FIaJjqxt5ANKZ5eiabC4=";
+    rev = "1e8a7998ca2fe434daebb41d586ac3cd5296433a";
+    sha256 = "sha256-TKJNaz+oWNYyReFZVefg1frPXyd3Yl96JDklp1qY1to=";
   };
 
   dontAddPrefix = true;
@@ -78,6 +80,8 @@ in stdenv.mkDerivation {
     ln -s $openjo/bin/* $out/bin
     rm -rf $out/opt
   '';
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = with lib; {
     description = "An open-source engine for Star Wars Jedi Academy game";


### PR DESCRIPTION
Without the change the build fails against `gcc-13` on `master` as https://hydra.nixos.org/build/249001657:

    In file included from /build/source/shared/qcommon/safe/gsl.h:4,
                     from /build/source/shared/qcommon/safe/sscanf.h:12,
                     from /build/source/shared/qcommon/safe/string.h:3,
                     from /build/source/shared/qcommon/safe/string.cpp:1:
    /build/source/lib/gsl-lite/include/gsl/gsl-lite.h:479:18: error: 'reverse_iterator' in namespace 'gsl::std' does not name a template type
      479 |     typedef std::reverse_iterator< iterator >                reverse_iterator;
          |                  ^~~~~~~~~~~~~~~~

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
