### PR TITLE
wleave: add missing resources

### DIFF
--- a/pkgs/tools/wayland/wleave/default.nix
+++ b/pkgs/tools/wayland/wleave/default.nix
@@ -36,7 +36,18 @@ rustPlatform.buildRustPackage rec {
     glib
   ];
 
+  postPatch = ''
+    substituteInPlace style.css \
+      --replace-fail "/usr/share/wleave" "$out/share/${pname}"
+
+    substituteInPlace src/main.rs \
+      --replace-fail "/etc/wleave" "$out/etc/${pname}"
+  '';
+
   postInstall = ''
+    install -Dm644 -t "$out/etc/wleave" {"style.css","layout"}
+    install -Dm644 -t "$out/share/wleave/icons" icons/*
+
     for f in man/*.scd; do
       local page="man/$(basename "$f" .scd)"
       scdoc < "$f" > "$page"


### PR DESCRIPTION
Adds resources (icons and default config files) to the derivation, and patches
the program to point to them. Without these, the program lacks a default configuration and `nix run nixpkgs#wleave` doesn't work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin