### PR TITLE
zabbix50: 5.0.37 -> 5.0.41, zabbix60: 6.0.21 -> 6.0.26

### DIFF
--- a/pkgs/servers/monitoring/zabbix/agent.nix
+++ b/pkgs/servers/monitoring/zabbix/agent.nix
@@ -1,13 +1,13 @@
 { lib, stdenv, fetchurl, pkg-config, libiconv, openssl, pcre }:
 
-import ./versions.nix ({ version, sha256, ... }:
+import ./versions.nix ({ version, hash, ... }:
   stdenv.mkDerivation {
     pname = "zabbix-agent";
     inherit version;
 
     src = fetchurl {
       url = "https://cdn.zabbix.com/zabbix/sources/stable/${lib.versions.majorMinor version}/zabbix-${version}.tar.gz";
-      inherit sha256;
+      inherit hash;
     };
 
     nativeBuildInputs = [ pkg-config ];

--- a/pkgs/servers/monitoring/zabbix/agent2.nix
+++ b/pkgs/servers/monitoring/zabbix/agent2.nix
@@ -1,13 +1,13 @@
 { lib, buildGoModule, fetchurl, autoreconfHook, pkg-config, libiconv, openssl, pcre, zlib }:
 
-import ./versions.nix ({ version, sha256, vendorHash ? throw "unsupported version ${version} for zabbix-agent2", ... }:
+import ./versions.nix ({ version, hash, vendorHash ? throw "unsupported version ${version} for zabbix-agent2", ... }:
   buildGoModule {
     pname = "zabbix-agent2";
     inherit version;
 
     src = fetchurl {
       url = "https://cdn.zabbix.com/zabbix/sources/stable/${lib.versions.majorMinor version}/zabbix-${version}.tar.gz";
-      inherit sha256;
+      inherit hash;
     };
 
     modRoot = "src/go";

--- a/pkgs/servers/monitoring/zabbix/proxy.nix
+++ b/pkgs/servers/monitoring/zabbix/proxy.nix
@@ -15,14 +15,14 @@ assert sqliteSupport -> !mysqlSupport && !postgresqlSupport;
 let
   inherit (lib) optional optionalString;
 in
-  import ./versions.nix ({ version, sha256, ... }:
+  import ./versions.nix ({ version, hash, ... }:
     stdenv.mkDerivation {
       pname = "zabbix-proxy";
       inherit version;
 
       src = fetchurl {
         url = "https://cdn.zabbix.com/zabbix/sources/stable/${lib.versions.majorMinor version}/zabbix-${version}.tar.gz";
-        inherit sha256;
+        inherit hash;
       };
 
       nativeBuildInputs = [ pkg-config ];

--- a/pkgs/servers/monitoring/zabbix/server.nix
+++ b/pkgs/servers/monitoring/zabbix/server.nix
@@ -16,14 +16,14 @@ assert postgresqlSupport -> !mysqlSupport;
 let
   inherit (lib) optional optionalString;
 in
-  import ./versions.nix ({ version, sha256, ... }:
+  import ./versions.nix ({ version, hash, ... }:
     stdenv.mkDerivation {
       pname = "zabbix-server";
       inherit version;
 
       src = fetchurl {
         url = "https://cdn.zabbix.com/zabbix/sources/stable/${lib.versions.majorMinor version}/zabbix-${version}.tar.gz";
-        inherit sha256;
+        inherit hash;
       };
 
       nativeBuildInputs = [ autoreconfHook pkg-config ];

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -1,7 +1,7 @@
 generic: {
   v60 = generic {
-    version = "6.0.21";
-    hash = "sha256-hdKPI5UEQvF/URH2eLWW32az3LMEse3UXIELOsfvwzk=";
+    version = "6.0.26";
+    hash = "sha256-MIOKe5hqfDecB1oWZKzbFmJCsQLuAGtp21l2WxxVG+g=";
     vendorHash = null;
   };
 

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -1,13 +1,13 @@
 generic: {
   v60 = generic {
     version = "6.0.21";
-    sha256 = "sha256-hdKPI5UEQvF/URH2eLWW32az3LMEse3UXIELOsfvwzk=";
+    hash = "sha256-hdKPI5UEQvF/URH2eLWW32az3LMEse3UXIELOsfvwzk=";
     vendorHash = null;
   };
 
   v50 = generic {
-    version = "5.0.37";
-    sha256 = "sha256-+C5fI+eMJKsynVnVJIYj27x1iFQwaG9Fnho0BXgENQI=";
-    vendorHash = "sha256-oSZBzIUL1yHXk7PnkSAlhI0i89aGMFrFHmbMN9rDAJ0=";
+    version = "5.0.41";
+    hash = "sha256-pPvw0lPoK1IpsXc5c8Qu9zFhx2oHJz2bwiX80vrYa58=";
+    vendorHash = "sha256-qLDoNnEFiSrWXbLtYlmQaqY8Rv6JaG8WbMYBlry5Evc=";
   };
 }

--- a/pkgs/servers/monitoring/zabbix/web.nix
+++ b/pkgs/servers/monitoring/zabbix/web.nix
@@ -1,13 +1,13 @@
 { lib, stdenv, fetchurl, writeText }:
 
-import ./versions.nix ({ version, sha256, ... }:
+import ./versions.nix ({ version, hash, ... }:
   stdenv.mkDerivation rec {
     pname = "zabbix-web";
     inherit version;
 
     src = fetchurl {
       url = "https://cdn.zabbix.com/zabbix/sources/stable/${lib.versions.majorMinor version}/zabbix-${version}.tar.gz";
-      inherit sha256;
+      inherit hash;
     };
 
     phpConfig = writeText "zabbix.conf.php" ''


### PR DESCRIPTION
## Description of changes

Fixes CVE-2024-22119 / https://support.zabbix.com/browse/ZBX-24070

Changes 5.0.x:
https://www.zabbix.com/rn/rn5.0.41
https://www.zabbix.com/rn/rn5.0.40
https://www.zabbix.com/rn/rn5.0.39
https://www.zabbix.com/rn/rn5.0.38

Changes 6.0.x:
https://www.zabbix.com/rn/rn6.0.26
https://www.zabbix.com/rn/rn6.0.25
https://www.zabbix.com/rn/rn6.0.24
https://www.zabbix.com/rn/rn6.0.23
https://www.zabbix.com/rn/rn6.0.22

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>16 packages built:</summary>
  <ul>
    <li>zabbix.agent</li>
    <li>zabbix.agent2</li>
    <li>zabbix.proxy-mysql</li>
    <li>zabbix.proxy-pgsql</li>
    <li>zabbix.proxy-sqlite</li>
    <li>zabbix.server</li>
    <li>zabbix.server-mysql</li>
    <li>zabbix.web</li>
    <li>zabbix50.agent</li>
    <li>zabbix50.agent2</li>
    <li>zabbix50.proxy-mysql</li>
    <li>zabbix50.proxy-pgsql</li>
    <li>zabbix50.proxy-sqlite</li>
    <li>zabbix50.server</li>
    <li>zabbix50.server-mysql</li>
    <li>zabbix50.web</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
