### PR TITLE
dotnet: fix dotnet executables in darwin sandbox

### DIFF
--- a/pkgs/build-support/dotnet/build-dotnet-module/default.nix
+++ b/pkgs/build-support/dotnet/build-dotnet-module/default.nix
@@ -185,6 +185,10 @@ stdenvNoCC.mkDerivation (args // {
 
   inherit selfContainedBuild useAppHost useDotnetFromEnv;
 
+  # propagate the runtime sandbox profile since the contents apply to published
+  # executables
+  propagatedSandboxProfile = toString dotnet-runtime.__propagatedSandboxProfile;
+
   passthru = {
     inherit nuget-source;
   } // lib.optionalAttrs (!lib.isDerivation nugetDeps) {
@@ -316,8 +320,4 @@ stdenvNoCC.mkDerivation (args // {
   } // args.passthru or { };
 
   meta = (args.meta or { }) // { inherit platforms; };
-}
-  # ICU tries to unconditionally load files from /usr/share/icu on Darwin, which makes builds fail
-  # in the sandbox, so disable ICU on Darwin. This, as far as I know, shouldn't cause any built packages
-  # to behave differently, just the dotnet build tool.
-  // lib.optionalAttrs stdenvNoCC.isDarwin { DOTNET_SYSTEM_GLOBALIZATION_INVARIANT = 1; })
+})

--- a/pkgs/development/compilers/dotnet/common.nix
+++ b/pkgs/development/compilers/dotnet/common.nix
@@ -134,6 +134,7 @@
           expect <<"EOF"
             set status 1
             spawn $env(src)/test
+            proc abort { } { exit 2 }
             expect_before default abort
             expect -re {Now listening on: ([^\r]+)\r} {
               set url $expect_out(1,string)
@@ -145,6 +146,8 @@
               exit 1
             }
             send \x03
+            expect_before timeout abort
+            expect eof
             catch wait result
             exit [lindex $result 3]
           EOF

--- a/pkgs/development/compilers/dotnet/stage0.nix
+++ b/pkgs/development/compilers/dotnet/stage0.nix
@@ -25,8 +25,6 @@ let
 
   patchNupkgs = pkgsBuildHost.callPackage ./patch-nupkgs.nix {};
 
-  signAppHost = callPackage ./sign-apphost.nix {};
-
   deps = mkNugetDeps {
     name = "dotnet-vmr-deps";
     sourceFile = depsFile;
@@ -51,12 +49,6 @@ let
         -s //Project -t elem -n Import \
         -i \$prev -t attr -n Project -v "${./patch-restored-packages.proj}" \
         src/*/Directory.Build.targets
-    '' + lib.optionalString stdenv.isDarwin ''
-      xmlstarlet ed \
-        --inplace \
-        -s //Project -t elem -n Import \
-        -i \$prev -t attr -n Project -v "${signAppHost}" \
-        src/runtime/Directory.Build.targets
     '';
 
     postConfigure = old.postConfigure or "" + ''


### PR DESCRIPTION
This fixes:

    Could not load ICU data. UErrorCode: 2

FYI @NixOS/dotnet 

I pulled this out of #190129, since it's useful on its own.

Without this, `dotnet-sdk_8.tests` will fail in a sandbox, because:

- it expects to find ICU in `/usr/lib`

We fix this by setting DYLD_LIBRARY_PATH, both in a wrapper of `/bin/dotnet`, and in a hook.  The hook is helpful for things that use `DOTNET_ROOT` to find the dotnet CLI.  The root executable itself can't be wrapped because if you change the name of the executable, it will fail to run.

- it expects to find `/usr/bin/codesign`

We fix this by patching a few things in `Sdk.targets`, and by removing the signatures from the apphost/singlefilehost binaries.  This is quite hacky, but I think it's reliable, and the actual calls to `codesign` are in C# so they aren't easy to patch.

Source builds (#190129) won't suffer from either of these problems, because they can patch the paths correctly.

I've had to temporarily bring in a fork of `sigtool`, because it depends on https://github.com/thefloweringash/sigtool/pull/16.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
