### PR TITLE
nixos/nsd: add multi-master-check and zonefiles-write options

### DIFF
--- a/nixos/modules/services/networking/nsd.nix
+++ b/nixos/modules/services/networking/nsd.nix
@@ -81,7 +81,6 @@ let
       zonesdir: "${stateDir}"
 
       # the list of dynamically added zones.
-      database:     "${stateDir}/var/nsd.db"
       pidfile:      "${pidFile}"
       xfrdfile:     "${stateDir}/var/xfrd.state"
       xfrdir:       "${stateDir}/tmp"
@@ -112,6 +111,7 @@ let
       ${maybeString "version: " cfg.version}
       xfrd-reload-timeout: ${toString cfg.xfrdReloadTimeout}
       zonefiles-check:     ${yesOrNo  cfg.zonefilesCheck}
+      zonefiles-write:     ${toString cfg.zonefilesWrite}
 
       ${maybeString "rrl-ipv4-prefix-length: " cfg.ratelimit.ipv4PrefixLength}
       ${maybeString "rrl-ipv6-prefix-length: " cfg.ratelimit.ipv6PrefixLength}
@@ -173,6 +173,7 @@ let
       ${maybeToString "min-retry-time:   " zone.minRetrySecs}
 
       allow-axfr-fallback: ${yesOrNo       zone.allowAXFRFallback}
+      multi-master-check: ${yesOrNo        zone.multiMasterCheck}
     ${forEach     "  allow-notify: "       zone.allowNotify}
     ${forEach     "  request-xfr: "        zone.requestXFR}
 
@@ -201,7 +202,7 @@ let
       allowAXFRFallback = mkOption {
         type = types.bool;
         default = true;
-        description = lib.mdDoc ''
+        description = ''
           If NSD as secondary server should be allowed to AXFR if the primary
           server does not allow IXFR.
         '';
@@ -213,7 +214,7 @@ let
         example = [ "192.0.2.0/24 NOKEY" "10.0.0.1-10.0.0.5 my_tsig_key_name"
                     "10.0.3.4&255.255.0.0 BLOCKED"
                   ];
-        description = lib.mdDoc ''
+        description = ''
           Listed primary servers are allowed to notify this secondary server.
 
           Format: `<ip> <key-name | NOKEY | BLOCKED>`
@@ -243,7 +244,7 @@ let
         # to default values, breaking the parent inheriting function.
         type = types.attrsOf types.anything;
         default = {};
-        description = lib.mdDoc ''
+        description = ''
           Children zones inherit all options of their parents. Attributes
           defined in a child will overwrite the ones of its parent. Only
           leaf zones will be actually served. This way it's possible to
@@ -256,29 +257,29 @@ let
       data = mkOption {
         type = types.lines;
         default = "";
-        description = lib.mdDoc ''
+        description = ''
           The actual zone data. This is the content of your zone file.
           Use imports or pkgs.lib.readFile if you don't want this data in your config file.
         '';
       };
 
-      dnssec = mkEnableOption (lib.mdDoc "DNSSEC");
+      dnssec = mkEnableOption "DNSSEC";
 
       dnssecPolicy = {
         algorithm = mkOption {
           type = types.str;
           default = "RSASHA256";
-          description = lib.mdDoc "Which algorithm to use for DNSSEC";
+          description = "Which algorithm to use for DNSSEC";
         };
         keyttl = mkOption {
           type = types.str;
           default = "1h";
-          description = lib.mdDoc "TTL for dnssec records";
+          description = "TTL for dnssec records";
         };
         coverage = mkOption {
           type = types.str;
           default = "1y";
-          description = lib.mdDoc ''
+          description = ''
             The length of time to ensure that keys will be correct; no action will be taken to create new keys to be activated after this time.
           '';
         };
@@ -289,7 +290,7 @@ let
                       postPublish = "1w";
                       rollPeriod = "1mo";
                     };
-          description = lib.mdDoc "Key policy for zone signing keys";
+          description = "Key policy for zone signing keys";
         };
         ksk = mkOption {
           type = keyPolicy;
@@ -298,14 +299,14 @@ let
                       postPublish = "1mo";
                       rollPeriod = "0";
                     };
