### PR TITLE
bavarder: init at 1.0.0-unstable-2024-03-23

### DIFF
--- a/pkgs/by-name/ba/bavarder/package.nix
+++ b/pkgs/by-name/ba/bavarder/package.nix
@@ -1,0 +1,72 @@
+{ appstream-glib
+, blueprint-compiler
+, desktop-file-utils
+, fetchFromGitHub
+, gettext
+, gtk4
+, gtksourceview5
+, lib
+, libadwaita
+, libportal
+, meson
+, ninja
+, pkg-config
+, python3Packages
+, wrapGAppsHook4
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "bavarder";
+  version = "1.0.0-unstable-2024-03-23";
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "Bavarder";
+    repo = "Bavarder";
+    rev = "bb6ca168f875e4f320fdd5d1eaf2d92d5a55bfa3";
+    hash = "sha256-vwuynsTjTajPTLr4mxufGSyulwEjknhuJJsmPjNisTA=";
+  };
+
+  patches = [
+    # Removes gpt4all support. It would be lots of work to package it properly
+    # and we already have ollama with working ROCm + CUDA in nixpkgs.
+    "${src}/0001-remove-gpt4all-support.patch"
+  ];
+
+  nativeBuildInputs = [
+    appstream-glib
+    blueprint-compiler
+    desktop-file-utils
+    gettext
+    gtk4
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gtksourceview5
+    libadwaita
+    libportal
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    babel
+    gst-python
+    lxml
+    openai
+    pillow
+    pygobject3
+    requests
+  ];
+
+  meta = with lib; {
+    description = "Chit-chat with an AI";
+    homepage = "https://github.com/Bavarder/Bavarder";
+    license = with licenses; [ gpl3Only ];
+    mainProgram = "bavarder";
+    maintainers = with maintainers; [ surfaceflinger ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Added a package for [Bavarder](https://github.com/Bavarder/Bavarder)
Required some patches - reasons in package.nix.

Initing at 1.0.0-unstable-2024-03-23 because the latest tagged release pulls unnecessary deps and is broken with the latest openai python lib which we have in nixpkgs. We also get more translations which is a11y bonus.

Patched out gpt4all support as we don't have py bindings for it packaged.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
