### PR TITLE
google-cloud-sdk: 452.0.1 -> 466.0.0 

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/components.json
+++ b/pkgs/tools/admin/google-cloud-sdk/components.json
@@ -5,7 +5,7 @@
         "checksum": "5a65179c291bc480696ca323d2f8c4874985458303eff8f233e16cdca4e88e6f",
         "contents_checksum": "038c999c7a7d70d5133eab7dc5868c4c3d0358431dad250f9833306af63016c8",
         "size": 800,
-        "source": "components/google-cloud-sdk-alpha-20231025210228.tar.gz",
+        "source": "components/google-cloud-sdk-alpha-20240226203415.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -22,8 +22,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20231025210228,
-        "version_string": "2023.10.25"
+        "build_number": 20240226203415,
+        "version_string": "2024.02.26"
       }
     },
     {
@@ -56,15 +56,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "1.4.4"
+        "version_string": "1.5.0"
       }
     },
     {
       "data": {
-        "checksum": "f197d04a40be89731ecd7a653f83900dcc4dcd84e54e0833c529f9f8dfa4395c",
-        "contents_checksum": "fa1d4910c1ce188c5c450d655c5d15e59a146364ec46e3fda0791db76c2edd17",
-        "size": 20108065,
-        "source": "components/google-cloud-sdk-anthos-auth-darwin-arm-20220923141408.tar.gz",
+        "checksum": "e644f1dfa8a4c25029b33fcf04f4c3c6e01c4c7ed2d572e550890c71d3e8105f",
+        "contents_checksum": "1f789abe50e6cc5423d39c2530995849bda198e866abbd61904ffb964688e3b3",
+        "size": 21674635,
+        "source": "components/google-cloud-sdk-anthos-auth-darwin-arm-20231201141418.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -88,16 +88,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20220923141408,
-        "version_string": "1.4.4"
+        "build_number": 20231201141418,
+        "version_string": "1.5.0"
       }
     },
     {
       "data": {
-        "checksum": "5417a11523868f36d6b7c3199e3029cf9f43c8cb99c57dba016942db4141c939",
-        "contents_checksum": "06a661642cbd20bcb9965c7a4b505d4d72944c48c30b8ada71db7e53c898d505",
-        "size": 21183974,
-        "source": "components/google-cloud-sdk-anthos-auth-darwin-x86_64-20220923141408.tar.gz",
+        "checksum": "72a93a9df0d0647ac5587be7dc0f423c9700d191d21e870d7f8218195e8b7c67",
+        "contents_checksum": "80a810795133e6ed5d17b963606a980c85e059011c9eeffc4b23fdecbbc95736",
+        "size": 22732157,
+        "source": "components/google-cloud-sdk-anthos-auth-darwin-x86_64-20231201141418.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -121,16 +121,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20220923141408,
-        "version_string": "1.4.4"
+        "build_number": 20231201141418,
+        "version_string": "1.5.0"
       }
     },
     {
       "data": {
-        "checksum": "c9dee264071d169de081880019f2f6fdb14edc22cbd20c19de76bb7cfa196eae",
-        "contents_checksum": "80ae98f1bfd1bd5cce9cddd642a1505d5401908d8890a22afa723490132b4342",
-        "size": 19755666,
-        "source": "components/google-cloud-sdk-anthos-auth-linux-arm-20220923141408.tar.gz",
+        "checksum": "c6201122eb946238b632d68c944880a172759e7c6e60086d878c8f65017d4614",
+        "contents_checksum": "def3aaea624bd24a35d2cd8321562cb5ef5f4b659415c552e439c47ea80be22b",
+        "size": 21172533,
+        "source": "components/google-cloud-sdk-anthos-auth-linux-arm-20231201141418.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -154,16 +154,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20220923141408,
-        "version_string": "1.4.4"
+        "build_number": 20231201141418,
+        "version_string": "1.5.0"
       }
     },
     {
       "data": {
-        "checksum": "b5efe7e9cd17f44905186242e663b97734183e14c66daed35553bc59bbf07a3a",
-        "contents_checksum": "57b753ecbde456973bed97af69aa7d1696694c1d30e9756d57658f79689fd925",
-        "size": 21362894,
-        "source": "components/google-cloud-sdk-anthos-auth-linux-x86_64-20220923141408.tar.gz",
+        "checksum": "1a674e3872d702e59c8ef9b275f7e6dfb3a2e428fbaaa177442341f46c62b92d",
+        "contents_checksum": "ce215c3c67f2445ff1e1bd7d3c897ed5e83b169edb6004ce0898da08a3dc5066",
+        "size": 22854830,
+        "source": "components/google-cloud-sdk-anthos-auth-linux-x86_64-20231201141418.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -187,16 +187,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20220923141408,
-        "version_string": "1.4.4"
+        "build_number": 20231201141418,
+        "version_string": "1.5.0"
       }
     },
     {
       "data": {
-        "checksum": "ab73e4c82e95a7b707f2298906a7a5fb9a2c1fe741c4584ab16e507bcf7b6d5b",
-        "contents_checksum": "38d10a97aa0e5fbf2c927acda1c853c25a2b729615bebd2ac8fce4eb77c2466a",
-        "size": 21470866,
-        "source": "components/google-cloud-sdk-anthos-auth-windows-x86_64-20220923141408.tar.gz",
+        "checksum": "340aff9659764a4b82358dc1face81ca6fccb6cdba0a4b176305d984706f136c",
+        "contents_checksum": "603ea38b094e85e9a4836061bd057c086b37778a8cc2c7134d1d9bbd43b68639",
+        "size": 23111838,
+        "source": "components/google-cloud-sdk-anthos-auth-windows-x86_64-20231201141418.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -220,8 +220,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20220923141408,
-        "version_string": "1.4.4"
+        "build_number": 20231201141418,
+        "version_string": "1.5.0"
       }
     },
     {
@@ -258,15 +258,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "0.2.42"
+        "version_string": "0.2.48"
       }
     },
     {
       "data": {
-        "checksum": "47cc151c673943cbfee58321453f85b32d673b3e453724fff31374a8605992b6",
-        "contents_checksum": "3ff8b9ef0510722872095c6d027b78f45dce430eadf07fc219b7f435c503dcf1",
-        "size": 70015524,
-        "source": "components/google-cloud-sdk-anthoscli-darwin-arm-20231023224440.tar.gz",
+        "checksum": "4072c0c3b3d6f40c5ca5969cf4ce3d530d45cb260b0ccea3d40099504307b7f4",
+        "contents_checksum": "0a6d7ed6b3073e8da7569f723fa6dd1c9907f0d270228dd02d16c9d1900089f7",
+        "size": 70276185,
+        "source": "components/google-cloud-sdk-anthoscli-darwin-arm-20240209195330.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -290,16 +290,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231023224440,
-        "version_string": "0.2.42"
+        "build_number": 20240209195330,
+        "version_string": "0.2.48"
       }
     },
     {
       "data": {
-        "checksum": "e99a7d19c60cbab6f5ce8578133e1c30c545e89b6f768b457abd2d84722f9c4d",
-        "contents_checksum": "348b94e8d769713049f005663b17056668dc4e3429e682a6956dd7f624fccbbf",
-        "size": 72896092,
-        "source": "components/google-cloud-sdk-anthoscli-darwin-x86-20231023224440.tar.gz",
+        "checksum": "6d8ae30ff42cbd2549a77dd9b4542f1d6bd444adf7a9c1166a8688ca7a2f96da",
+        "contents_checksum": "f6d26cbd246d289b9a5f6df50adc8a7179b98358dee21873f71283384cd260f5",
+        "size": 73173000,
+        "source": "components/google-cloud-sdk-anthoscli-darwin-x86-20240209195330.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -323,16 +323,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231023224440,
-        "version_string": "0.2.42"
+        "build_number": 20240209195330,
+        "version_string": "0.2.48"
       }
     },
     {
       "data": {
-        "checksum": "f9e5e6e59e910787542ed59cd7a31f27774e7795989457689bb974238ea58312",
-        "contents_checksum": "348b94e8d769713049f005663b17056668dc4e3429e682a6956dd7f624fccbbf",
-        "size": 72896095,
-        "source": "components/google-cloud-sdk-anthoscli-darwin-x86_64-20231023224440.tar.gz",
+        "checksum": "5aa411f1acee57507bd5ed78b9370ddc47b07ed7a97c551677c5847211ca9d12",
+        "contents_checksum": "f6d26cbd246d289b9a5f6df50adc8a7179b98358dee21873f71283384cd260f5",
+        "size": 73173003,
+        "source": "components/google-cloud-sdk-anthoscli-darwin-x86_64-20240209195330.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -356,16 +356,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231023224440,
-        "version_string": "0.2.42"
+        "build_number": 20240209195330,
+        "version_string": "0.2.48"
       }
     },
     {
       "data": {
-        "checksum": "768b260e7477339405cd191e43b5bcdc96150af0f309b58c24e48827237542be",
-        "contents_checksum": "d3d2363c63df31848603536b8af09769ce6bb8a0fefbeaefd0336b2362d0ef31",
-        "size": 67245549,
-        "source": "components/google-cloud-sdk-anthoscli-linux-arm-20231023224440.tar.gz",
+        "checksum": "132825b8e3d349181132c31f6a9d3789997eaf733e79b49e6207315a00b21592",
+        "contents_checksum": "32d0ae794185fd24adaecc5b1c31715f600afbb70f079546fdaa3c22a0a18823",
+        "size": 67454849,
+        "source": "components/google-cloud-sdk-anthoscli-linux-arm-20240209195330.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -389,16 +389,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231023224440,
-        "version_string": "0.2.42"
+        "build_number": 20240209195330,
+        "version_string": "0.2.48"
       }
     },
     {
       "data": {
-        "checksum": "390124c5fec46fb6800ca03dd9caf7f75259a6bc28d5841dcc972900cec9a9ba",
-        "contents_checksum": "bf1c54e0b66c498b1d086940dee6ddd11aaa7ed745c65d03cd98f10ef1c49e83",
-        "size": 65298977,
-        "source": "components/google-cloud-sdk-anthoscli-linux-x86-20231023224440.tar.gz",
+        "checksum": "f6451b9ed3b68042a5a58d5fa7d5281ac729291c3380733bb58e7fb4495339c5",
+        "contents_checksum": "1d0815760f9ee60b2837a16837c5550cffe144de6ff6d766521f553584dcccea",
+        "size": 65536636,
+        "source": "components/google-cloud-sdk-anthoscli-linux-x86-20240209195330.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -422,16 +422,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231023224440,
-        "version_string": "0.2.42"
+        "build_number": 20240209195330,
+        "version_string": "0.2.48"
       }
     },
     {
       "data": {
-        "checksum": "091730628a45921ef9f34db8b9fbc9568007b0a2a771c60ca786fbc45728b884",
-        "contents_checksum": "b30074343ee0a19121bf1163fccf5223b9e6125e744c00eef5c20977bcd3320a",
-        "size": 71982294,
-        "source": "components/google-cloud-sdk-anthoscli-linux-x86_64-20231023224440.tar.gz",
+        "checksum": "353c04a84703c0a507ce095bdd2dae814b464a8d11273b29b517894815232707",
+        "contents_checksum": "5c444bb3875fe95e3b4e961a425c30d0d664c18a8f61eaf82935b041bfc0e637",
+        "size": 72231225,
+        "source": "components/google-cloud-sdk-anthoscli-linux-x86_64-20240209195330.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -455,16 +455,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231023224440,
-        "version_string": "0.2.42"
+        "build_number": 20240209195330,
+        "version_string": "0.2.48"
       }
     },
     {
       "data": {
-        "checksum": "d6f16a6a028d3247de10be2cd63d523b954c4f76347d6a5c88a301c4cd35ddcb",
-        "contents_checksum": "2ad1786533a5cee19cddf36074f51726748422801d4417cb3793baff40ca9b0d",
-        "size": 67251009,
-        "source": "components/google-cloud-sdk-anthoscli-windows-x86-20231023224440.tar.gz",
+        "checksum": "dddd7a0af6168ce4f23dd26010f15232972c3c7ce134c7677605f81316bd9ef7",
+        "contents_checksum": "2f06c8d0090fdb54381888b0bcd66e8849c5c0e87a303a76bab56ab0a31c8bfd",
+        "size": 67482145,
+        "source": "components/google-cloud-sdk-anthoscli-windows-x86-20240209195330.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -488,16 +488,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231023224440,
-        "version_string": "0.2.42"
+        "build_number": 20240209195330,
+        "version_string": "0.2.48"
       }
     },
     {
       "data": {
-        "checksum": "de36bc756712c520d88572641ccd4810acb6d9342b055291a517e32eda2d9e25",
-        "contents_checksum": "686ac57e568ce4ae5b4ad352c3cc32643762e48d8c6009dae47eebb0fff7ae0d",
-        "size": 72608049,
-        "source": "components/google-cloud-sdk-anthoscli-windows-x86_64-20231023224440.tar.gz",
+        "checksum": "d4fd88249c1cc7a91a63ea9c1142b14c82d1c9c022d0302f0cd981963601c41d",
+        "contents_checksum": "a69fc1bacbf484cc8034c3eae2cb5479797c9db41461bef73cda18a96e26d672",
+        "size": 72854116,
+        "source": "components/google-cloud-sdk-anthoscli-windows-x86_64-20240209195330.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -521,8 +521,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231023224440,
-        "version_string": "0.2.42"
+        "build_number": 20240209195330,
+        "version_string": "0.2.48"
       }
     },
     {
@@ -560,15 +560,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "1.9.75"
+        "version_string": "1.9.76"
       }
     },
     {
       "data": {
-        "checksum": "88f025a6822f74ffa4c34d23b656158f6191891abf9fbe244a4664077a45f57c",
-        "contents_checksum": "7a27fc4862491e5690c8158b915dd6c2c27c4fd1668f273057e059af4977a6e8",
-        "size": 4469651,
-        "source": "components/google-cloud-sdk-app-engine-go-darwin-arm-20230417163046.tar.gz",
+        "checksum": "b1a1821583b0831db76219711dd5c5502a31d5a3a9b2f22c95c36f5457b91b7f",
+        "contents_checksum": "fe65695e8101cb234a298f5129d6f93d3d113440eb42d5dd60690a5b0be941bd",
+        "size": 4673886,
+        "source": "components/google-cloud-sdk-app-engine-go-darwin-arm-20231215195722.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -594,16 +594,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230417163046,
-        "version_string": "1.9.75"
+        "build_number": 20231215195722,
+        "version_string": "1.9.76"
       }
     },
     {
       "data": {
-        "checksum": "4a093245d248d58197ea5ec35a65b4b329fc7aed383df80dd9a9206700ca830e",
-        "contents_checksum": "f17f61e98b4f3221eae38212f727d736326ac5c803526067d2c0da965ade6000",
-        "size": 4658659,
-        "source": "components/google-cloud-sdk-app-engine-go-darwin-x86_64-20230417163046.tar.gz",
+        "checksum": "0e280be54d40ebfb84015f9238e3b58df562cecf9a1ba832ea87288f1d21b63b",
+        "contents_checksum": "b453bcc5bd1c9f4f0443462810dec6a4c31071b0e18c01f57e53cd6083306806",
+        "size": 4927378,
+        "source": "components/google-cloud-sdk-app-engine-go-darwin-x86_64-20231215195722.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -629,16 +629,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230417163046,
-        "version_string": "1.9.75"
+        "build_number": 20231215195722,
+        "version_string": "1.9.76"
       }
     },
     {
       "data": {
-        "checksum": "18e5f83a7ae30202e2794d5a46641319dba24d01ac43d1e427b906109ce9069a",
-        "contents_checksum": "22b5e43c2665f646b3b4c043ea8ce5d657576ba54392ffab81c64776ccb0e10e",
-        "size": 4426107,
-        "source": "components/google-cloud-sdk-app-engine-go-linux-arm-20230417163046.tar.gz",
+        "checksum": "fc68960029cfcb4e66a29e75e45ccf52459b9f25313f7e6a3cea995febf5b0d1",
+        "contents_checksum": "99a95e04cfa19eb3fed767ac461433d52c8cfd61dcc43f9c2a2b5be73c53a725",
+        "size": 4628999,
+        "source": "components/google-cloud-sdk-app-engine-go-linux-arm-20231215195722.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -664,16 +664,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230417163046,
-        "version_string": "1.9.75"
+        "build_number": 20231215195722,
+        "version_string": "1.9.76"
       }
     },
     {
       "data": {
-        "checksum": "e6271bd8ecf5309c573cae3cf2386a51099517dbe8ec3a8563e96586d6b5beb2",
-        "contents_checksum": "dab30a813f4c0da5028b46ca3ca4675b708358cb4d983b1bc52e03d385f49cfb",
-        "size": 4798186,
-        "source": "components/google-cloud-sdk-app-engine-go-linux-x86-20230417163046.tar.gz",
+        "checksum": "492f92731d80bea2b5ef828276bf1fc54b7f32dbd52517f64fa6b211ca4684d8",
+        "contents_checksum": "6ea55d86c3fa493cb0cfc0c1edeb625493976944f92765ffcfcb72fdef46ee9c",
+        "size": 4811027,
+        "source": "components/google-cloud-sdk-app-engine-go-linux-x86-20231215195722.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -699,16 +699,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230417163046,
-        "version_string": "1.9.75"
+        "build_number": 20231215195722,
+        "version_string": "1.9.76"
       }
     },
     {
       "data": {
-        "checksum": "1d5396984ff515be84c3bb526a802cfa9da49e677b46a23d192e09b063cad7d9",
-        "contents_checksum": "d4dce85cce2a173cdfac1e039f409c364b3db99624010cc0c38bcfbc96996cc3",
-        "size": 4731246,
-        "source": "components/google-cloud-sdk-app-engine-go-linux-x86_64-20230417163046.tar.gz",
+        "checksum": "aaf0cc3cb9782a103c36985f5dbcdde3fbfe50b3d18df580d298f9fd5fca3cc9",
+        "contents_checksum": "e5044222f13b99b75a7559425e2c397be40229803ba1e5480e63a7a66a68a6c8",
+        "size": 4957977,
+        "source": "components/google-cloud-sdk-app-engine-go-linux-x86_64-20231215195722.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -734,16 +734,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230417163046,
-        "version_string": "1.9.75"
+        "build_number": 20231215195722,
+        "version_string": "1.9.76"
       }
     },
     {
       "data": {
-        "checksum": "d1bbf796ff06580baeccc60c792c348cb1e466a3e6cc587ef6972ad0f67cd522",
-        "contents_checksum": "847ee7c88906720d640fbdb926b61105fd95e93d816fa5d1a83f1acf04ef8d74",
-        "size": 4900275,
-        "source": "components/google-cloud-sdk-app-engine-go-windows-x86-20230417163046.tar.gz",
+        "checksum": "190a523aa852a05e1d286936da6ee7e50f9f8e9f430813d08de42bc4b2266c57",
+        "contents_checksum": "c67be57a817917cb43238a4ebc5fe6f59cb80c8cad3debd4bca18d019d75ead8",
+        "size": 4901455,
+        "source": "components/google-cloud-sdk-app-engine-go-windows-x86-20231215195722.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -769,16 +769,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230417163046,
-        "version_string": "1.9.75"
+        "build_number": 20231215195722,
+        "version_string": "1.9.76"
       }
     },
     {
       "data": {
-        "checksum": "4f2b7379f39b50a092cf158174b5966f9e14f7cd3ca1ac5732f1164ae60ba94e",
-        "contents_checksum": "9bd2d84c68d600bb3da84855996341596df3b8716d732fc9b7502db972dc5da3",
-        "size": 4784860,
-        "source": "components/google-cloud-sdk-app-engine-go-windows-x86_64-20230417163046.tar.gz",
+        "checksum": "1d3808bff8faf031d4f3dc0352cf5832a8fab0ff6fda44add456f3351604316d",
+        "contents_checksum": "2c2bb14f552ba67a01ee7344075cee7a253d839668bdbbb5928b19ef4257c758",
+        "size": 5030525,
+        "source": "components/google-cloud-sdk-app-engine-go-windows-x86_64-20231215195722.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -804,8 +804,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230417163046,
-        "version_string": "1.9.75"
+        "build_number": 20231215195722,
+        "version_string": "1.9.76"
       }
     },
     {
@@ -1020,10 +1020,10 @@
     },
     {
       "data": {
-        "checksum": "38175db1182e07654ddef6ff8794d3ddf0d830c180920392342ea4ceff027a58",
-        "contents_checksum": "2fb9f245011b3b51c4173522e015f899dd2d6a4bc54ea12bff941c9265aba2e5",
-        "size": 129915384,
-        "source": "components/google-cloud-sdk-app-engine-java-20231023224440.tar.gz",
+        "checksum": "ae39996160cebbed748ed12a6ef89ff73e93848b4b1a22f153c371c8ec2153ad",
+        "contents_checksum": "66509cd7d0ee0046439e2bc0e70eed9afecb637d578e518d6771925267693055",
+        "size": 132057381,
+        "source": "components/google-cloud-sdk-app-engine-java-20240106004423.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1041,8 +1041,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20231023224440,
-        "version_string": "2.0.21"
+        "build_number": 20240106004423,
+        "version_string": "2.0.24"
       }
     },
     {
@@ -1142,10 +1142,10 @@
     },
     {
       "data": {
-        "checksum": "07c19454806ac60603f18bc9e7eeb56ae6eba1477e25a91fd95682c4011c6207",
-        "contents_checksum": "71ff9043af9fa982b8dbbc1f8f122d9f981cb5fe168356f4a7f13bf58ae23e25",
-        "size": 8748068,
-        "source": "components/google-cloud-sdk-app-engine-python-20231016163610.tar.gz",
+        "checksum": "893d741c65d65cfc20f3820fdf62cb71f111e814083c942fee4ced13b10944a2",
+        "contents_checksum": "a97004f0aedeff49894c2cce7b5f634762900f64f38f65c1676e7897f3fb2c53",
+        "size": 8780608,
+        "source": "components/google-cloud-sdk-app-engine-python-20240216153112.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1164,8 +1164,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20231016163610,
-        "version_string": "1.9.107"
+        "build_number": 20240216153112,
+        "version_string": "1.9.109"
       }
     },
     {
@@ -1432,7 +1432,7 @@
         "checksum": "707d412854a14450b4fddee199d258e75946fe51b44eb2980c8cd7e274c15760",
         "contents_checksum": "0b4e9d8e6394dc841aece07ca4da91920a460cbd7ec22495be4a2b4f46635b4d",
         "size": 797,
-        "source": "components/google-cloud-sdk-beta-20231025210228.tar.gz",
+        "source": "components/google-cloud-sdk-beta-20240226203415.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1449,8 +1449,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20231025210228,
-        "version_string": "2023.10.25"
+        "build_number": 20240226203415,
+        "version_string": "2024.02.26"
       }
     },
     {
@@ -1493,10 +1493,10 @@
     },
     {
       "data": {
-        "checksum": "5af8d24eb8da1c8229c414e9950bcdc453a9e316742541eefe830afaca8a158e",
-        "contents_checksum": "e08ae70a70d4da56bae3d13b09b898b865557461f01e7690fd25f82b91890910",
-        "size": 7097728,
-        "source": "components/google-cloud-sdk-bigtable-darwin-arm-20231006153333.tar.gz",
+        "checksum": "663eb2bb5e083b366f739b81bc95ce7853187a823890c34e07a8bacdfce35244",
+        "contents_checksum": "20101432339e657f9f272c5898dbdffd89dad2e08dcfccfa26c6609343f39f4c",
+        "size": 7149239,
+        "source": "components/google-cloud-sdk-bigtable-darwin-arm-20240112150613.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1521,7 +1521,7 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231006153333,
+        "build_number": 20240112150613,
         "version_string": ""
       }
     },