-          description = lib.mdDoc "Key policy for key signing keys";
+          description = "Key policy for key signing keys";
         };
       };
 
       maxRefreshSecs = mkOption {
         type = types.nullOr types.int;
         default = null;
-        description = lib.mdDoc ''
+        description = ''
           Limit refresh time for secondary zones. This is the timer which
           checks to see if the zone has to be refetched when it expires.
           Normally the value from the SOA record is used, but this  option
@@ -316,7 +317,7 @@ let
       minRefreshSecs = mkOption {
         type = types.nullOr types.int;
         default = null;
-        description = lib.mdDoc ''
+        description = ''
           Limit refresh time for secondary zones.
         '';
       };
@@ -324,7 +325,7 @@ let
       maxRetrySecs = mkOption {
         type = types.nullOr types.int;
         default = null;
-        description = lib.mdDoc ''
+        description = ''
           Limit retry time for secondary zones. This is the timeout after
           a failed fetch attempt for the zone. Normally the value from
           the SOA record is used, but this option restricts that value.
@@ -334,17 +335,26 @@ let
       minRetrySecs = mkOption {
         type = types.nullOr types.int;
         default = null;
-        description = lib.mdDoc ''
+        description = ''
           Limit retry time for secondary zones.
         '';
       };
 
+      multiMasterCheck = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          If enabled, checks all masters for the last zone version.
+          It uses the higher version from all configured masters.
+          Useful if you have multiple masters that have different version numbers served.
+        '';
+      };
 
       notify = mkOption {
         type = types.listOf types.str;
         default = [];
         example = [ "10.0.0.1@3721 my_key" "::5 NOKEY" ];
-        description = lib.mdDoc ''
+        description = ''
           This primary server will notify all given secondary servers about
           zone changes.
 
@@ -361,7 +371,7 @@ let
       notifyRetry = mkOption {
         type = types.int;
         default = 5;
-        description = lib.mdDoc ''
+        description = ''
           Specifies the number of retries for failed notifies. Set this along with notify.
         '';
       };
@@ -370,7 +380,7 @@ let
         type = types.nullOr types.str;
         default = null;
         example = "2000::1@1234";
-        description = lib.mdDoc ''
+        description = ''
           This address will be used for zone-transfer requests if configured
           as a secondary server or notifications in case of a primary server.
           Supply either a plain IPv4 or IPv6 address with an optional port
@@ -382,7 +392,7 @@ let
         type = types.listOf types.str;
         default = [];
         example = [ "192.0.2.0/24 NOKEY" "192.0.2.0/24 my_tsig_key_name" ];
-        description = lib.mdDoc ''
+        description = ''
           Allow these IPs and TSIG to transfer zones, addr TSIG|NOKEY|BLOCKED
           address range 192.0.2.0/24, 1.2.3.4&255.255.0.0, 3.0.2.20-3.0.2.40
         '';
@@ -391,7 +401,7 @@ let
       requestXFR = mkOption {
         type = types.listOf types.str;
         default = [];
-        description = lib.mdDoc ''
+        description = ''
           Format: `[AXFR|UDP] <ip-address> <key-name | NOKEY>`
         '';
       };
@@ -399,7 +409,7 @@ let
       rrlWhitelist = mkOption {
         type = with types; listOf (enum [ "nxdomain" "error" "referral" "any" "rrsig" "wildcard" "nodata" "dnskey" "positive" "all" ]);
         default = [];
-        description = lib.mdDoc ''
+        description = ''
           Whitelists the given rrl-types.
         '';
       };
@@ -408,7 +418,7 @@ let
         type = types.nullOr types.str;
         default = null;
         example = "%s";
-        description = lib.mdDoc ''
+        description = ''
           When set to something distinct to null NSD is able to collect
           statistics per zone. All statistics of this zone(s) will be added
           to the group specified by this given name. Use "%s" to use the zones
@@ -423,19 +433,19 @@ let
     options = {
       keySize = mkOption {
         type = types.int;
-        description = lib.mdDoc "Key size in bits";
+        description = "Key size in bits";
       };
       prePublish = mkOption {
         type = types.str;
-        description = lib.mdDoc "How long in advance to publish new keys";
+        description = "How long in advance to publish new keys";
       };
       postPublish = mkOption {
         type = types.str;
-        description = lib.mdDoc "How long after deactivation to keep a key in the zone";
+        description = "How long after deactivation to keep a key in the zone";
       };
       rollPeriod = mkOption {
         type = types.str;
-        description = lib.mdDoc "How frequently to change keys";
+        description = "How frequently to change keys";
       };
     };
   };
@@ -478,14 +488,14 @@ in
   # options are ordered alphanumerically
   options.services.nsd = {
 
-    enable = mkEnableOption (lib.mdDoc "NSD authoritative DNS server");
+    enable = mkEnableOption "NSD authoritative DNS server";
 
-    bind8Stats = mkEnableOption (lib.mdDoc "BIND8 like statistics");
+    bind8Stats = mkEnableOption "BIND8 like statistics";
 
     dnssecInterval = mkOption {
       type = types.str;
       default = "1h";
-      description = lib.mdDoc ''
+      description = ''
         How often to check whether dnssec key rollover is required
       '';
     };
@@ -493,7 +503,7 @@ in
     extraConfig = mkOption {
       type = types.lines;
       default = "";
-      description = lib.mdDoc ''
+      description = ''
         Extra nsd config.
       '';
     };
@@ -501,7 +511,7 @@ in
     hideVersion = mkOption {
       type = types.bool;
       default = true;
-      description = lib.mdDoc ''
+      description = ''
         Whether NSD should answer VERSION.BIND and VERSION.SERVER CHAOS class queries.
       '';
     };
@@ -509,7 +519,7 @@ in
     identity = mkOption {
       type = types.str;
       default = "unidentified server";
-      description = lib.mdDoc ''
+      description = ''
         Identify the server (CH TXT ID.SERVER entry).
       '';
     };
@@ -517,7 +527,7 @@ in
     interfaces = mkOption {
       type = types.listOf types.str;
       default = [ "127.0.0.0" "::1" ];
-      description = lib.mdDoc ''
+      description = ''
         What addresses the server should listen to.
       '';
     };
@@ -525,7 +535,7 @@ in
     ipFreebind = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Whether to bind to nonlocal addresses and interfaces that are down.
         Similar to ip-transparent.
       '';
@@ -534,7 +544,7 @@ in
     ipTransparent = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Allow binding to non local addresses.
       '';
     };
@@ -542,7 +552,7 @@ in
     ipv4 = mkOption {
       type = types.bool;
       default = true;
-      description = lib.mdDoc ''
+      description = ''
         Whether to listen on IPv4 connections.
       '';
     };
@@ -550,7 +560,7 @@ in
     ipv4EDNSSize = mkOption {
       type = types.int;
       default = 4096;
-      description = lib.mdDoc ''
+      description = ''
         Preferred EDNS buffer size for IPv4.
       '';
     };
@@ -558,7 +568,7 @@ in
     ipv6 = mkOption {
       type = types.bool;
       default = true;
-      description = lib.mdDoc ''
+      description = ''
         Whether to listen on IPv6 connections.
       '';
     };
@@ -566,7 +576,7 @@ in
     ipv6EDNSSize = mkOption {
       type = types.int;
       default = 4096;
-      description = lib.mdDoc ''
+      description = ''
         Preferred EDNS buffer size for IPv6.
       '';
     };
@@ -574,7 +584,7 @@ in
     logTimeAscii = mkOption {
       type = types.bool;
       default = true;
-      description = lib.mdDoc ''
+      description = ''
         Log time in ascii, if false then in unix epoch seconds.
       '';
     };
@@ -582,7 +592,7 @@ in
     nsid = mkOption {
       type = types.nullOr types.str;
       default = null;
-      description = lib.mdDoc ''
+      description = ''
         NSID identity (hex string, or "ascii_somestring").
       '';
     };
@@ -590,7 +600,7 @@ in
     port = mkOption {
       type = types.port;
       default = 53;
-      description = lib.mdDoc ''
+      description = ''
         Port the service should bind do.
       '';
     };
@@ -599,7 +609,7 @@ in
       type = types.bool;
       default = pkgs.stdenv.isLinux;
       defaultText = literalExpression "pkgs.stdenv.isLinux";
-      description = lib.mdDoc ''
+      description = ''
         Whether to enable SO_REUSEPORT on all used sockets. This lets multiple
         processes bind to the same port. This speeds up operation especially
         if the server count is greater than one and makes fast restarts less
@@ -610,18 +620,18 @@ in
     rootServer = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = ''
         Whether this server will be a root server (a DNS root server, you
         usually don't want that).
       '';
     };
 
-    roundRobin = mkEnableOption (lib.mdDoc "round robin rotation of records");
+    roundRobin = mkEnableOption "round robin rotation of records";
 
     serverCount = mkOption {
       type = types.int;
       default = 1;
-      description = lib.mdDoc ''
+      description = ''
         Number of NSD servers to fork. Put the number of CPUs to use here.
       '';
     };
@@ -629,7 +639,7 @@ in
     statistics = mkOption {
       type = types.nullOr types.int;
       default = null;
-      description = lib.mdDoc ''
+      description = ''
         Statistics are produced every number of seconds. Prints to log.
         If null no statistics are logged.
       '';
@@ -638,7 +648,7 @@ in
     tcpCount = mkOption {
       type = types.int;
       default = 100;
-      description = lib.mdDoc ''
+      description = ''
         Maximum number of concurrent TCP connections per server.
       '';
     };
@@ -646,7 +656,7 @@ in
     tcpQueryCount = mkOption {
       type = types.int;
       default = 0;
-      description = lib.mdDoc ''
+      description = ''
         Maximum number of queries served on a single TCP connection.
         0 means no maximum.
       '';
@@ -655,7 +665,7 @@ in
     tcpTimeout = mkOption {
       type = types.int;
       default = 120;
-      description = lib.mdDoc ''
+      description = ''
         TCP timeout in seconds.
       '';
     };
@@ -663,7 +673,7 @@ in
     verbosity = mkOption {
       type = types.int;
       default = 0;
-      description = lib.mdDoc ''
+      description = ''
         Verbosity level.
       '';
     };
@@ -671,7 +681,7 @@ in
     version = mkOption {
       type = types.nullOr types.str;
       default = null;
-      description = lib.mdDoc ''
+      description = ''
         The version string replied for CH TXT version.server and version.bind
         queries. Will use the compiled package version on null.
         See hideVersion for enabling/disabling this responses.
@@ -681,7 +691,7 @@ in
     xfrdReloadTimeout = mkOption {
       type = types.int;
       default = 1;
-      description = lib.mdDoc ''
+      description = ''
         Number of seconds between reloads triggered by xfrd.
       '';
     };
@@ -689,8 +699,19 @@ in
     zonefilesCheck = mkOption {
       type = types.bool;
       default = true;
-      description = lib.mdDoc ''
+      description = ''
         Whether to check mtime of all zone files on start and sighup.
+      '';
+    };
+
+    zonefilesWrite = mkOption {
+      type = types.int;
+      default = 0;
+      description = ''
+        Write changed secondary zones to their zonefile every N seconds.
+        If the zone (pattern) configuration has "" zonefile, it is not written.
+        Zones that have received zone transfer updates are written to their zonefile.
+        0 disables writing to zone files.
       '';
     };
 
@@ -702,14 +723,14 @@ in
           algorithm = mkOption {
             type = types.str;
             default = "hmac-sha256";
-            description = lib.mdDoc ''
+            description = ''
               Authentication algorithm for this key.
             '';
           };
 
           keyFile = mkOption {
             type = types.path;
-            description = lib.mdDoc ''
+            description = ''
               Path to the file which contains the actual base64 encoded
               key. The key will be copied into "${stateDir}/private" before
               NSD starts. The copied file is only accessibly by the NSD
@@ -727,7 +748,7 @@ in
           };
         }
       '';
-      description = lib.mdDoc ''
+      description = ''
         Define your TSIG keys here.
       '';
     };
@@ -735,12 +756,12 @@ in
 
     ratelimit = {
 
-      enable = mkEnableOption (lib.mdDoc "ratelimit capabilities");
+      enable = mkEnableOption "ratelimit capabilities";
 
       ipv4PrefixLength = mkOption {
         type = types.nullOr types.int;
         default = null;
-        description = lib.mdDoc ''
+        description = ''
           IPv4 prefix length. Addresses are grouped by netblock.
         '';
       };
@@ -748,7 +769,7 @@ in
       ipv6PrefixLength = mkOption {
         type = types.nullOr types.int;
         default = null;
-        description = lib.mdDoc ''
+        description = ''
           IPv6 prefix length. Addresses are grouped by netblock.
         '';
       };
@@ -756,7 +777,7 @@ in
       ratelimit = mkOption {
         type = types.int;
         default = 200;
-        description = lib.mdDoc ''
+        description = ''
           Max qps allowed from any query source.
           0 means unlimited. With an verbosity of 2 blocked and
           unblocked subnets will be logged.
@@ -766,7 +787,7 @@ in
       slip = mkOption {
         type = types.nullOr types.int;
         default = null;
-        description = lib.mdDoc ''
+        description = ''
           Number of packets that get discarded before replying a SLIP response.
           0 disables SLIP responses. 1 will make every response a SLIP response.
         '';
@@ -775,7 +796,7 @@ in
       size = mkOption {
         type = types.int;
         default = 1000000;
-        description = lib.mdDoc ''
+        description = ''
           Size of the hashtable. More buckets use more memory but lower
           the chance of hash hash collisions.
         '';
@@ -784,7 +805,7 @@ in
       whitelistRatelimit = mkOption {
         type = types.int;
         default = 2000;
-        description = lib.mdDoc ''
+        description = ''
           Max qps allowed from whitelisted sources.
           0 means unlimited. Set the rrl-whitelist option for specific
           queries to apply this limit instead of the default to them.
@@ -796,12 +817,12 @@ in
 
     remoteControl = {
 
-      enable = mkEnableOption (lib.mdDoc "remote control via nsd-control");
+      enable = mkEnableOption "remote control via nsd-control";
 
       controlCertFile = mkOption {
         type = types.path;
         default = "/etc/nsd/nsd_control.pem";
-        description = lib.mdDoc ''
+        description = ''
           Path to the client certificate signed with the server certificate.
           This file is used by nsd-control and generated by nsd-control-setup.
         '';
@@ -810,7 +831,7 @@ in
       controlKeyFile = mkOption {
         type = types.path;
         default = "/etc/nsd/nsd_control.key";
-        description = lib.mdDoc ''
+        description = ''
           Path to the client private key, which is used by nsd-control
           but not by the server. This file is generated by nsd-control-setup.
         '';
@@ -819,7 +840,7 @@ in
       interfaces = mkOption {
         type = types.listOf types.str;
         default = [ "127.0.0.1" "::1" ];
-        description = lib.mdDoc ''
+        description = ''
           Which interfaces NSD should bind to for remote control.
         '';
       };
@@ -827,7 +848,7 @@ in
       port = mkOption {
         type = types.port;
         default = 8952;
-        description = lib.mdDoc ''
+        description = ''
           Port number for remote control operations (uses TLS over TCP).
         '';
       };
@@ -835,7 +856,7 @@ in
       serverCertFile = mkOption {
         type = types.path;
         default = "/etc/nsd/nsd_server.pem";
-        description = lib.mdDoc ''
+        description = ''
           Path to the server self signed certificate, which is used by the server
           but and by nsd-control. This file is generated by nsd-control-setup.
         '';
@@ -844,7 +865,7 @@ in
       serverKeyFile = mkOption {
         type = types.path;
         default = "/etc/nsd/nsd_server.key";
-        description = lib.mdDoc ''
+        description = ''
           Path to the server private key, which is used by the server
           but not by nsd-control. This file is generated by nsd-control-setup.
         '';
@@ -886,7 +907,7 @@ in
           };
         }
       '';
-      description = lib.mdDoc ''
+      description = ''
         Define your zones here. Zones can cascade other zones and therefore
         inherit settings from parent zones. Look at the definition of
         children to learn about inheritance and child zones.


### PR DESCRIPTION
## Description of changes
Adds the options `services.nsd.zonefilesWrite` and `services.nsd.zones.<name>.multiMasterCheck`. Ideally this module should be updated to follow RFC42/freeform options but this fixes a small usability gap for now.

I left the `zonefilesWrite` default at 3600 seconds, but it might be better to default it to 0, as the module-generated zone files are unwritable and nsd complains in the logs. Unfortunately, it's a global option and can't be disabled only for the nixos-managed zones.

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
