### PR TITLE
rippled: fix `gcc-13` build failure

### DIFF
--- a/pkgs/servers/rippled/default.nix
+++ b/pkgs/servers/rippled/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchgit, fetchurl, git, cmake, pkg-config
+{ lib, stdenv, fetchgit, fetchurl, fetchpatch, git, cmake, pkg-config
 , openssl, boost, grpc, protobuf, libnsl, rocksdb_6_23, snappy }:
 
 let
@@ -99,6 +99,17 @@ in stdenv.mkDerivation rec {
     fetchSubmodules = true;
     hash = "sha256-VW/VmnhtF2xyHfEud3D6b3n8uTE0a/nDW1GISs5QfwM=";
   };
+
+  patches = [
+    # Fix gcc-13 build due to missing <cstdint> includes:
+    #   https://github.com/XRPLF/rippled/pull/4555
+    (fetchpatch {
+      name = "gcc-13.patch";
+      url  = "https://github.com/XRPLF/rippled/commit/c9a586c2437bc8ffd22e946c82e1cbe906e1fc40.patch";
+      hash = "sha256-+4BDTMFoQWUHljgwGB1gtczVPQH/U5MA0ojbnBykceg=";
+      excludes = [ "src/ripple/basics/StringUtilities.h" ];
+    })
+  ];
 
   hardeningDisable = ["format"];
   cmakeFlags = ["-Dstatic=OFF" "-DBoost_NO_BOOST_CMAKE=ON" "-DSNAPPY_INCLUDE_DIR=${snappy}/include" ];


### PR DESCRIPTION
Without the change the build fails on `master` as
https://hydra.nixos.org/build/246448950:

    In file included from /build/rippled/src/test/basics/base64_test.cpp:29,
                     from /build/rippled/build/CMakeFiles/rippled.dir/Unity/unity_23_cxx.cxx:4:
    /build/rippled/src/ripple/basics/base64.h:65:20: error: 'uint8_t' is not a member of 'std'; did you mean 'wint_t'?
       65 | base64_encode(std::uint8_t const* data, std::size_t len);
          |                    ^~~~~~~
          |                    wint_t

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
