### PR TITLE
warp-terminal: added initial linux support

### DIFF
--- a/pkgs/by-name/wa/warp-terminal/package.nix
+++ b/pkgs/by-name/wa/warp-terminal/package.nix
@@ -1,15 +1,74 @@
 { lib
 , stdenvNoCC
+, stdenv
 , fetchurl
+, autoPatchelfHook
 , undmg
+, zstd
+, curl
+, fontconfig
+, libglvnd
+, libxkbcommon
+, vulkan-loader
+, xdg-utils
+, xorg
+, zlib
 }:
-stdenvNoCC.mkDerivation (finalAttrs: {
-  pname = "warp-terminal";
-  version = "0.2023.12.05.08.02.stable_00";
 
+let
+pname = "warp-terminal";
+version = "0.2024.02.20.08.01.stable_01";
+
+linux = stdenv.mkDerivation (finalAttrs:  {
+  inherit pname version meta;
+  src = fetchurl {
+    url = "https://releases.warp.dev/stable/v${finalAttrs.version}/warp-terminal-v${finalAttrs.version}-1-x86_64.pkg.tar.zst";
+    hash = "sha256-L8alnqSE4crrDozRfPaAAMkLc+5+8d9XBKd5ddsxmD0=";
+  };
+
+  sourceRoot = ".";
+
+  postPatch = ''
+    substituteInPlace usr/bin/warp-terminal \
+      --replace-fail /opt/ $out/opt/
+  '';
+
+  nativeBuildInputs = [ autoPatchelfHook zstd ];
+
+  buildInputs = [
+    curl
+    fontconfig
+    stdenv.cc.cc.lib # libstdc++.so libgcc_s.so
+    zlib
+  ];
+
+  runtimeDependencies = [
+    libglvnd # for libegl
+    libxkbcommon
+    stdenv.cc.libc
+    vulkan-loader
+    xdg-utils
+    xorg.libX11
+    xorg.libxcb
+    xorg.libXcursor
+    xorg.libXi
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    cp -r opt usr/* $out
+
+    runHook postInstall
+  '';
+});
+
+darwin = stdenvNoCC.mkDerivation (finalAttrs: {
+  inherit pname version meta;
   src = fetchurl {
     url = "https://releases.warp.dev/stable/v${finalAttrs.version}/Warp.dmg";
-    hash = "sha256-9olAmczIPRXV15NYCOYmwuEmJ7lMeaQRTTfukaYXMR0=";
+    hash = "sha256-tFtoD8URMFfJ3HRkyKStuDStFkoRIV97y9kV4pbDPro=";
   };
 
   sourceRoot = ".";
@@ -24,13 +83,18 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+});
 
-  meta = with lib; {
-    description = "Rust-based terminal";
-    homepage = "https://www.warp.dev";
-    license = licenses.unfree;
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    maintainers = with maintainers; [ emilytrau Enzime ];
-    platforms = platforms.darwin;
-  };
-})
+meta = with lib; {
+  description = "Rust-based terminal";
+  homepage = "https://www.warp.dev";
+  license = licenses.unfree;
+  sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  maintainers = with maintainers; [ emilytrau Enzime ];
+  platforms = platforms.darwin ++ [ "x86_64-linux" ];
+};
+
+in
+if stdenvNoCC.isDarwin
+then darwin
+else linux


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added initial linux support via appimage. Unsure of the versioning - the dmg seems to rely an a url that has versioning that upstream provides but can't seem to find that for the appimage. Closes #290671.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc 