@@ -1561,10 +1561,10 @@
     },
     {
       "data": {
-        "checksum": "aa2d0f3e322a7912fac2b012fc1c368eaa129905372b82560488ec9b803494d5",
-        "contents_checksum": "7c84152ea5f2da5f06f9b55b035534d9bd2270c9959ae162c3cb5f8d392d6801",
-        "size": 7333846,
-        "source": "components/google-cloud-sdk-bigtable-darwin-x86_64-20231006153333.tar.gz",
+        "checksum": "c00519ab786c673527f79f72770d1f4b5bf599c16f9c5d4b42a3f6658414ac22",
+        "contents_checksum": "55675241aba0458e9e7e272511ed469bc30949464d23cf672b2e8549e16559a5",
+        "size": 7384031,
+        "source": "components/google-cloud-sdk-bigtable-darwin-x86_64-20240112150613.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1589,16 +1589,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231006153333,
+        "build_number": 20240112150613,
         "version_string": ""
       }
     },
     {
       "data": {
-        "checksum": "52ea181edb2b8b69fa3ebea25467238facc828dc79d1b22c2aafb79385e0f4e6",
-        "contents_checksum": "0dc475dc09c285508b6ba21ab40ebabf9151a9e5ecaf05a3754b3283a00df42a",
-        "size": 7011804,
-        "source": "components/google-cloud-sdk-bigtable-linux-arm-20231006153333.tar.gz",
+        "checksum": "bb6a7e3068ba643e11505e2cbf2fb7418662045566105c711ccda37bbce2f235",
+        "contents_checksum": "a2613adc36a34833bf1e11c7f725688389a330d89e3719e5f4e00387dfa20fb8",
+        "size": 7032893,
+        "source": "components/google-cloud-sdk-bigtable-linux-arm-20240112150613.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1623,16 +1623,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231006153333,
+        "build_number": 20240112150613,
         "version_string": ""
       }
     },
     {
       "data": {
-        "checksum": "972efb72c12e9fb15777d2f0b0ee49d34793bd088147eda1599826b261c54f8d",
-        "contents_checksum": "ea6f11df05804197e9a0f3ad1d52db162b23769aab97b2913248dc42044e2803",
-        "size": 7255397,
-        "source": "components/google-cloud-sdk-bigtable-linux-x86-20231006153333.tar.gz",
+        "checksum": "5e762be2009986b3a9594cefc861d186eb3130c0f1b0dbf08bef6534ce868761",
+        "contents_checksum": "2adb488dd36830e794eb141ec5243b0bc5f24206a6bd0ae5a731a31346f08078",
+        "size": 7287874,
+        "source": "components/google-cloud-sdk-bigtable-linux-x86-20240112150613.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1657,16 +1657,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231006153333,
+        "build_number": 20240112150613,
         "version_string": ""
       }
     },
     {
       "data": {
-        "checksum": "e62748c75c268a9648b26920838b281e50511b7f430dff0eca124f3f5763699e",
-        "contents_checksum": "19b5048d20242fc730b4544fe0b5ac800c30b02059efb4b26588eb31d1fc482a",
-        "size": 7454541,
-        "source": "components/google-cloud-sdk-bigtable-linux-x86_64-20231006153333.tar.gz",
+        "checksum": "b3c54cb77875fddf48a0ff41a8870cb55891bf49ae81e23adeb72c1280fc1fd0",
+        "contents_checksum": "711fd9de39fbf4583dbb22c52e7b3fa801ad81dee1e2a4d65d98992738f2aa34",
+        "size": 7488736,
+        "source": "components/google-cloud-sdk-bigtable-linux-x86_64-20240112150613.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1691,16 +1691,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231006153333,
+        "build_number": 20240112150613,
         "version_string": ""
       }
     },
     {
       "data": {
-        "checksum": "e031eb7a2735c0bd2db4d82d8da081a264cbaddc58ed9b84e2b1564994e54643",
-        "contents_checksum": "7751a9071bb5830f7f3f9dc9a229a268405a1ba76d5bdd19483a8c66089c72eb",
-        "size": 7288454,
-        "source": "components/google-cloud-sdk-bigtable-windows-x86-20231006153333.tar.gz",
+        "checksum": "7ae926f8aad9bb48247a2468da737b1cd239764aca4ef31b02aebe14437bc5f9",
+        "contents_checksum": "a4409d3c0f7bce7ab0aeaf66adb80ea96a2f8c3854aa0570f3badf21b8b7d430",
+        "size": 7317721,
+        "source": "components/google-cloud-sdk-bigtable-windows-x86-20240112150613.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1725,16 +1725,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231006153333,
+        "build_number": 20240112150613,
         "version_string": ""
       }
     },
     {
       "data": {
-        "checksum": "1f24acd6a6c63ed1c283e7b7bfbda31bc08a86b1241e5ad4f08858df7678d669",
-        "contents_checksum": "f640127893c4339c4f04791834143af3fe3931ac91877dd73dcb4ee3cecf6d01",
-        "size": 7451653,
-        "source": "components/google-cloud-sdk-bigtable-windows-x86_64-20231006153333.tar.gz",
+        "checksum": "96eac561a6b2efe89e840ff2c6fa22e50f368a536a5db6c168ce9072f6142271",
+        "contents_checksum": "7d9e07ff31df84f57a66a4f9b0d3d0d666c70c7a17174cb2c69feea2db8a194e",
+        "size": 7479168,
+        "source": "components/google-cloud-sdk-bigtable-windows-x86_64-20240112150613.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1759,16 +1759,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231006153333,
+        "build_number": 20240112150613,
         "version_string": ""
       }
     },
     {
       "data": {
-        "checksum": "5044841dc30f739de0c5f1a846580baf714a36b09070c00574360e906789d373",
-        "contents_checksum": "b1570cc1a0eb04a5856453cb234021a676ff276c0f779a248ddf589f5ed5724d",
-        "size": 1659622,
-        "source": "components/google-cloud-sdk-bq-20230913232318.tar.gz",
+        "checksum": "8918c7fd033de8f13f331152e59dc16a33f0f7007a6be615b7b53337197be33f",
+        "contents_checksum": "f516a7a4d24280d59d67bf908d80d0a560b8d680e8c2699efc1071b1c0039c1f",
+        "size": 1679148,
+        "source": "components/google-cloud-sdk-bq-20240112150613.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1787,16 +1787,16 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20230913232318,
-        "version_string": "2.0.98"
+        "build_number": 20240112150613,
+        "version_string": "2.0.101"
       }
     },
     {
       "data": {
-        "checksum": "b6a10d752554fb9cf518d697999f49806d1009455c78cc3c6fc67f6d97edf1b9",
-        "contents_checksum": "da65662d83df53b15ff35bdedace8671669280b875620876181ac0e9665cbc04",
-        "size": 2019,
-        "source": "components/google-cloud-sdk-bq-nix-20231025210228.tar.gz",
+        "checksum": "81d6fafb672c791a58b6d2cecbcb8a78ca1a1c7e885d359bcf3ec11ebf138ea0",
+        "contents_checksum": "fcd529ea7485a8621ac5d217ac7e7793cc8acabe5ba4c2c6f222b402580e5578",
+        "size": 2026,
+        "source": "components/google-cloud-sdk-bq-nix-20240106004423.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1821,16 +1821,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231025210228,
-        "version_string": "2.0.98"
+        "build_number": 20240106004423,
+        "version_string": "2.0.101"
       }
     },
     {
       "data": {
-        "checksum": "d4d4e87deaf12a2c8eefe6ae5d75d9fe160149488077579dc41d6010988ad432",
-        "contents_checksum": "515edb1628a75d42d3b465d7e8c8ad5d298538e75f78d00a0cda738ac9fcce5e",
-        "size": 2660,
-        "source": "components/google-cloud-sdk-bq-win-20230106151201.tar.gz",
+        "checksum": "5d3fdd2bd23beba4e15e60d8e2befdb3d68ae9faed8a19b14526ffacb247546e",
+        "contents_checksum": "aa61d0c34c3b3d6509e7a529b28446faaa645f15abb56a27be3b425ed6404fac",
+        "size": 2683,
+        "source": "components/google-cloud-sdk-bq-win-20240226203415.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -1852,8 +1852,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230106151201,
-        "version_string": "2.0.84"
+        "build_number": 20240226203415,
+        "version_string": "2.0.101"
       }
     },
     {
@@ -1963,8 +1963,8 @@
         "core"
       ],
       "details": {
-        "description": "Provides stand-alone Python 3.9.12 install.",
-        "display_name": "Bundled Python 3.9"
+        "description": "Provides stand-alone Python 3.11 install.",
+        "display_name": "Bundled Python 3.11"
       },
       "id": "bundled-python3",
       "is_configuration": false,
