### PR TITLE
Add meta.pkgConfigModules to gtk4 and dependencies

### DIFF
--- a/pkgs/development/libraries/appstream/default.nix
+++ b/pkgs/development/libraries/appstream/default.nix
@@ -25,10 +25,11 @@
 , curl
 , systemd
 , nixosTests
+, testers
 , withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "appstream";
   version = "1.0.1";
 
@@ -37,7 +38,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "ximion";
     repo = "appstream";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-ULqRHepWVuAluXsXJUoqxqJfrN168MGlwdVkoLLwSN0=";
   };
 
@@ -97,9 +98,10 @@ stdenv.mkDerivation rec {
     "-Dsystemd=false"
   ];
 
-  passthru = {
-    tests = {
-      installed-tests = nixosTests.installed-tests.appstream;
+  passthru.tests = {
+    installed-tests = nixosTests.installed-tests.appstream;
+    pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
     };
   };
 
@@ -115,5 +117,6 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl21Plus;
     mainProgram = "appstreamcli";
     platforms = platforms.unix;
+    pkgConfigModules = [ "appstream" ];
   };
-}
+})

--- a/pkgs/development/libraries/expat/default.nix
+++ b/pkgs/development/libraries/expat/default.nix
@@ -7,6 +7,7 @@
 , haskellPackages
 , luaPackages
 , ocamlPackages
+, testers
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -14,12 +15,12 @@
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "expat";
   version = "2.5.0";
 
   src = fetchurl {
-    url = "https://github.com/libexpat/libexpat/releases/download/R_${lib.replaceStrings ["."] ["_"] version}/${pname}-${version}.tar.xz";
+    url = with finalAttrs; "https://github.com/libexpat/libexpat/releases/download/R_${lib.replaceStrings ["."] ["_"] version}/${pname}-${version}.tar.xz";
     sha256 = "1gnwihpfz4x18rwd6cbrdggmfqjzwsdfh1gpmc0ph21c4gq2097g";
   };
 
@@ -43,7 +44,7 @@ stdenv.mkDerivation rec {
   # CMake files incorrectly calculate library path from dev prefix
   # https://github.com/libexpat/libexpat/issues/501
   postFixup = ''
-    substituteInPlace $dev/lib/cmake/expat-${version}/expat-noconfig.cmake \
+    substituteInPlace $dev/lib/cmake/expat-${finalAttrs.version}/expat-noconfig.cmake \
       --replace "$"'{_IMPORT_PREFIX}' $out
   '';
 
@@ -54,6 +55,9 @@ stdenv.mkDerivation rec {
     inherit (perlPackages) XMLSAXExpat XMLParser;
     inherit (luaPackages) luaexpat;
     inherit (ocamlPackages) ocaml_expat;
+    pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+    };
   };
 
   meta = with lib; {
@@ -61,5 +65,6 @@ stdenv.mkDerivation rec {
     description = "A stream-oriented XML parser library written in C";
     platforms = platforms.all;
     license = licenses.mit; # expat version
+    pkgConfigModules = [ "expat" ];
   };
-}
+})

--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -10,16 +10,17 @@
 , dejavu_fonts
 , autoreconfHook
 , CoreFoundation
+, testers
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "fontconfig";
   version = "2.15.0";
 
   outputs = [ "bin" "dev" "lib" "out" ]; # $out contains all the config
 
   src = fetchurl {
-    url = "https://www.freedesktop.org/software/fontconfig/release/${pname}-${version}.tar.xz";
+    url = with finalAttrs; "https://www.freedesktop.org/software/fontconfig/release/${pname}-${version}.tar.xz";
     hash = "sha256-Y6BljQ4G4PqIYQZFK1jvBPIfWCAuoCqUw53g0zNdfA4=";
   };
 
@@ -77,11 +78,18 @@ stdenv.mkDerivation rec {
     rm -r $bin/share/man/man3
   '';
 
+  passthru.tests = {
+    pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+    };
+  };
+
   meta = with lib; {
     description = "A library for font customization and configuration";
     homepage = "http://fontconfig.org/";
     license = licenses.bsd2; # custom but very bsd-like
     platforms = platforms.all;
     maintainers = with maintainers; teams.freedesktop.members ++ [ ];
+    pkgConfigModules = [ "fontconfig" ];
   };
