### PR TITLE
stdenv: fix missing dependencies in __sandboxProfile and __impureHostDeps

### DIFF
--- a/pkgs/applications/audio/musescore/default.nix
+++ b/pkgs/applications/audio/musescore/default.nix
@@ -84,11 +84,6 @@ in stdenv'.mkDerivation (finalAttrs: {
     "--set-default QT_QPA_PLATFORM xcb"
   ];
 
-  # HACK `propagatedSandboxProfile` does not appear to actually propagate the
-  # sandbox profile from `qtbase`, see:
-  # https://github.com/NixOS/nixpkgs/issues/237458
-  sandboxProfile = toString qtbase.__propagatedSandboxProfile or null;
-
   nativeBuildInputs = [
     wrapQtAppsHook
     cmake

--- a/pkgs/applications/misc/qtpass/default.nix
+++ b/pkgs/applications/misc/qtpass/default.nix
@@ -23,9 +23,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ qmake qttools wrapQtAppsHook ];
 
-  # HACK `propagatedSandboxProfile` does not appear to actually propagate the sandbox profile from `qt5.qtbase`
-  sandboxProfile = toString qtbase.__propagatedSandboxProfile;
-
   qmakeFlags = [
     # setup hook only sets QMAKE_LRELEASE, set QMAKE_LUPDATE too:
     "QMAKE_LUPDATE=${qttools.dev}/bin/lupdate"

--- a/pkgs/development/libraries/qtkeychain/default.nix
+++ b/pkgs/development/libraries/qtkeychain/default.nix
@@ -23,9 +23,6 @@ stdenv.mkDerivation rec {
 
   dontWrapQtApps = true;
 
-  # HACK `propagatedSandboxProfile` does not appear to actually propagate the sandbox profile from `qtbase`
-  sandboxProfile = toString qtbase.__propagatedSandboxProfile or null;
-
   cmakeFlags = [
     "-DBUILD_WITH_QT6=${if lib.versions.major qtbase.version == "6" then "ON" else "OFF"}"
     "-DQT_TRANSLATIONS_DIR=share/qt/translations"

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -413,25 +413,28 @@ else let
       requiredSystemFeatures = attrs.requiredSystemFeatures or [] ++ [ "gccarch-${stdenv.hostPlatform.gcc.arch}" ];
     } // optionalAttrs (stdenv.buildPlatform.isDarwin) (
       let
+        allDependencies = concatLists (concatLists dependencies);
+        allPropagatedDependencies = concatLists (concatLists propagatedDependencies);
+
         computedSandboxProfile =
           concatMap (input: input.__propagatedSandboxProfile or [])
             (stdenv.extraNativeBuildInputs
             ++ stdenv.extraBuildInputs
-            ++ concatLists dependencies);
+            ++ allDependencies);
 
         computedPropagatedSandboxProfile =
           concatMap (input: input.__propagatedSandboxProfile or [])
-            (concatLists propagatedDependencies);
+            allPropagatedDependencies;
 
         computedImpureHostDeps =
           unique (concatMap (input: input.__propagatedImpureHostDeps or [])
             (stdenv.extraNativeBuildInputs
             ++ stdenv.extraBuildInputs
-            ++ concatLists dependencies));
+            ++ allDependencies));
 
         computedPropagatedImpureHostDeps =
           unique (concatMap (input: input.__propagatedImpureHostDeps or [])
-            (concatLists propagatedDependencies));
+            allPropagatedDependencies);
     in {
       inherit __darwinAllowLocalNetworking;
       # TODO: remove `unique` once nix has a list canonicalization primitive


### PR DESCRIPTION
Fixes: 7f3ca3e21a22 (stdenv: Fix handling of dependencies and hooks)
Fixes: #237458

## Description of changes

These seem to have been broken ages ago.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
