### PR TITLE
atuin: small fixes

### DIFF
--- a/nixos/modules/services/misc/atuin.nix
+++ b/nixos/modules/services/misc/atuin.nix
@@ -52,10 +52,13 @@ in
         };
 
         uri = mkOption {
-          type = types.str;
+          type = types.nullOr types.str;
           default = "postgresql:///atuin?host=/run/postgresql";
           example = "postgresql://atuin@localhost:5432/atuin";
-          description = mdDoc "URI to the database";
+          description = mdDoc ''
+            URI to the database.
+            Can be set to null in which case ATUIN_DB_URI should be set through an EnvironmentFile
+          '';
         };
       };
     };
@@ -132,9 +135,10 @@ in
         ATUIN_PORT = toString cfg.port;
         ATUIN_MAX_HISTORY_LENGTH = toString cfg.maxHistoryLength;
         ATUIN_OPEN_REGISTRATION = lib.boolToString cfg.openRegistration;
-        ATUIN_DB_URI = cfg.database.uri;
         ATUIN_PATH = cfg.path;
         ATUIN_CONFIG_DIR = "/run/atuin"; # required to start, but not used as configuration is via environment variables
+      } // lib.optionalAttrs (cfg.database.uri != null) {
+        ATUIN_DB_URI = cfg.database.uri;
       };
     };
 

--- a/pkgs/by-name/at/atuin/package.nix
+++ b/pkgs/by-name/at/atuin/package.nix
@@ -25,6 +25,13 @@ rustPlatform.buildRustPackage rec {
     then "sha256-lHWgsVnjSeBmd7O4Fn0pUtTn4XbkBOAouaRHRozil50="
     else "sha256-LxfpllzvgUu7ZuD97n3W+el3bdOt5QGXzJbDQ0w8seo=";
 
+  # atuin's default features include 'check-updates', which do not make sense
+  # for distribution builds. List all other default features.
+  buildNoDefaultFeatures = true;
+  buildFeatures = [
+    "client" "sync" "server" "clipboard"
+  ];
+
   nativeBuildInputs = [ installShellFiles ];
 
   buildInputs = lib.optionals stdenv.isDarwin [

--- a/pkgs/by-name/at/atuin/package.nix
+++ b/pkgs/by-name/at/atuin/package.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , installShellFiles
 , rustPlatform
 , libiconv
@@ -18,6 +19,15 @@ rustPlatform.buildRustPackage rec {
     rev = "v${version}";
     hash = "sha256-fuVSn1vhKn2+Tw5f6zBYHFW3QSL4eisZ6d5pxsj5hh4=";
   };
+
+  patches = [
+    # atuin with bash-preexec wasn't recording history properly after searching,
+    # backport recent fix until next release
+    (fetchpatch {
+      url = "https://github.com/atuinsh/atuin/commit/cb11af25afddbad552d337a9c82e74ac4302feca.patch";
+      sha256 = "sha256-cG99aLKs5msatT7vXiX9Rn5xur2WUjQ/U33nOxuon7I=";
+    })
+  ];
 
   # TODO: unify this to one hash because updater do not support this
   cargoHash =


### PR DESCRIPTION
## Things done

This is three unrelated things, happy to split anything that you think warrants discussions but I think t's small enough to get in together.

1/ atuin: Allow setting database.uri to null

When a password is required to connect to postgres using services.atuin.database.uri directly would make the password be written in the nix store, which is suboptimal.
Instead we can have the password in a file accessible only to root by having systemd read an EnvironmentFile directly, but we must ensure that this file has priority over the environment set.
Not setting the variable in this case is more straightforward.

If you know of another way to unset just a single enviironment variable I'll be happy to drop this, but otherwise the impact is minimal and this brings in a bit of flexibility.

2/ atuin: disable check-updates feature

We don't want phone home in nixos afak. Happy to gate this as an option...

3/ atuin: backport fix for bash-preexec

This is purely selfish as it took me a while to understand why atuin worked when I built locally from main branch on a laptop and it didn't register commands properly on my server... That'll get in next update at some point, so can just wait this out if it's a bother.


- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @SuperSandro2000 @Sciencentistguy @0x4A6F (maintainers)