### PR TITLE
ocamlPackages.ctypes: 0.20.2 → 0.22.0

### DIFF
--- a/pkgs/development/libraries/libbap/default.nix
+++ b/pkgs/development/libraries/libbap/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, bap, ocaml, findlib, ctypes, autoreconfHook,
+{ lib, stdenv, fetchFromGitHub, bap, ocaml, findlib, ctypes, ctypes-foreign, autoreconfHook,
   which }:
 
 stdenv.mkDerivation {
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ autoreconfHook which ocaml findlib ];
-  buildInputs = [ bap ctypes ];
+  buildInputs = [ bap ctypes ctypes-foreign ];
 
   preInstall = ''
     mkdir -p $out/lib

--- a/pkgs/development/ocaml-modules/ctypes/default.nix
+++ b/pkgs/development/ocaml-modules/ctypes/default.nix
@@ -1,49 +1,35 @@
-{ lib, stdenv, fetchFromGitHub, ocaml, findlib, libffi, pkg-config, ncurses, integers, bigarray-compat }:
+{ lib
+, ocaml
+, fetchFromGitHub
+, buildDunePackage
+, dune-configurator
+, integers
+, bigarray-compat
+, ounit2
+}:
 
-if lib.versionOlder ocaml.version "4.02"
-then throw "ctypes is not available for OCaml ${ocaml.version}"
-else
-
-stdenv.mkDerivation rec {
-  pname = "ocaml${ocaml.version}-ctypes";
-  version = "0.20.2";
+buildDunePackage rec {
+  pname = "ctypes";
+  version = "0.21.1";
 
   src = fetchFromGitHub {
     owner = "ocamllabs";
     repo = "ocaml-ctypes";
     rev = version;
-    hash = "sha256-LzUrR8K88CjY/R5yUK3y6KG85hUMjbzuebHGqI8KhhM=";
+    hash = "sha256-Cay+8dwFxw4d1OgMP4CR94l4ic2269YCAaziesEqwHM=";
   };
 
-  nativeBuildInputs = [ pkg-config ocaml findlib ];
-  buildInputs = [ ncurses ];
-  propagatedBuildInputs = [ integers libffi bigarray-compat ];
+  buildInputs = [ dune-configurator ];
 
-  strictDeps = true;
+  propagatedBuildInputs = [ integers bigarray-compat ];
 
-  preConfigure = ''
-    substituteInPlace META --replace ' bytes ' ' '
-  '';
-
-  buildPhase = ''
-    runHook preBuild
-    make XEN=false libffi.config ctypes-base ctypes-stubs
-    make XEN=false ctypes-foreign
-    runHook postBuild
-  '';
-
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/stublibs
-    make install XEN=false
-    runHook postInstall
-  '';
+  doCheck = lib.versionAtLeast ocaml.version "4.08";
+  checkInputs = [ ounit2 ];
 
   meta = with lib; {
     homepage = "https://github.com/ocamllabs/ocaml-ctypes";
     description = "Library for binding to C libraries using pure OCaml";
     license = licenses.mit;
     maintainers = [ maintainers.ericbmerritt ];
-    inherit (ocaml.meta) platforms;
   };
 }

--- a/pkgs/development/ocaml-modules/ctypes/default.nix
+++ b/pkgs/development/ocaml-modules/ctypes/default.nix
@@ -10,13 +10,13 @@
 
 buildDunePackage rec {
   pname = "ctypes";
-  version = "0.21.1";
+  version = "0.22.0";
 
   src = fetchFromGitHub {
     owner = "ocamllabs";
     repo = "ocaml-ctypes";
     rev = version;
-    hash = "sha256-Cay+8dwFxw4d1OgMP4CR94l4ic2269YCAaziesEqwHM=";
+    hash = "sha256-xgDKupQuakjHTbjoap/r2aAjNQUpH9K4HmeLbbgw1x4=";
   };
 
   buildInputs = [ dune-configurator ];

--- a/pkgs/development/ocaml-modules/ctypes/foreign.nix
+++ b/pkgs/development/ocaml-modules/ctypes/foreign.nix
@@ -1,0 +1,23 @@
+{ buildDunePackage
+, ctypes
+, dune-configurator
+, libffi
+, ounit2
+, lwt
+}:
+
+buildDunePackage rec {
+  pname = "ctypes-foreign";
+
+  inherit (ctypes) version src doCheck;
+
+  buildInputs = [ dune-configurator ];
+
+  propagatedBuildInputs = [ ctypes libffi ];
+
+  checkInputs = [ ounit2 lwt ];
+
+  meta = ctypes.meta // {
+    description = "Dynamic access to foreign C libraries using Ctypes";
+  };
+}

--- a/pkgs/development/ocaml-modules/hacl-star/raw.nix
+++ b/pkgs/development/ocaml-modules/hacl-star/raw.nix
@@ -27,7 +27,10 @@ stdenv.mkDerivation rec {
   # strictoverflow is disabled because it breaks aarch64-darwin
   hardeningDisable = [ "strictoverflow" ];
 
+  # Compatibility with ctypes ≥ 0.21
+  # see: https://github.com/cryspen/hacl-packages/commit/81303b83a54a92d3b5f54f1b8ddbea60438cc2bf
   postPatch = ''
+    substituteInPlace hacl-star-raw/META --replace-warn 'requires="ctypes"' 'requires="ctypes ctypes.stubs"'
     patchShebangs ./
   '';
 

--- a/pkgs/development/ocaml-modules/janestreet/0.14.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.14.nix
@@ -130,7 +130,7 @@ with self;
     hash = "0ykys3ckpsx5crfgj26v2q3gy6wf684aq0bfb4q8p92ivwznvlzy";
     meta.description = "Async wrappers for SSL";
     buildInputs = [ dune-configurator ];
-    propagatedBuildInputs = [ async ctypes openssl ];
+    propagatedBuildInputs = [ async ctypes ctypes-foreign openssl ];
     # in ctypes.foreign 0.18.0 threaded and unthreaded have been merged
     postPatch = ''
       substituteInPlace bindings/dune \

--- a/pkgs/development/ocaml-modules/janestreet/0.15.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.15.nix
@@ -144,7 +144,7 @@ with self;
     hash = "1b7f7p3xj4jr2n2dxy2lp7a9k7944w6x2nrg6524clvcsd1ax4hn";
     meta.description = "Async wrappers for SSL";
     buildInputs = [ dune-configurator ];
-    propagatedBuildInputs = [ async ctypes openssl ];
+    propagatedBuildInputs = [ async ctypes ctypes-foreign openssl ];
     # in ctypes.foreign 0.18.0 threaded and unthreaded have been merged
     postPatch = ''
       substituteInPlace bindings/dune \

--- a/pkgs/development/ocaml-modules/janestreet/0.16.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.16.nix
@@ -146,7 +146,7 @@ with self;
     hash = "sha256-83YKxvVb/JwBnQG4R/R1Ztik9T/hO4cbiNTfFnErpG4=";
     meta.description = "Async wrappers for SSL";
     buildInputs = [ dune-configurator ];
-    propagatedBuildInputs = [ async ctypes openssl ];
+    propagatedBuildInputs = [ async ctypes ctypes-foreign openssl ];
   };
 
   async_unix = janePackage {

--- a/pkgs/development/ocaml-modules/lilv/default.nix
+++ b/pkgs/development/ocaml-modules/lilv/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildDunePackage, fetchFromGitHub, dune-configurator, ctypes, lilv }:
+{ lib, buildDunePackage, fetchFromGitHub, dune-configurator, ctypes, ctypes-foreign, lilv }:
 
 buildDunePackage rec {
   pname = "lilv";
@@ -14,7 +14,7 @@ buildDunePackage rec {
   minimalOCamlVersion = "4.03.0";
 
   buildInputs = [ dune-configurator ];
-  propagatedBuildInputs = [ ctypes lilv ];
+  propagatedBuildInputs = [ ctypes ctypes-foreign lilv ];
 
   meta = with lib; {
     homepage = "https://github.com/savonet/ocaml-lilv";

--- a/pkgs/development/ocaml-modules/mariadb/default.nix
+++ b/pkgs/development/ocaml-modules/mariadb/default.nix
@@ -15,10 +15,16 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-3/C1Gz6luUzS7oaudLlDHMT6JB2v5OdbLVzJhtayHGM=";
   };
 
-  patches = fetchpatch {
-    url = "https://github.com/andrenth/ocaml-mariadb/commit/9db2e4d8dec7c584213d0e0f03d079a36a35d9d5.patch";
-    hash = "sha256-heROtU02cYBJ5edIHMdYP1xNXcLv8h79GYGBuudJhgE=";
-  };
+  patches = lib.lists.map (x:
+    fetchpatch {
+      url = "https://github.com/andrenth/ocaml-mariadb/commit/${x.path}.patch";
+      inherit (x) hash;
+    })
+  [ { path = "9db2e4d8dec7c584213d0e0f03d079a36a35d9d5";
+      hash = "sha256-heROtU02cYBJ5edIHMdYP1xNXcLv8h79GYGBuudJhgE="; }
+    { path = "40cd3102bc7cce4ed826ed609464daeb1bbb4581";
+      hash = "sha256-YVsAMJiOgWRk9xPaRz2sDihBYLlXv+rhWtQIMOVLtSg="; }
+  ];
 
   postPatch = ''
     substituteInPlace setup.ml --replace '#use "topfind"' \

--- a/pkgs/development/ocaml-modules/srt/default.nix
+++ b/pkgs/development/ocaml-modules/srt/default.nix
@@ -2,6 +2,7 @@
 , dune-configurator
 , posix-socket
 , srt
+, ctypes-foreign
 }:
 
 buildDunePackage rec {
@@ -9,7 +10,6 @@ buildDunePackage rec {
   version = "0.3.0";
 
   minimalOCamlVersion = "4.08";
-  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "savonet";
@@ -19,7 +19,7 @@ buildDunePackage rec {
   };
 
   buildInputs = [ dune-configurator ];
-  propagatedBuildInputs = [ posix-socket srt ];
+  propagatedBuildInputs = [ ctypes-foreign posix-socket srt ];
 
   meta = with lib; {
     description = "OCaml bindings for the libsrt library";

--- a/pkgs/development/ocaml-modules/torch/default.nix
+++ b/pkgs/development/ocaml-modules/torch/default.nix
@@ -5,6 +5,7 @@
 , fetchpatch
 , cmdliner
 , ctypes
+, ctypes-foreign
 , dune-configurator
 , npy
 , ocaml-compiler-libs
@@ -42,6 +43,7 @@ buildDunePackage rec {
   propagatedBuildInputs = [
     cmdliner
     ctypes
+    ctypes-foreign
     npy
     ocaml-compiler-libs
     ppx_custom_printf

--- a/pkgs/development/ocaml-modules/tsdl/default.nix
+++ b/pkgs/development/ocaml-modules/tsdl/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, ctypes, result, SDL2, pkg-config
+{ lib, stdenv, fetchurl, ocaml, findlib, ocamlbuild, topkg, ctypes, ctypes-foreign, result, SDL2, pkg-config
 , AudioToolbox, Cocoa, CoreAudio, CoreVideo, ForceFeedback }:
 
 if lib.versionOlder ocaml.version "4.03"
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ pkg-config ocaml findlib ocamlbuild topkg ];
   buildInputs = [ topkg ];
-  propagatedBuildInputs = [ SDL2 ctypes ]
+  propagatedBuildInputs = [ SDL2 ctypes ctypes-foreign ]
     ++ lib.optionals stdenv.isDarwin [ AudioToolbox Cocoa CoreAudio CoreVideo ForceFeedback ];
 
   preConfigure = ''

--- a/pkgs/development/ocaml-modules/xxhash/default.nix
+++ b/pkgs/development/ocaml-modules/xxhash/default.nix
@@ -3,6 +3,7 @@
 , buildDunePackage
 , xxHash
 , ctypes
+, ctypes-foreign
 , dune-configurator
 , ppx_expect
 }:
@@ -20,12 +21,17 @@ buildDunePackage rec {
     hash = "sha256-0+ac5EWV9DCVMT4wOcXC95GVEwsUIZzFn2laSzmK6jE=";
   };
 
+  postPatch = ''
+    substituteInPlace stubs/dune --replace-warn 'ctypes))' 'ctypes ctypes.stubs))'
+  '';
+
   buildInputs = [
     dune-configurator
   ];
 
   propagatedBuildInputs = [
     ctypes
+    ctypes-foreign
     xxHash
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -22259,7 +22259,7 @@ with pkgs;
   libbacktrace = callPackage ../development/libraries/libbacktrace { };
 
   libbap = callPackage ../development/libraries/libbap {
-    inherit (ocaml-ng.ocamlPackages_4_14) bap ocaml findlib ctypes;
+    inherit (ocaml-ng.ocamlPackages_4_14) bap ocaml findlib ctypes ctypes-foreign;
   };
 
   libbaseencode = callPackage ../development/libraries/libbaseencode { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -283,6 +283,8 @@ let
 
     ctypes = callPackage ../development/ocaml-modules/ctypes { };
 
+    ctypes-foreign = callPackage ../development/ocaml-modules/ctypes/foreign.nix { };
+
     ctypes_stubs_js = callPackage ../development/ocaml-modules/ctypes_stubs_js {
       inherit (pkgs) nodejs;
     };
@@ -786,7 +788,7 @@ let
           inherit conduit ipaddr-sexp;
         };
       in {
-        inherit (self) dune-configurator alcotest re num octavius uutf ounit ctypes;
+        inherit (self) dune-configurator alcotest re num octavius uutf ounit ctypes ctypes-foreign;
         ppxlib = self.ppxlib.override { inherit (self') stdio; };
         cohttp-async = self.cohttp-async.override {
           inherit (self') ppx_sexp_conv base async async_kernel async_unix core_unix sexplib0 core;


### PR DESCRIPTION
## Description of changes

Support for future OCaml: https://raw.githubusercontent.com/yallop/ocaml-ctypes/0.22.0/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
