### PR TITLE
dotnet: infrastructure cleanup

### DIFF
--- a/pkgs/build-support/dotnet/nuget-to-nix/nuget-to-nix.sh
+++ b/pkgs/build-support/dotnet/nuget-to-nix/nuget-to-nix.sh
@@ -52,6 +52,7 @@ for package in *; do
     fi
 
     used_source="$(jq -r '.source' "$version"/.nupkg.metadata)"
+    found=false
 
     if [[ -d "$used_source" ]]; then
         continue
@@ -80,7 +81,7 @@ for package in *; do
       fi
     done
 
-    if ! ${found-false}; then
+    if [[ $found = false ]]; then
       echo "couldn't find $package $version" >&2
       exit 1
     fi

--- a/pkgs/development/compilers/dotnet/update.sh
+++ b/pkgs/development/compilers/dotnet/update.sh
@@ -36,11 +36,11 @@ release_platform_attr () {
 
 platform_sources () {
   local release_files="$1"
-  local platforms=( \
-    "x86_64-linux   linux-x64" \
-    "aarch64-linux  linux-arm64" \
-    "x86_64-darwin  osx-x64" \
-    "aarch64-darwin osx-arm64" \
+  local platforms=(
+    "x86_64-linux   linux-x64"
+    "aarch64-linux  linux-arm64"
+    "x86_64-darwin  osx-x64"
+    "aarch64-darwin osx-arm64"
   )
 
   echo "srcs = {"
@@ -117,31 +117,31 @@ aspnetcore_packages () {
     # Due to this, make sure to check if new SDK versions introduce any new packages.
     # This should not happend in minor or bugfix updates, but probably happens
     # with every new major .NET release.
-    local pkgs=( \
-      "Microsoft.AspNetCore.App.Runtime.linux-arm" \
-      "Microsoft.AspNetCore.App.Runtime.linux-arm64" \
-      "Microsoft.AspNetCore.App.Runtime.linux-musl-arm64" \
-      "Microsoft.AspNetCore.App.Runtime.linux-musl-x64" \
-      "Microsoft.AspNetCore.App.Runtime.linux-x64" \
-      "Microsoft.AspNetCore.App.Runtime.osx-x64" \
-      "Microsoft.AspNetCore.App.Runtime.win-arm64" \
-      "Microsoft.AspNetCore.App.Runtime.win-x64" \
-      "Microsoft.AspNetCore.App.Runtime.win-x86" \
+    local pkgs=(
+      "Microsoft.AspNetCore.App.Runtime.linux-arm"
+      "Microsoft.AspNetCore.App.Runtime.linux-arm64"
+      "Microsoft.AspNetCore.App.Runtime.linux-musl-arm64"
+      "Microsoft.AspNetCore.App.Runtime.linux-musl-x64"
+      "Microsoft.AspNetCore.App.Runtime.linux-x64"
+      "Microsoft.AspNetCore.App.Runtime.osx-x64"
+      "Microsoft.AspNetCore.App.Runtime.win-arm64"
+      "Microsoft.AspNetCore.App.Runtime.win-x64"
+      "Microsoft.AspNetCore.App.Runtime.win-x86"
     )
 
     # These packages are currently broken on .NET 8
     if version_older "$version" "8"; then
-        pkgs+=( \
-            "Microsoft.AspNetCore.App.Runtime.win-arm" \
+        pkgs+=(
+            "Microsoft.AspNetCore.App.Runtime.win-arm"
         )
     fi
 
     # Packages that only apply to .NET 6 and up
     if ! version_older "$version" "6"; then
-        pkgs+=( \
-          "Microsoft.AspNetCore.App.Ref" \
-          "Microsoft.AspNetCore.App.Runtime.linux-musl-arm" \
-          "Microsoft.AspNetCore.App.Runtime.osx-arm64" \
+        pkgs+=(
+          "Microsoft.AspNetCore.App.Ref"
+          "Microsoft.AspNetCore.App.Runtime.linux-musl-arm"
+          "Microsoft.AspNetCore.App.Runtime.osx-arm64"
         )
     fi
 
@@ -173,119 +173,119 @@ sdk_packages () {
     # Due to this, make sure to check if new SDK versions introduce any new packages.
     # This should not happend in minor or bugfix updates, but probably happens
     # with every new major .NET release.
-    local pkgs=( \
-      "Microsoft.NETCore.App.Host.linux-arm" \
-      "Microsoft.NETCore.App.Host.linux-arm64" \
-      "Microsoft.NETCore.App.Host.linux-musl-arm64" \
-      "Microsoft.NETCore.App.Host.linux-musl-x64" \
-      "Microsoft.NETCore.App.Host.linux-x64" \
-      "Microsoft.NETCore.App.Host.osx-x64" \
-      "Microsoft.NETCore.App.Host.win-arm64" \
-      "Microsoft.NETCore.App.Host.win-x64" \
-      "Microsoft.NETCore.App.Host.win-x86" \
-      "Microsoft.NETCore.App.Runtime.linux-arm" \
-      "Microsoft.NETCore.App.Runtime.linux-arm64" \
-      "Microsoft.NETCore.App.Runtime.linux-musl-arm64" \
-      "Microsoft.NETCore.App.Runtime.linux-musl-x64" \
-      "Microsoft.NETCore.App.Runtime.linux-x64" \
-      "Microsoft.NETCore.App.Runtime.osx-x64" \
-      "Microsoft.NETCore.App.Runtime.win-arm64" \
-      "Microsoft.NETCore.App.Runtime.win-x64" \
-      "Microsoft.NETCore.App.Runtime.win-x86" \
-      "Microsoft.NETCore.DotNetAppHost" \
-      "Microsoft.NETCore.DotNetHost" \
-      "Microsoft.NETCore.DotNetHostPolicy" \
-      "Microsoft.NETCore.DotNetHostResolver" \
-      "runtime.linux-arm64.Microsoft.NETCore.DotNetAppHost" \
-      "runtime.linux-arm64.Microsoft.NETCore.DotNetHost" \
-      "runtime.linux-arm64.Microsoft.NETCore.DotNetHostPolicy" \
-      "runtime.linux-arm64.Microsoft.NETCore.DotNetHostResolver" \
-      "runtime.linux-arm.Microsoft.NETCore.DotNetAppHost" \
-      "runtime.linux-arm.Microsoft.NETCore.DotNetHost" \
-      "runtime.linux-arm.Microsoft.NETCore.DotNetHostPolicy" \
-      "runtime.linux-arm.Microsoft.NETCore.DotNetHostResolver" \
-      "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetAppHost" \
-      "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHost" \
-      "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostPolicy" \
-      "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostResolver" \
-      "runtime.linux-musl-x64.Microsoft.NETCore.DotNetAppHost" \
-      "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHost" \
-      "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostPolicy" \
-      "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostResolver" \
-      "runtime.linux-x64.Microsoft.NETCore.DotNetAppHost" \
-      "runtime.linux-x64.Microsoft.NETCore.DotNetHost" \
-      "runtime.linux-x64.Microsoft.NETCore.DotNetHostPolicy" \
-      "runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" \
-      "runtime.osx-x64.Microsoft.NETCore.DotNetAppHost" \
-      "runtime.osx-x64.Microsoft.NETCore.DotNetHost" \
-      "runtime.osx-x64.Microsoft.NETCore.DotNetHostPolicy" \
-      "runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver" \
-      "runtime.win-arm64.Microsoft.NETCore.DotNetAppHost" \
-      "runtime.win-arm64.Microsoft.NETCore.DotNetHost" \
-      "runtime.win-arm64.Microsoft.NETCore.DotNetHostPolicy" \
-      "runtime.win-arm64.Microsoft.NETCore.DotNetHostResolver" \
-      "runtime.win-x64.Microsoft.NETCore.DotNetAppHost" \
-      "runtime.win-x64.Microsoft.NETCore.DotNetHost" \
-      "runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy" \
-      "runtime.win-x64.Microsoft.NETCore.DotNetHostResolver" \
-      "runtime.win-x86.Microsoft.NETCore.DotNetAppHost" \
-      "runtime.win-x86.Microsoft.NETCore.DotNetHost" \
-      "runtime.win-x86.Microsoft.NETCore.DotNetHostPolicy" \
-      "runtime.win-x86.Microsoft.NETCore.DotNetHostResolver" \
-      "Microsoft.NETCore.App.Host.linux-musl-arm" \
-      "Microsoft.NETCore.App.Host.osx-arm64" \
-      "Microsoft.NETCore.App.Runtime.linux-musl-arm" \
-      "Microsoft.NETCore.App.Runtime.osx-arm64" \
-      "Microsoft.NETCore.App.Ref" \
-      "Microsoft.NETCore.App.Runtime.Mono.linux-arm" \
-      "Microsoft.NETCore.App.Runtime.Mono.linux-arm64" \
-      "Microsoft.NETCore.App.Runtime.Mono.linux-musl-x64" \
-      "Microsoft.NETCore.App.Runtime.Mono.linux-x64" \
-      "Microsoft.NETCore.App.Runtime.Mono.osx-arm64" \
-      "Microsoft.NETCore.App.Runtime.Mono.osx-x64" \
-      "Microsoft.NETCore.App.Runtime.Mono.win-x64" \
-      "Microsoft.NETCore.App.Runtime.Mono.win-x86" \
-      "runtime.linux-musl-arm.Microsoft.NETCore.DotNetAppHost" \
-      "runtime.linux-musl-arm.Microsoft.NETCore.DotNetHost" \
-      "runtime.linux-musl-arm.Microsoft.NETCore.DotNetHostPolicy" \
-      "runtime.linux-musl-arm.Microsoft.NETCore.DotNetHostResolver" \
-      "runtime.osx-arm64.Microsoft.NETCore.DotNetAppHost" \
-      "runtime.osx-arm64.Microsoft.NETCore.DotNetHost" \
-      "runtime.osx-arm64.Microsoft.NETCore.DotNetHostPolicy" \
-      "runtime.osx-arm64.Microsoft.NETCore.DotNetHostResolver" \
-      "Microsoft.NETCore.App.Crossgen2.linux-musl-arm" \
-      "Microsoft.NETCore.App.Crossgen2.linux-musl-arm64" \
-      "Microsoft.NETCore.App.Crossgen2.linux-musl-x64" \
-      "Microsoft.NETCore.App.Crossgen2.linux-arm" \
-      "Microsoft.NETCore.App.Crossgen2.linux-arm64" \
-      "Microsoft.NETCore.App.Crossgen2.linux-x64" \
-      "Microsoft.NETCore.App.Crossgen2.osx-x64" \
+    local pkgs=(
+      "Microsoft.NETCore.App.Host.linux-arm"
+      "Microsoft.NETCore.App.Host.linux-arm64"
+      "Microsoft.NETCore.App.Host.linux-musl-arm64"
+      "Microsoft.NETCore.App.Host.linux-musl-x64"
+      "Microsoft.NETCore.App.Host.linux-x64"
+      "Microsoft.NETCore.App.Host.osx-x64"
+      "Microsoft.NETCore.App.Host.win-arm64"
+      "Microsoft.NETCore.App.Host.win-x64"
+      "Microsoft.NETCore.App.Host.win-x86"
+      "Microsoft.NETCore.App.Runtime.linux-arm"
+      "Microsoft.NETCore.App.Runtime.linux-arm64"
+      "Microsoft.NETCore.App.Runtime.linux-musl-arm64"
+      "Microsoft.NETCore.App.Runtime.linux-musl-x64"
+      "Microsoft.NETCore.App.Runtime.linux-x64"
+      "Microsoft.NETCore.App.Runtime.osx-x64"
+      "Microsoft.NETCore.App.Runtime.win-arm64"
+      "Microsoft.NETCore.App.Runtime.win-x64"
+      "Microsoft.NETCore.App.Runtime.win-x86"
+      "Microsoft.NETCore.DotNetAppHost"
+      "Microsoft.NETCore.DotNetHost"
+      "Microsoft.NETCore.DotNetHostPolicy"
+      "Microsoft.NETCore.DotNetHostResolver"
+      "runtime.linux-arm64.Microsoft.NETCore.DotNetAppHost"
+      "runtime.linux-arm64.Microsoft.NETCore.DotNetHost"
+      "runtime.linux-arm64.Microsoft.NETCore.DotNetHostPolicy"
+      "runtime.linux-arm64.Microsoft.NETCore.DotNetHostResolver"
+      "runtime.linux-arm.Microsoft.NETCore.DotNetAppHost"
+      "runtime.linux-arm.Microsoft.NETCore.DotNetHost"
+      "runtime.linux-arm.Microsoft.NETCore.DotNetHostPolicy"
+      "runtime.linux-arm.Microsoft.NETCore.DotNetHostResolver"
+      "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetAppHost"
+      "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHost"
+      "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostPolicy"
+      "runtime.linux-musl-arm64.Microsoft.NETCore.DotNetHostResolver"
+      "runtime.linux-musl-x64.Microsoft.NETCore.DotNetAppHost"
+      "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHost"
+      "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostPolicy"
+      "runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostResolver"
+      "runtime.linux-x64.Microsoft.NETCore.DotNetAppHost"
+      "runtime.linux-x64.Microsoft.NETCore.DotNetHost"
+      "runtime.linux-x64.Microsoft.NETCore.DotNetHostPolicy"
+      "runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver"
+      "runtime.osx-x64.Microsoft.NETCore.DotNetAppHost"
+      "runtime.osx-x64.Microsoft.NETCore.DotNetHost"
+      "runtime.osx-x64.Microsoft.NETCore.DotNetHostPolicy"
+      "runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver"
+      "runtime.win-arm64.Microsoft.NETCore.DotNetAppHost"
+      "runtime.win-arm64.Microsoft.NETCore.DotNetHost"
+      "runtime.win-arm64.Microsoft.NETCore.DotNetHostPolicy"
+      "runtime.win-arm64.Microsoft.NETCore.DotNetHostResolver"
+      "runtime.win-x64.Microsoft.NETCore.DotNetAppHost"
+      "runtime.win-x64.Microsoft.NETCore.DotNetHost"
+      "runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy"
+      "runtime.win-x64.Microsoft.NETCore.DotNetHostResolver"
+      "runtime.win-x86.Microsoft.NETCore.DotNetAppHost"
+      "runtime.win-x86.Microsoft.NETCore.DotNetHost"
+      "runtime.win-x86.Microsoft.NETCore.DotNetHostPolicy"
+      "runtime.win-x86.Microsoft.NETCore.DotNetHostResolver"
+      "Microsoft.NETCore.App.Host.linux-musl-arm"
+      "Microsoft.NETCore.App.Host.osx-arm64"
+      "Microsoft.NETCore.App.Runtime.linux-musl-arm"
+      "Microsoft.NETCore.App.Runtime.osx-arm64"
+      "Microsoft.NETCore.App.Ref"
+      "Microsoft.NETCore.App.Runtime.Mono.linux-arm"
+      "Microsoft.NETCore.App.Runtime.Mono.linux-arm64"
+      "Microsoft.NETCore.App.Runtime.Mono.linux-musl-x64"
+      "Microsoft.NETCore.App.Runtime.Mono.linux-x64"
+      "Microsoft.NETCore.App.Runtime.Mono.osx-arm64"
+      "Microsoft.NETCore.App.Runtime.Mono.osx-x64"
+      "Microsoft.NETCore.App.Runtime.Mono.win-x64"
+      "Microsoft.NETCore.App.Runtime.Mono.win-x86"
+      "runtime.linux-musl-arm.Microsoft.NETCore.DotNetAppHost"
+      "runtime.linux-musl-arm.Microsoft.NETCore.DotNetHost"
+      "runtime.linux-musl-arm.Microsoft.NETCore.DotNetHostPolicy"
+      "runtime.linux-musl-arm.Microsoft.NETCore.DotNetHostResolver"
+      "runtime.osx-arm64.Microsoft.NETCore.DotNetAppHost"
+      "runtime.osx-arm64.Microsoft.NETCore.DotNetHost"
+      "runtime.osx-arm64.Microsoft.NETCore.DotNetHostPolicy"
+      "runtime.osx-arm64.Microsoft.NETCore.DotNetHostResolver"
+      "Microsoft.NETCore.App.Crossgen2.linux-musl-arm"
+      "Microsoft.NETCore.App.Crossgen2.linux-musl-arm64"
+      "Microsoft.NETCore.App.Crossgen2.linux-musl-x64"
+      "Microsoft.NETCore.App.Crossgen2.linux-arm"
+      "Microsoft.NETCore.App.Crossgen2.linux-arm64"
+      "Microsoft.NETCore.App.Crossgen2.linux-x64"
+      "Microsoft.NETCore.App.Crossgen2.osx-x64"
       "Microsoft.NETCore.App.Crossgen2.osx-arm64"
     )
 
     # These packages were removed on .NET 8
     if version_older "$version" "8"; then
-        pkgs+=( \
-            "Microsoft.NETCore.App.Host.win-arm" \
-            "Microsoft.NETCore.App.Runtime.win-arm" \
-            "runtime.win-arm.Microsoft.NETCore.DotNetAppHost" \
-            "runtime.win-arm.Microsoft.NETCore.DotNetHost" \
-            "runtime.win-arm.Microsoft.NETCore.DotNetHostPolicy" \
-            "runtime.win-arm.Microsoft.NETCore.DotNetHostResolver" \
-            "Microsoft.NETCore.App.Composite" \
+        pkgs+=(
+            "Microsoft.NETCore.App.Host.win-arm"
+            "Microsoft.NETCore.App.Runtime.win-arm"
+            "runtime.win-arm.Microsoft.NETCore.DotNetAppHost"
+            "runtime.win-arm.Microsoft.NETCore.DotNetHost"
+            "runtime.win-arm.Microsoft.NETCore.DotNetHostPolicy"
+            "runtime.win-arm.Microsoft.NETCore.DotNetHostResolver"
+            "Microsoft.NETCore.App.Composite"
         )
     fi
 
     # Packages that only apply to .NET 7 and up
     if ! version_older "$version" "7"; then
-        pkgs+=( \
-          "runtime.linux-arm64.Microsoft.DotNet.ILCompiler" \
-          "runtime.linux-musl-arm64.Microsoft.DotNet.ILCompiler" \
-          "runtime.linux-musl-x64.Microsoft.DotNet.ILCompiler" \
-          "runtime.linux-x64.Microsoft.DotNet.ILCompiler" \
-          "runtime.osx-x64.Microsoft.DotNet.ILCompiler" \
-          "runtime.win-arm64.Microsoft.DotNet.ILCompiler" \
-          "runtime.win-x64.Microsoft.DotNet.ILCompiler" \
+        pkgs+=(
+          "runtime.linux-arm64.Microsoft.DotNet.ILCompiler"
+          "runtime.linux-musl-arm64.Microsoft.DotNet.ILCompiler"
+          "runtime.linux-musl-x64.Microsoft.DotNet.ILCompiler"
+          "runtime.linux-x64.Microsoft.DotNet.ILCompiler"
+          "runtime.osx-x64.Microsoft.DotNet.ILCompiler"
+          "runtime.win-arm64.Microsoft.DotNet.ILCompiler"
+          "runtime.win-x64.Microsoft.DotNet.ILCompiler"
         )
     fi
 

--- a/pkgs/development/compilers/dotnet/update.sh
+++ b/pkgs/development/compilers/dotnet/update.sh
@@ -85,7 +85,7 @@ version_older () {
     cur_version=$1
     max_version=$2
     result=$(nix-instantiate -I ../../../../. \
-        --eval -E "(import <nixpkgs> {}).lib.versionOlder \"$cur_version\" \"$max_version\"")
+        --eval -E "(import ../../../../. {}).lib.versionOlder \"$cur_version\" \"$max_version\"")
     if [[ "$result" == "true" ]]; then
         return 0
     else

--- a/pkgs/development/compilers/dotnet/update.sh
+++ b/pkgs/development/compilers/dotnet/update.sh
@@ -359,6 +359,13 @@ Examples:
     channel_version=$(jq -r '."channel-version"' <<< "$content")
     support_phase=$(jq -r '."support-phase"' <<< "$content")
 
+    aspnetcore_sources="$(platform_sources "$aspnetcore_files")"
+    runtime_sources="$(platform_sources "$runtime_files")"
+    sdk_sources="$(platform_sources "$sdk_files")"
+
+    aspnetcore_packages="$(aspnetcore_packages "${aspnetcore_version}")"
+    sdk_packages="$(sdk_packages "${runtime_version}")"
+
     result=$(mktemp)
     trap "rm -f $result" TERM INT EXIT
 
@@ -368,20 +375,20 @@ Examples:
 {
   aspnetcore_$major_minor_underscore = buildAspNetCore {
     version = \"${aspnetcore_version}\";
-    $(platform_sources "$aspnetcore_files")
+    $aspnetcore_sources
   };
 
   runtime_$major_minor_underscore = buildNetRuntime {
     version = \"${runtime_version}\";
-    $(platform_sources "$runtime_files")
+    $runtime_sources
   };
 
   sdk_$major_minor_underscore = buildNetSdk {
     version = \"${sdk_version}\";
-    $(platform_sources "$sdk_files")
+    $sdk_sources
     packages = { fetchNuGet }: [
-$(aspnetcore_packages "${aspnetcore_version}")
-$(sdk_packages "${runtime_version}")
+$aspnetcore_packages
+$sdk_packages
     ];
   };
 }" > "${result}"


### PR DESCRIPTION
## Description of changes

This is some infrastructure fixes and improvements pulled out of #190129

@NixOS/dotnet 

I've regenerated all the sdk `versions/*.nix` to verify that there are no changes. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
