### PR TITLE
[23.11] Bambu Studio backport

### DIFF
--- a/pkgs/applications/misc/bambu-studio/0001-not-for-upstream-CMakeLists-Link-against-webkit2gtk-.patch
+++ b/pkgs/applications/misc/bambu-studio/0001-not-for-upstream-CMakeLists-Link-against-webkit2gtk-.patch
@@ -1,0 +1,34 @@
+From 7eed499898226222a949a792e0400ec10db4a1c9 Mon Sep 17 00:00:00 2001
+From: Zhaofeng Li <hello@zhaofeng.li>
+Date: Tue, 22 Nov 2022 13:00:39 -0700
+Subject: [PATCH] [not for upstream] CMakeLists: Link against webkit2gtk in
+ libslic3r_gui
+
+WebView.cpp uses symbols from webkitgtk directly. Upstream setup
+links wxGTK statically so webkitgtk is already pulled in.
+
+> /nix/store/039g378vc3pc3dvi9dzdlrd0i4q93qwf-binutils-2.39/bin/ld: slic3r/liblibslic3r_gui.a(WebView.cpp.o): undefined reference to symbol 'webkit_web_view_run_javascript_finish'
+> /nix/store/039g378vc3pc3dvi9dzdlrd0i4q93qwf-binutils-2.39/bin/ld: /nix/store/8yvy428jy2nwq4dhmrcs7gj5r27a2pv6-webkitgtk-2.38.2+abi=4.0/lib/libwebkit2gtk-4.0.so.37: error adding symbols: DSO missing from command line
+---
+ src/CMakeLists.txt | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 9c5cb96..e92a0e3 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -175,6 +175,11 @@ if (WIN32)
+     target_link_libraries(BambuStudio_app_gui PRIVATE boost_headeronly)
+ endif ()
+ 
++# We link against webkit2gtk symbols in src/slic3r/GUI/Widgets/WebView.cpp
++if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
++    target_link_libraries(libslic3r_gui "-lwebkit2gtk-4.0")
++endif ()
++
+ # Link the resources dir to where Slic3r GUI expects it
+ set(output_dlls_Release "")
+ set(output_dlls_Debug "")
+-- 
+2.38.1
+

