### PR TITLE
vscode-extensions.equinusocio.vsc-material-theme: 33.8.0 -> 34.3.1

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1474,22 +1474,7 @@ let
         };
       };
 
-      equinusocio.vsc-material-theme = buildVscodeMarketplaceExtension {
-        mktplcRef = {
-          name = "vsc-material-theme";
-          publisher = "Equinusocio";
-          version = "33.8.0";
-          sha256 = "sha256-+I4AUwsrElT62XNvmuAC2iBfHfjNYY0bmAqzQvfwUYM=";
-        };
-        meta = {
-          changelog = "https://marketplace.visualstudio.com/items/Equinusocio.vsc-material-theme/changelog";
-          description = "The most epic theme now for Visual Studio Code";
-          downloadPage = "https://marketplace.visualstudio.com/items?itemName=Equinusocio.vsc-material-theme";
-          homepage = "https://github.com/material-theme/vsc-material-theme";
-          license = lib.licenses.asl20;
-          maintainers = [ lib.maintainers.stunkymonkey ];
-        };
-      };
+      equinusocio.vsc-material-theme = callPackage ./equinusocio.vsc-material-theme { };
 
       esbenp.prettier-vscode = buildVscodeMarketplaceExtension {
         mktplcRef = {

--- a/pkgs/applications/editors/vscode/extensions/equinusocio.vsc-material-theme/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/equinusocio.vsc-material-theme/default.nix
@@ -1,0 +1,21 @@
+{ lib
+, vscode-utils
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "vsc-material-theme";
+    publisher = "Equinusocio";
+    version = "34.3.1";
+    sha256 = "sha256-3yxFTMtjJR1b4EzBDfm55HF9chrya5OUF5wN+KHEduE=";
+  };
+
+  meta = with lib; {
+    changelog = "https://marketplace.visualstudio.com/items/Equinusocio.vsc-material-theme/changelog";
+    description = "The most epic theme now for Visual Studio Code";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=Equinusocio.vsc-material-theme";
+    homepage = "https://github.com/material-theme/vsc-material-theme";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ stunkymonkey ];
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/equinusocio.vsc-material-theme/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/equinusocio.vsc-material-theme/default.nix
@@ -10,6 +10,12 @@ vscode-utils.buildVscodeMarketplaceExtension {
     sha256 = "sha256-3yxFTMtjJR1b4EzBDfm55HF9chrya5OUF5wN+KHEduE=";
   };
 
+  # extensions wants to write at the /nix/store path, so we patch it to use the globalStorageUri instead.
+  prePatch = ''
+    substituteInPlace ./build/core/extension-manager.js \
+      --replace-fail "path_1.posix.join(extensionFolderUri.path, env_1.USER_CONFIG_FILE_NAME)" "path_1.posix.join(ExtensionContext.globalStorageUri.fsPath, env_1.USER_CONFIG_FILE_NAME)"
+  '';
+
   meta = with lib; {
     changelog = "https://marketplace.visualstudio.com/items/Equinusocio.vsc-material-theme/changelog";
     description = "The most epic theme now for Visual Studio Code";


### PR DESCRIPTION
## Description of changes

https://github.com/material-theme/vsc-material-theme/releases/tag/v34.3.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
