### PR TITLE
openorienteering-mapper: fix on darwin

### DIFF
--- a/pkgs/by-name/op/openorienteering-mapper/package.nix
+++ b/pkgs/by-name/op/openorienteering-mapper/package.nix
@@ -1,6 +1,5 @@
 { lib
 , stdenv
-, mkDerivation
 , fetchFromGitHub
 , fetchpatch
 , clipper
@@ -10,14 +9,11 @@
 , gdal
 , ninja
 , proj
-, qtimageformats
-, qtlocation
-, qtsensors
-, qttools
+, qt5
 , zlib
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "OpenOrienteering-Mapper";
   version = "0.9.5";
 
@@ -40,7 +36,8 @@ mkDerivation rec {
     cmake
     doxygen
     ninja
-    qttools
+    qt5.qttools
+    qt5.wrapQtAppsHook
   ];
 
   buildInputs = [
@@ -48,9 +45,9 @@ mkDerivation rec {
     cups
     gdal
     proj
-    qtimageformats
-    qtlocation
-    qtsensors
+    qt5.qtimageformats
+    qt5.qtlocation
+    qt5.qtsensors
     zlib
   ];
 

--- a/pkgs/by-name/op/openorienteering-mapper/package.nix
+++ b/pkgs/by-name/op/openorienteering-mapper/package.nix
@@ -32,6 +32,13 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace "find_package(ClangTidy" "#find_package(ClangTidy"
+    substituteInPlace packaging/custom_install.cmake.in \
+      --replace "fixup_bundle_portable(" "#fixup_bundle_portable("
+  '';
+
   nativeBuildInputs = [
     cmake
     doxygen
@@ -54,26 +61,25 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     # Building the manual and bundling licenses fails
     # See https://github.com/NixOS/nixpkgs/issues/85306
-    "-DLICENSING_PROVIDER:BOOL=OFF"
-    "-DMapper_MANUAL_QTHELP:BOOL=OFF"
+    (lib.cmakeBool "LICENSING_PROVIDER" false)
+    (lib.cmakeBool "Mapper_MANUAL_QTHELP" false)
   ] ++ lib.optionals stdenv.isDarwin [
     # FindGDAL is broken and always finds /Library/Framework unless this is
     # specified
-    "-DGDAL_INCLUDE_DIR=${gdal}/include"
-    "-DGDAL_CONFIG=${gdal}/bin/gdal-config"
-    "-DGDAL_LIBRARY=${gdal}/lib/libgdal.dylib"
+    (lib.cmakeFeature "GDAL_INCLUDE_DIR" "${gdal}/include")
+    (lib.cmakeFeature "GDAL_CONFIG" "${gdal}/bin/gdal-config")
+    (lib.cmakeFeature "GDAL_LIBRARY" "${gdal}/lib/libgdal.dylib")
     # Don't bundle libraries
-    "-DMapper_PACKAGE_PROJ=0"
-    "-DMapper_PACKAGE_QT=0"
-    "-DMapper_PACKAGE_ASSISTANT=0"
-    "-DMapper_PACKAGE_GDAL=0"
+    (lib.cmakeBool "Mapper_PACKAGE_PROJ" false)
+    (lib.cmakeBool "Mapper_PACKAGE_QT" false)
+    (lib.cmakeBool "Mapper_PACKAGE_ASSISTANT" false)
+    (lib.cmakeBool "Mapper_PACKAGE_GDAL" false)
   ];
 
   postInstall = with stdenv; lib.optionalString isDarwin ''
-    mkdir -p $out/Applications
+    mkdir -p $out/{Applications,bin}
     mv $out/Mapper.app $out/Applications
-    mkdir -p $out/bin
-    ln -s $out/Applications/Mapper.app/Contents/MacOS/Mapper $out/bin/mapper
+    ln -s $out/Applications/Mapper.app/Contents/MacOS/Mapper $out/bin/Mapper
   '';
 
   meta = with lib; {
@@ -83,7 +89,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ mpickering sikmir ];
     platforms = with platforms; unix;
-    broken = stdenv.isDarwin;
     mainProgram = "Mapper";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30091,8 +30091,6 @@ with pkgs;
     stdenv = if stdenv.isDarwin then overrideSDK stdenv "11.0" else stdenv;
   };
 
-  openorienteering-mapper = libsForQt5.callPackage ../applications/gis/openorienteering-mapper { };
-
   qgis-ltr = callPackage ../applications/gis/qgis/ltr.nix { };
 
   qgis = callPackage ../applications/gis/qgis { };


### PR DESCRIPTION
## Description of changes


## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