@@ -1982,7 +1982,7 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "3.9.12"
+        "version_string": "3.11.6"
       }
     },
     {
@@ -1991,8 +1991,8 @@
         "core"
       ],
       "details": {
-        "description": "Provides stand-alone Python 3.9.17 installation for UNIX.",
-        "display_name": "Bundled Python 3.9"
+        "description": "Provides stand-alone Python 3.11.7 installation for UNIX.",
+        "display_name": "Bundled Python 3.11"
       },
       "id": "bundled-python3-unix",
       "is_configuration": false,
@@ -2009,15 +2009,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "3.9.17"
+        "version_string": "3.11.7"
       }
     },
     {
       "data": {
-        "checksum": "ad591cffcb3cb00ea73e1e8fa13d76d4ebeded14bb7d4d54f4dbd90cff79911c",
-        "contents_checksum": "d2c4025b7acd5008a935cbd1a71c399d28cb5723065576b1b31f917f10bb0479",
-        "size": 65481810,
-        "source": "components/google-cloud-sdk-bundled-python3-unix-linux-x86_64-20231023224440.tar.gz",
+        "checksum": "d639422c20f0bcd70f80c36ef448bbb319b9556bf69213be7419702f999d2b5f",
+        "contents_checksum": "c8d13f25225421f05ef9fa81b4c3924d42fa04e9b36c4d64d8f368da780d2a13",
+        "size": 77407886,
+        "source": "components/google-cloud-sdk-bundled-python3-unix-linux-x86_64-20240129164525.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2025,8 +2025,8 @@
         "core"
       ],
       "details": {
-        "description": "Provides stand-alone Python 3.9.17 installation for UNIX.",
-        "display_name": "Bundled Python 3.9"
+        "description": "Provides stand-alone Python 3.11.7 installation for UNIX.",
+        "display_name": "Bundled Python 3.11"
       },
       "id": "bundled-python3-unix-linux-x86_64",
       "is_configuration": false,
@@ -2042,16 +2042,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231023224440,
-        "version_string": "3.9.17"
+        "build_number": 20240129164525,
+        "version_string": "3.11.7"
       }
     },
     {
       "data": {
-        "checksum": "f893470fa6f4cabc0bbbd73275b563b9c97682fd199514440c9027b6c5b94b54",
-        "contents_checksum": "c486cae0284bb1138814cf54bb930441fd39d9ff791366a564d27d6bfac7a789",
-        "size": 20778243,
-        "source": "components/google-cloud-sdk-bundled-python3-windows-x86-20231016163610.tar.gz",
+        "checksum": "78b090d3d133b622c8fa591e55d97dec41ebeceda117f1fc4c87a3a3053710fc",
+        "contents_checksum": "b18344f58a872b7fd500946a8ca7c7929608a4bf5257570e7c60c2f5b9208ad4",
+        "size": 20426074,
+        "source": "components/google-cloud-sdk-bundled-python3-windows-x86-20231110155547.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2059,8 +2059,8 @@
         "core"
       ],
       "details": {
-        "description": "Provides stand-alone Python 3.9.12 install.",
-        "display_name": "Bundled Python 3.9"
+        "description": "Provides stand-alone Python 3.11 install.",
+        "display_name": "Bundled Python 3.11"
       },
       "id": "bundled-python3-windows-x86",
       "is_configuration": false,
@@ -2076,16 +2076,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231016163610,
-        "version_string": "3.9.12"
+        "build_number": 20231110155547,
+        "version_string": "3.11.6"
       }
     },
     {
       "data": {
-        "checksum": "cabdb1da4996629632a90399276a75058e46be4a6b92019960c4bdb62efcc4ea",
-        "contents_checksum": "3bb2ec678153e5bd214be0439970173d86729baaa33f06176bd2ec8435d4304d",
-        "size": 22193214,
-        "source": "components/google-cloud-sdk-bundled-python3-windows-x86_64-20231016163610.tar.gz",
+        "checksum": "f80970b12053a77afb5888982362396c379392462806837c47c4ed3271c19aaf",
+        "contents_checksum": "3207aea9e98dcf0cf0ee6ad339235fda213dbf8ac997bfa823698c52d68b7f65",
+        "size": 22512051,
+        "source": "components/google-cloud-sdk-bundled-python3-windows-x86_64-20231110155547.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2093,8 +2093,8 @@
         "core"
       ],
       "details": {
-        "description": "Provides stand-alone Python 3.9.12 install.",
-        "display_name": "Bundled Python 3.9"
+        "description": "Provides stand-alone Python 3.11 install.",
+        "display_name": "Bundled Python 3.11"
       },
       "id": "bundled-python3-windows-x86_64",
       "is_configuration": false,
@@ -2110,8 +2110,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231016163610,
-        "version_string": "3.9.12"
+        "build_number": 20231110155547,
+        "version_string": "3.11.6"
       }
     },
     {
@@ -2148,15 +2148,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "0.16.2"
+        "version_string": "1.17.2"
       }
     },
     {
       "data": {
-        "checksum": "4cec674242be0d7a3de6d830325ef93d0b554eeab10431eaf0706199434d937c",
-        "contents_checksum": "c08a0d1bafbfc51f2aac4555268f1e1dba13f8222454ee8315a7855a114c7216",
-        "size": 16254518,
-        "source": "components/google-cloud-sdk-cbt-darwin-arm-20231006153333.tar.gz",
+        "checksum": "538df81550df3242dd9047437ceea867abb38125df24154ffafb5298dee1a2b8",
+        "contents_checksum": "02563cdae195531dc844381cd1cfed92ec8217adc475b9dac73898f1a25c0a45",
+        "size": 16720666,
+        "source": "components/google-cloud-sdk-cbt-darwin-arm-20240112150613.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2180,8 +2180,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231006153333,
-        "version_string": "0.16.2"
+        "build_number": 20240112150613,
+        "version_string": "1.17.2"
       }
     },
     {
@@ -2219,10 +2219,10 @@
     },
     {
       "data": {
-        "checksum": "cab9647842e2c6702f739bcf7f4a390098a245f58798035914d47b2e023f5003",
-        "contents_checksum": "5437ed3b7499b97a8dc71d81f1446b429ca635676fdaada94e5089d181f851f1",
-        "size": 16717237,
-        "source": "components/google-cloud-sdk-cbt-darwin-x86_64-20231006153333.tar.gz",
+        "checksum": "b9194d1a8371dea7c63147767a6f9e3f8c6f4b03fa30ca3bc5ea901d97acd011",
+        "contents_checksum": "c359de592aa1b957326c205b8723a59520cac0f142bf278b84eed03399b56b59",
+        "size": 17196541,
+        "source": "components/google-cloud-sdk-cbt-darwin-x86_64-20240112150613.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2246,16 +2246,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231006153333,
-        "version_string": "0.16.2"
+        "build_number": 20240112150613,
+        "version_string": "1.17.2"
       }
     },
     {
       "data": {
-        "checksum": "50481ebc4a0a82e068b9d11e8af938c81dceae23f39a5d7eff888c5d9d29d379",
-        "contents_checksum": "f1a58b3ed33e5728def81f61e7e28b46239f0a2a0201fc9685d808d11df38f3b",
-        "size": 15863768,
-        "source": "components/google-cloud-sdk-cbt-linux-arm-20231006153333.tar.gz",
+        "checksum": "eb0c6f7e7f9c3bfecbfd733ea018c09fb8ba61b78b1cf8c1c9263c7109ad8671",
+        "contents_checksum": "5c1a36f98fd4654ee47fccea2a9a50ce8b22cd70e013b83bb051fe357122638d",
+        "size": 16297518,
+        "source": "components/google-cloud-sdk-cbt-linux-arm-20240112150613.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2279,16 +2279,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231006153333,
-        "version_string": "0.16.2"
+        "build_number": 20240112150613,
+        "version_string": "1.17.2"
       }
     },
     {
       "data": {
-        "checksum": "5a5539eab4133fade3206d5f7b546e8d51a5af18c0ac3f0b6ada98249847fa1e",
-        "contents_checksum": "961c6d25d74bae5b5c00b4e0d48393702c529ac0b1de2b85056f07d63933eb8d",
-        "size": 16051931,
-        "source": "components/google-cloud-sdk-cbt-linux-x86-20231006153333.tar.gz",
+        "checksum": "39ca479add8bc11ad11a3b2965e562e62858901c96d79aa1aa2c938a7f40993c",
+        "contents_checksum": "fc6133d7e68b1ad303d87cb9e712bc94fd40511f3818979b4e20d7f5f2074df7",
+        "size": 16492482,
+        "source": "components/google-cloud-sdk-cbt-linux-x86-20240112150613.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2312,16 +2312,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231006153333,
-        "version_string": "0.16.2"
+        "build_number": 20240112150613,
+        "version_string": "1.17.2"
       }
     },
     {
       "data": {
-        "checksum": "74d5a97a01d246acda0897004a5ece95f9c9ced8aa3c89f0e8cf742edd4284b3",
-        "contents_checksum": "5fdf279f55e77702b62280f58d19f5eb0adcd5d81e20f76cc7759de07a224ca3",
-        "size": 16868331,
-        "source": "components/google-cloud-sdk-cbt-linux-x86_64-20231006153333.tar.gz",
+        "checksum": "23df574487ba9ddb32ffc8c387a0d428ef27be297d5769800710974266d4932c",
+        "contents_checksum": "8134edf246fa051787bf993034e8f1800bb1f04620bbd13cc1f40e965bf32599",
+        "size": 17340658,
+        "source": "components/google-cloud-sdk-cbt-linux-x86_64-20240112150613.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2345,16 +2345,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231006153333,
-        "version_string": "0.16.2"
+        "build_number": 20240112150613,
+        "version_string": "1.17.2"
       }
     },
     {
       "data": {
-        "checksum": "97b355f30dd40324f7724eb8a1e269d857316796a6d42fdcf3805fce9cefa402",
-        "contents_checksum": "e824180249e02e5d9c8805faa2cbbc1a237bac7fe53925d6290943234e42cf8c",
-        "size": 16305542,
-        "source": "components/google-cloud-sdk-cbt-windows-x86-20231006153333.tar.gz",
+        "checksum": "ae60d8116338562cc98ba1ad852842760d2ab78016377ec827701c80dc7b7b41",
+        "contents_checksum": "61f3390cc8c868a77e378f9d4aa37502d4e04357d8ab33735f1e5418a3a225e7",
+        "size": 16750394,
+        "source": "components/google-cloud-sdk-cbt-windows-x86-20240112150613.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2378,16 +2378,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231006153333,
-        "version_string": "0.16.2"
+        "build_number": 20240112150613,
+        "version_string": "1.17.2"
       }
     },
     {
       "data": {
-        "checksum": "fc7d710003577bf740e4d8dd5f6ad3929620a7f088c1de321a41ff229acb6084",
-        "contents_checksum": "038673c9ff153e08f9e4cb6af1c7963483796d3f6654e746cb5bf414ff4a63ee",
-        "size": 16944208,
-        "source": "components/google-cloud-sdk-cbt-windows-x86_64-20231006153333.tar.gz",
+        "checksum": "ce201b8cb3e4e10d4ae1cbec9ff253474dff5931eaff9c1d260b117ac03781e3",
+        "contents_checksum": "d28a7a0d5156bff526e51932172d63a6bc8fc6258138551e81ffc241e20faeb3",
+        "size": 17415844,
+        "source": "components/google-cloud-sdk-cbt-windows-x86_64-20240112150613.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2411,8 +2411,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231006153333,
-        "version_string": "0.16.2"
+        "build_number": 20240112150613,
+        "version_string": "1.17.2"
       }
     },
     {
@@ -2572,10 +2572,10 @@
     },
     {
       "data": {
-        "checksum": "1822e13b021d42edf1ee3d648b00be30960a57d3c74de708a14dd9758bb8f466",
-        "contents_checksum": "16cc1f413795a2197704184256179a5c65eb11b66d8af59f209bfbda798df11b",
-        "size": 44883913,
-        "source": "components/google-cloud-sdk-cloud-firestore-emulator-20230915145114.tar.gz",
+        "checksum": "b371b076f519a0f08bdd247feca05f926085d8ebf1302f86e69d67563337bbda",
+        "contents_checksum": "26eb8a9ca7d29ba6e8bdfb404f9407ad4e0e18526ac9511e38388a238ec9fe79",
+        "size": 46500128,
+        "source": "components/google-cloud-sdk-cloud-firestore-emulator-20240216153112.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2592,8 +2592,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20230915145114,
-        "version_string": "1.18.2"
+        "build_number": 20240216153112,
+        "version_string": "1.19.1"
       }
     },
     {
@@ -2818,15 +2818,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "1.5.10"
+        "version_string": "1.5.13"
       }
     },
     {
       "data": {
-        "checksum": "7460e9a21137063a8f9f8143f6da86d39d3fde425a956240b695924d45bf3e2f",
-        "contents_checksum": "3617a6b7497fc5cc13cb5764e374816940474072d2db432342c1bf0f6844f1c5",
-        "size": 36939704,
-        "source": "components/google-cloud-sdk-cloud-spanner-emulator-linux-x86_64-20230922151743.tar.gz",
+        "checksum": "7c8f4db773fae956a385c746203ef7d2784d992fd674cdbacf59720c4d3e0ca6",
+        "contents_checksum": "d3df9908458ec5b1115dd1c439b256fcc7ba00533f0c7363ac09685f5bc95790",
+        "size": 37731211,
+        "source": "components/google-cloud-sdk-cloud-spanner-emulator-linux-x86_64-20240106004423.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -2851,8 +2851,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230922151743,
-        "version_string": "1.5.10"
+        "build_number": 20240106004423,
+        "version_string": "1.5.13"
       }
     },
     {
@@ -3322,10 +3322,10 @@
     },
     {
       "data": {
-        "checksum": "8197db59e523d340b2da73594807ac5a2c0a09d2899fa5adb71cc6dbdb64c63e",
-        "contents_checksum": "a788f4961a718e4bc4717a5149874353b83ba4ad01f6587725d48bc2e689a07d",
-        "size": 23032301,
-        "source": "components/google-cloud-sdk-core-20231025210228.tar.gz",
+        "checksum": "5c9d7129a5c6ed76f10e154389ed2bd01713d8c6914471ab0edcecbb2a078992",
+        "contents_checksum": "e0bda8924d7c39f863b619a725672e5a062cd63aceb0e3f8ea3f1acf36b2a27d",
+        "size": 23805256,
+        "source": "components/google-cloud-sdk-core-20240226203415.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -3346,16 +3346,16 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20231025210228,
-        "version_string": "2023.10.25"
+        "build_number": 20240226203415,
+        "version_string": "2024.02.26"
       }
     },
     {
       "data": {
-        "checksum": "0d68f826ada61d2ab98721bbab6c94132a1c210080fdd85c750073e009ae6d39",
-        "contents_checksum": "3e23fcf9fd07d22bf46bca03f951e715a328cb8420e09f34ce2e7f5ef401b982",
-        "size": 2402,
-        "source": "components/google-cloud-sdk-core-nix-20231025210228.tar.gz",
+        "checksum": "b7f76cd9c7f391d8504d31fba7c180b7c3028646c0efda8fafdb1abd13056917",
+        "contents_checksum": "35b7e083b5dc365a7f2ff9fac444ad23ddfae564c22296c502183ee4eb9fab00",
+        "size": 2410,
+        "source": "components/google-cloud-sdk-core-nix-20240106004423.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -3382,16 +3382,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231025210228,
-        "version_string": "2023.10.25"
+        "build_number": 20240106004423,
+        "version_string": "2024.01.06"
       }
     },
     {
       "data": {
-        "checksum": "0af3f8e9ba07b24f3821758107b18d273edf7fa7703ff4d659b9732e84a73a37",
-        "contents_checksum": "2ac264344fcf75702a4770bfcba3e6f47573351303cbba558bcde7f8c32cc731",
-        "size": 3200,
-        "source": "components/google-cloud-sdk-core-win-20230915145114.tar.gz",
+        "checksum": "75e34fa5b9f7524861796258e8140d9e9bab9921ace5e9bcd6f0bdd03c718ceb",
+        "contents_checksum": "5770aeb4c914a1193d8f6311d16eab708f76a1c78eb143d0215a8999a82630ca",
+        "size": 3549,
+        "source": "components/google-cloud-sdk-core-win-20240226203415.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -3415,8 +3415,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230915145114,
-        "version_string": "2023.09.15"
+        "build_number": 20240226203415,
+        "version_string": "2024.02.26"
       }
     },
     {
@@ -3715,15 +3715,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "0.2.1"
+        "version_string": "0.3.2"
       }
     },
     {
       "data": {
-        "checksum": "01c037710f20fe53e05715439a5de469469f10ee3953076c61387de8afc38d1d",
-        "contents_checksum": "367a10efe8b2bb1ca828cc4e91472f81dcbe3e51d98b16843ebe29e250201fab",
-        "size": 6390940,
-        "source": "components/google-cloud-sdk-enterprise-certificate-proxy-darwin-arm-20230224152814.tar.gz",
+        "checksum": "a3e8f5c45ac19bd3430201339c07f2f6dc21296702375c2381ecf5c8d3e88279",
+        "contents_checksum": "22e8de82f1f0cb7a6db65e095c15017866869cac0f1d5556c146c92b1c49acb9",
+        "size": 8680702,
+        "source": "components/google-cloud-sdk-enterprise-certificate-proxy-darwin-arm-20231208151900.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -3747,16 +3747,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230224152814,
-        "version_string": "0.2.1"
+        "build_number": 20231208151900,
+        "version_string": "0.3.2"
       }
     },
     {
       "data": {
-        "checksum": "d0c4da5a4668b94ad0609f414beb05fad1e6ca153b28baa846155b9d6e353a64",
-        "contents_checksum": "9f784ec794093b9aa6867dd9895ca93f7b01eef4bc5a1893303e39e2d2141a31",
-        "size": 7001595,
-        "source": "components/google-cloud-sdk-enterprise-certificate-proxy-darwin-x86_64-20230224152814.tar.gz",
+        "checksum": "301757a2839dce01a6435ed4b0dfd05616f9a3c8aeba4624362b48f115e5b97a",
+        "contents_checksum": "6d407b55892613efd363344f855292ddda8fdbe81f549f318264480dc167b25a",
+        "size": 9536921,
+        "source": "components/google-cloud-sdk-enterprise-certificate-proxy-darwin-x86_64-20231208151900.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -3780,16 +3780,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230224152814,
-        "version_string": "0.2.1"
+        "build_number": 20231208151900,
+        "version_string": "0.3.2"
       }
     },
     {
       "data": {
-        "checksum": "01ac1d6276ab45779d87f28970906b050aa1d91d113a76ba1c62a40895519e8a",
-        "contents_checksum": "5dd83c5800e0c515bfc776f8e92e2c8e5c70d84089ccdba9eeb81cc3cd579adb",
-        "size": 8611365,
-        "source": "components/google-cloud-sdk-enterprise-certificate-proxy-linux-x86_64-20230714124024.tar.gz",
+        "checksum": "620e7f1598535dba84e52085cf12275e6e2264b281d7d43d71d4079ad0daab7e",
+        "contents_checksum": "1ccff0b7259285d34269926c6038535561cc6d24c0a5c40e3f1b49c7748c9808",
+        "size": 9012612,
+        "source": "components/google-cloud-sdk-enterprise-certificate-proxy-linux-x86_64-20231208151900.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -3813,16 +3813,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230714124024,
-        "version_string": "0.2.1"
+        "build_number": 20231208151900,
+        "version_string": "0.3.2"
       }
     },
     {
       "data": {
-        "checksum": "211f5ac63a9397b6f7ac95d22fd34e18c98b348acfdb2cbf3bcd1384ee1deeb0",
-        "contents_checksum": "16743f19efef5cd51b3f1038e27a60ef68f626317a700acd6a25e2f72e381992",
-        "size": 6778179,
-        "source": "components/google-cloud-sdk-enterprise-certificate-proxy-windows-x86_64-20230519173220.tar.gz",
+        "checksum": "d49562e0fac17a4ac3c4e30d7c7056320a69ebc157a6c3f3e744f5731bb16f92",
+        "contents_checksum": "bfa2c0f4ea80fb6e3299b6fb7554565213c39ed7b01140020f8ae00c260d09e1",
+        "size": 6801316,
+        "source": "components/google-cloud-sdk-enterprise-certificate-proxy-windows-x86_64-20231208151900.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -3846,8 +3846,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230519173220,
-        "version_string": "0.2.1"
+        "build_number": 20231208151900,
+        "version_string": "0.3.2"
       }
     },
     {
@@ -3907,10 +3907,10 @@
     },
     {
       "data": {
-        "checksum": "535ce4686c07b3bac76f7b107828d4059bf598c92aefac1ebb55d911d90cbc4c",
-        "contents_checksum": "e3b7aacbdc4d8a5adbf88bee4ac738d9e51755b994a700135dbfd8a758a054c2",
-        "size": 1243996,
-        "source": "components/google-cloud-sdk-gcloud-crc32c-darwin-arm-20231023224440.tar.gz",
+        "checksum": "77cacb09f213e98cd3461796567bb583dc05e7f2fe70c47da65e948daf2dfff7",
+        "contents_checksum": "d651a36a3f0e41f7cc7312d09bc3c089a55a583cdaaaa922b0d385e57dece361",
+        "size": 1242963,
+        "source": "components/google-cloud-sdk-gcloud-crc32c-darwin-arm-20231215195722.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -3934,16 +3934,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231023224440,
+        "build_number": 20231215195722,
         "version_string": "1.0.0"
       }
     },
     {
       "data": {
-        "checksum": "00972aba9c56aa0bc4916798ab672cc1e6806e76b00783e15b5c5bbc4e804900",
-        "contents_checksum": "2db99100afdae388afbf96ba0440977d1ab0e9b1fdaa997fac07c5d2c9d6040e",
-        "size": 1284906,
-        "source": "components/google-cloud-sdk-gcloud-crc32c-darwin-x86_64-20231023224440.tar.gz",
+        "checksum": "ef420a608c6446543cf660c7d168f6af297aebb760d163e11c3af278e34eb731",
+        "contents_checksum": "48cfe6b4f0f12b23a1271ef686966959314ba9d3ac21de9082009cbb5e9ab1d8",
+        "size": 1283814,
+        "source": "components/google-cloud-sdk-gcloud-crc32c-darwin-x86_64-20231215195722.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -3967,16 +3967,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231023224440,
+        "build_number": 20231215195722,
         "version_string": "1.0.0"
       }
     },
     {
       "data": {
-        "checksum": "d978d88831992d75a8d1c506c661e3caa702b65acb13bb881f7d2847360836ab",
-        "contents_checksum": "bc5cd52ce1950d6ac8b24d8f8a00c4bbf7f6af82a908fbe2be630b75ecfc35da",
-        "size": 1217581,
-        "source": "components/google-cloud-sdk-gcloud-crc32c-linux-arm-20231023224440.tar.gz",
+        "checksum": "c42492e21729fd33b413c7151e9b9d8c1b352a0f5fa94dbd42e39b0a417ea9da",
+        "contents_checksum": "06647040a666b59ce69c90e6ba9cbfba3f1763236a0872af722e62ea30e51e34",
+        "size": 1214415,
+        "source": "components/google-cloud-sdk-gcloud-crc32c-linux-arm-20231215195722.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4000,16 +4000,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231023224440,
+        "build_number": 20231215195722,
         "version_string": "1.0.0"
       }
     },
     {
       "data": {
-        "checksum": "5abf460069b1f95004805a1f3469061dc340dda0a44fe89fa969e9693cfdd1c1",
-        "contents_checksum": "6a50901818b7cd1a27b2229b350f1869edea9c6aa3bf62a526679b81e967e5f0",
-        "size": 1236281,
-        "source": "components/google-cloud-sdk-gcloud-crc32c-linux-x86-20231023224440.tar.gz",
+        "checksum": "111269e6760bcf2c8d86c435ba6e1814b96281089d38dc73c699b9b12489c662",
+        "contents_checksum": "93fa6c57934e224e3e9e20eec8386ca1d3169b5a4e8f2515f1b042b11e000564",
+        "size": 1233668,
+        "source": "components/google-cloud-sdk-gcloud-crc32c-linux-x86-20231215195722.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4033,16 +4033,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231023224440,
+        "build_number": 20231215195722,
         "version_string": "1.0.0"
       }
     },
     {
       "data": {
-        "checksum": "ec15e4bb7d1a361ae7d931c79626b7a27ded310f118208b5b80e6d54b4f7c793",
-        "contents_checksum": "3d6e552b35cbf9a7cb8e34026d14de0422241344032487ff418514503c133ad4",
-        "size": 1289207,
-        "source": "components/google-cloud-sdk-gcloud-crc32c-linux-x86_64-20231023224440.tar.gz",
+        "checksum": "3fe726e72437a2257264bedb9bb4d61949c15c80b9f587888717c267f65ab91e",
+        "contents_checksum": "0b6b618de4cf9fc339b414d44e6e834e6cdb5fae2ddb65bde3525ad78c595d51",
+        "size": 1287877,
+        "source": "components/google-cloud-sdk-gcloud-crc32c-linux-x86_64-20231215195722.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4066,16 +4066,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231023224440,
+        "build_number": 20231215195722,
         "version_string": "1.0.0"
       }
     },
     {
       "data": {
-        "checksum": "98febf85b26c1a33eb215b2af9f3c8bee847ee71c84be463b26b6d0a763f6400",
-        "contents_checksum": "2e7b929903bc28273be12f0c28dbd68c51315a66600c9751e749ff448d89696f",
-        "size": 1268435,
-        "source": "components/google-cloud-sdk-gcloud-crc32c-windows-x86-20231023224440.tar.gz",
+        "checksum": "46a658000be7850ef81652659448e70c67e089d20946a572c6ba521676af668c",
+        "contents_checksum": "58e78452a22e94789408f6afbb86a65544cb1fac500ef3fbe7422c5eb6b19c10",
+        "size": 1267116,
+        "source": "components/google-cloud-sdk-gcloud-crc32c-windows-x86-20231215195722.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4099,16 +4099,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231023224440,
+        "build_number": 20231215195722,
         "version_string": "1.0.0"
       }
     },
     {
       "data": {
-        "checksum": "a5ed8bb33c67304f57f1ab4c1922f0396565e868dd938b49ce9434a87992a5b8",
-        "contents_checksum": "0c794abb07a045e2c0110bbda9e4033410bb8b7a3d9ddcd329777626ab36d2b3",
-        "size": 1322057,
-        "source": "components/google-cloud-sdk-gcloud-crc32c-windows-x86_64-20231023224440.tar.gz",
+        "checksum": "b9752b5c9eccc0105ef06f322b2dff92f2542884475708b864ae02e800ef7765",
+        "contents_checksum": "96506b713c645adb109e0a7bf83fef4af59a24cd7f714f8455b8d66af8946213",
+        "size": 1321071,
+        "source": "components/google-cloud-sdk-gcloud-crc32c-windows-x86_64-20231215195722.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4132,16 +4132,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231023224440,
+        "build_number": 20231215195722,
         "version_string": "1.0.0"
       }
     },
     {
       "data": {
-        "checksum": "e6ff194b0ebb57cfca1c65a600e852bd5760a7257afb6240a0ed470ff0965fe0",
-        "contents_checksum": "25b6e403e06e65b9205d1258a1b9e09e5e84efb20007e5f940b90af41e3e7873",
-        "size": 12282466,
-        "source": "components/google-cloud-sdk-gcloud-deps-20231025210228.tar.gz",
+        "checksum": "cb411f3915fe2c9bcdacdfb5ded97ebd02454ca988d31fe200d3ef5b7c369a68",
+        "contents_checksum": "e73ea2ddc513ea87ea4820a482b0246d18dd2193371245a2ec8fcc020c25aa3d",
+        "size": 17399231,
+        "source": "components/google-cloud-sdk-gcloud-deps-20240216153112.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4164,8 +4164,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20231025210228,
-        "version_string": "2023.10.25"
+        "build_number": 20240216153112,
+        "version_string": "2024.02.16"
       }
     },
     {
@@ -4401,10 +4401,10 @@
     },
     {
       "data": {
-        "checksum": "a437611fe8ca14e5fbeada917374b7cd2f7d56ad2212e51b80fcb9e7b036a21a",
-        "contents_checksum": "4272d2b5be6e3778aaddfdd6a9d555b6dcf31d27428ed7d4aea76e68dfe5f839",
-        "size": 6464999,
-        "source": "components/google-cloud-sdk-gcloud-man-pages-nix-20231023224440.tar.gz",
+        "checksum": "ae1b2e23c49ec97bf16902cc432add781cadd3728496d1b5cd901d79061913e6",
+        "contents_checksum": "1ef6ae80fe5407994d68f370fb44b1f1d092e9b019cff0c75a1d7a7363aabd26",
+        "size": 6692526,
+        "source": "components/google-cloud-sdk-gcloud-man-pages-nix-20240226203415.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4429,7 +4429,7 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231023224440,
+        "build_number": 20240226203415,
         "version_string": ""
       }
     },
