### PR TITLE
ollama: 0.1.24 -> 0.1.26

### DIFF
--- a/pkgs/tools/misc/ollama/default.nix
+++ b/pkgs/tools/misc/ollama/default.nix
@@ -17,19 +17,47 @@
 , linuxPackages
 , darwin
 
-, enableRocm ? false
-, enableCuda ? false
+  # one of `[ null "rocm" "cuda" ]`
+, acceleration ? null
 }:
 
 let
   pname = "ollama";
   version = "0.1.26";
 
-  warnIfNotLinux = warning: (lib.warnIfNot stdenv.isLinux warning stdenv.isLinux);
-  gpuWarning = api: "building ollama with ${api} is only supported on linux; falling back to cpu";
-  rocmIsEnabled = enableRocm && (warnIfNotLinux (gpuWarning "rocm"));
-  cudaIsEnabled = enableCuda && (warnIfNotLinux (gpuWarning "cuda"));
-  enableLinuxGpu = rocmIsEnabled || cudaIsEnabled;
+  validAccel = lib.assertOneOf "ollama.acceleration" acceleration [ null "rocm" "cuda" ];
+
+  warnIfNotLinux = api: (lib.warnIfNot stdenv.isLinux
+    "building ollama with `${api}` is only supported on linux; falling back to cpu"
+    stdenv.isLinux);
+  enableRocm = validAccel && (acceleration == "rocm") && (warnIfNotLinux "rocm");
+  enableCuda = validAccel && (acceleration == "cuda") && (warnIfNotLinux "cuda");
+
+  rocmClang = linkFarm "rocm-clang" {
+    llvm = rocmPackages.llvm.clang;
+  };
+  rocmPath = buildEnv {
+    name = "rocm-path";
+    paths = [
+      rocmPackages.rocm-device-libs
+      rocmClang
+    ];
+  };
+
+  cudaToolkit = buildEnv {
+    name = "cuda-toolkit";
+    ignoreCollisions = true; # FIXME: find a cleaner way to do this without ignoring collisions
+    paths = [
+      cudaPackages.cudatoolkit
+      cudaPackages.cuda_cudart
+    ];
+  };
+
+  runtimeLibs = lib.optionals enableRocm [
+    rocmPackages.rocm-smi
+  ] ++ lib.optionals enableCuda [
+    linuxPackages.nvidia_x11
+  ];
 
   appleFrameworks = darwin.apple_sdk_11_0.frameworks;
   metalFrameworks = [
@@ -38,6 +66,13 @@ let
     appleFrameworks.MetalKit
     appleFrameworks.MetalPerformanceShaders
   ];
+
+
+  goBuild =
+    if enableCuda then
+      buildGoModule.override { stdenv = overrideCC stdenv gcc12; }
+    else
+      buildGoModule;
 
   src = fetchFromGitHub {
     owner = "jmorganca";
@@ -53,130 +88,87 @@ let
     extraPrefix = "llm/llama.cpp/";
   };
   inherit (lib) licenses platforms maintainers;
