### PR TITLE
python311Packages.eventlet: 0.33.3 -> 0.35.2

### DIFF
--- a/pkgs/development/python-modules/eventlet/default.nix
+++ b/pkgs/development/python-modules/eventlet/default.nix
@@ -2,11 +2,11 @@
 , stdenv
 , buildPythonPackage
 , fetchFromGitHub
-, fetchpatch
 , pythonAtLeast
 
 # build-system
-, setuptools
+, hatch-vcs
+, hatchling
 
 # dependencies
 , dnspython
@@ -15,7 +15,6 @@
 , six
 
 # tests
-, nose3
 , iana-etc
 , pytestCheckHook
 , libredirect
@@ -23,35 +22,19 @@
 
 buildPythonPackage rec {
   pname = "eventlet";
-  version = "0.33.3";
+  version = "0.35.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "eventlet";
-    repo = pname;
+    repo = "eventlet";
     rev = "v${version}";
-    hash = "sha256-iSSEZgPkK7RrZfU11z7hUk+JbFsCPH/SD16e+/f6TFU=";
+    hash = "sha256-jMbCxqIn9f9+16rFwpQdkBHj6NwTNkQxnSVV4qQ1fjM=";
   };
 
-  patches = [
-    # Python 3.12 fixes:
-    # - remove usage of distutils
-    # - replace ssl.wrap_socket usage
-    ./remove-distutils-usage.patch
-    (fetchpatch {
-      url = "https://src.fedoraproject.org/rpms/python-eventlet/raw/rawhide/f/python3.12.patch";
-      hash = "sha256-MxzprFaVcV1uamjjTeIz+2gPvfPy+Y1QaA20znMdwoA=";
-    })
-    # fix tests running on kernel 6.6 or newer
-    # https://github.com/eventlet/eventlet/pull/905
-    (fetchpatch {
-      url = "https://github.com/eventlet/eventlet/commit/413327b229c80a97e9c89c52f7714224942701b4.patch";
-      hash = "sha256-rbYPd5cg3ElSYWYaZJrS7bb4nMJkTMO0ScvNnXRXzE0=";
-    })
-  ];
-
   nativeBuildInputs = [
-    setuptools
+    hatch-vcs
+    hatchling
   ];
 
   propagatedBuildInputs = [
@@ -62,13 +45,11 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    nose3
   ];
 
   # libredirect is not available on darwin
   # tests hang on pypy indefinitely
-  # nose3 is incompatible with Python 3.12.
-  doCheck = !stdenv.isDarwin && !isPyPy && !(pythonAtLeast "3.12");
+  doCheck = !stdenv.isDarwin && !isPyPy;
 
   preCheck = lib.optionalString doCheck ''
     echo "nameserver 127.0.0.1" > resolv.conf
@@ -79,47 +60,14 @@ buildPythonPackage rec {
   '';
 
   disabledTests = [
+    # AssertionError: Expected single line "pass" in stdout
+    "test_fork_after_monkey_patch"
     # Tests requires network access
-    "test_017_ssl_zeroreturnerror"
-    "test_018b_http_10_keepalive_framing"
     "test_getaddrinfo"
     "test_hosts_no_network"
-    "test_leakage_from_tracebacks"
-    "test_patcher_existing_locks_locked"
-    # broken with pyopenssl 22.0.0
-    "test_sendall_timeout"
-    # broken on aarch64 and when using march in gcc
-    "test_fork_after_monkey_patch"
   ];
 
-  disabledTestPaths = [
-    # Tests are out-dated
-    "tests/stdlib/test_asynchat.py"
-    "tests/stdlib/test_asyncore.py"
-    "tests/stdlib/test_ftplib.py"
-    "tests/stdlib/test_httplib.py"
-    "tests/stdlib/test_httpservers.py"
-    "tests/stdlib/test_os.py"
-    "tests/stdlib/test_queue.py"
-    "tests/stdlib/test_select.py"
-    "tests/stdlib/test_SimpleHTTPServer.py"
-    "tests/stdlib/test_socket_ssl.py"
-    "tests/stdlib/test_socket.py"
-    "tests/stdlib/test_socketserver.py"
-    "tests/stdlib/test_ssl.py"
-    "tests/stdlib/test_subprocess.py"
-    "tests/stdlib/test_thread__boundedsem.py"
-    "tests/stdlib/test_thread.py"
-    "tests/stdlib/test_threading_local.py"
-    "tests/stdlib/test_threading.py"
-    "tests/stdlib/test_timeout.py"
-    "tests/stdlib/test_urllib.py"
-    "tests/stdlib/test_urllib2_localnet.py"
-    "tests/stdlib/test_urllib2.py"
-  ];
-
-  # unfortunately, it needs /etc/protocol to be present to not fail
-  # pythonImportsCheck = [ "eventlet" ];
+  pythonImportsCheck = [ "eventlet" ];
 
   meta = with lib; {
     changelog = "https://github.com/eventlet/eventlet/blob/v${version}/NEWS";


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/eventlet/eventlet/compare/v0.33.3...v0.35.2

Changelog: https://github.com/eventlet/eventlet/blob/v0.35.2/NEWS



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
