### PR TITLE
johnny-reborn: move to xesf's fork

### DIFF
--- a/pkgs/applications/misc/johnny-reborn/default.nix
+++ b/pkgs/applications/misc/johnny-reborn/default.nix
@@ -4,35 +4,34 @@
 , SDL2
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "johnny-reborn-engine";
-  version = "unstable-2020-12-06";
+  version = "0.30";
 
   src = fetchFromGitHub {
-    owner = "jno6809";
+    owner = "xesf";
     repo = "jc_reborn";
-    rev = "524a5803e4fa65f840379c781f40ce39a927032e";
-    hash = "sha256-YKAOCgdRnvNMzL6LJVXN0pLvjyJk4Zv/RCqGtDPFR90=";
+    rev = "v${version}";
+    hash = "sha256-n3ELNFvjeDzbamyQIdM9mf/A1sstuhCGzrL9NuXf90Y=";
   };
-
-  makefile = "Makefile.linux";
 
   buildInputs = [ SDL2 ];
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out
-    cp jc_reborn $out/
+    mkdir -p $out/bin
+    cp jc_reborn $out/bin/
 
     runHook postInstall
   '';
 
   meta = {
     description = "An open-source engine for the classic \"Johnny Castaway\" screensaver (engine only)";
-    homepage = "https://github.com/jno6809/jc_reborn";
+    homepage = "https://github.com/xesf/jc_reborn";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ pedrohlc ];
+    mainProgram = "jc_reborn";
     inherit (SDL2.meta) platforms;
   };
 }

--- a/pkgs/applications/misc/johnny-reborn/with-data.nix
+++ b/pkgs/applications/misc/johnny-reborn/with-data.nix
@@ -6,7 +6,6 @@
 , makeWrapper
 }:
 
-
 let
   sounds = fetchFromGitHub {
     owner = "nivs1978";
@@ -39,15 +38,15 @@ stdenvNoCC.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out
-    cp -t $out/ \
+    mkdir -p $out/share/jc_reborn/data
+    cp -t $out/share/jc_reborn/data/ \
       ../scrantic-source/RESOURCE.* \
       JCOS/Resources/sound*.wav
 
     makeWrapper \
-      ${johnny-reborn-engine}/jc_reborn \
-      $out/jc_reborn \
-      --chdir $out
+      ${johnny-reborn-engine}/bin/jc_reborn \
+      $out/bin/jc_reborn \
+      --chdir $out/share/jc_reborn
 
     runHook postInstall
   '';
@@ -56,6 +55,6 @@ stdenvNoCC.mkDerivation {
     description = "An open-source engine for the classic \"Johnny Castaway\" screensaver (ready to use, with resources)";
     license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [ pedrohlc ];
-    inherit (johnny-reborn-engine.meta) homepage platforms;
+    inherit (johnny-reborn-engine.meta) homepage platforms mainProgram;
   };
 }


### PR DESCRIPTION
## Description of changes

- Move to the more active and CI tested fork of xesf; (sorry for the miss-ping xesf)
- Add a proper FHS-like folder structure (`/bin` and `/share`);
- Add a `meta.mainProgram`.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