-  ollama = {
-    inherit pname version src;
-    vendorHash = "sha256-zTrBighPBqZ9hhkEV3UawJZUYyPRay7+P6wkhDtpY7M=";
-
-    nativeBuildInputs = [
-      cmake
-    ] ++ lib.optionals enableLinuxGpu [
-      makeWrapper
-    ] ++ lib.optionals stdenv.isDarwin
-      metalFrameworks;
-
-    patches = [
-      # remove uses of `git` in the `go generate` script
-      # instead use `patch` where necessary
-      ./remove-git.patch
-      # replace a hardcoded use of `g++` with `$CXX`
-      ./replace-gcc.patch
-
-      # ollama's patches of llama.cpp's example server
-      # `ollama/llm/generate/gen_common.sh` -> "apply temporary patches until fix is upstream"
-      (preparePatch "01-cache.diff" "sha256-MTTln2G0G8dntihUzEjPM1ruTsApb4ZToBczJb8EG68=")
-      (preparePatch "02-cudaleaks.diff" "sha256-Cu7E9iEcvddPL9mPPI5Z96qmwWigi3f0WgSpPRjGc88=")
-    ];
-    postPatch = ''
-      # use a patch from the nix store in the `go generate` script
-      substituteInPlace llm/generate/gen_common.sh \
-        --subst-var-by cmakeIncludePatch '${./cmake-include.patch}'
-      # `ollama/llm/generate/gen_common.sh` -> "avoid duplicate main symbols when we link into the cgo binary"
-      substituteInPlace llm/llama.cpp/examples/server/server.cpp \
-        --replace-fail 'int main(' 'int __main('
-      # replace inaccurate version number with actual release version
-      substituteInPlace version/version.go --replace-fail 0.0.0 '${version}'
-    '';
-    preBuild = ''
-      export OLLAMA_SKIP_PATCHING=true
-      # build llama.cpp libraries for ollama
-      go generate ./...
-    '';
-
-    ldflags = [
-      "-s"
-      "-w"
-      "-X=github.com/jmorganca/ollama/version.Version=${version}"
-      "-X=github.com/jmorganca/ollama/server.mode=release"
-    ];
-
-    meta = {
-      description = "Get up and running with large language models locally";
-      homepage = "https://github.com/jmorganca/ollama";
-      license = licenses.mit;
-      platforms = platforms.unix;
-      mainProgram = "ollama";
-      maintainers = with maintainers; [ abysssol dit7ya elohmeier ];
-    };
-  };
-
-
-  rocmClang = linkFarm "rocm-clang" {
-    llvm = rocmPackages.llvm.clang;
-  };
-  rocmPath = buildEnv {
-    name = "rocm-path";
-    paths = [
-      rocmPackages.rocm-device-libs
-      rocmClang
-    ];
-  };
-  rocmVars = {
-    ROCM_PATH = rocmPath;
-    CLBlast_DIR = "${clblast}/lib/cmake/CLBlast";
-  };
-
-  cudaToolkit = buildEnv {
-    name = "cuda-toolkit";
-    ignoreCollisions = true; # FIXME: find a cleaner way to do this without ignoring collisions
-    paths = [
-      cudaPackages.cudatoolkit
-      cudaPackages.cuda_cudart
-    ];
-  };
-  cudaVars = {
-    CUDA_LIB_DIR = "${cudaToolkit}/lib";
-    CUDACXX = "${cudaToolkit}/bin/nvcc";
-    CUDAToolkit_ROOT = cudaToolkit;
-  };
-
-  linuxGpuLibs = {
-    buildInputs = lib.optionals rocmIsEnabled [
-      rocmPackages.clr
-      rocmPackages.hipblas
-      rocmPackages.rocblas
-      rocmPackages.rocsolver
-      rocmPackages.rocsparse
-      libdrm
-    ] ++ lib.optionals cudaIsEnabled [
-      cudaPackages.cuda_cudart
-    ];
-  };
-
-  appleGpuLibs = { buildInputs = metalFrameworks; };
-
-  runtimeLibs = lib.optionals rocmIsEnabled [
-    rocmPackages.rocm-smi
-  ] ++ lib.optionals cudaIsEnabled [
-    linuxPackages.nvidia_x11
-  ];
-  runtimeLibWrapper = {
-    postFixup = ''
-      mv "$out/bin/${pname}" "$out/bin/.${pname}-unwrapped"
-      makeWrapper "$out/bin/.${pname}-unwrapped" "$out/bin/${pname}" \
-        --suffix LD_LIBRARY_PATH : '${lib.makeLibraryPath runtimeLibs}'
-    '';
-  };
-
-  goBuild =
-    if cudaIsEnabled then
-      buildGoModule.override { stdenv = overrideCC stdenv gcc12; }
-    else
-      buildGoModule;
 in
-goBuild (ollama
-  // (lib.optionalAttrs rocmIsEnabled rocmVars)
-  // (lib.optionalAttrs cudaIsEnabled cudaVars)
-  // (lib.optionalAttrs enableLinuxGpu linuxGpuLibs)
-  // (lib.optionalAttrs enableLinuxGpu runtimeLibWrapper)
+goBuild ((lib.optionalAttrs enableRocm {
+  ROCM_PATH = rocmPath;
+  CLBlast_DIR = "${clblast}/lib/cmake/CLBlast";
+}) // (lib.optionalAttrs enableCuda {
+  CUDA_LIB_DIR = "${cudaToolkit}/lib";
+  CUDACXX = "${cudaToolkit}/bin/nvcc";
+  CUDAToolkit_ROOT = cudaToolkit;
+}) // {
+  inherit pname version src;
+  vendorHash = "sha256-zTrBighPBqZ9hhkEV3UawJZUYyPRay7+P6wkhDtpY7M=";
 
