### PR TITLE
sbcl: set source provenance on binary bootstrap

### DIFF
--- a/pkgs/development/compilers/sbcl/bootstrap.nix
+++ b/pkgs/development/compilers/sbcl/bootstrap.nix
@@ -26,4 +26,6 @@ stdenv.mkDerivation rec {
   postFixup = lib.optionalString (!stdenv.isAarch32 && stdenv.isLinux) ''
     patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) $out/share/sbcl/sbcl
   '';
+
+  meta.sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
 }


### PR DESCRIPTION
Fixes nixos/nixpkgs#282476

## Description of changes

Set the source provenance meta attribute for the SBCL builds which use a binary bootstrap.


Test this on an affected platform (x86_64-darwin i686-linux armv7l-linux armv6l-linux x86_64-freebsd x86_64-solaris):

```
$ NIXPKGS_ALLOW_NONSOURCE=0 nix run --impure github:nixos/nixpkgs/pull/291393/head#sbcl
warning: Nix search path entry '/nix/var/nix/profiles/per-user/root/channels' does not exist, ignoring
error:
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'sbcl-2.4.1'
         whose name attribute is located at /nix/store/4flwkj2sqd9slv9wmp5vcvx6pr7990sh-source/pkgs/stdenv/generic/make-derivation.nix:353:7

       … while evaluating attribute 'buildPhase' of derivation 'sbcl-2.4.1'

         at /nix/store/4flwkj2sqd9slv9wmp5vcvx6pr7990sh-source/pkgs/development/compilers/sbcl/default.nix:151:3:

          150|
          151|   buildPhase = ''
             |   ^
          152|     runHook preBuild

       error: Package ‘sbcl-bootstrap-2.2.9’ in /nix/store/4flwkj2sqd9slv9wmp5vcvx6pr7990sh-source/pkgs/development/compilers/sbcl/bootstrap.nix:5 contains elements not built from source (‘binaryNativeCode’), refusing to evaluate.

       a) To temporarily allow packages not built from source, you can use an environment variable
          for a single invocation of the nix tools.

            $ export NIXPKGS_ALLOW_NONSOURCE=1

          Note: When using `nix shell`, `nix build`, `nix develop`, etc with a flake,
                then pass `--impure` in order to allow use of environment variables.

       b) For `nixos-rebuild` you can set
         { nixpkgs.config.allowNonSource = true; }
       in configuration.nix to override this.

       Alternatively you can configure a predicate to allow specific packages:
         { nixpkgs.config.allowNonSourcePredicate = pkg: builtins.elem (lib.getName pkg) [
             "sbcl-bootstrap-2.2.9"
           ];
         }

       c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
         { allowNonSource = true; }
       to ~/.config/nixpkgs/config.nix.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
