### PR TITLE
libtins: Force compilation using C++14.

### DIFF
--- a/pkgs/development/libraries/libtins/0001-force-cpp-14.patch
+++ b/pkgs/development/libraries/libtins/0001-force-cpp-14.patch
@@ -1,0 +1,26 @@
+This change bypasses all the code that attempts to see which C++11 features are enabled in your specific C++11 compiler.  C++14 is required for gtest 1.13+.
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 902233e676ee..49ac8a1010a4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -103,17 +103,9 @@ ENDIF()
+ # C++11 support
+ OPTION(LIBTINS_ENABLE_CXX11 "Compile libtins with c++11 features" ON)
+ IF(LIBTINS_ENABLE_CXX11)
+-    # We only use declval and decltype on gcc/clang as VC fails to build that code,
+-    # at least on VC2013
+-    IF(HAS_CXX11_RVALUE_REFERENCES AND HAS_CXX11_FUNCTIONAL AND HAS_CXX11_CHRONO AND
+-       HAS_CXX11_NOEXCEPT AND ((HAS_CXX11_DECLVAL AND HAS_CXX11_DECLTYPE) OR MSVC))
+-        SET(TINS_HAVE_CXX11 ON)
+-        MESSAGE(STATUS "Enabling C++11 features")
+-        SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX11_COMPILER_FLAGS}")
+-    ELSE()
+-        MESSAGE(WARNING "The compiler doesn't support the necessary C++11 features. "
+-                        "Disabling C++11 on this build")
+-    ENDIF()
++    SET(TINS_HAVE_CXX11 ON)
++    MESSAGE(STATUS "Using C++11 features")
++    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+ ELSE(LIBTINS_ENABLE_CXX11)
+     MESSAGE(
+         WARNING

--- a/pkgs/development/libraries/libtins/default.nix
+++ b/pkgs/development/libraries/libtins/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation rec {
       url = "https://github.com/mfontanini/libtins/commit/812be7966d445ec56e88eab512f8fd2d57152427.patch";
       hash = "sha256-5RCFPe95r1CBrAocjTPR2SvUlgaGa1aBc8RazyxUj3M=";
     })
+    # Required for gtest 1.13+.
+    ./0001-force-cpp-14.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
## Description of changes

#282245 breaks C++11 users.  Libtins is not only a C++11 user, but it also has chunks of code dedicated to working out which C++11 features are enabled to choose whether to include the C++ optimisations or not.

In this change, I've decided to just force C++14 mode and to remove the check on whether the features are enabled or not.  Otherwise I would have to port the enablement checks and probably perform a lot of renaming throughout the codebase for accuracy.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
