### PR TITLE
libvpl: patch to search `/run/opengl-drivers/lib/` for runtime implem…

### DIFF
--- a/pkgs/by-name/li/libvpl/opengl-driver-lib.patch
+++ b/pkgs/by-name/li/libvpl/opengl-driver-lib.patch
@@ -1,0 +1,19 @@
+--- a/libvpl/src/mfx_dispatcher_vpl_loader.cpp
++++ b/libvpl/src/mfx_dispatcher_vpl_loader.cpp
+@@ -548,6 +548,16 @@ mfxStatus LoaderCtxVPL::BuildListOfCandidateLibs() {
+         it++;
+     }
+
++    // fourth priority
++    searchDirList.clear();
++    searchDirList.push_back("@driverLink@/lib");
++    it = searchDirList.begin();
++    while (it != searchDirList.end()) {
++        STRING_TYPE nextDir = (*it);
++        sts                 = SearchDirForLibs(nextDir, m_libInfoList, LIB_PRIORITY_05);
++        it++;
++    }
++
+     // lowest priority: legacy MSDK installation
+     searchDirList.clear();
+     GetSearchPathsLegacy(searchDirList);

--- a/pkgs/by-name/li/libvpl/package.nix
+++ b/pkgs/by-name/li/libvpl/package.nix
@@ -3,6 +3,8 @@
 , fetchFromGitHub
 , cmake
 , pkg-config
+, substituteAll
+, addDriverRunpath
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -30,6 +32,13 @@ stdenv.mkDerivation (finalAttrs: {
       "-DENABLE_X11=ON"
       "-DINSTALL_EXAMPLE_CODE=OFF"
       "-DBUILD_TOOLS=OFF"
+  ];
+
+  patches = [
+    (substituteAll {
+      src = ./opengl-driver-lib.patch;
+      inherit (addDriverRunpath) driverLink;
+    })
   ];
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

libvpl: patch to search `/run/opengl-drivers/lib/` for runtime implementations.

This means instead of setting:
```
  environment.sessionVariables = {
    ONEVPL_SEARCH_PATH = lib.strings.makeLibraryPath (with pkgs; [oneVPL-intel-gpu]);
  };
```

To find `onevpl-intel-gpu` libraries instead it will pick it up from:
```
  hardware.opengl.extraPackages = [ pkgs.onevpl-intel-gpu ];
```

See https://github.com/NixOS/nixpkgs/pull/264621 for more detail.

Tagging @Atemu and @evanrichter for interest.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
