### PR TITLE
qtgreet: init at 2.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18130,6 +18130,12 @@
     githubId = 248016;
     name = "Solène Rapenne";
   };
+  sreehax = {
+    email = "me@ssree.dev";
+    github = "sreehax";
+    githubId = 23709124;
+    name = "Sreehari Sreedev";
+  };
   srghma = {
     email = "srghma@gmail.com";
     github = "srghma";

--- a/pkgs/applications/display-managers/greetd/qtgreet.nix
+++ b/pkgs/applications/display-managers/greetd/qtgreet.nix
@@ -1,0 +1,70 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, pkg-config
+, meson
+, ninja
+, qtbase
+, qttools
+, qtwayland
+, wrapQtAppsHook
+, dfl-applications
+, dfl-ipc
+, dfl-login1
+, dfl-utils
+, wayqt
+, wayland
+, wlroots
+, cmake
+, mpv
+, pixman
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qtgreet";
+  version = "2.0.1";
+
+  src = fetchFromGitLab {
+    owner = "marcusbritanicus";
+    repo = "QtGreet";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-Lm7OdB9/o7BltPusuxTIuPQ4w23rCIKugEsjGR5vgVg=";
+  };
+
+  nativeBuildInputs = [
+    wrapQtAppsHook
+    pkg-config
+    meson
+    ninja
+    qttools
+    cmake
+  ];
+
+  buildInputs = [
+    qtbase
+    wlroots
+    wayqt
+    wayland
+    dfl-applications
+    dfl-ipc
+    dfl-login1
+    dfl-utils
+    mpv
+    pixman
+    qtwayland
+  ];
+
+  mesonFlags = [
+    "-Duse_qt_version=qt6"
+    "-Dnodynpath=true"
+  ];
+
+  meta = with lib; {
+    description = "Qt based greeter for greetd, to be run under wayfire or similar wlr-based compositors.";
+    homepage = "https://gitlab.com/marcusbritanicus/QtGreet";
+    maintainers = with maintainers; [ sreehax ];
+    license = licenses.gpl3Only;
+    platforms = platforms.linux;
+    mainProgram = "qtgreet";
+  };
+})

--- a/pkgs/development/libraries/dfl/applications.nix
+++ b/pkgs/development/libraries/dfl/applications.nix
@@ -1,0 +1,52 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, meson
+, ninja
+, pkg-config
+, qttools
+, qtbase
+, dfl-ipc
+, cmake
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dfl-applications";
+  version = "0.2.0";
+
+  src = fetchFromGitLab {
+    owner = "desktop-frameworks";
+    repo = "applications";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-I6W37tThshlL79lmMipJqynXsfjFRw6WzLPPw0dvqH4=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    qttools
+    cmake
+  ];
+
+  buildInputs = [
+    dfl-ipc
+    qtbase
+  ];
+
+  mesonFlags = [
+    "-Duse_qt_version=qt6"
+  ];
+
+  dontWrapQtApps = true;
+
+  outputs = [ "out" "dev" ];
+
+  meta = {
+    homepage = "https://gitlab.com/desktop-frameworks/applications";
+    description = "This library provides a thin wrapper around QApplication, QGuiApplication and QCoreApplication, to provide
+single-instance functionality.";
+    maintainers = with lib.maintainers; [ sreehax ];
+    license = lib.licenses.gpl3Only;
+  };
+})

--- a/pkgs/development/libraries/dfl/ipc.nix
+++ b/pkgs/development/libraries/dfl/ipc.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, meson
+, ninja
+, pkg-config
+, qttools
+, qtbase
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dfl-ipc";
+  version = "0.2.0";
+
+  src = fetchFromGitLab {
+    owner = "desktop-frameworks";
+    repo = "ipc";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-Dz9ilrA/w+LR7cG7JBykC6n32s00kPoUayQtXuTkdss=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    qttools
+  ];
+
+  buildInputs = [
+    qtbase
+  ];
+
+  mesonFlags = [
+    "-Duse_qt_version=qt6"
+  ];
+
+  dontWrapQtApps = true;
+
+  outputs = [ "out" "dev" ];
+
+  meta = {
+    homepage = "https://gitlab.com/desktop-frameworks/ipc";
+    description = "A very simple set of IPC classes for inter-process communication.";
+    maintainers = with lib.maintainers; [ sreehax ];
+    license = lib.licenses.gpl3Only;
+  };
+})

