### PR TITLE
python3Packages.iodata: 0.1.7 -> 1.0.0a2

### DIFF
--- a/pkgs/development/python-modules/iodata/default.nix
+++ b/pkgs/development/python-modules/iodata/default.nix
@@ -2,22 +2,20 @@
 
 buildPythonPackage rec {
   pname = "iodata";
-  version = "0.1.7";
+  version = "1.0.0a2";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "theochem";
     repo = pname;
     rev = version;
-    hash = "sha256-Qn2xWFxdS12K92DhdHVzYrBjPRV+vYo7Cs27vkeCaxM=";
+    hash = "sha256-GFTCYE19Re7WLhV8eU+0i8OMp/Tsms/Xj9DRTcgjcz4=";
   };
-
-  leaveDotGit = true;
 
   nativeBuildInputs = [ cython nose ];
   propagatedBuildInputs = [ numpy scipy attrs ];
 
-  pythonImportsCheck = [ "iodata" "iodata.overlap_accel" ];
+  pythonImportsCheck = [ "iodata" ];
   doCheck = false; # Requires roberto or nose and a lenghtly setup to find the cython modules
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Updates IOData python package to the latest alpha release. The last stable release is many years old and other projects started using the alpha version.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
