### PR TITLE
invidious-router: init at 1.1 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18090,6 +18090,16 @@
     github = "silky";
     githubId = 129525;
   };
+  sils = {
+      name = "Silas Schöffel";
+      email = "sils@sils.li";
+      matrix = "@sils:vhack.eu";
+      github = "s1ls";
+      githubId = 91412114;
+      keys = [{
+        fingerprint = "C1DA A551 B422 7A6F 3FD9  6B3A 467B 7D12 9EA7 3AC9";
+      }];
+    };
   Silver-Golden = {
     name = "Brendan Golden";
     email = "github+nixpkgs@brendan.ie";

--- a/pkgs/by-name/in/invidious-router/package.nix
+++ b/pkgs/by-name/in/invidious-router/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  buildGo122Module,
+  fetchFromGitLab,
+}: let
+  version = "1.0";
+in
+  buildGo122Module {
+    pname = "invidious-router";
+    inherit version;
+
+    src = fetchFromGitLab {
+      owner = "gaincoder";
+      repo = "invidious-router";
+      rev = version;
+      hash = "sha256-6apw+UnhDSuPa9QB3S8b8Ej3NJTK+UCdbDjC2LkhLIg=";
+    };
+
+    vendorHash = "sha256-c03vYidm8SkoesRVQZdg/bCp9LIpdTmpXdfwInlHBKk=";
+
+    doCheck = true;
+
+    meta = {
+      homepage = "https://gitlab.com/gaincoder/invidious-router";
+      description = "A Go application that routes requests to different Invidious instances based on their health status and (optional) response time";
+      license = with lib.licenses; [mit];
+      maintainers = with lib.maintainers; [sils];
+      mainProgram = "invidious-router";
+    };
+  }

--- a/pkgs/by-name/in/invidious-router/package.nix
+++ b/pkgs/by-name/in/invidious-router/package.nix
@@ -3,7 +3,7 @@
   buildGo122Module,
   fetchFromGitLab,
 }: let
-  version = "1.0";
+  version = "1.1";
 in
   buildGo122Module {
     pname = "invidious-router";
@@ -13,7 +13,7 @@ in
       owner = "gaincoder";
       repo = "invidious-router";
       rev = version;
-      hash = "sha256-6apw+UnhDSuPa9QB3S8b8Ej3NJTK+UCdbDjC2LkhLIg=";
+      hash = "sha256-t8KQqMPkBbVis1odDcSu+H0uvyvoFqCmtWoHqVRxmfc=";
     };
 
     vendorHash = "sha256-c03vYidm8SkoesRVQZdg/bCp9LIpdTmpXdfwInlHBKk=";


### PR DESCRIPTION
## Description of changes

This packages [invidious-router](https://gitlab.com/gaincoder/invidious-router).

Invidious Router is a Go application that routes requests to different Invidious instances based on their health status and (optional) response time.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
