### PR TITLE
[23.11] hugin: add patches for CVE-2024-25442, CVE-2024-25443, CVE-2024-25445, CVE-2024-25446

### DIFF
--- a/pkgs/applications/graphics/hugin/CVE-2024-25442.CVE-2024-25443.CVE-2024-25445.CVE-2024-25446.part-1.patch
+++ b/pkgs/applications/graphics/hugin/CVE-2024-25442.CVE-2024-25443.CVE-2024-25445.CVE-2024-25446.part-1.patch
@@ -1,0 +1,37 @@
+# HG changeset patch
+# User tmodes
+# Date 1688055404 -7200
+#      Thu Jun 29 18:16:44 2023 +0200
+# Node ID 87ceecbc2bb5bf24a6e4f991d840275459502990
+# Parent  d31e86e33f1fa4050ee2a9538136d003cd5ce200
+Reject control characters when reading pto file
+
+diff -r d31e86e33f1f -r 87ceecbc2bb5 src/hugin_base/panodata/Panorama.cpp
+--- a/src/hugin_base/panodata/Panorama.cpp	Thu Jun 29 17:39:02 2023 +0200
++++ b/src/hugin_base/panodata/Panorama.cpp	Thu Jun 29 18:16:44 2023 +0200
+@@ -2439,6 +2439,8 @@
+     char * old_locale = strdup(p);
+     setlocale(LC_NUMERIC,"C");
+     std::string line;
++    // list of all control characters (char 0 .. 31)
++    const std::string controlCharacters { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31};
+ 
+     // vector with the different information lines about images
+     std::vector<PTScriptParsing::ImgInfo> oImgInfo;
+@@ -2473,6 +2475,16 @@
+     unsigned int lineNr = 0;    
+     while (i.good()) {
+         std::getline(i, line);
++        if (line.find_first_of(controlCharacters, 0) != std::string::npos)
++        {
++            // we found a binary character /control sequence in the text
++            // this is not allowed in a pto file
++            // reset locale
++            setlocale(LC_NUMERIC, old_locale);
++            free(old_locale);
++            // stop processing
++            return false;
++        };
+         lineNr++;
+         DEBUG_DEBUG(lineNr << ": " << line);
+         if (skipNextLine) {

--- a/pkgs/applications/graphics/hugin/CVE-2024-25442.CVE-2024-25443.CVE-2024-25445.CVE-2024-25446.part-2.patch
+++ b/pkgs/applications/graphics/hugin/CVE-2024-25442.CVE-2024-25443.CVE-2024-25445.CVE-2024-25446.part-2.patch
@@ -1,0 +1,716 @@
+# HG changeset patch
+# User tmodes
+# Date 1688059109 -7200
+#      Thu Jun 29 19:18:29 2023 +0200
+# Node ID 2bdc20dcca7e6c6fec16410adea91712a08cc344 (modified)
+# Parent  aeae17984212a86d818a642146e5fcdc86df89e9
+Move all input pto file handling into separate function
+
+This avoids duplication of input handling in nearly all command line tools
+
+# Modified to omit alterations to code not present in 2022.0.0
+
+diff -r aeae17984212 -r 2bdc20dcca7e src/celeste/Main.cpp
+--- a/src/celeste/Main.cpp	Thu Jun 29 18:58:08 2023 +0200
++++ b/src/celeste/Main.cpp	Thu Jun 29 19:18:29 2023 +0200
+@@ -370,22 +370,11 @@
+   		std::cout << "Parsing Hugin project file " << pto_file << std::endl << std::endl;
+ 
+         HuginBase::Panorama pano;
+-        std::ifstream prjfile(pto_file.c_str());
+-        if (!prjfile.good())
++        if (!pano.ReadPTOFile(pto_file, hugin_utils::getPathPrefix(pto_file)))
+         {
+-            std::cerr << "could not open script : " << pto_file << std::endl;
+             celeste::destroySVMmodel(model);
+             return 1;
+-        }
+-        pano.setFilePrefix(hugin_utils::getPathPrefix(pto_file));
+-        AppBase::DocumentData::ReadWriteError err = pano.readData(prjfile);
+-        if (err != AppBase::DocumentData::SUCCESSFUL)
+-        {
+-            std::cerr << "error while parsing panos tool script: " << pto_file << std::endl;
+-            std::cerr << "DocumentData::ReadWriteError code: " << err << std::endl;
+-            celeste::destroySVMmodel(model);
+-            return 1;
+-        }
++        };
+ 
+         for(unsigned int i=0;i<pano.getNrOfImages();i++)
+         {
+diff -r aeae17984212 -r 2bdc20dcca7e src/hugin1/base_wx/PanoCommand.cpp
+--- a/src/hugin1/base_wx/PanoCommand.cpp	Thu Jun 29 18:58:08 2023 +0200
++++ b/src/hugin1/base_wx/PanoCommand.cpp	Thu Jun 29 19:18:29 2023 +0200
+@@ -375,14 +375,10 @@
+ 
+     bool LoadPTProjectCmd::processPanorama(HuginBase::Panorama& pano)
+     {
+-        std::ifstream in(filename.c_str());
+-        AppBase::DocumentData::ReadWriteError err = pano.readData(in);
+-        if (err != AppBase::DocumentData::SUCCESSFUL)
++        if (!pano.ReadPTOFile(filename))
+         {
+-            DEBUG_ERROR("could not load panotools script");
+             return false;
+         }
+-        in.close();
+         return true;
+     }
+ 
+diff -r aeae17984212 -r 2bdc20dcca7e src/hugin1/executor/hugin_executor.cpp
+--- a/src/hugin1/executor/hugin_executor.cpp	Thu Jun 29 18:58:08 2023 +0200
++++ b/src/hugin1/executor/hugin_executor.cpp	Thu Jun 29 19:18:29 2023 +0200
+@@ -108,21 +108,10 @@
+         wxFileName inputFile(m_input);
+         inputFile.Normalize();
+         std::string input(inputFile.GetFullPath().mb_str(HUGIN_CONV_FILENAME));
+-        std::ifstream prjfile(input.c_str());
+-        if (!prjfile.good())
++        if (!pano.ReadPTOFile(input, hugin_utils::getPathPrefix(input)))
+         {
+-            std::cerr << "could not open script : " << input << std::endl;
+-            return -1;
+-        }
+-        pano.setFilePrefix(hugin_utils::getPathPrefix(input));
+-        AppBase::DocumentData::ReadWriteError err = pano.readData(prjfile);
+-        if (err != AppBase::DocumentData::SUCCESSFUL)
+-        {
+-            std::cerr << "error while parsing panos tool script: " << input << std::endl;
+-            std::cerr << "DocumentData::ReadWriteError code: " << err << std::endl;
+-            return -1;
+-        }
+-        prjfile.close();
++            return 1;
++        };
+ 
+         HuginQueue::CommandQueue* commands;
+         wxArrayString tempfiles;
+diff -r aeae17984212 -r 2bdc20dcca7e src/hugin_base/appbase/DocumentData.h
+--- a/src/hugin_base/appbase/DocumentData.h	Thu Jun 29 18:58:08 2023 +0200
++++ b/src/hugin_base/appbase/DocumentData.h	Thu Jun 29 19:18:29 2023 +0200
+@@ -50,7 +50,6 @@
+     public:
+         enum ReadWriteError { SUCCESSFUL=-1, UNKNOWN_ERROR, INCOMPATIBLE_TYPE, INVALID_DATA, PARSER_ERROR };
+             
+-        virtual ReadWriteError readData(std::istream& dataInput, std::string documentType = "") =0;
+         virtual ReadWriteError writeData(std::ostream& dataOutput, std::string documentType = "") =0;
+         
+         
+diff -r aeae17984212 -r 2bdc20dcca7e src/hugin_base/panodata/Panorama.cpp
+--- a/src/hugin_base/panodata/Panorama.cpp	Thu Jun 29 18:58:08 2023 +0200
++++ b/src/hugin_base/panodata/Panorama.cpp	Thu Jun 29 19:18:29 2023 +0200
+@@ -2020,28 +2020,40 @@
+     return t+1;
+ }
+ 
+-
+-Panorama::ReadWriteError Panorama::readData(std::istream& dataInput, std::string documentType)
++bool Panorama::ReadPTOFile(const std::string& filename, const std::string& prefix)
+ {
+-    // [TODO] check the document type, return INCOMPATIBLE_TYPE
+-    
+-    if(!dataInput.good() || dataInput.eof())
++    // check if filename is an image file
++    if (vigra::isImage(filename.c_str()))
+     {
+-        DEBUG_WARN("Failed to read from dataInput.");
+-        return INVALID_DATA;
+-    }
+-    
++        std::cerr << "file \"" << filename << "\" seems to be an image file and not a PTO file." << std::endl;
++        return false;
++    };
++    // open stream and check
++    std::ifstream dataInput(filename.c_str());
++    if (!dataInput.good() || dataInput.eof())
++    {
++        std::cerr << "could not open script : " << filename << std::endl;
++        return false;
++    };
++    // finally read pto file
+     PanoramaMemento newPano;
+     int ptoVersion;
+-    if (newPano.loadPTScript(dataInput, ptoVersion, getFilePrefix())) {
+-        
++    const bool result = newPano.loadPTScript(dataInput, ptoVersion, prefix);
++    // close stream
++    dataInput.close();
++    if (result)
++    {
++        // reading was sucessful, update current object
++        this->setFilePrefix(prefix);
+         this->setMemento(newPano);
+-        return SUCCESSFUL;
+-        
+-    } else {
+-        DEBUG_FATAL("Could not parse the data input successfully.");
+-        return PARSER_ERROR;
++        return true;
+     }
++    else
++    {
++        // failed to parse pto file
++        std::cerr << "error while parsing panos tool script: " << filename << std::endl;
++        return false;
++    };
+ }
+ 
+ ///
+diff -r aeae17984212 -r 2bdc20dcca7e src/hugin_base/panodata/Panorama.h
+--- a/src/hugin_base/panodata/Panorama.h	Thu Jun 29 18:58:08 2023 +0200
++++ b/src/hugin_base/panodata/Panorama.h	Thu Jun 29 19:18:29 2023 +0200
+@@ -623,12 +623,13 @@
+     //=========== Document Data ====================================================
+ 
+     public:
+-        /** Reads data. You have to check with refered images after data is
+-         *  loaded as the file path is likely to be relative, and the image
+-         *  property might have been changed since the project is saved.
+-         */
+-        ReadWriteError readData(std::istream& dataInput, std::string documentType = "");
+-        
++        /** read pto file from the given filename into Panorama object 
++        * it does some checks on the file and issues warnings to std::cerr
++        * @param filename the filename from which is pto file is read
++        * @param prefix path prefix to use for filepath mangling
++        * @return true, if file could be successful read */
++        bool ReadPTOFile(const std::string& filename, const std::string& prefix = "");
++
+         ///
+         ReadWriteError writeData(std::ostream& dataOutput, std::string documentType = "");
+ 
+diff -r aeae17984212 -r 2bdc20dcca7e src/hugin_cpfind/cpfind/PanoDetector.cpp
+--- a/src/hugin_cpfind/cpfind/PanoDetector.cpp	Thu Jun 29 18:58:08 2023 +0200
++++ b/src/hugin_cpfind/cpfind/PanoDetector.cpp	Thu Jun 29 19:18:29 2023 +0200
+@@ -742,12 +742,6 @@
+ 
+ bool PanoDetector::loadProject()
+ {
+-    std::ifstream ptoFile(_inputFile.c_str());
+-    if (ptoFile.bad())
+-    {
+-        std::cerr << "ERROR: could not open file: '" << _inputFile << "'!" << std::endl;
+-        return false;
+-    }
+     _prefix=hugin_utils::getPathPrefix(_inputFile);
+     if(_prefix.empty())
+     {
+@@ -763,11 +757,8 @@
+             _prefix=includeTrailingPathSep(_prefix);
+         }
+     };
+-    _panoramaInfo->setFilePrefix(_prefix);
+-    AppBase::DocumentData::ReadWriteError err = _panoramaInfo->readData(ptoFile);
+-    if (err != AppBase::DocumentData::SUCCESSFUL)
++    if (!_panoramaInfo->ReadPTOFile(_inputFile, _prefix))
+     {
+-        std::cerr << "ERROR: couldn't parse panos tool script: '" << _inputFile << "'!" << std::endl;
+         return false;
+     }
+ 
+diff -r aeae17984212 -r 2bdc20dcca7e src/tools/autooptimiser.cpp
+--- a/src/tools/autooptimiser.cpp	Thu Jun 29 18:58:08 2023 +0200
++++ b/src/tools/autooptimiser.cpp	Thu Jun 29 19:18:29 2023 +0200
+@@ -171,33 +171,10 @@
+     const char* scriptFile = argv[optind];
+ 
+     HuginBase::Panorama pano;
+-    if (scriptFile[0] == '-')
+-    {
+-        AppBase::DocumentData::ReadWriteError err = pano.readData(std::cin);
+-        if (err != AppBase::DocumentData::SUCCESSFUL)
+-        {
+-            std::cerr << "error while reading script file from stdin." << std::endl
+-                << "DocumentData::ReadWriteError code: " << err << std::endl;
+-            return 1;
+-        }
+-    }
+-    else
++    if (!pano.ReadPTOFile(scriptFile, hugin_utils::getPathPrefix(scriptFile)))
+     {
+-        std::ifstream prjfile(scriptFile);
+-        if (!prjfile.good())
+-        {
+-            std::cerr << "could not open script : " << scriptFile << std::endl;
+-            return 1;
+-        }
+-        pano.setFilePrefix(hugin_utils::getPathPrefix(scriptFile));
+-        AppBase::DocumentData::ReadWriteError err = pano.readData(prjfile);
+-        if (err != AppBase::DocumentData::SUCCESSFUL)
+-        {
+-            std::cerr << "error while parsing panos tool script: " << scriptFile << std::endl
+-                << "DocumentData::ReadWriteError code: " << err << std::endl;
+-            return 1;
+-        }
+-    }
++        return 1;
++    };
+ 
+     if (pano.getNrOfImages() == 0)
+     {
+diff -r aeae17984212 -r 2bdc20dcca7e src/tools/checkpto.cpp
+--- a/src/tools/checkpto.cpp	Thu Jun 29 18:58:08 2023 +0200
++++ b/src/tools/checkpto.cpp	Thu Jun 29 19:18:29 2023 +0200
+@@ -366,20 +366,10 @@
+     };
+ 
+     HuginBase::Panorama pano;
+-    std::ifstream prjfile(input.c_str());
+-    if (!prjfile.good())
++    if (!pano.ReadPTOFile(input, hugin_utils::getPathPrefix(input)))
+     {
+-        std::cerr << "could not open script : " << input << std::endl;
+         return -1;
+-    }
+-    pano.setFilePrefix(hugin_utils::getPathPrefix(input));
+-    AppBase::DocumentData::ReadWriteError err = pano.readData(prjfile);
+-    if (err != AppBase::DocumentData::SUCCESSFUL)
+-    {
+-        std::cerr << "error while parsing panos tool script: " << input << std::endl
+-            << "DocumentData::ReadWriteError code: " << err << std::endl;
+-        return -1;
+-    }
++    };
+ 
+     HuginBase::ConstStandardImageVariableGroups variable_groups(pano);
+     std::cout << std::endl
+diff -r aeae17984212 -r 2bdc20dcca7e src/tools/cpclean.cpp
+--- a/src/tools/cpclean.cpp	Thu Jun 29 18:58:08 2023 +0200
++++ b/src/tools/cpclean.cpp	Thu Jun 29 19:18:29 2023 +0200
+@@ -174,20 +174,10 @@
+     std::string input=argv[optind];
+ 
+     HuginBase::Panorama pano;
+-    std::ifstream prjfile(input.c_str());
+-    if (!prjfile.good())
++    if (!pano.ReadPTOFile(input, hugin_utils::getPathPrefix(input)))
+     {
+-        std::cerr << "could not open script : " << input << std::endl;
+         return 1;
+-    }
+-    pano.setFilePrefix(hugin_utils::getPathPrefix(input));
+-    AppBase::DocumentData::ReadWriteError err = pano.readData(prjfile);
+-    if (err != AppBase::DocumentData::SUCCESSFUL)
+-    {
+-        std::cerr << "error while parsing panos tool script: " << input << std::endl;
+-        std::cerr << "DocumentData::ReadWriteError code: " << err << std::endl;
+-        return 1;
+-    }
++    };
+ 
+     const size_t nrImg=pano.getNrOfImages();
+     if (nrImg < 2)
+diff -r aeae17984212 -r 2bdc20dcca7e src/tools/geocpset.cpp
+--- a/src/tools/geocpset.cpp	Thu Jun 29 18:58:08 2023 +0200
++++ b/src/tools/geocpset.cpp	Thu Jun 29 19:18:29 2023 +0200
+@@ -370,20 +370,10 @@
+     std::string input=argv[optind];
+     // read panorama
+     HuginBase::Panorama pano;
+-    std::ifstream prjfile(input.c_str());
+-    if (!prjfile.good())
++    if (!pano.ReadPTOFile(input, hugin_utils::getPathPrefix(input)))
+     {
+-        std::cerr << "could not open script : " << input << std::endl;
+         return 1;
+-    }
+-    pano.setFilePrefix(hugin_utils::getPathPrefix(input));
+-    AppBase::DocumentData::ReadWriteError err = pano.readData(prjfile);
+-    if (err != AppBase::DocumentData::SUCCESSFUL)
+-    {
+-        std::cerr << "error while parsing panos tool script: " << input << std::endl
+-            << "DocumentData::ReadWriteError code: " << err << std::endl;
+-        return 1;
+-    }
++    };
+ 
+     if(pano.getNrOfImages()==1)
+     {
+diff -r aeae17984212 -r 2bdc20dcca7e src/tools/hugin_lensdb.cpp
+--- a/src/tools/hugin_lensdb.cpp	Thu Jun 29 18:58:08 2023 +0200
++++ b/src/tools/hugin_lensdb.cpp	Thu Jun 29 19:18:29 2023 +0200
+@@ -78,23 +78,11 @@
+ {
+     // open project file
+     HuginBase::Panorama pano;
+-    std::string input = filename.string();
+-    std::ifstream prjfile(input.c_str());
+-    if (!prjfile.good())
++    const std::string input = filename.string();
++    if (!pano.ReadPTOFile(input, hugin_utils::getPathPrefix(input)))
+     {
+-        std::cerr << "ERROR: Could not open script: " << filename.string() << endl;
+-        return false;
+-    }
+-    std::string inputPathPrefix = hugin_utils::getPathPrefix(input);
+-    pano.setFilePrefix(inputPathPrefix);
+-    AppBase::DocumentData::ReadWriteError err = pano.readData(prjfile);
+-    if (err != AppBase::DocumentData::SUCCESSFUL)
+-    {
+-        std::cerr << "ERROR: error while parsing panos tool script: " << input << std::endl
+-                  << "DocumentData::ReadWriteError code: " << err << std::endl;
+-        return false;
++        return 1;
+     };
+-    prjfile.close();
+     if (pano.getNrOfImages() == 0)
+     {
+         return false;
+diff -r aeae17984212 -r 2bdc20dcca7e src/tools/linefind.cpp
+--- a/src/tools/linefind.cpp	Thu Jun 29 18:58:08 2023 +0200
++++ b/src/tools/linefind.cpp	Thu Jun 29 19:18:29 2023 +0200
+@@ -354,20 +354,10 @@
+     std::string input=argv[optind];
+     // read panorama
+     HuginBase::Panorama pano;
+-    std::ifstream prjfile(input.c_str());
+-    if (!prjfile.good())
++    if (!pano.ReadPTOFile(input, hugin_utils::getPathPrefix(input)))
+     {
+-        std::cerr << "could not open script : " << input << std::endl;
+         return 1;
+-    }
+-    pano.setFilePrefix(hugin_utils::getPathPrefix(input));
+-    AppBase::DocumentData::ReadWriteError err = pano.readData(prjfile);
+-    if (err != AppBase::DocumentData::SUCCESSFUL)
+-    {
+-        std::cerr << "error while parsing panos tool script: " << input << std::endl;
+-        std::cerr << "DocumentData::ReadWriteError code: " << err << std::endl;
+-        return 1;
+-    }
++    };
+ 
+     // disable progress messages from libpano optimizer
+     PT_setProgressFcn(ptProgress);
+diff -r aeae17984212 -r 2bdc20dcca7e src/tools/nona.cpp
+--- a/src/tools/nona.cpp	Thu Jun 29 18:58:08 2023 +0200
++++ b/src/tools/nona.cpp	Thu Jun 29 19:18:29 2023 +0200
+@@ -354,19 +354,10 @@
+     TIFFSetWarningHandler(0);
+ 
+     HuginBase::Panorama pano;
+-    std::ifstream prjfile(scriptFile);
+-    if (prjfile.bad())
++    if (!pano.ReadPTOFile(scriptFile, hugin_utils::getPathPrefix(scriptFile)))
+     {
+-        std::cerr << "could not open script : " << scriptFile << std::endl;
+         exit(1);
+-    }
+-    pano.setFilePrefix(hugin_utils::getPathPrefix(scriptFile));
+-    AppBase::DocumentData::ReadWriteError err = pano.readData(prjfile);
+-    if (err != AppBase::DocumentData::SUCCESSFUL)
+-    {
+-        std::cerr << "error while parsing panos tool script: " << scriptFile << std::endl;
+-        exit(1);
+-    }
++    };
+ 
+     if ( nCmdLineImgs > 0)
+     {
+diff -r aeae17984212 -r 2bdc20dcca7e src/tools/pano_modify.cpp
+--- a/src/tools/pano_modify.cpp	Thu Jun 29 18:58:08 2023 +0200
++++ b/src/tools/pano_modify.cpp	Thu Jun 29 19:18:29 2023 +0200
+@@ -610,20 +610,10 @@
+     std::string input=argv[optind];
+     // read panorama
+     HuginBase::Panorama pano;
+-    std::ifstream prjfile(input.c_str());
+-    if (!prjfile.good())
++    if (!pano.ReadPTOFile(input, hugin_utils::getPathPrefix(input)))
+     {
+-        std::cerr << "could not open script : " << input << std::endl;
+         return 1;
+-    }
+-    pano.setFilePrefix(hugin_utils::getPathPrefix(input));
+-    AppBase::DocumentData::ReadWriteError err = pano.readData(prjfile);
+-    if (err != AppBase::DocumentData::SUCCESSFUL)
+-    {
+-        std::cerr << "error while parsing panos tool script: " << input << std::endl;
+-        std::cerr << "DocumentData::ReadWriteError code: " << err << std::endl;
+-        return 1;
+-    }
++    };
+ 
+     // sets the projection
+     if(projection!=-1)
+diff -r aeae17984212 -r 2bdc20dcca7e src/tools/pano_trafo.cpp
+--- a/src/tools/pano_trafo.cpp	Thu Jun 29 18:58:08 2023 +0200
++++ b/src/tools/pano_trafo.cpp	Thu Jun 29 19:18:29 2023 +0200
+@@ -152,20 +152,10 @@
+     std::string input=argv[optind];
+ 
+     HuginBase::Panorama pano;
+-    std::ifstream prjfile(input.c_str());
+-    if (!prjfile.good())
++    if (!pano.ReadPTOFile(input, hugin_utils::getPathPrefix(input)))
+     {
+-        std::cerr << "could not open script : " << input << std::endl;
+         return 1;
+-    }
+-    pano.setFilePrefix(hugin_utils::getPathPrefix(input));
+-    AppBase::DocumentData::ReadWriteError err = pano.readData(prjfile);
+-    if (err != AppBase::DocumentData::SUCCESSFUL)
+-    {
+-        std::cerr << "error while parsing panos tool script: " << input << std::endl;
+-        std::cerr << "AppBase::DocumentData::ReadWriteError code: " << err << std::endl;
+-        return 1;
+-    }
++    };
+ 
+     // set up output format
+     std::cout.setf ( std::ios::fixed ) ;
+diff -r aeae17984212 -r 2bdc20dcca7e src/tools/pto_lensstack.cpp
+--- a/src/tools/pto_lensstack.cpp	Thu Jun 29 18:58:08 2023 +0200
++++ b/src/tools/pto_lensstack.cpp	Thu Jun 29 19:18:29 2023 +0200
+@@ -219,20 +219,10 @@
+     std::string input=argv[optind];
+     // read panorama
+     HuginBase::Panorama pano;
+-    std::ifstream prjfile(input.c_str());
+-    if (!prjfile.good())
++    if (!pano.ReadPTOFile(input, hugin_utils::getPathPrefix(input)))
+     {
+-        std::cerr << "could not open script : " << input << std::endl;
+         return 1;
+-    }
+-    pano.setFilePrefix(hugin_utils::getPathPrefix(input));
+-    AppBase::DocumentData::ReadWriteError err = pano.readData(prjfile);
+-    if (err != AppBase::DocumentData::SUCCESSFUL)
+-    {
+-        std::cerr << "error while parsing panos tool script: " << input << std::endl;
+-        std::cerr << "AppBase::DocumentData::ReadWriteError code: " << err << std::endl;
+-        return 1;
+-    }
++    };
+ 
+     // new lenses
+     if(!newLensImgs.empty())
+diff -r aeae17984212 -r 2bdc20dcca7e src/tools/pto_mask.cpp
+--- a/src/tools/pto_mask.cpp	Thu Jun 29 18:58:08 2023 +0200
++++ b/src/tools/pto_mask.cpp	Thu Jun 29 19:18:29 2023 +0200
+@@ -262,20 +262,10 @@
+     std::string input=argv[optind];
+     // read panorama
+     HuginBase::Panorama pano;
+-    std::ifstream prjfile(input.c_str());
+-    if (!prjfile.good())
++    if (!pano.ReadPTOFile(input, hugin_utils::getPathPrefix(input)))
+     {
+-        std::cerr << "Error: could not open script " << input << std::endl;
+         return 1;
+-    }
+-    pano.setFilePrefix(hugin_utils::getPathPrefix(input));
+-    AppBase::DocumentData::ReadWriteError err = pano.readData(prjfile);
+-    if (err != AppBase::DocumentData::SUCCESSFUL)
+-    {
+-        std::cerr << "Error while parsing panos tool script: " << input << std::endl;
+-        std::cerr << "AppBase::DocumentData::ReadWriteError code: " << err << std::endl;
+-        return 1;
+-    }
++    };
+ 
+     //delete masks
+     if (deleteAllMasks)
+diff -r aeae17984212 -r 2bdc20dcca7e src/tools/pto_merge.cpp
+--- a/src/tools/pto_merge.cpp	Thu Jun 29 18:58:08 2023 +0200
++++ b/src/tools/pto_merge.cpp	Thu Jun 29 19:18:29 2023 +0200
+@@ -89,40 +89,20 @@
+     std::string input=argv[optind];
+     // read panorama
+     HuginBase::Panorama pano;
+-    std::ifstream prjfile(input.c_str());
+-    if (!prjfile.good())
++    if (!pano.ReadPTOFile(input, hugin_utils::getPathPrefix(input)))
+     {
+-        std::cerr << "could not open script : " << input << std::endl;
+         return 1;
+-    }
+-    pano.setFilePrefix(hugin_utils::getPathPrefix(input));
+-    AppBase::DocumentData::ReadWriteError err = pano.readData(prjfile);
+-    if (err != AppBase::DocumentData::SUCCESSFUL)
+-    {
+-        std::cerr << "error while parsing panos tool script: " << input << std::endl;
+-        std::cerr << "AppBase::DocumentData::ReadWriteError code: " << err << std::endl;
+-        return 1;
+-    }
++    };
+ 
+     optind++;
+     while(optind<argc)
+     {
+         HuginBase::Panorama pano2;
+-        std::string input2=argv[optind];
+-        std::ifstream prjfile2(input2.c_str());
+-        if (!prjfile2.good())
++        const std::string input2=argv[optind];
++        if (!pano2.ReadPTOFile(input2, hugin_utils::getPathPrefix(input2)))
+         {
+-            std::cerr << "could not open script : " << input << std::endl;
+             return 1;
+-        }
+-        pano2.setFilePrefix(hugin_utils::getPathPrefix(input2));
+-        AppBase::DocumentData::ReadWriteError err = pano2.readData(prjfile2);
+-        if (err != AppBase::DocumentData::SUCCESSFUL)
+-        {
+-            std::cerr << "error while parsing panos tool script: " << input << std::endl;
+-            std::cerr << "AppBase::DocumentData::ReadWriteError code: " << err << std::endl;
+-            return 1;
+-        }
++        };
+         // read EXIF data, needed for lens detection in merged pano
+         for (size_t i = 0; i < pano.getNrOfImages(); ++i)
+         {
+diff -r aeae17984212 -r 2bdc20dcca7e src/tools/pto_move.cpp
+--- a/src/tools/pto_move.cpp	Thu Jun 29 18:58:08 2023 +0200
++++ b/src/tools/pto_move.cpp	Thu Jun 29 19:18:29 2023 +0200
+@@ -109,24 +109,13 @@
+               << "  to " << destFile.parent_path() << std::endl;
+     // open project file
+     HuginBase::Panorama pano;
+-    std::string input=src.string();
+-    std::ifstream prjfile(input.c_str());
+-    if (!prjfile.good())
++    const std::string input=src.string();
++    const std::string inputPathPrefix = hugin_utils::getPathPrefix(input);
++    const std::string outputPathPrefix = hugin_utils::getPathPrefix(destFile.string());
++    if (!pano.ReadPTOFile(input, inputPathPrefix))
+     {
+-        std::cerr << "ERROR: Could not open script: " << src.string() << std::endl;
+-        return false;
+-    }
+-    std::string inputPathPrefix=hugin_utils::getPathPrefix(input);
+-    std::string outputPathPrefix=hugin_utils::getPathPrefix(destFile.string());
+-    pano.setFilePrefix(inputPathPrefix);
+-    AppBase::DocumentData::ReadWriteError err = pano.readData(prjfile);
+-    if (err != AppBase::DocumentData::SUCCESSFUL)
+-    {
+-        std::cerr << "ERROR: error while parsing panos tool script: " << input << std::endl
+-                  << "AppBase::DocumentData::ReadWriteError code: " << err << std::endl;
+         return false;
+     };
+-    prjfile.close();
+     pathVec imagesFrom;
+     std::map<fs::path,fs::path> imagesTo;
+     // check if all images exists
+diff -r aeae17984212 -r 2bdc20dcca7e src/tools/pto_template.cpp
+--- a/src/tools/pto_template.cpp	Thu Jun 29 18:58:08 2023 +0200
++++ b/src/tools/pto_template.cpp	Thu Jun 29 19:18:29 2023 +0200
+@@ -114,36 +114,16 @@
+     std::string input=argv[optind];
+     // read panorama
+     HuginBase::Panorama pano;
+-    std::ifstream prjfile(input.c_str());
+-    if (!prjfile.good())
++    if (!pano.ReadPTOFile(input, hugin_utils::getPathPrefix(input)))
+     {
+-        std::cerr << "Error: could not open script : " << input << std::endl;
+         return 1;
+-    }
+-    pano.setFilePrefix(hugin_utils::getPathPrefix(input));
+-    AppBase::DocumentData::ReadWriteError err = pano.readData(prjfile);
+-    if (err != AppBase::DocumentData::SUCCESSFUL)
+-    {
+-        std::cerr << "Error while parsing panos tool script: " << input << std::endl;
+-        std::cerr << "AppBase::DocumentData::ReadWriteError code: " << err << std::endl;
+-        return 1;
+-    }
++    };
+ 
+     HuginBase::Panorama newPano;
+-    std::ifstream templateStream(templateFile.c_str());
+-    if (!templateStream.good())
++    if (!newPano.ReadPTOFile(templateFile, hugin_utils::getPathPrefix(templateFile)))
+     {
+-        std::cerr << "Error: could not open template script : " << templateFile << std::endl;
+         return 1;
+-    }
+-    newPano.setFilePrefix(hugin_utils::getPathPrefix(templateFile));
+-    err = newPano.readData(templateStream);
+-    if (err != AppBase::DocumentData::SUCCESSFUL)
+-    {
+-        std::cerr << "Error while parsing template script: " << templateFile << std::endl;
+-        std::cerr << "AppBase::DocumentData::ReadWriteError code: " << err << std::endl;
+-        return 1;
+-    }
++    };
+ 
+     if (pano.getNrOfImages() != newPano.getNrOfImages())
+     {
+diff -r aeae17984212 -r 2bdc20dcca7e src/tools/pto_var.cpp
+--- a/src/tools/pto_var.cpp	Thu Jun 29 18:58:08 2023 +0200
++++ b/src/tools/pto_var.cpp	Thu Jun 29 19:18:29 2023 +0200
+@@ -676,20 +676,10 @@
+     std::string input=argv[optind];
+     // read panorama
+     HuginBase::Panorama pano;
+-    std::ifstream prjfile(input.c_str());
+-    if (!prjfile.good())
++    if (!pano.ReadPTOFile(input, hugin_utils::getPathPrefix(input)))
+     {
+-        std::cerr << "could not open script : " << input << std::endl;
+         return 1;
+-    }
+-    pano.setFilePrefix(hugin_utils::getPathPrefix(input));
+-    AppBase::DocumentData::ReadWriteError err = pano.readData(prjfile);
+-    if (err != AppBase::DocumentData::SUCCESSFUL)
+-    {
+-        std::cerr << "error while parsing panos tool script: " << input << std::endl;
+-        std::cerr << "AppBase::DocumentData::ReadWriteError code: " << err << std::endl;
+-        return 1;
+-    }
++    };
+ 
+     //link/unlink variables
+     if(!linkVars.empty())
+diff -r aeae17984212 -r 2bdc20dcca7e src/tools/tca_correct.cpp
+--- a/src/tools/tca_correct.cpp	Thu Jun 29 18:58:08 2023 +0200
++++ b/src/tools/tca_correct.cpp	Thu Jun 29 19:18:29 2023 +0200
+@@ -692,19 +692,11 @@
+ {
+     HuginBase::Panorama pano;
+ 
+-    std::ifstream ptofile(filename);
+-    if (ptofile.bad())
++    const std::string filenameString(filename);
++    if (!pano.ReadPTOFile(filenameString, hugin_utils::getPathPrefix(filenameString)))
+     {
+-        std::cerr << "could not open script : " << filename << std::endl;
+         return 1;
+-    }
+-    pano.setFilePrefix(hugin_utils::getPathPrefix(filename));
+-    AppBase::DocumentData::ReadWriteError err = pano.readData(ptofile);
+-    if (err != AppBase::DocumentData::SUCCESSFUL)
+-    {
+-        std::cerr << "error while parsing script: " << filename << std::endl;
+-        return 1;
+-    }
++    };
+ 
+     return main2(pano);
+ }
+diff -r aeae17984212 -r 2bdc20dcca7e src/tools/vig_optimize.cpp
+--- a/src/tools/vig_optimize.cpp	Thu Jun 29 18:58:08 2023 +0200
++++ b/src/tools/vig_optimize.cpp	Thu Jun 29 19:18:29 2023 +0200
+@@ -215,20 +215,10 @@
+ 
+     const char* scriptFile = argv[optind];
+     HuginBase::Panorama pano;
+-    std::ifstream prjfile(scriptFile);
+-    if (!prjfile.good())
++    if (!pano.ReadPTOFile(scriptFile, hugin_utils::getPathPrefix(scriptFile)))
+     {
+-        std::cerr << "could not open script : " << scriptFile << std::endl;
+         return 1;
+-    }
+-    pano.setFilePrefix(hugin_utils::getPathPrefix(scriptFile));
+-    AppBase::DocumentData::ReadWriteError err = pano.readData(prjfile);
+-    if (err != AppBase::DocumentData::SUCCESSFUL)
+-    {
+-        std::cerr << "error while parsing panos tool script: " << scriptFile << std::endl;
+-        std::cerr << "AppBase::DocumentData::ReadWriteError code: " << err << std::endl;
+-        return 1;
+-    }
++    };
+ 
+     // Ensure photometric parameters are selected for optimizaion
+     if (!hasphotometricParams(pano))