@@ -4466,15 +4466,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "0.5.6"
+        "version_string": "0.5.8"
       }
     },
     {
       "data": {
-        "checksum": "748941d0f1088368cddbff04350c1156eb6c0b941fb4a8281f90e715de91600c",
-        "contents_checksum": "2e92b76de260589610789902d43950f9c23035d9492e9acde1ab81c2ce1b6f86",
-        "size": 7760852,
-        "source": "components/google-cloud-sdk-gke-gcloud-auth-plugin-darwin-arm-20230915145114.tar.gz",
+        "checksum": "327a609642f03ff8f40490eed3794ecf937c6d5fdabf16b41711f037f86c283a",
+        "contents_checksum": "e63fd07984cbb296b5359bb35569445a539ed4e58c8bce640d4216a94c8a6881",
+        "size": 7784812,
+        "source": "components/google-cloud-sdk-gke-gcloud-auth-plugin-darwin-arm-20240106004423.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4498,16 +4498,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230915145114,
-        "version_string": "0.5.6"
+        "build_number": 20240106004423,
+        "version_string": "0.5.8"
       }
     },
     {
       "data": {
-        "checksum": "87e8b9fa1ab657e6f9059b3e73987cdbcafcd0a54a7c0695933a1a630e8c40b6",
-        "contents_checksum": "e93346a6bed20405a41737b6894e5555fe6e65ff84e0c4dfef1c1ca8fbc8759a",
-        "size": 8135789,
-        "source": "components/google-cloud-sdk-gke-gcloud-auth-plugin-darwin-x86_64-20230915145114.tar.gz",
+        "checksum": "79c52f25361b485515fdf2d20283925997feeea6a3f276eb49f5476645c1fe10",
+        "contents_checksum": "aeff6edc3ea7bde1aa33f44744484644cd4e1ca56803f043e7ef27dba5e7b015",
+        "size": 8160991,
+        "source": "components/google-cloud-sdk-gke-gcloud-auth-plugin-darwin-x86_64-20240106004423.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4531,16 +4531,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230915145114,
-        "version_string": "0.5.6"
+        "build_number": 20240106004423,
+        "version_string": "0.5.8"
       }
     },
     {
       "data": {
-        "checksum": "ba39fbdeae5f44a54a83a730d8df93a0b9ce7e18369dabe6f87b023b06b27632",
-        "contents_checksum": "4fe1de8207994103e77bad7d93ebcc9bffde9cb4fa03fd6d658f009454863ba6",
-        "size": 7669387,
-        "source": "components/google-cloud-sdk-gke-gcloud-auth-plugin-linux-arm-20230915145114.tar.gz",
+        "checksum": "51fcd3459f2ef594b441faea5433a26cc8d94ab638cdac3b9028a2710a5adcbb",
+        "contents_checksum": "b33be7d31ad5e77814ae435860a3ab9688672baaccda4bf86c000a5b7d1eea67",
+        "size": 7695357,
+        "source": "components/google-cloud-sdk-gke-gcloud-auth-plugin-linux-arm-20240106004423.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4564,16 +4564,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230915145114,
-        "version_string": "0.5.6"
+        "build_number": 20240106004423,
+        "version_string": "0.5.8"
       }
     },
     {
       "data": {
-        "checksum": "dde5954dc3e5aeb70dd031d1f9dc06ca91fbfef353786dc7aeaf08fe47b8349e",
-        "contents_checksum": "23d71fc214901822027f64f6096b3a6559d963432c189b3bacc7ecf5bf36aef6",
-        "size": 8185793,
-        "source": "components/google-cloud-sdk-gke-gcloud-auth-plugin-linux-x86-20230915145114.tar.gz",
+        "checksum": "87066fca15ebfd79a716c54fd15ad5621fb67dc4a3a34d1e23bcd69d4b5ed5dd",
+        "contents_checksum": "2a425e75e5ec31bec2b7dbdec75ed1a4ca8920ccceee7b12bf658b2e1bd409a8",
+        "size": 8213296,
+        "source": "components/google-cloud-sdk-gke-gcloud-auth-plugin-linux-x86-20240106004423.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4597,16 +4597,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230915145114,
-        "version_string": "0.5.6"
+        "build_number": 20240106004423,
+        "version_string": "0.5.8"
       }
     },
     {
       "data": {
-        "checksum": "d8d9359bbbb0b8e2761bda8a315a50ad1580450d32e4b31d43da1805c408ec9a",
-        "contents_checksum": "08767b975276ca0651442a13bb7319c3c065dca875cf416a27251cf2093d576a",
-        "size": 8298454,
-        "source": "components/google-cloud-sdk-gke-gcloud-auth-plugin-linux-x86_64-20230915145114.tar.gz",
+        "checksum": "cb9856b2ae92bf1a5fd69c7f29bd6892abeb2a229732541f361adea37ede3d9f",
+        "contents_checksum": "811125a0907dc84d4603f7c3734cfd214509c7400397e705d234b06d31c6714f",
+        "size": 8323564,
+        "source": "components/google-cloud-sdk-gke-gcloud-auth-plugin-linux-x86_64-20240106004423.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4630,16 +4630,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230915145114,
-        "version_string": "0.5.6"
+        "build_number": 20240106004423,
+        "version_string": "0.5.8"
       }
     },
     {
       "data": {
-        "checksum": "4e53ce9e76364f936a3730aa26d8396fc905443093bfcba5107e50d999767a28",
-        "contents_checksum": "e13da874c2f1330b78675428fbf7aead7c0f4a4bb8152c911906659d1e7923bb",
-        "size": 8294371,
-        "source": "components/google-cloud-sdk-gke-gcloud-auth-plugin-windows-x86-20230915145114.tar.gz",
+        "checksum": "3b4ffda0fab2631a3b43229390bbb7c2d35d6aa6c7b283d47d8107499c44ee58",
+        "contents_checksum": "3f148312f9edea79f254274261b0bb1a928dc979bd569ca1410699f576433156",
+        "size": 8319970,
+        "source": "components/google-cloud-sdk-gke-gcloud-auth-plugin-windows-x86-20240106004423.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4663,16 +4663,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230915145114,
-        "version_string": "0.5.6"
+        "build_number": 20240106004423,
+        "version_string": "0.5.8"
       }
     },
     {
       "data": {
-        "checksum": "72c35b4ec450e1e30e301e681c322bb2ddd8c9158b60f6d7a6c86f5d1d082396",
-        "contents_checksum": "1a1de077982ffdcb3762e47dea8d515cfe301ec2fab336aa2d3f968a142cff56",
-        "size": 8448839,
-        "source": "components/google-cloud-sdk-gke-gcloud-auth-plugin-windows-x86_64-20230915145114.tar.gz",
+        "checksum": "56b20fa9e9fbe51bc2b8e5d8086088be75aaaf90fdeae444c7bb246bdd38454a",
+        "contents_checksum": "af802f48ffa244f12154321bc1bc4170e53d2ab7628df711cac7c36bb1b0493d",
+        "size": 8477137,
+        "source": "components/google-cloud-sdk-gke-gcloud-auth-plugin-windows-x86_64-20240106004423.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4696,8 +4696,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230915145114,
-        "version_string": "0.5.6"
+        "build_number": 20240106004423,
+        "version_string": "0.5.8"
       }
     },
     {
@@ -4730,10 +4730,10 @@
     },
     {
       "data": {
-        "checksum": "140a65cc728b7d7f0e0018c85f30ea6e7a0cae5e59af15fa51a6f1156f598ec8",
-        "contents_checksum": "865d885b3c86680b0f5581236d54916c71c2672b13e32c2c5b1d213429291bdf",
-        "size": 2035,
-        "source": "components/google-cloud-sdk-gsutil-nix-20231025210228.tar.gz",
+        "checksum": "0e203c936ca846514c498e1bf3f18ecfd8f4e031eb65f1f915812fa31824d246",
+        "contents_checksum": "023019da3e1594d499efe2047aa7069fd138fba4022da534f245de4a9b25597c",
+        "size": 2042,
+        "source": "components/google-cloud-sdk-gsutil-nix-20240106004423.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4758,16 +4758,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231025210228,
+        "build_number": 20240106004423,
         "version_string": "5.27"
       }
     },
     {
       "data": {
-        "checksum": "f44dc54214254bc4c977ac3635113b9299fc7077e2ff2ba649718b0b2b9754ee",
-        "contents_checksum": "d7ff72a9837188a8f602ba4833ea0f38bb0a55ac160121c59dba0b72fae4064e",
-        "size": 4125,
-        "source": "components/google-cloud-sdk-gsutil-win-20231025210228.tar.gz",
+        "checksum": "8b63a83d67b850db7e46f468c9a5370bcdf67aa826c39e5d686c1154e378cf27",
+        "contents_checksum": "0f40962ad671c9f7eb0c6d0d9fe2ea0cfa406fa550764864959335988172d5e6",
+        "size": 4160,
+        "source": "components/google-cloud-sdk-gsutil-win-20240226203415.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4789,7 +4789,7 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231025210228,
+        "build_number": 20240226203415,
         "version_string": "5.27"
       }
     },
