### PR TITLE
imsprog: init at 1.3.2; nixos/programs/imsprog: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -105,6 +105,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - [ALVR](https://github.com/alvr-org/alvr), a VR desktop streamer. Available as [programs.alvr](#opt-programs.alvr.enable)
 
+- [IMSProg](https://github.com/bigbigmdm/IMSProg), a program to read, write EEPROM chips use the CH341A programmer device. Available as [programs.imsprog](#opt-programs.imsprog.enable)
+
 - [RustDesk](https://rustdesk.com), a full-featured open source remote control alternative for self-hosting and security with minimal configuration. Alternative to TeamViewer.
 
 - [Scrutiny](https://github.com/AnalogJ/scrutiny), a S.M.A.R.T monitoring tool for hard disks with a web frontend.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -201,6 +201,7 @@
   ./programs/iay.nix
   ./programs/iftop.nix
   ./programs/i3lock.nix
+  ./programs/imsprog.nix
   ./programs/iotop.nix
   ./programs/java.nix
   ./programs/k3b.nix

--- a/nixos/modules/programs/imsprog.nix
+++ b/nixos/modules/programs/imsprog.nix
@@ -1,0 +1,22 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.imsprog;
+in
+{
+  options.programs.imsprog = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = lib.mdDoc ''
+        Installs IMSProg and configures udev rules for programmers used by IMSProg.
+      '';
+    };
+    package = lib.mkPackageOption pkgs "imsprog" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.udev.packages = [ cfg.package ];
+    environment.systemPackages = [ cfg.package ];
+  };
+}

--- a/pkgs/by-name/im/imsprog/package.nix
+++ b/pkgs/by-name/im/imsprog/package.nix
@@ -1,0 +1,81 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, libsForQt5
+, libusb1
+, pkg-config
+, makeWrapper
+, gnome
+, wget
+, bash
+}:
+
+stdenv.mkDerivation rec {
+  pname = "imsprog";
+  version = "1.3.2";
+
+  src = fetchFromGitHub {
+    owner = "bigbigmdm";
+    repo = "IMSProg";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-serRHyxYp+HV1h/MtEn8LOD8DkmfOb3vR5Mcypaq6RM=";
+  };
+
+  postPatch = ''
+    substituteInPlace IMSProg_programmer/CMakeLists.txt \
+      --replace-fail "set(UDEVDIR \"/usr/lib/udev\")" "" \
+      --replace-fail "''${UDEVDIR}/rules.d" "$out/lib/udev/rules.d"
+
+    substituteInPlace IMSProg_programmer/other/99-CH341.rules \
+      --replace-fail 'MODE="0660", GROUP="plugdev", TAG+="uaccess"' 'MODE="0666"'
+
+    substituteInPlace IMSProg_editor/ezp_chip_editor.cpp \
+      --replace-fail "/usr/share/imsprog/IMSProg.Dat" "$out/share/imsprog/IMSProg.Dat"
+
+    substituteInPlace IMSProg_programmer/mainwindow.cpp \
+      --replace-fail "/usr/share/imsprog/IMSProg.Dat" "$out/share/imsprog/IMSProg.Dat"
+
+    substituteInPlace IMSProg_editor/main.cpp \
+      --replace-fail "/usr/share/imsprog/" "$out/share/imsprog/"
+
+    substituteInPlace IMSProg_programmer/main.cpp \
+      --replace-fail "/usr/share/imsprog/" "$out/share/imsprog/"
+
+    substituteInPlace IMSProg_editor/other/IMSProg_editor.desktop \
+      --replace-fail "Exec=/usr/bin/IMSProg_editor" "Exec=$out/bin/IMSProg_editor" \
+      --replace-fail "Icon=/usr/share/pixmaps/chipEdit64.png" "Icon=$out/share/pixmaps/chipEdit64.png" \
+      --replace-fail "Path=/usr/bin/" "Path=$out/bin/"
+
+    substituteInPlace IMSProg_programmer/other/IMSProg_database_update.desktop \
+      --replace-fail "Exec=/usr/bin/IMSProg_database_update" "Exec=$out/bin/IMSProg_database_update" \
+      --replace-fail "Icon=/usr/share/pixmaps/IMSProg_database_update.png" "Icon=$out/share/pixmaps/IMSProg_database_update.png" \
+      --replace-fail "Path=/usr/bin/" "Path=$out/bin/"
+
+    substituteInPlace IMSProg_programmer/other/IMSProg.desktop \
+      --replace-fail "Exec=/usr/bin/IMSProg" "Exec=$out/bin/IMSProg" \
+      --replace-fail "Icon=/usr/share/pixmaps/IMSProg64.png" "Icon=$out/share/pixmaps/IMSProg64.png" \
+      --replace-fail "Path=/usr/bin/" "Path=$out/bin/"
+  '';
+
+  nativeBuildInputs = [ cmake pkg-config makeWrapper libsForQt5.wrapQtAppsHook ];
+
+  buildInputs = [ libusb1 bash libsForQt5.qtbase ];
+
+  strictDeps = true;
+
+  postFixup = ''
+    wrapProgram $out/bin/IMSProg_database_update \
+      --prefix PATH : ${lib.makeBinPath [ gnome.zenity wget ]}
+  '';
+
+  meta = with lib; {
+    changelog = "https://github.com/bigbigmdm/IMSProg?tab=readme-ov-file#revision-history";
+    description = "Program to read, write EEPROM chips use the CH341A programmer device";
+    homepage = "https://github.com/bigbigmdm/IMSProg";
+    license = licenses.gpl3Plus;
+    mainProgram = "IMSProg";
+    maintainers = with maintainers; [ sund3RRR ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes
[IMSProg](https://github.com/bigbigmdm/IMSProg) - I2C, MicroWire and SPI EEPROM/Flash chip Programmer - is a program to read, write EEPROM chips use the CH341A programmer device.

fixes https://github.com/NixOS/nixpkgs/issues/295050
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
