### PR TITLE
jasper: split outputs

### DIFF
--- a/pkgs/by-name/ja/jasper/package.nix
+++ b/pkgs/by-name/ja/jasper/package.nix
@@ -1,8 +1,15 @@
 { lib
-, stdenv
-, fetchFromGitHub
 , cmake
+, fetchFromGitHub
+, freeglut
+, libGL
+, libheif
+, libjpeg
 , pkg-config
+, stdenv
+, enableHEIFCodec ? true
+, enableJPGCodec ? true
+, enableOpenGL ? true
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -16,11 +23,21 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-SE3zB+8zZuuT+W6QYTuQhM+dBgYuFzYK4a7QaquGB60=";
   };
 
-  outputs = [ "out" "doc" "man" ];
+  outputs = [ "out" "dev" "doc" "lib" "man" ];
 
   nativeBuildInputs = [
     cmake
     pkg-config
+  ];
+
+  buildInputs = [
+  ] ++ lib.optionals enableHEIFCodec [
+    libheif
+  ] ++ lib.optionals enableJPGCodec [
+    libjpeg
+  ] ++ lib.optionals enableOpenGL [
+    freeglut
+    libGL
   ];
 
   # Since "build" already exists and is populated, cmake tries to use it,
@@ -28,6 +45,12 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeBuildDir = "build-directory";
   cmakeFlags = [
     (lib.cmakeBool "ALLOW_IN_SOURCE_BUILD" true)
+    (lib.cmakeBool "JAS_ENABLE_HEIC_CODEC" enableHEIFCodec)
+    (lib.cmakeBool "JAS_INCLUDE_HEIC_CODEC" enableHEIFCodec)
+    (lib.cmakeBool "JAS_ENABLE_JPG_CODEC" enableJPGCodec)
+    (lib.cmakeBool "JAS_INCLUDE_JPG_CODEC" enableJPGCodec)
+    (lib.cmakeBool "JAS_ENABLE_MIF_CODEC" false) # Dangerous!
+    (lib.cmakeBool "JAS_ENABLE_OPENGL" enableOpenGL)
   ];
 
   strictDeps = true;
@@ -53,6 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
       for most computing platforms when JasPer was first developed, circa 1999.
     '';
     license = lib.licenses.mit;
+    mainProgram = "jasper";
     maintainers = with lib.maintainers; [ AndersonTorres ];
     platforms = lib.platforms.unix;
 


### PR DESCRIPTION
- enable extras: HEIF, JPG, OpenGL

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