-}
+})

--- a/pkgs/development/libraries/fribidi/default.nix
+++ b/pkgs/development/libraries/fribidi/default.nix
@@ -6,9 +6,10 @@
 , pkg-config
 , fixDarwinDylibNames
 , python3
+, testers
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "fribidi";
   version = "1.0.13";
 
@@ -16,7 +17,7 @@ stdenv.mkDerivation rec {
 
   # NOTE: Only URL tarball has "Have pre-generated man pages: true", which works-around upstream usage of some rare ancient `c2man` fossil application.
   src = fetchurl {
-    url = "https://github.com/fribidi/fribidi/releases/download/v${version}/${pname}-${version}.tar.xz";
+    url = with finalAttrs; "https://github.com/fribidi/fribidi/releases/download/v${version}/${pname}-${version}.tar.xz";
     sha256 = "sha256-f6FsgMgb1iL3sZjTE1baE5zDGKY/x3YSF69BMJA/VKI=";
   };
 
@@ -32,10 +33,17 @@ stdenv.mkDerivation rec {
   doCheck = true;
   nativeCheckInputs = [ python3 ];
 
+  passthru.tests = {
+    pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+    };
+  };
+
   meta = with lib; {
     homepage = "https://github.com/fribidi/fribidi";
     description = "GNU implementation of the Unicode Bidirectional Algorithm (bidi)";
     license = licenses.lgpl21;
     platforms = platforms.unix;
+    pkgConfigModules = [ "fribidi" ];
   };
-}
+})

--- a/pkgs/development/libraries/graphene/default.nix
+++ b/pkgs/development/libraries/graphene/default.nix
@@ -19,9 +19,10 @@
 , gobject-introspection
 , withIntrospection ? lib.meta.availableOn stdenv.hostPlatform gobject-introspection && stdenv.hostPlatform.emulatorAvailable buildPackages
 , makeWrapper
+, testers
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "graphene";
   version = "1.10.8";
 
@@ -31,8 +32,8 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "ebassi";
-    repo = pname;
-    rev = version;
+    repo = finalAttrs.pname;
+    rev = finalAttrs.version;
     sha256 = "P6JQhSktzvyMHatP/iojNGXPmcsxsFxdYerXzS23ojI=";
   };
 
@@ -109,6 +110,9 @@ stdenv.mkDerivation rec {
   passthru = {
     tests = {
       installedTests = nixosTests.installed-tests.graphene;
+      pkg-config = testers.hasPkgConfigModules {
+        package = finalAttrs.finalPackage;
+      };
     };
 
     updateScript = nix-update-script { };
@@ -120,5 +124,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = teams.gnome.members ++ (with maintainers; [ ]);
     platforms = platforms.unix;
+    pkgConfigModules = [ "graphene-1.0" "graphene-gobject-1.0" ];
   };
-}
+})

--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -54,6 +54,7 @@
 , Cocoa
 , libexecinfo
 , broadwaySupport ? true
+, testers
 }:
 
 let
@@ -66,7 +67,7 @@ let
 
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gtk4";
   version = "4.12.4";
 
@@ -79,7 +80,7 @@ stdenv.mkDerivation rec {
   ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gtk/${lib.versions.majorMinor version}/gtk-${version}.tar.xz";
+    url = with finalAttrs; "mirror://gnome/sources/gtk/${lib.versions.majorMinor version}/gtk-${version}.tar.xz";
     sha256 = "umfGSY5Vmfko7a+54IoyCt+qUKsvDab8arIlL8LVdSA=";
   };
 
