### PR TITLE
clang: don't set -march for overridden target

### DIFF
--- a/pkgs/build-support/cc-wrapper/add-clang-cc-cflags-before.sh
+++ b/pkgs/build-support/cc-wrapper/add-clang-cc-cflags-before.sh
@@ -7,5 +7,5 @@ for p in "${params[@]}"; do
 done
 
 if $needsTarget; then
-    extraBefore+=(-target @defaultTarget@)
+    extraBefore+=(-target @defaultTarget@ @march@)
 fi

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -595,8 +595,11 @@ stdenv.mkDerivation {
     # Always add -march based on cpu in triple. Sometimes there is a
     # discrepency (x86_64 vs. x86-64), so we provide an "arch" arg in
     # that case.
+    #
+    # For clang, this is handled in add-clang-cc-cflags-before.sh
+
     # TODO: aarch64-darwin has mcpu incompatible with gcc
-    + optionalString ((targetPlatform ? gcc.arch) && (isClang || !(stdenv.isDarwin && stdenv.isAarch64)) &&
+    + optionalString ((targetPlatform ? gcc.arch) && !isClang && !(stdenv.isDarwin && stdenv.isAarch64) &&
                       isGccArchSupported targetPlatform.gcc.arch) ''
       echo "-march=${targetPlatform.gcc.arch}" >> $out/nix-support/cc-cflags-before
     ''
@@ -685,6 +688,10 @@ stdenv.mkDerivation {
     ## Needs to go after ^ because the for loop eats \n and makes this file an invalid script
     ##
     + optionalString isClang ''
+      # Escape twice: once for this script, once for the one it gets substituted into.
+      export march=${lib.escapeShellArg
+        (lib.optionalString (targetPlatform ? gcc.arch)
+          (lib.escapeShellArg "-march=${targetPlatform.gcc.arch}"))}
       export defaultTarget=${targetPlatform.config}
       substituteAll ${./add-clang-cc-cflags-before.sh} $out/nix-support/add-local-cc-cflags-before.sh
     ''


### PR DESCRIPTION
## Description of changes

If -target is explicitly passed to clang, we shouldn't pass our -march value for the default target, because it probably won't exist for the target being used.  Up until now, clang has been lenient with this, but it's a hard error with clang 17, so since gcc.arch is always set on aarch64, fixing this is a hard requirement for upgrading our default clang to 17.

Before (with clang 17 on aarch64-linux):

	$ clang -target bpf -c -o /dev/null test.bpf.c
	clang: warning: ignoring '-fstack-protector-strong' option as it is not currently supported for target 'bpf' [-Woption-ignored]
	clang: error: unsupported option '-march=' for target 'bpf'
	clang: warning: argument unused during compilation: '--gcc-toolchain=/nix/store/cngak08nb1yk44gnjipv5rg1ahh1xkax-gcc-13.2.0' [-Wunused-command-line-argument]

After:

	$ clang -target bpf -c -o /dev/null test.bpf.c
	clang: warning: ignoring '-fstack-protector-strong' option as it is not currently supported for target 'bpf' [-Woption-ignored]
	clang: warning: argument unused during compilation: '--gcc-toolchain=/nix/store/cngak08nb1yk44gnjipv5rg1ahh1xkax-gcc-13.2.0' [-Wunused-command-line-argument]
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
