### PR TITLE
wpsoffice{-cn}: fix bold font rendering glitch

### DIFF
--- a/pkgs/applications/office/wpsoffice/0000-WPS-compatiblity.patch
+++ b/pkgs/applications/office/wpsoffice/0000-WPS-compatiblity.patch
@@ -1,0 +1,42 @@
+From 4ad8eb493b63d9e81378b073cbc6f1440aa21fbb Mon Sep 17 00:00:00 2001
+From: Fushan Wen <qydwhotmail@gmail.com>
+Date: Sun, 17 Sep 2023 13:15:29 +0800
+Subject: [PATCH] src/base/ftsynth.c: keep compatiblity in
+ FT_GlyphSlot_Embolden
+
+The delta is highly a matter of taste, but the style should be consistent. In some old applications x_scale and y_scale do not always match x_ppem and y_ppem, so fixed delta values will break bold fonts in those existing applications.
+---
+ src/base/ftsynth.c | 17 ++++++++++++++++-
+ 1 file changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/src/base/ftsynth.c b/src/base/ftsynth.c
+index f32edd338..c397a374f 100644
+--- a/src/base/ftsynth.c
++++ b/src/base/ftsynth.c
+@@ -98,7 +98,22 @@
+   FT_EXPORT_DEF( void )
+   FT_GlyphSlot_Embolden( FT_GlyphSlot  slot )
+   {
+-    FT_GlyphSlot_AdjustWeight( slot, 0x0AAA, 0x0AAA );
++    FT_UShort        units_per_EM;
++    FT_Size_Metrics* metrics;
++    FT_Fixed         xdelta, ydelta;
++
++    if ( !slot )
++      return;
++
++    units_per_EM = slot->face->units_per_EM;
++    metrics      = &( slot->face->size->metrics );
++
++    xdelta = FT_MulFix( units_per_EM, metrics->x_scale / 24 ) * 1024 /
++             (FT_Pos)metrics->x_ppem;
++    ydelta = FT_MulFix( units_per_EM, metrics->y_scale / 24 ) * 1024 /
++             (FT_Pos)metrics->y_ppem;
++
++    FT_GlyphSlot_AdjustWeight( slot, xdelta, ydelta );
+   }
+ 
+ 
+-- 
+GitLab
+

--- a/pkgs/applications/office/wpsoffice/0001-Enable-long-PCF-family-names.patch
+++ b/pkgs/applications/office/wpsoffice/0001-Enable-long-PCF-family-names.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Jan Alexander Steffens (heftig)" <jan.steffens@gmail.com>
+Date: Sun, 14 May 2017 18:09:31 +0200
+Subject: [PATCH] Enable long PCF family names
+
+---
+ include/freetype/config/ftoption.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/freetype/config/ftoption.h b/include/freetype/config/ftoption.h
+index b3425e55feec..ecff3ccd12d6 100644
+--- a/include/freetype/config/ftoption.h
++++ b/include/freetype/config/ftoption.h
+@@ -887,7 +887,7 @@ FT_BEGIN_HEADER
+    * If this option is activated, it can be controlled with the
+    * `no-long-family-names` property of the 'pcf' driver module.
+    */
+-/* #define PCF_CONFIG_OPTION_LONG_FAMILY_NAMES */
++#define PCF_CONFIG_OPTION_LONG_FAMILY_NAMES
+ 
+ 
+   /*************************************************************************/

--- a/pkgs/applications/office/wpsoffice/default.nix
+++ b/pkgs/applications/office/wpsoffice/default.nix
@@ -20,6 +20,7 @@
 , curl
 , coreutils
 , cacert
+, freetype
 , useChineseVersion ? false
 }:
 let
@@ -114,6 +115,14 @@ stdenv.mkDerivation rec {
       substituteInPlace $i \
         --replace /usr/bin $out/bin
     done
+
+    rm -f $out/opt/kingsoft/wps-office/office6/libfreetype.so.6
+    ln -sf ${freetype.overrideAttrs (e: rec {
+      patches = e.patches ++ [
+        ./0000-WPS-compatiblity.patch
+        ./0001-Enable-long-PCF-family-names.patch
+       ];
+    })}/lib/libfreetype.so.6 $out/opt/kingsoft/wps-office/office6
     runHook postInstall
   '';
 


### PR DESCRIPTION
## Description of changes
Fixed: https://github.com/NixOS/nixpkgs/issues/279314

![图片](https://github.com/NixOS/nixpkgs/assets/65808665/d73d8eb5-6aa9-4645-a789-cb354db19748)

~~Currently, this pr depends on https://github.com/NixOS/nixpkgs/pull/291081. I will leave here as is unless prior pr is merged~~ Already merged

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