@@ -4854,6 +4854,169 @@
     },
     {
       "dependencies": [
+        "istioctl-darwin-arm",
+        "istioctl-darwin-x86_64",
+        "istioctl-linux-arm",
+        "istioctl-linux-x86_64"
+      ],
+      "details": {
+        "description": "Support tool for Cloud Service Mesh.",
+        "display_name": "istioctl"
+      },
+      "id": "istioctl",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm",
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX",
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 0,
+        "version_string": "1.19.52"
+      }
+    },
+    {
+      "data": {
+        "checksum": "d8006cbf29c46df5170e3851709deb590d6d9c85b68f135531bab3d9b56170de",
+        "contents_checksum": "14e138ea65634207c2470b9b2ba368528f25d4d2163c2dccad84376ad72a2831",
+        "size": 25263585,
+        "source": "components/google-cloud-sdk-istioctl-darwin-arm-20231208151900.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "istioctl"
+      ],
+      "details": {
+        "description": "Support tool for Cloud Service Mesh.",
+        "display_name": "istioctl"
+      },
+      "id": "istioctl-darwin-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20231208151900,
+        "version_string": "1.19.52"
+      }
+    },
+    {
+      "data": {
+        "checksum": "494c5dfd16263f52d44465f0de97d29548db0b3c5f050381deda3af725a013d7",
+        "contents_checksum": "cec78fbfe71bfd581699f69d20adb0b96ecc1652072ffe0947f46f0b127ab6ce",
+        "size": 26086965,
+        "source": "components/google-cloud-sdk-istioctl-darwin-x86_64-20231208151900.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "istioctl"
+      ],
+      "details": {
+        "description": "Support tool for Cloud Service Mesh.",
+        "display_name": "istioctl"
+      },
+      "id": "istioctl-darwin-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "MACOSX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20231208151900,
+        "version_string": "1.19.52"
+      }
+    },
+    {
+      "data": {
+        "checksum": "d56a77a5439afd6365c4cecba2c0b0b552fee491eac4def9ed83253bd3951f69",
+        "contents_checksum": "46d34cbbef0d8c29c44a44c75833bd4ee576a6d32ff3389e889cb8e97523849e",
+        "size": 22323528,
+        "source": "components/google-cloud-sdk-istioctl-linux-arm-20231208151900.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "istioctl"
+      ],
+      "details": {
+        "description": "Support tool for Cloud Service Mesh.",
+        "display_name": "istioctl"
+      },
+      "id": "istioctl-linux-arm",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "arm"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20231208151900,
+        "version_string": "1.19.52"
+      }
+    },
+    {
+      "data": {
+        "checksum": "41660670370aa1fe938754f291ba98a87eafe46d860b5d1e75db1d4e338a9285",
+        "contents_checksum": "3d34cb54217d1dc4cfde769596102821f9fce08929dd50421a3fe5ef621990df",
+        "size": 24472616,
+        "source": "components/google-cloud-sdk-istioctl-linux-x86_64-20231208151900.tar.gz",
+        "type": "tar"
+      },
+      "dependencies": [
+        "istioctl"
+      ],
+      "details": {
+        "description": "Support tool for Cloud Service Mesh.",
+        "display_name": "istioctl"
+      },
+      "id": "istioctl-linux-x86_64",
+      "is_configuration": false,
+      "is_hidden": true,
+      "is_required": false,
+      "platform": {
+        "architectures": [
+          "x86_64"
+        ],
+        "operating_systems": [
+          "LINUX"
+        ]
+      },
+      "platform_required": false,
+      "version": {
+        "build_number": 20231208151900,
+        "version_string": "1.19.52"
+      }
+    },
+    {
+      "dependencies": [
         "kpt-darwin-arm",
         "kpt-darwin-x86_64",
         "kpt-linux-arm",
@@ -4880,15 +5043,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "1.0.0-beta.45"
+        "version_string": "1.0.0-beta.49"
       }
     },
     {
       "data": {
-        "checksum": "165e0d01221c66f8a02ca770a613af9e10ca84c301908cee016c4b9f62228c90",
-        "contents_checksum": "d69220663dd3189ef2d75698793f173994662ab4a1331f832cce561122dd3347",
-        "size": 15098362,
-        "source": "components/google-cloud-sdk-kpt-darwin-arm-20231006153333.tar.gz",
+        "checksum": "0790df1606aadcd3818ad4dd7e7826d454602c6e7d2c93376285c8b73487a91b",
+        "contents_checksum": "3dbe499874490929331944b276ff0332f4e94f1babf071e6779cb52746bdc906",
+        "size": 15088020,
+        "source": "components/google-cloud-sdk-kpt-darwin-arm-20231215195722.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4912,16 +5075,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231006153333,
-        "version_string": "1.0.0-beta.45"
+        "build_number": 20231215195722,
+        "version_string": "1.0.0-beta.49"
       }
     },
     {
       "data": {
-        "checksum": "8a507cc40d952611f0d3d7ef881cd2564be93a09d91a01c8d9af13a8477eebe8",
-        "contents_checksum": "bba9c09fe778ebccbeb4c2d77f7fa1a008fc134eebc024d3cfa74ad8737de55d",
-        "size": 15865808,
-        "source": "components/google-cloud-sdk-kpt-darwin-x86_64-20231006153333.tar.gz",
+        "checksum": "ca3bceb9312bb492a1050ba6ed200b835102c58c76d55f9d1c6822c3e074d7e9",
+        "contents_checksum": "706fe93e6842fe68860507bc65fdbe08660e1063d61c882667dee51608789284",
+        "size": 15854938,
+        "source": "components/google-cloud-sdk-kpt-darwin-x86_64-20231215195722.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4945,16 +5108,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231006153333,
-        "version_string": "1.0.0-beta.45"
+        "build_number": 20231215195722,
+        "version_string": "1.0.0-beta.49"
       }
     },
     {
       "data": {
-        "checksum": "00242648b8722bdecbbc422dfe5e947a711d14aeb9adb575cb664e07b61a16c0",
-        "contents_checksum": "b7acebf0b9a28366a0a7ee8f283bb01baa7ba9ab0c85a31d994604c9ee62e587",
-        "size": 13639470,
-        "source": "components/google-cloud-sdk-kpt-linux-arm-20231006153333.tar.gz",
+        "checksum": "56d0a81d5b31304c153cf07d4b5eeb433a27245c095f9e181f49eb8b98536ace",
+        "contents_checksum": "78fe72d925a7144d71ac007c684d7fcbdb3f9b4e5e454bcd6c49ebc133cf132f",
+        "size": 13629886,
+        "source": "components/google-cloud-sdk-kpt-linux-arm-20231215195722.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -4978,16 +5141,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231006153333,
-        "version_string": "1.0.0-beta.45"
+        "build_number": 20231215195722,
+        "version_string": "1.0.0-beta.49"
       }
     },
     {
       "data": {
-        "checksum": "d429dbc12345c454e5494e3312bdff83d39ad5793a05423c4ae5fc07a8128aba",
-        "contents_checksum": "2d9bc0d3ace7952ca0e3e37df2545c0d30734162edd151f7759a75a186134604",
-        "size": 15103896,
-        "source": "components/google-cloud-sdk-kpt-linux-x86_64-20231006153333.tar.gz",
+        "checksum": "72b3a2a1e41963a892899e273fff38aa93a83acdc90d59c9f3c335fa62b1d30b",
+        "contents_checksum": "3de022e880f11c7cbb0e258281b2dc5a7c32ebf688958a99feecaae684cc62bd",
+        "size": 15090734,
+        "source": "components/google-cloud-sdk-kpt-linux-x86_64-20231215195722.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5011,16 +5174,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231006153333,
-        "version_string": "1.0.0-beta.45"
+        "build_number": 20231215195722,
+        "version_string": "1.0.0-beta.49"
       }
     },
     {
       "data": {
-        "checksum": "1856710bc0df7be64bab8bf90cb5efb07dc3ea87affbd82d5fb95b1a87a0fd38",
-        "contents_checksum": "40d66e6d7f3852fcf4d60000bb89743f36516642a9fb5e4b4ac72d5db2b7d00f",
-        "size": 35802,
-        "source": "components/google-cloud-sdk-kubectl-20230901141909.tar.gz",
+        "checksum": "e06b2f2bd331421fa8f8c5776b7370b793101232a8316c61420ebad9622e2709",
+        "contents_checksum": "d7c1385f3b9bedea994733230851e6d3548ea4be8f5014b1feadbf4ca2c6ca46",
+        "size": 35936,
+        "source": "components/google-cloud-sdk-kubectl-20240209195330.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5044,16 +5207,16 @@
       "platform": {},
       "platform_required": true,
       "version": {
-        "build_number": 20230901141909,
-        "version_string": "1.27.5"
+        "build_number": 20240209195330,
+        "version_string": "1.26.13"
       }
     },
     {
       "data": {
-        "checksum": "98705f1c24b4deb4c4705890b9d96cf7304b8df3f9fa21d16d971b1e8d577c85",
-        "contents_checksum": "713724b4e531400e61289f6649a0ebc2a390c23c17f9b13cf36ddf713e8c6fff",
-        "size": 103078284,
-        "source": "components/google-cloud-sdk-kubectl-darwin-arm-20230901141909.tar.gz",
+        "checksum": "ad4230981ddba174dc301d5ed31704c86819b99de90fc0a391d379197b221ff0",
+        "contents_checksum": "8208474ff6408f57a030648f9e0409eb66f854f95eb1cc8fc28897e3dae882b7",
+        "size": 76487537,
+        "source": "components/google-cloud-sdk-kubectl-darwin-arm-20240209195330.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5078,16 +5241,16 @@
       },
       "platform_required": true,
       "version": {
-        "build_number": 20230901141909,
-        "version_string": "1.27.5"
+        "build_number": 20240209195330,
+        "version_string": "1.26.13"
       }
     },
     {
       "data": {
-        "checksum": "89fd68aa32498f5fa73e569cc6897c6ef2d12c822870703ce2cc004711260ca6",
-        "contents_checksum": "76c149262b6b45f75eec6d812f6c800924ddc42627bdfa757fbe8ba57c87c856",
-        "size": 108009509,
-        "source": "components/google-cloud-sdk-kubectl-darwin-x86_64-20230901141909.tar.gz",
+        "checksum": "7154fc7e724a41ba9109fc4d3211fdfb24bb9c706f82175a0543158a74ea64f4",
+        "contents_checksum": "1db2fb77158d4aeb37b895ca7beb34d2380b6d7bda97e18189c03a235473a26f",
+        "size": 80131408,
+        "source": "components/google-cloud-sdk-kubectl-darwin-x86_64-20240209195330.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5112,16 +5275,16 @@
       },
       "platform_required": true,
       "version": {
-        "build_number": 20230901141909,
-        "version_string": "1.27.5"
+        "build_number": 20240209195330,
+        "version_string": "1.26.13"
       }
     },
     {
       "data": {
-        "checksum": "277ce37c99d1da67302f0b96be2f81712c7655b8bd6e8a681e5ec42c7e839f3d",
-        "contents_checksum": "603f81934af743bec8493385ef0742e396547ab8d4730f1b25243ce6f9d6583c",
-        "size": 96034568,
-        "source": "components/google-cloud-sdk-kubectl-linux-arm-20230901141909.tar.gz",
+        "checksum": "655be0e96cc23f6e04c4ec176ef19d6ac4164f0093de7e6a5ab882128bacf3cc",
+        "contents_checksum": "69a8d347c6cc78a42b8ec340794632e449b2ceac8f7a8cf3e677f97743fa6e66",
+        "size": 72277260,
+        "source": "components/google-cloud-sdk-kubectl-linux-arm-20240209195330.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5146,16 +5309,16 @@
       },
       "platform_required": true,
       "version": {
-        "build_number": 20230901141909,
-        "version_string": "1.27.5"
+        "build_number": 20240209195330,
+        "version_string": "1.26.13"
       }
     },
     {
       "data": {
-        "checksum": "d0aa47c656c3f62b046fcdebe292fdd4277423d27ae82e076b33b7ca9c39eefb",
-        "contents_checksum": "da0be2ec150a1178b21e571fc31f3a0c1bc97aec8808add47123f958c8c3f622",
-        "size": 96964577,
-        "source": "components/google-cloud-sdk-kubectl-linux-x86-20230901141909.tar.gz",
+        "checksum": "37931d1405a46bac8833f106c35734512445fc218cc9f1e007604bb48cdee55b",
+        "contents_checksum": "8222dd939577e50f8ffc0f667d6a2ccbd88c8a0813925f4889a58d27b180ff98",
+        "size": 71637401,
+        "source": "components/google-cloud-sdk-kubectl-linux-x86-20240209195330.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5180,16 +5343,16 @@
       },
       "platform_required": true,
       "version": {
-        "build_number": 20230901141909,
-        "version_string": "1.27.5"
+        "build_number": 20240209195330,
+        "version_string": "1.26.13"
       }
     },
     {
       "data": {
-        "checksum": "7ea12e2911cf031f4f1642d9be5a0336c9142d84b3e9511c2405ab742cddab5b",
-        "contents_checksum": "651b0f1e393ec6903229f7c170d1d54a41066fe5cfd6dd233c5a24e7ce08fb4d",
-        "size": 102779659,
-        "source": "components/google-cloud-sdk-kubectl-linux-x86_64-20230901141909.tar.gz",
+        "checksum": "479be7e5c55b77eacb26a86afb8063ee0c22664eca0af154c6725c6d413f4631",
+        "contents_checksum": "0d9e46f2a36f34ac1d485901b2243bbedc5f66e54cb3d8e42172cbc6484075ea",
+        "size": 76232083,
+        "source": "components/google-cloud-sdk-kubectl-linux-x86_64-20240209195330.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5214,8 +5377,8 @@
       },
       "platform_required": true,
       "version": {
-        "build_number": 20230901141909,
-        "version_string": "1.27.5"
+        "build_number": 20240209195330,
+        "version_string": "1.26.13"
       }
     },
     {
@@ -5248,15 +5411,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "1.4.4"
+        "version_string": "1.5.0"
       }
     },
     {
       "data": {
-        "checksum": "a7d9d1a977856dc342b82936bedfda0032e27ec4657fd380048cd7dc5de05039",
-        "contents_checksum": "2d656b34043e23ff6a98a7fb432efa86d251eb0b14c4452d17c537dc02e04eaf",
-        "size": 20108100,
-        "source": "components/google-cloud-sdk-kubectl-oidc-darwin-arm-20220923141408.tar.gz",
+        "checksum": "ca1e67289f1d377b6fc300777cdd8853a4ebc7eb11c00db85a3e7394c8daea30",
+        "contents_checksum": "3d35d8343042427849f27fe09652e94dbb563ebb6026ded792641beb1c536ebd",
+        "size": 21674622,
+        "source": "components/google-cloud-sdk-kubectl-oidc-darwin-arm-20231201141418.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5280,16 +5443,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20220923141408,
-        "version_string": "1.4.4"
+        "build_number": 20231201141418,
+        "version_string": "1.5.0"
       }
     },
     {
       "data": {
-        "checksum": "1d6d08431d911928ef8500d1979720278f8116e86ae52afc32ce0b76ec4a5fb0",
-        "contents_checksum": "497465b1a0c3a6781d2bb0b68a951af0a4d2230ae67caa84288d38b853800a53",
-        "size": 21183987,
-        "source": "components/google-cloud-sdk-kubectl-oidc-darwin-x86_64-20220923141408.tar.gz",
+        "checksum": "d8b175936d29c11412e099627cbc9d4bc4574e7201a48bd045714aa4d5039d97",
+        "contents_checksum": "b4c5609dd10b63e9946c1afaf9a6e242fe3b09cb0d5c0c453e4ead4fb173c4e2",
+        "size": 22732154,
+        "source": "components/google-cloud-sdk-kubectl-oidc-darwin-x86_64-20231201141418.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5313,16 +5476,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20220923141408,
-        "version_string": "1.4.4"
+        "build_number": 20231201141418,
+        "version_string": "1.5.0"
       }
     },
     {
       "data": {
-        "checksum": "87550a6e878b3091c8da5df8380c65f9e2579f012b7cbddc3e64fb637906fc38",
-        "contents_checksum": "2c33c85c5826938f014a33c21d28289676cccc09d7ffb87368fd94faf43b6cc1",
-        "size": 19755678,
-        "source": "components/google-cloud-sdk-kubectl-oidc-linux-arm-20220923141408.tar.gz",
+        "checksum": "da25e182095d25746563ded62b84c614f6ba87514e751e1f445b8ef9ddbcf239",
+        "contents_checksum": "f1bd3477dd4ad77ed8c02631cfd0b7e102000e6bac495dcd3fb69daf6b21ba93",
+        "size": 21172499,
+        "source": "components/google-cloud-sdk-kubectl-oidc-linux-arm-20231201141418.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5346,16 +5509,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20220923141408,
-        "version_string": "1.4.4"
+        "build_number": 20231201141418,
+        "version_string": "1.5.0"
       }
     },
     {
       "data": {
-        "checksum": "cd6945af71ecfdf94c693ee22b7629ad62dc650cf0c19d58761fe260f792e36f",
-        "contents_checksum": "c2092312910a7e7e86adcd8d72c9e97d7d9757d6dce2f3e24124d9bcadd0d9eb",
-        "size": 21362894,
-        "source": "components/google-cloud-sdk-kubectl-oidc-linux-x86_64-20220923141408.tar.gz",
+        "checksum": "94eb2344e8f1a5cff5b2f1db0c35e3cfc378336f148a701ac94e4111f17069f1",
+        "contents_checksum": "9ddfa977b16e32f97c5d5ad574ff09ae06f67b87f218f45a178cfae5f88d4355",
+        "size": 22854824,
+        "source": "components/google-cloud-sdk-kubectl-oidc-linux-x86_64-20231201141418.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5379,16 +5542,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20220923141408,
-        "version_string": "1.4.4"
+        "build_number": 20231201141418,
+        "version_string": "1.5.0"
       }
     },
     {
       "data": {
-        "checksum": "2cf3f2460446692a81c888ec16ac7cbd838fd83acdec46e99bd9225ed49a5d67",
-        "contents_checksum": "6477f1e7ad0e16d891b1b47c201c2bf0e4409789893be60e1697593c58f74025",
-        "size": 21470876,
-        "source": "components/google-cloud-sdk-kubectl-oidc-windows-x86_64-20220923141408.tar.gz",
+        "checksum": "386b201a127ea6723ba4f4ac943c596310d03aa0568d947f23980577fc0c5685",
+        "contents_checksum": "72ccfee0b039eaf5d4bd5445044806c84a1af5d55318de032a372af0fdf779c4",
+        "size": 23111830,
+        "source": "components/google-cloud-sdk-kubectl-oidc-windows-x86_64-20231201141418.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5412,16 +5575,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20220923141408,
-        "version_string": "1.4.4"
+        "build_number": 20231201141418,
+        "version_string": "1.5.0"
       }
     },
     {
       "data": {
-        "checksum": "f0f671d703d9f167ad6bd3eaa6160a1f3612f55cb4224a7f5d6e32fe24aad4bf",
-        "contents_checksum": "97933ed5d6afd63a6d24200980cadc6ebcfe962827cb1cc5fff294f425b02225",
-        "size": 101631898,
-        "source": "components/google-cloud-sdk-kubectl-windows-x86-20230901141909.tar.gz",
+        "checksum": "80b067c1eed2401d32b2078e9296322ceecad8de4903105c8627a182bc626f89",
+        "contents_checksum": "008b98a6902a2d260427a6067f7b26278c947c3da0f65a135bea6806906de7cc",
+        "size": 75077053,
+        "source": "components/google-cloud-sdk-kubectl-windows-x86-20240209195330.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5448,16 +5611,16 @@
       },
       "platform_required": true,
       "version": {
-        "build_number": 20230901141909,
-        "version_string": "1.27.5"
+        "build_number": 20240209195330,
+        "version_string": "1.26.13"
       }
     },
     {
       "data": {
-        "checksum": "be9dfaab70e30013b181ca6b01db0cbe33a9998c8b42b294cb6ae42586c08dcb",
-        "contents_checksum": "8646408cad8f64abcbf575a5b9606d304d3f0a1c914b5c7ba4148d4024c22b34",
-        "size": 103973366,
-        "source": "components/google-cloud-sdk-kubectl-windows-x86_64-20230901141909.tar.gz",
+        "checksum": "a632645797fb65db3f112548543ce4f7b1e048963f264bf5bc9e318f9f85cda2",
+        "contents_checksum": "bcdf97a387126e7b831c903b905bc96af608ff2fc5d2013482280535f077c21c",
+        "size": 77301897,
+        "source": "components/google-cloud-sdk-kubectl-windows-x86_64-20240209195330.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -5484,8 +5647,8 @@
       },
       "platform_required": true,
       "version": {
-        "build_number": 20230901141909,
-        "version_string": "1.27.5"
+        "build_number": 20240209195330,
+        "version_string": "1.26.13"
       }
     },
     {
@@ -6042,15 +6205,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "1.31.2"
+        "version_string": "1.32.0"
       }
     },
     {
       "data": {
-        "checksum": "78205e250353829eef8e4226427043612a26df3751750bdfeb4ce5096534477b",
-        "contents_checksum": "989ca8305dc5b0ac3ea012bde522d707e7893ec7b5601476015be170587c2484",
-        "size": 34507436,
-        "source": "components/google-cloud-sdk-minikube-darwin-arm-20230822145232.tar.gz",
+        "checksum": "6cdb5663bc455017a2c1b7a7d34acaacc7cb4b0af5785db6ccdbfb0beec199fd",
+        "contents_checksum": "f7ca3880897a3db31c4619210464df1577b933823248436b8d7b1981d5d302df",
+        "size": 35193661,
+        "source": "components/google-cloud-sdk-minikube-darwin-arm-20231201141418.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6074,16 +6237,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230822145232,
-        "version_string": "1.31.2"
+        "build_number": 20231201141418,
+        "version_string": "1.32.0"
       }
     },
     {
       "data": {
-        "checksum": "09de85445c6b3df96b513fa5ef0893e141f2dd276d6ebe2a5c14805e02966386",
-        "contents_checksum": "6599c91419fd71db290d9df3d12a37cb335d9e30c206533767bcbccfb8415894",
-        "size": 35694869,
-        "source": "components/google-cloud-sdk-minikube-darwin-x86_64-20230822145232.tar.gz",
+        "checksum": "cdad196423217d1a81f1a00f8d706d4e05a27f58c21660e383d78351f4eda51c",
+        "contents_checksum": "da96e69ac893ea621f909904c57c57e34b1ae56f60b2de84427fb5d0a6df568f",
+        "size": 36498067,
+        "source": "components/google-cloud-sdk-minikube-darwin-x86_64-20231201141418.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6107,16 +6270,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230822145232,
-        "version_string": "1.31.2"
+        "build_number": 20231201141418,
+        "version_string": "1.32.0"
       }
     },
     {
       "data": {
-        "checksum": "01f5ee655a8877b9d55912694d634151f411f84f59489c8f61129e60eec1dfbb",
-        "contents_checksum": "bdd299c7575c1365a3ebb3ece947b735a51234851358d24c53997228351232c9",
-        "size": 33636964,
-        "source": "components/google-cloud-sdk-minikube-linux-arm-20230822145232.tar.gz",
+        "checksum": "8a80e98200d3572f803d700c8475c25f143d30997491ff4aaddb30633ab2cf76",
+        "contents_checksum": "af8b9577ef05c98d3cb2fe6832a8c2bf182f2cd19cb64a22f492581fc2882d2b",
+        "size": 34568485,
+        "source": "components/google-cloud-sdk-minikube-linux-arm-20231201141418.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6140,16 +6303,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230822145232,
-        "version_string": "1.31.2"
+        "build_number": 20231201141418,
+        "version_string": "1.32.0"
       }
     },
     {
       "data": {
-        "checksum": "567adccb2ee4f3112208def4dda54ec4ec96815a95499444efde14b240175fde",
-        "contents_checksum": "8a3e8c01ca983d10eda486ffcae60cf59d6a1e7fa09e2e4424e5ee56be742d07",
-        "size": 36252687,
-        "source": "components/google-cloud-sdk-minikube-linux-x86_64-20230822145232.tar.gz",
+        "checksum": "54e5932d307b935e9033bfa9ab956f701ce2bee640c16fddf2ba1f061f2707cd",
+        "contents_checksum": "28c6cb2657e863e1023b2f905edf91735e0a122c210669fd59e914ecdcb25846",
+        "size": 37111912,
+        "source": "components/google-cloud-sdk-minikube-linux-x86_64-20231201141418.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6173,16 +6336,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230822145232,
-        "version_string": "1.31.2"
+        "build_number": 20231201141418,
+        "version_string": "1.32.0"
       }
     },
     {
       "data": {
-        "checksum": "2fc9ea9e26e672d5369e63e4084520b7e252f9c9eabf9e63edc30f362b79c751",
-        "contents_checksum": "f31c9d1fd17b363be49476ea676866474dabd71904101bc9cb748c1c8d50efa1",
-        "size": 36153509,
-        "source": "components/google-cloud-sdk-minikube-windows-x86_64-20230822145232.tar.gz",
+        "checksum": "66ccc0487812cac8ab071d878eda07fae7440eb232df9177520cd1522d67cd92",
+        "contents_checksum": "6a7de15384ab840952fdbcecad98e73b479542120dc0b9621b0c9452bcca4023",
+        "size": 37199202,
+        "source": "components/google-cloud-sdk-minikube-windows-x86_64-20231201141418.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6206,8 +6369,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20230822145232,
-        "version_string": "1.31.2"
+        "build_number": 20231201141418,
+        "version_string": "1.32.0"
       }
     },
     {
@@ -6235,15 +6398,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "1.16.2-rc.2"
+        "version_string": "1.17.1-rc.2"
       }
     },
     {
       "data": {
-        "checksum": "e985978e6f21b67b026ac23882b40fde32fce195c3618c845dce6e05e145359f",
-        "contents_checksum": "21fb7c2de16364b3e011aa4364c7b724cd7aacdfa21610ad891c1b8c3a388e02",
-        "size": 29892791,
-        "source": "components/google-cloud-sdk-nomos-darwin-x86_64-20231023224440.tar.gz",
+        "checksum": "890c27a935e373182f39648db4b2a4aca9a4df8cd7278dd9f5b9bf4f1f51db77",
+        "contents_checksum": "8d6257e877bd94af3d1ccf0da5838fda36f63c15586beb68e6c3807af03f6a2d",
+        "size": 29979984,
+        "source": "components/google-cloud-sdk-nomos-darwin-x86_64-20240202164548.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6267,16 +6430,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231023224440,
-        "version_string": "1.16.2-rc.2"
+        "build_number": 20240202164548,
+        "version_string": "1.17.1-rc.2"
       }
     },
     {
       "data": {
-        "checksum": "413f599d671855ce7bd0002a35b0f6793041282463342206246e42c01fd9c9b8",
-        "contents_checksum": "ef98a3d5add19c22799e9fe9031487e542f779b31fa604db671775dcd592b739",
-        "size": 30473701,
-        "source": "components/google-cloud-sdk-nomos-linux-x86_64-20231023224440.tar.gz",
+        "checksum": "a3213634edd8c57d952d9febcee45b17487af67dd7cf624b3d31f7e19fe4b93b",
+        "contents_checksum": "62ead218adc0e84b2fdd1f8c45475fdf2c021653aaa445220c50bba9faf41ecc",
+        "size": 30147124,
+        "source": "components/google-cloud-sdk-nomos-linux-x86_64-20240202164548.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6300,8 +6463,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231023224440,
-        "version_string": "1.16.2-rc.2"
+        "build_number": 20240202164548,
+        "version_string": "1.17.1-rc.2"
       }
     },
     {
@@ -6581,10 +6744,10 @@
     },
     {
       "data": {
-        "checksum": "28574de6bc04f41d2ffc96e94fb00243ae6ec5e6c19524de7c833afd082a0a20",
-        "contents_checksum": "ec18cbdb02d4f8c9f3abe177bd0f9255eedc1e1d7739121a4ed7a29ce9ff36f4",
-        "size": 65097027,
-        "source": "components/google-cloud-sdk-pubsub-emulator-20231016163610.tar.gz",
+        "checksum": "8edb08eff03c545ad413ae804f873d533762d91cfcf1edf777cb38049024f46e",
+        "contents_checksum": "c105033c76c4acd6a23264e1af6a1122f9336a0e39cbac0dcffca66402610a8b",
+        "size": 65151378,
+        "source": "components/google-cloud-sdk-pubsub-emulator-20240209195330.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6601,8 +6764,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20231016163610,
-        "version_string": "0.8.10"
+        "build_number": 20240209195330,
+        "version_string": "0.8.11"
       }
     },
     {
@@ -6636,15 +6799,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "2.7.1"
+        "version_string": "2.9.0"
       }
     },
     {
       "data": {
-        "checksum": "d82de49ad5de08e99bd6e77ec3dca58b7a48b6d440fffd24a136bc01d3f15c63",
-        "contents_checksum": "f919555748e2d8c1af435e9a62af9633d5146a251e152d0f077d6f3a5a90d5c5",
-        "size": 24334283,
-        "source": "components/google-cloud-sdk-skaffold-darwin-arm-20231002150006.tar.gz",
+        "checksum": "badd2854a9b5a3b4d3b8b55c163656776778c572eba854262bfd637c803ca3b7",
+        "contents_checksum": "45e2f3eb2703f29f735cbc820e9d4004f1e95bea1ab96e698ded74f2a5de857d",
+        "size": 24426195,
+        "source": "components/google-cloud-sdk-skaffold-darwin-arm-20231110155547.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6669,16 +6832,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231002150006,
-        "version_string": "2.7.1"
+        "build_number": 20231110155547,
+        "version_string": "2.9.0"
       }
     },
     {
       "data": {
-        "checksum": "80f62a636612be395d304441b70cb94eb2137a21c5f27363a746fd70f3670565",
-        "contents_checksum": "e446714207056f4c0a70739472eca48de9a4063c6260a1609c55291a0756f75a",
-        "size": 26431910,
-        "source": "components/google-cloud-sdk-skaffold-darwin-x86_64-20231002150006.tar.gz",
+        "checksum": "cba0d4046df4764747f9a15ebe061fec60f9f768d1079041feea2321c5cd5e76",
+        "contents_checksum": "941bc43d4633be69ed64eadf7ad3ba477929bd6dcb519dc668b77f29b5115a57",
+        "size": 26530698,
+        "source": "components/google-cloud-sdk-skaffold-darwin-x86_64-20231110155547.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6703,16 +6866,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231002150006,
-        "version_string": "2.7.1"
+        "build_number": 20231110155547,
+        "version_string": "2.9.0"
       }
     },
     {
       "data": {
-        "checksum": "6fd3ecbea23c64ccb1a7a43ba949df0108d5dcb279b8cd1d55a35f54b53bb674",
-        "contents_checksum": "d38419a04db49b0f30f761ae709c9fa902552871d0aa5522d1777643cc963579",
-        "size": 22351847,
-        "source": "components/google-cloud-sdk-skaffold-linux-arm-20231002150006.tar.gz",
+        "checksum": "45cb0e94d47b3b28db5d8dda5fbd1dd7fbfad96936ce3bbbdce3f2f8be63a093",
+        "contents_checksum": "2f36d4b1b0eab170b21fe0df2964aa31d79694a8860070c32b7eb7bc471a74aa",
+        "size": 22439050,
+        "source": "components/google-cloud-sdk-skaffold-linux-arm-20231110155547.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6737,16 +6900,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231002150006,
-        "version_string": "2.7.1"
+        "build_number": 20231110155547,
+        "version_string": "2.9.0"
       }
     },
     {
       "data": {
-        "checksum": "6ed058de92dfa76751028437b05c76ce17030fc19d4ff7fde5f0d5c915b94110",
-        "contents_checksum": "c86e65478b18bc05b803e0d4d2c4cf5387b05bd99def05b7017dd74fd478bebc",
-        "size": 24456326,
-        "source": "components/google-cloud-sdk-skaffold-linux-x86_64-20231002150006.tar.gz",
+        "checksum": "6add62f50ef3b9d77259177118ee30251c2f07074fc4555d516a3ae5dfbbb3b6",
+        "contents_checksum": "065a00f4d25312efad8a854d21809862d9f0e41588511a1c1930ed5c34e7e57b",
+        "size": 24544699,
+        "source": "components/google-cloud-sdk-skaffold-linux-x86_64-20231110155547.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6771,16 +6934,16 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231002150006,
-        "version_string": "2.7.1"
+        "build_number": 20231110155547,
+        "version_string": "2.9.0"
       }
     },
     {
       "data": {
-        "checksum": "c81abe9107f9b03476de18df93b7272bfe4942629e5202eea60611b0294f5883",
-        "contents_checksum": "027478d2605b71896dfffeb11c85da30e6fa3e6164b55701c5186137047e2771",
-        "size": 24939189,
-        "source": "components/google-cloud-sdk-skaffold-windows-x86_64-20231002150006.tar.gz",
+        "checksum": "577504b2686302f74a7e00bebe9a561b0caa15d3294dc0c9e15dba2d9d745f32",
+        "contents_checksum": "940d470dd53773d3e907de4d80ef70df247824167fcb95a05494e66e6bb28c9a",
+        "size": 25035980,
+        "source": "components/google-cloud-sdk-skaffold-windows-x86_64-20231110155547.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6805,8 +6968,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231002150006,
-        "version_string": "2.7.1"
+        "build_number": 20231110155547,
+        "version_string": "2.9.0"
       }
     },
     {
@@ -6832,15 +6995,15 @@
       "platform_required": false,
       "version": {
         "build_number": 0,
-        "version_string": "3.1.3"
+        "version_string": "3.2.2"
       }
     },
     {
       "data": {
-        "checksum": "f329d03249adcbd72707b0c723b3229bc3957bc2865ae0c2c13a90339ffed4f0",
-        "contents_checksum": "280d4a1fac4f797c9ca31c3a60ac377f32633678e92c45cb3d9c52d9ed697b52",
-        "size": 23033348,
-        "source": "components/google-cloud-sdk-spanner-migration-tool-linux-x86_64-20231023224440.tar.gz",
+        "checksum": "6f55289b6cdb9206c110e5e1f3e040e4c9a69aa129c5c0caae71bc668b17bca9",
+        "contents_checksum": "2284e73fc19acea54651526b45fd808530a9272fd56b0c553386bbfaac02f729",
+        "size": 24615874,
+        "source": "components/google-cloud-sdk-spanner-migration-tool-linux-x86_64-20240112150613.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -6864,8 +7027,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20231023224440,
-        "version_string": "3.1.3"
+        "build_number": 20240112150613,
+        "version_string": "3.2.2"
       }
     },
     {
@@ -7022,10 +7185,10 @@
     },
     {
       "data": {
-        "checksum": "be800db8eba62f286ff49c2ad59c399a6375429bcab4d06285a0f6851b10ee01",
-        "contents_checksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        "size": 105,
-        "source": "components/google-cloud-sdk-terraform-tools-linux-arm-20220325151342.tar.gz",
+        "checksum": "a227491c831d1ed3619bfebd69a3a4379729372b302de64c77891f0955316445",
+        "contents_checksum": "84c92ebb4b1ae244c96595c4774a9594857e37d900306958fb63fcc58ef61a0f",
+        "size": 64183072,
+        "source": "components/google-cloud-sdk-terraform-tools-linux-arm-20231201141418.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -7049,8 +7212,8 @@
       },
       "platform_required": false,
       "version": {
-        "build_number": 20220325151342,
-        "version_string": "0.2.1"
+        "build_number": 20231201141418,
+        "version_string": "0.11.1"
       }
     },
     {
@@ -7121,10 +7284,10 @@
     },
     {
       "data": {
-        "checksum": "5f1b1acfd653d1c7906dca110f939cf3e3389778ae0d4328c722348e69c3ba58",
-        "contents_checksum": "7fa3155ffbfc1c7b90d78a1eabb7e722f274149645f0e3979a5493aad1fd9df1",
-        "size": 50896581,
-        "source": "components/google-cloud-sdk-tests-20231025210228.tar.gz",
+        "checksum": "e6b92ad3a74110451dec21468794532dd2c7c7264a36e1f649adc5575e025ce2",
+        "contents_checksum": "74f91e9a687bc76f8b51929f16cdf5325813468eeca88e1206b3461fd015cb9a",
+        "size": 51401473,
+        "source": "components/google-cloud-sdk-tests-20240226203415.tar.gz",
         "type": "tar"
       },
       "dependencies": [
@@ -7141,8 +7304,8 @@
       "platform": {},
       "platform_required": false,
       "version": {
-        "build_number": 20231025210228,
-        "version_string": "2023.10.25"
+        "build_number": 20240226203415,
+        "version_string": "2024.02.26"
       }
     }
   ],
