### PR TITLE
nixos/ec2-metadata-fetcher: decompress EC2 user data if compressed

### DIFF
--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -102,6 +102,7 @@ in
         file
         gzip
         mktemp
+        xz
       ];
       script = builtins.readFile ./ec2-metadata-fetcher.sh;
       serviceConfig.Type = "oneshot";

--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -103,6 +103,7 @@ in
         gzip
         mktemp
         xz
+        zstd
       ];
       script = builtins.readFile ./ec2-metadata-fetcher.sh;
       serviceConfig.Type = "oneshot";

--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -96,7 +96,12 @@ in
       wantedBy = [ "multi-user.target" ];
       wants = [ "network-online.target" ];
       after = [ "network-online.target" ];
-      path = [ pkgs.curl ];
+      path = with pkgs; [
+        curl
+        file
+        gzip
+        mktemp
+      ];
       script = builtins.readFile ./ec2-metadata-fetcher.sh;
       serviceConfig.Type = "oneshot";
       serviceConfig.StandardOutput = "journal+console";

--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -101,6 +101,7 @@ in
         curl
         file
         gzip
+        lzip
         mktemp
         xz
         zstd

--- a/nixos/modules/virtualisation/amazon-image.nix
+++ b/nixos/modules/virtualisation/amazon-image.nix
@@ -97,6 +97,7 @@ in
       wants = [ "network-online.target" ];
       after = [ "network-online.target" ];
       path = with pkgs; [
+        bzip2
         curl
         file
         gzip

--- a/nixos/modules/virtualisation/ec2-metadata-fetcher.sh
+++ b/nixos/modules/virtualisation/ec2-metadata-fetcher.sh
@@ -62,22 +62,24 @@ get_imds() {
 }
 
 try_decompress() {
-  local temp ftype
+  local temp ftype decompress_cmd
   if [ ! -s "$1" ]; then
     return
   fi
   ftype=$(file --brief "$1")
   case $ftype in
-    gzip*)
-      echo "decompressing: $1"
-      temp=$(mktemp)
-      if zcat "$1" > "$temp"; then
-        mv "$temp" "$1"
-      else
-        echo "failed to decompress: $1"
-        rm -f "$temp"
-      fi
+    gzip*)  decompress_cmd=zcat ;;
+    bzip2*) decompress_cmd=bzcat ;;
+    *)      return ;;
   esac
+  echo "decompressing: $1"
+  temp=$(mktemp)
+  if $decompress_cmd "$1" > "$temp"; then
+    mv "$temp" "$1"
+  else
+    echo "failed to decompress: $1"
+    rm -f "$temp"
+  fi
 }
 
 get_imds -o "$metaDir/ami-manifest-path" http://169.254.169.254/1.0/meta-data/ami-manifest-path

--- a/nixos/modules/virtualisation/ec2-metadata-fetcher.sh
+++ b/nixos/modules/virtualisation/ec2-metadata-fetcher.sh
@@ -62,14 +62,21 @@ get_imds() {
 }
 
 try_decompress() {
-  local temp
+  local temp ftype
+  if [ ! -s "$1" ]; then
+    return
+  fi
   ftype=$(file --brief "$1")
   case $ftype in
     gzip*)
       echo "decompressing: $1"
       temp=$(mktemp)
-      zcat "$1" > "$temp"
-      mv "$temp" "$1"
+      if zcat "$1" > "$temp"; then
+        mv "$temp" "$1"
+      else
+        echo "failed to decompress: $1"
+        rm -f "$temp"
+      fi
   esac
 }
 

--- a/nixos/modules/virtualisation/ec2-metadata-fetcher.sh
+++ b/nixos/modules/virtualisation/ec2-metadata-fetcher.sh
@@ -68,10 +68,11 @@ try_decompress() {
   fi
   ftype=$(file --brief "$1")
   case $ftype in
-    gzip*)  decompress_cmd=zcat ;;
-    bzip2*) decompress_cmd=bzcat ;;
-    XZ*)    decompress_cmd=xzcat ;;
-    *)      return ;;
+    gzip*)       decompress_cmd=zcat ;;
+    bzip2*)      decompress_cmd=bzcat ;;
+    XZ*)         decompress_cmd=xzcat ;;
+    Zstandard*)  decompress_cmd=zstdcat ;;
+    *)           return ;;
   esac
   echo "decompressing: $1"
   temp=$(mktemp)

--- a/nixos/modules/virtualisation/ec2-metadata-fetcher.sh
+++ b/nixos/modules/virtualisation/ec2-metadata-fetcher.sh
@@ -70,6 +70,7 @@ try_decompress() {
   case $ftype in
     gzip*)  decompress_cmd=zcat ;;
     bzip2*) decompress_cmd=bzcat ;;
+    XZ*)    decompress_cmd=xzcat ;;
     *)      return ;;
   esac
   echo "decompressing: $1"

--- a/nixos/modules/virtualisation/ec2-metadata-fetcher.sh
+++ b/nixos/modules/virtualisation/ec2-metadata-fetcher.sh
@@ -72,6 +72,7 @@ try_decompress() {
     bzip2*)      decompress_cmd=bzcat ;;
     XZ*)         decompress_cmd=xzcat ;;
     Zstandard*)  decompress_cmd=zstdcat ;;
