### PR TITLE
losslesscut-bin: add passthru.updateScript

### DIFF
--- a/pkgs/applications/video/losslesscut-bin/build-from-appimage.nix
+++ b/pkgs/applications/video/losslesscut-bin/build-from-appimage.nix
@@ -53,6 +53,7 @@ in
     platforms = [ "x86_64-linux" ];
     mainProgram = "losslesscut";
   };
-}) // {
+}).overrideAttrs (finalAttrs: previousAttrs: {
   inherit pname version;
-}
+  name = "${finalAttrs.pname}-${finalAttrs.version}";
+})

--- a/pkgs/applications/video/losslesscut-bin/default.nix
+++ b/pkgs/applications/video/losslesscut-bin/default.nix
@@ -39,17 +39,22 @@ in
   else if stdenv.hostPlatform.isDarwin then x86_64-dmg
   else if stdenv.hostPlatform.isCygwin then x86_64-windows
   else x86_64-appimage
-).overrideAttrs
-  (oldAttrs: {
-    passthru = (oldAttrs.passthru or { }) // {
-      inherit x86_64-appimage x86_64-dmg aarch64-dmg x86_64-windows;
+).overrideAttrs (finalAttrs: previousAttrs: {
+  passthru = (previousAttrs.passthru or { }) // {
+    inherit x86_64-appimage x86_64-dmg aarch64-dmg x86_64-windows;
+    updateBinaryPackage = callPackage ./update-binary-package.nix { };
+    updateScript = finalAttrs.passthru.updateBinaryPackage {
+      filesToOverride = [ (toString ./default.nix) ];
+      formatAttrNames = [ "x86_64-appimage" "x86_64-dmg" "aarch64-dmg" "x86_64-windows" ];
+      repoUrl = "https://github.com/mifi/lossless-cut";
     };
-    meta = oldAttrs.meta // {
-      platforms = lib.unique (
-        x86_64-appimage.meta.platforms
-          ++ x86_64-dmg.meta.platforms
-          ++ aarch64-dmg.meta.platforms
-          ++ x86_64-windows.meta.platforms
-      );
-    };
-  })
+  };
+  meta = previousAttrs.meta // {
+    platforms = lib.unique (
+      x86_64-appimage.meta.platforms
+        ++ x86_64-dmg.meta.platforms
+        ++ aarch64-dmg.meta.platforms
+        ++ x86_64-windows.meta.platforms
+    );
+  };
+})

--- a/pkgs/applications/video/losslesscut-bin/update-binary-package.nix
+++ b/pkgs/applications/video/losslesscut-bin/update-binary-package.nix
@@ -1,0 +1,87 @@
+{ lib
+, writeShellApplication
+, gnused
+, jo
+, lastversion
+, nix-prefetch
+}:
+
+let
+  concatMapStringAttrsSep = sep: f: attrs:
+    lib.concatMapStringsSep sep (name: f name attrs.${name}) (lib.attrNames attrs);
+in
+lib.makeOverridable (
+{ attrPath ? null
+, filesToOverride
+, formatAttrNames
+, prefetchHashAlgo ? "sha256"
+, repoUrl
+, fetchVersionCommand ? [ "lastversion" repoUrl ]
+}@args:
+let
+  updateScriptBin = writeShellApplication {
+    name = "update-binary-package";
+    runtimeInputs = [
+      gnused
+      jo
+      lastversion
+      nix-prefetch
+    ];
+    text = ''
+      set -x
+      ${concatMapStringAttrsSep "\n" lib.toShellVar ({
+        inherit
+          formatAttrNames
+          prefetchHashAlgo
+          ;
+      })}
+      mainAttrPath="''$UPDATE_NIX_ATTR_PATH"
+      oldVersion="''${UPDATE_NIX_OLD_VERSION:-$(nix --extra-experimental-features "nix-command" eval --impure --raw --expr "(import ./. { }).$mainAttrPath.version")}"
+      newVersion="''${VERSION:-$(${if lib.isList fetchVersionCommand then lib.escapeShellArgs fetchVersionCommand else fetchVersionCommand})}"
+      filesToOverride=("$@")
+      if [[ "$oldVersion" == "$newVersion" ]]; then
+        echo "No version change detected. Both are $oldVersion." >&2
+        echo []
+        exit 0
+      fi
+      declare -a oldHashes=()
+      for format in "''${formatAttrNames[@]}"; do
+        oldHashes+=("$(nix --extra-experimental-features "nix-command" eval --impure --raw --expr "(import ./. { }).$mainAttrPath.$format.src.outputHash")")
+      done
+      for fileToOverride in "''${filesToOverride[@]}"; do
+        sed -i "s#\"$oldVersion\"#\"$newVersion\"#g" "$fileToOverride"
+      done
+      declare -a newHashes=()
+      for formatAttrName in "''${formatAttrNames[@]}"; do
+        newHashes+=("$(nix-prefetch --expr "{ $prefetchHashAlgo }: ((import ./. { }).$mainAttrPath.$formatAttrName.override { hash = $prefetchHashAlgo; }).src")")
+      done
+      declare -a sedHashCommand=()
+      for i in "''${!formatAttrNames[@]}"; do
+        sedHashCommand+=(-e "s#''${oldHashes[$i]}#''${newHashes[$i]}#g")
+      done
+      for fileToOverride in "''${filesToOverride[@]}"; do
+        sed -i "''${sedHashCommand[@]}" "$fileToOverride"
+      done
+      jo -p -a "$(jo -- \
+        -s attrPath="$mainAttrPath" \
+        -s oldVersion="$oldVersion" \
+        -s newVersion="$newVersion" \
+        files="$(jo -a "''${filesToOverride[@]}")" \
+      )"
+    '';
+  };
+in
+{
+  command = [
+    (lib.getExe updateScriptBin)
+  ] ++ filesToOverride;
+  supportedFeatures = [
+    "commit"
+  ];
+  # This is for debugging purpose.
+  # Invoke the following command to see how  how the result updateScript work in real time:
+  # UPDATE_NIX_ATTR_PATH=<attribute path> nix run .#<attribute path>.updateScript.updateScriptBin <files in need of update>
+  inherit updateScriptBin; # for debugging purpose
+} // lib.optionalAttrs (attrPath != null) {
+  inherit attrPath;
+})