--- a/pkgs/applications/misc/bambu-studio/default.nix
+++ b/pkgs/applications/misc/bambu-studio/default.nix
@@ -168,5 +168,6 @@ stdenv.mkDerivation rec {
     license = licenses.agpl3;
     maintainers = with maintainers; [ zhaofengli ];
     mainProgram = "bambu-studio";
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/misc/bambu-studio/default.nix
+++ b/pkgs/applications/misc/bambu-studio/default.nix
@@ -58,13 +58,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "bambu-studio";
-  version = "01.08.02.56";
+  version = "01.08.04.51";
 
   src = fetchFromGitHub {
     owner = "bambulab";
     repo = "BambuStudio";
     rev = "v${version}";
-    hash = "sha256-9AUHS7dXqWx8LPkTP7/scxu3Cc/mxuK+v+5PrCvUPf0=";
+    hash = "sha256-rqD1+3Q4ZUBgS57iCItuLX6ZMP7VQuedaJmgKB1szgs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/bambu-studio/default.nix
+++ b/pkgs/applications/misc/bambu-studio/default.nix
@@ -24,6 +24,7 @@
 , gstreamer
 , gst-plugins-base
 , gst-plugins-bad
+, gst-plugins-good
 , gtest
 , gtk3
 , hicolor-icon-theme
@@ -90,6 +91,7 @@ stdenv.mkDerivation rec {
     gstreamer
     gst-plugins-base
     gst-plugins-bad
+    gst-plugins-good
     gtk3
     hicolor-icon-theme
     ilmbase

--- a/pkgs/applications/misc/bambu-studio/default.nix
+++ b/pkgs/applications/misc/bambu-studio/default.nix
@@ -57,13 +57,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "bambu-studio";
-  version = "01.08.01.57";
+  version = "01.08.02.56";
 
   src = fetchFromGitHub {
     owner = "bambulab";
     repo = "BambuStudio";
     rev = "v${version}";
-    hash = "sha256-15Eq+ylQK+xlxG7cg6xoCPb+zJ66qqwQIKd1zA13I5o=";
+    hash = "sha256-9AUHS7dXqWx8LPkTP7/scxu3Cc/mxuK+v+5PrCvUPf0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/bambu-studio/default.nix
+++ b/pkgs/applications/misc/bambu-studio/default.nix
@@ -57,13 +57,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "bambu-studio";
-  version = "01.08.00.62";
+  version = "01.08.01.57";
 
   src = fetchFromGitHub {
     owner = "bambulab";
     repo = "BambuStudio";
     rev = "v${version}";
-    hash = "sha256-Rb8YNf+ZQ8+9jAP/ZLze0PfY/liE7Rr2bJX33AENsbg=";
+    hash = "sha256-15Eq+ylQK+xlxG7cg6xoCPb+zJ66qqwQIKd1zA13I5o=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/bambu-studio/default.nix
+++ b/pkgs/applications/misc/bambu-studio/default.nix
@@ -1,0 +1,172 @@
+{ stdenv
+, lib
+, openexr
+, jemalloc
+, c-blosc
+, binutils
+, fetchFromGitHub
+, cmake
+, pkg-config
+, wrapGAppsHook
+, boost179
+, cereal
+, cgal_5
+, curl
+, dbus
+, eigen
+, expat
+, gcc-unwrapped
+, glew
+, glfw
+, glib
+, glib-networking
+, gmp
+, gstreamer
+, gst-plugins-base
+, gst-plugins-bad
+, gtest
+, gtk3
+, hicolor-icon-theme
+, ilmbase
+, libpng
+, mesa
+, mpfr
+, nlopt
+, opencascade-occt
+, openvdb
+, pcre
+, qhull
+, systemd
+, tbb_2021_8
+, webkitgtk
+, wxGTK31
+, xorg
+, fetchpatch
+, withSystemd ? stdenv.isLinux
+}:
+let
+  wxGTK31' = wxGTK31.overrideAttrs (old: {
+    configureFlags = old.configureFlags ++ [
+      # Disable noisy debug dialogs
+      "--enable-debug=no"
+    ];
+  });
+  openvdb_tbb_2021_8 = openvdb.overrideAttrs (old: rec {
+    buildInputs = [ openexr boost179 tbb_2021_8 jemalloc c-blosc ilmbase ];
+  });
+in
+stdenv.mkDerivation rec {
+  pname = "bambu-studio";
+  version = "01.08.00.62";
+
+  src = fetchFromGitHub {
+    owner = "bambulab";
+    repo = "BambuStudio";
+    rev = "v${version}";
+    hash = "sha256-Rb8YNf+ZQ8+9jAP/ZLze0PfY/liE7Rr2bJX33AENsbg=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    wrapGAppsHook
+  ];
+
+  buildInputs = [
+    binutils
+    boost179
+    cereal
+    cgal_5
+    curl
+    dbus
+    eigen
+    expat
+    gcc-unwrapped
+    glew
+    glfw
+    glib
+    glib-networking
+    gmp
+    gstreamer
+    gst-plugins-base
+    gst-plugins-bad
+    gtk3
+    hicolor-icon-theme
+    ilmbase
+    libpng
+    mesa.osmesa
+    mpfr
+    nlopt
+    opencascade-occt
+    openvdb_tbb_2021_8
+    pcre
+    tbb_2021_8
+    webkitgtk
+    wxGTK31'
+    xorg.libX11
+  ] ++ lib.optionals withSystemd [
+    systemd
+  ] ++ checkInputs;
+
+  patches = [
+    # Fix for webkitgtk linking
+    ./0001-not-for-upstream-CMakeLists-Link-against-webkit2gtk-.patch
+  ];
+
+  doCheck = true;
+  checkInputs = [ gtest ];
+
+  separateDebugInfo = true;
+
+  # The build system uses custom logic - defined in
+  # cmake/modules/FindNLopt.cmake in the package source - for finding the nlopt
+  # library, which doesn't pick up the package in the nix store.  We
+  # additionally need to set the path via the NLOPT environment variable.
+  NLOPT = nlopt;
+
+  # Disable compiler warnings that clutter the build log.
+  # It seems to be a known issue for Eigen:
+  # http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1221
+  NIX_CFLAGS_COMPILE = "-Wno-ignored-attributes";
+
+  # prusa-slicer uses dlopen on `libudev.so` at runtime
+  NIX_LDFLAGS = lib.optionalString withSystemd "-ludev";
+
+  # TODO: macOS
+  prePatch = ''
+    # Since version 2.5.0 of nlopt we need to link to libnlopt, as libnlopt_cxx
+    # now seems to be integrated into the main lib.
+    sed -i 's|nlopt_cxx|nlopt|g' cmake/modules/FindNLopt.cmake
+  '';
+
+  cmakeFlags = [
+    "-DSLIC3R_STATIC=0"
+    "-DSLIC3R_FHS=1"
+    "-DSLIC3R_GTK=3"
+
+    # BambuStudio-specific
+    "-DBBL_RELEASE_TO_PUBLIC=1"
+    "-DBBL_INTERNAL_TESTING=0"
+    "-DDEP_WX_GTK3=ON"
+    "-DSLIC3R_BUILD_TESTS=0"
+    "-DCMAKE_CXX_FLAGS=-DBOOST_LOG_DYN_LINK"
+  ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH : "$out/lib"
+
+      # Fixes intermittent crash
+      # The upstream setup links in glew statically
+      --prefix LD_PRELOAD : "${glew.out}/lib/libGLEW.so"
+    )
+  '';
+
+  meta = with lib; {
+    description = "PC Software for BambuLab's 3D printers";
+    homepage = "https://github.com/bambulab/BambuStudio";
+    license = licenses.agpl3;
+    maintainers = with maintainers; [ zhaofengli ];
+    mainProgram = "bambu-studio";
+  };
+}

--- a/pkgs/applications/misc/bambu-studio/orca-slicer.nix
+++ b/pkgs/applications/misc/bambu-studio/orca-slicer.nix
@@ -1,0 +1,24 @@
+{ lib, fetchFromGitHub, makeDesktopItem, bambu-studio }:
+let
+  orca-slicer = bambu-studio.overrideAttrs (finalAttrs: previousAttrs: {
+    version = "1.8.1";
+    pname = "orca-slicer";
+
+    src = fetchFromGitHub {
+      owner = "SoftFever";
+      repo = "OrcaSlicer";
+      rev = "v${finalAttrs.version}";
+      hash = "sha256-3aIVi7Wsit4vpFrGdqe7DUEC6HieWAXCdAADVtB5HKc=";
+    };
+
+    meta = with lib; {
+      description = "G-code generator for 3D printers (Bambu, Prusa, Voron, VzBot, RatRig, Creality, etc";
+      homepage = "https://github.com/SoftFever/OrcaSlicer";
+      license = licenses.agpl3Only;
+      maintainers = with maintainers; [ zhaofengli ovlach pinpox ];
+      mainProgram = "orca-slicer";
+      platforms = platforms.linux;
+    };
+  });
+in
+orca-slicer

--- a/pkgs/applications/misc/bambu-studio/orca-slicer.nix
+++ b/pkgs/applications/misc/bambu-studio/orca-slicer.nix
@@ -1,14 +1,14 @@
 { lib, fetchFromGitHub, makeDesktopItem, bambu-studio }:
 let
   orca-slicer = bambu-studio.overrideAttrs (finalAttrs: previousAttrs: {
-    version = "1.8.1";
+    version = "1.9.0";
     pname = "orca-slicer";
 
     src = fetchFromGitHub {
       owner = "SoftFever";
       repo = "OrcaSlicer";
       rev = "v${finalAttrs.version}";
-      hash = "sha256-3aIVi7Wsit4vpFrGdqe7DUEC6HieWAXCdAADVtB5HKc=";
+      hash = "sha256-v6REKDlFhyW6kEEfpcm8Sjezkh6uLaBusMuVk8n3Ts0=";
     };
 
     meta = with lib; {

--- a/pkgs/development/libraries/wxwidgets/wxGTK31.nix
+++ b/pkgs/development/libraries/wxwidgets/wxGTK31.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, curl
 , gst_all_1
 , gtk3
 , libGL
@@ -14,6 +15,8 @@
 , compat28 ? false
 , compat30 ? true
 , unicode ? true
+, withCurl ? false
+, withPrivateFonts ? false
 , withEGL ? true
 , withMesa ? !stdenv.isDarwin
 , withWebKit ? stdenv.isDarwin
@@ -59,6 +62,7 @@ stdenv.mkDerivation rec {
     libXxf86vm
     xorgproto
   ]
+  ++ lib.optional withCurl curl
   ++ lib.optional withMesa libGLU
   ++ lib.optional (withWebKit && !stdenv.isDarwin) webkitgtk
   ++ lib.optional (withWebKit && stdenv.isDarwin) WebKit
@@ -85,6 +89,8 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optional (!withEGL) "--disable-glcanvasegl"
   ++ lib.optional unicode "--enable-unicode"
+  ++ lib.optional withCurl "--enable-webrequest"
+  ++ lib.optional withPrivateFonts "--enable-privatefonts"
   ++ lib.optional withMesa "--with-opengl"
   ++ lib.optionals stdenv.isDarwin [
     "--with-osx_cocoa"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35525,7 +35525,7 @@ with pkgs;
   super-slicer-latest = super-slicer.latest;
 
   bambu-studio = callPackage ../applications/misc/bambu-studio {
-    inherit (gst_all_1) gstreamer gst-plugins-base gst-plugins-bad;
+    inherit (gst_all_1) gstreamer gst-plugins-base gst-plugins-bad gst-plugins-good;
 
     glew = glew-egl;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35536,6 +35536,8 @@ with pkgs;
     };
   };
 
+  orca-slicer = callPackage ../applications/misc/bambu-studio/orca-slicer.nix {};
+
   snapmaker-luban = callPackage ../applications/misc/snapmaker-luban { };
 
   robustirc-bridge = callPackage ../servers/irc/robustirc-bridge { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35524,6 +35524,18 @@ with pkgs;
 
   super-slicer-latest = super-slicer.latest;
 
+  bambu-studio = callPackage ../applications/misc/bambu-studio {
+    inherit (gst_all_1) gstreamer gst-plugins-base gst-plugins-bad;
+
+    glew = glew-egl;
+
+    wxGTK31 = wxGTK31.override {
+      withCurl = true;
+      withPrivateFonts = true;
+      withWebKit = true;
+    };
+  };
+
   snapmaker-luban = callPackage ../applications/misc/snapmaker-luban { };
 
   robustirc-bridge = callPackage ../servers/irc/robustirc-bridge { };


### PR DESCRIPTION
## Description of changes

Backport of Bambu Studio and Orca Slicer to 23.11. Due to its dependency on Mesa it is difficult to use from unstable.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
