### PR TITLE
novops: init at v0.12.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15011,6 +15011,12 @@
       fingerprint = "E005 48D5 D6AC 812C AAD2  AFFA 9C42 B05E 5913 60DC";
     }];
   };
+  pbeucher = {
+    email = "pierre@crafteo.io";
+    github = "PierreBeucher";
+    githubId = 5041481;
+    name = "Pierre Beucher";
+  };
   pblkt = {
     email = "pebblekite@gmail.com";
     github = "pblkt";

--- a/pkgs/by-name/no/novops/package.nix
+++ b/pkgs/by-name/no/novops/package.nix
@@ -1,0 +1,48 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, openssl
+, stdenv
+, libiconv
+, darwin
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "novops";
+  version = "0.12.1";
+
+  src = fetchFromGitHub {
+    owner = "PierreBeucher";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-iQFw3m7dpAii/Nc1UQ/ZXTuHvj5vGsp3SOqd14uHUpc=";
+  };
+
+  cargoHash = "sha256-mQ7Vm80S4FALWiEsV+68pNrah36aYu7PediRlJUXLAk=";
+
+  buildInputs = [
+    openssl # required for openssl-sys
+  ] ++ lib.optional stdenv.isDarwin [
+    libiconv
+    darwin.apple_sdk.frameworks.SystemConfiguration
+  ];
+
+  nativeBuildInputs = [
+    pkg-config # required for openssl-sys
+  ];
+
+  cargoTestFlags = [
+      # Only run lib tests (unit tests)
+      # All other tests are integration tests which should not be run with Nix build
+      "--lib"
+  ];
+
+  meta = with lib; {
+    description = "Cross-platform secret & config manager for development and CI environments";
+    homepage = "https://github.com/PierreBeucher/novops";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ pbeucher ];
+    mainProgram = "novops";
+  };
+}


### PR DESCRIPTION
## Description of changes

[Novops](https://github.com/PierreBeucher/novops) is a secret and config manager for development and CI environment. It loads secrets and configs as files and environment variable in current environment. Secrets are securely loaded (as tmpfs files or directly in process memory) and only kept for as long as they are needed.

Novops works on x86_64 / aarch64 and Linux / Darwin, though I was not able to test specifically aarch64 Nix build (non-Nix build works). 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
