### PR TITLE
Fixes for my maintainer status

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -271,13 +271,13 @@ pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
 /pkgs/applications/editors/vscode/extensions   @jonringer
 
 # PHP interpreter, packages, extensions, tests and documentation
-/doc/languages-frameworks/php.section.md          @aanderse @drupol @etu @globin @ma27 @talyz
-/nixos/tests/php                                  @aanderse @drupol @etu @globin @ma27 @talyz
-/pkgs/build-support/php/build-pecl.nix            @aanderse @drupol @etu @globin @ma27 @talyz
-/pkgs/build-support/php                                     @drupol @etu
-/pkgs/development/interpreters/php       @jtojnar @aanderse @drupol @etu @globin @ma27 @talyz
-/pkgs/development/php-packages                    @aanderse @drupol @etu @globin @ma27 @talyz
-/pkgs/top-level/php-packages.nix         @jtojnar @aanderse @drupol @etu @globin @ma27 @talyz
+/doc/languages-frameworks/php.section.md          @aanderse @drupol @globin @ma27 @talyz
+/nixos/tests/php                                  @aanderse @drupol @globin @ma27 @talyz
+/pkgs/build-support/php/build-pecl.nix            @aanderse @drupol @globin @ma27 @talyz
+/pkgs/build-support/php                                     @drupol
+/pkgs/development/interpreters/php       @jtojnar @aanderse @drupol @globin @ma27 @talyz
+/pkgs/development/php-packages                    @aanderse @drupol @globin @ma27 @talyz
+/pkgs/top-level/php-packages.nix         @jtojnar @aanderse @drupol @globin @ma27 @talyz
 
 # Docker tools
 /pkgs/build-support/docker                   @roberth

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5931,7 +5931,7 @@
   };
   etu = {
     email = "elis@hirwing.se";
-    matrix = "@etu:semi.social";
+    matrix = "@etu:failar.nu";
     github = "etu";
     githubId = 461970;
     name = "Elis Hirwing";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -775,7 +775,6 @@ with lib.maintainers; {
     members = [
       aanderse
       drupol
-      etu
       ma27
       talyz
     ];


### PR DESCRIPTION
## Description of changes
This is a sad thing for me to do. But due to life circumstances with work, family, small children, own company, contracting jobs, volonteer work for different organizations in my local area, working out, taking care of both mental and physical health and other reasons...

I've realized that I for quite some time have taken some big steps back on my PHP maintainership. This isn't new... but it's something that is hitting my mail inbox quite a lot.

So this change is really just to reflect the reality.

There were a time when I was very active in working on PHP. However, recent years. The excelent @drupol has taken PHP in NixOS to places I only could dream of. I've happily helped him out with motivation, testing and suggestions whenever possible. And as a note to you @drupol, you're doing great work, and if you need someone to talk to... you should know that I'm still here for you. I just want fewer emails in my inbox so I have an easier time to focus on the things where I actually spend my time :slightly_smiling_face: 

I know that I was the one that created the @NixOS/php team back in 2020, however, I feel confident that @drupol and the other people will take good care of it :slightly_smiling_face: 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