@@ -7161,11 +7324,11 @@
   ],
   "post_processing_command": "components post-process",
   "release_notes_url": "RELEASE_NOTES",
-  "revision": 20231025210228,
+  "revision": 20240226203415,
   "schema_version": {
     "no_update": false,
     "url": "https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz",
     "version": 3
   },
-  "version": "452.0.1"
+  "version": "466.0.0"
 }

--- a/pkgs/tools/admin/google-cloud-sdk/data.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/data.nix
@@ -1,32 +1,32 @@
 # DO NOT EDIT! This file is generated automatically by update.sh
 { }:
 {
-  version = "452.0.1";
+  version = "466.0.0";
   googleCloudSdkPkgs = {
     x86_64-linux =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-452.0.1-linux-x86_64.tar.gz";
-        sha256 = "0dj0hzhfvw1p74ja079jmhrhzrbsivgfm0509rxf9xvh1a0kb8zx";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-466.0.0-linux-x86_64.tar.gz";
+        sha256 = "06rzwqyqaam7g46db0x50zyd7l4x15hrnijrmnn4nhximklmwf84";
       };
     x86_64-darwin =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-452.0.1-darwin-x86_64.tar.gz";
-        sha256 = "0gxz12sblc3slw9rhy0i7x8k61sakr0gwipx75h3cghf72hsx0cn";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-466.0.0-darwin-x86_64.tar.gz";
+        sha256 = "0ca5jrh1w522cp9f9qywqzqhb85fa2qgk5w2dhrcgb02p1w3czh8";
       };
     aarch64-linux =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-452.0.1-linux-arm.tar.gz";
