### PR TITLE
python3Packages.mediafile: 0.10.1 -> 0.12.0

### DIFF
--- a/pkgs/development/python-modules/mediafile/default.nix
+++ b/pkgs/development/python-modules/mediafile/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "mediafile";
-  version = "0.10.1";
+  version = "0.12.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.6";
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "beetbox";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-2h17FA0GTY4R+WhZiQtPFYf6gH7XLbI3aOB/nUXFtJI=";
+    hash = "sha256-5HHfG1hCIbM/QSXgB61yHNNWJTsuyAh6CQJ7SZhZuvo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -1,6 +1,7 @@
 { lib
 , callPackage
 , fetchFromGitHub
+, fetchPypi
 , fetchpatch
 , python3Packages
 }:
@@ -17,11 +18,25 @@
 **   alternatives = { enable = true; propagatedBuildInputs = [ beetsPackages.alternatives ]; };
 ** }; }
 */
-lib.makeExtensible (self: {
+let
+  legacyMediafilePython3Packages = python3Packages.override {
+    overrides = self: super: {
+      mediafile = super.mediafile.overridePythonAttrs (oldAttrs: rec {
+        version = "0.10.1";
+        format = "pyproject";
+        src = fetchPypi {
+          pname = "mediafile";
+          inherit version;
+          hash = "sha256-kpZCoX7lAjuQhiIc6AzcLFHQYCGokNRDOwvVvTLysp8=";
+        };
+      });
+    };
+  };
+in lib.makeExtensible (self: {
   beets = self.beets-stable;
 
   beets-stable = callPackage ./common.nix rec {
-    inherit python3Packages;
+    python3Packages = legacyMediafilePython3Packages;
     # NOTE: ./builtin-plugins.nix and ./common.nix can have some conditionals
     # be removed when stable version updates
     version = "1.6.0";


### PR DESCRIPTION
## Description of changes
Updated from 0.10.1 to 0.12.0
[Mediafile changelog:](https://mediafile.readthedocs.io/en/latest/#)
> v0.12.0
Add the multiple-valued properties artists_credit, artists_sort, albumartists_credit, and albumartists_sort.
v0.11.0
List-valued properties now return None instead of an empty list when the underlying tags are missing altogether.

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
