### PR TITLE
labelife-label-printer: init at 1.2.1

### DIFF
--- a/pkgs/by-name/la/labelife-label-printer/package.nix
+++ b/pkgs/by-name/la/labelife-label-printer/package.nix
@@ -1,0 +1,60 @@
+{ lib
+, stdenv
+, fetchurl
+, cups
+, autoPatchelfHook
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "labelife-label-printer";
+  version = "1.2.1";
+
+  arch =
+    if stdenv.hostPlatform.system == "x86_64-linux" then "x86_64"
+    else if stdenv.hostPlatform.system == "i686-linux" then "i386"
+      else throw "Unsupported system: ${stdenv.hostPlatform.system}";
+
+  src = fetchurl {
+    url = "https://oss.saas.aimocloud.com/saas/Lablife/bag/LabelPrinter-${finalAttrs.version}.tar.gz";
+    hash = "sha256-twnIFMBMyEM3xGlsuk3763C3emz3mgpEnlfvnL0XRWw=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+  buildInputs = [ cups ];
+
+  installPhase =
+  ''
+    runHook preInstall
+    # Install the CUPS filter with executable permissions
+    install -Dm755 ./${finalAttrs.arch}/rastertolabeltspl $out/lib/cups/filter/rastertolabeltspl
+
+    # Install all PPD files with read and write permissions for owner, and read for group and others
+    for ppd in ./ppds/*.ppd; do
+      install -Dm644 $ppd $out/share/cups/model/label/$(basename $ppd)
+    done
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "CUPS driver for several Labelife-compatible thermal label printers";
+    downloadPage = "https://labelife.net/#/chart";
+    homepage = "https://labelife.net";
+    license = lib.licenses.unfree;
+    longDescription = ''
+    Supported printer models include:
+    - D520 & D520BT
+    - PM-201
+    - PM-241 & PM-241-BT
+    - PM-246 & PM-246S
+
+    Brands using Labelife drivers include:
+    - Phomemo
+    - Itari
+    - Omezizy
+    - Aimo
+    '';
+    maintainers = with lib.maintainers; [ daniel-fahey ];
+    platforms = with lib; [ "i686-linux" "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
## Description of changes
CUPS filter and PPDs for various [Labelife-compatible](https://labelife.net/#/chart) thermal label printers.

Supported printer models include:
- D520 & D520BT
- PM-201
- PM-241 & PM-241-BT
- PM-246 & PM-246S

Brands using Labelife drivers include:
- Phomemo
- Itari
- Omezizy
- Aimo

I have contacted Labelife re: permission to redistribute their unfree driver.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Tested with PM-241-BT: printer works successfully
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
