### PR TITLE
paho-mqtt-c(pp): pass static/shared build to cmake

### DIFF
--- a/pkgs/development/libraries/paho-mqtt-c/default.nix
+++ b/pkgs/development/libraries/paho-mqtt-c/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, openssl }:
+{ lib, stdenv, fetchFromGitHub, cmake, openssl, enableStatic ? stdenv.hostPlatform.isStatic, enableShared ? !stdenv.hostPlatform.isStatic }:
 
 stdenv.mkDerivation rec {
   pname = "paho.mqtt.c";
@@ -21,7 +21,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ openssl ];
 
-  cmakeFlags = [ "-DPAHO_WITH_SSL=TRUE" ];
+  cmakeFlags = [
+    (lib.cmakeBool "PAHO_WITH_SSL" true)
+    (lib.cmakeBool "PAHO_BUILD_STATIC" enableStatic)
+    (lib.cmakeBool "PAHO_BUILD_SHARED" enableShared)
+  ];
 
   meta = with lib; {
     description = "Eclipse Paho MQTT C Client Library";

--- a/pkgs/development/libraries/paho-mqtt-cpp/default.nix
+++ b/pkgs/development/libraries/paho-mqtt-cpp/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, openssl, paho-mqtt-c }:
+{ lib, stdenv, fetchFromGitHub, cmake, openssl, paho-mqtt-c, enableStatic ? stdenv.hostPlatform.isStatic, enableShared ? !stdenv.hostPlatform.isStatic }:
 
 stdenv.mkDerivation rec {
   pname = "paho.mqtt.cpp";
@@ -14,6 +14,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [ openssl paho-mqtt-c ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "PAHO_WITH_SSL" true)
+    (lib.cmakeBool "PAHO_BUILD_STATIC" enableStatic)
+    (lib.cmakeBool "PAHO_BUILD_SHARED" enableShared)
+  ];
 
   meta = with lib; {
     description = "Eclipse Paho MQTT C++ Client Library";


### PR DESCRIPTION
## Description of changes

Allows to build paho-mqtt-c with pkgsStatic,
which results in the following build failure without this change:
```console
$ nix build ".#paho-mqtt-c"
error: builder for '/nix/store/519ajxyj9vgzzk0mi1yll0df29synv5z-paho.mqtt.c-static-x86_64-unknown-linux-musl-1.3.13.drv' failed with exit code 2;
       last 10 log lines:
       > collect2: error: ld returned 1 exit status
       > make[2]: *** [src/CMakeFiles/paho-mqtt3cs.dir/build.make:163: src/libpaho-mqtt3cs.so.1.3.13] Error 1
       > make[1]: *** [CMakeFiles/Makefile2:295: src/CMakeFiles/paho-mqtt3cs.dir/all] Error 2
       > [ 64%] Linking C shared library libpaho-mqtt3as.so
       > /nix/store/zq91mr9h32cippzbnn321vrmbqkh4mi5-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: /nix/store/xqh4v9h8zlizphynp8d0mik2j2rzd94s-x86_64-unknown-linux-musl-gcc-13.2.0/lib/gcc/x86_64-unknown-linux-musl/13.2.0/crtbeginT.o: relocation R_X86_64_32 against hidden symbol `__TMC_END__' can not be used when making a shared object
       > /nix/store/zq91mr9h32cippzbnn321vrmbqkh4mi5-x86_64-unknown-linux-musl-binutils-2.40/bin/x86_64-unknown-linux-musl-ld: failed to set dynamic section sizes: bad value
       > collect2: error: ld returned 1 exit status
       > make[2]: *** [src/CMakeFiles/paho-mqtt3as.dir/build.make:179: src/libpaho-mqtt3as.so.1.3.13] Error 1
       > make[1]: *** [CMakeFiles/Makefile2:321: src/CMakeFiles/paho-mqtt3as.dir/all] Error 2
       > make: *** [Makefile:166: all] Error 2
       For full logs, run 'nix log /nix/store/519ajxyj9vgzzk0mi1yll0df29synv5z-paho.mqtt.c-static-x86_64-unknown-linux-musl-1.3.13.drv'.
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
