### PR TITLE
libkiwix: 12.1.1 -> 13.1.0

### DIFF
--- a/pkgs/applications/misc/kiwix/default.nix
+++ b/pkgs/applications/misc/kiwix/default.nix
@@ -9,15 +9,15 @@
 , aria2
 }:
 
-mkDerivation rec {
+mkDerivation {
   pname = "kiwix";
-  version = "2.3.1";
+  version = "2.3.1-unstable-2024-02-20";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = "${pname}-desktop";
-    rev = version;
-    sha256 = "sha256-ghx4pW6IkWPzZXk0TtMGeQZIzm9HEN3mR4XQFJ1xHDo=";
+    owner = "kiwix";
+    repo = "kiwix-desktop";
+    rev = "17ac566b07814aefb1decf108e4ba6d7ad9ef7bc";
+    hash = "sha256-BZzFnQE8/dyZkpY0X3zZ6yC6yLZ002Q/RoDzEhSOa/g=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/kiwix/lib.nix
+++ b/pkgs/applications/misc/kiwix/lib.nix
@@ -11,15 +11,15 @@
 , gtest
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libkiwix";
-  version = "12.1.1";
+  version = "13.1.0";
 
   src = fetchFromGitHub {
     owner = "kiwix";
-    repo = pname;
-    rev = version;
-    sha256 = "sha256-hcwLxfn1fiUAiwsnIddv4HukvVrFePtx7sDQUD1lGUA=";
+    repo = "libkiwix";
+    rev = finalAttrs.version;
+    hash = "sha256-DKOwzfGyad/3diOaV1K8hXqT8YGfqCP6QDKDkxWu/1U=";
   };
 
   nativeBuildInputs = [
@@ -55,8 +55,9 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Common code base for all Kiwix ports";
     homepage = "https://kiwix.org";
+    changelog = "https://github.com/kiwix/libkiwix/releases/tag/${finalAttrs.version}";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ colinsane ];
   };
-}
+})

--- a/pkgs/applications/misc/kiwix/tools.nix
+++ b/pkgs/applications/misc/kiwix/tools.nix
@@ -9,15 +9,15 @@
 , stdenv
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "kiwix-tools";
-  version = "3.5.0";
+  version = "3.6.0";
 
   src = fetchFromGitHub {
     owner = "kiwix";
     repo = "kiwix-tools";
-    rev = version;
-    sha256 = "sha256-bOxi51H28LhA+5caX6kllIY5B3Q1FoGVFadFIhYRkG0=";
+    rev = finalAttrs.version;
+    hash = "sha256-+th86lMAuCcmWj06yQoZ1L7rLZKqNvuTrV+Rra2km44=";
   };
 
   nativeBuildInputs = [
@@ -36,9 +36,9 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Command line Kiwix tools: kiwix-serve, kiwix-manage, ...";
     homepage = "https://kiwix.org";
+    changelog = "https://github.com/kiwix/kiwix-tools/releases/tag/${finalAttrs.version}";
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [ colinsane ];
   };
-}
-
+})


### PR DESCRIPTION
## Description of changes

- updates libkiwix to fix the build break described [here](https://github.com/NixOS/nixpkgs/pull/274680#issuecomment-1960589919).
- updates `kiwix-tools` and `kiwix` to versions which are compatible with this new `libkiwix`.

note that `kiwix` is updated to a development snapshot because upstream has not cut a release which is compatible with libkiwix 13.x, nor does there appear to be any simple patch to make the last stable release compatible with newest libkiwix.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
