### PR TITLE
[WIP]: unstableGitUpdater: follow current conventions

### DIFF
--- a/pkgs/common-updater/unstable-updater.nix
+++ b/pkgs/common-updater/unstable-updater.nix
@@ -10,7 +10,7 @@
 # commit.
 { url ? null # The git url, if empty it will be set to src.gitRepoUrl
 , branch ? null
-, stableVersion ? false # Use version format according to RFC 107 (i.e. LAST_TAG+date=YYYY-MM-DD)
+, stableVersion ? false # Use version format according to RFC 147 (i.e. LAST_TAG-unstable-YYYY-MM-DD or 0-unstable-YYYY-MM-DD)
 , tagPrefix ? "" # strip this prefix from a tag name when using stable version
 , shallowClone ? true
 }:
@@ -92,12 +92,12 @@ let
         done
         if [[ -z "$last_tag" ]]; then
             echo "Cound not found a tag within last 10000 commits" > /dev/stderr
-            exit 1
+            last_tag="0"
         fi
         if [[ -n "$tag_prefix" ]]; then
           last_tag="''${last_tag#$tag_prefix}"
         fi
-        new_version="$last_tag+date=$commit_date"
+        new_version="$last_tag-unstable-$commit_date"
     fi
     popd
     # ${coreutils}/bin/rm -rf "$tmpdir"

--- a/pkgs/common-updater/unstable-updater.nix
+++ b/pkgs/common-updater/unstable-updater.nix
@@ -10,7 +10,7 @@
 # commit.
 { url ? null # The git url, if empty it will be set to src.gitRepoUrl
 , branch ? null
-, stableVersion ? false # Use version format according to RFC 147 (i.e. LAST_TAG-unstable-YYYY-MM-DD or 0-unstable-YYYY-MM-DD)
+, stableVersion ? true # Use version format according to RFC 147 (i.e. LAST_TAG-unstable-YYYY-MM-DD or 0-unstable-YYYY-MM-DD)
 , tagPrefix ? "" # strip this prefix from a tag name when using stable version
 , shallowClone ? true
 }:

--- a/pkgs/common-updater/unstable-updater.nix
+++ b/pkgs/common-updater/unstable-updater.nix
@@ -91,7 +91,7 @@ let
             depth=$(( $depth * 2 ))
         done
         if [[ -z "$last_tag" ]]; then
-            echo "Cound not found a tag within last 10000 commits" > /dev/stderr
+            echo "Could not find a tag within last 10000 commits" > /dev/stderr
             last_tag="0"
         fi
         if [[ -n "$tag_prefix" ]]; then


### PR DESCRIPTION
## Description of changes

Enforce the current versioning conventions in the unstable git updater.
Fixes #291729.

**Note: this is still being developed and tested - do not merge**

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
