### PR TITLE
[Backport release-23.11] linux/kernel/common-config: Reenable the rfkill-input module

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -290,6 +290,7 @@ let
       # At the time of writing (25-06-2023): this is only used in a "correct" way by ath drivers for initiating DFS radiation
       # for "certified devices"
       EXPERT                      = option yes; # this is needed for offering the certification option
+      RFKILL_INPUT                = option yes; # counteract an undesired effect of setting EXPERT
       CFG80211_CERTIFICATION_ONUS = option yes;
       # DFS: "Dynamic Frequency Selection" is a spectrum-sharing mechanism that allows
       # you to use certain interesting frequency when your local regulatory domain mandates it.


### PR DESCRIPTION
Backport #279368 to 23.11. Closes #261880.

The default value of the RFKILL_INPUT Kconfig option depends on the EXPERT option which was changed in 3b07356d2d55c5eacc7a11eb08c3a8de97884b2f. However, disabling the rfkill-input module was unintentional and causes some airplane mode buttons on laptops to not function [1].

[1]: https://github.com/NixOS/nixpkgs/issues/261880

(cherry picked from commit 470f8945e6f987c8477cf5e547ff3bdad5f6ab3e)

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
