### PR TITLE
borgmatic-exporter: init at 0.2.5

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -27,6 +27,7 @@ let
     "bird"
     "bitcoin"
     "blackbox"
+    "borgmatic"
     "buildkite-agent"
     "collectd"
     "deluge"

--- a/nixos/modules/services/monitoring/prometheus/exporters/borgmatic.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/borgmatic.nix
@@ -1,0 +1,34 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.prometheus.exporters.borgmatic;
+in
+{
+  port = 9996;
+  extraOpts.configFile = lib.mkOption {
+    type = lib.types.path;
+    default = "/etc/borgmatic/config.yaml";
+    description = ''
+      The path to the borgmatic config file
+    '';
+  };
+
+  serviceOpts = {
+    serviceConfig = {
+      DynamicUser = false;
+      ProtectSystem = false;
+      ProtectHome = lib.mkForce false;
+      ExecStart = ''
+        ${pkgs.prometheus-borgmatic-exporter}/bin/borgmatic-exporter run \
+          --port ${toString cfg.port} \
+          --config ${toString cfg.configFile} \
+          ${lib.concatMapStringsSep " " (f: lib.escapeShellArg f) cfg.extraFlags}
+      '';
+    };
+  };
+}

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -177,6 +177,26 @@ let
       '';
     };
 
+    borgmatic = {
+      exporterConfig = {
+        enable = true;
+        user = "root";
+      };
+      metricProvider = {
+        services.borgmatic.enable = true;
+        services.borgmatic.settings.source_directories = [ "/home" ];
+        services.borgmatic.settings.repositories = [ { label = "local"; path = "/var/backup"; } ];
+        services.borgmatic.settings.keep_daily = 10;
+      };
+      exporterTest = ''
+        succeed("borgmatic rcreate -e none")
+        succeed("borgmatic")
+        wait_for_unit("prometheus-borgmatic-exporter.service")
+        wait_for_open_port(9996)
+        succeed("curl -sSf localhost:9996/metrics | grep 'borg_total_backups{repository=\"/var/backup\"} 1'")
+      '';
+    };
+
     collectd = {
       exporterConfig = {
         enable = true;

--- a/pkgs/by-name/pr/prometheus-borgmatic-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-borgmatic-exporter/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  borgmatic,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "prometheus-borgmatic-exporter";
+  version = "0.2.5";
+    pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "maxim-mityutko";
+    repo = "borgmatic-exporter";
+    rev = "v${version}";
+    hash = "sha256-SgP1utu4Eqs9214pYOT9wP0Ms7AUQH1A3czQF8+qBRo=";
+  };
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    pytest-mock
+  ];
+
+  buildInputs = [python3Packages.poetry-core];
+
+  propagatedBuildInputs =
+    [ borgmatic ]
+    ++ (with python3Packages; [
+      flask
+      arrow
+      click
+      loguru
+      pretty-errors
+      prometheus-client
+      timy
+      waitress
+    ]);
+
+  meta = with lib; {
+    description = "Prometheus exporter for Borgmatic";
+    homepage = "https://github.com/maxim-mityutko/borgmatic-exporter";
+    license = licenses.mit;
+    maintainers = with maintainers; [ flandweber ];
+    mainProgram = "borgmatic-exporter";
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/maxim-mityutko/borgmatic-exporter

fix https://github.com/NixOS/nixpkgs/issues/289977

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
