### PR TITLE
imv: 4.4.0 -> 4.5.0

### DIFF
--- a/pkgs/applications/graphics/imv/default.nix
+++ b/pkgs/applications/graphics/imv/default.nix
@@ -17,10 +17,11 @@
 , libGLU
 , wayland
 # "libnsgif" is disabled until https://todo.sr.ht/~exec64/imv/55 is solved
-, withBackends ? [ "freeimage" "libtiff" "libjpeg" "libpng" "librsvg" "libheif" ]
+, withBackends ? [ "libjxl" "libtiff" "libjpeg" "libpng" "librsvg" "libheif" ]
 , freeimage
 , libtiff
 , libjpeg_turbo
+, libjxl
 , libpng
 , librsvg
 , netsurf
@@ -41,7 +42,7 @@ let
   };
 
   backends = {
-    inherit freeimage libtiff libpng librsvg libheif;
+    inherit freeimage libtiff libpng librsvg libheif libjxl;
     libjpeg = libjpeg_turbo;
     inherit (netsurf) libnsgif;
   };
@@ -63,14 +64,14 @@ assert builtins.all
 
 stdenv.mkDerivation rec {
   pname = "imv";
-  version = "4.4.0";
+  version = "4.5.0";
   outputs = [ "out" "man" ];
 
   src = fetchFromSourcehut {
     owner = "~exec64";
     repo = "imv";
     rev = "v${version}";
-    sha256 = "sha256-LLEEbriHzZhAOQivqHqdr6g7lh4uj++ytlme8AfRjf4=";
+    sha256 = "sha256-aJ2EXgsS0WUTxMqC1Q+uOWLG8BeuwAyXPmJB/9/NCCU=";
   };
 
   mesonFlags = [


### PR DESCRIPTION
## Description of changes

Update imv to v4.5.0.
announce: https://lists.sr.ht/~exec64/imv-announce/%3C625aeeea-4f72-4cec-838e-a01d91eb895c%40harry.pm%3E
changelog: https://git.sr.ht/~exec64/imv/tree/master/item/CHANGELOG

While here, remove freeimage, which is optional and has known vulnerabilities (ref. https://github.com/NixOS/nixpkgs/pull/280835).
Also add libxjl.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
