### PR TITLE
lib/tests/test-with-nix.nix: init entrypoint for NixOS/nix CI

### DIFF
--- a/lib/tests/release.nix
+++ b/lib/tests/release.nix
@@ -9,60 +9,7 @@
 let
   lib = import ../.;
   testWithNix = nix:
-    pkgs.runCommand "nixpkgs-lib-tests-nix-${nix.version}" {
-      buildInputs = [
-        (import ./check-eval.nix)
-        (import ./maintainers.nix {
-          inherit pkgs;
-          lib = import ../.;
-        })
-        (import ./teams.nix {
-          inherit pkgs;
-          lib = import ../.;
-        })
-        (import ../path/tests {
-          inherit pkgs;
-        })
-      ];
-      nativeBuildInputs = [
-        nix
-        pkgs.gitMinimal
-      ] ++ lib.optional pkgs.stdenv.isLinux pkgs.inotify-tools;
-      strictDeps = true;
-    } ''
-      datadir="${nix}/share"
-      export TEST_ROOT=$(pwd)/test-tmp
-      export HOME=$(mktemp -d)
-      export NIX_BUILD_HOOK=
-      export NIX_CONF_DIR=$TEST_ROOT/etc
-      export NIX_LOCALSTATE_DIR=$TEST_ROOT/var
-      export NIX_LOG_DIR=$TEST_ROOT/var/log/nix
-      export NIX_STATE_DIR=$TEST_ROOT/var/nix
-      export NIX_STORE_DIR=$TEST_ROOT/store
-      export PAGER=cat
-      cacheDir=$TEST_ROOT/binary-cache
-
-      nix-store --init
-
-      cp -r ${../.} lib
-      echo "Running lib/tests/modules.sh"
-      bash lib/tests/modules.sh
-
-      echo "Running lib/tests/filesystem.sh"
-      TEST_LIB=$PWD/lib bash lib/tests/filesystem.sh
-
-      echo "Running lib/tests/sources.sh"
-      TEST_LIB=$PWD/lib bash lib/tests/sources.sh
-
-      echo "Running lib/fileset/tests.sh"
-      TEST_LIB=$PWD/lib bash lib/fileset/tests.sh
-
-      echo "Running lib/tests/systems.nix"
-      [[ $(nix-instantiate --eval --strict lib/tests/systems.nix | tee /dev/stderr) == '[ ]' ]];
-
-      mkdir $out
-      echo success > $out/${nix.version}
-    '';
+    import ./test-with-nix.nix { inherit lib nix pkgs; };
 
 in
   pkgs.symlinkJoin {

--- a/lib/tests/test-with-nix.nix
+++ b/lib/tests/test-with-nix.nix
@@ -1,0 +1,70 @@
+/**
+ * Instantiate the library tests for a given Nix version.
+ *
+ * IMPORTANT:
+ * This is used by the github.com/NixOS/nix CI.
+ *
+ * Try not to change the interface of this file, or if you need to, ping the
+ * Nix maintainers for help. Thank you!
+ */
+{
+  pkgs,
+  lib,
+  # Only ever use this nix; see comment at top
+  nix,
+}:
+
+pkgs.runCommand "nixpkgs-lib-tests-nix-${nix.version}" {
+  buildInputs = [
+    (import ./check-eval.nix)
+    (import ./maintainers.nix {
+      inherit pkgs;
+      lib = import ../.;
+    })
+    (import ./teams.nix {
+      inherit pkgs;
+      lib = import ../.;
+    })
+    (import ../path/tests {
+      inherit pkgs;
+    })
+  ];
+  nativeBuildInputs = [
+    nix
+    pkgs.gitMinimal
+  ] ++ lib.optional pkgs.stdenv.isLinux pkgs.inotify-tools;
+  strictDeps = true;
+} ''
+  datadir="${nix}/share"
+  export TEST_ROOT=$(pwd)/test-tmp
+  export HOME=$(mktemp -d)
+  export NIX_BUILD_HOOK=
+  export NIX_CONF_DIR=$TEST_ROOT/etc
+  export NIX_LOCALSTATE_DIR=$TEST_ROOT/var
+  export NIX_LOG_DIR=$TEST_ROOT/var/log/nix
+  export NIX_STATE_DIR=$TEST_ROOT/var/nix
+  export NIX_STORE_DIR=$TEST_ROOT/store
+  export PAGER=cat
+  cacheDir=$TEST_ROOT/binary-cache
+
+  nix-store --init
+
+  cp -r ${../.} lib
+  echo "Running lib/tests/modules.sh"
+  bash lib/tests/modules.sh
+
+  echo "Running lib/tests/filesystem.sh"
+  TEST_LIB=$PWD/lib bash lib/tests/filesystem.sh
+
+  echo "Running lib/tests/sources.sh"
+  TEST_LIB=$PWD/lib bash lib/tests/sources.sh
+
+  echo "Running lib/fileset/tests.sh"
+  TEST_LIB=$PWD/lib bash lib/fileset/tests.sh
+
+  echo "Running lib/tests/systems.nix"
+  [[ $(nix-instantiate --eval --strict lib/tests/systems.nix | tee /dev/stderr) == '[ ]' ]];
+
+  mkdir $out
+  echo success > $out/${nix.version}
+''


### PR DESCRIPTION

## Description of changes


Provide a file that the `nix` CI can import. This helps ascertain the release worthiness of Nix itself during its development.
It previously used the following, but that broke somewhat recently.

```nix
              import (nixpkgs + "/lib/tests/release.nix")
                { inherit pkgs;
                  nixVersions = [ nix ];
                }
```

This is intended to be used on the Nix side in
- https://github.com/NixOS/nix/pull/9900



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