+    lzip*)       decompress_cmd="lzip -dc" ;;
     *)           return ;;
   esac
   echo "decompressing: $1"

--- a/nixos/tests/ec2-image.nix
+++ b/nixos/tests/ec2-image.nix
@@ -273,6 +273,11 @@ in
             test_data = b"#!/bin/bash\necho gzip-decompression-test\n"
             test_userdata_decompression(machine, user_data_path, gzip_mod.compress(test_data), "gzip")
 
+        with subtest("Decompression of bzip2-compressed user-data"):
+            import bz2
+            test_data = b"#!/bin/bash\necho bzip2-decompression-test\n"
+            test_userdata_decompression(machine, user_data_path, bz2.compress(test_data), "bzip2")
+
     finally:
         machine.shutdown()
         temp_dir.cleanup()

--- a/nixos/tests/ec2-image.nix
+++ b/nixos/tests/ec2-image.nix
@@ -283,6 +283,14 @@ in
             test_data = b"#!/bin/bash\necho xz-decompression-test\n"
             test_userdata_decompression(machine, user_data_path, lzma.compress(test_data), "xz")
 
+        with subtest("Decompression of zstd-compressed user-data"):
+            test_data = b"#!/bin/bash\necho zstd-decompression-test\n"
+            proc = subprocess.run(
+                ["${hostPkgs.zstd}/bin/zstd", "-c"],
+                input=test_data, capture_output=True, check=True,
+            )
+            test_userdata_decompression(machine, user_data_path, proc.stdout, "zstd")
+
     finally:
         machine.shutdown()
         temp_dir.cleanup()

--- a/nixos/tests/ec2-image.nix
+++ b/nixos/tests/ec2-image.nix
@@ -291,6 +291,14 @@ in
             )
             test_userdata_decompression(machine, user_data_path, proc.stdout, "zstd")
 
+        with subtest("Decompression of lzip-compressed user-data"):
+            test_data = b"#!/bin/bash\necho lzip-decompression-test\n"
+            proc = subprocess.run(
+                ["${hostPkgs.lzip}/bin/lzip", "-c"],
+                input=test_data, capture_output=True, check=True,
+            )
+            test_userdata_decompression(machine, user_data_path, proc.stdout, "lzip")
+
     finally:
         machine.shutdown()
         temp_dir.cleanup()

--- a/nixos/tests/ec2-image.nix
+++ b/nixos/tests/ec2-image.nix
@@ -278,6 +278,11 @@ in
             test_data = b"#!/bin/bash\necho bzip2-decompression-test\n"
             test_userdata_decompression(machine, user_data_path, bz2.compress(test_data), "bzip2")
 
+        with subtest("Decompression of xz-compressed user-data"):
+            import lzma
+            test_data = b"#!/bin/bash\necho xz-decompression-test\n"
+            test_userdata_decompression(machine, user_data_path, lzma.compress(test_data), "xz")
+
     finally:
         machine.shutdown()
         temp_dir.cleanup()

--- a/nixos/tests/ec2-image.nix
+++ b/nixos/tests/ec2-image.nix
@@ -182,7 +182,18 @@ in
             + " $QEMU_OPTS"
         )
 
-        return create_machine(start_command)
+        return create_machine(start_command), metadata_dir
+
+    def test_userdata_decompression(machine, user_data_path, compressed_data, format_name):
+        """Test that compressed user-data is decompressed by fetch-ec2-metadata"""
+        test_marker = f"{format_name}-decompression-test"
+        with open(user_data_path, "wb") as f:
+            f.write(compressed_data)
+        machine.succeed("systemctl restart fetch-ec2-metadata")
+        result = machine.succeed("cat /etc/ec2-metadata/user-data")
+        assert test_marker in result, f"Expected '{test_marker}' in decompressed {format_name} content, got: {result}"
+        journal = machine.succeed("journalctl -u fetch-ec2-metadata --no-pager -b")
+        assert "decompressing:" in journal, f"Expected decompression log in journal for {format_name}"
 
     # Create temporary directory for metadata (scoped for cleanup)
     temp_dir = tempfile.TemporaryDirectory()
@@ -194,7 +205,8 @@ in
     client_pubkey, client_private_key = generate_client_ssh_key()
 
     # Set up machine with client's public key in metadata service
-    machine = setup_machine(temp_dir, client_pubkey)
+    machine, metadata_dir = setup_machine(temp_dir, client_pubkey)
+    user_data_path = os.path.join(metadata_dir, "1.0", "user-data")
 
     try:
         machine.start()
@@ -255,6 +267,11 @@ in
 
         with subtest("Basic EC2 functionality"):
             machine.succeed("findmnt / -o SIZE -n | grep -E '[0-9]+G'")
+
+        with subtest("Decompression of gzip-compressed user-data"):
+            import gzip as gzip_mod
+            test_data = b"#!/bin/bash\necho gzip-decompression-test\n"
+            test_userdata_decompression(machine, user_data_path, gzip_mod.compress(test_data), "gzip")
 
     finally:
         machine.shutdown()


### PR DESCRIPTION
## Description of changes

Decompress EC2 user data when compressed with `gzip`.

Closes https://github.com/NixOS/nixpkgs/issues/290336.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

This has been tested with uncompressed user data and user data compressed by Terraform's `base64gzip()` function. We are actively using these changes locally.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
