### PR TITLE
codefresh: init at 0.87.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18989,6 +18989,12 @@
     githubId = 321799;
     name = "Paul Colomiets";
   };
+  takac = {
+    email = "cammann.tom@gmail.com";
+    github = "takac";
+    githubId = 1015381;
+    name = "Tom Cammann";
+  };
   takagiy = {
     email = "takagiy.4dev@gmail.com";
     github = "takagiy";

--- a/pkgs/by-name/co/codefresh/package.json
+++ b/pkgs/by-name/co/codefresh/package.json
@@ -1,0 +1,118 @@
+{
+  "name": "codefresh",
+  "version": "0.87.3",
+  "description": "Codefresh command line utility",
+  "main": "index.js",
+  "preferGlobal": true,
+  "scripts": {
+    "generate-completion": "node ./lib/interface/cli/completion/generate",
+    "test": "jest .spec.js --coverage",
+    "e2e": "bash e2e/e2e.spec.sh",
+    "eslint": "eslint --fix lib/logic/**",
+    "pkg": "pkg . -t node16-alpine-x64,node16-macos-x64,node16-linux-x64,node16-win-x64,node16-linux-arm64 --out-path ./dist",
+    "serve-docs": "yarn build-local-docs && cd temp && hugo server -D",
+    "serve-docs-beta": "ALLOW_BETA_COMMANDS=true yarn build-local-docs && cd temp && hugo server -D",
+    "build-local-docs": "node ./docs/index.js",
+    "build-public-docs": "node ./docs/index.js && cd temp && hugo",
+    "postinstall": "node run-check-version.js"
+  },
+  "bin": {
+    "codefresh": "lib/interface/cli/codefresh"
+  },
+  "repository": "git+https://github.com/codefresh-io/cli.git",
+  "keywords": [
+    "command line"
+  ],
+  "pkg": {
+    "scripts": [
+      "lib/**/*.js",
+      "node_modules/codefresh-sdk/lib/**/*.js",
+      "node_modules/kubernetes-client/**/*.js"
+    ],
+    "assets": "lib/**/*.hbs"
+  },
+  "resolutions": {
+    "websocket-extensions": "^0.1.4",
+    "lodash": "^4.17.21",
+    "json-schema": "^0.4.0",
+    "ajv": "^6.12.6",
+    "normalize-url": "^4.5.1",
+    "ansi-regex": "^5.0.1",
+    "y18n": "^4.0.1",
+    "shelljs": "^0.8.5",
+    "codefresh-sdk/swagger-client/qs": "6.9.7",
+    "kubernetes-client/qs": "6.9.7",
+    "**/request/qs": "6.5.3"
+  },
+  "dependencies": {
+    "@codefresh-io/docker-reference": "^0.0.5",
+    "adm-zip": "^0.5.5",
+    "ajv": "^6.12.6",
+    "bluebird": "^3.5.1",
+    "cf-errors": "^0.1.16",
+    "chalk": "^4.1.0",
+    "cli-progress": "3.10.0",
+    "codefresh-sdk": "^1.12.0",
+    "colors": "1.4.0",
+    "columnify": "^1.6.0",
+    "compare-versions": "^3.4.0",
+    "copy-dir": "^0.3.0",
+    "debug": "^3.1.0",
+    "diff": "^3.5.0",
+    "dockerode": "^2.5.7",
+    "draftlog": "^1.0.12",
+    "figlet": "^1.4.0",
+    "filesize": "^3.5.11",
+    "firebase": "git+https://github.com/codefresh-io/firebase.git#80b2ed883ff281cd67b53bd0f6a0bbd6f330fed5",
+    "flat": "^4.1.1",
+    "inquirer": "^7.1.0",
+    "js-yaml": "^3.10.0",
+    "kefir": "^3.8.1",
+    "kubernetes-client": "^9.0.0",
+    "lodash": "^4.17.21",
+    "mkdirp": "^0.5.1",
+    "moment": "^2.29.4",
+    "mongodb": "^4.17.2",
+    "node-forge": "^1.3.0",
+    "ora": "^5.4.1",
+    "prettyjson": "^1.2.5",
+    "promise-retry": "^2.0.1",
+    "recursive-readdir": "^2.2.3",
+    "request": "^2.88.0",
+    "request-promise": "^4.2.2",
+    "requestretry": "^7.0.2",
+    "rimraf": "^2.6.2",
+    "semver": "^7.5.4",
+    "tar-stream": "^2.2.0",
+    "uuid": "^3.1.0",
+    "yaml": "^1.10.0",
+    "yargs": "^15.4.1",
+    "yargs-parser": "^13.0.0",
+    "zip": "^1.2.0"
+  },
+  "devDependencies": {
+    "@types/node-forge": "^1.0.1",
+    "eslint": "^7.32.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-plugin-import": "^2.25.4",
+    "eslint-plugin-jest": "^27.6.3",
+    "hugo-cli": "^0.5.4",
+    "jest": "^29.7.0",
+    "pkg": "5.5.2"
+  },
+  "bugs": {
+    "url": "https://github.com/codefresh-io/cli/issues"
+  },
+  "homepage": "https://github.com/codefresh-io/cli#readme",
+  "author": "Codefresh",
+  "license": "ISC",
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "setupFiles": [
+      "./test-setup.js"
+    ]
+  }
+}

--- a/pkgs/by-name/co/codefresh/package.nix
+++ b/pkgs/by-name/co/codefresh/package.nix
@@ -1,0 +1,36 @@
+{ lib, mkYarnPackage, fetchFromGitHub, fetchYarnDeps, testers, codefresh }:
+
+mkYarnPackage rec {
+  pname = "codefresh";
+  version = "0.87.3";
+
+  src = fetchFromGitHub {
+    owner = "codefresh-io";
+    repo = "cli";
+    rev = "v${version}";
+    hash = "sha256-SUwt0oWls823EeLxT4CW+LDdsjAtSxxxKkllhMJXCtM=";
+  };
+
+  offlineCache = fetchYarnDeps {
+    yarnLock = "${src}/yarn.lock";
+    hash = "sha256-tzsHbvoQ59MwE4TYdPweLaAv9r4V8oyTQyvdeyPCsHY=";
+  };
+  packageJSON = ./package.json;
+
+  doDist = false;
+
+  passthru.tests.version = testers.testVersion {
+    package = codefresh;
+    # codefresh needs to read a config file, this is faked out with a subshell
+    command = "codefresh --cfconfig <(echo 'contexts:') version";
+  };
+
+  meta = {
+    changelog = "https://github.com/codefresh-io/cli/releases/tag/v${version}";
+    description = "Codefresh CLI tool to interact with Codefresh services.";
+    homepage = "https://github.com/codefresh-io/cli";
+    license = lib.licenses.mit;
+    mainProgram = "codefresh";
+    maintainers = [ lib.maintainers.takac ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Add codefresh cli[1] tool to interact with codefresh[2] service.

[1] https://github.com/codefresh-io/cli
[2] https://codefresh.io/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
