### PR TITLE
pyload-ng: apply patches for CVE-2024-22416

### DIFF
--- a/pkgs/applications/networking/pyload-ng/CVE-2024-22416.patch
+++ b/pkgs/applications/networking/pyload-ng/CVE-2024-22416.patch
@@ -1,0 +1,74 @@
+From 63b26a03dfa91fda47783a1a02ed5ae1f41433d3 Mon Sep 17 00:00:00 2001
+From: GammaC0de <gammac0de@users.noreply.github.com>
+Date: Thu, 18 Jan 2024 00:56:58 +0200
+Subject: [PATCH 1/2] fix GHSA-pgpj-v85q-h5fm security advisory
+
+(cherry picked from commit c7cdc18ad9134a75222974b39e8b427c4af845fc)
+---
+ setup.cfg                        | 7 +++----
+ src/pyload/webui/app/__init__.py | 1 +
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/setup.cfg b/setup.cfg
+index b168fa1ff..dde44a869 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -53,13 +53,12 @@ package_dir =
+ 	= src
+ install_requires = 
+ 	Cheroot~=8.4
+-	Flask;python_version<"3.8"
+-	Flask~=2.3.0;python_version>="3.8"
++	Flask
+ 	Flask-Babel~=1.0
+ 	Flask-Caching~=1.9
+ 	Flask-Compress~=1.8
+-	Flask-Session~=0.3;python_version<"3.7"
+-	Flask-Session2~=1.3;python_version>="3.7"
++	Flask-Session~=0.4.1;python_version<"3.7"
++	Flask-Session;python_version>="3.7"
+ 	Flask-Themes2~=1.0
+ 	bitmath~=1.3
+ 	cryptography>=35.0.0
+diff --git a/src/pyload/webui/app/__init__.py b/src/pyload/webui/app/__init__.py
+index 2c9226b1c..7f4ecf016 100644
+--- a/src/pyload/webui/app/__init__.py
++++ b/src/pyload/webui/app/__init__.py
+@@ -112,6 +112,7 @@ class App:
+         app.config["SESSION_FILE_DIR"] = cache_path
+         app.config["SESSION_TYPE"] = "filesystem"
+         app.config["SESSION_COOKIE_NAME"] = "pyload_session"
++        app.config["SESSION_COOKIE_SAMESITE"] = "None"
+         app.config["SESSION_COOKIE_SECURE"] = app.config["PYLOAD_API"].get_config_value("webui", "use_ssl")
+         app.config["SESSION_PERMANENT"] = False
+ 
+-- 
+2.43.2
+
+
+From d727404b2de55337a92261cc2100d79e5c68945a Mon Sep 17 00:00:00 2001
+From: GammaC0de <gammac0de@users.noreply.github.com>
+Date: Thu, 18 Jan 2024 01:11:24 +0200
+Subject: [PATCH 2/2] fix GHSA-pgpj-v85q-h5fm security advisory (2)
+
+(cherry picked from commit 1374c824271cb7e927740664d06d2e577624ca3e)
+---
+ src/pyload/webui/app/__init__.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/pyload/webui/app/__init__.py b/src/pyload/webui/app/__init__.py
+index 7f4ecf016..3e2933f0e 100644
+--- a/src/pyload/webui/app/__init__.py
++++ b/src/pyload/webui/app/__init__.py
+@@ -112,7 +112,7 @@ class App:
+         app.config["SESSION_FILE_DIR"] = cache_path
+         app.config["SESSION_TYPE"] = "filesystem"
+         app.config["SESSION_COOKIE_NAME"] = "pyload_session"
+-        app.config["SESSION_COOKIE_SAMESITE"] = "None"
++        app.config["SESSION_COOKIE_SAMESITE"] = "Strict"
+         app.config["SESSION_COOKIE_SECURE"] = app.config["PYLOAD_API"].get_config_value("webui", "use_ssl")
+         app.config["SESSION_PERMANENT"] = False
+ 
+-- 
+2.43.2
+

--- a/pkgs/applications/networking/pyload-ng/default.nix
+++ b/pkgs/applications/networking/pyload-ng/default.nix
@@ -10,11 +10,13 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-pcbJc23Fylh/JoWRmbZmC8xUzUqh2ej6gT+B2w8DHFQ=";
   };
 
+  patches = [
+    ./CVE-2024-22416.patch
+  ];
+
   postPatch = ''
     # relax version bounds
     sed -i 's/\([A-z0-9]*\)~=.*$/\1/' setup.cfg
-    # not sure what Flask-Session2 is but flask-session works just fine
-    sed -i '/Flask-Session2/d' setup.cfg
   '';
 
   propagatedBuildInputs = with python3.pkgs; [


### PR DESCRIPTION
## Description of changes

Given that no changelogs are provided and that the versions are not tagged in upstream repository it is a bit hard to evaluate if we can backport the upgrades directly. The patches for the security issue are small so this seems a less risky way.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
