### PR TITLE
qemu-vm.nix refactoring

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -1046,14 +1046,6 @@ in
 
     boot.loader.supportsInitrdSecrets = mkIf (!cfg.useBootLoader) (mkVMOverride false);
 
-    systemd.tmpfiles.settings."10-qemu-vm" = {
-      "/etc/NIXOS".f = {
-        mode = "0644";
-        user = "root";
-        group = "root";
-      };
-    };
-
     # After booting, register the closure of the paths in
     # `virtualisation.additionalPaths' in the Nix database in the VM.  This
     # allows Nix operations to work in the VM.  The path to the

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -1242,7 +1242,6 @@ in
         "/boot" = lib.mkIf (cfg.useBootLoader && cfg.bootPartition != null) {
           device = cfg.bootPartition;
           fsType = "vfat";
-          noCheck = true; # fsck fails on a r/o filesystem
         };
       }
     ];

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -393,7 +393,7 @@ in
             The path (inside the VM) to the device containing the EFI System Partition (ESP).
 
             If you are *not* booting from a UEFI firmware, this value is, by
-            default, `null`. The ESP is mounted under `/boot`.
+            default, `null`. The ESP is mounted to `boot.loader.efi.efiSysMountpoint`.
           '';
       };
 
@@ -1052,11 +1052,6 @@ in
         user = "root";
         group = "root";
       };
-      "${config.boot.loader.efi.efiSysMountPoint}".d = {
-        mode = "0644";
-        user = "root";
-        group = "root";
-      };
     };
 
     # After booting, register the closure of the paths in
@@ -1239,7 +1234,7 @@ in
           options = [ "mode=0755" ];
           neededForBoot = true;
         };
-        "/boot" = lib.mkIf (cfg.useBootLoader && cfg.bootPartition != null) {
+        "${config.boot.loader.efi.efiSysMountPoint}" = lib.mkIf (cfg.useBootLoader && cfg.bootPartition != null) {
           device = cfg.bootPartition;
           fsType = "vfat";
         };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -799,6 +799,7 @@ in {
   qemu-vm-restrictnetwork = handleTest ./qemu-vm-restrictnetwork.nix {};
   qemu-vm-volatile-root = runTest ./qemu-vm-volatile-root.nix;
   qemu-vm-external-disk-image = runTest ./qemu-vm-external-disk-image.nix;
+  qemu-vm-store = runTest ./qemu-vm-store.nix;
   qgis = handleTest ./qgis.nix { qgisPackage = pkgs.qgis; };
   qgis-ltr = handleTest ./qgis.nix { qgisPackage = pkgs.qgis-ltr; };
   qownnotes = handleTest ./qownnotes.nix {};

--- a/nixos/tests/qemu-vm-store.nix
+++ b/nixos/tests/qemu-vm-store.nix
@@ -1,0 +1,71 @@
+{ lib, ... }: {
+
+  name = "qemu-vm-store";
+
+  meta.maintainers = with lib.maintainers; [ nikstur ];
+
+  nodes = {
+    sharedWritable = {
+      virtualisation.writableStore = true;
+    };
+
+    sharedReadOnly = {
+      virtualisation.writableStore = false;
+    };
+
+    imageWritable = {
+      virtualisation.useNixStoreImage = true;
+      virtualisation.writableStore = true;
+    };
+
+    imageReadOnly = {
+      virtualisation.useNixStoreImage = true;
+      virtualisation.writableStore = false;
+    };
+
+    fullDisk = {
+      virtualisation.useBootLoader = true;
+    };
+  };
+
+  testScript = ''
+    build_derivation = """
+      nix-build --option substitute false -E 'derivation {
+        name = "t";
+        builder = "/bin/sh";
+        args = ["-c" "echo something > $out"];
+        system = builtins.currentSystem;
+        preferLocalBuild = true;
+      }'
+    """
+
+    start_all()
+
+    with subtest("Nix Store is writable"):
+      sharedWritable.succeed(build_derivation)
+      imageWritable.succeed(build_derivation)
+      fullDisk.succeed(build_derivation)
+
+    with subtest("Nix Store is read only"):
+      sharedReadOnly.fail(build_derivation)
+      imageReadOnly.fail(build_derivation)
+
+    # Checking whether the fs type is 9P is just a proxy to test whether the
+    # Nix Store is shared. If we switch to a different technology (e.g.
+    # virtiofs) for sharing, we need to adjust these tests.
+
+    with subtest("Nix store is shared from the host via 9P"):
+      sharedWritable.succeed("findmnt --kernel --type 9P /nix/.ro-store")
+      sharedReadOnly.succeed("findmnt --kernel --type 9P /nix/.ro-store")
+
+    with subtest("Nix store is not shared via 9P"):
+      imageWritable.fail("findmnt --kernel --type 9P /nix/.ro-store")
+      imageReadOnly.fail("findmnt --kernel --type 9P /nix/.ro-store")
+
+    with subtest("Nix store is not mounted separately"):
+      rootDevice = fullDisk.succeed("stat -c %d /")
+      nixStoreDevice = fullDisk.succeed("stat -c %d /nix/store")
+      assert rootDevice == nixStoreDevice, "Nix store is mounted separately from the root fs"
+  '';
+
+}


### PR DESCRIPTION
## Description of changes

Refactor the qemu-vm module with a few common sense de-duplications/improvements.
Most notable is the switch to the new overlayfs API and the qemu-vm-store test.

Review commit by commit will be useful.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
