### PR TITLE
llvmPackages_git.libcxxabi: unbreak on x86_64-darwin

### DIFF
--- a/pkgs/development/compilers/llvm/git/libcxx/0001-darwin-10.12-mbstate_t-fix.patch
+++ b/pkgs/development/compilers/llvm/git/libcxx/0001-darwin-10.12-mbstate_t-fix.patch
@@ -1,0 +1,31 @@
+From 9c1cb26c1dd3f92d1c1177e548107d2cd3c5e616 Mon Sep 17 00:00:00 2001
+From: annalee <150648636+a-n-n-a-l-e-e@users.noreply.github.com>
+Date: Fri, 23 Feb 2024 22:58:58 +0000
+Subject: [PATCH] darwin 10.12 mbstate_t fix
+
+https://github.com/llvm/llvm-project/issues/64226
+
+removes space from
+https://github.com/macports/macports-ports/raw/acd8acb171f1658596ed1cf25da48d5b932e2d19/lang/llvm-17/files/0042-mbstate_t-not-defined.patch
+so it applies cleanly
+---
+ include/__mbstate_t.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/include/__mbstate_t.h b/include/__mbstate_t.h
+index bfa6d61..5f51112 100644
+--- a/include/__mbstate_t.h
++++ b/include/__mbstate_t.h
+@@ -42,6 +42,9 @@
+ #elif __has_include(<bits/types/mbstate_t.h>)
+ #  include <bits/types/mbstate_t.h> // works on most Unixes
+ #elif __has_include(<sys/_types/_mbstate_t.h>)
++#  if __has_include(<machine/_types.h>)
++#    include <machine/_types.h>
++#  endif
+ #  include <sys/_types/_mbstate_t.h> // works on Darwin
+ #elif !defined(_LIBCPP_HAS_NO_WIDE_CHARACTERS) && __has_include_next(<wchar.h>)
+ #  include_next <wchar.h> // fall back to the C standard provider of mbstate_t
+-- 
+2.43.0
+

--- a/pkgs/development/compilers/llvm/git/libcxx/default.nix
+++ b/pkgs/development/compilers/llvm/git/libcxx/default.nix
@@ -45,6 +45,11 @@ stdenv.mkDerivation rec {
     chmod -R u+w .
   '';
 
+  patches = lib.optionals (stdenv.isDarwin && lib.versionOlder stdenv.hostPlatform.darwinMinVersion "10.13") [
+    # https://github.com/llvm/llvm-project/issues/64226
+    ./0001-darwin-10.12-mbstate_t-fix.patch
+  ];
+
   postPatch = ''
     cd ../runtimes
   '';

--- a/pkgs/development/compilers/llvm/git/libcxxabi/default.nix
+++ b/pkgs/development/compilers/llvm/git/libcxxabi/default.nix
@@ -126,8 +126,5 @@ stdenv.mkDerivation rec {
     # the UIUC License (a BSD-like license)":
     license = with lib.licenses; [ mit ncsa ];
     maintainers = llvm_meta.maintainers ++ [ lib.maintainers.vlstill ];
-    # Broken until https://github.com/llvm/llvm-project/issues/64226 is resolved
-    # We should check if the version is not 10.13 but that is currently broken.
-    broken = stdenv.isDarwin && stdenv.isx86_64;
   };
 }


### PR DESCRIPTION
## Description of changes

~Unlike LLVM 17, this actually works.~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
