### PR TITLE
libqtdbustest: unstable-2017-01-06 -> 0.3.2; libqtdbusmock: unstable-2017-03-16 -> 0.9.1

### DIFF
--- a/pkgs/development/libraries/libqtdbusmock/default.nix
+++ b/pkgs/development/libraries/libqtdbusmock/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , lib
-, fetchbzr
+, fetchFromGitLab
 , testers
 , cmake
 , cmake-extras
@@ -17,19 +17,16 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libqtdbusmock";
-  version = "unstable-2017-03-16";
+  version = "0.9.1";
 
-  src = fetchbzr {
-    url = "lp:libqtdbusmock";
-    rev = "49";
-    sha256 = "sha256-q3jL8yGLgcNxXHPh9M9cTVtUvonrBUPNxuPJIvu7Q/s=";
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/libqtdbusmock";
+    rev = finalAttrs.version;
+    hash = "sha256-hVw2HnIHlA7vvt0Sr6F2qVhvBZ33aCeqb9vgbu3rgBo=";
   };
 
   postPatch = ''
-    # Look for the new(?) name
-    substituteInPlace CMakeLists.txt \
-      --replace 'NetworkManager' 'libnm'
-
     # Workaround for "error: expected unqualified-id before 'public'" on "**signals"
     sed -i -e '/add_definitions/a -DQT_NO_KEYWORDS' CMakeLists.txt
   '' + lib.optionalString (!finalAttrs.finalPackage.doCheck) ''

--- a/pkgs/development/libraries/libqtdbustest/default.nix
+++ b/pkgs/development/libraries/libqtdbustest/default.nix
@@ -1,6 +1,6 @@
 { stdenv
 , lib
-, fetchbzr
+, fetchFromGitLab
 , fetchpatch
 , testers
 , cmake
@@ -16,12 +16,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libqtdbustest";
-  version = "unstable-2017-01-06";
+  version = "0.3.2";
 
-  src = fetchbzr {
-    url = "lp:libqtdbustest";
-    rev = "42";
-    sha256 = "sha256-5MQdGGtEVE/pM9u0B0xFXyITiRln9p+8/MLtrrCZqi8=";
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/libqtdbustest";
+    rev = finalAttrs.version;
+    hash = "sha256-yqqyKxsbqiVTrkas79YoPMi28dKFNntiE7+dx1v+Qh4=";
   };
 
   patches = [
@@ -31,13 +32,13 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Disable QProcess start timeout
     (fetchpatch {
-      url = "https://salsa.debian.org/debian-ayatana-team/libqtdbustest/-/raw/0788df10bc6f2aa47c2b73fc1df944686a9ace1e/debian/patches/1003_no-QProcess-waitForstarted-timeout.patch";
+      url = "https://salsa.debian.org/ubports-team/libqtdbustest/-/raw/debian/0.3.2-3/debian/patches/1003_no-QProcess-waitForstarted-timeout.patch";
       hash = "sha256-ThDbn6URvkj5ARDMj+xO0fb1Qh2YQRzVy24O03KglHI=";
     })
 
     # More robust dbus address reading
     (fetchpatch {
-      url = "https://salsa.debian.org/debian-ayatana-team/libqtdbustest/-/raw/7e55c79cd032c702b30d834c1fb0b65661fc6eeb/debian/patches/1004_make-reading-address-from-dbus-daemon-more-robust.patch";
+      url = "https://salsa.debian.org/ubports-team/libqtdbustest/-/raw/debian/0.3.2-3/debian/patches/1004_make-reading-address-from-dbus-daemon-more-robust.patch";
       hash = "sha256-hq8pdducp/udxoGWGt1dgL/7VHcbJO/oT1dOY1zew8M=";
     })
   ];

--- a/pkgs/development/libraries/libqtdbustest/less-pedantic-process-finding.patch
+++ b/pkgs/development/libraries/libqtdbustest/less-pedantic-process-finding.patch
@@ -74,12 +74,13 @@ diff '--color=auto' -ur '--color=never' a/tests/libqtdbustest/TestQProcessDBusSe
 diff '--color=auto' -ur '--color=never' a/tests/libqtdbustest/TestSuicidalProcess.cpp b/tests/libqtdbustest/TestSuicidalProcess.cpp
 --- a/tests/libqtdbustest/TestSuicidalProcess.cpp	2023-01-20 21:36:16.948292559 +0100
 +++ b/tests/libqtdbustest/TestSuicidalProcess.cpp	2023-01-20 21:55:07.219951081 +0100
-@@ -51,8 +51,7 @@
+@@ -51,9 +51,7 @@
  	pgrep.waitForFinished();
  	pgrep.waitForReadyRead();
- 
--	EXPECT_EQ("sleep 5",
--			QString::fromUtf8(pgrep.readAll().trimmed()).toStdString());
+
+-	EXPECT_TRUE(QString::fromUtf8(pgrep.readAll().trimmed())
+-                .toStdString()
+-                .find("sleep 5") != std::string::npos);
 +	EXPECT_TRUE(pgrep.readAll().contains("sleep 5"));
  }
  


### PR DESCRIPTION
## Description of changes

https://gitlab.com/ubports/development/core/libqtdbustest/-/blob/0.3.2/ChangeLog
https://gitlab.com/ubports/development/core/libqtdbusmock/-/blob/0.9.1/ChangeLog

Note: this changes the source of the repositories.  This change is following the same upstream move which Debian has already performed between bookworm and trixie.

This fixes breakage caused by #282245 as newer versions of libqtdbustest use C++17 by default.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
