### PR TITLE
python311Packages.sapi-python-client: 0.7.1 -> 0.7.2

### DIFF
--- a/pkgs/development/python-modules/kbcstorage/default.nix
+++ b/pkgs/development/python-modules/kbcstorage/default.nix
@@ -1,35 +1,37 @@
 { lib
+, azure-storage-blob
+, boto3
 , buildPythonPackage
 , fetchFromGitHub
+, python-dotenv
 , pythonOlder
-
-# build
+, requests
+, responses
 , setuptools
 , setuptools-git-versioning
 , setuptools-scm
-
-# propagates
-, azure-storage-blob
-, boto3
-, requests
-
-# tests
-, responses
 , unittestCheckHook
+, urllib3
 }:
+
 buildPythonPackage rec {
   pname = "sapi-python-client";
-  version = "0.7.1";
-  format = "pyproject";
+  version = "0.7.2";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "keboola";
-    repo = pname;
+    repo = "sapi-python-client";
     rev = "refs/tags/${version}";
-    hash = "sha256-74sChw6eMkBtfHV6hiaaLNOr/J0Sa73LB93Z8muLaiI=";
+    hash = "sha256-uZo2kEq7zIMGRlhX36kZyihQPZegw5XgVzgVQQOmpc4=";
   };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "urllib3<2.0.0" "urllib3"
+  '';
 
   nativeBuildInputs = [
     setuptools
@@ -40,17 +42,15 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     azure-storage-blob
     boto3
+    python-dotenv
     requests
+    responses
+    urllib3
   ];
 
   # Requires API token and an active Keboola bucket
   # ValueError: Root URL is required.
   doCheck = false;
-
-  nativeCheckInputs = [
-    unittestCheckHook
-    responses
-  ];
 
   pythonImportsCheck = [
     "kbcstorage"


### PR DESCRIPTION
Diff: https://github.com/keboola/sapi-python-client/compare/refs/tags/0.7.1...0.7.2

Changelog: https://github.com/keboola/sapi-python-client/releases/tag/0.7.2

## Description of changes
Fix build (https://hydra.nixos.org/build/251047075)
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
