### PR TITLE
catppuccin-gtk: fix nix derivation for build scripts

### DIFF
--- a/pkgs/data/themes/catppuccin-gtk/colloid-src-git-reset.patch
+++ b/pkgs/data/themes/catppuccin-gtk/colloid-src-git-reset.patch
@@ -1,0 +1,17 @@
+diff --git a/scripts/create_theme.py b/scripts/create_theme.py
+index 074dc43..7e7a8eb 100644
+--- a/scripts/create_theme.py
++++ b/scripts/create_theme.py
+@@ -34,7 +34,11 @@ def create_theme(types: List[str], accents: List[str], dest: str, link: bool = F
+             os.chdir(work_dir)
+             subprocess.call("./build.sh", shell=True) # Rebuild all scss
+             subprocess.call(install_cmd, shell=True) # Install the theme globally for you
+-            subprocess.call("git reset --hard HEAD", shell=True)  # reset colloid repo to original state
++            # subprocess.call("git reset --hard HEAD", shell=True)  # reset colloid repo to original state
++            # recreate git reset
++            os.chdir(repo_dir)
++            shutil.rmtree("colloid")
++            shutil.copytree("colloid-base", "colloid")
+ 
+             try:
+                 # Rename colloid generated files as per catppuccin

--- a/pkgs/data/themes/catppuccin-gtk/default.nix
+++ b/pkgs/data/themes/catppuccin-gtk/default.nix
@@ -40,6 +40,10 @@ stdenvNoCC.mkDerivation rec {
 
   nativeBuildInputs = [ gtk3 sassc ];
 
+  patches = [
+    ./colloid-src-git-reset.patch
+  ];
+
   buildInputs = [
     gnome-themes-extra
     (python3.withPackages (ps: [ ps.catppuccin ]))
@@ -54,7 +58,7 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   postPatch = ''
-    patchShebangs --build colloid/install.sh
+    patchShebangs --build colloid/install.sh colloid/build.sh
   '';
 
   dontConfigure = true;
@@ -63,6 +67,7 @@ stdenvNoCC.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
+    cp -r colloid colloid-base
     mkdir -p $out/share/themes
     export HOME=$(mktemp -d)
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The previous derivation wouldn't actually run the build scripts or support multiple accent colors (since it expects the source to be reset with `git` after each theme generation).

- Patch build.sh shebang in colloid

- Add patch for `create_theme.py` to emulate git reset

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
