### PR TITLE
idb-companion: init at 1.1.8

### DIFF
--- a/pkgs/by-name/id/idb-companion/package.nix
+++ b/pkgs/by-name/id/idb-companion/package.nix
@@ -1,0 +1,35 @@
+{ lib
+, stdenv
+, fetchurl
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "idb-companion";
+  version = "1.1.8";
+
+  src = fetchurl {
+    url = "https://github.com/facebook/idb/releases/download/v${finalAttrs.version}/idb-companion.universal.tar.gz";
+    hash = "sha256-O3LMappbGiKhiCBahAkNOilDR6hGGA79dVzxo8hI4+c=";
+  };
+
+  sourceRoot = "idb-companion.universal";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r . $out/
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A powerful command line tool for automating iOS simulators and devices";
+    homepage = "https://github.com/facebook/idb";
+    license = licenses.mit;
+    platforms = platforms.darwin;
+    mainProgram = "idb_companion";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ siddarthkay ];
+  };
+})


### PR DESCRIPTION
## Description of changes

[idb-companion](https://github.com/facebook/idb) s a `gRPC` server in Objective-C++ that runs on macOS. It talks to the native APIs that are used for automating Simulators and Devices.

nix derivation of idb-companion in status-mobile repo -> https://github.com/status-im/status-mobile/blob/develop/nix/pkgs/idb-companion/default.nix

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