@@ -109,7 +110,7 @@ stdenv.mkDerivation rec {
     wayland-scanner
   ] ++ lib.optionals vulkanSupport [
     shaderc # for glslc
-  ] ++ setupHooks;
+  ] ++ finalAttrs.setupHooks;
 
   buildInputs = [
     libxkbcommon
@@ -245,7 +246,7 @@ stdenv.mkDerivation rec {
 
     for program in ''${demos[@]}; do
       wrapProgram $dev/bin/$program \
-        --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:$out/share/gsettings-schemas/${pname}-${version}"
+        --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:$out/share/gsettings-schemas/${finalAttrs.pname}-${finalAttrs.version}"
     done
   '' + lib.optionalString x11Support ''
     # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
@@ -257,6 +258,11 @@ stdenv.mkDerivation rec {
       packageName = "gtk";
       versionPolicy = "odd-unstable";
       attrPath = "gtk4";
+    };
+    tests = {
+      pkg-config = testers.hasPkgConfigModules {
+        package = finalAttrs.finalPackage;
+      };
     };
   };
 
@@ -276,6 +282,13 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl2Plus;
     maintainers = teams.gnome.members ++ (with maintainers; [ raskin ]);
     platforms = platforms.all;
-    changelog = "https://gitlab.gnome.org/GNOME/gtk/-/raw/${version}/NEWS";
+    changelog = "https://gitlab.gnome.org/GNOME/gtk/-/raw/${finalAttrs.version}/NEWS";
+    pkgConfigModules = [
+      "gtk4"
+      "gtk4-broadway"
+      "gtk4-unix-print"
+      "gtk4-wayland"
+      "gtk4-x11"
+    ];
   };
-}
+})

--- a/pkgs/development/libraries/iso-codes/default.nix
+++ b/pkgs/development/libraries/iso-codes/default.nix
@@ -1,11 +1,11 @@
-{ lib, stdenv, fetchurl, gettext, python3 }:
+{ lib, stdenv, fetchurl, gettext, python3, testers }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "iso-codes";
   version = "4.16.0";
 
   src = fetchurl {
-    url = "https://salsa.debian.org/iso-codes-team/iso-codes/-/archive/v${version}/${pname}-v${version}.tar.gz";
+    url = with finalAttrs; "https://salsa.debian.org/iso-codes-team/iso-codes/-/archive/v${version}/${pname}-v${version}.tar.gz";
     sha256 = "sha256-fJkPw5oFl1vtsBdeP/Cfw4MEiBX2i0Yqu/BVqAMuZsw=";
   };
 
@@ -13,10 +13,17 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  passthru.tests = {
+    pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+    };
+  };
+
   meta = with lib; {
     homepage = "https://salsa.debian.org/iso-codes-team/iso-codes";
     description = "Various ISO codes packaged as XML files";
     license = licenses.lgpl21;
     platforms = platforms.all;
+    pkgConfigModules = [ "iso-codes" ];
   };
-}
+})

--- a/pkgs/development/libraries/libadwaita/default.nix
+++ b/pkgs/development/libraries/libadwaita/default.nix
@@ -17,9 +17,10 @@
 , xvfb-run
 , AppKit
 , Foundation
+, testers
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libadwaita";
   version = "1.4.3";
 
@@ -30,7 +31,7 @@ stdenv.mkDerivation rec {
     domain = "gitlab.gnome.org";
     owner = "GNOME";
     repo = "libadwaita";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-ctHAN0SY6k68jaBpmIpMm8DngC9DPiL1vAmGhECpNic=";
   };
 
@@ -50,7 +51,7 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dgtk_doc=true"
-  ] ++ lib.optionals (!doCheck) [
+  ] ++ lib.optionals (!finalAttrs.doCheck) [
     "-Dtests=false"
   ];
 
@@ -106,16 +107,20 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = finalAttrs.pname;
+    };
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
     };
   };
 
   meta = with lib; {
-    changelog = "https://gitlab.gnome.org/GNOME/libadwaita/-/blob/${src.rev}/NEWS";
+    changelog = "https://gitlab.gnome.org/GNOME/libadwaita/-/blob/${finalAttrs.src.rev}/NEWS";
     description = "Library to help with developing UI for mobile devices using GTK/GNOME";
     homepage = "https://gitlab.gnome.org/GNOME/libadwaita";
     license = licenses.lgpl21Plus;
     maintainers = teams.gnome.members ++ (with maintainers; [ dotlambda ]);
     platforms = platforms.unix;
+    pkgConfigModules = [ "libadwaita-1" ];
   };
-}
+})

--- a/pkgs/development/libraries/libdeflate/default.nix
+++ b/pkgs/development/libraries/libdeflate/default.nix
@@ -4,15 +4,17 @@
 , fixDarwinDylibNames
 , pkgsStatic
 , cmake
