### PR TITLE
immersed-vr: add support for darwin

### DIFF
--- a/pkgs/by-name/im/immersed-vr/darwin.nix
+++ b/pkgs/by-name/im/immersed-vr/darwin.nix
@@ -1,0 +1,24 @@
+{ stdenv
+, pname
+, version
+, src
+, meta
+, unzip
+, undmg
+}:
+
+stdenv.mkDerivation {
+  inherit pname version src meta;
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    mkdir -p $out/Applications
+    cp -r *.app $out/Applications
+  '';
+
+  # Immersed is notarized.
+  dontFixup = true;
+}

--- a/pkgs/by-name/im/immersed-vr/darwin.nix
+++ b/pkgs/by-name/im/immersed-vr/darwin.nix
@@ -3,7 +3,6 @@
 , version
 , src
 , meta
-, unzip
 , undmg
 }:
 
@@ -15,8 +14,12 @@ stdenv.mkDerivation {
   sourceRoot = ".";
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/Applications
     cp -r *.app $out/Applications
+
+    runHook postInstall
   '';
 
   # Immersed is notarized.

--- a/pkgs/by-name/im/immersed-vr/linux.nix
+++ b/pkgs/by-name/im/immersed-vr/linux.nix
@@ -1,0 +1,15 @@
+{ stdenv
+, pname
+, version
+, src
+, meta
+, appimageTools
+}:
+appimageTools.wrapType2 rec {
+  inherit pname version src meta;
+  name = "${pname}-${version}";
+
+  extraInstallCommands = ''
+    mv $out/bin/{${name},${pname}}
+  '';
+}

--- a/pkgs/by-name/im/immersed-vr/linux.nix
+++ b/pkgs/by-name/im/immersed-vr/linux.nix
@@ -1,5 +1,4 @@
-{ stdenv
-, pname
+{ pname
 , version
 , src
 , meta

--- a/pkgs/by-name/im/immersed-vr/package.nix
+++ b/pkgs/by-name/im/immersed-vr/package.nix
@@ -1,27 +1,38 @@
 { lib
 , appimageTools
+, callPackage
 , fetchurl
+, stdenv
 }:
-appimageTools.wrapType2 rec {
+let
   pname = "immersed-vr";
   version = "9.10";
   name = "${pname}-${version}";
 
-  src = fetchurl {
-    url = "https://web.archive.org/web/20240210075929/https://static.immersed.com/dl/Immersed-x86_64.AppImage";
-    hash = "sha256-Mx8UnV4fZSebj9ah650ZqsL/EIJpM6jl8tYmXJZiJpA=";
+  sources = rec {
+    x86_64-linux = {
+      url = "https://web.archive.org/web/20240210075929/https://static.immersed.com/dl/Immersed-x86_64.AppImage";
+      hash = "sha256-Mx8UnV4fZSebj9ah650ZqsL/EIJpM6jl8tYmXJZiJpA=";
+    };
+    aarch64-linux = x86_64-linux;
+    x86_64-darwin = {
+      url = "https://web.archive.org/web/20240210075929/https://static.immersed.com/dl/Immersed.dmg";
+      hash = "sha256-CR2KylovlS7zerZIEScnadm4+ENNhib5QnS6z5Ihv1Y=";
+    };
+    aarch64-darwin = x86_64-darwin;
   };
 
-  extraInstallCommands = ''
-    mv $out/bin/{${name},${pname}}
-  '';
+  src = fetchurl (sources.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}"));
 
   meta = with lib; {
     description = "A VR coworking platform";
     homepage = "https://immersed.com";
     license = licenses.unfree;
     maintainers = with maintainers; [ haruki7049 ];
-    platforms = [ "x86_64-linux" ];
+    platforms = builtins.attrNames sources;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
   };
-}
+
+in if stdenv.isDarwin
+then callPackage ./darwin.nix { inherit pname version src meta; }
+else callPackage ./linux.nix { inherit pname version src meta; }

--- a/pkgs/by-name/im/immersed-vr/package.nix
+++ b/pkgs/by-name/im/immersed-vr/package.nix
@@ -7,14 +7,12 @@
 let
   pname = "immersed-vr";
   version = "9.10";
-  name = "${pname}-${version}";
 
   sources = rec {
     x86_64-linux = {
       url = "https://web.archive.org/web/20240210075929/https://static.immersed.com/dl/Immersed-x86_64.AppImage";
       hash = "sha256-Mx8UnV4fZSebj9ah650ZqsL/EIJpM6jl8tYmXJZiJpA=";
     };
-    aarch64-linux = x86_64-linux;
     x86_64-darwin = {
       url = "https://web.archive.org/web/20240210075929/https://static.immersed.com/dl/Immersed.dmg";
       hash = "sha256-CR2KylovlS7zerZIEScnadm4+ENNhib5QnS6z5Ihv1Y=";


### PR DESCRIPTION
Add support for darwin machines for the immersed-vr package.

## Description of changes

Added support for darwin machines for the immersed-vr package. I took inspiration from the 1password-gui package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