-  // (lib.optionalAttrs stdenv.isDarwin appleGpuLibs))
+  nativeBuildInputs = [
+    cmake
+  ] ++ lib.optionals (enableRocm || enableCuda) [
+    makeWrapper
+  ] ++ lib.optionals stdenv.isDarwin
+    metalFrameworks;
+
+  buildInputs = lib.optionals enableRocm [
+    rocmPackages.clr
+    rocmPackages.hipblas
+    rocmPackages.rocblas
+    rocmPackages.rocsolver
+    rocmPackages.rocsparse
+    libdrm
+  ] ++ lib.optionals enableCuda [
+    cudaPackages.cuda_cudart
+  ] ++ lib.optionals stdenv.isDarwin
+    metalFrameworks;
+
+  patches = [
+    # remove uses of `git` in the `go generate` script
+    # instead use `patch` where necessary
+    ./remove-git.patch
+    # replace a hardcoded use of `g++` with `$CXX`
+    ./replace-gcc.patch
+
+    # ollama's patches of llama.cpp's example server
+    # `ollama/llm/generate/gen_common.sh` -> "apply temporary patches until fix is upstream"
+    (preparePatch "01-cache.diff" "sha256-MTTln2G0G8dntihUzEjPM1ruTsApb4ZToBczJb8EG68=")
+    (preparePatch "02-cudaleaks.diff" "sha256-Cu7E9iEcvddPL9mPPI5Z96qmwWigi3f0WgSpPRjGc88=")
+  ];
+  postPatch = ''
+    # use a patch from the nix store in the `go generate` script
+    substituteInPlace llm/generate/gen_common.sh \
+      --subst-var-by cmakeIncludePatch '${./cmake-include.patch}'
+    # `ollama/llm/generate/gen_common.sh` -> "avoid duplicate main symbols when we link into the cgo binary"
+    substituteInPlace llm/llama.cpp/examples/server/server.cpp \
+      --replace-fail 'int main(' 'int __main('
+    # replace inaccurate version number with actual release version
+    substituteInPlace version/version.go --replace-fail 0.0.0 '${version}'
+  '';
+  preBuild = ''
+    export OLLAMA_SKIP_PATCHING=true
+    # build llama.cpp libraries for ollama
+    go generate ./...
+  '';
+  postFixup = ''
+    # the app doesn't appear functional at the moment, so hide it
+    mv "$out/bin/app" "$out/bin/.ollama-app"
+  '' + lib.optionalString (enableRocm || enableCuda) ''
+    # expose runtime libraries necessary to use the gpu
+    mv "$out/bin/ollama" "$out/bin/.ollama-unwrapped"
+    makeWrapper "$out/bin/.ollama-unwrapped" "$out/bin/ollama" \
+      --suffix LD_LIBRARY_PATH : '/run/opengl-driver/lib:${lib.makeLibraryPath runtimeLibs}'
+  '';
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/jmorganca/ollama/version.Version=${version}"
+    "-X=github.com/jmorganca/ollama/server.mode=release"
+  ];
+
+  meta = {
+    description = "Get up and running with large language models locally";
+    homepage = "https://github.com/jmorganca/ollama";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    mainProgram = "ollama";
+    maintainers = with maintainers; [ abysssol dit7ya elohmeier ];
+  };
+})

--- a/pkgs/tools/misc/ollama/default.nix
+++ b/pkgs/tools/misc/ollama/default.nix
@@ -23,7 +23,7 @@
 
 let
   pname = "ollama";
-  version = "0.1.24";
+  version = "0.1.26";
 
   warnIfNotLinux = warning: (lib.warnIfNot stdenv.isLinux warning stdenv.isLinux);
   gpuWarning = api: "building ollama with ${api} is only supported on linux; falling back to cpu";
@@ -43,7 +43,7 @@ let
     owner = "jmorganca";
     repo = "ollama";
     rev = "v${version}";
