### PR TITLE
kord: fix build due to changed compiler features

### DIFF
--- a/pkgs/applications/misc/kord/default.nix
+++ b/pkgs/applications/misc/kord/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , darwin
 , fetchFromGitHub
+, fetchpatch
 , rustPlatform
 , pkg-config
 , alsa-lib
@@ -27,6 +28,17 @@ rustPlatform.buildRustPackage rec {
       "bincode-2.0.0-rc.2" = "sha256-0BfKKGOi5EVIoF0HvIk0QS2fHUMG3tpsMLe2SkXeZlo=";
     };
   };
+
+  patches = [
+    # Fixes build issues due to refactored Rust compiler feature annotations.
+    # Should be removable with the next release after v. 0.6.1.
+    (fetchpatch {
+      name = "fix-rust-features.patch";
+      url = "https://github.com/twitchax/kord/commit/fa9bb979b17d77f54812a915657c3121f76c5d82.patch";
+      hash = "sha256-XQu9P7372J2dHWzvpvbPtALS0Bh8EC+J1EyG3qlak2M=";
+      excludes = [ "Cargo.*" ];
+    })
+  ];
 
   nativeBuildInputs = lib.optionals stdenv.isLinux [ pkg-config ]
     ++ lib.optionals stdenv.isDarwin [ rustPlatform.bindgenHook ];


### PR DESCRIPTION
The rust feature `no_coverage` has been replaced by one called `coverage_attribute` (and respective `#[no_coverage]` declarations must now be annotated as `#[coverage(off)]`. Because of this, the build of `kord` fails on current versions of the Rust compiler.

Upstream has already resolved these issues [^1], but there haven't been any new releases since these fixes have been committed to trunk. This change pulls the respective patch in using `fetchpatch` for now -- this patch should be removable with the next release.

[^1]: https://github.com/twitchax/kord/commit/fa9bb979b17d77f54812a915657c3121f76c5d82

Failing Hydra build: https://hydra.nixos.org/build/250755802
Hydra log: https://hydra.nixos.org/build/250755802/nixlog/1

Relevant log excerpt:
```
error[E0557]: feature has been removed
  --> src/lib.rs:49:12
   |
49 | #![feature(no_coverage)]
   |            ^^^^^^^^^^^ feature has been removed
   |
   = note: renamed to `coverage_attribute`

error: cannot find attribute `no_coverage` in this scope
    --> src/core/chord.rs:1233:7
     |
1233 |     #[no_coverage]
     |       ^^^^^^^^^^^ help: a built-in attribute with a similar name exists: `coverage`
```

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
