### PR TITLE
babl: 0.1.106 → 0.1.108

### DIFF
--- a/pkgs/development/libraries/babl/default.nix
+++ b/pkgs/development/libraries/babl/default.nix
@@ -1,30 +1,36 @@
 { stdenv
 , lib
-, fetchpatch
 , fetchurl
 , meson
 , ninja
 , pkg-config
+, gi-docgen
 , gobject-introspection
 , lcms2
 , vala
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "babl";
-  version = "0.1.106";
+  version = "0.1.108";
 
-  outputs = [ "out" "dev" ];
+  outputs = [ "out" "dev" "devdoc" ];
 
   src = fetchurl {
-    url = "https://download.gimp.org/pub/babl/${lib.versions.majorMinor version}/babl-${version}.tar.xz";
-    hash = "sha256-0yUTXTME8IjBNMxiABOs8DXeLl0SWlCi2RBU5zd8QV8=";
+    url = "https://download.gimp.org/pub/babl/${lib.versions.majorMinor finalAttrs.version}/babl-${finalAttrs.version}.tar.xz";
+    hash = "sha256-Jt7+neqresTQ4HbKtJwqDW69DfDDH9IJklpfB+3uFHU=";
   };
+
+  patches = [
+    # Allow overriding path to dev output that will be hardcoded e.g. in pkg-config file.
+    ./dev-prefix.patch
+  ];
 
   nativeBuildInputs = [
     meson
     ninja
     pkg-config
+    gi-docgen
     gobject-introspection
     vala
   ];
@@ -32,6 +38,15 @@ stdenv.mkDerivation rec {
   buildInputs = [
     lcms2
   ];
+
+  mesonFlags = [
+    "-Dprefix-dev=${placeholder "dev"}"
+  ];
+
+  postFixup = ''
+    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
+    moveToOutput "share/doc" "$devdoc"
+  '';
 
   meta = with lib; {
     description = "Image pixel format conversion library";
@@ -42,4 +57,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ jtojnar ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/development/libraries/babl/dev-prefix.patch
+++ b/pkgs/development/libraries/babl/dev-prefix.patch
@@ -1,0 +1,29 @@
+diff --git a/meson.build b/meson.build
+index 2350a1f..56f015d 100644
+--- a/meson.build
++++ b/meson.build
+@@ -551,7 +551,7 @@ pkgconfig.generate(
+   variables: [
+     'datadir=${prefix}/share',
+     'pluginsdir=${libdir}/@0@'.format(lib_name),
+-    'girdir=${datadir}/gir-1.0',
++    'girdir=@0@/share/gir-1.0'.format(get_option('prefix-dev')),
+     'typelibdir=${libdir}/girepository-1.0',
+   ],
+   uninstalled_variables: [
+diff --git a/meson_options.txt b/meson_options.txt
+index f9d558c..3cac593 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -9,6 +9,11 @@ option('enable-gir',
+   choices: ['auto', 'true', 'false'],
+   description: 'gobject introspection .gir generation'
+ )
++option('prefix-dev',
++  type: 'string',
++  value: '',
++  description: 'Like prefix but for dev output of the package'
++)
+ option('enable-vapi',
+   type: 'boolean',
+   value: 'true', 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@jtojnar 