### PR TITLE
kicad: 7.0.10 -> 8.0.1

### DIFF
--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -21,6 +21,10 @@
 , libpthreadstubs
 , libXdmcp
 , unixODBC
+, libgit2
+, libsecret
+, libgcrypt
+, libgpg-error
 
 , util-linux
 , libselinux
@@ -98,6 +102,10 @@ stdenv.mkDerivation rec {
     # should be resolved in the next major? release
     "-DCMAKE_CTEST_ARGUMENTS='--exclude-regex;qa_eeschema'"
   ]
+  ++ optionals (!stable) [
+    # 8 failures, not finding files, some wrong calculations; but upstream runs the tests...
+    "-DCMAKE_CTEST_ARGUMENTS='--exclude-regex;qa_spice'"
+  ]
   ++ optional (stable && !withNgspice) "-DKICAD_SPICE=OFF"
   ++ optionals (!withScripting) [
     "-DKICAD_SCRIPTING_WXPYTHON=OFF"
@@ -126,6 +134,12 @@ stdenv.mkDerivation rec {
     doxygen
     graphviz
     pkg-config
+  ]
+  ++ optionals (!stable) [
+    libgit2
+    libsecret
+    libgcrypt
+    libgpg-error
   ]
   # wanted by configuration on linux, doesn't seem to affect performance
   # no effect on closure size

--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -99,6 +99,8 @@ stdenv.mkDerivation rec {
     # https://gitlab.com/kicad/code/kicad/-/issues/17133
     "-DCMAKE_CTEST_ARGUMENTS='--exclude-regex;qa_spice'"
   ]
+  ++ optional (stdenv.hostPlatform.system == "aarch64-linux")
+    "-DCMAKE_CTEST_ARGUMENTS=--exclude-regex;'qa_spice|qa_cli'"
   ++ optional (stable && !withNgspice) "-DKICAD_SPICE=OFF"
   ++ optionals (!withScripting) [
     "-DKICAD_SCRIPTING_WXPYTHON=OFF"

--- a/pkgs/applications/science/electronics/kicad/base.nix
+++ b/pkgs/applications/science/electronics/kicad/base.nix
@@ -96,14 +96,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DKICAD_USE_EGL=ON"
     "-DOCC_INCLUDE_DIR=${opencascade-occt}/include/opencascade"
-  ]
-  ++ optionals (stable) [
-    # https://gitlab.com/kicad/code/kicad/-/issues/12491
-    # should be resolved in the next major? release
-    "-DCMAKE_CTEST_ARGUMENTS='--exclude-regex;qa_eeschema'"
-  ]
-  ++ optionals (!stable) [
-    # 8 failures, not finding files, some wrong calculations; but upstream runs the tests...
+    # https://gitlab.com/kicad/code/kicad/-/issues/17133
     "-DCMAKE_CTEST_ARGUMENTS='--exclude-regex;qa_spice'"
   ]
   ++ optional (stable && !withNgspice) "-DKICAD_SPICE=OFF"
@@ -134,8 +127,6 @@ stdenv.mkDerivation rec {
     doxygen
     graphviz
     pkg-config
-  ]
-  ++ optionals (!stable) [
     libgit2
     libsecret
     libgcrypt
@@ -194,13 +185,14 @@ stdenv.mkDerivation rec {
   doInstallCheck = !(debug);
   installCheckTarget = "test";
 
-  pythonForTests = python.withPackages(ps: with ps; [
-    numpy
-    pytest
-    cairosvg
-    pytest-image-diff
-  ]);
-  nativeInstallCheckInputs = optional (!stable) pythonForTests;
+  nativeInstallCheckInputs = [
+    (python.withPackages(ps: with ps; [
+      numpy
+      pytest
+      cairosvg
+      pytest-image-diff
+    ]))
+  ];
 
   dontStrip = debug;
 

--- a/pkgs/applications/science/electronics/kicad/default.nix
+++ b/pkgs/applications/science/electronics/kicad/default.nix
@@ -205,9 +205,9 @@ stdenv.mkDerivation rec {
     "--prefix GIO_EXTRA_MODULES : ${dconf}/lib/gio/modules"
     # required to open a bug report link in firefox-wayland
     "--set-default MOZ_DBUS_REMOTE 1"
-    "--set-default KICAD7_FOOTPRINT_DIR ${footprints}/share/kicad/footprints"
-    "--set-default KICAD7_SYMBOL_DIR ${symbols}/share/kicad/symbols"
-    "--set-default KICAD7_TEMPLATE_DIR ${template_dir}"
+    "--set-default KICAD8_FOOTPRINT_DIR ${footprints}/share/kicad/footprints"
+    "--set-default KICAD8_SYMBOL_DIR ${symbols}/share/kicad/symbols"
+    "--set-default KICAD8_TEMPLATE_DIR ${template_dir}"
   ]
   ++ optionals (addons != [ ]) (
     let stockDataPath = symlinkJoin {
@@ -218,11 +218,11 @@ stdenv.mkDerivation rec {
       ];
     };
     in
-    [ "--set-default NIX_KICAD7_STOCK_DATA_PATH ${stockDataPath}" ]
+    [ "--set-default NIX_KICAD8_STOCK_DATA_PATH ${stockDataPath}" ]
   )
   ++ optionals (with3d)
   [
-    "--set-default KICAD7_3DMODEL_DIR ${packages3d}/share/kicad/3dmodels"
+    "--set-default KICAD8_3DMODEL_DIR ${packages3d}/share/kicad/3dmodels"
   ]
   ++ optionals (withNgspice) [ "--prefix LD_LIBRARY_PATH : ${libngspice}/lib" ]
 

--- a/pkgs/applications/science/electronics/kicad/runtime_stock_data_path.patch
+++ b/pkgs/applications/science/electronics/kicad/runtime_stock_data_path.patch
@@ -6,7 +6,7 @@ index a74cdd9..790cc58 100644
  {
      wxString path;
 
-+    if( wxGetEnv( wxT( "NIX_KICAD7_STOCK_DATA_PATH" ), &path ) ) {
++    if( wxGetEnv( wxT( "NIX_KICAD8_STOCK_DATA_PATH" ), &path ) ) {
 +        return path;
 +    }
 +

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -47,23 +47,23 @@
   };
   "kicad-unstable" = {
     kicadVersion = {
-      version =			"2023-08-15";
+      version =			"2024-02-07";
       src = {
-        rev =			"e0d4cf2d5b023a7e5b70d854452376aa3510acd8";
-        sha256 =		"0666j4q3vz24smcjw9m4ib3ca2dqiqgx2amhv7ys4rzqb6v2pvn2";
+        rev =			"8efd90e6e89b7fdc6702ad49c2f4fc7cef68a0c9";
+        sha256 =		"0ypsk8r8lk0711qp7wid7y48kb44m0sxzrs991ipxm1j5hmvla6d";
       };
     };
     libVersion = {
-      version =			"2023-08-15";
+      version =			"2024-02-07";
       libSources = {
-        symbols.rev =		"06d20a4b9f7e5375329194d141b096dcdcb7518a";
-        symbols.sha256 =	"1wr754m4ykidds3i14gqhvyrj3mbkchp2hkfnr0rjsdaqf4zmqdf";
-        templates.rev =		"867eef383a0f61015cb69677d5c632d78a2ea01a";
-        templates.sha256 =	"1qi20mrsfn4fxmr1fyphmil2i9p2nzmwk5rlfchc5aq2194nj3lq";
-        footprints.rev =	"5d2ac73ae72bfe8b8ee9eeb081a7851b2ca84c24";
-        footprints.sha256 =	"1qg016ysf0ddm3bd5bkjawlrc0z4r3zhmdjkqkwaaaydnpwp23qz";
-        packages3d.rev =	"f1dae9f95e59216f3b974f585e5b420db853da9e";
-        packages3d.sha256 =	"0ciri6lhnh0w9i00z167snj5acnjndi1rgmyls08p45zj4rma8y2";
+        symbols.rev =		"f33b7bae11538dbcec1b4d5d2c8c2b7816eabab2";
+        symbols.sha256 =	"1vg7cdnnf632gca8dwv8zazqnh04dplvmkf4g1db1dc0bdpnylan";
+        templates.rev =		"ff6e3193e6ff6029f65e7cce8ab39fafeafecdd6";
+        templates.sha256 =	"0mykfwwik7472i4r0isc5szj3dnmvd0538p0vlmzh4rcgj3pj3vm";
+        footprints.rev =	"7ba15cf3f64c245c751adee5751cb6621bfa1900";
+        footprints.sha256 =	"1a2nw989qi5c4zwa5z6dfsxq6nfvrzjdim0lgqhvspqi0kiqbl0a";
+        packages3d.rev =	"7005c85cded7a5d59fd3413eb5912d46301e6d12";
+        packages3d.sha256 =	"04r54zwfyz17w1j7v2hk4dylvvazhivlwkpl0xki1d4vn3w66d9m";
       };
     };
   };

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -3,67 +3,67 @@
 {
   "kicad" = {
     kicadVersion = {
-      version =			"7.0.11";
+      version =			"8.0.0";
       src = {
-        rev =			"8b7c6b9db0de4f39131845aa8a1a66693c4a93a4";
-        sha256 =		"0gwf6yb05cm3f9sz4jp96imskir3rf0a7kaqaszzrjxr3zcigwjv";
+        rev =			"ef34436d7d4bb488a9559d7fae32dc956d37c669";
+        sha256 =		"060j6f7k4p2bbx2z8iy482w9qgzf0wqxzrsv1kv19pmsi5cx1zp3";
       };
     };
     libVersion = {
-      version =			"7.0.11";
+      version =			"8.0.0";
       libSources = {
-        symbols.rev =		"b1ecf3147604884cde9c44daad99e8e13a15e021";
-        symbols.sha256 =	"057zmhf4h3p3p4y6jqxch9cj1wqf129k6kmvx2gshb9lgda0kjr8";
-        templates.rev =		"45dd19e76ec8d75fd932e462a164239baf253dfc";
-        templates.sha256 =	"0mykfwwik7472i4r0isc5szj3dnmvd0538p0vlmzh4rcgj3pj3vm";
-        footprints.rev =	"6b91a79be61f214b7d69eb574b12e8120b2179ae";
-        footprints.sha256 =	"1r9v8v41n0yrgwsqaksskmdgb9vyw1sb92xh81bwrv2ag3p5vdg7";
-        packages3d.rev =	"778443c8880b21bea6be5fccbd4a03bfdb8625a8";
+        symbols.rev =		"e228d4e8b295364e90e36c57f4023d8285ba88cd";
+        symbols.sha256 =	"049h2a7yn6ks8sybppixa872dbvyd0rwf9r6nixvdg6d13fl6rwf";
+        templates.rev =		"2e00c233b67e35323f90d04c190bf70237a252f2";
+        templates.sha256 =	"0m9bggz3cm27kqpjjwxy19mqzk0c69bywcjkqcni7kafr21c6k4z";
+        footprints.rev =	"6e5329a6d4aaa81290e23af3eba88f505c2f61b0";
+        footprints.sha256 =	"0ypjlbmzmcl3pha3q2361va70c988b1drxy8320gm66jkzfc21a1";
+        packages3d.rev =	"d1e521228d9f5888836b1a6a35fb05fb925456fa";
         packages3d.sha256 =	"0lcy1av7ixg1f7arflk50jllpc1749sfvf3h62hkxsz97wkr97xj";
       };
     };
   };
   "kicad-testing" = {
     kicadVersion = {
-      version =			"7.0-2024-01-27";
+      version =			"8.0-2024-02-23";
       src = {
-        rev =			"13fcb571f7e5bf4bf142d151651fc577aca32053";
-        sha256 =		"0wvk3wx5lm2jvyip6b96ja464hdzp9klb7b7ng5i3mdldabh0jba";
+        rev =			"14d71c8ca6b48d2eb956bb069acf05a37b1b2652";
+        sha256 =		"0xqd0xbpnvsvba75526nwgzr8l2cfxy99sjmg13sjxfx7rq16kqi";
       };
     };
     libVersion = {
-      version =			"7.0-2024-01-27";
+      version =			"8.0-2024-02-23";
       libSources = {
-        symbols.rev =		"eedf6c9ddac2816023e817d4dc91032f9d7390b9";
-        symbols.sha256 =	"0nlgmxf9z1vf4g350dfkxql1dawgmw275wqxkgszsfxmhdfpmi9v";
-        templates.rev =		"9ce98cc45f3778e05c404edebf0f98de5c247ffe";
-        templates.sha256 =	"0mykfwwik7472i4r0isc5szj3dnmvd0538p0vlmzh4rcgj3pj3vm";
-        footprints.rev =	"7061fc9847ecc1b838e60dc6826db534028494f6";
-        footprints.sha256 =	"1az6fzh1lma71mj12bc4bblnmzjayrxhkb8w9rjvlhvvgv33cdmy";
-        packages3d.rev =	"d7345b34daaa23acf0d4506ed937fb424b5b18cd";
-        packages3d.sha256 =	"0xzyi4mgyifwc6dppdzh6jq294mkj0a71cwkqw2ymz1kfbksw626";
+        symbols.rev =		"e228d4e8b295364e90e36c57f4023d8285ba88cd";
+        symbols.sha256 =	"049h2a7yn6ks8sybppixa872dbvyd0rwf9r6nixvdg6d13fl6rwf";
+        templates.rev =		"2e00c233b67e35323f90d04c190bf70237a252f2";
+        templates.sha256 =	"0m9bggz3cm27kqpjjwxy19mqzk0c69bywcjkqcni7kafr21c6k4z";
+        footprints.rev =	"6e5329a6d4aaa81290e23af3eba88f505c2f61b0";
+        footprints.sha256 =	"0ypjlbmzmcl3pha3q2361va70c988b1drxy8320gm66jkzfc21a1";
+        packages3d.rev =	"d1e521228d9f5888836b1a6a35fb05fb925456fa";
+        packages3d.sha256 =	"0lcy1av7ixg1f7arflk50jllpc1749sfvf3h62hkxsz97wkr97xj";
       };
     };
   };
   "kicad-unstable" = {
     kicadVersion = {
-      version =			"2024-02-07";
+      version =			"2024-02-23";
       src = {
-        rev =			"8efd90e6e89b7fdc6702ad49c2f4fc7cef68a0c9";
-        sha256 =		"0ypsk8r8lk0711qp7wid7y48kb44m0sxzrs991ipxm1j5hmvla6d";
+        rev =			"b7b64d959f37f00bb0d14b007c3b3908196e1024";
+        sha256 =		"1gl7mjqpmqq4m55z6crwb77983g00gi2161ichsc7hsfhs4c8grh";
       };
     };
     libVersion = {
-      version =			"2024-02-07";
+      version =			"2024-02-23";
       libSources = {
-        symbols.rev =		"f33b7bae11538dbcec1b4d5d2c8c2b7816eabab2";
-        symbols.sha256 =	"1vg7cdnnf632gca8dwv8zazqnh04dplvmkf4g1db1dc0bdpnylan";
-        templates.rev =		"ff6e3193e6ff6029f65e7cce8ab39fafeafecdd6";
-        templates.sha256 =	"0mykfwwik7472i4r0isc5szj3dnmvd0538p0vlmzh4rcgj3pj3vm";
-        footprints.rev =	"7ba15cf3f64c245c751adee5751cb6621bfa1900";
-        footprints.sha256 =	"1a2nw989qi5c4zwa5z6dfsxq6nfvrzjdim0lgqhvspqi0kiqbl0a";
-        packages3d.rev =	"7005c85cded7a5d59fd3413eb5912d46301e6d12";
-        packages3d.sha256 =	"04r54zwfyz17w1j7v2hk4dylvvazhivlwkpl0xki1d4vn3w66d9m";
+        symbols.rev =		"8b0c343d8694fe0a968e5c4af69fd161bacf7da1";
+        symbols.sha256 =	"049h2a7yn6ks8sybppixa872dbvyd0rwf9r6nixvdg6d13fl6rwf";
+        templates.rev =		"0a6c4f798a68a5c639d54b4d3093460ab9267816";
+        templates.sha256 =	"0m9bggz3cm27kqpjjwxy19mqzk0c69bywcjkqcni7kafr21c6k4z";
+        footprints.rev =	"ded6b053460faae5783c538a38e91e2b4bddcf2e";
+        footprints.sha256 =	"035bf37n4vrihaj4zfdncisdx9fly1vya7lhkxhlsbv5blpi4a5y";
+        packages3d.rev =	"984667325076d4e50dab14e755aeacf97f42194c";
+        packages3d.sha256 =	"0lkaxv02h4sxrnm8zr17wl9d07mazlisad78r35gry741i362cdg";
       };
     };
   };

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -3,23 +3,23 @@
 {
   "kicad" = {
     kicadVersion = {
-      version =			"8.0.0";
+      version =			"8.0.1";
       src = {
-        rev =			"ef34436d7d4bb488a9559d7fae32dc956d37c669";
-        sha256 =		"060j6f7k4p2bbx2z8iy482w9qgzf0wqxzrsv1kv19pmsi5cx1zp3";
+        rev =			"20421d65e5a7ede894345d337ab47b469f5ba154";
+        sha256 =		"096kvmm96ccxir1rspgzzjkp6y2j80l3w2vphg9iv3drxmjp7qjv";
       };
     };
     libVersion = {
-      version =			"8.0.0";
+      version =			"8.0.1";
       libSources = {
-        symbols.rev =		"e228d4e8b295364e90e36c57f4023d8285ba88cd";
-        symbols.sha256 =	"049h2a7yn6ks8sybppixa872dbvyd0rwf9r6nixvdg6d13fl6rwf";
-        templates.rev =		"2e00c233b67e35323f90d04c190bf70237a252f2";
+        symbols.rev =		"d6aff3948edfca2bacf36900ff080f6b3f65fe4c";
+        symbols.sha256 =	"00xnvikmqd1zkg9p1f89kvryvkybl5f20baij6babqyc29nbzkwy";
+        templates.rev =		"0a6c4f798a68a5c639d54b4d3093460ab9267816";
         templates.sha256 =	"0m9bggz3cm27kqpjjwxy19mqzk0c69bywcjkqcni7kafr21c6k4z";
-        footprints.rev =	"6e5329a6d4aaa81290e23af3eba88f505c2f61b0";
-        footprints.sha256 =	"0ypjlbmzmcl3pha3q2361va70c988b1drxy8320gm66jkzfc21a1";
-        packages3d.rev =	"d1e521228d9f5888836b1a6a35fb05fb925456fa";
-        packages3d.sha256 =	"0lcy1av7ixg1f7arflk50jllpc1749sfvf3h62hkxsz97wkr97xj";
+        footprints.rev =	"226b4f3d5c10a4126d88b895188bdab629fe60b0";
+        footprints.sha256 =	"1bb3mb2a7vkridgmqqm9ib3hv2m4zx1i14mglb11sribypy0ma5p";
+        packages3d.rev =	"49c1cd4017499b8a7f6dedbe7ede834d1713eb28";
+        packages3d.sha256 =	"0b5jwr5bbd0kzb75nj3028knjrv0872dk54sbsnxaz669q8zaxap";
       };
     };
   };

--- a/pkgs/applications/science/electronics/kicad/versions.nix
+++ b/pkgs/applications/science/electronics/kicad/versions.nix
@@ -3,23 +3,23 @@
 {
   "kicad" = {
     kicadVersion = {
-      version =			"7.0.10";
+      version =			"7.0.11";
       src = {
-        rev =			"7daac78752749fc919e932be6156914aa83c926f";
-        sha256 =		"0z459yi0s02mwdgbr3xxw43gn9yjhvfkjnsxmns5mksgzsr5nmhh";
+        rev =			"8b7c6b9db0de4f39131845aa8a1a66693c4a93a4";
+        sha256 =		"0gwf6yb05cm3f9sz4jp96imskir3rf0a7kaqaszzrjxr3zcigwjv";
       };
     };
     libVersion = {
-      version =			"7.0.10";
+      version =			"7.0.11";
       libSources = {
-        symbols.rev =		"eedf6c9ddac2816023e817d4dc91032f9d7390b9";
-        symbols.sha256 =	"0nlgmxf9z1vf4g350dfkxql1dawgmw275wqxkgszsfxmhdfpmi9v";
-        templates.rev =		"9ce98cc45f3778e05c404edebf0f98de5c247ffe";
+        symbols.rev =		"b1ecf3147604884cde9c44daad99e8e13a15e021";
+        symbols.sha256 =	"057zmhf4h3p3p4y6jqxch9cj1wqf129k6kmvx2gshb9lgda0kjr8";
+        templates.rev =		"45dd19e76ec8d75fd932e462a164239baf253dfc";
         templates.sha256 =	"0mykfwwik7472i4r0isc5szj3dnmvd0538p0vlmzh4rcgj3pj3vm";
-        footprints.rev =	"7061fc9847ecc1b838e60dc6826db534028494f6";
-        footprints.sha256 =	"1az6fzh1lma71mj12bc4bblnmzjayrxhkb8w9rjvlhvvgv33cdmy";
-        packages3d.rev =	"d7345b34daaa23acf0d4506ed937fb424b5b18cd";
-        packages3d.sha256 =	"0xzyi4mgyifwc6dppdzh6jq294mkj0a71cwkqw2ymz1kfbksw626";
+        footprints.rev =	"6b91a79be61f214b7d69eb574b12e8120b2179ae";
+        footprints.sha256 =	"1r9v8v41n0yrgwsqaksskmdgb9vyw1sb92xh81bwrv2ag3p5vdg7";
+        packages3d.rev =	"778443c8880b21bea6be5fccbd4a03bfdb8625a8";
+        packages3d.sha256 =	"0lcy1av7ixg1f7arflk50jllpc1749sfvf3h62hkxsz97wkr97xj";
       };
     };
   };


### PR DESCRIPTION
## Description of changes

[7.0.11 release blog post](https://www.kicad.org/blog/2024/02/KiCad-7.0.11-Release/)
[8.0.0 release blog post](https://www.kicad.org/blog/2024/02/Version-8.0.0-Released/)
[8.0.1 release blog post](https://www.kicad.org/blog/2024/03/KiCad-8.0.1-Release)

## Things done

bump 7.0.10 to 7.0.11 (included separately to stay reachable and be backported to 23.11)
bump kicad-unstable to 2024-02-07 (fixes its build, adds dependencies that are now part of 8.0.0, update wrapper env vars)
bump 7.0.11 to 8.0.0 (uses the kicad-unstable new dependencies and env var wrappers)
(also bumps kicad-unstable and kicad-testing, should be almost exactly the same at the moment)

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - 4 packages failed to build: kicadAddons.kikit kicadAddons.kikit-library kikit kikit.dist
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
