### PR TITLE
stellar-core: fix `gcc-13` build

### DIFF
--- a/pkgs/applications/blockchains/stellar-core/default.nix
+++ b/pkgs/applications/blockchains/stellar-core/default.nix
@@ -2,6 +2,7 @@
 , automake
 , bison
 , fetchFromGitHub
+, fetchpatch
 , flex
 , git
 , lib
@@ -24,6 +25,23 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-lxBn/T01Tsa7tid3mRJUigUwv9d3BAPZhV9Mp1lywBU=";
     fetchSubmodules = true;
   };
+
+  patches = [
+    # Fix gcc-13 build failure due to missing <stdexcept> include
+    #   https://github.com/stellar/medida/pull/34
+    (fetchpatch {
+      name = "gcc-13-p1.patch";
+      url = "https://github.com/stellar/medida/commit/f91354b0055de939779d392999975d611b1b1ad5.patch";
+      stripLen = 1;
+      extraPrefix = "lib/libmedida/";
+      hash = "sha256-iVeSUY5Rcy62apIKJdbcHGgxAxpQCkygf85oSjbTTXU=";
+    })
+    (fetchpatch {
+      name = "gcc-13-p2.patch";
+      url = "https://github.com/stellar/stellar-core/commit/477b3135281b629554cabaeacfcdbcdc170aa335.patch";
+      hash = "sha256-UVRcAIA5LEaCn16lWfhg19UU7b/apigzTsfPROLZtYg=";
+    })
+  ];
 
   nativeBuildInputs = [
     automake


### PR DESCRIPTION
Without the change build fails on `master` as
https://hydra.nixos.org/build/249037972:

    libmedida/src/medida/histogram.cc: In constructor 'medida::Histogram::Impl::Impl(medida::SamplingInterface::SampleType, std::chrono::seconds)':
    libmedida/src/medida/histogram.cc:134:18: error: 'invalid_argument' is not a member of 'std'
      134 |       throw std::invalid_argument("invalid sample_type");
          |                  ^~~~~~~~~~~~~~~~

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
