### PR TITLE
plasticity: init at 1.4.15

### DIFF
--- a/pkgs/by-name/pl/plasticity/package.nix
+++ b/pkgs/by-name/pl/plasticity/package.nix
@@ -1,0 +1,128 @@
+{ alsa-lib
+, at-spi2-atk
+, autoPatchelfHook
+, cairo
+, cups
+, dbus
+, desktop-file-utils
+, expat
+, fetchurl
+, gdk-pixbuf
+, gtk3
+, gvfs
+, hicolor-icon-theme
+, lib
+, libdrm
+, libglvnd
+, libnotify
+, libsForQt5
+, libxkbcommon
+, mesa
+, nspr
+, nss
+, openssl
+, pango
+, rpmextract
+, stdenv
+, systemd
+, trash-cli
+, vulkan-loader
+, wrapGAppsHook
+, xdg-utils
+, xorg
+}:
+stdenv.mkDerivation rec  {
+  pname = "plasticity";
+  version = "1.4.15";
+
+  src = fetchurl {
+    url = "https://github.com/nkallen/plasticity/releases/download/v${version}/Plasticity-${version}-1.x86_64.rpm";
+    hash = "sha256-wiUpDsfGVkhyjoXVpxaw3fqpo1aAfi0AkkvlkAZxTYI=";
+  };
+
+  passthru.updateScript = ./update.sh;
+
+  nativeBuildInputs = [ wrapGAppsHook autoPatchelfHook rpmextract mesa ];
+
+  buildInputs = [
+    alsa-lib
+    at-spi2-atk
+    cairo
+    cups
+    dbus
+    desktop-file-utils
+    expat
+    gdk-pixbuf
+    gtk3
+    gvfs
+    hicolor-icon-theme
+    libdrm
+    libnotify
+    libsForQt5.kde-cli-tools
+    libxkbcommon
+    nspr
+    nss
+    openssl
+    pango
+    stdenv.cc.cc.lib
+    trash-cli
+    xdg-utils
+  ];
+
+  runtimeDependencies = [
+    systemd
+    libglvnd
+    vulkan-loader #may help with nvidia users
+    xorg.libX11
+    xorg.libxcb
+    xorg.libXcomposite
+    xorg.libXdamage
+    xorg.libXext
+    xorg.libXfixes
+    xorg.libXrandr
+    xorg.libXtst
+  ];
+
+  dontUnpack = true;
+
+  # can't find anything on the internet about these files, no clue what they do
+  autoPatchelfIgnoreMissingDeps = [
+    "ACCAMERA.tx"
+    "AcMPolygonObj15.tx"
+    "ATEXT.tx"
+    "ISM.tx"
+    "RText.tx"
+    "SCENEOE.tx"
+    "TD_DbEntities.tx"
+    "TD_DbIO.tx"
+    "WipeOut.tx"
+   ];
+
+installPhase = ''
+  runHook preInstall
+
+  mkdir $out
+  cd $out
+  rpmextract $src
+  mv $out/usr/* $out
+  rm -r $out/usr
+
+  runHook postInstall
+'';
+
+  #--use-gl=egl for it to use hardware rendering it seems. Otherwise there are terrible framerates
+  postInstall = ''
+    substituteInPlace share/applications/Plasticity.desktop \
+      --replace-fail 'Exec=Plasticity %U' "Exec=Plasticity --use-gl=egl %U"
+  '';
+
+  meta = with lib; {
+    description = "CAD for artists";
+    homepage = "https://www.plasticity.xyz";
+    license = licenses.unfree;
+    mainProgram = "Plasticity";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ imadnyc ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/by-name/pl/plasticity/update.sh
+++ b/pkgs/by-name/pl/plasticity/update.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq common-updater-scripts
+#shellcheck shell=bash
+
+set -eu -o pipefail
+
+version=$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
+    curl -s https://api.github.com/repos/nkallen/plasticity/releases/latest | jq -e -r ".tag_name | .[1:]")
+old_version=$(nix-instantiate --eval -A plasticity.version | jq -e -r)
+
+if [[ $version == "$old_version" ]]; then
+    echo "New version same as old version, nothing to do." >&2
+    exit 0
+fi
+
+update-source-version plasticity "$version"
+


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Finally got it working - for some reason electron apps need `systemd` and I forgot that. I replaced the exec in the `.desktop` file with the flag `--use-gl=desktop`, which seems to enable hardware rendering. I'm not sure about nvidia users though, so I would appreciate someone with a nvidia card testing performance. 

I also have no idea what the `.tx` files that are required by Plasticity. I tried searching with zero results, and can similarly find zero about `libTd_db.so`. Would appreciate someone telling me what those are, but it seems to work fine without it? 

Also added myself as a maintainer of this package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
