### PR TITLE
Nvtop 3.10 + refactoring

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -105,6 +105,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - `idris2` was updated to v0.7.0. This version introduces breaking changes. Check out the [changelog](https://github.com/idris-lang/Idris2/blob/v0.7.0/CHANGELOG.md#v070) for details.
 
+- `nvtop` family of packages was reorganized into nested attrset. `nvtop` has been renamed to `nvtopPackages.full`, and all `nvtop-{amd,nvidia,intel,msm}` packages are now named as `nvtopPackages.{amd,nvidia,intel,msm}`
+
 - `neo4j` has been updated to 5, you may want to read the [release notes for Neo4j 5](https://neo4j.com/release-notes/database/neo4j-5/)
 
 - `services.neo4j.allowUpgrade` was removed and no longer has any effect. Neo4j 5 supports automatic rolling upgrades.

--- a/pkgs/tools/system/nvtop/build-nvtop.nix
+++ b/pkgs/tools/system/nvtop/build-nvtop.nix
@@ -1,0 +1,90 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, gtest
+, cudatoolkit
+, libdrm
+, ncurses
+, testers
+, udev
+, addOpenGLRunpath
+, amd ? false
+, intel ? false
+, msm ? false
+, nvidia ? false
+, apple ? false
+, panfrost ? false
+, panthor ? false
+, ascend ? false
+}:
+
+let
+  drm-postFixup = ''
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${lib.makeLibraryPath [ libdrm ncurses udev ]}" \
+      $out/bin/nvtop
+  '';
+  needDrm = (amd || msm || panfrost || panthor);
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nvtop";
+  version = "3.1.0";
+
+  src = fetchFromGitHub {
+    owner = "Syllo";
+    repo = "nvtop";
+    rev = finalAttrs.version;
+    hash = "sha256-MkkBY2PR6FZnmRMqv9MWqwPWRgixfkUQW5TWJtHEzwA=";
+  };
+
+  cmakeFlags = with lib.strings; [
+    (cmakeBool "BUILD_TESTING" true)
+    (cmakeBool "USE_LIBUDEV_OVER_LIBSYSTEMD" true)
+    (cmakeBool "AMDGPU_SUPPORT" amd)
+    (cmakeBool "NVIDIA_SUPPORT" nvidia)
+    (cmakeBool "INTEL_SUPPORT" intel)
+    (cmakeBool "APPLE_SUPPORT" apple)
+    (cmakeBool "MSM_SUPPORT" msm)
+    (cmakeBool "PANFROST_SUPPORT" panfrost)
+    (cmakeBool "PANTHOR_SUPPORT" panthor)
+    (cmakeBool "ASCEND_SUPPORT" ascend)
+  ];
+  nativeBuildInputs = [ cmake gtest ] ++ lib.optional nvidia addOpenGLRunpath;
+
+  buildInputs = with lib; [ ncurses udev ]
+    ++ optional nvidia cudatoolkit
+    ++ optional needDrm libdrm
+  ;
+
+  # this helps cmake to find <drm.h>
+  env.NIX_CFLAGS_COMPILE = lib.optionalString needDrm "-isystem ${lib.getDev libdrm}/include/libdrm";
+
+  # ordering of fixups is important
+  postFixup = (lib.optionalString needDrm drm-postFixup) + (lib.optionalString nvidia "addOpenGLRunpath $out/bin/nvtop");
+
+  doCheck = true;
+
+  passthru = {
+    tests.version = testers.testVersion {
+      inherit (finalAttrs) version;
+      package = finalAttrs.finalPackage;
+      command = "nvtop --version";
+    };
+  };
+
+  meta = with lib; {
+    description = "A (h)top like task monitor for AMD, Adreno, Intel and NVIDIA GPUs";
+    longDescription = ''
+      Nvtop stands for Neat Videocard TOP, a (h)top like task monitor for AMD, Adreno, Intel and NVIDIA GPUs.
+      It can handle multiple GPUs and print information about them in a htop familiar way.
+    '';
+    homepage = "https://github.com/Syllo/nvtop";
+    changelog = "https://github.com/Syllo/nvtop/releases/tag/${finalAttrs.version}";
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ willibutz gbtb anthonyroussel ];
+    mainProgram = "nvtop";
+  };
+})

