### PR TITLE
Refactor flashprog

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6782,6 +6782,15 @@
     githubId = 21362942;
     name = "Fugi";
   };
+  funkeleinhorn = {
+    email = "git@funkeleinhorn.com";
+    github = "funkeleinhorn";
+    githubId = 103313934;
+    name = "Funkeleinhorn";
+    keys = [{
+      fingerprint = "689D 1C81 DA0D 1EB2 F029  D24E C7BE A25A 0A33 5A72";
+    }];
+  };
   fusion809 = {
     email = "brentonhorne77@gmail.com";
     github = "fusion809";

--- a/pkgs/by-name/fl/flashprog/package.nix
+++ b/pkgs/by-name/fl/flashprog/package.nix
@@ -2,15 +2,17 @@
 , installShellFiles
 , lib
 , libftdi1
-, libgpiod_1
+, libgpiod
 , libjaylink
 , libusb1
 , pciutils
 , pkg-config
 , stdenv
+, withJlink ? true
+, withGpio ? stdenv.isLinux
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "flashprog";
   version = "1.0.1";
 
@@ -24,24 +26,36 @@ stdenv.mkDerivation rec {
     installShellFiles
     pkg-config
   ];
-
   buildInputs = [
     libftdi1
-    libjaylink
     libusb1
   ] ++ lib.optionals (!stdenv.isDarwin) [
-    libgpiod_1
     pciutils
+  ] ++ lib.optionals (withJlink) [
+    libjaylink
+  ] ++ lib.optionals (withGpio) [
+    libgpiod
   ];
 
-  makeFlags = [ "PREFIX=$(out)" "libinstall" ]
-    ++ lib.optionals stdenv.isDarwin [ "CONFIG_ENABLE_LIBPCI_PROGRAMMERS=no" ]
-    ++ lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [ "CONFIG_INTERNAL_X86=no" "CONFIG_INTERNAL_DMI=no" "CONFIG_RAYER_SPI=0" ];
+  makeFlags =
+    let
+      yesNo = flag: if flag then "yes" else "no";
+    in
+    [
+      "libinstall"
+      "PREFIX=$(out)"
+      "CONFIG_JLINK_SPI=${yesNo withJlink}"
+      "CONFIG_LINUX_GPIO_SPI=${yesNo withGpio}"
+      "CONFIG_ENABLE_LIBPCI_PROGRAMMERS=${yesNo (!stdenv.isDarwin)}"
+      "CONFIG_INTERNAL_X86=${yesNo (!(stdenv.isDarwin) && stdenv.isx86_64)}"
+      "CONFIG_INTERNAL_DMI=${yesNo (!(stdenv.isDarwin) && stdenv.isx86_64)}"
+      "CONFIG_RAYER_SPI=${yesNo (!(stdenv.isDarwin) && stdenv.isx86_64)}"
+    ];
 
   meta = with lib; {
     homepage = "https://flashprog.org";
     description = "Utility for reading, writing, erasing and verifying flash ROM chips";
-    license = with licenses; [ gpl2 gpl2Plus ];
+    license = with licenses; [ gpl2Plus ];
     maintainers = with maintainers; [ felixsinger ];
     platforms = platforms.all;
     mainProgram = "flashprog";


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Flashprog](https://flashprog.org) is a fork of flashrom. It would be nice for users to be able to choose which of them they would like to use. Also flashprog has some features flashrom does not have (yet) like support for multiple SPI chip selects.

based on pkgs/tools/misc/flashrom/default.nix
can also be used with the nixos option
```nix
programs.flashrom = {
  enable = true;
  package = pkgs.flashprog;
};
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [X] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
