### PR TITLE
mattermost 8.1.10 → 9.5.1

### DIFF
--- a/pkgs/servers/mattermost/default.nix
+++ b/pkgs/servers/mattermost/default.nix
@@ -1,35 +1,44 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
-, fetchpatch
 , fetchurl
 , nixosTests
 }:
 
 buildGoModule rec {
   pname = "mattermost";
-  version = "8.1.10";
+  # ESR releases only.
+  version = "9.5.1";
 
   src = fetchFromGitHub {
     owner = "mattermost";
     repo = "mattermost";
     rev = "v${version}";
-    hash = "sha256-eloO83koCNZOR/NYzUCdKOtVdF7rk+VrZ9U2bKWkxNU=";
-  } + "/server";
+    hash = "sha256-w+VF8VoS7oIcDlYS5kCFzSX4rgD9l1B99XBHeJDB6JI=";
+  };
 
-  # this can probably be removed again in versions newer than 8.1.10
+  # Needed because buildGoModule does not support go workspaces yet.
+  # We use go 1.22's workspace vendor command, which is not yet available
+  # in the default version of go used in nixpkgs, nor is it used by upstream:
+  # https://github.com/mattermost/mattermost/issues/26221#issuecomment-1945351597
   overrideModAttrs = (_: {
-    preBuild = ''
-      go mod tidy
+    buildPhase = ''
+      make setup-go-work
+      go work vendor -e
     '';
   });
 
   webapp = fetchurl {
     url = "https://releases.mattermost.com/${version}/mattermost-${version}-linux-amd64.tar.gz";
-    hash = "sha256-qxFW/P+INcMKSzaGZtOOr1Mi/glgZeiKvQ+YN0qX070=";
+    hash = "sha256-F32NWulKUhoyHPCmCCih6Hb9+W2iuF/Mxy9USrgp1pM=";
   };
 
-  vendorHash = "sha256-ZbLSxG9Gyhk7PBC2V6sMtrQNXvm+ugMfliFIHWO1VLs=";
+  vendorHash = "sha256-TJCtgNf56A1U0EbV5gXjTro+YudVBRWiSZoBC3nJxnE=";
+
+  modRoot = "./server";
+  preBuild = ''
+    make setup-go-work
+  '';
 
   subPackages = [ "cmd/mattermost" ];
 
@@ -44,7 +53,6 @@ buildGoModule rec {
     "-X github.com/mattermost/mattermost/server/public/model.BuildHash=v${version}"
     "-X github.com/mattermost/mattermost/server/public/model.BuildHashEnterprise=none"
     "-X github.com/mattermost/mattermost/server/public/model.BuildEnterpriseReady=false"
-    "-X github.com/mattermost/mattermost/server/public/model.MockCWS=false"
   ];
 
   postInstall = ''

--- a/pkgs/servers/mattermost/default.nix
+++ b/pkgs/servers/mattermost/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildGoModule
 , fetchFromGitHub
+, nix-update-script
 , fetchurl
 , nixosTests
 }:
@@ -8,6 +9,9 @@
 buildGoModule rec {
   pname = "mattermost";
   # ESR releases only.
+  # See https://docs.mattermost.com/upgrade/extended-support-release.html
+  # When a new ESR version is available (e.g. 8.1.x -> 9.5.x), update
+  # the version regex in passthru.updateScript as well.
   version = "9.5.1";
 
   src = fetchFromGitHub {
@@ -63,7 +67,12 @@ buildGoModule rec {
     find $out/{client,i18n,fonts,templates,config} -type f -exec chmod -x {} \;
   '';
 
-  passthru.tests.mattermost = nixosTests.mattermost;
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [ "--version-regex" "^v(9\.5\.([0-9.]+))" ];
+    };
+    tests.mattermost = nixosTests.mattermost;
+  };
 
   meta = with lib; {
     description = "Mattermost is an open source platform for secure collaboration across the entire software development lifecycle";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26455,7 +26455,7 @@ with pkgs;
 
   matrix-alertmanager = callPackage ../servers/monitoring/matrix-alertmanager { };
 
-  mattermost = callPackage ../servers/mattermost { };
+  mattermost = callPackage ../servers/mattermost { buildGoModule = buildGo122Module; };
   matterircd = callPackage ../servers/mattermost/matterircd.nix { };
   matterbridge = callPackage ../servers/matterbridge { };
 


### PR DESCRIPTION
## Description of changes

This jumps Mattermost ESR Versions ([see here for their release cycle](https://docs.mattermost.com/upgrade/extended-support-release.html)). The new version makes use of Go's workspace feature, which unfortunately the `buildGoModule` function [does not (yet?) support](https://github.com/NixOS/nixpkgs/issues/203039), which breaks our previous build process for mattermost.

Further, the new release also makes use of private modules only included in the (non-free) enterprise version of mattermost which makes it impossible to build in the usual way even [outside of nixpkgs's build abstractions](https://github.com/mattermost/mattermost/issues/26221) if vendoring is required.

Both issues can be solved by using Go 1.22, which has added support for vendoring when using workspaces, and instructing it to ignore missing module errors with the `-e` flag (this works via the new `go work vendor` command; the "missing" modules turn out to be unimportant during the build, so it still succeeds). This requires overriding the go-modules derivation's buildPhase via `overrideModAttrs`. The resulting binary passes the nixos tests, and I have deployed on a production server without issues.

Additionally, @emilylange showed me how to use `passthru.updateScript`, so this PR incorporates this as well. Previously, the versions of mattermost in nixpkgs always tended to lag behind upstream's released versions a little by a minor (security-patch) version or two, and it'd be nice to improve this situation & hopefully this will help.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
    - Note on this: I'm not sure what constitutes "major" here — is it enough that e.g. downgrading might be hard after a database migration?
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