-    hash = "sha256-GwZA1QUH8I8m2bGToIcMMaB5MBnioQP4+n1SauUJYP8=";
+    hash = "sha256-Kw3tt9ayEMgI2V6OeaOkWfNwqfCL7MDD/nN5iXk5LnY=";
     fetchSubmodules = true;
   };
   preparePatch = patch: hash: fetchpatch {
@@ -55,7 +55,7 @@ let
   inherit (lib) licenses platforms maintainers;
   ollama = {
     inherit pname version src;
-    vendorHash = "sha256-wXRbfnkbeXPTOalm7SFLvHQ9j46S/yLNbFy+OWNSamQ=";
+    vendorHash = "sha256-zTrBighPBqZ9hhkEV3UawJZUYyPRay7+P6wkhDtpY7M=";
 
     nativeBuildInputs = [
       cmake
@@ -73,8 +73,8 @@ let
 
       # ollama's patches of llama.cpp's example server
       # `ollama/llm/generate/gen_common.sh` -> "apply temporary patches until fix is upstream"
-      (preparePatch "01-cache.diff" "sha256-PC4yN98hFvK+PEITiDihL8ki3bJuLVXrAm0CGf8GPJE=")
-      (preparePatch "02-shutdown.diff" "sha256-cElAp9Z9exxN964vB/YFuBhZoEcoAwGSMCnbh+l/V4Q=")
+      (preparePatch "01-cache.diff" "sha256-MTTln2G0G8dntihUzEjPM1ruTsApb4ZToBczJb8EG68=")
+      (preparePatch "02-cudaleaks.diff" "sha256-Cu7E9iEcvddPL9mPPI5Z96qmwWigi3f0WgSpPRjGc88=")
     ];
     postPatch = ''
       # use a patch from the nix store in the `go generate` script

--- a/pkgs/tools/misc/ollama/default.nix
+++ b/pkgs/tools/misc/ollama/default.nix
@@ -8,6 +8,7 @@
 , makeWrapper
 , stdenv
 
+, pkgs
 , cmake
 , gcc12
 , clblast
@@ -162,6 +163,12 @@ goBuild ((lib.optionalAttrs enableRocm {
     "-X=github.com/jmorganca/ollama/version.Version=${version}"
     "-X=github.com/jmorganca/ollama/server.mode=release"
   ];
+
+  # for now, just test that rocm and cuda build
+  passthru.tests = lib.optionalAttrs stdenv.isLinux {
+    rocm = pkgs.ollama.override { acceleration = "rocm"; };
+    cuda = pkgs.ollama.override { acceleration = "cuda"; };
+  };
 
   meta = {
     description = "Get up and running with large language models locally";


### PR DESCRIPTION
## Description of changes

Update ollama to version 0.1.26.

Testing is needed for cuda and darwin to ensure correct functionality and utilization of the gpu.

I expect 0.1.26 to be a good candidate for backporting, as long as no major problems are discovered.

Resolves #291217

### What's Changed

<details><summary>

#### ollama release [v0.1.25](https://github.com/ollama/ollama/releases/tag/v0.1.25)

</summary>

- Ollama on Windows is now available in preview.
- Fixed an issue where requests would hang after being repeated several times
- Ollama will now correctly error when provided an unsupported image format
- Fixed issue where ollama serve wouldn't immediately quit when receiving a termination signal
- Fixed issues with prompt templating for the /api/chat endpoint, such as where Ollama would omit the second system prompt in a series of messages
- Fixed issue where providing an empty list of messages would return a non-empty response instead of loading the model
- Setting a negative keep_alive value (e.g. -1) will now correctly keep the model loaded indefinitely

</details><details><summary>

#### ollama release [v0.1.26](https://github.com/ollama/ollama/releases/tag/v0.1.26)

</summary>

- Support for bert and nomic-bert embedding models
- Fixed issue where system prompt and prompt template would not be updated when loading a new model
- Quotes will now be trimmed around the value of the OLLAMA_HOST on Windows
- Fixed duplicate button issue on the Windows taskbar menu.
- Fixed issue where system prompt would be be overriden when using the /api/chat endpoint
- Hardened AMD driver lookup logic
- Fixed issue where two versions of Ollama on Windows would run at the same time
- Fixed issue where memory would not be released after a model is unloaded with modern CUDA-enabled GPUs
- Fixed issue where AVX2 was required for GPU on Windows machines with GPUs
- Fixed issue where /bye or /exit would not work with trailing spaces or characters after them

</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
