### PR TITLE
yamlscript: init at 0.1.38

### DIFF
--- a/pkgs/by-name/ya/yamlscript/package.nix
+++ b/pkgs/by-name/ya/yamlscript/package.nix
@@ -1,0 +1,40 @@
+{ lib, buildGraalvmNativeImage, fetchurl }:
+
+buildGraalvmNativeImage rec {
+  pname = "yamlscript";
+  version = "0.1.38";
+
+  src = fetchurl {
+    url = "https://github.com/yaml/yamlscript/releases/download/${version}/yamlscript.cli-${version}-standalone.jar";
+    hash = "sha256-cdRMmeJTlkEmF4jbElrXgobSU+VIvh/k9Lr9WkOSTl8=";
+  };
+
+  executable = "ys";
+
+  extraNativeImageBuildArgs = [
+    "--native-image-info"
+    "--no-fallback"
+    "--initialize-at-build-time"
+    "--enable-preview"
+    "-H:+ReportExceptionStackTraces"
+    "-H:IncludeResources=SCI_VERSION"
+    "-H:Log=registerResource:"
+    "-J-Dclojure.spec.skip-macros=true"
+    "-J-Dclojure.compiler.direct-linking=true"
+  ];
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    $out/bin/ys  -e 'say: (+ 1 2)' | fgrep 3
+  '';
+
+  meta = with lib; {
+    description = "Programming in YAML";
+    homepage = "https://github.com/yaml/yamlscript";
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
+    license = licenses.mit;
+    mainProgram = "ys";
+    maintainers = with maintainers; [ sgo ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Add yamlscript 0.1.38

https://yamlscript.org/


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
