### PR TITLE
elf-info: init at 0.3.0

### DIFF
--- a/pkgs/by-name/el/elf-info/package.nix
+++ b/pkgs/by-name/el/elf-info/package.nix
@@ -1,0 +1,29 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, nix-update-script
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "elf-info";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "kevin-lesenechal";
+    repo = "elf-info";
+    rev = "v${version}";
+    hash = "sha256-wbFVuoarOoxV9FqmuHJ9eZlG4rRqy1rsnuqbGorC2Rk=";
+  };
+
+  cargoHash = "sha256-r4GcJhQn9x5c2hbL+813mS3HbIg8OwNDsMg/fHQoL9Y=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Inspect and dissect an ELF file with pretty formatting";
+    homepage = "https://github.com/kevin-lesenechal/elf-info";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ viperML ];
+    mainProgram = "elf";
+  };
+}


### PR DESCRIPTION
## Description of changes

https://github.com/kevin-lesenechal/elf-info

> elf-info can inspect and display information about ELF binaries, the executable format mostly used on Linux. This CLI tools aims at being ergonomic, without the need of using two different commands (objdump and readelf) that have impossible to remember options. elf-info commands and options are easy to remember yet short and easy to type. Efforts are made on the presentation of the data, using colors and ASCII tables.



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
