### PR TITLE
[23.11] wayland-pipewire-idle-inhibit: init at 0.4.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15008,6 +15008,12 @@
     github = "rafaelrc7";
     githubId = 5376043;
   };
+  rafameou = {
+    email = "rafaelmazz22@gmail.com";
+    name = "Rafael Mazzutti";
+    github = "rafameou";
+    githubId = 26395874;
+  };
   ragge = {
     email = "r.dahlen@gmail.com";
     github = "ragnard";

--- a/pkgs/by-name/wa/wayland-pipewire-idle-inhibit/package.nix
+++ b/pkgs/by-name/wa/wayland-pipewire-idle-inhibit/package.nix
@@ -1,0 +1,46 @@
+{ clang
+, lib
+, libclang
+, fetchFromGitHub
+, pipewire
+, pkg-config
+, rustPlatform
+, wayland
+, wayland-protocols
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "wayland-pipewire-idle-inhibit";
+  version = "0.4.5";
+
+  src = fetchFromGitHub {
+    owner = "rafaelrc7";
+    repo = "wayland-pipewire-idle-inhibit";
+    rev = "v${version}";
+    sha256 = "sha256-VOP1VOeXOyjn+AJfSHzVNT0l+rgm63ev9p4uTfMfYY0=";
+  };
+
+  cargoSha256 = "sha256-7XuDZ57+F8Ot5oNO9/BXjFljNmoMgNgURfmPEIy2PHo=";
+
+  nativeBuildInputs = [
+    clang
+    pkg-config
+  ];
+
+  buildInputs = [
+    pipewire
+    wayland
+    wayland-protocols
+  ];
+
+  LIBCLANG_PATH = "${libclang.lib}/lib";
+
+  meta = with lib; {
+    description = "Suspends automatic idling of Wayland compositors when media is being played through Pipewire.";
+    homepage = "https://github.com/rafaelrc7/wayland-pipewire-idle-inhibit/";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ rafameou ];
+    mainProgram = "wayland-pipewire-idle-inhibit";
+  };
+}
+

--- a/pkgs/by-name/wa/wayland-pipewire-idle-inhibit/package.nix
+++ b/pkgs/by-name/wa/wayland-pipewire-idle-inhibit/package.nix
@@ -1,6 +1,4 @@
-{ clang
-, lib
-, libclang
+{ lib
 , fetchFromGitHub
 , pipewire
 , pkg-config
@@ -22,8 +20,8 @@ rustPlatform.buildRustPackage rec {
   cargoSha256 = "sha256-7XuDZ57+F8Ot5oNO9/BXjFljNmoMgNgURfmPEIy2PHo=";
 
   nativeBuildInputs = [
-    clang
     pkg-config
+    rustPlatform.bindgenHook
   ];
 
   buildInputs = [
@@ -31,8 +29,6 @@ rustPlatform.buildRustPackage rec {
     wayland
     wayland-protocols
   ];
-
-  LIBCLANG_PATH = "${libclang.lib}/lib";
 
   meta = with lib; {
     description = "Suspends automatic idling of Wayland compositors when media is being played through Pipewire.";


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Master pull request: https://github.com/NixOS/nixpkgs/pull/290278
Homepage: https://github.com/rafaelrc7/wayland-pipewire-idle-inhibit
Description: Suspends automatic idling of Wayland compositors when media is being played through Pipewire.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
