### PR TITLE
deepin.deepin-reader: Build tests with C++14.

### DIFF
--- a/pkgs/desktops/deepin/apps/deepin-reader/0001-build-tests-with-cpp-14.patch
+++ b/pkgs/desktops/deepin/apps/deepin-reader/0001-build-tests-with-cpp-14.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/tests.pro b/tests/tests2.pro
+index 314cad227646..48f1c66ee3f7 100644
+--- a/tests/tests.pro
++++ b/tests/tests.pro
+@@ -6,7 +6,7 @@ QT += core gui sql printsupport dbus testlib widgets
+ #QMAKE_CXXFLAGS += -g -fsanitize=undefined,address -O2
+ #QMAKE_LFLAGS += -g -fsanitize=undefined,address -O2
+ 
+-CONFIG += c++11 link_pkgconfig resources_big testcase no_testcase_installs
++CONFIG += c++14 link_pkgconfig resources_big testcase no_testcase_installs
+ 
+ #访问私有方法 -fno-access-control
+ QMAKE_CXXFLAGS += -g -Wall -fprofile-arcs -ftest-coverage -fno-access-control -O0 -fno-inline

--- a/pkgs/desktops/deepin/apps/deepin-reader/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-reader/default.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-G5UZ8lBrUo5G3jMae70p/zi9kOVqHWMNCedOy45L1PA=";
   };
 
+  patches = [ ./0001-build-tests-with-cpp-14.patch ];
+
   # don't use vendored htmltopdf
   postPatch = ''
     substituteInPlace deepin_reader.pro \


### PR DESCRIPTION
## Description of changes

Fixes issues caused by #282245 which requires C++14 or higher now.

This only changes the version used in tests, not in the rest of the build, because gtest isn't present in the rest of the build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
