### PR TITLE
 nixos/sddm: allow running on wayland without xserver enabled 

### DIFF
--- a/nixos/doc/manual/configuration/modularity.section.md
+++ b/nixos/doc/manual/configuration/modularity.section.md
@@ -27,7 +27,7 @@ Here, we include two modules from the same directory, `vpn.nix` and
 { config, pkgs, ... }:
 
 { services.xserver.enable = true;
-  services.xserver.displayManager.sddm.enable = true;
+  services.displayManager.sddm.enable = true;
   services.xserver.desktopManager.plasma5.enable = true;
   environment.systemPackages = [ pkgs.vim ];
 }

--- a/nixos/doc/manual/configuration/profiles/demo.section.md
+++ b/nixos/doc/manual/configuration/profiles/demo.section.md
@@ -1,4 +1,4 @@
 # Demo {#sec-profile-demo}
 
 This profile just enables a `demo` user, with password `demo`, uid `1000`, `wheel` group and
-[autologin in the SDDM display manager](#opt-services.xserver.displayManager.autoLogin).
+[autologin in the SDDM display manager](#opt-services.displayManager.autoLogin).

--- a/nixos/doc/manual/configuration/profiles/graphical.section.md
+++ b/nixos/doc/manual/configuration/profiles/graphical.section.md
@@ -4,7 +4,7 @@ Defines a NixOS configuration with the Plasma 5 desktop. It's used by the
 graphical installation CD.
 
 It sets [](#opt-services.xserver.enable),
-[](#opt-services.xserver.displayManager.sddm.enable),
+[](#opt-services.displayManager.sddm.enable),
 [](#opt-services.xserver.desktopManager.plasma5.enable),
 and [](#opt-services.xserver.libinput.enable) to true. It also
 includes glxinfo and firefox in the system packages list.

--- a/nixos/doc/manual/configuration/x-windows.chapter.md
+++ b/nixos/doc/manual/configuration/x-windows.chapter.md
@@ -45,7 +45,7 @@ alternative one by picking one of the following lines:
 
 ```nix
 {
-  services.xserver.displayManager.sddm.enable = true;
+  services.displayManager.sddm.enable = true;
   services.xserver.displayManager.gdm.enable = true;
 }
 ```
@@ -99,7 +99,7 @@ your window manager, you'd define:
 
 ```nix
 {
-  services.xserver.displayManager.defaultSession = "none+i3";
+  services.displayManager.defaultSession = "none+i3";
 }
 ```
 
@@ -109,8 +109,8 @@ using lightdm for a user `alice`:
 ```nix
 {
   services.xserver.displayManager.lightdm.enable = true;
-  services.xserver.displayManager.autoLogin.enable = true;
-  services.xserver.displayManager.autoLogin.user = "alice";
+  services.displayManager.autoLogin.enable = true;
+  services.displayManager.autoLogin.user = "alice";
 }
 ```
 

--- a/nixos/doc/manual/configuration/xfce.chapter.md
+++ b/nixos/doc/manual/configuration/xfce.chapter.md
@@ -5,7 +5,7 @@ To enable the Xfce Desktop Environment, set
 ```nix
 {
   services.xserver.desktopManager.xfce.enable = true;
-  services.xserver.displayManager.defaultSession = "xfce";
+  services.displayManager.defaultSession = "xfce";
 }
 ```
 

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares-gnome.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares-gnome.nix
@@ -35,20 +35,19 @@
     QT_QPA_PLATFORM = "$([[ $XDG_SESSION_TYPE = \"wayland\" ]] && echo \"wayland\")";
   };
 
-  services.xserver.displayManager = {
-    gdm = {
-      enable = true;
-      # autoSuspend makes the machine automatically suspend after inactivity.
-      # It's possible someone could/try to ssh'd into the machine and obviously
-      # have issues because it's inactive.
-      # See:
-      # * https://github.com/NixOS/nixpkgs/pull/63790
-      # * https://gitlab.gnome.org/GNOME/gnome-control-center/issues/22
-      autoSuspend = false;
-    };
-    autoLogin = {
-      enable = true;
-      user = "nixos";
-    };
+  services.xserver.displayManager.gdm = {
+    enable = true;
+    # autoSuspend makes the machine automatically suspend after inactivity.
+    # It's possible someone could/try to ssh'd into the machine and obviously
+    # have issues because it's inactive.
+    # See:
+    # * https://github.com/NixOS/nixpkgs/pull/63790
+    # * https://gitlab.gnome.org/GNOME/gnome-control-center/issues/22
+    autoSuspend = false;
+  };
+
+  services.displayManager.autoLogin = {
+    enable = true;
+    user = "nixos";
   };
 }

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares-plasma5.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares-plasma5.nix
@@ -8,18 +8,16 @@
 
   isoImage.edition = "plasma5";
 
-  services.xserver = {
-    desktopManager.plasma5 = {
-      enable = true;
-    };
+  services.xserver.desktopManager.plasma5 = {
+    enable = true;
+  };
 
-    # Automatically login as nixos.
-    displayManager = {
-      sddm.enable = true;
-      autoLogin = {
-        enable = true;
-        user = "nixos";
-      };
+  # Automatically login as nixos.
+  services.displayManager = {
+    sddm.enable = true;
+    autoLogin = {
+      enable = true;
+      user = "nixos";
     };
   };
 

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares-plasma6.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares-plasma6.nix
@@ -7,16 +7,14 @@
 
   isoImage.edition = "plasma6";
 
-  services.xserver = {
-    desktopManager.plasma6.enable = true;
+  services.desktopManager.plasma6.enable = true;
 
-    # Automatically login as nixos.
-    displayManager = {
-      sddm.enable = true;
-      autoLogin = {
-        enable = true;
-        user = "nixos";
-      };
+  # Automatically login as nixos.
+  services.displayManager = {
+    sddm.enable = true;
+    autoLogin = {
+      enable = true;
+      user = "nixos";
     };
   };
 

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-gnome.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-gnome.nix
@@ -16,21 +16,19 @@
     enable = true;
   };
 
-  services.xserver.displayManager = {
-    gdm = {
-      enable = true;
-      # autoSuspend makes the machine automatically suspend after inactivity.
-      # It's possible someone could/try to ssh'd into the machine and obviously
-      # have issues because it's inactive.
-      # See:
-      # * https://github.com/NixOS/nixpkgs/pull/63790
-      # * https://gitlab.gnome.org/GNOME/gnome-control-center/issues/22
-      autoSuspend = false;
-    };
-    autoLogin = {
-      enable = true;
-      user = "nixos";
-    };
+  services.xserver.displayManager.gdm = {
+    enable = true;
+    # autoSuspend makes the machine automatically suspend after inactivity.
+    # It's possible someone could/try to ssh'd into the machine and obviously
+    # have issues because it's inactive.
+    # See:
+    # * https://github.com/NixOS/nixpkgs/pull/63790
+    # * https://gitlab.gnome.org/GNOME/gnome-control-center/issues/22
+    autoSuspend = false;
   };
 
+  services.displayManager.autoLogin = {
+    enable = true;
+    user = "nixos";
+  };
 }

--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-plasma5.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-plasma5.nix
@@ -8,18 +8,16 @@
 
   isoImage.edition = "plasma5";
 
-  services.xserver = {
-    desktopManager.plasma5 = {
-      enable = true;
-    };
+  services.xserver.desktopManager.plasma5 = {
+    enable = true;
+  };
 
-    # Automatically login as nixos.
-    displayManager = {
-      sddm.enable = true;
-      autoLogin = {
-        enable = true;
-        user = "nixos";
-      };
+  # Automatically login as nixos.
+  services.displayManager = {
+    sddm.enable = true;
+    autoLogin = {
+      enable = true;
+      user = "nixos";
     };
   };
 

--- a/nixos/modules/installer/virtualbox-demo.nix
+++ b/nixos/modules/installer/virtualbox-demo.nix
@@ -40,7 +40,7 @@ with lib;
   # If you prefer another desktop manager or display manager, you may want
   # to disable the default.
   # services.xserver.desktopManager.plasma5.enable = lib.mkForce false;
-  # services.xserver.displayManager.sddm.enable = lib.mkForce false;
+  # services.displayManager.sddm.enable = lib.mkForce false;
 
   # Enable GDM/GNOME by uncommenting above two lines and two lines below.
   # services.xserver.displayManager.gdm.enable = true;

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -508,6 +508,7 @@
   ./services/development/nixseparatedebuginfod.nix
   ./services/development/rstudio-server/default.nix
   ./services/development/zammad.nix
+  ./services/display-managers/default.nix
   ./services/display-managers/greetd.nix
   ./services/editors/emacs.nix
   ./services/editors/haste.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -510,6 +510,7 @@
   ./services/development/zammad.nix
   ./services/display-managers/default.nix
   ./services/display-managers/greetd.nix
+  ./services/display-managers/sddm.nix
   ./services/editors/emacs.nix
   ./services/editors/haste.nix
   ./services/editors/infinoted.nix
@@ -1445,7 +1446,6 @@
   ./services/x11/display-managers/default.nix
   ./services/x11/display-managers/gdm.nix
   ./services/x11/display-managers/lightdm.nix
-  ./services/x11/display-managers/sddm.nix
   ./services/x11/display-managers/slim.nix
   ./services/x11/display-managers/startx.nix
   ./services/x11/display-managers/sx.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -710,6 +710,7 @@
   ./services/misc/gogs.nix
   ./services/misc/gollum.nix
   ./services/misc/gpsd.nix
+  ./services/misc/graphical-desktop.nix
   ./services/misc/greenclip.nix
   ./services/misc/guix
   ./services/misc/headphones.nix

--- a/nixos/modules/programs/miriway.nix
+++ b/nixos/modules/programs/miriway.nix
@@ -71,7 +71,7 @@ in {
     programs.xwayland.enable = lib.mkDefault true;
 
     # To make the Miriway session available if a display manager like SDDM is enabled:
-    services.xserver.displayManager.sessionPackages = [ pkgs.miriway ];
+    services.displayManager.sessionPackages = [ pkgs.miriway ];
   };
 
   meta.maintainers = with lib.maintainers; [ OPNA2608 ];

--- a/nixos/modules/programs/steam.nix
+++ b/nixos/modules/programs/steam.nix
@@ -161,7 +161,7 @@ in {
     };
 
     programs.gamescope.enable = mkDefault cfg.gamescopeSession.enable;
-    services.xserver.displayManager.sessionPackages = mkIf cfg.gamescopeSession.enable [ gamescopeSessionFile ];
+    services.displayManager.sessionPackages = mkIf cfg.gamescopeSession.enable [ gamescopeSessionFile ];
 
     # optionally enable 32bit pulseaudio support if pulseaudio is enabled
     hardware.pulseaudio.support32Bit = config.hardware.pulseaudio.enable;

--- a/nixos/modules/programs/wayland/cardboard.nix
+++ b/nixos/modules/programs/wayland/cardboard.nix
@@ -17,7 +17,7 @@ in
       environment.systemPackages = [ cfg.package ];
 
       # To make a cardboard session available for certain DMs like SDDM
-      services.xserver.displayManager.sessionPackages = [ cfg.package ];
+      services.displayManager.sessionPackages = [ cfg.package ];
     }
     (import ./wayland-session.nix { inherit lib pkgs; })
   ]);

--- a/nixos/modules/programs/wayland/hyprland.nix
+++ b/nixos/modules/programs/wayland/hyprland.nix
@@ -66,7 +66,7 @@ in
 
     security.polkit.enable = true;
 
-    services.xserver.displayManager.sessionPackages = [ cfg.finalPackage ];
+    services.displayManager.sessionPackages = [ cfg.finalPackage ];
 
     xdg.portal = {
       enable = mkDefault true;

--- a/nixos/modules/programs/wayland/labwc.nix
+++ b/nixos/modules/programs/wayland/labwc.nix
@@ -18,7 +18,7 @@ in
       xdg.portal.config.wlroots.default = lib.mkDefault [ "wlr" "gtk" ];
 
       # To make a labwc session available for certain DMs like SDDM
-      services.xserver.displayManager.sessionPackages = [ cfg.package ];
+      services.displayManager.sessionPackages = [ cfg.package ];
     }
     (import ./wayland-session.nix { inherit lib pkgs; })
   ]);

--- a/nixos/modules/programs/wayland/river.nix
+++ b/nixos/modules/programs/wayland/river.nix
@@ -47,7 +47,7 @@ in {
         environment.systemPackages = optional (cfg.package != null) cfg.package ++ cfg.extraPackages;
 
         # To make a river session available if a display manager like SDDM is enabled:
-        services.xserver.displayManager.sessionPackages = optionals (cfg.package != null) [ cfg.package ];
+        services.displayManager.sessionPackages = optionals (cfg.package != null) [ cfg.package ];
 
         # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1050913
         xdg.portal.config.river.default = mkDefault [ "wlr" "gtk" ];

--- a/nixos/modules/programs/wayland/sway.nix
+++ b/nixos/modules/programs/wayland/sway.nix
@@ -174,7 +174,7 @@ in {
         xdg.portal.config.sway.default = mkDefault [ "wlr" "gtk" ];
 
         # To make a Sway session available if a display manager like SDDM is enabled:
-        services.xserver.displayManager.sessionPackages = optionals (cfg.package != null) [ cfg.package ]; }
+        services.displayManager.sessionPackages = optionals (cfg.package != null) [ cfg.package ]; }
       (import ./wayland-session.nix { inherit lib pkgs; })
     ]);
 

--- a/nixos/modules/programs/wayland/wayfire.nix
+++ b/nixos/modules/programs/wayland/wayfire.nix
@@ -38,7 +38,7 @@ in
       finalPackage
     ];
 
-    services.xserver.displayManager.sessionPackages = [ finalPackage ];
+    services.displayManager.sessionPackages = [ finalPackage ];
 
     xdg.portal = {
       enable = lib.mkDefault true;

--- a/nixos/modules/rename.nix
+++ b/nixos/modules/rename.nix
@@ -93,7 +93,7 @@ in
       The services.xserver.displayManager.auto module has been removed
       because it was only intended for use in internal NixOS tests, and gave the
       false impression of it being a special display manager when it's actually
-      LightDM. Please use the services.xserver.displayManager.autoLogin options
+      LightDM. Please use the services.displayManager.autoLogin options
       instead, or any other display manager in NixOS as they all support auto-login.
     '')
     (mkRemovedOptionModule [ "services" "xserver" "multitouch" ] ''

--- a/nixos/modules/services/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/desktop-managers/plasma6.nix
@@ -246,11 +246,11 @@ in {
     xdg.portal.configPackages = mkDefault [kdePackages.xdg-desktop-portal-kde];
     services.pipewire.enable = mkDefault true;
 
-    services.xserver.displayManager = {
+    services.displayManager = {
       sessionPackages = [kdePackages.plasma-workspace];
       defaultSession = mkDefault "plasma";
     };
-    services.xserver.displayManager.sddm = {
+    services.displayManager.sddm = {
       package = kdePackages.sddm;
       theme = mkDefault "breeze";
       wayland.compositor = "kwin";

--- a/nixos/modules/services/display-managers/default.nix
+++ b/nixos/modules/services/display-managers/default.nix
@@ -121,7 +121,7 @@ in
           check = d:
             lib.assertMsg (d != null -> (lib.types.str.check d && lib.elem d config.services.displayManager.sessionData.sessionNames)) ''
                 Default graphical session, '${d}', not found.
-                Valid names for 'services.xserver.displayManager.defaultSession' are:
+                Valid names for 'services.displayManager.defaultSession' are:
                   ${lib.concatStringsSep "\n  " cfg.displayManager.sessionData.sessionNames}
               '';
         };
@@ -226,7 +226,7 @@ in
     systemd.services.display-manager.enable =
       let dmConf = config.services.xserver.displayManager;
           noDmUsed = !(dmConf.gdm.enable
-                    || dmConf.sddm.enable
+                    || cfg.sddm.enable
                     || dmConf.xpra.enable
                     || dmConf.lightdm.enable);
       in lib.mkIf noDmUsed (lib.mkDefault false);

--- a/nixos/modules/services/display-managers/default.nix
+++ b/nixos/modules/services/display-managers/default.nix
@@ -1,0 +1,257 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.displayManager;
+
+  installedSessions = pkgs.runCommand "desktops"
+    { # trivial derivation
+      preferLocalBuild = true;
+      allowSubstitutes = false;
+    }
+    ''
+      mkdir -p "$out/share/"{xsessions,wayland-sessions}
+
+      ${lib.concatMapStrings (pkg: ''
+        for n in ${lib.concatStringsSep " " pkg.providedSessions}; do
+          if ! test -f ${pkg}/share/wayland-sessions/$n.desktop -o \
+                    -f ${pkg}/share/xsessions/$n.desktop; then
+            echo "Couldn't find provided session name, $n.desktop, in session package ${pkg.name}:"
+            echo "  ${pkg}"
+            return 1
+          fi
+        done
+
+        if test -d ${pkg}/share/xsessions; then
+          ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${pkg}/share/xsessions $out/share/xsessions
+        fi
+        if test -d ${pkg}/share/wayland-sessions; then
+          ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${pkg}/share/wayland-sessions $out/share/wayland-sessions
+        fi
+      '') cfg.sessionPackages}
+    '';
+
+  dmDefault = config.services.xserver.desktopManager.default;
+  # fallback default for cases when only default wm is set
+  dmFallbackDefault = if dmDefault != null then dmDefault else "none";
+  wmDefault = config.services.xserver.windowManager.default;
+  defaultSessionFromLegacyOptions = dmFallbackDefault + lib.optionalString (wmDefault != null && wmDefault != "none") "+${wmDefault}";
+in
+{
+  options = {
+    services.displayManager = {
+      enable = lib.mkEnableOption "systemd's display-manager service";
+
+      preStart = lib.mkOption {
+        type = lib.types.lines;
+        default = "";
+        example = "rm -f /var/log/my-display-manager.log";
+        description = lib.mdDoc "Script executed before the display manager is started.";
+      };
+
+      execCmd = lib.mkOption {
+        type = lib.types.str;
+        example = lib.literalExpression ''"''${pkgs.lightdm}/bin/lightdm"'';
+        description = lib.mdDoc "Command to start the display manager.";
+      };
+
+      environment = lib.mkOption {
+        type = with lib.types; attrsOf unspecified;
+        default = {};
+        description = lib.mdDoc "Additional environment variables needed by the display manager.";
+      };
+
+      hiddenUsers = lib.mkOption {
+        type = with lib.types; listOf str;
+        default = [ "nobody" ];
+        description = lib.mdDoc ''
+          A list of users which will not be shown in the display manager.
+        '';
+      };
+
+      logToFile = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = lib.mdDoc ''
+          Whether the display manager redirects the output of the
+          session script to {file}`~/.xsession-errors`.
+        '';
+      };
+
+      logToJournal = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = lib.mdDoc ''
+          Whether the display manager redirects the output of the
+          session script to the systemd journal.
+        '';
+      };
+
+      # Configuration for automatic login. Common for all DM.
+      autoLogin = lib.mkOption {
+        type = lib.types.submodule ({ config, options, ... }: {
+          options = {
+            enable = lib.mkOption {
+              type = lib.types.bool;
+              default = config.user != null;
+              defaultText = lib.literalExpression "config.${options.user} != null";
+              description = lib.mdDoc ''
+                Automatically log in as {option}`autoLogin.user`.
+              '';
+            };
+
+            user = lib.mkOption {
+              type = with lib.types; nullOr str;
+              default = null;
+              description = lib.mdDoc ''
+                User to be used for the automatic login.
+              '';
+            };
+          };
+        });
+
+        default = {};
+        description = lib.mdDoc ''
+          Auto login configuration attrset.
+        '';
+      };
+
+      defaultSession = lib.mkOption {
+        type = lib.types.nullOr lib.types.str // {
+          description = "session name";
+          check = d:
+            lib.assertMsg (d != null -> (lib.types.str.check d && lib.elem d config.services.displayManager.sessionData.sessionNames)) ''
+                Default graphical session, '${d}', not found.
+                Valid names for 'services.xserver.displayManager.defaultSession' are:
+                  ${lib.concatStringsSep "\n  " cfg.displayManager.sessionData.sessionNames}
+              '';
+        };
+        default =
+          if dmDefault != null || wmDefault != null then
+            defaultSessionFromLegacyOptions
+          else
+            null;
+        defaultText = lib.literalMD ''
+          Taken from display manager settings or window manager settings, if either is set.
+        '';
+        example = "gnome";
+        description = lib.mdDoc ''
+          Graphical session to pre-select in the session chooser (only effective for GDM, LightDM and SDDM).
+
+          On GDM, LightDM and SDDM, it will also be used as a session for auto-login.
+        '';
+      };
+
+      sessionData = lib.mkOption {
+        description = lib.mdDoc "Data exported for display managers’ convenience";
+        internal = true;
+        default = {};
+      };
+
+      sessionPackages = lib.mkOption {
+        type = lib.types.listOf (lib.types.package // {
+          description = "package with provided sessions";
+          check = p: lib.assertMsg
+            (lib.types.package.check p && p ? providedSessions
+            && p.providedSessions != [] && lib.all lib.isString p.providedSessions)
+            ''
+              Package, '${p.name}', did not specify any session names, as strings, in
+              'passthru.providedSessions'. This is required when used as a session package.
+
+              The session names can be looked up in:
+                ${p}/share/xsessions
+                ${p}/share/wayland-sessions
+           '';
+        });
+        default = [];
+        description = lib.mdDoc ''
+          A list of packages containing x11 or wayland session files to be passed to the display manager.
+        '';
+      };
+    };
+  };
+
+  imports = [
+    (lib.mkRenamedOptionModule [ "services" "xserver" "displayManager" "autoLogin" ] [ "services" "displayManager" "autoLogin" ])
+    (lib.mkRenamedOptionModule [ "services" "xserver" "displayManager" "defaultSession" ] [ "services" "displayManager" "defaultSession" ])
+    (lib.mkRenamedOptionModule [ "services" "xserver" "displayManager" "job" "environment" ] [ "services" "displayManager" "environment" ])
+    (lib.mkRenamedOptionModule [ "services" "xserver" "displayManager" "job" "execCmd" ] [ "services" "displayManager" "execCmd" ])
+    (lib.mkRenamedOptionModule [ "services" "xserver" "displayManager" "job" "logToFile" ] [ "services" "displayManager" "logToFile" ])
+    (lib.mkRenamedOptionModule [ "services" "xserver" "displayManager" "job" "logToJournal" ] [ "services" "displayManager" "logToJournal" ])
+    (lib.mkRenamedOptionModule [ "services" "xserver" "displayManager" "job" "preStart" ] [ "services" "displayManager" "preStart" ])
+  ];
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      { assertion = cfg.autoLogin.enable -> cfg.autoLogin.user != null;
+        message = ''
+          services.displayManager.autoLogin.enable requires services.displayManager.autoLogin.user to be set
+        '';
+      }
+    ];
+
+    warnings =
+      lib.mkIf (dmDefault != null || wmDefault != null) [
+        ''
+          The following options are deprecated:
+            ${lib.concatStringsSep "\n  " (map ({c, t}: t) (lib.filter ({c, t}: c != null) [
+            { c = dmDefault; t = "- services.xserver.desktopManager.default"; }
+            { c = wmDefault; t = "- services.xserver.windowManager.default"; }
+            ]))}
+          Please use
+            services.displayManager.defaultSession = "${defaultSessionFromLegacyOptions}";
+          instead.
+        ''
+      ];
+
+    # Make xsessions and wayland sessions available in XDG_DATA_DIRS
+    # as some programs have behavior that depends on them being present
+    environment.sessionVariables.XDG_DATA_DIRS = lib.mkIf (cfg.sessionPackages != [ ]) [
+      "${cfg.sessionData.desktops}/share"
+    ];
+
+    services.displayManager.sessionData = {
+      desktops = installedSessions;
+      sessionNames = lib.concatMap (p: p.providedSessions) config.services.displayManager.sessionPackages;
+      # We do not want to force users to set defaultSession when they have only single DE.
+      autologinSession =
+        if cfg.defaultSession != null then
+          cfg.defaultSession
+        else if cfg.sessionData.sessionNames != [] then
+          lib.head cfg.sessionData.sessionNames
+        else
+          null;
+    };
+
+    # so that the service won't be enabled when only startx is used
+    systemd.services.display-manager.enable =
+      let dmConf = config.services.xserver.displayManager;
+          noDmUsed = !(dmConf.gdm.enable
+                    || dmConf.sddm.enable
+                    || dmConf.xpra.enable
+                    || dmConf.lightdm.enable);
+      in lib.mkIf noDmUsed (lib.mkDefault false);
+
+    systemd.services.display-manager = {
+      description = "Display Manager";
+      after = [ "acpid.service" "systemd-logind.service" "systemd-user-sessions.service" ];
+      restartIfChanged = false;
+
+      environment = lib.optionalAttrs config.hardware.opengl.setLdLibraryPath {
+        LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.addOpenGLRunpath.driverLink ];
+      } // cfg.environment;
+
+      preStart = cfg.preStart;
+      script = lib.mkIf (config.systemd.services.display-manager.enable == true) cfg.execCmd;
+
+      # Stop restarting if the display manager stops (crashes) 2 times
+      # in one minute. Starting X typically takes 3-4s.
+      startLimitIntervalSec = 30;
+      startLimitBurst = 3;
+      serviceConfig = {
+        Restart = "always";
+        RestartSec = "200ms";
+        SyslogIdentifier = "display-manager";
+      };
+    };
+  };
+}

