### PR TITLE
icu: fix cross compilation

### DIFF
--- a/pkgs/development/libraries/icu/default.nix
+++ b/pkgs/development/libraries/icu/default.nix
@@ -2,64 +2,53 @@
 
 let
   make-icu = (import ./make-icu.nix) {
-    inherit stdenv lib fetchurl fixDarwinDylibNames testers;
+    inherit stdenv lib buildPackages fetchurl fixDarwinDylibNames testers;
   };
 in
 {
   icu74 = make-icu {
     version = "74.2";
     hash = "sha256-aNsIIhKpbW9T411g9H04uWLp+dIHp0z6x4Apro/14Iw=";
-    nativeBuildRoot = buildPackages.icu74.override { buildRootOnly = true; };
   };
   icu73 = make-icu {
     version = "73.2";
     hash = "sha256-gYqAcS7TyqzZtlIwXgGvx/oWfm8ulJltpEuQwqtgTOE=";
-    nativeBuildRoot = buildPackages.icu73.override { buildRootOnly = true; };
   };
   icu72 = make-icu {
     version = "72.1";
     hash = "sha256-otLTghcJKn7VZjXjRGf5L5drNw4gGCrTJe3qZoGnHWg=";
-    nativeBuildRoot = buildPackages.icu72.override { buildRootOnly = true; };
   };
   icu71 = make-icu {
     version = "71.1";
     hash = "sha256-Z6fm5R9h+vEwa2k1Mz4TssSKvY2m0vRs5q3KJLHiHr8=";
-    nativeBuildRoot = buildPackages.icu71.override { buildRootOnly = true; };
   };
   icu70 = make-icu {
     version = "70.1";
     hash = "sha256-jSBUKMF78Tu1NTAGae0oszihV7HAGuZtMdDT4tR8P9U=";
-    nativeBuildRoot = buildPackages.icu70.override { buildRootOnly = true; };
   };
   icu69 = make-icu {
     version = "69.1";
     hash = "sha256-TLp7es0dPELES7DBS+ZjcJjH+vKzMM6Ha8XzuRXQl0U=";
-    nativeBuildRoot = buildPackages.icu69.override { buildRootOnly = true; };
   };
   icu68 = make-icu {
     version = "68.2";
     hash = "sha256-x5GT3uOQeiGZuClqk7UsXLdDMsJvPRZyaUh2gNR51iU=";
-    nativeBuildRoot = buildPackages.icu68.override { buildRootOnly = true; };
   };
   icu67 = make-icu {
     version = "67.1";
     hash = "sha256-lKgM1vJRpTvSqZf28bWsZlP+eR36tm4esCJ3QPuG1dw=";
-    nativeBuildRoot = buildPackages.icu67.override { buildRootOnly = true; };
   };
   icu66 = make-icu {
     version = "66.1";
     hash = "sha256-UqPyIJq5VVnBzwoU8kM4AB84lhW/AOJYXvPbxD7PCi4=";
-    nativeBuildRoot = buildPackages.icu66.override { buildRootOnly = true; };
   };
   icu64 = make-icu {
     version = "64.2";
     hash = "sha256-Yn1dhHjm2W/IyQ/tSFEjkHmlYaaoueSLCJLyToLTHWw=";
-    nativeBuildRoot = buildPackages.icu64.override { buildRootOnly = true; };
   };
   icu63 = make-icu {
     version = "63.1";
     hash = "sha256-BcSQtpRU/OWGC36OKCEjFnSvChHX7y/r6poyUSmYy50=";
-    nativeBuildRoot = buildPackages.icu63.override { buildRootOnly = true; };
     patches = [
       # https://bugzilla.mozilla.org/show_bug.cgi?id=1499398
       (fetchpatch {
@@ -72,12 +61,10 @@ in
   icu60 = make-icu {
     version = "60.2";
     hash = "sha256-8HPqjzW5JtcLsz5ld1CKpkKosxaoA/Eb4grzhIEdtBg=";
-    nativeBuildRoot = buildPackages.icu60.override { buildRootOnly = true; };
   };
   icu58 = make-icu {
     version = "58.2";
     hash = "sha256-KwpEEBU6myDeDiDH2LZgSacq7yRLU2g9DXUhNxaD2gw=";
-    nativeBuildRoot = buildPackages.icu58.override { buildRootOnly = true; };
     patches = [
       (fetchurl {
         url = "http://bugs.icu-project.org/trac/changeset/39484?format=diff";
@@ -87,4 +74,4 @@ in
     ];
     patchFlags = [ "-p4" ];
   };
- }
+}


### PR DESCRIPTION
## Description of changes

recent [icu package refactoring](https://github.com/NixOS/nixpkgs/pull/290266) caused `pkgsCross.aarch64-multiplatform.icu` to fail with
```
error: function 'anonymous lambda' called with unexpected argument 'buildRootOnly'
``` 

so lets refactor it further :) and expose the build roots via `passthru` and thereby pass arguments in such a way that external users can use `.override` as if these were all ordinary packages. 

## Things done

- deployed a cross-compiled aarch64-multiplatform sway system with this patch
- deployed a native x86_64 system with this patch (it shouldn't trigger any rebuilds)
- Built on platform(s)
  - [x] x86_64-linux  (and `pkgsCross.aarch64-multiplatform.icu`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
