### PR TITLE
memorymappingHook,memstreamHook: fix for derivations that call gcc/clang as assembler

### DIFF
--- a/pkgs/development/libraries/memorymapping/default.nix
+++ b/pkgs/development/libraries/memorymapping/default.nix
@@ -18,7 +18,10 @@ stdenv.mkDerivation {
 
     $CC -c src/fmemopen.c
     $AR rcs libmemorymapping.a fmemopen.o
-    sed -e '1i#include <stdio.h>' -i src/fmemopen.h
+    sed -i src/fmemopen.h \
+      -e '1i#ifndef __ASSEMBLER__' \
+      -e '1i#include <stdio.h>' \
+      -e '$a#endif'
 
     runHook postBuild
   '';

--- a/pkgs/development/libraries/memstream/default.nix
+++ b/pkgs/development/libraries/memstream/default.nix
@@ -13,6 +13,9 @@ stdenv.mkDerivation rec {
 
   postBuild = ''
     $AR rcs libmemstream.a memstream.o
+    sed -i memstream.h \
+      -e '1i#ifndef __ASSEMBLER__' \
+      -e '$a#endif'
   '';
 
   doCheck = true;


### PR DESCRIPTION
## Description of changes

Fixes a small defect that prevents the Hooks from being used in `mesa` (e.g. instead of the #290525) where `gcc foo.S` is being used and `-include` tries to load a C file into an assembly listing.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