--- a/pkgs/development/libraries/dfl/login1.nix
+++ b/pkgs/development/libraries/dfl/login1.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, meson
+, ninja
+, pkg-config
+, qttools
+, qtbase
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dfl-login1";
+  version = "0.2.0";
+
+  src = fetchFromGitLab {
+    owner = "desktop-frameworks";
+    repo = "login1";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-3BiYN8CdRTvopQuEfpemfAM3pQ7DAlCvZepBEf7IXiU=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    qttools
+  ];
+
+  buildInputs = [
+    qtbase
+  ];
+
+  mesonFlags = [
+    "-Duse_qt_version=qt6"
+  ];
+
+  dontWrapQtApps = true;
+
+  outputs = [ "out" "dev" ];
+
+  meta = {
+    homepage = "https://gitlab.com/desktop-frameworks/login1";
+    description = "Implementation of systemd/elogind for DFL";
+    maintainers = with lib.maintainers; [ sreehax ];
+    license = lib.licenses.gpl3Only;
+  };
+})

--- a/pkgs/development/libraries/dfl/utils.nix
+++ b/pkgs/development/libraries/dfl/utils.nix
@@ -1,0 +1,46 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, meson
+, ninja
+, pkg-config
+, qttools
+, qtbase
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dfl-utils";
+  version = "0.2.0";
+
+  src = fetchFromGitLab {
+    owner = "desktop-frameworks";
+    repo = "utils";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-IxWYxQP9y51XbZAR+VOex/GYZblAWs8KmoaoFvU0rCY=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    qttools
+  ];
+
+  buildInputs = [
+    qtbase
+  ];
+
+  mesonFlags = [
+    "-Duse_qt_version=qt6"
+  ];
+
+  dontWrapQtApps = true;
+
+  outputs = [ "out" "dev" ];
+
+  meta = {
+    homepage = "https://gitlab.com/desktop-frameworks/utils";
+    description = "Some utilities for DFL";
+    maintainers = with lib.maintainers; [ sreehax ];
+    license = lib.licenses.gpl3Only;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31493,6 +31493,7 @@ with pkgs;
     dlm = callPackage ../applications/display-managers/greetd/dlm.nix { };
     greetd = callPackage ../applications/display-managers/greetd { };
     gtkgreet = callPackage ../applications/display-managers/greetd/gtkgreet.nix { };
+    qtgreet = qt6Packages.callPackage ../applications/display-managers/greetd/qtgreet.nix { };
     regreet = callPackage ../applications/display-managers/greetd/regreet.nix { };
     tuigreet = callPackage ../applications/display-managers/greetd/tuigreet.nix { };
     wlgreet = callPackage ../applications/display-managers/greetd/wlgreet.nix { };

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -31,6 +31,11 @@ makeScopeWithSplicing' {
   # LIBRARIES
   appstream-qt = callPackage ../development/libraries/appstream/qt.nix { };
 
+  dfl-applications = callPackage ../development/libraries/dfl/applications.nix { };
+  dfl-ipc = callPackage ../development/libraries/dfl/ipc.nix { };
+  dfl-login1 = callPackage ../development/libraries/dfl/login1.nix { };
+  dfl-utils = callPackage ../development/libraries/dfl/utils.nix { };
+
   kdsoap = callPackage ../development/libraries/kdsoap { };
 
   futuresql = callPackage ../development/libraries/futuresql { };


### PR DESCRIPTION
## Description of changes
https://gitlab.com/marcusbritanicus/QtGreet
Qt based greeter for greetd.

## Things done

I have added greetd.qtgreet and qt6Packages.dfl-{applications,ipc,login1,utils}.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
