### PR TITLE
ocamlPackages.magic-trace: 1.1.0 → 1.2.1

### DIFF
--- a/pkgs/development/ocaml-modules/magic-trace/default.nix
+++ b/pkgs/development/ocaml-modules/magic-trace/default.nix
@@ -1,21 +1,49 @@
-{ lib, fetchFromGitHub, buildDunePackage, async, cohttp_static_handler ? null
-, core_unix ? null, owee, ppx_jane, shell ? null }:
+{ lib
+, fetchFromGitHub
+, buildDunePackage
+, ocaml-crunch
+, angstrom
+, async
+, cohttp
+, cohttp_static_handler ? null
+, core
+, core_unix ? null
+, fzf
+, owee
+, ppx_jane
+, re
+, shell ? null
+}:
 
 buildDunePackage rec {
   pname = "magic-trace";
-  version = "1.1.0";
+  version = "1.2.1";
 
   minimalOCamlVersion = "4.12";
-  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "janestreet";
     repo = "magic-trace";
     rev = "v${version}";
-    sha256 = "sha256-615AOkrbQI6vRosA5Kz3Epipe9f9+Gs9+g3bVl5gzBY=";
+    hash = "sha256-/9TDjCG/06mhGyqbjAdUmk6fcaq9fNDqVSw51w5EEy4=";
   };
 
-  buildInputs = [ async cohttp_static_handler core_unix owee ppx_jane shell ];
+  nativeBuildInputs = [
+    ocaml-crunch
+  ];
+  buildInputs = [
+    angstrom
+    async
+    cohttp
+    cohttp_static_handler
+    core
+    core_unix
+    fzf
+    owee
+    ppx_jane
+    re
+    shell
+  ];
 
   meta = with lib; {
     description =

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -824,8 +824,6 @@ let
         cfstream = self.cfstream.override { inherit core_kernel; };
       };
 
-      magic-trace = callPackage ../development/ocaml-modules/magic-trace { };
-
       phylogenetics = let
         angstrom = self.angstrom.override { inherit ppx_let; };
       in callPackage ../development/ocaml-modules/phylogenetics {
@@ -1022,7 +1020,7 @@ let
 
     magic-mime = callPackage ../development/ocaml-modules/magic-mime { };
 
-    magic-trace = janeStreet_0_15.magic-trace;
+    magic-trace = callPackage ../development/ocaml-modules/magic-trace { };
 
     mariadb = callPackage ../development/ocaml-modules/mariadb {
       inherit (pkgs) mariadb;


### PR DESCRIPTION
## Description of changes

Compatibility with latest OCaml.

cc maintainer @Alizter.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
