### PR TITLE
flashgbx: init at 3.37

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7283,6 +7283,12 @@
     githubId = 76716;
     name = "Graham Christensen";
   };
+  grahamnorris = {
+    email = "oss@grahamjnorris.com";
+    github = "grahamnorris";
+    githubId = 66037909;
+    name = "Graham J. Norris";
+  };
   gravndal = {
     email = "gaute.ravndal+nixos@gmail.com";
     github = "gravndal";

--- a/pkgs/by-name/fl/flashgbx/package.nix
+++ b/pkgs/by-name/fl/flashgbx/package.nix
@@ -1,0 +1,63 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+, makeDesktopItem
+, copyDesktopItems
+, qt6
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "flashgbx";
+  version = "3.37";
+
+  src = fetchFromGitHub {
+    repo = "FlashGBX";
+    owner = "lesserkuma";
+    rev = version;
+    hash = "sha256-3527QmSSpGotFHKTg0yb6MgHKSze+9BECQWqZM3qKsw=";
+  };
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "flashgbx";
+      desktopName = "FlashGBX UI";
+      icon = "flashgbx";
+      exec = meta.mainProgram;
+      comment = "UI for reading and writing Game Boy and Game Boy Advance cartridges";
+      categories = [ "Utility" ];
+    })
+  ];
+
+  postInstall =
+  ''
+      install -D FlashGBX/res/icon.png $out/share/icons/hicolor/256x256/apps/flashgbx.png
+  '';
+
+  pyproject = true;
+
+  nativeBuildInputs = [
+    python3Packages.setuptools
+    copyDesktopItems
+    qt6.wrapQtAppsHook
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    pillow
+    pyserial
+    pyside6
+    python-dateutil
+    requests
+    setuptools
+    qt6.qtbase
+  ] ++ lib.optionals stdenv.isLinux [
+    qt6.qtwayland
+  ];
+
+  meta = with lib; {
+    description = "GUI for reading and writing GB and GBA cartridges with the GBxCart RW";
+    homepage = "https://github.com/lesserkuma/FlashGBX";
+    license = licenses.gpl3Only;
+    mainProgram = "flashgbx";
+    maintainers = with maintainers; [ grahamnorris ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds [FlashGBX](https://github.com/lesserkuma/FlashGBX), a command-line and GUI utility for reading and writing to Game Boy, Game Boy Color, and Game Boy Advance cartridges using [GBxCart RW](https://www.gbxcart.com/) hardware.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Tested that this launches on aarch64-darwin and launches and functions correctly on x86_64-linux, including wayland.
The desktop icon does not appear correct on KDE plasma wayland, but AFAICT, this is due to the presence of a PNG rather than SVG icon.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
