### PR TITLE
mmctl: 9.2.2 → 9.5.1, use override on mattermost

### DIFF
--- a/pkgs/tools/misc/mmctl/0001-module-replace-public.patch
+++ b/pkgs/tools/misc/mmctl/0001-module-replace-public.patch
@@ -1,8 +1,0 @@
---- a/go.mod
-+++ b/go.mod
-@@ -218,3 +218,5 @@ exclude (
- 	github.com/dyatlov/go-opengraph v0.0.0-20210112100619-dae8665a5b09
- 	github.com/willf/bitset v1.2.0
- )
-+
-+replace github.com/mattermost/mattermost/server/public => ./public

--- a/pkgs/tools/misc/mmctl/default.nix
+++ b/pkgs/tools/misc/mmctl/default.nix
@@ -1,43 +1,12 @@
-{ lib
-, fetchFromGitHub
-, buildGoModule
+{ mattermost
 }:
 
-buildGoModule rec {
+mattermost.overrideAttrs (o: {
   pname = "mmctl";
-  version = "9.2.2";
-
-  src = fetchFromGitHub {
-    owner = "mattermost";
-    repo = "mattermost";
-    rev = "v${version}";
-    hash = "sha256-53L2F20vaLLxtQS3DP/u0ZxLtnXHmjfcOMbXd4i+A6Y=";
-  } + "/server";
-
-  vendorHash = "sha256-v8aKZyb4emrwuIgSBDgla5wzwyt6PVGakbXjB9JVaCk=";
-
-  patches = [ ./0001-module-replace-public.patch ];
-
   subPackages = [ "cmd/mmctl" ];
 
-  checkPhase = "go test -tags unit -timeout 30m ./cmd/mmctl/...";
-
-  ldflags = [
-    "-s"
-    "-w"
-    "-X github.com/mattermost/mattermost/server/public/model.Version=${version}"
-    "-X github.com/mattermost/mattermost/server/public/model.BuildNumber=${version}-nixpkgs"
-    "-X github.com/mattermost/mattermost/server/public/model.BuildDate=1970-01-01"
-    "-X github.com/mattermost/mattermost/server/public/model.BuildHash=v${version}"
-    "-X github.com/mattermost/mattermost/server/public/model.BuildHashEnterprise=none"
-    "-X github.com/mattermost/mattermost/server/public/model.BuildEnterpriseReady=false"
-  ];
-
-  meta = with lib; {
+  meta = o.meta // {
     description = "A remote CLI tool for Mattermost";
-    homepage = "https://github.com/mattermost/mmctl";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ ppom mgdelacroix ];
     mainProgram = "mmctl";
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5986,11 +5986,7 @@ with pkgs;
 
   mlarchive2maildir = callPackage ../applications/networking/mailreaders/mlarchive2maildir { };
 
-  mmctl = callPackage ../tools/misc/mmctl {
-    # mmctl tests currently fail with go1.21. See
-    # https://mattermost.atlassian.net/browse/MM-55465
-    buildGoModule = buildGo120Module;
-  };
+  mmctl = callPackage ../tools/misc/mmctl { };
 
   moar = callPackage ../tools/misc/moar { };
 


### PR DESCRIPTION
## Description of changes

As per the discussion in https://github.com/NixOS/nixpkgs/pull/291409, this makes the `mmctl` package be an override on the `mattermost` package, as these were both moved by upstream [into the same monorepo](https://github.com/mattermost/mattermost) and now use the same build system. Nevertheless, it makes sense to keep them in separate packages, as the mmctl utility is usually used on a different machine than the mattermost server.

The package's meta information is retained as it was before, but the maintainer list of both packages was merged as maintaining them is now essentially the same task.

As a side effect of the above, this also updates `mmctl` from 9.2.2 to 9.5.1.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