+, testers
 }:
-stdenv.mkDerivation rec {
+
+stdenv.mkDerivation (finalAttrs: {
   pname = "libdeflate";
   version = "1.19";
 
   src = fetchFromGitHub {
     owner = "ebiggers";
     repo = "libdeflate";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-HgZ2an1PCPhiLsd3ZA7tgZ1wVTOdHzDr8FHrqJhEbQw=";
   };
 
@@ -21,14 +23,20 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ]
     ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
 
-  passthru.tests.static = pkgsStatic.libdeflate;
+  passthru.tests = {
+    static = pkgsStatic.libdeflate;
+    pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+    };
+  };
 
   meta = with lib; {
     description = "Fast DEFLATE/zlib/gzip compressor and decompressor";
     license = licenses.mit;
     homepage = "https://github.com/ebiggers/libdeflate";
-    changelog = "https://github.com/ebiggers/libdeflate/blob/v${version}/NEWS.md";
+    changelog = "https://github.com/ebiggers/libdeflate/blob/v${finalAttrs.version}/NEWS.md";
     platforms = platforms.unix;
     maintainers = with maintainers; [ orivej kaction ];
+    pkgConfigModules = [ "libdeflate" ];
   };
-}
+})

--- a/pkgs/development/libraries/libffi/default.nix
+++ b/pkgs/development/libraries/libffi/default.nix
@@ -6,14 +6,15 @@
 , doCheck ? !(stdenv.hostPlatform.isStatic)
 , dejagnu
 , nix-update-script
+, testers
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libffi";
   version = "3.4.4";
 
   src = fetchurl {
-    url = "https://github.com/libffi/libffi/releases/download/v${version}/${pname}-${version}.tar.gz";
+    url = with finalAttrs; "https://github.com/libffi/libffi/releases/download/v${version}/${pname}-${version}.tar.gz";
     sha256 = "sha256-1mxWrSWags8qnfxAizK/XaUjcVALhHRff7i2RXEt9nY=";
   };
 
@@ -53,6 +54,11 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = nix-update-script { };
+    tests = {
+      pkg-config = testers.hasPkgConfigModules {
+        package = finalAttrs.finalPackage;
+      };
+    };
   };
 
   meta = with lib; {
@@ -75,5 +81,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ matthewbauer ];
     platforms = platforms.all;
+    pkgConfigModules = [ "libffi" ];
   };
-}
+})

--- a/pkgs/development/libraries/libtiff/default.nix
+++ b/pkgs/development/libraries/libtiff/default.nix
@@ -20,9 +20,10 @@
 , gdal
 , openimageio
 , freeimage
+, testers
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libtiff";
   version = "4.6.0";
 
@@ -32,7 +33,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitLab {
     owner = "libtiff";
     repo = "libtiff";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-qCg5qjsPPynCHIg0JsPJldwVdcYkI68zYmyNAKUCoyw=";
   };
 
@@ -77,6 +78,9 @@ stdenv.mkDerivation rec {
     tests = {
       inherit libgeotiff imagemagick graphicsmagick gdal openimageio freeimage;
       inherit (python3Packages) pillow imread;
+      pkg-config = testers.hasPkgConfigModules {
+        package = finalAttrs.finalPackage;
+      };
     };
     updateScript = nix-update-script { };
   };
@@ -84,8 +88,9 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Library and utilities for working with the TIFF image file format";
     homepage = "https://libtiff.gitlab.io/libtiff";
-    changelog = "https://libtiff.gitlab.io/libtiff/v${version}.html";
+    changelog = "https://libtiff.gitlab.io/libtiff/v${finalAttrs.version}.html";
     license = licenses.libtiff;
     platforms = platforms.unix;
+    pkgConfigModules = [ "libtiff-4" ];
   };
-}
+})

--- a/pkgs/development/libraries/libxkbcommon/default.nix
+++ b/pkgs/development/libraries/libxkbcommon/default.nix
@@ -17,14 +17,15 @@
 , wayland
 , wayland-protocols
 , wayland-scanner
