### PR TITLE
nixos/systemd: merge unit options as lists when at least one value is a list

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -348,6 +348,11 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - The `mpich` package expression now requires `withPm` to be a list, e.g. `"hydra:gforker"` becomes `[ "hydra" "gforker" ]`.
 
+- When merging systemd unit options (of type `unitOption`),
+  if at least one definition is a list, all those which aren't are now lifted into a list,
+  making it possible to accumulate definitions without resorting to `mkForce`,
+  hence to retain the definitions not anticipating that need.
+
 - YouTrack is bumped to 2023.3. The update is not performed automatically, it requires manual interaction. See the YouTrack section in the manual for details.
 
 - QtMultimedia has changed its default backend to `QT_MEDIA_BACKEND=ffmpeg` (previously `gstreamer` on Linux or `darwin` on MacOS).

--- a/nixos/lib/systemd-unit-options.nix
+++ b/nixos/lib/systemd-unit-options.nix
@@ -21,14 +21,8 @@ in rec {
       let
         defs' = filterOverrides defs;
       in
-        if isList (head defs').value
-        then concatMap (def:
-          if builtins.typeOf def.value == "list"
-          then def.value
-          else
-            throw "The definitions for systemd unit options should be either all lists, representing repeatable options, or all non-lists, but for the option ${showOption loc}, the definitions are a mix of list and non-list ${lib.options.showDefs defs'}"
-        ) defs'
-
+        if any (def: isList def.value) defs'
+        then concatMap (def: toList def.value) defs'
         else mergeEqualOption loc defs';
   };
 

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -174,4 +174,6 @@ with pkgs;
   nixpkgs-check-by-name = callPackage ./nixpkgs-check-by-name { };
 
   auto-patchelf-hook = callPackage ./auto-patchelf-hook { };
+
+  systemd = callPackage ./systemd { };
 }

--- a/pkgs/test/systemd/default.nix
+++ b/pkgs/test/systemd/default.nix
@@ -1,0 +1,5 @@
+{ lib, callPackage }:
+
+lib.recurseIntoAttrs {
+  nixos = callPackage ./nixos { };
+}

--- a/pkgs/test/systemd/nixos/default.nix
+++ b/pkgs/test/systemd/nixos/default.nix
@@ -1,0 +1,37 @@
+{ pkgs, lib, stdenv, ... }:
+
+lib.runTests {
+  # Merging two non-list definitions must still result in an error
+  # about a conflicting definition.
+  test-unitOption-merging-non-lists-conflict =
+    let nixos = pkgs.nixos {
+        system.stateVersion = lib.trivial.release;
+        systemd.services.systemd-test-nixos = {
+          serviceConfig = lib.mkMerge [
+            { StateDirectory = "foo"; }
+            { StateDirectory = "bar"; }
+          ];
+        };
+      };
+    in {
+    expr = (builtins.tryEval (nixos.config.systemd.services.systemd-test-nixos.serviceConfig.StateDirectory)).success;
+    expected = false;
+  };
+
+  # Merging must lift non-list definitions to a list
+  # if at least one of them is a list.
+  test-unitOption-merging-list-non-list-append =
+    let nixos = pkgs.nixos {
+        system.stateVersion = lib.trivial.release;
+        systemd.services.systemd-test-nixos = {
+          serviceConfig = lib.mkMerge [
+            { StateDirectory = "foo"; }
+            { StateDirectory = ["bar"]; }
+          ];
+        };
+      };
+    in {
+    expr = nixos.config.systemd.services.systemd-test-nixos.serviceConfig.StateDirectory;
+    expected = [ "foo" "bar" ];
+  };
+}


### PR DESCRIPTION
## Description of changes
When merging values of systemd `unitOption`s, if at least one is a list, all of them are now lifted with `toList`, making it possible to accumulate values on `unitOption`s of services not anticipating that need.

Previously the definitions for systemd unit options had to either be all lists, representing repeatable options, or all non-lists.

This PR springs from [another PR on `systemd-confinement`](https://github.com/NixOS/nixpkgs/pull/289593#issuecomment-1953233856).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