--- a/pkgs/tools/system/nvtop/default.nix
+++ b/pkgs/tools/system/nvtop/default.nix
@@ -1,83 +1,18 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, cmake
-, gtest
-, cudatoolkit
-, libdrm
-, ncurses
-, nvtop
-, testers
-, udev
-, addOpenGLRunpath
-, amd ? true
-, intel ? true
-, msm ? true
-, nvidia ? true
-}:
-
+{ callPackage }:
 let
-  nvidia-postFixup = "addOpenGLRunpath $out/bin/nvtop";
-  libPath = lib.makeLibraryPath [ libdrm ncurses udev ];
-  drm-postFixup = ''
-    patchelf \
-      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
-      --set-rpath "${libPath}" \
-      $out/bin/nvtop
-  '';
+  # this GPU families are supported "by-default" upstream (see https://github.com/Syllo/nvtop/blob/3a69c2d060298cd6f92cb09db944eded98be1c23/CMakeLists.txt#L81)
+  # coincidentally, these families are also easy to build in nixpkgs at the moment
+  defaultGPUFamilies = [ "amd" "intel" "msm" "nvidia" "panfrost" "panthor" ];
+  # these GPU families are partially supported upstream, they are also tricky to build in nixpkgs
+  # volunteers with specific hardware needed to build and test these package variants
+  additionalGPUFamilies = [ "apple" "ascend" ];
+  defaultSupport = builtins.listToAttrs (builtins.map (gpu: { name = gpu; value = true; }) defaultGPUFamilies);
 in
-stdenv.mkDerivation rec {
-  pname = "nvtop";
-  version = "3.1.0";
-
-  src = fetchFromGitHub {
-    owner = "Syllo";
-    repo = "nvtop";
-    rev = version;
-    hash = "sha256-MkkBY2PR6FZnmRMqv9MWqwPWRgixfkUQW5TWJtHEzwA=";
-  };
-
-  cmakeFlags = with lib; [
-    "-DBUILD_TESTING=ON"
-    "-DUSE_LIBUDEV_OVER_LIBSYSTEMD=ON"
-  ] ++ optional nvidia "-DNVML_INCLUDE_DIRS=${cudatoolkit}/include"
-  ++ optional nvidia "-DNVML_LIBRARIES=${cudatoolkit}/targets/x86_64-linux/lib/stubs/libnvidia-ml.so"
-  ++ optional (!amd) "-DAMDGPU_SUPPORT=OFF"
-  ++ optional (!intel) "-DINTEL_SUPPORT=OFF"
-  ++ optional (!msm) "-DMSM_SUPPORT=OFF"
-  ++ optional (!nvidia) "-DNVIDIA_SUPPORT=OFF"
-  ++ optional (amd || msm) "-DLibdrm_INCLUDE_DIRS=${libdrm}/lib/stubs/libdrm.so.2"
-  ;
-  nativeBuildInputs = [ cmake gtest ] ++ lib.optional nvidia addOpenGLRunpath;
-  buildInputs = with lib; [ ncurses udev ]
-    ++ optional nvidia cudatoolkit
-    ++ optional (amd || msm) libdrm
-  ;
-
-  # ordering of fixups is important
-  postFixup = (lib.optionalString (amd || msm) drm-postFixup) + (lib.optionalString nvidia nvidia-postFixup);
-
-  doCheck = true;
-
-  passthru = {
-    tests.version = testers.testVersion {
-      inherit version;
-      package = nvtop;
-      command = "nvtop --version";
-    };
-  };
-
-  meta = with lib; {
-    description = "A (h)top like task monitor for AMD, Adreno, Intel and NVIDIA GPUs";
-    longDescription = ''
-      Nvtop stands for Neat Videocard TOP, a (h)top like task monitor for AMD, Adreno, Intel and NVIDIA GPUs.
-      It can handle multiple GPUs and print information about them in a htop familiar way.
-    '';
-    homepage = "https://github.com/Syllo/nvtop";
-    changelog = "https://github.com/Syllo/nvtop/releases/tag/${version}";
-    license = licenses.gpl3Only;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ willibutz gbtb anthonyroussel ];
-    mainProgram = "nvtop";
-  };
+{
+  full = callPackage ./build-nvtop.nix defaultSupport; #this package supports all default GPU families
 }
