### PR TITLE
rustc: move crt-static default override to wrapper

### DIFF
--- a/pkgs/build-support/rust/rustc-wrapper/default.nix
+++ b/pkgs/build-support/rust/rustc-wrapper/default.nix
@@ -8,6 +8,26 @@ runCommand "${rustc-unwrapped.pname}-wrapper-${rustc-unwrapped.version}" {
   env = {
     prog = "${rustc-unwrapped}/bin/rustc";
     sysroot = lib.optionalString (sysroot != null) "--sysroot ${sysroot}";
+
+    # Upstream rustc still assumes that musl = static[1].  The fix for
+    # this is to disable crt-static by default for non-static musl
+    # targets.
+    #
+    # Even though Cargo will build build.rs files for the build platform,
+    # cross-compiling _from_ musl appears to work fine, so we only need
+    # to do this when rustc's target platform is dynamically linked musl.
+    #
+    # [1]: https://github.com/rust-lang/compiler-team/issues/422
+    #
+    # WARNING: using defaultArgs is dangerous, as it will apply to all
+    # targets used by this compiler (host and target).  This means
+    # that it can't be used to set arguments that should only be
+    # applied to the target.  It's fine to do this for -crt-static,
+    # because rustc does not support +crt-static host platforms
+    # anyway.
+    defaultArgs = lib.optionalString
+      (with rustc-unwrapped.stdenv.targetPlatform; isMusl && !isStatic)
+      "-C target-feature=-crt-static";
   };
 
   passthru = {

--- a/pkgs/build-support/rust/rustc-wrapper/rustc-wrapper.sh
+++ b/pkgs/build-support/rust/rustc-wrapper/rustc-wrapper.sh
@@ -13,7 +13,7 @@ for arg; do
     esac
 done
 
-extraBefore=("${defaultSysroot[@]}")
+extraBefore=(@defaultArgs@ "${defaultSysroot[@]}")
 extraAfter=($NIX_RUSTFLAGS)
 
 # Optionally print debug info.

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -24,42 +24,6 @@ rustPlatform.buildRustPackage.override {
     inherit (rustc.unwrapped) tests;
   };
 
-  # Upstream rustc still assumes that musl = static[1].  The fix for
-  # this is to disable crt-static by default for non-static musl
-  # targets.
-  #
-  # For every package apart from Cargo, we can fix this by just
-  # patching rustc to not have crt-static by default.  But Cargo is
-  # built with the upstream bootstrap binary for rustc, which we can't
-  # easily patch.  This means we need to find another way to make sure
-  # crt-static is not used during the build of pkgsMusl.cargo.
-  #
-  # By default, Cargo doesn't apply RUSTFLAGS when building build.rs
-  # if --target is passed, so the only good way to set -crt-static for
-  # build.rs files used in the Cargo build is to use the unstable
-  # -Zhost-config Cargo feature.  This allows us to specify flags that
-  # should be passed to rustc when building for the build platform.
-  # We also need to use -Ztarget-applies-to-host, because using
-  # -Zhost-config requires it.
-  #
-  # When doing this, we also have to specify the linker, or cargo
-  # won't pass a -C linker= argument to rustc.  This will make rustc
-  # try to use its default value of "cc", which won't be available
-  # when cross-compiling.
-  #
-  # [1]: https://github.com/rust-lang/compiler-team/issues/422
-  postPatch = lib.optionalString (with stdenv.buildPlatform; isMusl && !isStatic) ''
-    mkdir -p .cargo
-    cat <<EOF >> .cargo/config
-    [host]
-    rustflags = "-C target-feature=-crt-static"
-    linker = "${pkgsBuildHost.stdenv.cc}/bin/${pkgsBuildHost.stdenv.cc.targetPrefix}cc"
-    [unstable]
-    host-config = true
-    target-applies-to-host = true
-    EOF
-  '';
-
   # changes hash of vendor directory otherwise
   dontUpdateAutotoolsGnuConfigScripts = true;
 

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -197,18 +197,6 @@ in stdenv.mkDerivation (finalAttrs: {
 
     # Useful debugging parameter
     # export VERBOSE=1
-  '' + lib.optionalString (stdenv.targetPlatform.isMusl && !stdenv.targetPlatform.isStatic) ''
-    # Upstream rustc still assumes that musl = static[1].  The fix for
-    # this is to disable crt-static by default for non-static musl
-    # targets.
-    #
-    # Even though Cargo will build build.rs files for the build platform,
-    # cross-compiling _from_ musl appears to work fine, so we only need
-    # to do this when rustc's target platform is dynamically linked musl.
-    #
-    # [1]: https://github.com/rust-lang/compiler-team/issues/422
-    substituteInPlace compiler/rustc_target/src/spec/base/linux_musl.rs \
-        --replace "base.crt_static_default = true" "base.crt_static_default = false"
   '' + lib.optionalString (stdenv.isDarwin && stdenv.isx86_64) ''
     # See https://github.com/jemalloc/jemalloc/issues/1997
     # Using a value of 48 should work on both emulated and native x86_64-darwin.


### PR DESCRIPTION
## Description of changes

Previously, when cross compiling from non-musl to musl, the crt-static default override wouldn't be applied, because the compiler wouldn't have been built with it due to fastCross.  Moving it to the wrapper fixes this without having to introduce extra compiler rebuilds.

Unlike --sysroot, rustc allows -C target-feature= to be passed multiple times, with later instances taking precedence over earlier ones.  This means that it's very easy to set the default in the wrapper, just by our overridden default before any other arguments.

This fixes pkgsCross.aarch64-multiplatform-musl.mesa from x86_64-linux.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
