### PR TITLE
calamares: 3.2.62 -> 3.3.3 

### DIFF
--- a/pkgs/tools/misc/calamares-nixos-extensions/default.nix
+++ b/pkgs/tools/misc/calamares-nixos-extensions/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "calamares-nixos-extensions";
-  version = "0.3.14";
+  version = "0.3.15";
 
   src = fetchFromGitHub {
     owner = "NixOS";
     repo = "calamares-nixos-extensions";
     rev = version;
-    hash = "sha256-wRKZ80yU3WsUkGn5/ft4wDR22s39/WTxTrjFE0/9mlc=";
+    hash = "sha256-PZQjrteLWcInXIavuANHfzfl9gOXATWtIlDUp45j5Ao=";
   };
 
   installPhase = ''

--- a/pkgs/tools/misc/calamares/default.nix
+++ b/pkgs/tools/misc/calamares/default.nix
@@ -7,12 +7,12 @@
 
 mkDerivation rec {
   pname = "calamares";
-  version = "3.2.62";
+  version = "3.3.3";
 
   # release including submodule
   src = fetchurl {
     url = "https://github.com/calamares/calamares/releases/download/v${version}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-oPvOwqQ4aTdT/BdCIDVhGa1624orGcMXUYqhywJdbdA=";
+    sha256 = "sha256-XCp2Qc2y9eF2Z0BqfTtzUkf6860KzHl1lZE7kiHZbQM=";
   };
 
   patches = lib.optionals nixos-extensions [

--- a/pkgs/tools/misc/calamares/nixos-extensions-paths.patch
+++ b/pkgs/tools/misc/calamares/nixos-extensions-paths.patch
@@ -1,21 +1,20 @@
 diff --git a/src/calamares/main.cpp b/src/calamares/main.cpp
-index de709156f..a0b6c5faf 100644
+index e0491e5f9..faf272016 100644
 --- a/src/calamares/main.cpp
 +++ b/src/calamares/main.cpp
-@@ -131,6 +132,8 @@ main( int argc, char* argv[] )
-     // TODO: umount anything in /tmp/calamares-... as an emergency save function
+@@ -132,6 +132,7 @@ main( int argc, char* argv[] )
  #endif
  
-+    CalamaresUtils::setNixosDirs();
-+
-     bool is_debug = handle_args( a );
- 
- #ifdef WITH_KF5DBus
+     std::unique_ptr< KDSingleApplication > possiblyUnique;
++    Calamares::setNixosDirs();
+     const bool is_debug = handle_args( a );
+     if ( !is_debug )
+     {
 diff --git a/src/libcalamares/utils/Dirs.cpp b/src/libcalamares/utils/Dirs.cpp
-index f333d6e64..6118fb412 100644
+index c42768a08..bac98645a 100644
 --- a/src/libcalamares/utils/Dirs.cpp
 +++ b/src/libcalamares/utils/Dirs.cpp
-@@ -115,6 +116,14 @@ setXdgDirs()
+@@ -114,6 +114,14 @@ setXdgDirs()
      s_haveExtraDirs = !( s_extraConfigDirs.isEmpty() && s_extraDataDirs.isEmpty() );
  }
  
@@ -31,7 +30,7 @@ index f333d6e64..6118fb412 100644
  extraConfigDirs()
  {
 diff --git a/src/libcalamares/utils/Dirs.h b/src/libcalamares/utils/Dirs.h
-index 445cbe1f1..da869d446 100644
+index d0edd7a4f..26bd16b4e 100644
 --- a/src/libcalamares/utils/Dirs.h
 +++ b/src/libcalamares/utils/Dirs.h
 @@ -50,6 +50,9 @@ DLLEXPORT bool isAppDataDirOverridden();

--- a/pkgs/tools/misc/calamares/nonroot.patch
+++ b/pkgs/tools/misc/calamares/nonroot.patch
@@ -1,8 +1,8 @@
 diff --git a/src/libcalamares/utils/Runner.cpp b/src/libcalamares/utils/Runner.cpp
-index c7146c2d7..e165d9a8f 100644
+index 632f32028..fe9052449 100644
 --- a/src/libcalamares/utils/Runner.cpp
 +++ b/src/libcalamares/utils/Runner.cpp
-@@ -140,13 +140,13 @@ Calamares::Utils::Runner::run()
+@@ -137,13 +137,13 @@ Calamares::Utils::Runner::run()
      }
      if ( m_location == RunLocation::RunInTarget )
      {
@@ -21,10 +21,10 @@ index c7146c2d7..e165d9a8f 100644
  
      if ( m_output )
 diff --git a/src/modules/mount/main.py b/src/modules/mount/main.py
-index a3318d1a0..5fbe202fd 100644
+index 4202639f3..de2556b91 100644
 --- a/src/modules/mount/main.py
 +++ b/src/modules/mount/main.py
-@@ -152,7 +152,8 @@ def mount_partition(root_mount_point, partition, partitions):
+@@ -235,7 +235,8 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
  
      # Ensure that the created directory has the correct SELinux context on
      # SELinux-enabled systems.
@@ -34,7 +34,7 @@ index a3318d1a0..5fbe202fd 100644
      try:
          subprocess.call(['chcon', '--reference=' + raw_mount_point, mount_point])
      except FileNotFoundError as e:
-@@ -193,13 +194,13 @@ def mount_partition(root_mount_point, partition, partitions):
+@@ -278,13 +279,13 @@ def mount_partition(root_mount_point, partition, partitions, mount_options, moun
          for s in btrfs_subvolumes:
              if not s["subvolume"]:
                  continue
@@ -52,10 +52,10 @@ index a3318d1a0..5fbe202fd 100644
          device = partition["device"]
  
 diff --git a/src/modules/welcome/checker/GeneralRequirements.cpp b/src/modules/welcome/checker/GeneralRequirements.cpp
-index ca7219ca4..6ac682ba4 100644
+index a58f3df83..b66576b09 100644
 --- a/src/modules/welcome/checker/GeneralRequirements.cpp
 +++ b/src/modules/welcome/checker/GeneralRequirements.cpp
-@@ -371,10 +371,34 @@ GeneralRequirements::checkEnoughStorage( qint64 requiredSpace )
+@@ -431,10 +431,35 @@ GeneralRequirements::checkEnoughStorage( qint64 requiredSpace )
      cWarning() << "GeneralRequirements is configured without libparted.";
      return false;
  #else
@@ -88,9 +88,10 @@ index ca7219ca4..6ac682ba4 100644
 +
 +    return false;
 +}
- 
++
  bool
  GeneralRequirements::checkEnoughRam( qint64 requiredRam )
+ {
 diff --git a/src/modules/welcome/checker/GeneralRequirements.h b/src/modules/welcome/checker/GeneralRequirements.h
 index b6646da11..ea27324fa 100644
 --- a/src/modules/welcome/checker/GeneralRequirements.h

--- a/pkgs/tools/misc/calamares/supportedlocale.patch
+++ b/pkgs/tools/misc/calamares/supportedlocale.patch
@@ -1,5 +1,5 @@
 diff --git a/src/modules/locale/Config.cpp b/src/modules/locale/Config.cpp
-index 2357019a7..75b547430 100644
+index 54ff5eb64..1a2b98c9c 100644
 --- a/src/modules/locale/Config.cpp
 +++ b/src/modules/locale/Config.cpp
 @@ -48,7 +48,7 @@ loadLocales( const QString& localeGenPath )

--- a/pkgs/tools/misc/calamares/uimod.patch
+++ b/pkgs/tools/misc/calamares/uimod.patch
@@ -1,33 +1,33 @@
 diff --git a/src/modules/finished/FinishedPage.cpp b/src/modules/finished/FinishedPage.cpp
-index 6c5f9ad16..24d75e07b 100644
+index 23cb194c4..8714937f6 100644
 --- a/src/modules/finished/FinishedPage.cpp
 +++ b/src/modules/finished/FinishedPage.cpp
-@@ -71,7 +71,10 @@ FinishedPage::retranslate()
+@@ -74,7 +74,10 @@ FinishedPage::retranslate()
          {
              ui->mainText->setText( tr( "<h1>All done.</h1><br/>"
                                         "%1 has been set up on your computer.<br/>"
--                                       "You may now start using your new system." )
+-                                       "You may now start using your new system.", "@info" )
 +                                       "You may now start using your new system.<br/>"
 +                                       "You can change every setting later except the bootloader.<br/>"
 +                                       "Check the <a href=\"https://nixos.org/manual/nixos/stable/\">manual</a> for instructions on how to install software, upgrade the system or enable services.<br/>"
-+                                       "You can find ways to get in touch with the <a href=\"https://nixos.org/community/\">community on the website!</a>")
++                                       "You can find ways to get in touch with the <a href=\"https://nixos.org/community/\">community on the website!</a>", "@info" )
                                         .arg( branding->versionedName() ) );
              ui->restartCheckBox->setToolTip( tr( "<html><head/><body>"
                                                   "<p>When this box is checked, your system will "
-@@ -84,7 +87,10 @@ FinishedPage::retranslate()
+@@ -87,7 +90,10 @@ FinishedPage::retranslate()
              ui->mainText->setText( tr( "<h1>All done.</h1><br/>"
                                         "%1 has been installed on your computer.<br/>"
                                         "You may now restart into your new system, or continue "
--                                       "using the %2 Live environment." )
+-                                       "using the %2 Live environment.", "@info" )
 +                                       "using the %2 Live environment.<br/>"
 +                                       "You can change every setting later except the bootloader.<br/>"
 +                                       "Check the <a href=\"https://nixos.org/manual/nixos/stable/\">manual</a> for instructions on how to install software, upgrade the system or enable services.<br/>"
-+                                       "You can find ways to get in touch with the <a href=\"https://nixos.org/community/\">community on the website!</a>")
++                                       "You can find ways to get in touch with the <a href=\"https://nixos.org/community/\">community on the website!</a>", "@info" )
                                         .arg( branding->versionedName(), branding->productName() ) );
              ui->restartCheckBox->setToolTip( tr( "<html><head/><body>"
                                                   "<p>When this box is checked, your system will "
 diff --git a/src/modules/packagechooser/PackageChooserPage.cpp b/src/modules/packagechooser/PackageChooserPage.cpp
-index 721329c1b..164b9945e 100644
+index 44a570d2f..4dc931bf3 100644
 --- a/src/modules/packagechooser/PackageChooserPage.cpp
 +++ b/src/modules/packagechooser/PackageChooserPage.cpp
 @@ -52,6 +52,7 @@ PackageChooserPage::currentChanged( const QModelIndex& index )
@@ -39,14 +39,14 @@ index 721329c1b..164b9945e 100644
          ui->productDescription->setText( m_introduction.description.get() );
      }
 diff --git a/src/modules/packagechooser/page_package.ui b/src/modules/packagechooser/page_package.ui
-index d021b08b3..fecfa3060 100644
+index 2ab5b7f13..bed462069 100644
 --- a/src/modules/packagechooser/page_package.ui
 +++ b/src/modules/packagechooser/page_package.ui
-@@ -38,19 +38,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
+@@ -37,20 +37,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
+       </widget>
       </item>
       <item>
 -      <layout class="QVBoxLayout" name="verticalLayout" stretch="1,30,1">
-+      <layout class="QVBoxLayout" name="verticalLayout" stretch="30,1,1">
 -       <item>
 -        <widget class="QLabel" name="productName">
 -         <property name="sizePolicy">
@@ -60,6 +60,7 @@ index d021b08b3..fecfa3060 100644
 -         </property>
 -        </widget>
 -       </item>
++      <layout class="QVBoxLayout" name="verticalLayout" stretch="30,1,1">
         <item>
          <widget class="FixedAspectRatioLabel" name="productScreenshot">
           <property name="sizePolicy">

--- a/pkgs/tools/misc/calamares/waylandkbd.patch
+++ b/pkgs/tools/misc/calamares/waylandkbd.patch
@@ -1,20 +1,20 @@
 diff --git a/src/modules/keyboard/Config.cpp b/src/modules/keyboard/Config.cpp
-index 720588810..af0dd1c8d 100644
+index d8b1e8e86..b2e1b7b5f 100644
 --- a/src/modules/keyboard/Config.cpp
 +++ b/src/modules/keyboard/Config.cpp
-@@ -219,7 +219,10 @@ Config::xkbApply()
+@@ -307,7 +307,10 @@ Config::xkbApply()
+                            xkbmap_layout_args( { m_additionalLayoutInfo.additionalLayout, m_selectedLayout },
                                                 { m_additionalLayoutInfo.additionalVariant, m_selectedVariant },
                                                 m_additionalLayoutInfo.groupSwitcher ) );
- 
 -
 +        QString xkbmap = QString( "[('xkb','%1\%2'),('xkb','%3\%4')]").arg(
-+                m_selectedLayout, ((!m_selectedVariant.isEmpty()) ? "+" + m_selectedVariant : ""),
-+                m_additionalLayoutInfo.additionalLayout, ((!m_additionalLayoutInfo.additionalVariant.isEmpty()) ? "+" + m_additionalLayoutInfo.additionalVariant : ""));
++                                  m_selectedLayout, ((!m_selectedVariant.isEmpty()) ? "+" + m_selectedVariant : ""),
++                                  m_additionalLayoutInfo.additionalLayout, ((!m_additionalLayoutInfo.additionalVariant.isEmpty()) ? "+" + m_additionalLayoutInfo.additionalVariant : ""));
 +        QProcess::execute( "sh", { "-c", "if command -v gsettings; then gsettings set org.gnome.desktop.input-sources sources \"$0\"; fi", xkbmap });
          cDebug() << "xkbmap selection changed to: " << m_selectedLayout << '-' << m_selectedVariant << "(added "
                   << m_additionalLayoutInfo.additionalLayout << "-" << m_additionalLayoutInfo.additionalVariant
                   << " since current layout is not ASCII-capable)";
-@@ -227,6 +230,8 @@ Config::xkbApply()
+@@ -315,6 +318,8 @@ Config::xkbApply()
      else
      {
          QProcess::execute( "setxkbmap", xkbmap_layout_args( m_selectedLayout, m_selectedVariant ) );


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updates Calamares and related patches to 3.3.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Calamares NixOS specific patches updated
- Calamares encryption settings now uses LUKS2 by default
- Fixes networking part of #172134

---

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
