### PR TITLE
nibtools: init at unstable-2024-02-22

### DIFF
--- a/pkgs/by-name/ni/nibtools/package.nix
+++ b/pkgs/by-name/ni/nibtools/package.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, opencbm
+, cc65
+}:
+
+stdenv.mkDerivation {
+  pname = "nibtools";
+  version = "0-unstable-2024-02-22";
+
+  src = fetchFromGitHub {
+    owner = "OpenCBM";
+    repo = "nibtools";
+    rev = "1d69f64eec55031c346a2ce115227479f9579a8a";
+    hash = "sha256-+hnkj0uevURkRboTH8WbSt82pZTdWL4ii2PKr6NO0Cg=";
+  };
+
+  NIX_CFLAGS_COMPILE = "-Wno-error=format-security";
+
+  nativeBuildInputs = [
+    cc65
+  ];
+
+  buildInputs = [
+    opencbm
+  ];
+
+  preBuild = "mkdir build";
+  makeFlags = [ "-f" "GNU/Makefile" "linux" ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    mv nibread nibwrite nibscan nibconv nibrepair nibsrqtest $out/bin/
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "disk transfer utility for imaging and converting commodore 64 disk images";
+    homepage = "https://github.com/OpenCBM/nibtools/";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ matthewcroughan ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

Packaged as gplv2 because:

https://c64preservation.com/dp.php?pg=nibtools

 > "The C64PP project originally started when I took Markus Brenner's GPL source for MNIB and figured out how to add a routine to make it write the disk images back out to real disks. This part turned out to be easy, but I opened up a can of worms that has taken lots of time to perfect. :)"

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
