### PR TITLE
pythonPackages.csvdiff3: Init at 0.99.8

### DIFF
--- a/pkgs/development/python-modules/csvdiff3/csvdiff3.patch
+++ b/pkgs/development/python-modules/csvdiff3/csvdiff3.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/diff2_logic_test.py b/tests/diff2_logic_test.py
+index 4ccd559..e097158 100644
+--- a/tests/diff2_logic_test.py
++++ b/tests/diff2_logic_test.py
+@@ -5,7 +5,7 @@ import os
+ import filecmp
+
+ from csvdiff3 import merge3
+-from output import Diff2OutputDriver
++from csvdiff3.output import Diff2OutputDriver
+
+ class Debug:
+     # Set this true to disable all tests; a single test can then be

--- a/pkgs/development/python-modules/csvdiff3/default.nix
+++ b/pkgs/development/python-modules/csvdiff3/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, click
+, colorama
+, orderedmultidict
+}:
+
+buildPythonPackage rec {
+  pname = "csvdiff3";
+  version = "0.99.8";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "sctweedie";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-Nq4ZOxtO1hmDdPganbPPQ7asRNiPatz4VCRHJ2Jhpns=";
+  };
+
+  patches = [
+    ./csvdiff3.patch
+  ];
+
+  propagatedBuildInputs = [
+    click
+    colorama
+    orderedmultidict
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  # For some reason it doesn't find the tests in that place
+  preCheck = ''
+    cp -r tests/testdata .
+  '';
+
+  # FIXME Can't get all them tests to run, help please!
+  # doCheck = false;
+
+  meta = with lib; {
+    description = "3-way diff/merge tools for CSV files";
+    homepage = "https://github.com/sctweedie/csvdiff3";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ turion ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2522,6 +2522,8 @@ self: super: with self; {
 
   cstruct = callPackage ../development/python-modules/cstruct { };
 
+  csvdiff3 = callPackage ../development/python-modules/csvdiff3 { };
+
   csvw = callPackage ../development/python-modules/csvw { };
 
   ctap-keyring-device = callPackage ../development/python-modules/ctap-keyring-device { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

CC @sctweedie I'm trying to package this for nixpkgs, but currently I have the following test failures:

```
FAILED tests/diff2_logic_test.py::TestFormatting::test_add_lines - AssertionError: False is not true : Error comparing with expected output fi...
FAILED tests/diff2_logic_test.py::TestFormatting::test_edit_lines - AssertionError: False is not true : Error comparing with expected output fi...
FAILED tests/diff2_logic_test.py::TestFormatting::test_reorder_lines - AssertionError: False is not true : Error comparing with expected output fi...
```
Is it possible that these tests fail on v0.99.8?

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