+, testers
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libxkbcommon";
   version = "1.5.0";
 
   src = fetchurl {
-    url = "https://xkbcommon.org/download/${pname}-${version}.tar.xz";
+    url = with finalAttrs; "https://xkbcommon.org/download/${pname}-${version}.tar.xz";
     sha256 = "sha256-Vg8RxLu8oQ9JXz7306aqTKYrT4+wtS59RZ0Yom5G4Bc=";
   };
 
@@ -49,6 +50,12 @@ stdenv.mkDerivation rec {
     patchShebangs ../test/
   '';
 
+  passthru = {
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+    };
+  };
+
   meta = with lib; {
     description = "A library to handle keyboard descriptions";
     longDescription = ''
@@ -58,7 +65,7 @@ stdenv.mkDerivation rec {
       and dead keys.
     ''; # and a separate library for listing available keyboard layouts.
     homepage = "https://xkbcommon.org";
-    changelog = "https://github.com/xkbcommon/libxkbcommon/blob/xkbcommon-${version}/NEWS";
+    changelog = "https://github.com/xkbcommon/libxkbcommon/blob/xkbcommon-${finalAttrs.version}/NEWS";
     license = licenses.mit;
     maintainers = with maintainers; [ primeos ttuegel ];
     mainProgram = "xkbcli";
@@ -69,4 +76,4 @@ stdenv.mkDerivation rec {
       "xkbregistry"
     ];
   };
-}
+})

--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -20,6 +20,7 @@
 , enableShared ? !stdenv.hostPlatform.isMinGW && !stdenv.hostPlatform.isStatic
 , enableStatic ? !enableShared
 , gnome
+, testers
 }:
 
 let
@@ -32,7 +33,7 @@ in
   assert oldVer -> stdenv.isDarwin; # reduce likelihood of using old libxml2 unintentionally
 
 let
-libxml = stdenv.mkDerivation rec {
+libxml = stdenv.mkDerivation (finalAttrs: rec {
   pname = "libxml2";
   version = "2.12.4";
 
@@ -123,6 +124,11 @@ libxml = stdenv.mkDerivation rec {
       packageName = pname;
       versionPolicy = "none";
     };
+    tests = {
+      pkg-config = testers.hasPkgConfigModules {
+        package = finalAttrs.finalPackage;
+      };
+    };
   };
 
   meta = with lib; {
@@ -131,8 +137,9 @@ libxml = stdenv.mkDerivation rec {
     license = licenses.mit;
     platforms = platforms.all;
     maintainers = with maintainers; [ eelco jtojnar ];
+    pkgConfigModules = [ "libxml-2.0" ];
   };
-};
+});
 in
 if oldVer then
   libxml.overrideAttrs (attrs: rec {

--- a/pkgs/development/libraries/pango/default.nix
+++ b/pkgs/development/libraries/pango/default.nix
@@ -19,16 +19,17 @@
 , x11Support? !stdenv.isDarwin, libXft
 , withIntrospection ? lib.meta.availableOn stdenv.hostPlatform gobject-introspection && stdenv.hostPlatform.emulatorAvailable buildPackages
 , buildPackages, gobject-introspection
+, testers
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "pango";
   version = "1.51.0";
 
   outputs = [ "bin" "out" "dev" ] ++ lib.optional withIntrospection "devdoc";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    url = with finalAttrs; "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "dO/BCa5vkDu+avd+qirGCUuO4kWi4j8TKnqPCGLRqfU=";
   };
 
@@ -93,9 +94,14 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = finalAttrs.pname;
       # 1.90 is alpha for API 2.
       freeze = "1.90.0";
+    };
+    tests = {
+      pkg-config = testers.hasPkgConfigModules {
+        package = finalAttrs.finalPackage;
+      };
     };
   };
 
@@ -125,4 +131,4 @@ stdenv.mkDerivation rec {
       "pangoxft"
     ];
   };
-}
+})

--- a/pkgs/development/libraries/pixman/default.nix
+++ b/pkgs/development/libraries/pixman/default.nix
@@ -16,14 +16,15 @@
 , xwayland
 
 , gitUpdater
