### PR TITLE
opencolorio: fix tests on staging-next

### DIFF
--- a/pkgs/development/libraries/opencolorio/default.nix
+++ b/pkgs/development/libraries/opencolorio/default.nix
@@ -45,6 +45,8 @@ stdenv.mkDerivation rec {
     # Workaround for https://gitlab.kitware.com/cmake/cmake/-/issues/25200.
     # Needed for zlib >= 1.3 && cmake < 3.27.4.
     ./broken-cmake-zlib-version.patch
+    # Fix incorrect line number in test
+    ./line-numbers.patch
   ];
 
   postPatch = lib.optionalString stdenv.isDarwin ''

--- a/pkgs/development/libraries/opencolorio/line-numbers.patch
+++ b/pkgs/development/libraries/opencolorio/line-numbers.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/cpu/fileformats/FileFormatCTF_tests.cpp b/tests/cpu/fileformats/FileFormatCTF_tests.cpp
+index 7a7ab67b..18c1f55e 100644
+--- a/tests/cpu/fileformats/FileFormatCTF_tests.cpp
++++ b/tests/cpu/fileformats/FileFormatCTF_tests.cpp
+@@ -1416,7 +1416,7 @@ OCIO_ADD_TEST(FileFormatCTF, difficult_xml_unknown_elements)
+             "(37): Unrecognized element 'just_ignore' where its parent is 'ProcessList' (8): Unknown element",
+             "(69): Unrecognized element 'just_ignore' where its parent is 'Description' (66)",
+             "(70): Unrecognized element 'just_ignore' where its parent is 'just_ignore' (69)",
+-            "(75): Unrecognized element 'Matrix' where its parent is 'LUT1D' (43): 'Matrix' not allowed in this element",
++            "(75): Unrecognized element 'Matrix' where its parent is 'LUT1D' (46): 'Matrix' not allowed in this element",
+             "(76): Unrecognized element 'Description' where its parent is 'Matrix' (75)",
+             "(77): Unrecognized element 'Array' where its parent is 'Matrix' (75)"
+         };


### PR DESCRIPTION
## Description of changes

Seems like expat 2.6.0 changed how line numbers are counted?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
