### PR TITLE
nosql-workbench: init at 3.11.0

### DIFF
--- a/pkgs/by-name/no/nosql-workbench/package.nix
+++ b/pkgs/by-name/no/nosql-workbench/package.nix
@@ -1,0 +1,101 @@
+{
+  appimageTools,
+  lib,
+  fetchurl,
+  jdk21,
+  stdenv,
+  undmg
+}:
+let
+  pname = "nosql-workbench";
+  version = "3.11.0";
+
+  src = fetchurl {
+    x86_64-darwin = {
+      url = "https://s3.amazonaws.com/nosql-workbench/NoSQL%20Workbench-mac-x64-${version}.dmg";
+      hash = "sha256-KM3aDDsQGZwUKU/or0eOoP8okAOPH7q8KL46RwfqhzM=";
+    };
+    aarch64-darwin = {
+      url = "https://s3.amazonaws.com/nosql-workbench/NoSQL%20Workbench-mac-arm64-${version}.dmg";
+      hash = "sha256-LzHiCMrDOWDuMNkkojLgKn+UG7x76wSAz0BapyWkAzU=";
+    };
+    x86_64-linux = {
+      url = "https://s3.amazonaws.com/nosql-workbench/NoSQL%20Workbench-linux-${version}.AppImage";
+      hash = "sha256-cDOSbhAEFBHvAluxTxqVpva1GJSlFhiozzRfuM4MK5c=";
+    };
+  }.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
+
+  meta = {
+    description = "Visual tool that provides data modeling, data visualization, and query development features to help you design, create, query, and manage DynamoDB tables";
+    homepage = "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/workbench.html";
+    changelog = "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkbenchDocumentHistory.html";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ DataHearth ];
+    platforms = [ "aarch64-darwin" "x86_64-darwin" "x86_64-linux" ];
+  };
+in
+if stdenv.isDarwin then stdenv.mkDerivation {
+  inherit pname version src meta;
+
+  sourceRoot = ".";
+
+  buildInputs = [ jdk21 ];
+
+  # DMG file is using APFS which is unsupported by "undmg".
+  # Fix found: https://discourse.nixos.org/t/help-with-error-only-hfs-file-systems-are-supported-on-ventura/25873/8
+  # "undmg" issue: https://github.com/matthewbauer/undmg/issues/4
+  unpackCmd = ''
+    echo "Creating temp directory"
+    mnt=$(TMPDIR=/tmp mktemp -d -t nix-XXXXXXXXXX)
+
+    function finish {
+      echo "Ejecting temp directory"
+      /usr/bin/hdiutil detach $mnt -force
+      rm -rf $mnt
+    }
+    # Detach volume when receiving SIG "0"
+    trap finish EXIT
+
+    # Mount DMG file
+    echo "Mounting DMG file into \"$mnt\""
+    /usr/bin/hdiutil attach -nobrowse -mountpoint $mnt $curSrc
+
+    # Copy content to local dir for later use
+    echo 'Copying extracted content into "sourceRoot"'
+    cp -a $mnt/NoSQL\ Workbench.app $PWD/
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications"
+    mv NoSQL\ Workbench.app $out/Applications/
+
+    runHook postInstall
+  '';
+
+} else appimageTools.wrapType2 {
+  inherit pname version src meta;
+
+  extraPkgs = ps: (appimageTools.defaultFhsEnvArgs.multiPkgs ps) ++ [
+    # Required to run DynamoDB locally
+    ps.jdk21
+  ];
+
+  extraInstallCommands = let
+    appimageContents = appimageTools.extract {
+      inherit pname version src;
+    };
+  in ''
+    # Replace version from binary name
+    mv $out/bin/${pname}-${version} $out/bin/${pname}
+
+    # Install XDG Desktop file and its icon
+    install -Dm444 ${appimageContents}/nosql-workbench.desktop -t $out/share/applications
+    install -Dm444 ${appimageContents}/nosql-workbench.png -t $out/share/pixmaps
+
+    # Replace wrong exec statement in XDG Desktop file
+    substituteInPlace $out/share/applications/nosql-workbench.desktop \
+        --replace 'Exec=AppRun --no-sandbox %U' 'Exec=nosql-workbench'
+  '';
+}


### PR DESCRIPTION
## Description of changes

NoSQL Workbench for Amazon DynamoDB is a cross-platform, client-side GUI application that you can use for modern database development and operations.
<https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/workbench.html>

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes #154802

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
