### PR TITLE
srsran: fix `gcc-13` build

### DIFF
--- a/pkgs/applications/radio/srsran/default.nix
+++ b/pkgs/applications/radio/srsran/default.nix
@@ -41,6 +41,8 @@ stdenv.mkDerivation rec {
     zeromq
   ];
 
+  cmakeFlags = [ "-DENABLE_WERROR=OFF" ];
+
   meta = with lib; {
     homepage = "https://www.srslte.com/";
     description = "Open-source 4G and 5G software radio suite.";


### PR DESCRIPTION
Without the change build fails on `master` as
https://hydra.nixos.org/build/250334809:

    In file included from /build/source/srsue/hdr/phy/phy_metrics.h:26,
                     from /build/source/srsue/hdr/phy/phy_common.h:25,
                     from /build/source/srsue/src/phy/phy_common.cc:26:
    In member function 'std::array<_Tp, _Nm>::value_type& std::array<_Tp, _Nm>::operator[](size_type) [with _Tp = float; long unsigned int _Nm = 5]',
        inlined from 'void srsue::phy_common::reset_measurements(uint32_t)' at /build/source/srsue/src/phy/phy_common.cc:662:18,
        inlined from 'void srsue::phy_common::reset()' at /build/source/srsue/src/phy/phy_common.cc:918:21:
    /nix/store/qs1nwzbp2ml3cxzsxihn82hl0w73snr0-gcc-13.2.0/include/c++/13.2.0/array:203:24: error: array subscript 5 is above array bounds of 'std::__array_traits<float, 5>::_Type' {aka 'float [5]'} [-Werror=array-bounds=]
      203 |         return _M_elems[__n];
          |                ~~~~~~~~^

Blanket `-Werror` is prone to build failures on newer toolchains. Disable it via exposed `cmake` configure knob.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
