### PR TITLE
CONTRIBUTING.md: change table column order for staging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -439,14 +439,14 @@ gitGraph
 
 Here's an overview of the different branches:
 
-| branch | `master` | `staging` | `staging-next` |
+| branch | `master` | `staging-next` | `staging` |
 | --- | --- | --- | --- |
-| Used for development | ✔️ | ✔️ | ❌ |
-| Built by Hydra | ✔️ | ❌ | ✔️ |
-| [Mass rebuilds][mass-rebuild] | ❌ | ✔️ | ⚠️  Only to fix Hydra builds |
-| Critical security fixes | ✔️ for non-mass-rebuilds | ❌ | ✔️ for mass-rebuilds |
-| Automatically merged into | `staging-next` | - | `staging` |
-| Manually merged into | - | `staging-next` | `master` |
+| Used for development | ✔️ | ❌ | ✔️ |
+| Built by Hydra | ✔️ | ✔️ | ❌ |
+| [Mass rebuilds][mass-rebuild] | ❌ | ⚠️  Only to fix Hydra builds | ✔️ |
+| Critical security fixes | ✔️ for non-mass-rebuilds | ✔️ for mass-rebuilds | ❌ |
+| Automatically merged into | `staging-next` | `staging` | - |
+| Manually merged into | - | `master` | `staging-next` |
 
 The staging workflow is used for all main branches, `master` and `release-YY.MM`, with corresponding names:
 - `master`/`release-YY.MM`


### PR DESCRIPTION
## Description of changes

Changes the table column order for the staging/staging-next workflow to better match the order in which merging happens.

The graph right above the table has the order as `master` ⇒ `staging-next` ⇒ `staging`. This corresponds with the workflow, i.e. automatic merges happen in that direction and the manual merging is in reverse direction of that. As a first time reader of this document the table was very confusing due to the disparity of that. With this change the table should read more fluently for people not familiar with the workflow since the table follows the step-by-step flow of commits.

Effectively it means when reading the table you don't have to jump between the first and third column and then the second and third but you can read from first via second to third in one go.
This is of course an opinionated change, so feel free to reject it.

<details> 
  <summary>For convenience a graphical comparison</summary>
<h3>old version</h3>
<p><img src="https://github.com/NixOS/nixpkgs/assets/6145260/e9eaaaec-526d-4e9e-8a59-3fa3486cba1a"/></p>
<h3>new version</h3><br/>
<p><img src="https://github.com/NixOS/nixpkgs/assets/6145260/7b90831f-08b2-4ded-8ba7-718d65b38d1c"/></p>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ~~Built on platform(s)~~
  - [ ] ~~x86_64-linux~~
  - [ ] ~~aarch64-linux~~
  - [ ] ~~x86_64-darwin~~
  - [ ] ~~aarch64-darwin~~
- ~~For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~~
  - [ ] ~~`sandbox = relaxed`~~
  - [ ] ~~`sandbox = true`~~
- [ ] ~~Tested, as applicable:~~
  - ~~[NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~
  - ~~and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)~~
  - ~~or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)~~
  - ~~made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages~~
- [ ] ~~Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)~~
- [ ] ~~Tested basic functionality of all binary files (usually in `./result/bin/`)~~
- ~~[24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)~~
  - [ ] ~~(Package updates) Added a release notes entry if the change is major or breaking~~
  - [ ] ~~(Module updates) Added a release notes entry if the change is significant~~
  - [ ] ~~(Module addition) Added a release notes entry if adding a new NixOS module~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
