### PR TITLE
uefisettings: init at unstable-2024-02-20

### DIFF
--- a/pkgs/by-name/ue/uefisettings/package.nix
+++ b/pkgs/by-name/ue/uefisettings/package.nix
@@ -1,0 +1,30 @@
+{ fetchFromGitHub
+, lib
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage {
+  name = "uefisettings";
+  version = "unstable-2024-02-20";
+
+  src = fetchFromGitHub {
+    owner = "linuxboot";
+    repo = "uefisettings";
+    rev = "eae8b8b622b7ac3c572eeb3b3513ed623e272fcc";
+    hash = "sha256-zLgrxYBj5bEMZRw5sKWqKuV3jQOJ6dnzbzpoqE0OhKs=";
+  };
+
+  cargoHash = "sha256-FCQ/1E6SZyVOOAlpqyaDWEZx0y0Wk3Caosvr48VamAA=";
+
+  # Tests expect filesystem access to directories like /proc
+  doCheck = false;
+
+  meta = with lib; {
+    description = "CLI tool to read/get/extract and write/change/modify BIOS/UEFI settings.";
+    homepage = "https://github.com/linuxboot/uefisettings";
+    license = with licenses; [ bsd3 ];
+    mainProgram = "uefisettings";
+    maintainers = with maintainers; [ surfaceflinger ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

this thing just saved my ass so im packaging it
basically allows to modify ALL settings on AMI BIOS that your GaMiNg mobo OEM hidden from you.
(what if declarative uefi settings??????????????)

Tests are disabled because of thingies like this https://github.com/linuxboot/uefisettings/blob/eae8b8b622b7ac3c572eeb3b3513ed623e272fcc/src/lib/hii/efivarfs.rs#L158

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
