### PR TITLE
chadwm: init at 0-unstable-2024-02-14

### DIFF
--- a/pkgs/by-name/ch/chadwm/package.nix
+++ b/pkgs/by-name/ch/chadwm/package.nix
@@ -11,7 +11,7 @@
 
 stdenv.mkDerivation {
   name = "chadwm";
-  version = "unstable-2024-02-14";
+  version = "0-unstable-2024-02-14";
   src = fetchFromGitHub {
     owner = "siduck";
     repo = "chadwm";

--- a/pkgs/by-name/ch/chadwm/package.nix
+++ b/pkgs/by-name/ch/chadwm/package.nix
@@ -1,0 +1,42 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, xorg
+, imlib2
+, picom
+, feh
+, acpi
+, rofi
+}:
+
+stdenv.mkDerivation {
+  name = "chadwm";
+  version = "unstable-2024-02-14";
+  src = fetchFromGitHub {
+    owner = "siduck";
+    repo = "chadwm";
+    rev = "566de97abf2c06a18abec7c776a9d2d2edd12055";
+    hash = "sha256-WX1vsbivOCEduAmTfXNTEKzNHQuh62LVkr5SmYrfte0=";
+  };
+  buildInputs = [
+    imlib2
+    picom
+    feh
+    acpi
+    rofi
+    xorg.libX11
+    xorg.libXft
+    xorg.libXinerama
+    xorg.xsetroot
+  ];
+  makeFlags = [ "PREFIX=$(out)" ];
+  preBuild = "cd chadwm";
+
+    meta = with lib; {
+    homepage = "https://github.com/siduck/chadwm";
+    description = "Dwm fork that is amazingly efficient";
+    license = licenses.mit;
+    maintainers = with maintainers; [ binarycat ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/by-name/ch/chadwm/package.nix
+++ b/pkgs/by-name/ch/chadwm/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
   makeFlags = [ "PREFIX=$(out)" ];
   preBuild = "cd chadwm";
 
-    meta = with lib; {
+  meta = with lib; {
     homepage = "https://github.com/siduck/chadwm";
     description = "Dwm fork that is amazingly efficient";
     license = licenses.mit;


### PR DESCRIPTION
## Description of changes
Closes #282239 


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
