### PR TITLE
python311Packages.httpx-auth: 0.19.0 -> 0.21.0

### DIFF
--- a/pkgs/development/python-modules/httpx-auth/default.nix
+++ b/pkgs/development/python-modules/httpx-auth/default.nix
@@ -1,19 +1,20 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, httpx
+, pyjwt
+, pytest-asyncio
+, pytest-httpx
+, pytestCheckHook
 , pythonOlder
 , setuptools
 , setuptools-scm
-, wheel
-, httpx
-, pyjwt
-, pytest-httpx
-, pytestCheckHook
+, time-machine
 }:
 
 buildPythonPackage rec {
   pname = "httpx-auth";
-  version = "0.19.0";
+  version = "0.21.0";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -22,13 +23,12 @@ buildPythonPackage rec {
     owner = "Colin-b";
     repo = "httpx_auth";
     rev = "refs/tags/v${version}";
-    hash = "sha256-ptxM0gabr+NmfkXqYlWd+G0c0yClJawRNKjbtPKSGFY=";
+    hash = "sha256-tKEYFoIHxiBG18JWyCHzQEwUvrWk/zuCWqj1uYsmh84=";
   };
 
   nativeBuildInputs = [
     setuptools
     setuptools-scm
-    wheel
   ];
 
   propagatedBuildInputs = [
@@ -37,11 +37,15 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pyjwt
+    pytest-asyncio
     pytest-httpx
     pytestCheckHook
+    time-machine
   ];
 
-  pythonImportsCheck = [ "httpx_auth" ];
+  pythonImportsCheck = [
+    "httpx_auth"
+  ];
 
   __darwinAllowLocalNetworking = true;
 


### PR DESCRIPTION
Diff: https://github.com/Colin-b/httpx_auth/compare/refs/tags/v0.21.0...v0.21.0

Changelog: https://github.com/Colin-b/httpx_auth/blob/refs/tags/v0.21.0/CHANGELOG.md

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
