### PR TITLE
nixos/lxc/generator: remove sysctl error handling

### DIFF
--- a/pkgs/tools/virtualization/distrobuilder/nixos-generator.patch
+++ b/pkgs/tools/virtualization/distrobuilder/nixos-generator.patch
@@ -1,5 +1,5 @@
 diff --git a/distrobuilder/lxc.generator b/distrobuilder/lxc.generator
-index 0ad81d1..69dbfe7 100644
+index 0ad81d1..21ddb39 100644
 --- a/distrobuilder/lxc.generator
 +++ b/distrobuilder/lxc.generator
 @@ -25,16 +25,6 @@ is_incus_vm() {
@@ -73,9 +73,22 @@ index 0ad81d1..69dbfe7 100644
  
  	mkdir -p /run/systemd/system/systemd-udev-trigger.service.d
  	cat <<-EOF > /run/systemd/system/systemd-udev-trigger.service.d/zzz-lxc-override.conf
-@@ -145,24 +97,12 @@ EOF
+@@ -132,37 +84,13 @@ ExecStart=-${cmd} trigger --type=devices --action=add
+ EOF
  }
  
+-# fix_systemd_sysctl overrides the systemd-sysctl.service to use "ExecStart=-" instead of "ExecStart=".
+-fix_systemd_sysctl() {
+-	cmd=/usr/lib/systemd/systemd-sysctl
+-	! [ -e "${cmd}" ] && cmd=/lib/systemd/systemd-sysctl
+-	mkdir -p /run/systemd/system/systemd-sysctl.service.d
+-	cat <<-EOF > /run/systemd/system/systemd-sysctl.service.d/zzz-lxc-override.conf
+-[Service]
+-ExecStart=
+-ExecStart=-${cmd}
+-EOF
+-}
+-
  ## Main logic
 -# Nothing to do in Incus VM but deployed in case it is later converted to a container
 -is_incus_vm || is_lxd_vm && exit 0
@@ -99,7 +112,15 @@ index 0ad81d1..69dbfe7 100644
  
  # Determine distro name and release
  ID=""
-@@ -222,11 +162,6 @@ ACTION=="add|change|move", ENV{ID_NET_DRIVER}=="veth", ENV{INTERFACE}=="eth[0-9]
+@@ -192,7 +120,6 @@ fi
+ 
+ # Ignore failures on some units.
+ fix_systemd_udev_trigger
+-fix_systemd_sysctl
+ 
+ # Mask some units.
+ fix_systemd_mask dev-hugepages.mount
+@@ -222,11 +149,6 @@ ACTION=="add|change|move", ENV{ID_NET_DRIVER}=="veth", ENV{INTERFACE}=="eth[0-9]
  EOF
  fi
  


### PR DESCRIPTION
## Description of changes

Removed a function in the generator that rewrites the systemd-sysctl exec with an FHS path. I traced this back through git, but the original PR provides no context for why this was added. https://github.com/lxc/distrobuilder/pull/453 Therefore, let's just try removing it outright, and if we actually need this functionality we should modify this in our lxc container module.

I also took this as another opportunity to audit the script for more potential path issues like this and this seems to be the last one.

Closes: https://github.com/NixOS/nixpkgs/issues/289174

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