--- a/pkgs/applications/graphics/hugin/default.nix
+++ b/pkgs/applications/graphics/hugin/default.nix
@@ -51,6 +51,8 @@ stdenv.mkDerivation rec {
       url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-gfx/hugin/files/hugin-2022.0.0-exiv2-0.28.patch?id=d18335caa756f5e5c1478d5fe3ba17f011a78c80";
       hash = "sha256-Y+79bFb926GW5oLOL0e5y7kLhqU/vZcry+kLL4H2fUE=";
     })
+    ./CVE-2024-25442.CVE-2024-25443.CVE-2024-25445.CVE-2024-25446.part-1.patch
+    ./CVE-2024-25442.CVE-2024-25443.CVE-2024-25445.CVE-2024-25446.part-2.patch
   ];
 
   buildInputs = [


### PR DESCRIPTION
## Description of changes
https://nvd.nist.gov/vuln/detail/CVE-2024-25442
https://nvd.nist.gov/vuln/detail/CVE-2024-25443
https://nvd.nist.gov/vuln/detail/CVE-2024-25445
https://nvd.nist.gov/vuln/detail/CVE-2024-25446

Included in-tree because sourceforge has no accessible patch url and one needed modification. 23.11 is also a dead-end branch, so we won't have to carry these patches in our history forever.

I'd love if someone who actually uses hugin could test this for us.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
