### PR TITLE
jupyter related packages updates 2024-02-27

### DIFF
--- a/pkgs/development/python-modules/ipykernel/default.nix
+++ b/pkgs/development/python-modules/ipykernel/default.nix
@@ -22,14 +22,14 @@
 
 buildPythonPackage rec {
   pname = "ipykernel";
-  version = "6.29.2";
+  version = "6.29.3";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-O63igATj/2JO1Xl0lIEWZwYErF9nbRIzlpPzFCF20/A=";
+    hash = "sha256-4UwlDR+eo5iUkCJcwaVCeBsJWhihlEf88rXq99CsW9I=";
   };
 
   # debugpy is optional, see https://github.com/ipython/ipykernel/pull/767

--- a/pkgs/development/python-modules/ipyvuetify/default.nix
+++ b/pkgs/development/python-modules/ipyvuetify/default.nix
@@ -2,19 +2,43 @@
 , buildPythonPackage
 , fetchPypi
   # Python Inputs
+, jupyter-packaging
+, jupyterlab
+, setuptools
+, wheel
 , ipyvue
 }:
 
 buildPythonPackage rec {
   pname = "ipyvuetify";
-  version = "1.8.10";
-  format = "setuptools";
+  version = "1.9.0";
+  pyproject = true;
 
   # GitHub version tries to run npm (Node JS)
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-m6RCeUefM/XLg69AaqgTBQ7pYgGVXCy6CH/SOoQ9W04=";
+    hash = "sha256-nFN+IYKZ3jIZSx2pSda5a//mwA82u2A1QJ8khf64gec=";
   };
+
+  # drop pynpm which tries to install node_modules
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "jupyter_packaging~=0.7.9" "jupyter_packaging" \
+      --replace-fail "jupyterlab~=3.0" "jupyterlab" \
+      --replace-fail '"pynpm"' ""
+
+    substituteInPlace setup.py \
+      --replace-fail "from pynpm import NPMPackage" "" \
+      --replace-fail "from generate_source import generate_source" "" \
+      --replace-fail 'setup(cmdclass={"egg_info": js_prerelease(egg_info)})' 'setup()'
+  '';
+
+  nativeBuildInputs = [
+    jupyter-packaging
+    jupyterlab
+    setuptools
+    wheel
+  ];
 
   propagatedBuildInputs = [ ipyvue ];
 

--- a/pkgs/development/python-modules/jupyter-lsp/default.nix
+++ b/pkgs/development/python-modules/jupyter-lsp/default.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "jupyter-lsp";
-  version = "2.2.2";
+  version = "2.2.3";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-JW0kYgVCrku6BKUPwfb/4ggJOgfY5pf+oKjRuMobfls=";
+    hash = "sha256-M9vLxd8kI3/1yLaWsE/0aJ/NMWy41JV9Yg/lUE19LD8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/jupyterlab-server/default.nix
+++ b/pkgs/development/python-modules/jupyterlab-server/default.nix
@@ -21,7 +21,7 @@
 
 buildPythonPackage rec {
   pname = "jupyterlab-server";
-  version = "2.25.2";
+  version = "2.25.3";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "jupyterlab_server";
     inherit version;
-    hash = "sha256-vQ7HqZ687ci8/5Oe+G5Sw3jkTCcH4FP82B0EbOl57mM=";
+    hash = "sha256-hG8SWooZZWYR31sD5ZEsg5POppAIWbqmT6UV62So3EA=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/nbconvert/default.nix
+++ b/pkgs/development/python-modules/nbconvert/default.nix
@@ -33,14 +33,14 @@ let
   };
 in buildPythonPackage rec {
   pname = "nbconvert";
-  version = "7.16.0";
+  version = "7.16.1";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-gT5lU3ljYkia5XLjm6G/+XhTYZL7UY4QgmsOjK3wPsg=";
+    hash = "sha256-555qB09Juj7SlCjthkh79RUJ2aq2E72FIqwI9tKP1/0=";
   };
 
   # Add $out/share/jupyter to the list of paths that are used to search for

--- a/pkgs/development/python-modules/notebook-shim/default.nix
+++ b/pkgs/development/python-modules/notebook-shim/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "notebook-shim";
-  version = "0.2.3";
+  version = "0.2.4";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "jupyter";
     repo = "notebook_shim";
     rev = "refs/tags/v${version}";
-    hash = "sha256-eAYZuNYqOMKC6joDbbKk4Q4nrfdbO7b+yZeSvMdWWrI=";
+    hash = "sha256-CWnXOKE1xvr+a/qWNY6XCTB5+G/fg2O/glgeLzYD+Zc=";
   };
 
   nativeBuildInputs = [ hatchling ];

--- a/pkgs/development/python-modules/pytest-jupyter/default.nix
+++ b/pkgs/development/python-modules/pytest-jupyter/default.nix
@@ -22,14 +22,14 @@
 
 let self = buildPythonPackage rec {
   pname = "pytest-jupyter";
-  version = "0.8.0";
+  version = "0.9.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jupyter-server";
     repo = "pytest-jupyter";
     rev = "refs/tags/v${version}";
-    hash = "sha256-ND51UpPsvZGH6LdEaNFXaBLoCMB4n7caPoo1/Go9fNs=";
+    hash = "sha256-8pQNtzMylW9b3vk0kp7NcJnXAJKYeoFsHy/lyQFCNzc=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

> [!CAUTION]
> This bump seems to break notebook shortcuts.
>
> Edit:
> drop bumps of `jupyterlab`, `notebook` and `jupyterlab-lsp`
> https://github.com/NixOS/nixpkgs/compare/df0d3c57143e01e7833af9baf4d84e77dfcda421..771c3dfe45ea64dd41aa5f5f3ff3f51c93da36c5

Update jupyter-related packages at once to avoid building hundreds of packages over and over again.

This PR is based on the commits generated by the following command.

```
nix search nixpkgs#python311Packages 'ipython|jupyter|notebook' --json | jq -r 'keys | .[]' | cut -d . -f 3,4 | xargs -n 1 nix-update --commit
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
