### PR TITLE
jacktrip: 1.10.1 -> 2.2.2

### DIFF
--- a/pkgs/applications/audio/jacktrip/default.nix
+++ b/pkgs/applications/audio/jacktrip/default.nix
@@ -1,25 +1,17 @@
-{ lib, mkDerivation, fetchFromGitHub
+{ lib, stdenv, fetchFromGitHub
 , pkg-config
 , help2man
-, qmake
-, alsa-lib
 , libjack2
 , dbus
-, qtbase
-, qttools
-, qtx11extras
+, qt6
 , meson
 , python3
 , rtaudio
 , ninja
-, qtquickcontrols2
-, qtnetworkauth
-, qtwebsockets
-, qtgraphicaleffects
 }:
 
-mkDerivation rec {
-  version = "1.10.1";
+stdenv.mkDerivation rec {
+  version = "2.2.2";
   pname = "jacktrip";
 
   src = fetchFromGitHub {
@@ -27,7 +19,7 @@ mkDerivation rec {
     repo = "jacktrip";
     rev = "v${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-bdYhyLsdL4LDkCzJiWXdi+7CTtqhSiA7HNYhg190NWs=";
+    sha256 = "sha256-idfetMiMqjl9Qrun4hlFhQaGWcvasgjojTts+0F3GGE=";
   };
 
   preConfigure = ''
@@ -36,8 +28,8 @@ mkDerivation rec {
 
   buildInputs = [
     rtaudio
-    qtbase
-    qtx11extras
+    qt6.qtbase
+    qt6.qtwayland
     libjack2
     dbus
   ];
@@ -49,12 +41,13 @@ mkDerivation rec {
     ninja
     help2man
     meson
-    qmake
-    qttools
-    qtquickcontrols2
-    qtnetworkauth
-    qtwebsockets
-    qtgraphicaleffects
+    qt6.qt5compat
+    qt6.qtnetworkauth
+    qt6.qtwebsockets
+    qt6.qtwebengine
+    qt6.qtdeclarative
+    qt6.qtsvg
+    qt6.wrapQtAppsHook
     pkg-config
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40250,7 +40250,7 @@ with pkgs;
   jack-autoconnect = libsForQt5.callPackage ../applications/audio/jack-autoconnect { };
   jack_autoconnect = jack-autoconnect;
 
-  jacktrip = libsForQt5.callPackage ../applications/audio/jacktrip { };
+  jacktrip = callPackage ../applications/audio/jacktrip { };
 
   j2cli = with python3Packages; toPythonApplication j2cli;
 


### PR DESCRIPTION
## Description of changes

Update jacktrip to the latest version of the major release, for  #281544

The new version uses Qt6 (vs Qt5 before), so that's the main change to the package definition.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
