### PR TITLE
python311Packages.textnets: 0.9.3 -> 0.9.4

### DIFF
--- a/pkgs/development/python-modules/textnets/default.nix
+++ b/pkgs/development/python-modules/textnets/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , cairocffi
-, cython
+, cython_3
 , fetchPypi
 , igraph
 , leidenalg
@@ -9,6 +9,7 @@
 , poetry-core
 , pytestCheckHook
 , pythonOlder
+, pythonRelaxDepsHook
 , scipy
 , setuptools
 , spacy
@@ -21,21 +22,24 @@
 
 buildPythonPackage rec {
   pname = "textnets";
-  version = "0.9.3";
+  version = "0.9.4";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-fx2S43IqpSMsfJow26jB/D27dyUFQ1PlXP1rbUIZPPQ=";
+    hash = "sha256-4154ytzo1QpwhKA1BkVMss9fNIkysnClW/yfSVlX33M=";
   };
 
   nativeBuildInputs = [
-    cython
+    pythonRelaxDepsHook
+    cython_3
     poetry-core
     setuptools
   ];
+
+  pythonRelaxDeps = [ "igraph" "leidenalg" ];
 
   propagatedBuildInputs = [
     cairocffi
@@ -59,10 +63,14 @@ buildPythonPackage rec {
     "textnets"
   ];
 
+  # Enables the package to find the cythonized .so files during testing. See #255262
+  preCheck = ''
+    rm -r textnets
+  '';
+
   disabledTests = [
-    # Test fails: A warning is triggered because of a deprecation notice by pandas.
-    # TODO: Try to re-enable it when pandas is updated to 2.1.1
-    "test_corpus_czech"
+    # Test fails: Throws a UserWarning asking the user to install `textnets[fca]`.
+    "test_context"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

1. Bump to version 0.9.4 (previous 0.9.3 isn't listed as a release in github repo)
2. Relax dependencies due to version conflicts with newer `leidenalg` and `igraph`.
3. `rm -r textnets` in the preCheck phase to let test expecting a .so file find it. 
4. Disables one test that has been marked as expected to fail, but now throws a *different* exception (UserWarning).

Fixes #291937

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
