### PR TITLE
certmonger: init at 0.79.19

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1170,6 +1170,7 @@
   ./services/security/aesmd.nix
   ./services/security/authelia.nix
   ./services/security/certmgr.nix
+  ./services/security/certmonger.nix
   ./services/security/cfssl.nix
   ./services/security/clamav.nix
   ./services/security/endlessh-go.nix

--- a/nixos/modules/services/security/certmonger.nix
+++ b/nixos/modules/services/security/certmonger.nix
@@ -1,0 +1,75 @@
+{ pkgs, lib, config, ... }:
+let
+  cfg = config.services.certmonger;
+
+  cfgFile = pkgs.writeText "certmonger.conf" cfg.config;
+in
+{
+  options.services.certmonger = {
+    enable = lib.mkEnableOption (lib.mdDoc "certmonger service");
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.certmonger;
+      defaultText = lib.literalExpression "pkgs.certmonger";
+      description = lib.mdDoc "certmonger package";
+    };
+
+    overrideHosts = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = lib.mdDoc ''
+        Remove /etc/hosts entries for "127.0.0.2" and "::1" defined in nixos/modules/config/networking.nix
+        networking.fqdn must be able to resolve their hostnames to their IP addresses, through PTR records
+        or /etc/hosts entries. Overwise IPA krb5 Keytab will try register as localhost.
+      '';
+    };
+
+    config = lib.mkOption {
+      type = lib.types.lines;
+      description = lib.mdDoc ''
+        Contents of {file}`certmonger.conf`.
+
+        The certmonger.conf file contains default settings used by certmonger.
+        Its format is more or less that of a typical INI-style file.
+        The only sections currently of note are named defaults, selfsign and local.
+
+        For more details see {manpage}`certmonger.conf(5)`.
+      '';
+      default = "";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    networking.hosts = lib.mkIf cfg.overrideHosts {
+      "127.0.0.2" = lib.mkForce [ ];
+      "::1" = lib.mkForce [ ];
+    };
+
+    environment.systemPackages = [ cfg.package ];
+
+    environment.etc."certmonger/certmonger.conf".source = cfgFile;
+
+    systemd.services.certmonger = {
+      after = [ "network.target" "dbus.service" ];
+      partOf = [ "dbus.service" ];
+      wantedBy = [ "multi-user.target" ];
+
+      restartTriggers = [ cfgFile ];
+      environment = {
+        CERTMONGER_CONFIG_DIR = "/etc/certmonger";
+      };
+
+      serviceConfig = {
+        Type = "dbus";
+        StateDirectory = "certmonger";
+        RuntimeDirectory = "certmonger";
+        StateDirectoryMode = "0750";
+        RuntimeDirectoryMode = "0750";
+        PIDFile = "/run/certmonger/certmonger.pid";
+        ExecStart = "${cfg.package}/bin/certmonger -S -p /run/certmonger/certmonger.pid -n";
+        BusName = "org.fedorahosted.certmonger";
+      };
+    };
+  };
+}

