### PR TITLE
gdtoolkit_4: init at 4.2.2

### DIFF
--- a/pkgs/by-name/gd/gdtoolkit_3/package.nix
+++ b/pkgs/by-name/gd/gdtoolkit_3/package.nix
@@ -23,7 +23,7 @@ let
   };
 in
 python.pkgs.buildPythonApplication rec {
-  pname = "gdtoolkit";
+  pname = "gdtoolkit3";
   version = "3.3.1";
 
   # If we try to get using fetchPypi it requires GeoIP (but the package dont has that dep!?)
@@ -62,7 +62,8 @@ python.pkgs.buildPythonApplication rec {
          - disable doCheck for gdtoolkit, or
          - provide a compatible godot-server version to gdtoolkit"
       '';
-    in lib.throwIf (godotServerMajorVersion != gdtoolkitMajorVersion) msg ''
+    in
+    lib.throwIf (godotServerMajorVersion != gdtoolkitMajorVersion) msg ''
       # The tests want to run the installed executables
       export PATH=$out/bin:$PATH
 

--- a/pkgs/by-name/gd/gdtoolkit_4/package.nix
+++ b/pkgs/by-name/gd/gdtoolkit_4/package.nix
@@ -1,0 +1,73 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+
+let
+  python = python3.override {
+    packageOverrides = self: super: {
+      lark = super.lark.overridePythonAttrs (old: rec {
+        # gdtoolkit needs exactly this lark version
+        version = "1.1.9";
+        src = fetchFromGitHub {
+          owner = "lark-parser";
+          repo = "lark";
+          rev = version;
+          hash = "sha256-vDu+VPAXONY8J+A6oS7EiMeOMgzGms0nWpE+DKI1MVU=";
+          fetchSubmodules = true;
+        };
+        patches = [ ];
+      });
+    };
+  };
+in
+python.pkgs.buildPythonApplication rec {
+  pname = "gdtoolkit";
+  version = "4.2.2";
+
+  src = fetchFromGitHub {
+    owner = "Scony";
+    repo = "godot-gdscript-toolkit";
+    rev = version;
+    hash = "sha256-SvEKKuDnfxV+5AArg5ssrQzgIwRITdek4KYEs3d0n4Y=";
+  };
+
+  disabled = python.pythonOlder "3.7";
+
+  propagatedBuildInputs = with python.pkgs; [
+    docopt
+    lark
+    pyyaml
+    setuptools
+  ];
+
+  doCheck = true;
+
+  nativeCheckInputs = with python.pkgs; [
+    pytestCheckHook
+    hypothesis
+  ];
+
+  preCheck = ''
+      # The tests want to run the installed executables
+      export PATH=$out/bin:$PATH
+
+      # gdtoolkit tries to write cache variables to $HOME/.cache
+      export HOME=$TMP
+    '';
+
+  # The tests are not working on NixOS
+  disabledTestPaths = [
+    "tests/generated/test_expression_parsing.py"
+    "tests/gdradon/test_executable.py"
+  ];
+
+  pythonImportsCheck = [ "gdtoolkit" "gdtoolkit.formatter" "gdtoolkit.linter" "gdtoolkit.parser" ];
+
+  meta = with lib; {
+    description = "Independent set of tools for working with Godot's GDScript - parser, linter and formatter";
+    homepage = "https://github.com/Scony/godot-gdscript-toolkit";
+    license = licenses.mit;
+    maintainers = with maintainers; [ squarepear ];
+  };
+}

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -414,6 +414,8 @@ mapAliases ({
   godot-headless = throw "godot-headless has been renamed to godot3-headless to distinguish from version 4"; # Added 2023-07-16
   godot-server = throw "godot-server has been renamed to godot3-server to distinguish from version 4"; # Added 2023-07-16
 
+  gdtoolkit = throw "gdtoolkit has been renamed to gdtoolkit_3 to distinguish from version 4"; # Added 2024-02-17
+
   google-chrome-beta = throw "'google-chrome-beta' has been removed due to the lack of maintenance in nixpkgs. Consider using 'google-chrome' instead."; # Added 2023-10-18
   google-chrome-dev = throw "'google-chrome-dev' has been removed due to the lack of maintenance in nixpkgs. Consider using 'google-chrome' instead."; # Added 2023-10-18
   google-gflags = throw "'google-gflags' has been renamed to/replaced by 'gflags'"; # Converted to throw 2023-09-10

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8423,8 +8423,6 @@ with pkgs;
 
   gdmap = callPackage ../tools/system/gdmap { };
 
-  gdtoolkit = callPackage ../development/tools/gdtoolkit { };
-
   gef = callPackage ../development/tools/misc/gef { };
 
   gelasio = callPackage ../data/fonts/gelasio { };


### PR DESCRIPTION
## Description of changes

Rename gdtoolkit to gdtoolkit_3
Init gdtoolkit_4 at v4.2.2
Update gdtoolkit_3 to v3.5.0

Tested and seems to be working fine.

Resolves #267249

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
