### PR TITLE
doc: Fix typo resulting in broken link in manual

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -175,7 +175,7 @@ following are specific to `buildPythonPackage`:
   from `build-system.requires` to `build-system`. Note that the pyproject
   format falls back to using `setuptools`, so you can use `pyproject = true`
   even if the package only has a `setup.py`. When set to `false`, you can
-  use the existing [hooks](#setup-hooks0 or provide your own logic to build the
+  use the existing [hooks](#setup-hooks) or provide your own logic to build the
   package. This can be useful for packages that don't support the pyproject
   format. When unset, the legacy `setuptools` hooks are used for backwards
   compatibility.


### PR DESCRIPTION
## Description of changes

I was looking at
https://nixos.org/manual/nixpkgs/stable/#buildpythonpackage-parameters to import a Python package and noticed that the link for the `hooks` in `pyproject` option is broken due to a typo (used <kbd>0</kbd> instead of <kbd>)</kbd>).

## Things done

None, it is a simple typo fix.