### PR TITLE
kikit: 1.4.0 -> 1.5.0

### DIFF
--- a/pkgs/by-name/ki/kikit/default.nix
+++ b/pkgs/by-name/ki/kikit/default.nix
@@ -10,6 +10,7 @@
 , numpy
 , click
 , markdown2
+, openscad
 , pytestCheckHook
 , commentjson
 , wxpython
@@ -23,7 +24,7 @@ let
 in
 buildPythonApplication rec {
   pname = "kikit";
-  version = "1.4.0";
+  version = "1.5.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -32,7 +33,7 @@ buildPythonApplication rec {
     owner = "yaqwsx";
     repo = "KiKit";
     rev = "refs/tags/v${version}";
-    hash = "sha256-88/1bL3MtawR/8P8U1jHatMbq+JxF1qb+plH3rYh1qU=";
+    hash = "sha256-f8FB6EEy9Ch4LcMKd9PADXV9QrSb7e22Ui86G6AnQKE=";
   };
 
   propagatedBuildInputs = [
@@ -40,6 +41,9 @@ buildPythonApplication rec {
     numpy
     click
     markdown2
+    # OpenSCAD is an optional dependency (see
+    # https://github.com/yaqwsx/KiKit/blob/v1.5.0/docs/installation/intro.md#optional-dependencies).
+    openscad
     commentjson
     # https://github.com/yaqwsx/KiKit/issues/575
     wxpython


### PR DESCRIPTION
This includes support for KiCad 8 (see complete changelog [here](https://github.com/yaqwsx/KiKit/releases/tag/v1.5.0)), which should unblock https://github.com/NixOS/nixpkgs/pull/291134.

With this upgrade, a test started failing:

    $ nix build .#kikit
    ...
    kikit> not ok 40 Steel stencils
    kikit> # (in test file /build/source/test/system/stencil.bats, line 6)
    kikit> #   `kikit stencil create  --jigsize 60 60 $RES/conn.kicad_pcb steelStencil' failed
    kikit> # 04:32:16: Error: Directory '/homeless-shelter' couldn't be created (error 13: Permission denied)
    kikit> # An error occurred: OpenSCAD is not available.
    kikit> # Did you install it? Program `openscad` has to be in PATH
    kikit> # No output files produced
    kikit> not ok 41 Steel stencils with cutout
    kikit> # (in test file /build/source/test/system/stencil.bats, line 10)
    kikit> #   `kikit stencil create  --jigsize 60 60 --cutout J4 $RES/conn.kicad_pcb steelStencil' failed
    kikit> # 04:32:17: Error: Directory '/homeless-shelter' couldn't be created (error 13: Permission denied)
    kikit> # An error occurred: OpenSCAD is not available.
    kikit> # Did you install it? Program `openscad` has to be in PATH
    kikit> # No output files produced
    kikit> not ok 42 Printed stencils
    kikit> # (in test file /build/source/test/system/stencil.bats, line 14)
    kikit> #   `kikit stencil createprinted \' failed
    kikit> # 04:32:17: Error: Directory '/homeless-shelter' couldn't be created (error 13: Permission denied)
    kikit> # An error occurred: OpenSCAD is not available.
    kikit> # Did you install it? Program `openscad` has to be in PATH
    kikit> # No output files produced
    kikit> make: *** [Makefile:40: test-system] Error 1
    kikit> /nix/store/3qnm3nwjajgqa771dmi2dnwxrw0kzq5m-stdenv-linux/setup: line 131: pop_var_context: head of shell_variables not a function context
    error: builder for '/nix/store/f3klmz0qvi6yr3qfy7cww434f2z4kjx5-kikit-1.5.0.drv' failed with exit code 2;

This is failing in some pretty old kikit code, so I think this is just failing due to kikit now having more complete code coverage. While researching this, I discovered kikit's documentation about [optional dependencies], which I suppose we don't have good support for right now. Rather than invent a new option for that, I've opted to preserve the existing behavior and just do the bare minimum to keep the build passing.

[optional dependencies]: https://github.com/yaqwsx/KiKit/blob/v1.5.0/docs/installation/intro.md#optional-dependencies

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
