### PR TITLE
fishPlugins.gruvbox: init at 0-unstable-2021-10-12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13130,6 +13130,12 @@
     githubId = 133448;
     name = "Mikołaj Siedlarek";
   };
+  msladecek = {
+    email = "martin.sladecek+nixpkgs@gmail.com";
+    name = "Martin Sladecek";
+    github = "msladecek";
+    githubId = 7304317;
+  };
   mslingsby = {
     email = "morten.slingsby@eviny.no";
     github = "MortenSlingsby";

--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -36,6 +36,8 @@ lib.makeScope newScope (self: with self; {
 
   grc = callPackage ./grc.nix { };
 
+  gruvbox = callPackage ./gruvbox.nix { };
+
   humantime-fish = callPackage ./humantime-fish.nix { };
 
   hydro = callPackage ./hydro.nix { };

--- a/pkgs/shells/fish/plugins/gruvbox.nix
+++ b/pkgs/shells/fish/plugins/gruvbox.nix
@@ -1,0 +1,17 @@
+{ lib , buildFishPlugin , fetchFromGitHub }:
+buildFishPlugin {
+  pname = "gruvbox";
+  version = "0-unstable-2021-10-12";
+  src = fetchFromGitHub {
+    owner = "jomik";
+    repo = "fish-gruvbox";
+    rev = "80a6f3a7b31beb6f087b0c56cbf3470204759d1c";
+    hash = "sha256-vL2/Nm9Z9cdaptx8sJqbX5AnRtfd68x4ZKWdQk5Cngo=";
+  };
+  meta = {
+    description = "Gruvbox theme for fish shell.";
+    homepage = "https://github.com/Jomik/fish-gruvbox";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ msladecek ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Add a new package `fishPlugin.gruvbox` which configures fish for the gruvbox colorscheme.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable: (N/A)
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)  (N/A) 
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
