### PR TITLE
chatd: init at 1.1.0

### DIFF
--- a/pkgs/by-name/ch/chatd/package.nix
+++ b/pkgs/by-name/ch/chatd/package.nix
@@ -1,0 +1,68 @@
+{ buildNpmPackage
+, lib
+, electron
+, fetchFromGitHub
+, ollama
+, makeWrapper
+, nix-update-script
+}:
+
+buildNpmPackage rec {
+  pname = "chatd";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "BruceMacD";
+    repo = "chatd";
+    rev = "v${version}";
+    hash = "sha256-3VtF2vLs+bdT9VX3A+A8hntzNZZ+SL5UZqs5Cm/1264=";
+  };
+
+  npmDepsHash = "sha256-RwugV6548zaxuAHoWImNKKokPkMnCWQWaUvQhH/AxGU=";
+
+  dontNpmBuild = true;
+
+  npmFlags = [ "--ignore-scripts" ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    electron
+  ];
+
+  postPatch = ''
+    # basically https://github.com/BruceMacD/chatd/pull/35
+    # requires a new release to work with remote ollama instances
+    substituteInPlace src/service/ollama/ollama.js \
+      --replace 'this.host = "http://127.0.0.1:11434";' 'this.host = process.env.OLLAMA_HOST || "http://127.0.0.1:11434";'
+  '';
+
+  buildPhase = ''
+  runHook preBuild
+
+  runHook postBuild
+  '';
+
+  installPhase = ''
+    mkdir -p $out/{bin,share}
+    cp -r . $out/share/chatd
+    rm -rf $out/share/electron{,-winstaller} $(find $out -name 'win32')
+
+    for bin in ollama-darwin ollama-linux; do
+      makeWrapper ${lib.getExe ollama} $out/share/chatd/src/service/ollama/runners/$bin
+    done
+
+    makeWrapper ${lib.getExe electron} $out/bin/chatd \
+      --add-flags $out/share/chatd/src/index.js
+  '';
+
+  passthru.updateScript = nix-update-script {};
+
+  meta = with lib; {
+    mainProgram = "chatd";
+    description = "Chat with your documents using local AI";
+    homepage = "https://github.com/BruceMacD/chatd";
+    maintainers = [ maintainers.lucasew ];
+    platforms = electron.meta.platforms;
+    license = licenses.mit;
+  };
+}


### PR DESCRIPTION
## Description of changes
Introduces chatd, a utility app that uses Ollama under the hood.

Right now it doesn't support using external Ollama instances but the commits to support it are already there + the patch to use `OLLAMA_HOST` (basically what https://github.com/BruceMacD/chatd/pull/35 does but idempotently applied). Next release would work unmodified if that PR is merged before the next release.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
