### PR TITLE
haskellPackages.haskell-language-server: Correct dependency versions

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -28,6 +28,10 @@ default-package-overrides:
   - gi-gdkx11 < 4
   # 2021-11-09: ghc-bignum is bundled starting with 9.0.1; only 1.0 builds with GHCs prior to 9.2.1
   - ghc-bignum == 1.0
+  # 2024-02-22: Needed for haskell-language-server-2.6.0.0
+  - lsp < 2.4.0.0
+  # 2024-02-22: Needed for hls-fourmolu-plugin-2.6.0.0 and others
+  - lsp-test < 0.17.0.0
 
 extra-packages:
   - Cabal-syntax == 3.6.*               # Dummy package that ensures packages depending on Cabal-syntax can work for Cabal < 3.8


### PR DESCRIPTION
This is for merging into the `haskell-updates` branch, PR #279413, cc @sternenseemann.

It fixes the build of `haskellPackages.haskell-language-server`. I'm not sure of any better way to do it.