### PR TITLE
python311Packages.catppuccin: 1.3.2 -> 2.2.0, catppuccin-gtk: 0.7.1 -> 0.7.2

### DIFF
--- a/pkgs/data/themes/catppuccin-gtk/default.nix
+++ b/pkgs/data/themes/catppuccin-gtk/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenvNoCC
 , fetchFromGitHub
+, fetchpatch
 , gtk3
 , colloid-gtk-theme
 , gnome-themes-extra
@@ -29,19 +30,27 @@ lib.checkListOfEnum "${pname}: tweaks" validTweaks tweaks
 
 stdenvNoCC.mkDerivation rec {
   inherit pname;
-  version = "0.7.1";
+  version = "0.7.2";
 
   src = fetchFromGitHub {
     owner = "catppuccin";
     repo = "gtk";
     rev = "v${version}";
-    hash = "sha256-V3JasiHaATbVDQJeJPeFq5sjbkQnSMbDRWsaRzGccXU=";
+    hash = "sha256-7EvKcyh9gH/QbiXKlyAKMSBXMF3DmbHD+wJD3Sq39DE=";
   };
 
   nativeBuildInputs = [ gtk3 sassc ];
 
   patches = [
     ./colloid-src-git-reset.patch
+
+    # Can be removed next release
+    # Adds compatibility with the 2.x.x versions of the catppuccin python package
+    (fetchpatch {
+      name = "catppuccin-python-compatibility.patch";
+      url = "https://github.com/catppuccin/gtk/commit/355e12387f73b27cf4734a6a3eb431554fabb74f.patch";
+      hash = "sha256-4vgZbNeGMtsQEitIWDCVb5o4fAjhVu3iIUttUYqtHPc=";
+    })
   ];
 
   buildInputs = [

--- a/pkgs/development/python-modules/catppuccin/default.nix
+++ b/pkgs/development/python-modules/catppuccin/default.nix
@@ -10,10 +10,7 @@
 
 buildPythonPackage rec {
   pname = "catppuccin";
-  version = "1.3.2";
-  # Note: updating to later versions breaks catppuccin-gtk
-  # It would be ideal to only update this after catppuccin-gtk
-  # gets support for the newer version
+  version = "2.2.0";
 
   pyproject = true;
 
@@ -21,7 +18,7 @@ buildPythonPackage rec {
     owner = "catppuccin";
     repo = "python";
     rev = "refs/tags/v${version}";
-    hash = "sha256-spPZdQ+x3isyeBXZ/J2QE6zNhyHRfyRQGiHreuXzzik=";
+    hash = "sha256-+V1rln3FlFvs1FEIANIch7k/b2EsI9xBxhg3Bwg99+I=";
   };
 
   build-system = [
@@ -37,11 +34,6 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
   ] ++ lib.flatten (lib.attrValues optional-dependencies);
-
-  # can be removed next version
-  disabledTestPaths = [
-    "tests/test_flavour.py" # would download a json to check correctness of flavours
-  ];
 
   pythonImportsCheck = [ "catppuccin" ];
 


### PR DESCRIPTION
## Description of changes

This PR bumps the version of the `catppuccin` python package and `catppuccin-gtk` too.

Changes: https://github.com/catppuccin/python/compare/v1.3.2...v2.2.0
Changes: https://github.com/catppuccin/python/compare/v0.7.1...v0.7.2
\+ patch: https://github.com/catppuccin/gtk/commit/355e12387f73b27cf4734a6a3eb431554fabb74f

Release notes:
 - https://github.com/catppuccin/python/releases/tag/v2.0.0
 - https://github.com/catppuccin/python/releases/tag/v2.1.0
 - https://github.com/catppuccin/python/releases/tag/v2.2.0
 - https://github.com/catppuccin/gtk/releases/tag/v0.7.2

The tests were reworked, so we no longer need to disable a test.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
