### PR TITLE
lastversion, python3Packages.lastversion: init at 3.5.0

### DIFF
--- a/pkgs/by-name/la/lastversion/package.nix
+++ b/pkgs/by-name/la/lastversion/package.nix
@@ -1,0 +1,4 @@
+{ python3Packages }:
+
+with python3Packages;
+toPythonApplication lastversion

--- a/pkgs/development/python-modules/lastversion/default.nix
+++ b/pkgs/development/python-modules/lastversion/default.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  # nativeBuildInputs
+  setuptools,
+  # nativeCheckInputs
+  pytestCheckHook,
+  # install_requires
+  appdirs,
+  beautifulsoup4,
+  cachecontrol,
+  distro,
+  feedparser,
+  packaging,
+  python-dateutil,
+  pyyaml,
+  requests,
+  tqdm,
+  urllib3,
+}:
+
+buildPythonPackage rec {
+  pname = "lastversion";
+  version = "3.5.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.6";
+
+  src = fetchFromGitHub {
+    owner = "dvershinin";
+    repo = "lastversion";
+    rev = "v${version}";
+    hash = "sha256-SeDLpMP8cF6CC3qJ6V8dLErl6ihpnl4lHeBkp7jtQgI=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    appdirs
+    beautifulsoup4
+    cachecontrol
+    distro
+    feedparser
+    packaging
+    python-dateutil
+    pyyaml
+    requests
+    tqdm
+    urllib3
+  ] ++ cachecontrol.optional-dependencies.filecache;
+
+  pythonRelaxDeps = [
+    "cachecontrol" # Use newer cachecontrol that uses filelock instead of lockfile
+    "urllib3" # The cachecontrol and requests incompatibility issue is closed
+  ];
+
+  pythonRemoveDeps = [
+    "lockfile" # "cachecontrol" now uses filelock
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pytestFlags = [
+    "tests/test_cli.py"
+    "-k"
+    "test_cli_format"
+  ];
+
+  # CLI tests expect the output bin/ in PATH
+  preCheck = ''
+    PATH="$out/bin:$PATH"
+  '';
+
+  pythonImportsCheck = [ "lastversion" ];
+
+  meta = {
+    description = "Find the latest release version of an arbitrary project";
+    homepage = "https://github.com/dvershinin/lastversion";
+    changelog = "https://github.com/dvershinin/lastversion/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ ShamrockLee ];
+    mainProgram = "lastversion";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7235,6 +7235,8 @@ self: super: with self; {
 
   laspy = callPackage ../development/python-modules/laspy { };
 
+  lastversion = callPackage ../development/python-modules/lastversion { };
+
   laszip = callPackage ../development/python-modules/laszip {
     inherit (pkgs) cmake ninja;
     inherit (pkgs.__splicedPackages) laszip;


### PR DESCRIPTION
## Description of changes

Add lastversion, a command-line utility and Python library to get the latest release of various projects.

Aside from release version fetching from various sources, lastversion also identify pre-releases and exclude them by default. This is necessary for binary-based packages, since not all the projects vendor binaries along with pre-releases.

Examples:

```sh
$ lastversion https://github.com/mifi/lossless-cut
3.59.1

$ lastversion --pre https://github.com/mifi/lossless-cut
3.60.0
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
