### PR TITLE
river-filtile: init at 1.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15173,6 +15173,13 @@
     githubId = 4056630;
     name = "Patrick Steinhardt";
   };
+  pkulak = {
+    name = "Phil Kulak";
+    email = "phil@kulak.us";
+    matrix = "@phil:kulak.us";
+    github = "pkulak";
+    githubId = 502905;
+  };
   plabadens = {
     name = "Pierre Labadens";
     email = "labadens.pierre+nixpkgs@gmail.com";

--- a/pkgs/by-name/ri/river-filtile/package.nix
+++ b/pkgs/by-name/ri/river-filtile/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "river-filtile";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "pkulak";
     repo = "filtile";
     rev = "v${version}";
-    hash = "sha256-51lrmti5/fTJpl0eF4BRvosT76wWfWdYI1yJJahi0Aw=";
+    hash = "sha256-Zcn0hjq4bJ1V5fwaMUq3XSlGaG9QdwsVxN3aHBKAgZs=";
   };
 
-  cargoHash = "sha256-KWapy2p9kVzgx5oqCo0+7DNaVlDaHYHNi8Mra2I13DQ=";
+  cargoHash = "sha256-xA0k9FS8GjI5945uztwcUOJwEFJcBeWgEZTOu0Xocno=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/ri/river-filtile/package.nix
+++ b/pkgs/by-name/ri/river-filtile/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "river-filtile";
-  version = "1.2.0";
+  version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "pkulak";
     repo = "filtile";
     rev = "v${version}";
-    hash = "sha256-Zcn0hjq4bJ1V5fwaMUq3XSlGaG9QdwsVxN3aHBKAgZs=";
+    hash = "sha256-wBU4CX6KGnTvrBsXvFAlRrvDqvHHbAlVkDqTCJx90G8=";
   };
 
-  cargoHash = "sha256-xA0k9FS8GjI5945uztwcUOJwEFJcBeWgEZTOu0Xocno=";
+  cargoHash = "sha256-W5e19gzkZZjTTSZdww2x7M0LnR/gClQxMeAiDITO3HY=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/ri/river-filtile/package.nix
+++ b/pkgs/by-name/ri/river-filtile/package.nix
@@ -1,0 +1,31 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "river-filtile";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "pkulak";
+    repo = "filtile";
+    rev = "v${version}";
+    hash = "sha256-51lrmti5/fTJpl0eF4BRvosT76wWfWdYI1yJJahi0Aw=";
+  };
+
+  cargoHash = "sha256-KWapy2p9kVzgx5oqCo0+7DNaVlDaHYHNi8Mra2I13DQ=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  meta = with lib; {
+    description = "A layout manager for the River window manager";
+    homepage = "https://github.com/pkulak/filtile";
+    license = licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ pkulak ];
+    mainProgram = "filtile";
+  };
+}


### PR DESCRIPTION
## Description of changes

Added a new layout manager for the River window manager:

https://github.com/pkulak/filtile

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Reviewed: 291198 and 291242

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
