### PR TITLE
poetry: 1.7.1 -> 1.8.1

### DIFF
--- a/pkgs/development/python-modules/cachecontrol/default.nix
+++ b/pkgs/development/python-modules/cachecontrol/default.nix
@@ -62,6 +62,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/ionrock/cachecontrol";
     changelog = "https://github.com/psf/cachecontrol/releases/tag/v${version}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ dotlambda ];
   };
 }

--- a/pkgs/development/python-modules/cachecontrol/default.nix
+++ b/pkgs/development/python-modules/cachecontrol/default.nix
@@ -14,26 +14,19 @@
 
 buildPythonPackage rec {
   pname = "cachecontrol";
-  version = "0.13.1";
-  format = "pyproject";
+  version = "0.14.0";
+  pyproject = true;
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.7";
 
   __darwinAllowLocalNetworking = true;
 
   src = fetchFromGitHub {
     owner = "ionrock";
-    repo = pname;
+    repo = "cachecontrol";
     rev = "refs/tags/v${version}";
-    hash = "sha256-4N+vk65WxOrT+IJRn+lEnbs5vlWQh9ievVHWWe3BKJ0=";
+    hash = "sha256-myyqiUGna+5S2GJGnwZTOfLh49NhjfHAvpUB49dQbgY=";
   };
-
-  postPatch = ''
-    # https://github.com/ionrock/cachecontrol/issues/297
-    substituteInPlace tests/test_etag.py --replace \
-      "requests.adapters.HTTPResponse.from_httplib" \
-      "urllib3.response.HTTPResponse.from_httplib"
-  '';
 
   nativeBuildInputs = [
     flit-core

--- a/pkgs/tools/package-management/poetry/default.nix
+++ b/pkgs/tools/package-management/poetry/default.nix
@@ -12,12 +12,12 @@ let
       # We keep the override around even when the versions match, as
       # it's likely to become relevant again after the next Poetry update.
       poetry-core = super.poetry-core.overridePythonAttrs (old: rec {
-        version = "1.8.1";
+        version = "1.9.0";
         src = fetchFromGitHub {
           owner = "python-poetry";
           repo = "poetry-core";
-          rev = version;
-          hash = "sha256-RnCJ67jaL2knwv+Uo7p0zOejHAT73f40weaJnfqOYoM=";
+          rev = "refs/tags/${version}";
+          hash = "sha256-vvwKbzGlvv2LTbXfJxQVM3nUXFGntgJxsku6cbRxCzw=";
         };
       });
     } // (plugins self);

--- a/pkgs/tools/package-management/poetry/unwrapped.nix
+++ b/pkgs/tools/package-management/poetry/unwrapped.nix
@@ -4,7 +4,6 @@
 , pythonOlder
 , fetchFromGitHub
 , installShellFiles
-, pythonRelaxDepsHook
 , build
 , cachecontrol
 , cleo
@@ -29,41 +28,30 @@
 , xattr
 , tomli
 , importlib-metadata
-, cachy
 , deepdiff
-, flatdict
 , pytestCheckHook
 , httpretty
 , pytest-mock
 , pytest-xdist
-, pythonAtLeast
 , darwin
 }:
 
 buildPythonPackage rec {
   pname = "poetry";
-  version = "1.7.1";
+  version = "1.8.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "python-poetry";
-    repo = pname;
+    repo = "poetry";
     rev = "refs/tags/${version}";
-    hash = "sha256-PM3FIZYso7p0Oe0RpiPuxHrQrgnMlkT5SVeaJPK/J94=";
+    hash = "sha256-tHtd5vO3TMjO0gqyECuS0FUAcE90nkKZwOm3ne6poFQ=";
   };
 
   nativeBuildInputs = [
     installShellFiles
-    pythonRelaxDepsHook
-  ];
-
-  pythonRelaxDeps = [
-    # platformdirs 4.x is backwards compatible; https://github.com/python-poetry/poetry/commit/eb80d10846f7336b0b2a66ce2964e72dffee9a1c
-    "platformdirs"
-    # xattr 1.0 is backwards compatible modulo dropping Python 2 support: https://github.com/xattr/xattr/compare/v0.10.0...v1.0.0
-    "xattr"
   ];
 
   propagatedBuildInputs = [
@@ -104,9 +92,7 @@ buildPythonPackage rec {
   '';
 
   nativeCheckInputs = [
-    cachy
     deepdiff
-    flatdict
     pytestCheckHook
     httpretty
     pytest-mock
@@ -127,32 +113,14 @@ buildPythonPackage rec {
   '';
 
   disabledTests = [
-    "test_env_system_packages_are_relative_to_lib"
-    "test_install_warning_corrupt_root"
-    "test_installer_with_pypi_repository"
-    # touches network
-    "git"
-    "solver"
-    "load"
-    "vcs"
-    "prereleases_if_they_are_compatible"
-    "test_builder_setup_generation_runs_with_pip_editable"
-    "test_executor"
-    # requires git history to work correctly
-    "default_with_excluded_data"
-    # toml ordering has changed
-    "lock"
-    # fs permission errors
     "test_builder_should_execute_build_scripts"
-    # poetry.installation.chef.ChefBuildError: Backend 'poetry.core.masonry.api' is not available.
-    "test_isolated_env_install_success"
-    "test_prepare_sdist"
-    "test_prepare_directory"
-    "test_prepare_directory_with_extensions"
-    "test_prepare_directory_editable"
-  ] ++ lib.optionals (pythonAtLeast "3.10") [
-    # RuntimeError: 'auto_spec' might be a typo; use unsafe=True if this is intended
-    "test_info_setup_complex_pep517_error"
+    "test_env_system_packages_are_relative_to_lib"
+    "test_executor_known_hashes"
+    "test_install_warning_corrupt_root"
+  ];
+
+  pytestFlagsArray = [
+    "-m 'not network'"
   ];
 
   # Allow for package to use pep420's native namespaces


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/python-poetry/poetry/compare/refs/tags/1.7.1...1.8.1

Changelog: https://github.com/python-poetry/poetry/blob/refs/tags/1.8.1/CHANGELOG.md
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