+# additional packages with only one specific GPU family support
+// builtins.listToAttrs (builtins.map (gpu: { name = gpu; value = (callPackage ./build-nvtop.nix { "${gpu}" = true; }); }) defaultGPUFamilies)
+
+
+

--- a/pkgs/tools/system/nvtop/default.nix
+++ b/pkgs/tools/system/nvtop/default.nix
@@ -28,13 +28,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "nvtop";
-  version = "3.0.2";
+  version = "3.1.0";
 
   src = fetchFromGitHub {
     owner = "Syllo";
     repo = "nvtop";
     rev = version;
-    hash = "sha256-SHKdjzbc3ZZfOW2p8RLFRKKBfLnO+Z8/bKVxcdLLqxw=";
+    hash = "sha256-MkkBY2PR6FZnmRMqv9MWqwPWRgixfkUQW5TWJtHEzwA=";
   };
 
   cmakeFlags = with lib; [

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -768,6 +768,11 @@ mapAliases ({
   noto-fonts-extra = noto-fonts; # Added 2023-04-08
   NSPlist = nsplist; # Added 2024-01-05
   nvidia-thrust = throw "nvidia-thrust has been removed because the project was deprecated; use cudaPackages.cuda_cccl";
+  nvtop = lib.warn "nvtop has been renamed to nvtopPackages.full" nvtopPackages.full; # Added 2024-02-25
+  nvtop-amd = lib.warn "nvtop-amd has been renamed to nvtopPackages.amd" nvtopPackages.amd; # Added 2024-02-25
+  nvtop-nvidia = lib.warn "nvtop-nvidia has been renamed to nvtopPackages.nvidia" nvtopPackages.nvidia; # Added 2024-02-25
+  nvtop-intel = lib.warn "nvtop-intel has been renamed to nvtopPackages.intel" nvtopPackages.intel; # Added 2024-02-25
+  nvtop-msm = lib.warn "nvtop-msm has been renamed to nvtopPackages.msm" nvtopPackages.msm; # Added 2024-02-25
 
   ### O ###
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24069,31 +24069,7 @@ with pkgs;
 
   nvitop = callPackage ../tools/system/nvitop { };
 
-  nvtop = callPackage ../tools/system/nvtop { };
-  nvtop-amd = (callPackage ../tools/system/nvtop {
-    amd = true;
-    intel = false;
-    msm = false;
-    nvidia = false;
-  }).overrideAttrs { pname = "nvtop-amd"; };
-  nvtop-intel = (callPackage ../tools/system/nvtop {
-    amd = false;
-    intel = true;
-    msm = false;
-    nvidia = false;
-  }).overrideAttrs { pname = "nvtop-intel"; };
-  nvtop-msm = (callPackage ../tools/system/nvtop {
-    amd = false;
-    intel = false;
-    msm = true;
-    nvidia = false;
-  }).overrideAttrs { pname = "nvtop-msm"; };
-  nvtop-nvidia = (callPackage ../tools/system/nvtop {
-    amd = false;
-    intel = false;
-    msm = false;
-    nvidia = true;
-  }).overrideAttrs { pname = "nvtop-nvidia"; };
+  nvtopPackages = recurseIntoAttrs (import ../tools/system/nvtop { inherit callPackage; });
 
   ocl-icd = callPackage ../development/libraries/ocl-icd { };
 


### PR DESCRIPTION
## Description of changes

Update to 3.10 brought additional GPU architectures, that broke the build because of the way we were dealing with ON/OFF switches for particular drivers support. I've refactored code to DRY declarations in all-packages.nix and enabled build of all 6 "default-supported" drivers.


## Things done

1. **Breaking change** in naming of nvtop package variants. Since the number of supported variants increased to 6 separate packages and one "full" package, I've decided to use nested attrset instead of multiple top-level packages. Namely, nvtop became nvtopPackages.full, nvtop-amd became nvtopPackages.amd, etc.
2. Added feature-flags for all 8 GPU architectures supported upstream. Also changed behavior with regards to ON/OFF cmake switches for architectures - now we are explicitly setting all of them and don't rely on upstream defaults.
3. Ascend and Apple GPU architectures require specific hardware/OS to build and test, so its support turned off by default, unless some volunteers step up.
4. I've confirmed that all 7 variants of package builds on my x86-64 machine, and that info from my AMD GPU is displayed. It would be nice that folks with different hardware also test their variants.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
