### PR TITLE
lsd2dsl: 0.5.4 → 0.6.0

### DIFF
--- a/pkgs/by-name/ls/lsd2dsl/package.nix
+++ b/pkgs/by-name/ls/lsd2dsl/package.nix
@@ -1,23 +1,40 @@
 { lib, stdenv, fetchFromGitHub
 , makeDesktopItem, copyDesktopItems, cmake
-, boost, libvorbis, libsndfile, minizip, gtest, qt5 }:
+, boost, cups, fmt, libvorbis, libsndfile, minizip, gtest, qt6 }:
 
 stdenv.mkDerivation rec {
   pname = "lsd2dsl";
-  version = "0.5.4";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "nongeneric";
     repo = "lsd2dsl";
     rev = "v${version}";
-    sha256 = "sha256-PLgfsVVrNBTxI4J0ukEOFRoBkbmB55/sLNn5KyiHeAc=";
+    hash = "sha256-0UsxDNpuWpBrfjh4q3JhZnOyXhHatSa3t/cApiG2JzM=";
   };
 
-  nativeBuildInputs = [ cmake qt5.wrapQtAppsHook ] ++ lib.optional stdenv.isLinux copyDesktopItems;
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace "-Werror" ""
+  '';
 
-  buildInputs = [ boost libvorbis libsndfile minizip gtest qt5.qtwebkit ];
+  nativeBuildInputs = [
+    cmake
+    qt6.wrapQtAppsHook
+  ] ++ lib.optional stdenv.isLinux copyDesktopItems;
 
-  env.NIX_CFLAGS_COMPILE = "-Wno-error=unused-result -Wno-error=missing-braces";
+  buildInputs = [
+    boost
+    cups
+    fmt
+    libvorbis
+    libsndfile
+    minizip
+    gtest
+    qt6.qt5compat
+    qt6.qtwebengine
+  ];
+
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-int-conversion";
 
   desktopItems = lib.singleton (makeDesktopItem {
     name = "lsd2dsl";

--- a/pkgs/by-name/ls/lsd2dsl/package.nix
+++ b/pkgs/by-name/ls/lsd2dsl/package.nix
@@ -1,21 +1,21 @@
-{ lib, stdenv, mkDerivation, fetchFromGitHub
+{ lib, stdenv, fetchFromGitHub
 , makeDesktopItem, copyDesktopItems, cmake
-, boost, libvorbis, libsndfile, minizip, gtest, qtwebkit }:
+, boost, libvorbis, libsndfile, minizip, gtest, qt5 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "lsd2dsl";
   version = "0.5.4";
 
   src = fetchFromGitHub {
     owner = "nongeneric";
-    repo = pname;
+    repo = "lsd2dsl";
     rev = "v${version}";
     sha256 = "sha256-PLgfsVVrNBTxI4J0ukEOFRoBkbmB55/sLNn5KyiHeAc=";
   };
 
-  nativeBuildInputs = [ cmake ] ++ lib.optional stdenv.isLinux copyDesktopItems;
+  nativeBuildInputs = [ cmake qt5.wrapQtAppsHook ] ++ lib.optional stdenv.isLinux copyDesktopItems;
 
-  buildInputs = [ boost libvorbis libsndfile minizip gtest qtwebkit ];
+  buildInputs = [ boost libvorbis libsndfile minizip gtest qt5.qtwebkit ];
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error=unused-result -Wno-error=missing-braces";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33251,8 +33251,6 @@ with pkgs;
 
   loxodo = callPackage ../applications/misc/loxodo { };
 
-  lsd2dsl = libsForQt5.callPackage ../applications/misc/lsd2dsl { };
-
   lrzsz = callPackage ../tools/misc/lrzsz { };
 
   lsp-plugins = callPackage ../applications/audio/lsp-plugins { php = php81; };


### PR DESCRIPTION
## Description of changes
https://github.com/nongeneric/lsd2dsl/releases

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
