### PR TITLE
pythonCatchConflictsHook: avoid infinite recursion

### DIFF
--- a/pkgs/development/interpreters/python/catch_conflicts/catch_conflicts.py
+++ b/pkgs/development/interpreters/python/catch_conflicts/catch_conflicts.py
@@ -57,7 +57,8 @@ def find_packages(store_path: Path, site_packages_path: str, parents: List[str])
         with open(propagated_build_inputs, "r") as f:
             build_inputs: List[str] = f.read().strip().split(" ")
             for build_input in build_inputs:
-                find_packages(Path(build_input), site_packages_path, parents + [build_input])
+                if build_input not in parents:
+                    find_packages(Path(build_input), site_packages_path, parents + [build_input])
 
 
 find_packages(out_path, site_packages_path, [f"this derivation: {out_path}"])

--- a/pkgs/development/interpreters/python/hooks/python-catch-conflicts-hook-tests.nix
+++ b/pkgs/development/interpreters/python/hooks/python-catch-conflicts-hook-tests.nix
@@ -78,6 +78,15 @@ in {
       ];
     };
 
+  # multi-output derivation with dependency on itself must not crash
+  cyclic-dependencies =
+    generatePythonPackage {
+      pname = "cyclic-dependencies";
+      preFixup = ''
+        propagatedBuildInputs+=("$out")
+      '';
+    };
+
   # Simplest test case that should trigger a conflict
   catches-simple-conflict = let
     # this build must fail due to conflicts


### PR DESCRIPTION
## Description of changes

Since https://github.com/NixOS/nixpkgs/pull/287957, the `pythonCatchConflictsHook` follows dependency cycles in `propagatedBuildInputs`, leading to an infinite recursion.

While such a scenario is rare and certainly unorthodox, it is possible:

*   A package might declare itself a propagated build inputs for dependent packages,
*   packages of a multi-output derivation might reference each other.

An example is the `rastertosag-gdi` package, which currently fails in `staging-next` due to a self-reference: https://hydra.nixos.org/build/250853789

This is caused by `patchPpdFilesHook`: It needs to declare dependencies of gzipped ppd files as propagated build inputs (Nix cannot identify dependency's store hashes in compressed files).  This mechanism is needed particularly so that dependencies in multi-output derivations are correctly resolved.

The pull request at hand updates `catch_conflicts.py` so that, while still recursively processing all propagated build inputs, it refrains from processing a package twice.  It also adds a test case with a trivial cycle.

The PR being a mass rebuild, I couldn't test all affected packages with `nixpkgs-review`.  However, I successfully built `cups-drv-rastertosag-gdi` and all of `python3Packages.pythonCatchConflictsHook.tests`.

Notifying author of https://github.com/NixOS/nixpkgs/pull/287957 @DavHau


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
