### PR TITLE
zoho-mail: init

### DIFF
--- a/pkgs/by-name/zo/zoho-mail/package.nix
+++ b/pkgs/by-name/zo/zoho-mail/package.nix
@@ -1,0 +1,70 @@
+{ lib
+, stdenv
+, fetchurl
+, autoPatchelfHook
+, dpkg
+, ffmpeg_5-full
+, glib
+, gtk3
+, wrapGAppsHook
+, nss
+, xdg-utils
+, nspr
+, mesa
+, systemd
+, libglvnd
+, libGL
+, libGLU
+}:
+stdenv.mkDerivation rec  {
+  pname = "zoho-mail";
+  version = "1.6.1";
+
+  src = fetchurl {
+    url = "https://downloads.zohocdn.com/zmail-desktop/linux/zoho-mail-desktop-lite-installer-x64-v${version}.deb";
+    hash = "sha256-+c5RyymxeL0vppQpA+zceIlQ8336TLhmFgdgINTAQaY=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook wrapGAppsHook ];
+
+	dontWrapGApps = true;
+
+  buildInputs = [
+    dpkg
+    ffmpeg_5-full
+    glib
+    gtk3
+    nss
+    xdg-utils
+    nspr
+    mesa
+    libglvnd
+    libGL
+    libGLU
+	];
+
+
+	runtimeDependencies = buildInputs ++ [systemd];
+
+	dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+		mkdir -p $out/bin/
+		dpkg -x $src $out/bin/
+    cd $out
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "CAD for artists";
+    homepage = "https://www.plasticity.xyz";
+    # license = licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ imadnyc ];
+    platforms = [ "x86_64-linux" ];
+  };
+}
+


### PR DESCRIPTION
## Description of changes
Packaged using the deb, could not sign in. Signed in, then would repeatedly crash giving me a null error. Switched to the appimage version, same issue. This may be something on my end? 

There error that I'm getting is this:
```
DRI driver not from this Mesa build ('23.1.9' vs '24.0.1')
failed to bind extensions
```
However, this error appears after spawning the initial login window, which does seem to function as expected. The error after logging in seems to be something else. Would appreciate someone else testing this and checking out if it's an issue on my end. 

Would close  #289938. 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