--- a/pkgs/by-name/ce/certmonger/package.nix
+++ b/pkgs/by-name/ce/certmonger/package.nix
@@ -1,0 +1,143 @@
+{ lib
+, stdenv
+, fetchurl
+, autoreconfHook
+, gettext
+, pkg-config
+, writeShellScript
+, openldap
+, libkrb5
+, dbus
+, nspr
+, nss
+, openssl
+, libidn2
+, libuuid
+, talloc
+, tevent
+, curl
+, libxml2
+, xmlrpc_c
+, jansson
+, popt
+, runtimeDir ? "/run/certmonger"
+, storeDir ? "/var/lib/certmonger"
+}:
+let
+  # patch runtime /libexec + storeDir (it is hardcoded in binary for runtime)
+  # needed for non-NixOS systems
+  # For example "certmonger" will create file in "/var/lib/certmonger/cas/20240222033838" with hardcoded path:
+  # ca_external_helper=/nix/store/h3xp6zjjvq5gy2wcllfv5l578fbjr9il-certmonger-0.79.15/libexec/certmonger/certmaster-submit
+  certmongerWrapper = writeShellScript "certmongerWrapper" ''
+    # create runtime impure binaries
+    if [ ! -d "${runtimeDir}" ]; then
+      mkdir -m 0750 -p "${runtimeDir}"
+    fi
+    if [ "$(readlink "${runtimeDir}/libexec")" != "@out@/libexec" ]; then
+      rm -f "${runtimeDir}/libexec"
+      ln -s "@out@/libexec" "${runtimeDir}/libexec"
+    fi
+
+    # create required directories
+    if [ ! -d "${storeDir}/cas" ]; then
+      mkdir -m 0700 -p "${storeDir}/cas"
+    fi
+    if [ ! -d "${storeDir}/local" ]; then
+      mkdir -m 0700 -p "${storeDir}/local"
+    fi
+    if [ ! -d "${storeDir}/requests" ]; then
+      mkdir -m 0700 -p "${storeDir}/requests"
+    fi
+
+    # run original binary
+    fileName="''${0##*/}"
+    exec "@out@/.bin-unwrapped/$fileName" "$@"
+  '';
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "certmonger";
+  version = "0.79.19";
+
+  src = fetchurl {
+    url = "https://pagure.io/certmonger/archive/${finalAttrs.version}/certmonger-${finalAttrs.version}.tar.gz";
+    hash = "sha256-MoyPHbbsN0B8Dd9qyz64y9CCkSBpgbFe82hImJwf+LE=";
+  };
+
+  nativeBuildInputs = [
+    gettext
+    pkg-config
+    autoreconfHook
+  ];
+
+  buildInputs = [
+    openldap
+    libkrb5
+    dbus
+    nspr
+    nss
+    openssl
+    libidn2
+    libuuid
+    talloc
+    tevent
+    curl
+    libxml2
+    xmlrpc_c
+    jansson
+    popt
+  ];
+
+  postPatch = ''
+    # patch required if '--enable-systemd' is enabled
+    substituteInPlace configure.ac \
+      --replace '`pkg-config --variable=systemdsystemunitdir systemd 2> /dev/null`' '"${placeholder "out"}/lib/systemd/system"'
+
+    # patch runtime /libexec
+    substituteInPlace configure.ac \
+      --replace 'mylibexecdir="$libexecdir/''${PACKAGE_NAME}"' 'mylibexecdir="${runtimeDir}/libexec/certmonger"'
+
+    # skip installing /var/lib/certmonger
+    substituteInPlace src/Makefile.am \
+      --replace '	mkdir -m 700 -p $(DESTDIR)@CM_STORE' '# mkdir -m 700 -p $(DESTDIR)@CM_STORE'
+  '';
+
+  configureFlags = [
+    "--with-system-bus-services-dir=${placeholder "out"}/etc/dbus-1/system.d"
+    "--with-session-bus-services-dir=${placeholder "out"}/etc/dbus-1/session.d"
+    "--with-homedir=${runtimeDir}"
+    "--with-tmpdir=${runtimeDir}"
+    "--with-file-store-dir=${storeDir}"
+    "--with-xmlrpc"
+    (lib.enableFeature true "systemd")
+    (lib.enableFeature true "tmpfiles")
+    (lib.enableFeature false "dsa")
+    (lib.enableFeature true "pie")
+    (lib.enableFeature true "now")
+  ];
+
+  postFixup = ''
+    mkdir -p $out/.bin-unwrapped
+    for file in $out/bin/*; do
+      fileName=$(basename $file)
+      mv "$out/bin/$fileName" "$out/.bin-unwrapped/$fileName"
+      ln -s "$out/.bin-unwrapped/.wrapper" "$out/bin/$fileName"
+    done;
+
+    substitute ${certmongerWrapper} $out/.bin-unwrapped/.wrapper \
+      --subst-var out
+    chmod +x $out/.bin-unwrapped/.wrapper
+  '';
+
+  meta = with lib; {
+    description = "Certificate status monitor and PKI enrollment client";
+    longDescription = ''
+      Certmonger is a service which is primarily concerned with getting your
+      system enrolled with a certificate authority (CA) and keeping it enrolled.
+    '';
+    homepage = "https://pagure.io/certmonger/";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.patryk4815 ];
+    platforms = platforms.linux;
+    mainProgram = "certmonger";
+  };
+})


### PR DESCRIPTION
## Description of changes

This PR adds certmonger. This is freeIPA certificate manager.

How to test:
```
fqdn=$(hostname -f)
REALM="<put same value like in security.ipa.realm >"
ipa-getcert request -f $fqdn.crt -k $fqdn.key -r -K HTTP/$fqdn@$REALM -N $fqdn
ipa-getcert list
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
