### PR TITLE
python3.pkgs.pygobject-stubs: Make libraries configurable

### DIFF
--- a/pkgs/development/python-modules/pygobject-stubs/default.nix
+++ b/pkgs/development/python-modules/pygobject-stubs/default.nix
@@ -4,8 +4,19 @@
 , pygobject3
 , pythonOlder
 , setuptools
+, useGtk3 ? false
+, useLibsoup2 ? false
 }:
 
+let
+  config = lib.optionals useGtk3 [
+    "Gtk3"
+    "Gdk3"
+    "GtkSource4"
+  ] ++ lib.optionals useLibsoup2 [
+    "Soup2"
+  ];
+in
 buildPythonPackage rec {
   pname = "pygobject-stubs";
   version = "2.10.0";
@@ -26,6 +37,11 @@ buildPythonPackage rec {
 
   # This package does not include any tests.
   doCheck = false;
+
+  env = lib.optionalAttrs (config != []) {
+    # Choose which version of libraries to use since only one version can be exported under the name.
+    PYGOBJECT_STUB_CONFIG = lib.concatStringsSep "," config;
+  };
 
   meta = with lib; {
     description = "PEP 561 Typing Stubs for PyGObject";


### PR DESCRIPTION
## Description of changes

Follow up to https://github.com/NixOS/nixpkgs/pull/249663, adding config from https://github.com/NixOS/nixpkgs/pull/218186.

By default, the latest versions are selected. Let’s allow using older versions for apps that have not upgraded yet.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
