### PR TITLE
furmark: init at 2.3.0.0

### DIFF
--- a/pkgs/by-name/fu/furmark/package.nix
+++ b/pkgs/by-name/fu/furmark/package.nix
@@ -1,0 +1,107 @@
+{
+  autoPatchelfHook,
+  copyDesktopItems,
+  fetchzip,
+  lib,
+  libGL,
+  libGLU,
+  libxcrypt-legacy,
+  makeDesktopItem,
+  makeWrapper,
+  stdenv,
+  testers,
+  vulkan-loader,
+}:
+
+let
+  description = "OpenGL and Vulkan Benchmark and Stress Test";
+
+  versions = {
+    "x86_64-linux" = "2.3.0.0";
+    "aarch64-linux" = "2.3.0.0";
+    "i686-linux" = "2.0.16";
+  };
+
+  sources = {
+    "x86_64-linux" = {
+      url = "https://gpumagick.com/downloads/files/2024/furmark2/FurMark_${versions.x86_64-linux}_linux64.zip";
+      hash = "sha256-9xwnOo8gh6XlX2uTwvEorXsx9FafaeCyCPPPJLJGeuE=";
+    };
+    "aarch64-linux" = {
+      url = "https://gpumagick.com/downloads/files/2024/furmark2/FurMark_${versions.x86_64-linux}_rpi64.zip";
+      hash = "sha256-az4prQbg9I+6rt2y1OTy3t21/VHyZS++57r4Ahe3fcQ=";
+    };
+    "i686-linux" = {
+      url = "https://gpumagick.com/downloads/files/2024/furmark2/FurMark_${versions.i686-linux}_linux32.zip";
+      hash = "sha256-yXd90FgL3WbTga5x0mXT40BonA2NQtqLzRVzn4s4lLc=";
+    };
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "furmark";
+  version = versions.${stdenv.hostPlatform.system};
+
+  src = fetchzip sources.${stdenv.hostPlatform.system};
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libGL
+    libGLU
+  ] ++ lib.optionals stdenv.isAarch64 [ libxcrypt-legacy ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/furmark
+    cp -rp * $out/share/furmark
+
+    mkdir -p $out/bin
+    for i in $(find $out/share/furmark -maxdepth 1 -type f -executable); do
+      ln -s "$i" "$out/bin/$(basename "$i")"
+    done
+
+    runHook postInstall
+  '';
+
+  appendRunpaths = [ (lib.makeLibraryPath [ vulkan-loader ]) ];
+
+  desktopItems = [
+    (makeDesktopItem rec {
+      name = "FurMark";
+      exec = "FurMark_GUI";
+      comment = description;
+      desktopName = name;
+      genericName = name;
+      categories = [
+        "System"
+        "Monitor"
+      ];
+    })
+  ];
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      command = "furmark --version";
+    };
+  };
+
+  meta = {
+    homepage = "https://www.geeks3d.com/furmark/v2/";
+    license = lib.licenses.unfree;
+    mainProgram = "FurMark_GUI";
+    maintainers = with lib.maintainers; [ surfaceflinger ];
+    platforms = [
+      "aarch64-linux"
+      "i686-linux"
+      "x86_64-linux"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    inherit description;
+  };
+})


### PR DESCRIPTION
## Description of changes

closes #301760

Added a package for [FurMark v2](https://www.geeks3d.com/furmark/v2/) 

Uses makeWrapper hackery because it tries to access files at the same directory as executable and because it has trouble finding Vulkan like Chromium.

No icon set because FurMark doesn't have any easily accessible logo anywhere for this case. 
Should I leave it as it is or change it to `application-x-executable`?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
