### PR TITLE
sbd: init at 1.37

### DIFF
--- a/pkgs/by-name/sb/sbd/package.nix
+++ b/pkgs/by-name/sb/sbd/package.nix
@@ -1,0 +1,31 @@
+{ lib
+, stdenv
+, fetchurl
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sbd";
+  version = "1.37";
+
+  src = fetchurl {
+    url = "https://web.archive.org/web/20220626230420/http://www.tigerteam.se/dl/sbd/sbd-${finalAttrs.version}.tar.gz";
+    hash = "sha256-Qt5Q3PynV80DAXxuVqx6L4dTKgjnBDQjzSDZEf1kX10=";
+  };
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "CC=cc"
+  ];
+
+  buildFlags = lib.optional stdenv.isLinux "unix"
+               ++ lib.optional stdenv.isDarwin "darwin";
+
+  meta = with lib; {
+    description = "Netcat-clone, portable, offers strong encryption - features AES-128-CBC + HMAC-SHA1 encryption, program execution, choosing source port, continuous reconnection with delay and more";
+    mainProgram = "sbd";
+    homepage = "https://web.archive.org/web/20220626230420/http://www.tigerteam.se/dl/sbd/";
+    license = licenses.gpl2Plus;
+    maintainers = with maintainers; [ d3vil0p3r ];
+    platforms = platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description of changes

The official website tigerteam.se (not more available) had also latest version [1.37](https://web.archive.org/web/20220626230420/http://www.tigerteam.se/dl/sbd/sbd-1.37.tar.gz), that should be the version used in [Kali Linux](https://gitlab.com/kalilinux/packages/sbd). Not sure if a good idea could be to upload this latest version to the packetstormsecurity website, that was the main website where the devs of sbd uploaded the different versions of sbd (except the last one).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