--- a/nixos/modules/services/display-managers/sddm.nix
+++ b/nixos/modules/services/display-managers/sddm.nix
@@ -281,9 +281,9 @@ in
 
     assertions = [
       {
-        assertion = xcfg.enable;
+        assertion = xcfg.enable || cfg.wayland.enable;
         message = ''
-          SDDM requires services.xserver.enable to be true
+          SDDM requires either services.xserver.enable or services.xserver.displayManager.sddm.wayland.enable to be true
         '';
       }
       {

--- a/nixos/modules/services/display-managers/sddm.nix
+++ b/nixos/modules/services/display-managers/sddm.nix
@@ -3,7 +3,7 @@
 let
   xcfg = config.services.xserver;
   dmcfg = xcfg.displayManager;
-  cfg = dmcfg.sddm;
+  cfg = config.services.displayManager.sddm;
   xEnv = config.systemd.services.display-manager.environment;
 
   sddm = cfg.package.override (old: {
@@ -128,6 +128,19 @@ let
 in
 {
   imports = [
+    (mkRenamedOptionModule [ "services" "xserver" "displayManager" "sddm" "autoLogin" "minimumUid" ] [ "services" "displayManager" "sddm" "autoLogin" "minimumUid" ])
+    (mkRenamedOptionModule [ "services" "xserver" "displayManager" "sddm" "autoLogin" "relogin" ] [ "services" "displayManager" "sddm" "autoLogin" "relogin" ])
+    (mkRenamedOptionModule [ "services" "xserver" "displayManager" "sddm" "autoNumlock" ] [ "services" "displayManager" "sddm" "autoNumlock" ])
+    (mkRenamedOptionModule [ "services" "xserver" "displayManager" "sddm" "enable" ]      [ "services" "displayManager" "sddm" "enable" ])
+    (mkRenamedOptionModule [ "services" "xserver" "displayManager" "sddm" "enableHidpi" ] [ "services" "displayManager" "sddm" "enableHidpi" ])
+    (mkRenamedOptionModule [ "services" "xserver" "displayManager" "sddm" "extraPackages" ] [ "services" "displayManager" "sddm" "extraPackages" ])
+    (mkRenamedOptionModule [ "services" "xserver" "displayManager" "sddm" "package" ]     [ "services" "displayManager" "sddm" "package" ])
+    (mkRenamedOptionModule [ "services" "xserver" "displayManager" "sddm" "settings" ]    [ "services" "displayManager" "sddm" "settings" ])
+    (mkRenamedOptionModule [ "services" "xserver" "displayManager" "sddm" "setupScript" ] [ "services" "displayManager" "sddm" "setupScript" ])
+    (mkRenamedOptionModule [ "services" "xserver" "displayManager" "sddm" "stopScript" ]  [ "services" "displayManager" "sddm" "stopScript" ])
+    (mkRenamedOptionModule [ "services" "xserver" "displayManager" "sddm" "theme" ]       [ "services" "displayManager" "sddm" "theme" ])
+    (mkRenamedOptionModule [ "services" "xserver" "displayManager" "sddm" "wayland" "enable" ] [ "services" "displayManager" "sddm" "wayland" "enable" ])
+
     (mkRemovedOptionModule
       [ "services" "displayManager" "sddm" "themes" ]
       "Set the option `services.displayManager.sddm.package' instead.")
@@ -144,7 +157,7 @@ in
 
   options = {
 
-    services.xserver.displayManager.sddm = {
+    services.displayManager.sddm = {
       enable = mkOption {
         type = types.bool;
         default = false;
@@ -281,7 +294,10 @@ in
       }
     ];
 
-    services.displayManager.execCmd = "exec /run/current-system/sw/bin/sddm";
+    services.displayManager = {
+      enable = true;
+      execCmd = "exec /run/current-system/sw/bin/sddm";
+    };
 
     security.pam.services = {
       sddm.text = ''
@@ -340,7 +356,6 @@ in
     services = {
       dbus.packages = [ sddm ];
       xserver = {
-        displayManager.job.execCmd = "exec /run/current-system/sw/bin/sddm";
         # To enable user switching, allow sddm to allocate TTYs/displays dynamically.
         tty = null;
         display = null;

--- a/nixos/modules/services/misc/graphical-desktop.nix
+++ b/nixos/modules/services/misc/graphical-desktop.nix
@@ -1,0 +1,54 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  xcfg = config.services.xserver;
+  dmcfg = config.services.displayManager;
+in
+{
+  config = lib.mkIf (xcfg.enable || dmcfg.enable) {
+    # The default max inotify watches is 8192.
+    # Nowadays most apps require a good number of inotify watches,
+    # the value below is used by default on several other distros.
+    boot.kernel.sysctl = {
+      "fs.inotify.max_user_instances" = lib.mkDefault 524288;
+      "fs.inotify.max_user_watches" = lib.mkDefault 524288;
+    };
+
+    environment = {
+      # localectl looks into 00-keyboard.conf
+      etc."X11/xorg.conf.d/00-keyboard.conf".text = ''
+        Section "InputClass"
+          Identifier "Keyboard catchall"
+          MatchIsKeyboard "on"
+          Option "XkbModel" "${xcfg.xkb.model}"
+          Option "XkbLayout" "${xcfg.xkb.layout}"
+          Option "XkbOptions" "${xcfg.xkb.options}"
+          Option "XkbVariant" "${xcfg.xkb.variant}"
+        EndSection
+      '';
+      systemPackages = with pkgs; [
+        nixos-icons # needed for gnome and pantheon about dialog, nixos-manual and maybe more
+        xdg-utils
+      ];
+    };
+
+    fonts.enableDefaultPackages = lib.mkDefault true;
+
+    hardware.opengl.enable = lib.mkDefault true;
+
+    programs.gnupg.agent.pinentryPackage = lib.mkOverride 1100 pkgs.pinentry-gnome3;
+
+    systemd.defaultUnit = lib.mkIf (xcfg.autorun || dmcfg.enable) "graphical.target";
+
+    xdg = {
+      autostart.enable = true;
+      menus.enable = true;
+      mime.enable = true;
+      icons.enable = true;
+    };
+  };
+}

--- a/nixos/modules/services/system/nix-daemon.nix
+++ b/nixos/modules/services/system/nix-daemon.nix
@@ -247,7 +247,7 @@ in
 
     users.users = nixbldUsers;
 
-    services.xserver.displayManager.hiddenUsers = attrNames nixbldUsers;
+    services.displayManager.hiddenUsers = attrNames nixbldUsers;
 
     # Legacy configuration conversion.
     nix.settings = mkMerge [

--- a/nixos/modules/services/x11/desktop-managers/budgie.nix
+++ b/nixos/modules/services/x11/desktop-managers/budgie.nix
@@ -91,7 +91,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    services.xserver.displayManager.sessionPackages = with pkgs; [
+    services.displayManager.sessionPackages = with pkgs; [
       budgie.budgie-desktop
     ];
 

--- a/nixos/modules/services/x11/desktop-managers/cinnamon.nix
+++ b/nixos/modules/services/x11/desktop-managers/cinnamon.nix
@@ -60,7 +60,7 @@ in
 
   config = mkMerge [
     (mkIf cfg.enable {
-      services.xserver.displayManager.sessionPackages = [ pkgs.cinnamon.cinnamon-common ];
+      services.displayManager.sessionPackages = [ pkgs.cinnamon.cinnamon-common ];
 
       services.xserver.displayManager.lightdm.greeters.slick = {
         enable = mkDefault true;

--- a/nixos/modules/services/x11/desktop-managers/deepin.nix
+++ b/nixos/modules/services/x11/desktop-managers/deepin.nix
@@ -38,8 +38,8 @@ in
 
   config = mkIf cfg.enable
     {
-      services.xserver.displayManager.sessionPackages = [ pkgs.deepin.dde-session ];
-      services.xserver.displayManager.defaultSession = mkDefault "dde-x11";
+      services.displayManager.sessionPackages = [ pkgs.deepin.dde-session ];
+      services.displayManager.defaultSession = mkDefault "dde-x11";
 
       # Update the DBus activation environment after launching the desktop manager.
       services.xserver.displayManager.sessionCommands = ''

--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -87,7 +87,7 @@ in
         default = null;
         example = "none";
         description = lib.mdDoc ''
-          **Deprecated**, please use [](#opt-services.xserver.displayManager.defaultSession) instead.
+          **Deprecated**, please use [](#opt-services.displayManager.defaultSession) instead.
 
           Default desktop manager loaded if none have been chosen.
         '';

--- a/nixos/modules/services/x11/desktop-managers/enlightenment.nix
+++ b/nixos/modules/services/x11/desktop-managers/enlightenment.nix
@@ -54,7 +54,7 @@ in
       "/share/locale"
     ];
 
-    services.xserver.displayManager.sessionPackages = [ pkgs.enlightenment.enlightenment ];
+    services.displayManager.sessionPackages = [ pkgs.enlightenment.enlightenment ];
 
     services.xserver.displayManager.sessionCommands = ''
       if test "$XDG_CURRENT_DESKTOP" = "Enlightenment"; then

--- a/nixos/modules/services/x11/desktop-managers/gnome.nix
+++ b/nixos/modules/services/x11/desktop-managers/gnome.nix
@@ -261,7 +261,7 @@ in
       services.gnome.core-shell.enable = true;
       services.gnome.core-utilities.enable = mkDefault true;
 
-      services.xserver.displayManager.sessionPackages = [ pkgs.gnome.gnome-session.sessions ];
+      services.displayManager.sessionPackages = [ pkgs.gnome.gnome-session.sessions ];
 
       environment.extraInit = ''
         ${concatMapStrings (p: ''
@@ -285,7 +285,7 @@ in
     })
 
     (mkIf flashbackEnabled {
-      services.xserver.displayManager.sessionPackages =
+      services.displayManager.sessionPackages =
         let
           wmNames = map (wm: wm.wmName) flashbackWms;
           namesAreUnique = lib.unique wmNames == wmNames;

--- a/nixos/modules/services/x11/desktop-managers/lumina.nix
+++ b/nixos/modules/services/x11/desktop-managers/lumina.nix
@@ -27,7 +27,7 @@ in
 
   config = mkIf cfg.enable {
 
-    services.xserver.displayManager.sessionPackages = [
+    services.displayManager.sessionPackages = [
       pkgs.lumina.lumina
     ];
 

--- a/nixos/modules/services/x11/desktop-managers/mate.nix
+++ b/nixos/modules/services/x11/desktop-managers/mate.nix
@@ -49,7 +49,7 @@ in
 
   config = mkMerge [
     (mkIf (cfg.enable || cfg.enableWaylandSession) {
-      services.xserver.displayManager.sessionPackages = [
+      services.displayManager.sessionPackages = [
         pkgs.mate.mate-session-manager
       ];
 
@@ -103,7 +103,7 @@ in
       environment.sessionVariables.NIX_GSETTINGS_OVERRIDES_DIR = "${pkgs.mate.mate-gsettings-overrides}/share/gsettings-schemas/nixos-gsettings-overrides/glib-2.0/schemas";
 
       environment.systemPackages = [ pkgs.mate.mate-wayland-session ];
-      services.xserver.displayManager.sessionPackages = [ pkgs.mate.mate-wayland-session ];
+      services.displayManager.sessionPackages = [ pkgs.mate.mate-wayland-session ];
     })
   ];
 }

--- a/nixos/modules/services/x11/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.nix
@@ -96,7 +96,7 @@ in
         pkgs.pantheon.pantheon-agent-geoclue2
       ] config.environment.pantheon.excludePackages;
 
-      services.xserver.displayManager.sessionPackages = [ pkgs.pantheon.elementary-session-settings ];
+      services.displayManager.sessionPackages = [ pkgs.pantheon.elementary-session-settings ];
 
       # Ensure lightdm is used when Pantheon is enabled
       # Without it screen locking will be nonfunctional because of the use of lightlocker
@@ -109,7 +109,7 @@ in
 
       # Without this, elementary LightDM greeter will pre-select non-existent `default` session
       # https://github.com/elementary/greeter/issues/368
-      services.xserver.displayManager.defaultSession = mkDefault "pantheon";
+      services.displayManager.defaultSession = mkDefault "pantheon";
 
       services.xserver.displayManager.sessionCommands = ''
         if test "$XDG_CURRENT_DESKTOP" = "Pantheon"; then

--- a/nixos/modules/services/x11/desktop-managers/phosh.nix
+++ b/nixos/modules/services/x11/desktop-managers/phosh.nix
@@ -220,7 +220,7 @@ in
 
     services.gnome.core-shell.enable = true;
     services.gnome.core-os-services.enable = true;
-    services.xserver.displayManager.sessionPackages = [ cfg.package ];
+    services.displayManager.sessionPackages = [ cfg.package ];
 
     environment.etc."phosh/phoc.ini".source =
       if builtins.isPath cfg.phocConfig then cfg.phocConfig

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -357,7 +357,7 @@ in
         pkgs.media-player-info
       ];
 
-      services.xserver.displayManager.sddm = {
+      services.displayManager.sddm = {
         theme = mkDefault "breeze";
       };
 
@@ -403,16 +403,16 @@ in
       system.nixos-generate-config.desktopConfiguration = [
         ''
           # Enable the Plasma 5 Desktop Environment.
-          services.xserver.displayManager.sddm.enable = true;
+          services.displayManager.sddm.enable = true;
           services.xserver.desktopManager.plasma5.enable = true;
         ''
       ];
 
-      services.xserver.displayManager.sessionPackages = [ pkgs.plasma5Packages.plasma-workspace ];
+      services.displayManager.sessionPackages = [ pkgs.plasma5Packages.plasma-workspace ];
       # Default to be `plasma` (X11) instead of `plasmawayland`, since plasma wayland currently has
       # many tiny bugs.
       # See: https://github.com/NixOS/nixpkgs/issues/143272
-      services.xserver.displayManager.defaultSession = mkDefault "plasma";
+      services.displayManager.defaultSession = mkDefault "plasma";
 
       environment.systemPackages =
         with pkgs.plasma5Packages;
@@ -538,7 +538,7 @@ in
         };
       };
 
-      services.xserver.displayManager.sessionPackages = [ pkgs.plasma5Packages.plasma-mobile ];
+      services.displayManager.sessionPackages = [ pkgs.plasma5Packages.plasma-mobile ];
     })
 
     # Plasma Bigscreen
@@ -559,7 +559,7 @@ in
           kdeconnect-kde
         ];
 
-      services.xserver.displayManager.sessionPackages = [ pkgs.plasma5Packages.plasma-bigscreen ];
+      services.displayManager.sessionPackages = [ pkgs.plasma5Packages.plasma-bigscreen ];
 
       # required for plasma-remotecontrollers to work correctly
       hardware.uinput.enable = true;

--- a/nixos/modules/services/x11/desktop-managers/surf-display.nix
+++ b/nixos/modules/services/x11/desktop-managers/surf-display.nix
@@ -119,7 +119,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    services.xserver.displayManager.sessionPackages = [
+    services.displayManager.sessionPackages = [
       pkgs.surf-display
     ];
 

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -69,14 +69,14 @@ let
           source ~/.xprofile
       fi
 
-      ${optionalString cfg.displayManager.job.logToJournal ''
+      ${optionalString config.services.displayManager.logToJournal ''
         if [ -z "$_DID_SYSTEMD_CAT" ]; then
           export _DID_SYSTEMD_CAT=1
           exec ${config.systemd.package}/bin/systemd-cat -t xsession "$0" "$@"
         fi
       ''}
 
-      ${optionalString cfg.displayManager.job.logToFile ''
+      ${optionalString config.services.displayManager.logToFile ''
         exec &> >(tee ~/.xsession-errors)
       ''}
 
@@ -225,7 +225,7 @@ in
     assertions = [
       {
         assertion = cfg.desktopManager.default != null || cfg.windowManager.default != null -> cfg.displayManager.defaultSession == defaultSessionFromLegacyOptions;
-        message = "You cannot use both services.xserver.displayManager.defaultSession option and legacy options (services.xserver.desktopManager.default and services.xserver.windowManager.default).";
+        message = "You cannot use both services.displayManager.defaultSession option and legacy options (services.xserver.desktopManager.default and services.xserver.windowManager.default).";
       }
     ];
 

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -14,7 +14,6 @@ with lib;
 let
 
   cfg = config.services.xserver;
-  opt = options.services.xserver;
   xorg = pkgs.xorg;
 
   fontconfig = config.fonts.fontconfig;
@@ -130,41 +129,6 @@ let
           exit 1
       fi
     '';
-
-  installedSessions = pkgs.runCommand "desktops"
-    { # trivial derivation
-      preferLocalBuild = true;
-      allowSubstitutes = false;
-    }
-    ''
-      mkdir -p "$out/share/"{xsessions,wayland-sessions}
-
-      ${concatMapStrings (pkg: ''
-        for n in ${concatStringsSep " " pkg.providedSessions}; do
-          if ! test -f ${pkg}/share/wayland-sessions/$n.desktop -o \
-                    -f ${pkg}/share/xsessions/$n.desktop; then
-            echo "Couldn't find provided session name, $n.desktop, in session package ${pkg.name}:"
-            echo "  ${pkg}"
-            return 1
-          fi
-        done
-
-        if test -d ${pkg}/share/xsessions; then
-          ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${pkg}/share/xsessions $out/share/xsessions
-        fi
-        if test -d ${pkg}/share/wayland-sessions; then
-          ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${pkg}/share/wayland-sessions $out/share/wayland-sessions
-        fi
-      '') cfg.displayManager.sessionPackages}
-    '';
-
-  dmDefault = cfg.desktopManager.default;
-  # fallback default for cases when only default wm is set
-  dmFallbackDefault = if dmDefault != null then dmDefault else "none";
-  wmDefault = cfg.windowManager.default;
-
-  defaultSessionFromLegacyOptions = dmFallbackDefault + optionalString (wmDefault != null && wmDefault != "none") "+${wmDefault}";
-
 in
 
 {
@@ -215,35 +179,6 @@ in
         '';
       };
 
-      hiddenUsers = mkOption {
-        type = types.listOf types.str;
-        default = [ "nobody" ];
-        description = lib.mdDoc ''
-          A list of users which will not be shown in the display manager.
-        '';
-      };
-
-      sessionPackages = mkOption {
-        type = with types; listOf (package // {
-          description = "package with provided sessions";
-          check = p: assertMsg
-            (package.check p && p ? providedSessions
-            && p.providedSessions != [] && all isString p.providedSessions)
-            ''
-              Package, '${p.name}', did not specify any session names, as strings, in
-              'passthru.providedSessions'. This is required when used as a session package.
-
-              The session names can be looked up in:
-                ${p}/share/xsessions
-                ${p}/share/wayland-sessions
-           '';
-        });
-        default = [];
-        description = lib.mdDoc ''
-          A list of packages containing x11 or wayland session files to be passed to the display manager.
-        '';
-      };
-
       session = mkOption {
         default = [];
         type = types.listOf types.attrs;
@@ -274,126 +209,11 @@ in
         '';
       };
 
-      sessionData = mkOption {
-        description = lib.mdDoc "Data exported for display managers’ convenience";
-        internal = true;
-        default = {};
-        apply = val: {
-          wrapper = xsessionWrapper;
-          desktops = installedSessions;
-          sessionNames = concatMap (p: p.providedSessions) cfg.displayManager.sessionPackages;
-          # We do not want to force users to set defaultSession when they have only single DE.
-          autologinSession =
-            if cfg.displayManager.defaultSession != null then
-              cfg.displayManager.defaultSession
-            else if cfg.displayManager.sessionData.sessionNames != [] then
-              head cfg.displayManager.sessionData.sessionNames
-            else
-              null;
-        };
-      };
-
-      defaultSession = mkOption {
-        type = with types; nullOr str // {
-          description = "session name";
-          check = d:
-            assertMsg (d != null -> (str.check d && elem d cfg.displayManager.sessionData.sessionNames)) ''
-                Default graphical session, '${d}', not found.
-                Valid names for 'services.xserver.displayManager.defaultSession' are:
-                  ${concatStringsSep "\n  " cfg.displayManager.sessionData.sessionNames}
-              '';
-        };
-        default =
-          if dmDefault != null || wmDefault != null then
-            defaultSessionFromLegacyOptions
-          else
-            null;
-        defaultText = literalMD ''
-          Taken from display manager settings or window manager settings, if either is set.
-        '';
-        example = "gnome";
-        description = lib.mdDoc ''
-          Graphical session to pre-select in the session chooser (only effective for GDM, LightDM and SDDM).
-
-          On GDM, LightDM and SDDM, it will also be used as a session for auto-login.
-        '';
-      };
-
       importedVariables = mkOption {
         type = types.listOf (types.strMatching "[a-zA-Z_][a-zA-Z0-9_]*");
         visible = false;
         description = lib.mdDoc ''
           Environment variables to import into the systemd user environment.
-        '';
-      };
-
-      job = {
-
-        preStart = mkOption {
-          type = types.lines;
-          default = "";
-          example = "rm -f /var/log/my-display-manager.log";
-          description = lib.mdDoc "Script executed before the display manager is started.";
-        };
-
-        execCmd = mkOption {
-          type = types.str;
-          example = literalExpression ''"''${pkgs.lightdm}/bin/lightdm"'';
-          description = lib.mdDoc "Command to start the display manager.";
-        };
-
-        environment = mkOption {
-          type = types.attrsOf types.unspecified;
-          default = {};
-          description = lib.mdDoc "Additional environment variables needed by the display manager.";
-        };
-
-        logToFile = mkOption {
-          type = types.bool;
-          default = false;
-          description = lib.mdDoc ''
-            Whether the display manager redirects the output of the
-            session script to {file}`~/.xsession-errors`.
-          '';
-        };
-
-        logToJournal = mkOption {
-          type = types.bool;
-          default = true;
-          description = lib.mdDoc ''
-            Whether the display manager redirects the output of the
-            session script to the systemd journal.
-          '';
-        };
-
-      };
-
-      # Configuration for automatic login. Common for all DM.
-      autoLogin = mkOption {
-        type = types.submodule ({ config, options, ... }: {
-          options = {
-            enable = mkOption {
-              type = types.bool;
-              default = config.user != null;
-              defaultText = literalExpression "config.${options.user} != null";
-              description = lib.mdDoc ''
-                Automatically log in as {option}`autoLogin.user`.
-              '';
-            };
-
-            user = mkOption {
-              type = types.nullOr types.str;
-              default = null;
-              description = lib.mdDoc ''
-                User to be used for the automatic login.
-              '';
-            };
-          };
-        });
-
-        default = {};
-        description = lib.mdDoc ''
-          Auto login configuration attrset.
         '';
       };
 
@@ -403,30 +223,13 @@ in
 
   config = {
     assertions = [
-      { assertion = cfg.displayManager.autoLogin.enable -> cfg.displayManager.autoLogin.user != null;
-        message = ''
-          services.xserver.displayManager.autoLogin.enable requires services.xserver.displayManager.autoLogin.user to be set
-        '';
-      }
       {
         assertion = cfg.desktopManager.default != null || cfg.windowManager.default != null -> cfg.displayManager.defaultSession == defaultSessionFromLegacyOptions;
         message = "You cannot use both services.xserver.displayManager.defaultSession option and legacy options (services.xserver.desktopManager.default and services.xserver.windowManager.default).";
       }
     ];
 
-    warnings =
-      mkIf (dmDefault != null || wmDefault != null) [
-        ''
-          The following options are deprecated:
-            ${concatStringsSep "\n  " (map ({c, t}: t) (filter ({c, t}: c != null) [
-            { c = dmDefault; t = "- services.xserver.desktopManager.default"; }
-            { c = wmDefault; t = "- services.xserver.windowManager.default"; }
-            ]))}
-          Please use
-            services.xserver.displayManager.defaultSession = "${defaultSessionFromLegacyOptions}";
-          instead.
-        ''
-      ];
+    services.displayManager.sessionData.wrapper = xsessionWrapper;
 
     services.xserver.displayManager.xserverBin = "${xorg.xorgserver.out}/bin/X";
 
@@ -449,7 +252,7 @@ in
 
     # Create desktop files and scripts for starting sessions for WMs/DMs
     # that do not have upstream session files (those defined using services.{display,desktop,window}Manager.session options).
-    services.xserver.displayManager.sessionPackages =
+    services.displayManager.sessionPackages =
       let
         dms = filter (s: s.manage == "desktop") cfg.displayManager.session;
         wms = filter (s: s.manage == "window") cfg.displayManager.session;
@@ -511,20 +314,14 @@ in
             )
             (cartesianProductOfSets { dm = dms; wm = wms; })
           );
-
-    # Make xsessions and wayland sessions available in XDG_DATA_DIRS
-    # as some programs have behavior that depends on them being present
-    environment.sessionVariables.XDG_DATA_DIRS = lib.mkIf (cfg.displayManager.sessionPackages != [ ]) [
-      "${cfg.displayManager.sessionData.desktops}/share"
-    ];
   };
 
   imports = [
     (mkRemovedOptionModule [ "services" "xserver" "displayManager" "desktopManagerHandlesLidAndPower" ]
      "The option is no longer necessary because all display managers have already delegated lid management to systemd.")
-    (mkRenamedOptionModule [ "services" "xserver" "displayManager" "job" "logsXsession" ] [ "services" "xserver" "displayManager" "job" "logToFile" ])
-    (mkRenamedOptionModule [ "services" "xserver" "displayManager" "logToJournal" ] [ "services" "xserver" "displayManager" "job" "logToJournal" ])
-    (mkRenamedOptionModule [ "services" "xserver" "displayManager" "extraSessionFilesPackages" ] [ "services" "xserver" "displayManager" "sessionPackages" ])
+    (mkRenamedOptionModule [ "services" "xserver" "displayManager" "job" "logsXsession" ] [ "services" "displayManager" "logToFile" ])
+    (mkRenamedOptionModule [ "services" "xserver" "displayManager" "logToJournal" ] [ "services" "displayManager" "logToJournal" ])
+    (mkRenamedOptionModule [ "services" "xserver" "displayManager" "extraSessionFilesPackages" ] [ "services" "displayManager" "sessionPackages" ])
   ];
 
 }

--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -32,7 +32,7 @@ let
     load-module module-position-event-sounds
   '';
 
-  defaultSessionName = config.services.xserver.displayManager.defaultSession;
+  defaultSessionName = config.services.displayManager.defaultSession;
 
   setSessionScript = pkgs.callPackage ./account-service-util.nix { };
 in
@@ -41,14 +41,12 @@ in
   imports = [
     (mkRenamedOptionModule [ "services" "xserver" "displayManager" "gdm" "autoLogin" "enable" ] [
       "services"
-      "xserver"
       "displayManager"
       "autoLogin"
       "enable"
     ])
     (mkRenamedOptionModule [ "services" "xserver" "displayManager" "gdm" "autoLogin" "user" ] [
       "services"
-      "xserver"
       "displayManager"
       "autoLogin"
       "user"
@@ -148,14 +146,14 @@ in
     services.xserver.display = null;
     services.xserver.verbose = null;
 
-    services.xserver.displayManager.job =
+    services.displayManager =
       {
         environment = {
           GDM_X_SERVER_EXTRA_ARGS = toString
             (filter (arg: arg != "-terminate") cfg.xserverArgs);
           XDG_DATA_DIRS = lib.makeSearchPath "share" [
             gdm # for gnome-login.session
-            cfg.sessionData.desktops
+            config.services.displayManager.sessionData.desktops
             pkgs.gnome.gnome-control-center # for accessibility icon
             pkgs.gnome.adwaita-icon-theme
             pkgs.hicolor-icon-theme # empty icon theme as a base
@@ -169,7 +167,7 @@ in
         execCmd = "exec ${gdm}/bin/gdm";
         preStart = optionalString (defaultSessionName != null) ''
           # Set default session in session chooser to a specified values – basically ignore session history.
-          ${setSessionScript}/bin/set-session ${cfg.sessionData.autologinSession}
+          ${setSessionScript}/bin/set-session ${config.services.displayManager.sessionData.autologinSession}
         '';
       };
 
@@ -265,14 +263,14 @@ in
       daemon = mkMerge [
         { WaylandEnable = cfg.gdm.wayland; }
         # nested if else didn't work
-        (mkIf (cfg.autoLogin.enable && cfg.gdm.autoLogin.delay != 0 ) {
+        (mkIf (config.services.displayManager.autoLogin.enable && cfg.gdm.autoLogin.delay != 0 ) {
           TimedLoginEnable = true;
-          TimedLogin = cfg.autoLogin.user;
+          TimedLogin = config.services.displayManager.autoLogin.user;
           TimedLoginDelay = cfg.gdm.autoLogin.delay;
         })
-        (mkIf (cfg.autoLogin.enable && cfg.gdm.autoLogin.delay == 0 ) {
+        (mkIf (config.services.displayManager.autoLogin.enable && cfg.gdm.autoLogin.delay == 0 ) {
           AutomaticLoginEnable = true;
-          AutomaticLogin = cfg.autoLogin.user;
+          AutomaticLogin = config.services.displayManager.autoLogin.user;
         })
       ];
       debug = mkIf cfg.gdm.debug {
@@ -282,7 +280,7 @@ in
 
     environment.etc."gdm/custom.conf".source = configFile;
 
-    environment.etc."gdm/Xsession".source = config.services.xserver.displayManager.sessionData.wrapper;
+    environment.etc."gdm/Xsession".source = config.services.displayManager.sessionData.wrapper;
 
     # GDM LFS PAM modules, adapted somehow to NixOS
     security.pam.services = {

--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/mini.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/mini.nix
@@ -60,7 +60,7 @@ in
 
           Note that this greeter starts only the default X session.
           You can configure the default X session using
-          [](#opt-services.xserver.displayManager.defaultSession).
+          [](#opt-services.displayManager.defaultSession).
         '';
       };
 

--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/tiny.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/tiny.nix
@@ -22,7 +22,7 @@ in
 
           Note that this greeter starts only the default X session.
           You can configure the default X session using
-          [](#opt-services.xserver.displayManager.defaultSession).
+          [](#opt-services.displayManager.defaultSession).
         '';
       };
 
@@ -81,7 +81,7 @@ in
       {
         assertion = dmcfg.defaultSession != null;
         message = ''
-          Please set: services.xserver.displayManager.defaultSession
+          Please set: services.displayManager.defaultSession
         '';
       }
     ];

--- a/nixos/modules/services/x11/display-managers/sddm.nix
+++ b/nixos/modules/services/x11/display-managers/sddm.nix
@@ -129,17 +129,17 @@ in
 {
   imports = [
     (mkRemovedOptionModule
-      [ "services" "xserver" "displayManager" "sddm" "themes" ]
-      "Set the option `services.xserver.displayManager.sddm.package' instead.")
+      [ "services" "displayManager" "sddm" "themes" ]
+      "Set the option `services.displayManager.sddm.package' instead.")
     (mkRenamedOptionModule
-      [ "services" "xserver" "displayManager" "sddm" "autoLogin" "enable" ]
-      [ "services" "xserver" "displayManager" "autoLogin" "enable" ])
+      [ "services" "displayManager" "sddm" "autoLogin" "enable" ]
+      [ "services" "displayManager" "autoLogin" "enable" ])
     (mkRenamedOptionModule
-      [ "services" "xserver" "displayManager" "sddm" "autoLogin" "user" ]
-      [ "services" "xserver" "displayManager" "autoLogin" "user" ])
+      [ "services" "displayManager" "sddm" "autoLogin" "user" ]
+      [ "services" "displayManager" "autoLogin" "user" ])
     (mkRemovedOptionModule
-      [ "services" "xserver" "displayManager" "sddm" "extraConfig" ]
-      "Set the option `services.xserver.displayManager.sddm.settings' instead.")
+      [ "services" "displayManager" "sddm" "extraConfig" ]
+      "Set the option `services.displayManager.sddm.settings' instead.")
   ];
 
   options = {
@@ -280,6 +280,8 @@ in
         '';
       }
     ];
+
+    services.displayManager.execCmd = "exec /run/current-system/sw/bin/sddm";
 
     security.pam.services = {
       sddm.text = ''

--- a/nixos/modules/services/x11/display-managers/xpra.nix
+++ b/nixos/modules/services/x11/display-managers/xpra.nix
@@ -226,7 +226,7 @@ in
       VideoRam 192000
     '';
 
-    services.xserver.displayManager.job.execCmd = ''
+    services.displayManager.execCmd = ''
       ${optionalString (cfg.pulseaudio)
         "export PULSE_COOKIE=/run/pulse/.config/pulse/cookie"}
       exec ${pkgs.xpra}/bin/xpra ${if cfg.desktop == null then "start" else "start-desktop --start=${cfg.desktop}"} \

--- a/nixos/modules/services/x11/window-managers/default.nix
+++ b/nixos/modules/services/x11/window-managers/default.nix
@@ -77,7 +77,7 @@ in
         default = null;
         example = "wmii";
         description = lib.mdDoc ''
-          **Deprecated**, please use [](#opt-services.xserver.displayManager.defaultSession) instead.
+          **Deprecated**, please use [](#opt-services.displayManager.defaultSession) instead.
 
           Default window manager loaded if none have been chosen.
         '';

--- a/nixos/modules/services/x11/window-managers/ragnarwm.nix
+++ b/nixos/modules/services/x11/window-managers/ragnarwm.nix
@@ -18,7 +18,7 @@ in
   ###### implementation
 
   config = mkIf cfg.enable {
-    services.xserver.displayManager.sessionPackages = [ cfg.package ];
+    services.displayManager.sessionPackages = [ cfg.package ];
     environment.systemPackages = [ cfg.package ];
   };
 

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -644,7 +644,7 @@ in
     services.xserver.displayManager.lightdm.enable =
       let dmConf = cfg.displayManager;
           default = !(dmConf.gdm.enable
-                    || dmConf.sddm.enable
+                    || config.services.displayManager.sddm.enable
                     || dmConf.xpra.enable
                     || dmConf.sx.enable
                     || dmConf.startx.enable
@@ -719,17 +719,17 @@ in
         environment =
           optionalAttrs config.hardware.opengl.setLdLibraryPath
             { LD_LIBRARY_PATH = lib.makeLibraryPath [ pkgs.addOpenGLRunpath.driverLink ]; }
-          // cfg.displayManager.job.environment;
+          // config.services.displayManager.environment;
 
         preStart =
           ''
-            ${cfg.displayManager.job.preStart}
+            ${config.services.displayManager.preStart}
 
             rm -f /tmp/.X0-lock
           '';
 
         # TODO: move declaring the systemd service to its own mkIf
-        script = mkIf (config.systemd.services.display-manager.enable == true) "${cfg.displayManager.job.execCmd}";
+        script = mkIf (config.systemd.services.display-manager.enable == true) "${config.services.displayManager.execCmd}";
 
         # Stop restarting if the display manager stops (crashes) 2 times
         # in one minute. Starting X typically takes 3-4s.

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -651,8 +651,6 @@ in
                     || config.services.greetd.enable);
       in mkIf (default) (mkDefault true);
 
-    hardware.opengl.enable = mkDefault true;
-
     services.xserver.videoDrivers = mkIf (cfg.videoDriver != null) [ cfg.videoDriver ];
 
     # FIXME: somehow check for unknown driver names.
@@ -686,19 +684,6 @@ in
           # -xkbdir command line option does not seems to be passed to xkbcomp.
           "X11/xkb".source = "${cfg.xkb.dir}";
         })
-      # localectl looks into 00-keyboard.conf
-      //{
-          "X11/xorg.conf.d/00-keyboard.conf".text = ''
-            Section "InputClass"
-              Identifier "Keyboard catchall"
-              MatchIsKeyboard "on"
-              Option "XkbModel" "${cfg.xkb.model}"
-              Option "XkbLayout" "${cfg.xkb.layout}"
-              Option "XkbOptions" "${cfg.xkb.options}"
-              Option "XkbVariant" "${cfg.xkb.variant}"
-            EndSection
-          '';
-        }
       # Needed since 1.18; see https://bugs.freedesktop.org/show_bug.cgi?id=89023#c5
       // (let cfgPath = "X11/xorg.conf.d/10-evdev.conf"; in
         {
@@ -718,30 +703,11 @@ in
         xorg.xprop
         xorg.xauth
         pkgs.xterm
-        pkgs.xdg-utils
         xorg.xf86inputevdev.out # get evdev.4 man page
-        pkgs.nixos-icons # needed for gnome and pantheon about dialog, nixos-manual and maybe more
       ] config.services.xserver.excludePackages
       ++ optional (elem "virtualbox" cfg.videoDrivers) xorg.xrefresh;
 
     environment.pathsToLink = [ "/share/X11" ];
-
-    xdg = {
-      autostart.enable = true;
-      menus.enable = true;
-      mime.enable = true;
-      icons.enable = true;
-    };
-
-    # The default max inotify watches is 8192.
-    # Nowadays most apps require a good number of inotify watches,
-    # the value below is used by default on several other distros.
-    boot.kernel.sysctl."fs.inotify.max_user_instances" = mkDefault 524288;
-    boot.kernel.sysctl."fs.inotify.max_user_watches" = mkDefault 524288;
-
-    programs.gnupg.agent.pinentryPackage = lib.mkOverride 1100 pkgs.pinentry-gnome3;
-
-    systemd.defaultUnit = mkIf cfg.autorun "graphical.target";
 
     systemd.services.display-manager =
       { description = "Display Manager";
@@ -902,7 +868,6 @@ in
         ${cfg.extraConfig}
       '';
 
-    fonts.enableDefaultPackages = mkDefault true;
     fonts.packages = [
       (if cfg.upscaleDefaultCursor then fontcursormisc_hidpi else pkgs.xorg.fontcursormisc)
       pkgs.xorg.fontmiscmisc

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -639,6 +639,7 @@ in
   ###### implementation
 
   config = mkIf cfg.enable {
+    services.displayManager.enable = true;
 
     services.xserver.displayManager.lightdm.enable =
       let dmConf = cfg.displayManager;
@@ -649,15 +650,6 @@ in
                     || dmConf.startx.enable
                     || config.services.greetd.enable);
       in mkIf (default) (mkDefault true);
-
-    # so that the service won't be enabled when only startx is used
-    systemd.services.display-manager.enable  =
-      let dmConf = cfg.displayManager;
-          noDmUsed = !(dmConf.gdm.enable
-                    || dmConf.sddm.enable
-                    || dmConf.xpra.enable
-                    || dmConf.lightdm.enable);
-      in mkIf (noDmUsed) (mkDefault false);
 
     hardware.opengl.enable = mkDefault true;
 

--- a/nixos/modules/testing/test-instrumentation.nix
+++ b/nixos/modules/testing/test-instrumentation.nix
@@ -216,7 +216,7 @@ in
     # uses credentials to set passwords on users.
     users.users.root.hashedPasswordFile = mkOverride 150 "${pkgs.writeText "hashed-password.root" ""}";
 
-    services.xserver.displayManager.job.logToJournal = true;
+    services.displayManager.logToJournal = true;
 
     # Make sure we use the Guest Agent from the QEMU package for testing
     # to reduce the closure size required for the tests.

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -441,7 +441,7 @@ in rec {
 
     kde = makeClosure ({ ... }:
       { services.xserver.enable = true;
-        services.xserver.displayManager.sddm.enable = true;
+        services.displayManager.sddm.enable = true;
         services.xserver.desktopManager.plasma5.enable = true;
       });
 

--- a/nixos/tests/ayatana-indicators.nix
+++ b/nixos/tests/ayatana-indicators.nix
@@ -21,8 +21,8 @@ in {
     services.xserver = {
       enable = true;
       desktopManager.mate.enable = true;
-      displayManager.defaultSession = lib.mkForce "mate";
     };
+    services.displayManager.defaultSession = lib.mkForce "mate";
 
     services.ayatana-indicators = {
       enable = true;

--- a/nixos/tests/cinnamon-wayland.nix
+++ b/nixos/tests/cinnamon-wayland.nix
@@ -7,7 +7,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     imports = [ ./common/user-account.nix ];
     services.xserver.enable = true;
     services.xserver.desktopManager.cinnamon.enable = true;
-    services.xserver.displayManager = {
+    services.displayManager = {
       autoLogin.enable = true;
       autoLogin.user = nodes.machine.users.users.alice.name;
       defaultSession = "cinnamon-wayland";

--- a/nixos/tests/common/auto.nix
+++ b/nixos/tests/common/auto.nix
@@ -30,12 +30,10 @@ in
   ###### implementation
 
   config = lib.mkIf cfg.enable {
-    services.xserver.displayManager = {
-      lightdm.enable = true;
-      autoLogin = {
-        enable = true;
-        user = cfg.user;
-      };
+    services.xserver.displayManager.lightdm.enable = true;
+    services.displayManager.autoLogin = {
+      enable = true;
+      user = cfg.user;
     };
 
     # lightdm by default doesn't allow auto login for root, which is

--- a/nixos/tests/common/x11.nix
+++ b/nixos/tests/common/x11.nix
@@ -12,6 +12,6 @@
 
   # Use IceWM as the window manager.
   # Don't use a desktop manager.
-  services.xserver.displayManager.defaultSession = lib.mkDefault "none+icewm";
+  services.displayManager.defaultSession = lib.mkDefault "none+icewm";
   services.xserver.windowManager.icewm.enable = true;
 }

--- a/nixos/tests/gnome-flashback.nix
+++ b/nixos/tests/gnome-flashback.nix
@@ -14,16 +14,17 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : {
       services.xserver.displayManager = {
         gdm.enable = true;
         gdm.debug = true;
-        autoLogin = {
-          enable = true;
-          user = user.name;
-        };
+      };
+
+      services.displayManager.autoLogin = {
+        enable = true;
+        user = user.name;
       };
 
       services.xserver.desktopManager.gnome.enable = true;
       services.xserver.desktopManager.gnome.debug = true;
       services.xserver.desktopManager.gnome.flashback.enableMetacity = true;
-      services.xserver.displayManager.defaultSession = "gnome-flashback-metacity";
+      services.displayManager.defaultSession = "gnome-flashback-metacity";
     };
 
   testScript = { nodes, ... }: let

--- a/nixos/tests/gnome-xorg.nix
+++ b/nixos/tests/gnome-xorg.nix
@@ -15,15 +15,16 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : {
       services.xserver.displayManager = {
         gdm.enable = true;
         gdm.debug = true;
-        autoLogin = {
-          enable = true;
-          user = user.name;
-        };
+      };
+
+      services.displayManager.autoLogin = {
+        enable = true;
+        user = user.name;
       };
 
       services.xserver.desktopManager.gnome.enable = true;
       services.xserver.desktopManager.gnome.debug = true;
-      services.xserver.displayManager.defaultSession = "gnome-xorg";
+      services.displayManager.defaultSession = "gnome-xorg";
 
       systemd.user.services = {
         "org.gnome.Shell@x11" = {

--- a/nixos/tests/gnome.nix
+++ b/nixos/tests/gnome.nix
@@ -12,10 +12,11 @@ import ./make-test-python.nix ({ pkgs, lib, ...} : {
       services.xserver.displayManager = {
         gdm.enable = true;
         gdm.debug = true;
-        autoLogin = {
-          enable = true;
-          user = "alice";
-        };
+      };
+
+      services.displayManager.autoLogin = {
+        enable = true;
+        user = "alice";
       };
 
       services.xserver.desktopManager.gnome.enable = true;

--- a/nixos/tests/herbstluftwm.nix
+++ b/nixos/tests/herbstluftwm.nix
@@ -8,7 +8,7 @@ import ./make-test-python.nix ({ lib, ...} : {
   nodes.machine = { pkgs, lib, ... }: {
     imports = [ ./common/x11.nix ./common/user-account.nix ];
     test-support.displayManager.auto.user = "alice";
-    services.xserver.displayManager.defaultSession = lib.mkForce "none+herbstluftwm";
+    services.displayManager.defaultSession = lib.mkForce "none+herbstluftwm";
     services.xserver.windowManager.herbstluftwm.enable = true;
     environment.systemPackages = [ pkgs.dzen2 ]; # needed for upstream provided panel
   };

--- a/nixos/tests/i3wm.nix
+++ b/nixos/tests/i3wm.nix
@@ -7,7 +7,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
   nodes.machine = { lib, ... }: {
     imports = [ ./common/x11.nix ./common/user-account.nix ];
     test-support.displayManager.auto.user = "alice";
-    services.xserver.displayManager.defaultSession = lib.mkForce "none+i3";
+    services.displayManager.defaultSession = lib.mkForce "none+i3";
     services.xserver.windowManager.i3.enable = true;
   };
 

--- a/nixos/tests/lightdm.nix
+++ b/nixos/tests/lightdm.nix
@@ -8,7 +8,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
     imports = [ ./common/user-account.nix ];
     services.xserver.enable = true;
     services.xserver.displayManager.lightdm.enable = true;
-    services.xserver.displayManager.defaultSession = "none+icewm";
+    services.displayManager.defaultSession = "none+icewm";
     services.xserver.windowManager.icewm.enable = true;
   };
 

--- a/nixos/tests/maestral.nix
+++ b/nixos/tests/maestral.nix
@@ -29,11 +29,14 @@ import ./make-test-python.nix ({ pkgs, ... }: {
       gui = { ... }: common {
         services.xserver = {
           enable = true;
-          displayManager.sddm.enable = true;
-          displayManager.defaultSession = "plasma";
           desktopManager.plasma5.enable = true;
           desktopManager.plasma5.runUsingSystemd = true;
-          displayManager.autoLogin = {
+        };
+
+        services.displayManager = {
+          sddm.enable = true;
+          defaultSession = "plasma";
+          autoLogin = {
             enable = true;
             user = "alice";
           };

--- a/nixos/tests/mate-wayland.nix
+++ b/nixos/tests/mate-wayland.nix
@@ -9,7 +9,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     ];
 
     services.xserver.enable = true;
-    services.xserver.displayManager = {
+    services.displayManager = {
       sddm.enable = true; # https://github.com/canonical/lightdm/issues/63
       sddm.wayland.enable = true;
       defaultSession = "MATE";

--- a/nixos/tests/miriway.nix
+++ b/nixos/tests/miriway.nix
@@ -19,10 +19,8 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
       user = "alice";
     };
 
-    services.xserver = {
-      enable = true;
-      displayManager.defaultSession = lib.mkForce "miriway";
-    };
+    services.xserver.enable = true;
+    services.displayManager.defaultSession = lib.mkForce "miriway";
 
     programs.miriway = {
       enable = true;

--- a/nixos/tests/nimdow.nix
+++ b/nixos/tests/nimdow.nix
@@ -7,7 +7,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
   nodes.machine = { lib, ... }: {
     imports = [ ./common/x11.nix ./common/user-account.nix ];
     test-support.displayManager.auto.user = "alice";
-    services.xserver.displayManager.defaultSession = lib.mkForce "none+nimdow";
+    services.displayManager.defaultSession = lib.mkForce "none+nimdow";
     services.xserver.windowManager.nimdow.enable = true;
   };
 

--- a/nixos/tests/plasma-bigscreen.nix
+++ b/nixos/tests/plasma-bigscreen.nix
@@ -11,10 +11,10 @@ import ./make-test-python.nix ({ pkgs, ...} :
   {
     imports = [ ./common/user-account.nix ];
     services.xserver.enable = true;
-    services.xserver.displayManager.sddm.enable = true;
-    services.xserver.displayManager.defaultSession = "plasma-bigscreen-x11";
+    services.displayManager.sddm.enable = true;
+    services.displayManager.defaultSession = "plasma-bigscreen-x11";
     services.xserver.desktopManager.plasma5.bigscreen.enable = true;
-    services.xserver.displayManager.autoLogin = {
+    services.displayManager.autoLogin = {
       enable = true;
       user = "alice";
     };

--- a/nixos/tests/plasma5-systemd-start.nix
+++ b/nixos/tests/plasma5-systemd-start.nix
@@ -12,11 +12,14 @@ import ./make-test-python.nix ({ pkgs, ...} :
     imports = [ ./common/user-account.nix ];
     services.xserver = {
       enable = true;
-      displayManager.sddm.enable = true;
-      displayManager.defaultSession = "plasma";
       desktopManager.plasma5.enable = true;
       desktopManager.plasma5.runUsingSystemd = true;
-      displayManager.autoLogin = {
+    };
+
+    services.displayManager = {
+      sddm.enable = true;
+      defaultSession = "plasma";
+      autoLogin = {
         enable = true;
         user = "alice";
       };

--- a/nixos/tests/plasma5.nix
+++ b/nixos/tests/plasma5.nix
@@ -11,11 +11,11 @@ import ./make-test-python.nix ({ pkgs, ...} :
   {
     imports = [ ./common/user-account.nix ];
     services.xserver.enable = true;
-    services.xserver.displayManager.sddm.enable = true;
-    services.xserver.displayManager.defaultSession = "plasma";
+    services.displayManager.sddm.enable = true;
+    services.displayManager.defaultSession = "plasma";
     services.xserver.desktopManager.plasma5.enable = true;
     environment.plasma5.excludePackages = [ pkgs.plasma5Packages.elisa ];
-    services.xserver.displayManager.autoLogin = {
+    services.displayManager.autoLogin = {
       enable = true;
       user = "alice";
     };

--- a/nixos/tests/plasma6.nix
+++ b/nixos/tests/plasma6.nix
@@ -11,12 +11,12 @@ import ./make-test-python.nix ({ pkgs, ...} :
   {
     imports = [ ./common/user-account.nix ];
     services.xserver.enable = true;
-    services.xserver.displayManager.sddm.enable = true;
+    services.displayManager.sddm.enable = true;
     # FIXME: this should be testing Wayland
-    services.xserver.displayManager.defaultSession = "plasmax11";
-    services.xserver.desktopManager.plasma6.enable = true;
+    services.displayManager.defaultSession = "plasmax11";
+    services.desktopManager.plasma6.enable = true;
     environment.plasma6.excludePackages = [ pkgs.kdePackages.elisa ];
-    services.xserver.displayManager.autoLogin = {
+    services.displayManager.autoLogin = {
       enable = true;
       user = "alice";
     };

--- a/nixos/tests/ragnarwm.nix
+++ b/nixos/tests/ragnarwm.nix
@@ -8,7 +8,7 @@ import ./make-test-python.nix ({ lib, ...} : {
   nodes.machine = { pkgs, lib, ... }: {
     imports = [ ./common/x11.nix ./common/user-account.nix ];
     test-support.displayManager.auto.user = "alice";
-    services.xserver.displayManager.defaultSession = lib.mkForce "ragnar";
+    services.displayManager.defaultSession = lib.mkForce "ragnar";
     services.xserver.windowManager.ragnarwm.enable = true;
 
     # Setup the default terminal of Ragnar

--- a/nixos/tests/sddm.nix
+++ b/nixos/tests/sddm.nix
@@ -15,8 +15,8 @@ let
       nodes.machine = { ... }: {
         imports = [ ./common/user-account.nix ];
         services.xserver.enable = true;
-        services.xserver.displayManager.sddm.enable = true;
-        services.xserver.displayManager.defaultSession = "none+icewm";
+        services.displayManager.sddm.enable = true;
+        services.displayManager.defaultSession = "none+icewm";
         services.xserver.windowManager.icewm.enable = true;
       };
 
@@ -44,14 +44,14 @@ let
       nodes.machine = { ... }: {
         imports = [ ./common/user-account.nix ];
         services.xserver.enable = true;
-        services.xserver.displayManager = {
+        services.displayManager = {
           sddm.enable = true;
           autoLogin = {
             enable = true;
             user = "alice";
           };
         };
-        services.xserver.displayManager.defaultSession = "none+icewm";
+        services.displayManager.defaultSession = "none+icewm";
         services.xserver.windowManager.icewm.enable = true;
       };
 

--- a/nixos/tests/wmderland.nix
+++ b/nixos/tests/wmderland.nix
@@ -7,7 +7,7 @@ import ./make-test-python.nix ({ pkgs, ...} : {
   nodes.machine = { lib, ... }: {
     imports = [ ./common/x11.nix ./common/user-account.nix ];
     test-support.displayManager.auto.user = "alice";
-    services.xserver.displayManager.defaultSession = lib.mkForce "none+wmderland";
+    services.displayManager.defaultSession = lib.mkForce "none+wmderland";
     services.xserver.windowManager.wmderland.enable = true;
 
     systemd.services.setupWmderlandConfig = {

--- a/nixos/tests/xfce.nix
+++ b/nixos/tests/xfce.nix
@@ -10,13 +10,11 @@ import ./make-test-python.nix ({ pkgs, ...} : {
       ];
 
       services.xserver.enable = true;
+      services.xserver.displayManager.lightdm.enable = true;
 
-      services.xserver.displayManager = {
-        lightdm.enable = true;
-        autoLogin = {
-          enable = true;
-          user = "alice";
-        };
+      services.displayManager.autoLogin = {
+        enable = true;
+        user = "alice";
       };
 
       services.xserver.desktopManager.xfce.enable = true;

--- a/nixos/tests/xmonad-xdg-autostart.nix
+++ b/nixos/tests/xmonad-xdg-autostart.nix
@@ -5,7 +5,7 @@ import ./make-test-python.nix ({ lib, ... }: {
   nodes.machine = { pkgs, config, ... }: {
     imports = [ ./common/x11.nix ./common/user-account.nix ];
     test-support.displayManager.auto.user = "alice";
-    services.xserver.displayManager.defaultSession = "none+xmonad";
+    services.displayManager.defaultSession = "none+xmonad";
     services.xserver.windowManager.xmonad.enable = true;
     services.xserver.desktopManager.runXdgAutostartIfNone = true;
 

--- a/nixos/tests/xmonad.nix
+++ b/nixos/tests/xmonad.nix
@@ -61,7 +61,7 @@ in {
   nodes.machine = { pkgs, ... }: {
     imports = [ ./common/x11.nix ./common/user-account.nix ];
     test-support.displayManager.auto.user = "alice";
-    services.xserver.displayManager.defaultSession = "none+xmonad";
+    services.displayManager.defaultSession = "none+xmonad";
     services.xserver.windowManager.xmonad = {
       enable = true;
       enableConfiguredRecompile = true;


### PR DESCRIPTION
## Description of changes

~~I've only ever tested this with #286522, so we are going to wait until that is merged.~~

~~Next step would be to move things not related to xserver out of the xserver setting and to something more generic.~~

Some history irrelevant history to to this: I am thinking about decoupling wayland from xserver since at least September last year motivated by @tanneberger 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
