### PR TITLE
pnpm.fetchDeps: init

### DIFF
--- a/doc/languages-frameworks/javascript.section.md
+++ b/doc/languages-frameworks/javascript.section.md
@@ -348,6 +348,8 @@ In case you are patching `package.json` or `pnpm-lock.yaml`, make sure to pass `
 
 #### Dealing with `sourceRoot` {#javascript-pnpm-sourceRoot}
 
+NOTE: Nixpkgs pnpm tooling doesn't support building projects with a `pnpm-workspace.yaml`, or building monorepos. It maybe possible to use `pnpm.fetchDeps` for these projects, but it may be hard or impossible to produce a binary from such projects ([an example attempt](https://github.com/NixOS/nixpkgs/pull/290715#issuecomment-2144543728)).
+
 If the pnpm project is in a subdirectory, you can just define `sourceRoot` or `setSourceRoot` for `fetchDeps`. Note, that projects using `pnpm-workspace.yaml` are currently not supported, and will probably not work using this approach.
 If `sourceRoot` is different between the parent derivation and `fetchDeps`, you will have to set `pnpmRoot` to effectively be the same location as it is in `fetchDeps`.
 

--- a/pkgs/applications/networking/geph/default.nix
+++ b/pkgs/applications/networking/geph/default.nix
@@ -4,7 +4,8 @@
 , fetchFromGitHub
 , buildGoModule
 , makeWrapper
-, nodePackages
+, nodejs
+, pnpm
 , cacert
 , esbuild
 , jq
@@ -48,7 +49,7 @@ in
     };
   };
 
-  gui = stdenvNoCC.mkDerivation rec {
+  gui = stdenvNoCC.mkDerivation (finalAttrs: {
     pname = "geph-gui";
     inherit version;
 
@@ -60,42 +61,11 @@ in
       fetchSubmodules = true;
     };
 
-    pnpm-deps = stdenvNoCC.mkDerivation {
-      pname = "${pname}-pnpm-deps";
-      inherit src version;
-
-      sourceRoot = "${src.name}/gephgui-wry/gephgui";
-
-      nativeBuildInputs = [
-        jq
-        moreutils
-        nodePackages.pnpm
-        cacert
-      ];
-
-      installPhase = ''
-        export HOME=$(mktemp -d)
-        pnpm config set store-dir $out
-        pnpm install --ignore-scripts
-
-        # Remove timestamp and sort the json files
-        rm -rf $out/v3/tmp
-        for f in $(find $out -name "*.json"); do
-          sed -i -E -e 's/"checkedAt":[0-9]+,//g' $f
-          jq --sort-keys . $f | sponge $f
-        done
-      '';
-
-      dontFixup = true;
-      outputHashMode = "recursive";
-      outputHash = "sha256-OKPx5xRI7DWd6m31nYx1biP0k6pcZ7fq7dfVlHda4O0=";
-    };
-
     gephgui-wry = rustPlatform.buildRustPackage {
       pname = "gephgui-wry";
-      inherit version src;
+      inherit (finalAttrs) version src;
 
-      sourceRoot = "${src.name}/gephgui-wry";
+      sourceRoot = "${finalAttrs.src.name}/gephgui-wry";
 
       cargoLock = {
         lockFile = ./Cargo.lock;
@@ -105,10 +75,17 @@ in
         };
       };
 
+      pnpmDeps = pnpm.fetchDeps {
+        inherit (finalAttrs) pname version src;
+        sourceRoot = "${finalAttrs.src.name}/gephgui-wry/gephgui";
+        hash = "sha256-0MGlsLEgugQ1wEz07ROIwkanTa8PSKwIaxNahyS1014=";
+      };
+
       nativeBuildInputs = [
         pkg-config
-        nodePackages.pnpm
+        pnpm.configHook
         makeWrapper
+        nodejs
       ];
 
       buildInputs = [
@@ -132,22 +109,19 @@ in
         });
       })}";
 
+      pnpmRoot = "gephgui";
+
       preBuild = ''
-        cd gephgui
-        export HOME=$(mktemp -d)
-        pnpm config set store-dir ${pnpm-deps}
-        pnpm install --ignore-scripts --offline
-        chmod -R +w node_modules
-        pnpm rebuild
+        pushd gephgui
         pnpm build
-        cd ..
+        popd
       '';
     };
 
     dontBuild = true;
 
     installPhase = ''
-      install -Dt $out/bin ${gephgui-wry}/bin/gephgui-wry
+      install -Dt $out/bin ${finalAttrs.gephgui-wry}/bin/gephgui-wry
       install -d $out/share/icons/hicolor
       for i in '16' '32' '64' '128' '256'
       do
@@ -163,5 +137,5 @@ in
     meta = geph-meta // {
       license = with lib.licenses; [ unfree ];
     };
-  };
+  });
 }

--- a/pkgs/by-name/ki/kiwitalk/package.nix
+++ b/pkgs/by-name/ki/kiwitalk/package.nix
@@ -2,7 +2,6 @@
 , fetchFromGitHub
 , copyDesktopItems
 , stdenv
-, stdenvNoCC
 , rustc
 , rustPlatform
 , cargo
@@ -12,20 +11,18 @@
 , webkitgtk
 , pkg-config
 , makeDesktopItem
-, jq
-, moreutils
-, nodePackages
-, cacert
+, pnpm
+, nodejs
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "kiwitalk";
   version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "KiwiTalk";
     repo = "KiwiTalk";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-Th8q+Zbc102fIk2v7O3OOeSriUV/ydz60QwxzmS7AY8=";
   };
 
@@ -34,43 +31,9 @@ stdenv.mkDerivation rec {
       --replace "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
   '';
 
-  pnpm-deps = stdenvNoCC.mkDerivation {
-    pname = "${pname}-pnpm-deps";
-    inherit src version;
-
-    nativeBuildInputs = [
-      jq
-      moreutils
-      nodePackages.pnpm
-      cacert
-    ];
-
-    installPhase = ''
-      export HOME=$(mktemp -d)
-      pnpm config set store-dir $out
-      # This version of the package has different versions of esbuild as a dependency.
-      # You can use the command below to get esbuild binaries for a specific platform and calculate hashes for that platforms. (linux, darwin for os, and x86, arm64, ia32 for cpu)
-      # cat package.json | jq '.pnpm.supportedArchitectures += { "os": ["linux"], "cpu": ["arm64"] }' | sponge package.json
-      pnpm install --frozen-lockfile --ignore-script
-
-      # Remove timestamp and sort the json files.
-      rm -rf $out/v3/tmp
-      for f in $(find $out -name "*.json"); do
-        sed -i -E -e 's/"checkedAt":[0-9]+,//g' $f
-        jq --sort-keys . $f | sponge $f
-      done
-    '';
-
-    dontBuild = true;
-    dontFixup = true;
-    outputHashMode = "recursive";
-    outputHash = {
-      x86_64-linux = "sha256-LJPjWNpVfdUu8F5BMhAzpTo/h6ax7lxY2EESHj5P390=";
-      aarch64-linux = "sha256-N1K4pV5rbWmO/KonvYegzBoWa6TYQIqhQyxH/sWjOJQ=";
-      i686-linux = "sha256-/Q7VZahYhLdKVFB25CanROYxD2etQOcRg+4bXZUMqTc=";
-      x86_64-darwin = "sha256-9biFAbFD7Bva7KPKztgCvcaoX8E6AlJBKkjlDQdP6Zw=";
-      aarch64-darwin = "sha256-to5Y0R9tm9b7jUQAK3eBylLhpu+w5oDd63FbBCBAvd8=";
-    }.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-gf3vmKUta8KksUOxyhQS4UO6ycAJDfEicyXVGMW8+4c=";
   };
 
   cargoDeps = rustPlatform.importCargoLock {
@@ -86,7 +49,8 @@ stdenv.mkDerivation rec {
     cargo
     rustc
     cargo-tauri
-    nodePackages.pnpm
+    nodejs
+    pnpm.configHook
     copyDesktopItems
     pkg-config
   ];
@@ -98,10 +62,6 @@ stdenv.mkDerivation rec {
   ];
 
   preBuild = ''
-    export HOME=$(mktemp -d)
-    pnpm config set store-dir ${pnpm-deps}
-    pnpm install --offline --frozen-lockfile --ignore-script
-    pnpm rebuild
     cargo tauri build -b deb
   '';
 
@@ -131,4 +91,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux ++ platforms.darwin;
     mainProgram = "kiwi-talk";
   };
- }
+})

--- a/pkgs/by-name/ve/vesktop/package.nix
+++ b/pkgs/by-name/ve/vesktop/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   stdenv,
-  stdenvNoCC,
   fetchFromGitHub,
   substituteAll,
   makeWrapper,
@@ -10,13 +9,11 @@
   vencord,
   electron,
   libicns,
-  jq,
-  moreutils,
-  cacert,
-  nodePackages,
   pipewire,
   libpulseaudio,
   autoPatchelfHook,
+  pnpm,
+  nodejs,
   withTTS ? true,
   # Enables the use of vencord from nixpkgs instead of
   # letting vesktop manage it's own version
@@ -33,66 +30,17 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-cZOyydwpIW9Xq716KVi1RGtSlgVnOP3w8vXDwouS70E=";
   };
 
-  # NOTE: This requires pnpm 8.10.0 or newer
-  # https://github.com/pnpm/pnpm/pull/7214
-  pnpmDeps =
-    assert lib.versionAtLeast nodePackages.pnpm.version "8.10.0";
-    stdenvNoCC.mkDerivation {
-      pname = "${finalAttrs.pname}-pnpm-deps";
-      inherit (finalAttrs)
-        src
-        version
-        patches
-        ELECTRON_SKIP_BINARY_DOWNLOAD
-        ;
-
-      nativeBuildInputs = [
-        cacert
-        jq
-        moreutils
-        nodePackages.pnpm
-      ];
-
-      # inspired by https://github.com/NixOS/nixpkgs/blob/763e59ffedb5c25774387bf99bc725df5df82d10/pkgs/applications/misc/pot/default.nix#L56
-      # and based on https://github.com/NixOS/nixpkgs/pull/290715
-      installPhase = ''
-        runHook preInstall
-
-        export HOME=$(mktemp -d)
-        pnpm config set store-dir $out
-        # Some packages produce platform dependent outputs. We do not want to cache those in the global store
-        pnpm config set side-effects-cache false
-        # pnpm is going to warn us about using --force
-        # --force allows us to fetch all dependencies including ones that aren't meant for our host platform
-        pnpm install --force --frozen-lockfile --ignore-script
-
-      '';
-
-      fixupPhase = ''
-        runHook preFixup
-
-        # Remove timestamp and sort the json files
-        rm -rf $out/v3/tmp
-        for f in $(find $out -name "*.json"); do
-          sed -i -E -e 's/"checkedAt":[0-9]+,//g' $f
-          jq --sort-keys . $f | sponge $f
-        done
-
-        runHook postFixup
-      '';
-
-      dontConfigure = true;
-      dontBuild = true;
-      outputHashMode = "recursive";
-      outputHash = "sha256-PogE8uf3W5cKSCqFHMz7FOvT7ONUP4FiFWGBgtk3UC8=";
-    };
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (finalAttrs) pname version src patches;
+    hash = "sha256-PogE8uf3W5cKSCqFHMz7FOvT7ONUP4FiFWGBgtk3UC8=";
+  };
 
   nativeBuildInputs = [
     autoPatchelfHook
     copyDesktopItems
     makeWrapper
-    nodePackages.pnpm
-    nodePackages.nodejs
+    nodejs
+    pnpm.configHook
   ];
 
   buildInputs = [
@@ -109,22 +57,6 @@ stdenv.mkDerivation (finalAttrs: {
     });
 
   ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
-
-  configurePhase = ''
-    runHook preConfigure
-
-    export HOME=$(mktemp -d)
-    export STORE_PATH=$(mktemp -d)
-
-    cp -Tr "$pnpmDeps" "$STORE_PATH"
-    chmod -R +w "$STORE_PATH"
-
-    pnpm config set store-dir "$STORE_PATH"
-    pnpm install --frozen-lockfile --ignore-script --offline
-    patchShebangs node_modules/{*,.*}
-
-    runHook postConfigure
-  '';
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/development/tools/pnpm/default.nix
+++ b/pkgs/development/tools/pnpm/default.nix
@@ -1,0 +1,20 @@
+{ lib, callPackage }:
+let
+  inherit (lib) mapAttrs' nameValuePair;
+
+  variants = {
+    "8" = {
+      version = "8.15.8";
+      hash = "sha256-aR/hdu6pqKgN8g5JdvPftEoEhBzriFY4/iomF0+B5l4=";
+    };
+    "9" = {
+      version = "9.1.1";
+      hash = "sha256-lVHoA9y3oYOf31QWFTqEQGDHvOATIYzoI0EFMlBKwQs=";
+    };
+  };
+
+  callPnpm = variant: callPackage ./generic.nix {inherit (variant) version hash;};
+
+  mkPnpm = versionSuffix: variant: nameValuePair "pnpm_${versionSuffix}" (callPnpm variant);
+in
+mapAttrs' mkPnpm variants

--- a/pkgs/development/tools/pnpm/fetch-deps/default.nix
+++ b/pkgs/development/tools/pnpm/fetch-deps/default.nix
@@ -1,0 +1,83 @@
+{
+  stdenvNoCC,
+  fetchurl,
+  jq,
+  moreutils,
+  cacert,
+  makeSetupHook,
+  pnpm,
+}:
+{
+  fetchDeps =
+    {
+      src,
+      hash ? "",
+      pname,
+      ...
+    }@args:
+    let
+      args' = builtins.removeAttrs args [
+        "hash"
+        "pname"
+      ];
+      hash' =
+        if hash != "" then
+          { outputHash = hash; }
+        else
+          {
+            outputHash = "";
+            outputHashAlgo = "sha256";
+          };
+    in
+    stdenvNoCC.mkDerivation (
+      args'
+      // {
+        name = "${pname}-pnpm-deps";
+
+        nativeBuildInputs = [
+          jq
+          moreutils
+          pnpm
+          cacert
+        ];
+
+        installPhase = ''
+          runHook preInstall
+
+          export HOME=$(mktemp -d)
+          pnpm config set store-dir $out
+          # Some packages produce platform dependent outputs. We do not want to cache those in the global store
+          pnpm config set side-effects-cache false
+          # As we pin pnpm versions, we don't really care about updates
+          pnpm config set update-notifier false
+          # pnpm is going to warn us about using --force
+          # --force allows us to fetch all dependencies including ones that aren't meant for our host platform
+          pnpm install --frozen-lockfile --ignore-script --force
+
+          runHook postInstall
+        '';
+
+        fixupPhase = ''
+          runHook preFixup
+
+          # Remove timestamp and sort the json files
+          rm -rf $out/v3/tmp
+          for f in $(find $out -name "*.json"); do
+            jq --sort-keys "del(.. | .checkedAt?)" $f | sponge $f
+          done
+
+          runHook postFixup
+        '';
+
+        dontConfigure = true;
+        dontBuild = true;
+        outputHashMode = "recursive";
+      }
+      // hash'
+    );
+
+  configHook = makeSetupHook {
+    name = "pnpm-config-hook";
+    propagatedBuildInputs = [ pnpm ];
+  } ./pnpm-config-hook.sh;
+}

--- a/pkgs/development/tools/pnpm/fetch-deps/default.nix
+++ b/pkgs/development/tools/pnpm/fetch-deps/default.nix
@@ -1,6 +1,7 @@
 {
   stdenvNoCC,
   fetchurl,
+  callPackage,
   jq,
   moreutils,
   cacert,
@@ -29,7 +30,7 @@
             outputHashAlgo = "sha256";
           };
     in
-    stdenvNoCC.mkDerivation (
+    stdenvNoCC.mkDerivation (finalAttrs: (
       args'
       // {
         name = "${pname}-pnpm-deps";
@@ -69,12 +70,19 @@
           runHook postFixup
         '';
 
+        passthru = {
+          serve = callPackage ./serve.nix {
+            inherit pnpm;
+            pnpmDeps = finalAttrs.finalPackage;
+          };
+        };
+
         dontConfigure = true;
         dontBuild = true;
         outputHashMode = "recursive";
       }
       // hash'
-    );
+    ));
 
   configHook = makeSetupHook {
     name = "pnpm-config-hook";

--- a/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
+++ b/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
@@ -1,0 +1,40 @@
+# shellcheck shell=bash
+
+pnpmConfigHook() {
+    echo "Executing pnpmConfigHook"
+
+    if [ -n "${pnpmRoot-}" ]; then
+      pushd "$pnpmRoot"
+    fi
+
+    if [ -z "${pnpmDeps-}" ]; then
+      echo "Error: 'pnpmDeps' must be set when using pnpmConfigHook."
+      exit 1
+    fi
+
+    echo "Configuring pnpm store"
+
+    export HOME=$(mktemp -d)
+    export STORE_PATH=$(mktemp -d)
+
+    cp -Tr "$pnpmDeps" "$STORE_PATH"
+    chmod -R +w "$STORE_PATH"
+
+    pnpm config set store-dir "$STORE_PATH"
+
+    echo "Installing dependencies"
+
+    pnpm install --offline --frozen-lockfile --ignore-script
+
+    echo "Patching scripts"
+
+    patchShebangs node_modules/{*,.*}
+
+    if [ -n "${pnpmRoot-}" ]; then
+      popd
+    fi
+
+    echo "Finished pnpmConfigHook"
+}
+
+postConfigureHooks+=(pnpmConfigHook)

--- a/pkgs/development/tools/pnpm/fetch-deps/serve.nix
+++ b/pkgs/development/tools/pnpm/fetch-deps/serve.nix
@@ -1,0 +1,30 @@
+{ writeShellApplication, pnpm, pnpmDeps }:
+writeShellApplication {
+  name = "serve-pnpm-store";
+
+  runtimeInputs = [
+    pnpm
+  ];
+
+  text = ''
+    storePath=$(mktemp -d)
+
+    clean() {
+      echo "Cleaning up temporary store at '$storePath'..."
+
+      rm -rf "$storePath"
+    }
+
+    echo "Copying pnpm store '${pnpmDeps}' to temporary store..."
+
+    cp -Tr "${pnpmDeps}" "$storePath"
+    chmod -R +w "$storePath"
+
+    echo "Run 'pnpm install --store-dir \"$storePath\"' to install packages from this store."
+
+    trap clean EXIT
+
+    pnpm server start \
+      --store-dir "$storePath"
+  '';
+}

--- a/pkgs/development/tools/pnpm/generic.nix
+++ b/pkgs/development/tools/pnpm/generic.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenvNoCC,
+  callPackages,
   fetchurl,
   nodejs,
   testers,
@@ -8,9 +9,7 @@
 
   version,
   hash,
-}:
-
-stdenvNoCC.mkDerivation (finalAttrs: {
+}: stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "pnpm";
   inherit version;
 
@@ -32,7 +31,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru = {
+  passthru = let
+    fetchDepsAttrs = callPackages ./fetch-deps { pnpm = finalAttrs.finalPackage; };
+  in {
+    inherit (fetchDepsAttrs) fetchDeps configHook;
+
     tests.version = lib.optionalAttrs withNode (
       testers.testVersion { package = finalAttrs.finalPackage; }
     );

--- a/pkgs/development/tools/pnpm/generic.nix
+++ b/pkgs/development/tools/pnpm/generic.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  nodejs,
+  testers,
+  withNode ? true,
+
+  version,
+  hash,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "pnpm";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://registry.npmjs.org/pnpm/-/pnpm-${finalAttrs.version}.tgz";
+    inherit hash;
+  };
+
+  buildInputs = lib.optionals withNode [ nodejs ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -d $out/{bin,libexec}
+    cp -R . $out/libexec/pnpm
+    ln -s $out/libexec/pnpm/bin/pnpm.cjs $out/bin/pnpm
+    ln -s $out/libexec/pnpm/bin/pnpx.cjs $out/bin/pnpx
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    tests.version = lib.optionalAttrs withNode (
+      testers.testVersion { package = finalAttrs.finalPackage; }
+    );
+  };
+
+  meta = with lib; {
+    description = "Fast, disk space efficient package manager for JavaScript";
+    homepage = "https://pnpm.io/";
+    changelog = "https://github.com/pnpm/pnpm/releases/tag/v${finalAttrs.version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ Scrumplex ];
+    platforms = platforms.all;
+    mainProgram = "pnpm";
+  };
+})

--- a/pkgs/development/tools/pnpm/generic.nix
+++ b/pkgs/development/tools/pnpm/generic.nix
@@ -17,6 +17,11 @@
     url = "https://registry.npmjs.org/pnpm/-/pnpm-${finalAttrs.version}.tgz";
     inherit hash;
   };
+  # Remove binary files from src, we don't need them, and this way we make sure
+  # our distribution is free of binaryNativeCode
+  preConfigure = ''
+    rm -r dist/reflink.*node dist/vendor
+  '';
 
   buildInputs = lib.optionals withNode [ nodejs ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32126,6 +32126,8 @@ with pkgs;
 
   kitsas = libsForQt5.callPackage ../applications/office/kitsas { };
 
+  kiwitalk = callPackage ../by-name/ki/kiwitalk/package.nix { pnpm = pnpm_8; };
+
   kiwix = libsForQt5.callPackage ../applications/misc/kiwix { };
 
   kiwix-tools = callPackage ../applications/misc/kiwix/tools.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14077,6 +14077,8 @@ with pkgs;
 
   viking = callPackage ../applications/misc/viking { };
 
+  vikunja = callPackage ../by-name/vi/vikunja/package.nix { pnpm = pnpm_8; };
+
   vim-vint = callPackage ../development/tools/vim-vint { };
 
   vimer = callPackage ../tools/misc/vimer { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35833,7 +35833,7 @@ with pkgs;
 
   youtube-dl-light = with python3Packages; toPythonApplication youtube-dl-light;
 
-  youtube-music = callPackage ../applications/audio/youtube-music { };
+  youtube-music = callPackage ../applications/audio/youtube-music { pnpm = pnpm_8; };
 
   youtube-tui = callPackage ../applications/video/youtube-tui {
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security AppKit;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24773,6 +24773,8 @@ with pkgs;
 
   vencord-web-extension = callPackage ../by-name/ve/vencord/package.nix { buildWebExtension = true; };
 
+  vesktop = callPackage ../by-name/ve/vesktop/package.nix { pnpm = pnpm_8; };
+
   vid-stab = callPackage ../development/libraries/vid-stab {
     inherit (llvmPackages) openmp;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20827,7 +20827,7 @@ with pkgs;
   gecode_6 = qt5.callPackage ../development/libraries/gecode { };
   gecode = gecode_6;
 
-  geph = recurseIntoAttrs (callPackages ../applications/networking/geph { });
+  geph = recurseIntoAttrs (callPackages ../applications/networking/geph { pnpm = pnpm_8; });
 
   gephi = callPackage ../applications/science/misc/gephi { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11888,6 +11888,10 @@ with pkgs;
 
   pngquant = callPackage ../tools/graphics/pngquant { };
 
+  inherit (callPackages ../development/tools/pnpm { })
+    pnpm_8 pnpm_9;
+  pnpm = pnpm_9;
+
   po4a = perlPackages.Po4a;
 
   poac = callPackage ../development/tools/poac {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2913,6 +2913,8 @@ with pkgs;
 
   portfolio-filemanager = callPackage ../applications/file-managers/portfolio-filemanager { };
 
+  pot = callPackage ../by-name/po/pot/package.nix { pnpm = pnpm_8; };
+
   potreeconverter = callPackage ../applications/graphics/potreeconverter { };
 
   ranger = callPackage ../applications/file-managers/ranger { };


### PR DESCRIPTION
## Description of changes


Nowadays [pnpm](https://pnpm.io/) is almost unavoidable when working with any larger Node.js project. In an effort to support this package manager in Nixpkgs, this PR introduces `pnpm.fetchDeps` which produces a FOD containing a pnpm store that can be used for a reproducible offline build.

Closes #231513

### To-dos
- [ ] Disable `withNode` for `pnpm` when used in a derivation
- [x] Add a `pnpm server start` script to `pnpmDeps` FODs
- [ ] Support `pnpm-workspace.yaml` projects

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
