### PR TITLE
zfs: rename zfsStable -> zfs_2_2; zfsUnstable -> zfs_unstable; remove enableUnstable option in favor of package

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -1458,9 +1458,9 @@ in
         '';
       }
       {
-        assertion = config.security.pam.zfs.enable -> (config.boot.zfs.enabled || config.boot.zfs.enableUnstable);
+        assertion = config.security.pam.zfs.enable -> config.boot.zfs.enabled;
         message = ''
-          `security.pam.zfs.enable` requires enabling ZFS (`boot.zfs.enabled` or `boot.zfs.enableUnstable`).
+          `security.pam.zfs.enable` requires enabling ZFS (`boot.zfs.enabled`).
         '';
       }
       {

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -220,7 +220,7 @@ in
       package = mkOption {
         type = types.package;
         default = if cfgZfs.enableUnstable then pkgs.zfsUnstable else pkgs.zfs;
-        defaultText = literalExpression "if zfsUnstable is enabled then pkgs.zfsUnstable else pkgs.zfs";
+        defaultText = literalExpression "if enableUnstable is enabled then pkgs.zfsUnstable else pkgs.zfs";
         description = lib.mdDoc "Configured ZFS userland tools package, use `pkgs.zfsUnstable` if you want to track the latest staging ZFS branch.";
       };
 

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -219,9 +219,9 @@ in
     boot.zfs = {
       package = mkOption {
         type = types.package;
-        default = if cfgZfs.enableUnstable then pkgs.zfsUnstable else pkgs.zfs;
-        defaultText = literalExpression "if enableUnstable is enabled then pkgs.zfsUnstable else pkgs.zfs";
-        description = lib.mdDoc "Configured ZFS userland tools package, use `pkgs.zfsUnstable` if you want to track the latest staging ZFS branch.";
+        default = if cfgZfs.enableUnstable then pkgs.zfs_unstable else pkgs.zfs;
+        defaultText = literalExpression "if enableUnstable is enabled then pkgs.zfs_unstable else pkgs.zfs";
+        description = lib.mdDoc "Configured ZFS userland tools package, use `pkgs.zfs_unstable` if you want to track the latest staging ZFS branch.";
       };
 
       modulePackage = mkOption {

--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -211,6 +211,7 @@ in
 
   imports = [
     (mkRemovedOptionModule [ "boot" "zfs" "enableLegacyCrypto" ] "The corresponding package was removed from nixpkgs.")
+    (mkRemovedOptionModule [ "boot" "zfs" "enableUnstable" ] "Instead set `boot.zfs.package = pkgs.zfs_unstable;`")
   ];
 
   ###### interface
@@ -219,8 +220,8 @@ in
     boot.zfs = {
       package = mkOption {
         type = types.package;
-        default = if cfgZfs.enableUnstable then pkgs.zfs_unstable else pkgs.zfs;
-        defaultText = literalExpression "if enableUnstable is enabled then pkgs.zfs_unstable else pkgs.zfs";
+        default = pkgs.zfs;
+        defaultText = literalExpression "pkgs.zfs";
         description = lib.mdDoc "Configured ZFS userland tools package, use `pkgs.zfs_unstable` if you want to track the latest staging ZFS branch.";
       };
 
@@ -237,19 +238,6 @@ in
         default = inInitrd || inSystem;
         defaultText = literalMD "`true` if ZFS filesystem support is enabled";
         description = lib.mdDoc "True if ZFS filesystem support is enabled";
-      };
-
-      enableUnstable = mkOption {
-        type = types.bool;
-        default = false;
-        description = lib.mdDoc ''
-          Use the unstable zfs package. This might be an option, if the latest
-          kernel is not yet supported by a published release of ZFS. Enabling
-          this option will install a development version of ZFS on Linux. The
-          version will have already passed an extensive test suite, but it is
-          more likely to hit an undiscovered bug compared to running a released
-          version of ZFS on Linux.
-          '';
       };
 
       allowHibernation = mkOption {

--- a/nixos/tests/zfs.nix
+++ b/nixos/tests/zfs.nix
@@ -203,12 +203,12 @@ in {
   };
 
   unstable = makeZfsTest rec {
-    zfsPackage = pkgs.zfsUnstable;
+    zfsPackage = pkgs.zfs_unstable;
     kernelPackages = zfsPackage.latestCompatibleLinuxPackages;
   };
 
   unstableWithSystemdStage1 = makeZfsTest rec {
-    zfsPackage = pkgs.zfsUnstable;
+    zfsPackage = pkgs.zfs_unstable;
     kernelPackages = zfsPackage.latestCompatibleLinuxPackages;
     enableSystemdStage1 = true;
   };

--- a/nixos/tests/zfs.nix
+++ b/nixos/tests/zfs.nix
@@ -192,22 +192,22 @@ let
 in {
 
   # maintainer: @raitobezarius
-  series_2_1 = makeZfsTest "2.1-series" {
+  series_2_1 = makeZfsTest "zfs_2_1" {
     zfsPackage = pkgs.zfs_2_1;
     kernelPackages = pkgs.linuxPackages;
   };
 
-  stable = makeZfsTest "stable" {
-    zfsPackage = pkgs.zfsStable;
+  series_2_2 = makeZfsTest "zfs_2_2" {
+    zfsPackage = pkgs.zfs_2_2;
     kernelPackages = pkgs.linuxPackages;
   };
 
-  unstable = makeZfsTest "unstable" rec {
+  unstable = makeZfsTest "zfsUnstable" rec {
     zfsPackage = pkgs.zfsUnstable;
     kernelPackages = zfsPackage.latestCompatibleLinuxPackages;
   };
 
-  unstableWithSystemdStage1 = makeZfsTest "unstable" rec {
+  unstableWithSystemdStage1 = makeZfsTest "zfsUnstable" rec {
     zfsPackage = pkgs.zfsUnstable;
     kernelPackages = zfsPackage.latestCompatibleLinuxPackages;
     enableSystemdStage1 = true;

--- a/nixos/tests/zfs.nix
+++ b/nixos/tests/zfs.nix
@@ -7,14 +7,14 @@ with import ../lib/testing-python.nix { inherit system pkgs; };
 
 let
 
-  makeZfsTest = name:
+  makeZfsTest =
     { kernelPackages
     , enableSystemdStage1 ? false
     , zfsPackage
     , extraTest ? ""
     }:
     makeTest {
-      name = "zfs-" + name;
+      name = zfsPackage.kernelModuleAttribute;
       meta = with pkgs.lib.maintainers; {
         maintainers = [ elvishjerricco ];
       };
@@ -192,22 +192,22 @@ let
 in {
 
   # maintainer: @raitobezarius
-  series_2_1 = makeZfsTest "zfs_2_1" {
+  series_2_1 = makeZfsTest {
     zfsPackage = pkgs.zfs_2_1;
     kernelPackages = pkgs.linuxPackages;
   };
 
-  series_2_2 = makeZfsTest "zfs_2_2" {
+  series_2_2 = makeZfsTest {
     zfsPackage = pkgs.zfs_2_2;
     kernelPackages = pkgs.linuxPackages;
   };
 
-  unstable = makeZfsTest "zfsUnstable" rec {
+  unstable = makeZfsTest rec {
     zfsPackage = pkgs.zfsUnstable;
     kernelPackages = zfsPackage.latestCompatibleLinuxPackages;
   };
 
-  unstableWithSystemdStage1 = makeZfsTest "zfsUnstable" rec {
+  unstableWithSystemdStage1 = makeZfsTest rec {
     zfsPackage = pkgs.zfsUnstable;
     kernelPackages = zfsPackage.latestCompatibleLinuxPackages;
     enableSystemdStage1 = true;

--- a/pkgs/os-specific/linux/zfs/2_2.nix
+++ b/pkgs/os-specific/linux/zfs/2_2.nix
@@ -12,7 +12,7 @@ in
 callPackage ./generic.nix args {
   # You have to ensure that in `pkgs/top-level/linux-kernels.nix`
   # this attribute is the correct one for this package.
-  kernelModuleAttribute = "zfs";
+  kernelModuleAttribute = "zfs_2_2";
   # check the release notes for compatible kernels
   kernelCompatible = kernel.kernelOlder "6.8";
 
@@ -23,7 +23,7 @@ callPackage ./generic.nix args {
 
   tests = [
     nixosTests.zfs.installer
-    nixosTests.zfs.stable
+    nixosTests.zfs.series_2_2
   ];
 
   hash = "sha256-Bzkow15OitUUQ+mTYhCXgTrQl+ao/B4feleHY/rSSjg=";

--- a/pkgs/os-specific/linux/zfs/generic.nix
+++ b/pkgs/os-specific/linux/zfs/generic.nix
@@ -235,7 +235,7 @@ let
       inherit maintainers;
       mainProgram = "zfs";
       # If your Linux kernel version is not yet supported by zfs, try zfs_unstable.
-      # On NixOS set the option boot.zfs.enableUnstable.
+      # On NixOS set the option `boot.zfs.package = pkgs.zfs_unstable`.
       broken = buildKernel && (kernelCompatible != null) && !kernelCompatible;
     };
   };

--- a/pkgs/os-specific/linux/zfs/generic.nix
+++ b/pkgs/os-specific/linux/zfs/generic.nix
@@ -234,7 +234,7 @@ let
 
       inherit maintainers;
       mainProgram = "zfs";
-      # If your Linux kernel version is not yet supported by zfs, try zfsUnstable.
+      # If your Linux kernel version is not yet supported by zfs, try zfs_unstable.
       # On NixOS set the option boot.zfs.enableUnstable.
       broken = buildKernel && (kernelCompatible != null) && !kernelCompatible;
     };

--- a/pkgs/os-specific/linux/zfs/unstable.nix
+++ b/pkgs/os-specific/linux/zfs/unstable.nix
@@ -12,7 +12,7 @@ in
 callPackage ./generic.nix args {
   # You have to ensure that in `pkgs/top-level/linux-kernels.nix`
   # this attribute is the correct one for this package.
-  kernelModuleAttribute = "zfsUnstable";
+  kernelModuleAttribute = "zfs_unstable";
   # check the release notes for compatible kernels
   kernelCompatible = kernel.kernelOlder "6.9";
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1211,6 +1211,7 @@ mapAliases ({
   ### Z ###
 
   zabbix40 = throw "'zabbix40' has been removed as it has reached end of life"; # Added 2024-01-07
+  zfsStable = zfs; # Added 2024-02-26
   zinc = zincsearch; # Added 2023-05-28
   zkg = throw "'zkg' has been replaced by 'zeek'";
   zq = zed.overrideAttrs (old: { meta = old.meta // { mainProgram = "zq"; }; }); # Added 2023-02-06

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1212,6 +1212,7 @@ mapAliases ({
 
   zabbix40 = throw "'zabbix40' has been removed as it has reached end of life"; # Added 2024-01-07
   zfsStable = zfs; # Added 2024-02-26
+  zfsUnstable = zfs_unstable; # Added 2024-02-26
   zinc = zincsearch; # Added 2023-05-28
   zkg = throw "'zkg' has been replaced by 'zeek'";
   zq = zed.overrideAttrs (old: { meta = old.meta // { mainProgram = "zq"; }; }); # Added 2023-02-06

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28726,15 +28726,21 @@ with pkgs;
 
   zenmonitor = callPackage ../os-specific/linux/zenmonitor { };
 
-  zfs_2_1 = callPackage ../os-specific/linux/zfs/2_1.nix {
-    configFile = "user";
-  };
-  zfs_2_2 = callPackage ../os-specific/linux/zfs/2_2.nix {
-    configFile = "user";
-  };
-  zfs_unstable = callPackage ../os-specific/linux/zfs/unstable.nix {
-    configFile = "user";
-  };
+  inherit
+    ({
+      zfs_2_1 = callPackage ../os-specific/linux/zfs/2_1.nix {
+        configFile = "user";
+      };
+      zfs_2_2 = callPackage ../os-specific/linux/zfs/2_2.nix {
+        configFile = "user";
+      };
+      zfs_unstable = callPackage ../os-specific/linux/zfs/unstable.nix {
+        configFile = "user";
+      };
+    })
+    zfs_2_1
+    zfs_2_2
+    zfs_unstable;
   zfs = zfs_2_2;
 
   ### DATA

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28729,13 +28729,13 @@ with pkgs;
   zfs_2_1 = callPackage ../os-specific/linux/zfs/2_1.nix {
     configFile = "user";
   };
-  zfsStable = callPackage ../os-specific/linux/zfs/stable.nix {
+  zfs_2_2 = callPackage ../os-specific/linux/zfs/2_2.nix {
     configFile = "user";
   };
   zfsUnstable = callPackage ../os-specific/linux/zfs/unstable.nix {
     configFile = "user";
   };
-  zfs = zfsStable;
+  zfs = zfs_2_2;
 
   ### DATA
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28732,7 +28732,7 @@ with pkgs;
   zfs_2_2 = callPackage ../os-specific/linux/zfs/2_2.nix {
     configFile = "user";
   };
-  zfsUnstable = callPackage ../os-specific/linux/zfs/unstable.nix {
+  zfs_unstable = callPackage ../os-specific/linux/zfs/unstable.nix {
     configFile = "user";
   };
   zfs = zfs_2_2;

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -565,7 +565,7 @@ in {
       configFile = "kernel";
       inherit pkgs kernel;
     };
-    zfsStable = callPackage ../os-specific/linux/zfs/stable.nix {
+    zfs_2_2 = callPackage ../os-specific/linux/zfs/2_2.nix {
       configFile = "kernel";
       inherit pkgs kernel;
     };
@@ -573,7 +573,7 @@ in {
       configFile = "kernel";
       inherit pkgs kernel;
     };
-    zfs = zfsStable;
+    zfs = zfs_2_2;
 
     can-isotp = callPackage ../os-specific/linux/can-isotp { };
 

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -569,7 +569,7 @@ in {
       configFile = "kernel";
       inherit pkgs kernel;
     };
-    zfsUnstable = callPackage ../os-specific/linux/zfs/unstable.nix {
+    zfs_unstable = callPackage ../os-specific/linux/zfs/unstable.nix {
       configFile = "kernel";
       inherit pkgs kernel;
     };


### PR DESCRIPTION
## Description of changes

Please see individual commit messages for more details (also suggest reviewing per-commit, as the commits are reasonably atomic). Putting as one PR since most of the changes either build on each other semantically or would conflict, but can split up if some parts warrant more discussion. 

Overall the goal here is to improve consistency in the naming and handling of different ZFS versions.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
