### PR TITLE
pg_featureserv: install assets and configuration file

### DIFF
--- a/pkgs/servers/geospatial/pg_featureserv/default.nix
+++ b/pkgs/servers/geospatial/pg_featureserv/default.nix
@@ -13,7 +13,27 @@ buildGoModule rec {
 
   vendorHash = "sha256-BHiEVyi3FXPovYy3iDP8q+y+LgfI4ElDPVZexd7nnuo=";
 
+  postPatch = ''
+    # fix default configuration file location
+    substituteInPlace \
+      internal/conf/config.go \
+      --replace-fail "viper.AddConfigPath(\"/etc\")" "viper.AddConfigPath(\"$out/share/config\")"
+
+    # fix assets location in configuration file
+    substituteInPlace \
+      config/pg_featureserv.toml.example \
+      --replace-fail "AssetsPath = \"./assets\"" "AssetsPath = \"$out/share/assets\""
+  '';
+
   ldflags = [ "-s" "-w" "-X github.com/CrunchyData/pg_featureserv/conf.setVersion=${version}" ];
+
+  postInstall = ''
+    mkdir -p $out/share
+    cp -r assets $out/share
+
+    mkdir -p $out/share/config
+    cp config/pg_featureserv.toml.example $out/share/config/pg_featureserv.toml
+  '';
 
   meta = with lib; {
     description = "Lightweight RESTful Geospatial Feature Server for PostGIS in Go";


### PR DESCRIPTION
## Description of changes

Install missing assets files and configuration file.

Manually tested:

```
$ DATABASE_URL="host=localhost" ./result/bin/pg_featureserv

INFO[0000] ----  pg_featureserv - Version 1.3.1 ----------
INFO[0000] Using config file: /nix/store/1xdvidb87cnqw1q66casrxmf5xplni54-pg_featureserv-1.3.1/share/config/pg_featureserv.toml
INFO[0000] Using database connection info from environment variable DATABASE_URL
INFO[0000] Connected as imincik to  @ localhost
INFO[0000] Serving HTTP  at http://0.0.0.0:9000
INFO[0000] CORS Allowed Origins: *
INFO[0000] ====  Service: pg-featureserv  ====
```
```
$ curl http://localhost:9000/

{"title":"pg-featureserv","description":"Crunchy Data Feature Server for PostGIS","links":[{"href":"http://localhost:9000/index","rel":"self","type":"application/json","title":"This document as JSON"},{"href":"http://localhost:9000/index.html","rel":"alternate","type":"text/html","title":"This document as HTML"},{"href":"http://localhost:9000/api","rel":"service-desc","type":"application/vnd.oai.openapi+json;version=3.0","title":"API definition"},{"href":"http://localhost:9000/conformance","rel":"conformance","type":"application/json","title":"OGC API conformance classes implemented by this server"},{"href":"http://localhost:9000/collections","rel":"data","type":"application/json","title":"collections"},{"href":"http://localhost:9000/functions","rel":"functions","type":"application/json","title":"functions"}]}% 
```

Without this PR, application would crash with missing asset files error.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