+, testers
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "pixman";
   version = "0.43.2";
 
   src = fetchurl {
-    urls = [
+    urls = with finalAttrs; [
       "mirror://xorg/individual/lib/${pname}-${version}.tar.gz"
       "https://cairographics.org/releases/${pname}-${version}.tar.gz"
     ];
@@ -60,6 +61,9 @@ stdenv.mkDerivation rec {
   passthru = {
     tests = {
       inherit cairo qemu scribus tigervnc wlroots xwayland;
+      pkg-config = testers.hasPkgConfigModules {
+        package = finalAttrs.finalPackage;
+      };
     };
     updateScript = gitUpdater {
       url = "https://gitlab.freedesktop.org/pixman/pixman.git";
@@ -72,5 +76,6 @@ stdenv.mkDerivation rec {
     description = "A low-level library for pixel manipulation";
     license = licenses.mit;
     platforms = platforms.all;
+    pkgConfigModules = [ "pixman-1" ];
   };
-}
+})

--- a/pkgs/development/libraries/silgraphite/graphite2.nix
+++ b/pkgs/development/libraries/silgraphite/graphite2.nix
@@ -5,15 +5,15 @@
 , freetype
 , cmake
 , static ? stdenv.hostPlatform.isStatic
+, testers
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "1.3.14";
   pname = "graphite2";
 
   src = fetchurl {
-    url = "https://github.com/silnrsi/graphite/releases/download/"
-      + "${version}/graphite2-${version}.tgz";
+    url = with finalAttrs; "https://github.com/silnrsi/graphite/releases/download/${version}/${pname}-${version}.tgz";
     sha256 = "1790ajyhk0ax8xxamnrk176gc9gvhadzy78qia4rd8jzm89ir7gr";
   };
 
@@ -46,12 +46,19 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
+  passthru.tests = {
+    pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+    };
+  };
+
   meta = with lib; {
     description = "An advanced font engine";
     homepage = "https://graphite.sil.org/";
     license = licenses.lgpl21;
     maintainers = [ maintainers.raskin ];
+    pkgConfigModules = [ "graphite2" ];
     mainProgram = "gr2fonttest";
     platforms = platforms.unix ++ platforms.windows;
   };
-}
+})

--- a/pkgs/development/libraries/tracker/default.nix
+++ b/pkgs/development/libraries/tracker/default.nix
@@ -28,16 +28,17 @@
 , systemd
 , dbus
 , writeText
+, testers
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tracker";
   version = "3.6.0";
 
   outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    url = with finalAttrs; "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     sha256 = "Ulks/hm6/9FtvkdHW+fadQ29C2Mz/XrLYPqp2lvEDfI=";
   };
 
@@ -162,7 +163,10 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = finalAttrs.pname;
+    };
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
     };
   };
 
@@ -172,5 +176,6 @@ stdenv.mkDerivation rec {
     maintainers = teams.gnome.members;
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
+    pkgConfigModules = [ "tracker-sparql-3.0" "tracker-testutils-3.0" ];
   };
-}
+})

--- a/pkgs/development/libraries/vulkan-loader/default.nix
+++ b/pkgs/development/libraries/vulkan-loader/default.nix
@@ -1,14 +1,15 @@
 { lib, stdenv, fetchFromGitHub, cmake, pkg-config, libX11, libxcb
-, libXrandr, wayland, moltenvk, vulkan-headers, addOpenGLRunpath }:
+, libXrandr, wayland, moltenvk, vulkan-headers, addOpenGLRunpath
+, testers }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "vulkan-loader";
   version = "1.3.275.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "Vulkan-Loader";
-    rev = "vulkan-sdk-${version}";
+    rev = "vulkan-sdk-${finalAttrs.version}";
     hash = "sha256-53PUXAWiK38ciV6oMvD7ZHdXi4RU4r0RmDWUUHU3mE0=";
   };
 
@@ -34,12 +35,19 @@ stdenv.mkDerivation rec {
     }
   '';
 
+  passthru = {
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+    };
+  };
+
   meta = with lib; {
     description = "LunarG Vulkan loader";
     homepage    = "https://www.lunarg.com";
     platforms   = platforms.unix ++ platforms.windows;
     license     = licenses.asl20;
     maintainers = [ maintainers.ralith ];
-    broken = (version != vulkan-headers.version);
+    broken = finalAttrs.version != vulkan-headers.version;
+    pkgConfigModules = [ "vulkan" ];
   };
-}
+})

