### PR TITLE
xmrig-mo: 6.20.0-mo1 -> 6.21.0-mo2

### DIFF
--- a/pkgs/applications/misc/xmrig/moneroocean.nix
+++ b/pkgs/applications/misc/xmrig/moneroocean.nix
@@ -1,15 +1,30 @@
-{ stdenv, fetchFromGitHub, lib, xmrig }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, xmrig
+}:
 
 xmrig.overrideAttrs (oldAttrs: rec {
   pname = "xmrig-mo";
-  version = "6.20.0-mo1";
+  version = "6.21.0-mo2";
 
   src = fetchFromGitHub {
     owner = "MoneroOcean";
     repo = "xmrig";
     rev = "v${version}";
-    sha256 = "sha256-yHAipyZJXwH21u4YwjUqDCsXHVrI+eSnp4Iqt3AZC9A=";
+    hash = "sha256-OKyJcmhlY8gfDKyBf83KHhokp4qA8EDyessTwKReaD8=";
   };
+
+  patches = [
+    # Fix build against gcc-13 due to missing <stdexcept> include
+    #   https://github.com/MoneroOcean/xmrig/pull/123
+    (fetchpatch {
+      name = "gcc-13.patch";
+      url = "https://github.com/MoneroOcean/xmrig/commit/7d3ea51d68049c35e9d4c75732c751eefbc5ab29.patch";
+      hash = "sha256-iNrtZ8LxNJMzn8kXLhYGEFAy0ughfOZobDVRImpVPC0=";
+    })
+  ];
 
   meta = with lib; {
     description = "A fork of the XMRig CPU miner with support for algorithm switching";


### PR DESCRIPTION
Changes: https://github.com/MoneroOcean/xmrig/releases/tag/v6.21.0-mo2

Without the change build fails on `master` against `gcc-13` as https://hydra.nixos.org/build/248994717:

    /build/source/src/backend/opencl/runners/OclRyoRunner.cpp: In member function 'virtual void xmrig::OclRyoRunner::set(const xmrig::Job&, uint8_t*)':
    /build/source/src/backend/opencl/runners/OclRyoRunner.cpp:92:20: error: 'length_error' is not a member of 'std'
       92 |         throw std::length_error("job size too big");
          |                    ^~~~~~~~~~~~

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
