### PR TITLE
kicad: 7.0.10 -> 7.0.11

### DIFF
--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -3,23 +3,23 @@
 {
   "kicad" = {
     kicadVersion = {
-      version =			"7.0.10";
+      version =			"7.0.11";
       src = {
-        rev =			"7daac78752749fc919e932be6156914aa83c926f";
-        sha256 =		"0z459yi0s02mwdgbr3xxw43gn9yjhvfkjnsxmns5mksgzsr5nmhh";
+        rev =			"8b7c6b9db0de4f39131845aa8a1a66693c4a93a4";
+        sha256 =		"0gwf6yb05cm3f9sz4jp96imskir3rf0a7kaqaszzrjxr3zcigwjv";
       };
     };
     libVersion = {
-      version =			"7.0.10";
+      version =			"7.0.11";
       libSources = {
-        symbols.rev =		"eedf6c9ddac2816023e817d4dc91032f9d7390b9";
-        symbols.sha256 =	"0nlgmxf9z1vf4g350dfkxql1dawgmw275wqxkgszsfxmhdfpmi9v";
-        templates.rev =		"9ce98cc45f3778e05c404edebf0f98de5c247ffe";
+        symbols.rev =		"b1ecf3147604884cde9c44daad99e8e13a15e021";
+        symbols.sha256 =	"057zmhf4h3p3p4y6jqxch9cj1wqf129k6kmvx2gshb9lgda0kjr8";
+        templates.rev =		"45dd19e76ec8d75fd932e462a164239baf253dfc";
         templates.sha256 =	"0mykfwwik7472i4r0isc5szj3dnmvd0538p0vlmzh4rcgj3pj3vm";
-        footprints.rev =	"7061fc9847ecc1b838e60dc6826db534028494f6";
-        footprints.sha256 =	"1az6fzh1lma71mj12bc4bblnmzjayrxhkb8w9rjvlhvvgv33cdmy";
-        packages3d.rev =	"d7345b34daaa23acf0d4506ed937fb424b5b18cd";
-        packages3d.sha256 =	"0xzyi4mgyifwc6dppdzh6jq294mkj0a71cwkqw2ymz1kfbksw626";
+        footprints.rev =	"6b91a79be61f214b7d69eb574b12e8120b2179ae";
+        footprints.sha256 =	"1r9v8v41n0yrgwsqaksskmdgb9vyw1sb92xh81bwrv2ag3p5vdg7";
+        packages3d.rev =	"778443c8880b21bea6be5fccbd4a03bfdb8625a8";
+        packages3d.sha256 =	"0lcy1av7ixg1f7arflk50jllpc1749sfvf3h62hkxsz97wkr97xj";
       };
     };
   };


### PR DESCRIPTION
## Description of changes

[release blog post](https://www.kicad.org/blog/2024/02/KiCad-7.0.11-Release/)

## Things done

bump versions.nix

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
