### PR TITLE
[23.11] c-ares: apply patch for CVE-2024-25629

### DIFF
--- a/pkgs/development/libraries/c-ares/CVE-2024-25629.patch
+++ b/pkgs/development/libraries/c-ares/CVE-2024-25629.patch
@@ -1,0 +1,32 @@
+From 1ca7410a8e2b841d5dd7ce6790dbefdb3811284d Mon Sep 17 00:00:00 2001
+From: Brad House <brad@brad-house.com>
+Date: Thu, 22 Feb 2024 16:23:33 -0500
+Subject: [PATCH] Merge pull request from GHSA-mg26-v6qh-x48q
+
+(cherry picked from commit a804c04ddc8245fc8adf0e92368709639125e183)
+---
+ src/lib/ares__read_line.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/src/lib/ares__read_line.c b/src/lib/ares__read_line.c
+index c62ad2a..16627e4 100644
+--- a/src/lib/ares__read_line.c
++++ b/src/lib/ares__read_line.c
+@@ -49,6 +49,14 @@ int ares__read_line(FILE *fp, char **buf, size_t *bufsize)
+       if (!fgets(*buf + offset, bytestoread, fp))
+         return (offset != 0) ? 0 : (ferror(fp)) ? ARES_EFILE : ARES_EOF;
+       len = offset + strlen(*buf + offset);
++
++      /* Probably means there was an embedded NULL as the first character in
++      * the line, throw away line */
++      if (len == 0) {
++        offset = 0;
++        continue;
++      }
++
+       if ((*buf)[len - 1] == '\n')
+         {
+           (*buf)[len - 1] = 0;
+-- 
+2.43.2
+

--- a/pkgs/development/libraries/c-ares/default.nix
+++ b/pkgs/development/libraries/c-ares/default.nix
@@ -20,6 +20,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-MhcAOZty7Q4DfQB0xinndB9rLsLdqSlWq+PpZx0+Jo4=";
   };
 
+  patches = [
+    ./CVE-2024-25629.patch
+  ];
+
   outputs = [ "out" "dev" "man" ];
 
   nativeBuildInputs = lib.optionals withCMake [ cmake ];


### PR DESCRIPTION
## Description of changes

Slightly adjusted https://github.com/c-ares/c-ares/commit/a804c04ddc8245fc8adf0e92368709639125e183 to be applicable on top of 1.19.1.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (on top of release-23.11)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
