### PR TITLE
ocamlPackages.caqti: 1.9.1 → 2.1.1

### DIFF
--- a/pkgs/development/ocaml-modules/caqti/async.nix
+++ b/pkgs/development/ocaml-modules/caqti/async.nix
@@ -4,7 +4,7 @@ buildDunePackage {
   pname = "caqti-async";
   inherit (caqti) version src;
 
-  duneVersion = "3";
+  minimalOCamlVersion = "4.14";
 
   propagatedBuildInputs = [ async_kernel async_unix caqti core_kernel ];
 

--- a/pkgs/development/ocaml-modules/caqti/default.nix
+++ b/pkgs/development/ocaml-modules/caqti/default.nix
@@ -1,25 +1,34 @@
-{ lib, fetchurl, buildDunePackage, ocaml
-, cppo, logs, ptime, uri, bigstringaf
-, re, cmdliner, alcotest
+{ lib
+, fetchurl
+, buildDunePackage
+, angstrom
+, bigstringaf
+, domain-name
+, dune-site
+, ipaddr
+, logs
+, lwt-dllist
+, mtime
+, ptime
+, uri
 }:
 
 buildDunePackage rec {
   pname = "caqti";
-  version = "1.9.1";
+  version = "2.1.1";
 
-  minimalOCamlVersion = "4.04";
-  duneVersion = "3";
+  minimalOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/paurkedal/ocaml-caqti/releases/download/v${version}/caqti-v${version}.tbz";
-    sha256 = "sha256-PQBgJBNx3IcE6/vyNIf26a2xStU22LBhff8eM6UPaJ4=";
+    hash = "sha256-SDpTX0HiZBkX/BgyzkrRX/w/ToKDsbMBiiYXNJWDCQo=";
   };
 
-  nativeBuildInputs = [ cppo ];
-  propagatedBuildInputs = [ logs ptime uri bigstringaf ];
-  checkInputs = [ re cmdliner alcotest ];
+  buildInputs = [ dune-site ];
+  propagatedBuildInputs = [ angstrom bigstringaf domain-name ipaddr logs lwt-dllist mtime ptime uri ];
 
-  doCheck = lib.versionAtLeast ocaml.version "4.08";
+  # Checks depend on caqti-driver-sqlite3 (circural dependency)
+  doCheck = false;
 
   meta = {
     description = "Unified interface to relational database libraries";

--- a/pkgs/development/ocaml-modules/caqti/driver-mariadb.nix
+++ b/pkgs/development/ocaml-modules/caqti/driver-mariadb.nix
@@ -6,8 +6,6 @@ buildDunePackage {
 
   propagatedBuildInputs = [ caqti mariadb ];
 
-  duneVersion = "3";
-
   meta = caqti.meta // {
     description = "MariaDB driver for Caqti using C bindings";
   };

--- a/pkgs/development/ocaml-modules/caqti/driver-postgresql.nix
+++ b/pkgs/development/ocaml-modules/caqti/driver-postgresql.nix
@@ -4,8 +4,6 @@ buildDunePackage {
   pname = "caqti-driver-postgresql";
   inherit (caqti) version src;
 
-  duneVersion = "3";
-
   propagatedBuildInputs = [ caqti postgresql ];
 
   meta = caqti.meta // {

--- a/pkgs/development/ocaml-modules/caqti/driver-sqlite3.nix
+++ b/pkgs/development/ocaml-modules/caqti/driver-sqlite3.nix
@@ -1,12 +1,14 @@
-{ lib, buildDunePackage, caqti, ocaml_sqlite3 }:
+{ lib, buildDunePackage, caqti, ocaml_sqlite3, alcotest }:
 
 buildDunePackage {
   pname = "caqti-driver-sqlite3";
   inherit (caqti) version src;
 
-  duneVersion = "3";
-
   propagatedBuildInputs = [ caqti ocaml_sqlite3 ];
+
+  checkInputs = [ alcotest ];
+
+  doCheck = true;
 
   meta = caqti.meta // {
     description = "Sqlite3 driver for Caqti using C bindings";

--- a/pkgs/development/ocaml-modules/caqti/dynload.nix
+++ b/pkgs/development/ocaml-modules/caqti/dynload.nix
@@ -4,8 +4,6 @@ buildDunePackage {
   pname = "caqti-dynload";
   inherit (caqti) version src;
 
-  duneVersion = "3";
-
   propagatedBuildInputs = [ caqti findlib ];
 
   meta = caqti.meta // {

--- a/pkgs/development/ocaml-modules/caqti/lwt.nix
+++ b/pkgs/development/ocaml-modules/caqti/lwt.nix
@@ -4,8 +4,6 @@ buildDunePackage {
   pname = "caqti-lwt";
   inherit (caqti) version src;
 
-  duneVersion = "3";
-
   propagatedBuildInputs = [ caqti logs lwt ];
 
   meta = caqti.meta // { description = "Lwt support for Caqti"; };

--- a/pkgs/development/ocaml-modules/caqti/type-calendar.nix
+++ b/pkgs/development/ocaml-modules/caqti/type-calendar.nix
@@ -4,8 +4,6 @@ buildDunePackage {
   pname = "caqti-type-calendar";
   inherit (caqti) src version;
 
-  duneVersion = "3";
-
   propagatedBuildInputs = [ calendar caqti ];
 
   meta = caqti.meta // {


### PR DESCRIPTION
## Description of changes

https://raw.githubusercontent.com/paurkedal/ocaml-caqti/v2.1.1/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