-        sha256 = "1jcacwqxa5ylffpfp5mr509imay24ddsv43l04fygzahv2sv8a2d";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-466.0.0-linux-arm.tar.gz";
+        sha256 = "1lnvhl74m4rg0d8474sdr0aq457fibxmf1ica1yhkqbc53gc0439";
       };
     aarch64-darwin =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-452.0.1-darwin-arm.tar.gz";
-        sha256 = "1mpydxqkmfrnqiifgplvc5ghn6rs4981p4pw5zgxip7khw64dfap";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-466.0.0-darwin-arm.tar.gz";
+        sha256 = "0g28dj2cxjp65zvxdd3xqhsb6vckvfm4ba2dp6lwgxcy8ki96njj";
       };
     i686-linux =
       {
-        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-452.0.1-linux-x86.tar.gz";
-        sha256 = "1whijjp2bn24j78rlfpp01y832fnlgj557v6fim9l78zcavgnahz";
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-466.0.0-linux-x86.tar.gz";
+        sha256 = "1r7ky2hbhgsqjk2ih3dnl1pngfrpxkv8n355xa6rka4d4xbslbrq";
       };
   };
 }


### PR DESCRIPTION
## Description of changes

1. Git pulled `nixpkgs`
2. `cd pkgs/tools/admin/google-cloud-sdk/`
3. `export UPDATE_NIX_OLD_VERSION=452.0.1`
4. `./update.sh`
5.  Update was successful.


Tested with `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` with the following output:
```sh
> cat report.json
  {
    "blacklisted": [],
    "broken": [],
    "built": [
      "cve-bin-tool",
      "cve-bin-tool.dist",
      "google-cloud-sdk",
      "google-cloud-sdk-gce"
    ],
    "extra-nixpkgs-config": null,
    "failed": [],
    "non-existent": [],
    "pr": null,
    "system": "x86_64-linux",
    "tests": []
  }
  ```
Also ran a quick check on the built binaries and they look good.
```sh
> ./results/google-cloud-sdk/bin/gcloud --version
Google Cloud SDK 466.0.0
bq 2.0.101
bundled-python3-unix 3.11.7
core 2024.02.26
gcloud-crc32c 1.0.0
gsutil 5.27
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
