### PR TITLE
gramps: 5.1.6 -> 5.2.0, drop legacy builder

### DIFF
--- a/pkgs/applications/misc/gramps/check-locale-hasattr-textdomain.patch
+++ b/pkgs/applications/misc/gramps/check-locale-hasattr-textdomain.patch
@@ -1,0 +1,19 @@
+diff --git a/gramps/gen/utils/grampslocale.py b/gramps/gen/utils/grampslocale.py
+index f25030e..59c1c90 100644
+--- a/gramps/gen/utils/grampslocale.py
++++ b/gramps/gen/utils/grampslocale.py
+@@ -370,8 +370,12 @@ class GrampsLocale:
+                 )
+             else:
+                 # bug12278, _build_popup_ui() under linux and macOS
+-                locale.textdomain(self.localedomain)
+-                locale.bindtextdomain(self.localedomain, self.localedir)
++                if hasattr(locale, 'textdomain'):
++                    locale.textdomain(self.localedomain)
++                    locale.bindtextdomain(self.localedomain, self.localedir)
++                else:
++                    gettext.textdomain(self.localedomain)
++                    gettext.bindtextdomain(self.localedomain, self.localedir)
+ 
+         self.rtl_locale = False
+         if self.language[0] in _RTL_LOCALES:

--- a/pkgs/applications/misc/gramps/disable-gtk-warning-dialog.patch
+++ b/pkgs/applications/misc/gramps/disable-gtk-warning-dialog.patch
@@ -1,0 +1,14 @@
+diff --git a/gramps/gui/grampsgui.py b/gramps/gui/grampsgui.py
+index 0c0d4c3..522f65a 100644
+--- a/gramps/gui/grampsgui.py
++++ b/gramps/gui/grampsgui.py
+@@ -573,9 +573,6 @@ class Gramps:
+         dbstate = DbState()
+         self._vm = ViewManager(app, dbstate, config.get("interface.view-categories"))
+ 
+-        if lin() and glocale.lang != "C" and not gettext.find(GTK_GETTEXT_DOMAIN):
+-            _display_gtk_gettext_message(parent=self._vm.window)
+-
+         _display_translator_message(parent=self._vm.window)
+ 
+         self._vm.init_interface()


### PR DESCRIPTION
## Description of changes

This PR updates the `gramps` package to the latest release.

It also drops the old `installPhase` logic, which was a copied-out version of a now removed python builder script.

I changed `pythonPath` over to `propagatedBuildInputs`, not sure what the real differences are.

I could also remove a patch, which was no longer needed.

I added a patch, which disables the incomplete GTK install warning dialog appearing on launch

I fixed testing by using `unittestCheckHook` and creating an empty `.git` directory (so that it know it hasn't been installed yet)

I avoided double-wrapping the executable by using `dontWrapGApps` with `preFixup`

I added the `disabled` attribute using `pythonOlder` 

I added `meta.mainProgram`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