--- a/pkgs/development/python-modules/lastversion/default.nix
+++ b/pkgs/development/python-modules/lastversion/default.nix
@@ -1,0 +1,116 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+  # nativeBuildInputs
+, pythonRelaxDepsHook
+, setuptools
+  # nativeCheckInputs
+, pytestCheckHook
+  # install_requires
+, appdirs
+, beautifulsoup4
+, cachecontrol
+, distro
+, feedparser
+, lockfile
+, packaging
+, python-dateutil
+, pyyaml
+, requests
+, tqdm
+, urllib3
+  # test_requires
+, pytest
+, flake8
+, flake8-bugbear
+, pytest-xdist
+, pytest-cov
+  # doc_requires
+, mkdocs
+, mkdocs-material
+, mkdocstrings
+, mkdocstrings-python
+}:
+let
+  self = buildPythonPackage rec {
+    pname = "lastversion";
+    version = "3.5.0";
+    pyproject = true;
+
+    disabled = pythonOlder "3.6";
+
+    src = fetchFromGitHub {
+      owner = "dvershinin";
+      repo = "lastversion";
+      rev = "v${version}";
+      hash = "sha256-SeDLpMP8cF6CC3qJ6V8dLErl6ihpnl4lHeBkp7jtQgI=";
+    };
+
+    nativeBuildInputs = [
+      pythonRelaxDepsHook
+      setuptools
+    ];
+
+    propagatedBuildInputs = [
+      appdirs
+      beautifulsoup4
+      cachecontrol
+      cachecontrol.optional-dependencies.filecache
+      distro
+      feedparser
+      packaging
+      python-dateutil
+      pyyaml
+      requests
+      tqdm
+      urllib3
+    ];
+
+    pythonImportsCheck = [ "lastversion" ];
+
+    pythonRelaxDeps = [
+      # install_requires
+      "cachecontrol" # Use newer cachecontrol that uses filelock instead of lockfile
+      "urllib3" # The cachecontrol and requests incompatibility issue is closed
+      # tests_requires
+      "pytest-xdist" # The upstream issue is closed
+      # docs_requires
+      "mkdocs"
+      "mkdors-material"
+    ];
+
+    pythonRemoveDeps = [
+      "lockfile" # "cachecontrol" now uses filelock instead
+    ];
+
+    passthru = {
+      optional-dependencies = {
+        docs = [
+          mkdocs
+          mkdocs-material
+          mkdocstrings
+          mkdocstrings-python
+        ];
+        # Not going to test here, as the tests require internet connection.
+        tests = [
+          pytest
+          flake8
+          flake8-bugbear
+          pytest-xdist
+          pytest-cov
+        ];
+      };
+    };
+
+    meta = with lib; {
+      description = "Find the latest release version of an arbitrary project";
+      homepage = "https://github.com/dvershinin/lastversion";
+      changelog = "https://github.com/dvershinin/lastversion/blob/master/CHANGELOG.md";
+      license = licenses.bsd2;
+      maintainers = with maintainers; [ ShamrockLee ];
+      mainProgram = "lastversion";
+    };
+  };
+in
+self

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1926,6 +1926,8 @@ with pkgs;
 
   kubevirt = callPackage ../tools/virtualization/kubevirt { };
 
+  lastversion = with python3Packages; toPythonApplication lastversion;
+
   lektor = callPackage ../tools/misc/lektor { };
 
   licenseclassifier = callPackage ../development/tools/misc/licenseclassifier { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6238,6 +6238,8 @@ self: super: with self; {
 
   laspy = callPackage ../development/python-modules/laspy { };
 
+  lastversion = callPackage ../development/python-modules/lastversion { };
+
   laszip = callPackage ../development/python-modules/laszip {
     inherit (pkgs) cmake ninja;
   };


### PR DESCRIPTION
## Description of changes

Add lastversion, a command-line utility and Python library to get the latest release of various projects.

Aside from release version fetching from various sources, lastversion also identify pre-releases and exclude them by default. This is necessary for binary-based packages, since not all the projects vendor binaries along with pre-releases.

A binary package like `losslesscut-bin` is made up with multiple binary format for different platforms. This means that it comes with different hashes, and the `losslesscut-bin.src.outputHash` only reflects the hash of the binary vendored for that specific platform. A custom update script is needed to handle such use case.

This PR also provide `losslesscut-bin.passthru.updateBinaryPackage`, a `writeShellApplication`-based build helper to construct attrset-like updateScript that updates the Nix expression of a binary package of this kind (e.g. `caprine-bin`).

Depends on: #291176 #291190
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
