### PR TITLE
exam-monitor: init at 24044

### DIFF
--- a/pkgs/by-name/ex/exam-monitor/package.nix
+++ b/pkgs/by-name/ex/exam-monitor/package.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, fetchurl, makeWrapper, jre }:
+
+stdenv.mkDerivation rec {
+  pname = "exam-monitor";
+  version = "24044";
+
+  src = fetchurl {
+    url = "https://login.exammonitor.dk/exam.jar";
+    sha256 = "0kb07m1r8p71ipzvwv2armfm68g2pnbnf0m724ldwf0jk665x285";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    mkdir -p $out/share/java $out/bin
+    cp $src $out/share/java/exam.jar
+    makeWrapper ${jre}/bin/java $out/bin/exam-monitor \
+      --add-flags "-Dhttp.agent=EM/ -Dapple.eawt.quitStrategy=CLOSE_ALL_WINDOWS -Xms64m -Xmx512m -jar $out/share/java/exam.jar SDU"
+  '';
+
+  meta = with lib; {
+    homepage = "https://sdu.exammonitor.dk/";
+    description =
+      "A tool used for monitoring of students during exams at the University of Southern Denmark";
+    mainProgram = "exam-monitor";
+    platforms = platforms.unix;
+    license = licenses.unfree;
+    maintainers = with maintainers; [ xdhampus ];
+  };
+}


### PR DESCRIPTION
## Description of changes
Packages the [exam monitoring tool](https://sdu.exammonitor.dk/) used at the University of Southern Denmark. 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