--- a/pkgs/tools/compression/xz/default.nix
+++ b/pkgs/tools/compression/xz/default.nix
@@ -1,6 +1,7 @@
 { lib, stdenv, fetchurl
 , enableStatic ? stdenv.hostPlatform.isStatic
 , writeScript
+, testers
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -8,12 +9,12 @@
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "xz";
   version = "5.4.6";
 
   src = fetchurl {
-    url = "https://github.com/tukaani-project/xz/releases/download/v${version}/xz-${version}.tar.bz2";
+    url = with finalAttrs; "https://github.com/tukaani-project/xz/releases/download/v${version}/xz-${version}.tar.bz2";
     sha256 = "sha256-kThRsnTo4dMXgeyUnxwj6NvPDs9uc6JDbcIXad0+b0k=";
   };
 
@@ -47,8 +48,11 @@ stdenv.mkDerivation rec {
       new_version="$(curl -s https://tukaani.org/xz/ |
           pcregrep -o1 '>xz-([0-9.]+)[.]tar[.]bz2</a>' |
           head -n1)"
-      update-source-version ${pname} "$new_version"
+      update-source-version ${finalAttrs.pname} "$new_version"
     '';
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+    };
   };
 
   meta = with lib; {
@@ -72,5 +76,6 @@ stdenv.mkDerivation rec {
     license = with licenses; [ gpl2Plus lgpl21Plus ];
     maintainers = with maintainers; [ sander ];
     platforms = platforms.all;
+    pkgConfigModules = [ "liblzma" ];
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23639,8 +23639,8 @@ with pkgs;
   in pkgs.buildEnv { # slightly hacky
     name = "libxml2+py-${res.libxml2.version}";
     paths = with libxml2; [ dev bin py ];
-    # Avoid update.nix conflicts with libxml2.
-    passthru = builtins.removeAttrs libxml2.passthru [ "updateScript" ];
+    # Avoid update.nix/tests conflicts with libxml2.
+    passthru = builtins.removeAttrs libxml2.passthru [ "updateScript" "tests" ];
     # the hook to find catalogs is hidden by buildEnv
     postBuild = ''
       mkdir "$out/nix-support"


### PR DESCRIPTION
## Description of changes

This is PR #285125 from @eldritch-cookie, with review comments fixed, and rebased.

## Things done

Built on platform: `x86_64-linux`

I used the following file to test the changes:
```nix
{ pkgs ? import ./default.nix { } }:

with pkgs;

let
  changed = [
    appstream
    expat
    fontconfig
    fribidi
    graphene
    gtk4
    isocodes
    libadwaita
    libdeflate
    libepoxy
    libffi
    libtiff
    libxkbcommon
    libxml2
    pango
    pixman
    graphite2
    tracker
    vulkan-loader
    wayland
    xz
  ];

  relevant = [
    libxml2Python
  ];

in
{
  together = linkFarmFromDrvs "eval-meta-pkgConfigModules" (changed ++ relevant);

  newChecks = linkFarmFromDrvs "test-pkgConfigModules"
    (lib.concatMap (drv: map (output: output.tests.pkg-config) drv.all) changed);

  metas = let
    dumpJSON = xs: "[\n${lib.concatMapStringsSep ",\n" builtins.toJSON xs}\n]\n";
    getMeta = drv: builtins.removeAttrs drv.meta [ "pkgConfigModules" "position" ];
  in
    runCommandLocal "metas.json" {
    nativeBuildInputs = [ jq ];
    metas = dumpJSON (map getMeta changed);
  } ''
    jq . <<< "$metas" > $out
  '';
}
```

To ensure that only package `meta` has changed, not the derivations, I compare store paths before and after applying these changes:

```
$ nix path-info -f ./test-meta-pkgConfigModules.nix together
/nix/store/q072z4gx5wa16lw15rjh7r4cy867vki7-eval-meta-pkgConfigModules
```

And to run `testers.hasPkgConfigModules` for each modified package:
```
$ nix build -L -f test-meta-pkgConfigModules.nix newChecks
```

Checking that `meta` has not changed for any package (besides `meta.pkgConfigModules`), I run this before and after applying these changes, and check that the resulting file is exactly the same:
```
$ nix build -L -f test-meta-pkgConfigModules.nix metas -o metas-after
```