### PR TITLE
rapidjson-unstable: Remove C++11 mode.

### DIFF
--- a/pkgs/development/libraries/rapidjson/unstable.nix
+++ b/pkgs/development/libraries/rapidjson/unstable.nix
@@ -6,8 +6,6 @@
 , graphviz
 , gtest
 , valgrind
-# One of "11" or "17"; default in source is CXX 11
-, cxxStandard ? "11"
 , buildDocs ? true
 , buildTests ? !stdenv.hostPlatform.isStatic && !stdenv.isDarwin
 , buildExamples ? true
@@ -49,8 +47,9 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "RAPIDJSON_BUILD_DOC" buildDocs)
     (lib.cmakeBool "RAPIDJSON_BUILD_TESTS" buildTests)
     (lib.cmakeBool "RAPIDJSON_BUILD_EXAMPLES" buildExamples)
-    (lib.cmakeBool "RAPIDJSON_BUILD_CXX11" (cxxStandard == "11"))
-    (lib.cmakeBool "RAPIDJSON_BUILD_CXX17" (cxxStandard == "17"))
+    # gtest 1.13+ requires C++14 or later.
+    (lib.cmakeBool "RAPIDJSON_BUILD_CXX11" false)
+    (lib.cmakeBool "RAPIDJSON_BUILD_CXX17" true)
   ] ++ lib.optionals buildTests [
     (lib.cmakeFeature "GTEST_INCLUDE_DIR" "${lib.getDev gtest}")
   ];
@@ -77,6 +76,5 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.mit;
     platforms = platforms.unix;
     maintainers = with maintainers; [ Madouura ];
-    broken = (cxxStandard != "11" && cxxStandard != "17");
   };
 })


### PR DESCRIPTION
## Description of changes

Starting with gtest 1.13 (#282245), only C++14 and above is supported.

As such, this removes C++11 mode from rapidjson-unstable.

Notably, this caused no dependent rebuilds, so I'm assuming that means nobody relies upon this package, but it does show as broken by my change, so I'm providing this fix..

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
