### PR TITLE
slskd: fix nginx options and make slskd.yml writable

### DIFF
--- a/nixos/modules/services/web-apps/slskd.nix
+++ b/nixos/modules/services/web-apps/slskd.nix
@@ -22,7 +22,7 @@ in {
     };
 
     nginx = mkOption {
-      description = mdDoc "options for nginx";
+      description = "options for nginx";
       example = {
         enable = true;
         domain = "example.com";
@@ -39,7 +39,7 @@ in {
           contextPath = mkOption {
             type = path;
             default = "/";
-            description = mdDoc ''
+            description = ''
               The context path, i.e., the last part of the slskd
               URL. Typically '/' or '/slskd'. Default '/'
             '';
@@ -48,7 +48,7 @@ in {
             type = str;
             default = "localhost";
             example = "10.0.0.1";
-            description = mdDoc ''
+            description = ''
               The address at which slskd serves its web interface.
             '';
           };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR modifies the following aspects of the `slskd` module:
- it fixes the behaviour of the nginx configuration in order to actually take the `enable` option into account, as it was not the case before;
- it removes the `enableACME` option of the nginx configuration, as this is not the responsibility of this module to enable it (users could want to set up the proxy host with e.g. the `useACMEHost` option; see other web-related modules like `nextcloud`);
- it adds a `bindAddress` option for the nginx proxy, which tells nginx which address to use to contact slskd. Indeed, this is necessary in some scenarios, as slskd might be reachable from a specific interface, and not `lo`;
- it generates the config at service startup, which makes it writable. This allows for later modifications at runtime, which is necessary in order to update e.g. the listening port if it is obtained dynamically. This is also the approach taken by the `transmission` module for instance. Password is now provided through a `passwordFile` for consistency with this new approach (again, following what is done in the transmission module)

I am aware that this last change breaks the behaviour of the existing module, as it replaces the existing `environmentFile`. Feel free to tell me how to modify my request in order to either combine both behaviours or deprecate the previous method, etc., as this is my first pull request here :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
