### PR TITLE
ollama: 0.1.26 -> 0.1.27

### DIFF
--- a/nixos/modules/services/misc/ollama.nix
+++ b/nixos/modules/services/misc/ollama.nix
@@ -1,11 +1,13 @@
 { config, lib, pkgs, ... }:
 let
-  inherit (lib.types) nullOr enum;
+  inherit (lib) types;
 
   cfg = config.services.ollama;
   ollamaPackage = cfg.package.override {
     inherit (cfg) acceleration;
-    linuxPackages.nvidia_x11 = config.hardware.nvidia.package;
+    linuxPackages = config.boot.kernelPackages.overrideAttrs {
+      nvidia_x11 = config.hardware.nvidia.package;
+    };
   };
 in
 {
@@ -15,14 +17,14 @@ in
         lib.mdDoc "Server for local large language models"
       );
       listenAddress = lib.mkOption {
-        type = lib.types.str;
+        type = types.str;
         default = "127.0.0.1:11434";
         description = lib.mdDoc ''
           Specifies the bind address on which the ollama server HTTP interface listens.
         '';
       };
       acceleration = lib.mkOption {
-        type = nullOr (enum [ "rocm" "cuda" ]);
+        type = types.nullOr (types.enum [ "rocm" "cuda" ]);
         default = null;
         example = "rocm";
         description = lib.mdDoc ''

--- a/pkgs/tools/misc/ollama/default.nix
+++ b/pkgs/tools/misc/ollama/default.nix
@@ -24,7 +24,14 @@
 
 let
   pname = "ollama";
-  version = "0.1.26";
+  version = "0.1.27";
+  src = fetchFromGitHub {
+    owner = "jmorganca";
+    repo = "ollama";
+    rev = "v${version}";
+    hash = "sha256-+ayby+yVknFHLTyLjMAPMnOTMSzTKqzi9caN/TppcEg=";
+    fetchSubmodules = true;
+  };
 
   validAccel = lib.assertOneOf "ollama.acceleration" acceleration [ null "rocm" "cuda" ];
 
@@ -74,14 +81,6 @@ let
       buildGoModule.override { stdenv = overrideCC stdenv gcc12; }
     else
       buildGoModule;
-
-  src = fetchFromGitHub {
-    owner = "jmorganca";
-    repo = "ollama";
-    rev = "v${version}";
-    hash = "sha256-Kw3tt9ayEMgI2V6OeaOkWfNwqfCL7MDD/nN5iXk5LnY=";
-    fetchSubmodules = true;
-  };
   preparePatch = patch: hash: fetchpatch {
     url = "file://${src}/llm/patches/${patch}";
     inherit hash;


### PR DESCRIPTION
## Description of changes
Ollama 0.1.27 seems to be a rather minor release, the most notable change being the version update of the vendored llama.cpp, which improved performance with the gemma model.

### What changed

<details><summary>

#### release [0.1.27](https://github.com/ollama/ollama/releases/tag/v0.1.27)

</summary>

- Performance improvements (up to 2x) when running [Gemma](https://ollama.com/library/gemma) models
- Fixed performance issues on Windows without GPU acceleration. Systems with AVX and AVX2 instruction sets should be 2-4x faster.
- Reduced likelihood of false positive Windows Defender alerts on Windows.

</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
