### PR TITLE
python311Packages.openusd: Initial support for x86_64 darwin

### DIFF
--- a/pkgs/development/python-modules/openusd/default.nix
+++ b/pkgs/development/python-modules/openusd/default.nix
@@ -28,6 +28,7 @@
 , bison
 , qt6
 , python
+, darwin
 }:
 let
   # Matches the pyside6-uic implementation
@@ -45,6 +46,11 @@ buildPythonPackage rec {
     rev = "refs/tags/v${version}";
     hash = "sha256-5zQrfB14kXs75WbL3s4eyhxELglhLNxU2L2aVXiyVjg=";
   };
+
+  stdenv = if python.stdenv.isDarwin then
+    darwin.apple_sdk_11_0.stdenv
+  else
+    python.stdenv;
 
   outputs = ["out" "doc"];
 
@@ -72,9 +78,9 @@ buildPythonPackage rec {
     "-DPXR_BUILD_PYTHON_DOCUMENTATION=ON"
     "-DPXR_BUILD_EMBREE_PLUGIN=ON"
     "-DPXR_BUILD_ALEMBIC_PLUGIN=ON"
-    "-DPXR_ENABLE_OSL_SUPPORT=ON"
     "-DPXR_BUILD_DRACO_PLUGIN=ON"
     "-DPXR_BUILD_MONOLITHIC=ON" # Seems to be commonly linked to monolithically
+    (lib.cmakeBool "PXR_ENABLE_OSL_SUPPORT" (!stdenv.isDarwin))
   ];
 
   nativeBuildInputs = [
@@ -100,8 +106,12 @@ buildPythonPackage rec {
     boost
     draco
     qt6.qtbase
-    qt6.qtwayland
-  ];
+  ]
+    ++ lib.optionals stdenv.isLinux [ qt6.qtwayland ]
+    ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk_11_0.frameworks; [
+      Cocoa
+    ])
+  ;
 
   pythonImportsCheck = [ "pxr" "pxr.Usd" ];
 


### PR DESCRIPTION

## Description of changes

I had to disable OSL support as I was getting an error when trying to link openimageio. I'm sure that this is fixable, but building this package takes multiple hours on my macbook and I don't have the time to dig deep into this. `darwin.apple_sdk_11_0.stdenv` is required for the specific Cocoa version as far as I'm aware. I've tested the usdview binary and it renders via Metal.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
