### PR TITLE
libsForQt5.mauiPackages: 3.0.2 -> 3.1.0

### DIFF
--- a/pkgs/applications/maui/default.nix
+++ b/pkgs/applications/maui/default.nix
@@ -15,7 +15,7 @@ See also `pkgs/applications/kde` as this is what this is based on.
 # Updates
 
 1. Update the URL in `./fetch.sh`.
-2. Run `callPackage ./maintainers/scripts/fetch-kde-qt.sh pkgs/applications/maui`
+2. Run `./maintainers/scripts/fetch-kde-qt.sh pkgs/applications/maui`
    from the top of the Nixpkgs tree.
 3. Use `nixpkgs-review wip` to check that everything builds.
 4. Commit the changes and open a pull request.

--- a/pkgs/applications/maui/srcs.nix
+++ b/pkgs/applications/maui/srcs.nix
@@ -4,59 +4,59 @@
 
 {
   agenda = {
-    version = "0.5.2";
+    version = "0.5.3";
     src = fetchurl {
-      url = "${mirror}/stable/maui/agenda/0.5.2/agenda-0.5.2.tar.xz";
-      sha256 = "160y0pq3mj72wxyfnnl45488j4kpl26xpf83vlnfshiwvc6c0m3y";
-      name = "agenda-0.5.2.tar.xz";
+      url = "${mirror}/stable/maui/agenda/0.5.3/agenda-0.5.3.tar.xz";
+      sha256 = "0kx5adv8w0dm84hibaazik6y9bcxw7w7zikw546d4dlaq13pk97i";
+      name = "agenda-0.5.3.tar.xz";
     };
   };
   arca = {
-    version = "0.5.2";
+    version = "0.5.3";
     src = fetchurl {
-      url = "${mirror}/stable/maui/arca/0.5.2/arca-0.5.2.tar.xz";
-      sha256 = "0l0x24m55hc20yc40yjj0zx910yzh31qn911swdli39iy4c6mxk2";
-      name = "arca-0.5.2.tar.xz";
+      url = "${mirror}/stable/maui/arca/0.5.3/arca-0.5.3.tar.xz";
+      sha256 = "0mgn3y2jh9ifxg41fb6z14gp27f1pwfk9y8492qfp3wqfhhmycmk";
+      name = "arca-0.5.3.tar.xz";
     };
   };
   bonsai = {
-    version = "1.1.2";
+    version = "1.1.3";
     src = fetchurl {
-      url = "${mirror}/stable/maui/bonsai/1.1.2/bonsai-1.1.2.tar.xz";
-      sha256 = "0nzp0ixxap3q1llv42l71rygxv98hvcmqwqdw7690w650hja7zvj";
-      name = "bonsai-1.1.2.tar.xz";
+      url = "${mirror}/stable/maui/bonsai/1.1.3/bonsai-1.1.3.tar.xz";
+      sha256 = "0xyfqaihzjdbgcd0mg81qpd12w304zlhdw8mmiyqfamxh33xksql";
+      name = "bonsai-1.1.3.tar.xz";
     };
   };
   booth = {
-    version = "1.1.2";
+    version = "1.1.3";
     src = fetchurl {
-      url = "${mirror}/stable/maui/booth/1.1.2/booth-1.1.2.tar.xz";
-      sha256 = "06gg4zgpn8arnzmi54x7xbdg5wyc3a86v9z5x6y101imh6cwbhyw";
-      name = "booth-1.1.2.tar.xz";
+      url = "${mirror}/stable/maui/booth/1.1.3/booth-1.1.3.tar.xz";
+      sha256 = "0l7bjlpm3m2wc528c6y5s5yf9rlxrl5h0c1lk9s90zzkmyhzpxrl";
+      name = "booth-1.1.3.tar.xz";
     };
   };
   buho = {
-    version = "3.0.2";
+    version = "3.1.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/buho/3.0.2/buho-3.0.2.tar.xz";
-      sha256 = "0sllffddngzxc2wi2wszjxzb75rca0a42bdylm7pxmr5p8mafn1l";
-      name = "buho-3.0.2.tar.xz";
+      url = "${mirror}/stable/maui/buho/3.1.0/buho-3.1.0.tar.xz";
+      sha256 = "0pw8ljnhb3xsbsls6ynihvb5vargk13bija02s963kkbyvcrka0a";
+      name = "buho-3.1.0.tar.xz";
     };
   };
   clip = {
-    version = "3.0.2";
+    version = "3.1.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/clip/3.0.2/clip-3.0.2.tar.xz";
-      sha256 = "0pjqk1l1cwkvwrlv1lb113cl8kggppxqhdsild83wrzbfqx9nrva";
-      name = "clip-3.0.2.tar.xz";
+      url = "${mirror}/stable/maui/clip/3.1.0/clip-3.1.0.tar.xz";
+      sha256 = "1pcka3z5ik5s9hv0np83f6g1fp1pgzq14h83k4l38wfcvbmnjngb";
+      name = "clip-3.1.0.tar.xz";
     };
   };
   communicator = {
-    version = "3.0.2";
+    version = "3.1.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/communicator/3.0.2/communicator-3.0.2.tar.xz";
-      sha256 = "0hmapwsgrlaiwvprpmllfy943w0sclnk4vg7sb6rys1i96f3yz6r";
-      name = "communicator-3.0.2.tar.xz";
+      url = "${mirror}/stable/maui/communicator/3.1.0/communicator-3.1.0.tar.xz";
+      sha256 = "0207jz891d8hs36ma51jbm9af53423lvfir41xmbw5k8j1wi925p";
+      name = "communicator-3.1.0.tar.xz";
     };
   };
   era = {
@@ -68,139 +68,139 @@
     };
   };
   fiery = {
-    version = "1.1.2";
+    version = "1.1.3";
     src = fetchurl {
-      url = "${mirror}/stable/maui/fiery/1.1.2/fiery-1.1.2.tar.xz";
-      sha256 = "0ba3bxhvfzkpwrrnfyhbvprlhdv2vmgmi41lpq2pian0d3nkc05s";
-      name = "fiery-1.1.2.tar.xz";
+      url = "${mirror}/stable/maui/fiery/1.1.3/fiery-1.1.3.tar.xz";
+      sha256 = "1wkvrp1b0y0b7mppwymxmlfrbczxqgxaws10y2001mdxryjf160b";
+      name = "fiery-1.1.3.tar.xz";
     };
   };
   index-fm = {
-    version = "3.0.2";
+    version = "3.1.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/index/3.0.2/index-fm-3.0.2.tar.xz";
-      sha256 = "08ncjliqzx71scmfxl3h24w9s8dgrp6gd7nf6pczyn5arqf96d81";
-      name = "index-fm-3.0.2.tar.xz";
+      url = "${mirror}/stable/maui/index/3.1.0/index-fm-3.1.0.tar.xz";
+      sha256 = "13pvx4rildnc0yqb3km9r9spd2wf6vwayfh0i6bai2vfklv405yg";
+      name = "index-fm-3.1.0.tar.xz";
     };
   };
   mauikit = {
-    version = "3.0.2";
+    version = "3.1.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauikit/3.0.2/mauikit-3.0.2.tar.xz";
-      sha256 = "19317xfbyy3cg9nm1dqknvypsj9kq8phz36srwvwfyxd26kaqs2s";
-      name = "mauikit-3.0.2.tar.xz";
+      url = "${mirror}/stable/maui/mauikit/3.1.0/mauikit-3.1.0.tar.xz";
+      sha256 = "1v7nas1mdkpfyz6580y1z1rk3ad0azh047y19bjy0rrpp75iclmz";
+      name = "mauikit-3.1.0.tar.xz";
     };
   };
   mauikit-accounts = {
-    version = "3.0.2";
+    version = "3.1.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauikit-accounts/3.0.2/mauikit-accounts-3.0.2.tar.xz";
-      sha256 = "1h876vz9vfyl44pryhf5s4lkzik00zwhjvyrv7f4b1zwjz3xbqai";
-      name = "mauikit-accounts-3.0.2.tar.xz";
+      url = "${mirror}/stable/maui/mauikit-accounts/3.1.0/mauikit-accounts-3.1.0.tar.xz";
+      sha256 = "0blzmjdv4cs2m4967mksj0pxpd1gvgjpkgwbwkhya36qc443yfya";
+      name = "mauikit-accounts-3.1.0.tar.xz";
     };
   };
   mauikit-calendar = {
-    version = "3.0.2";
+    version = "3.1.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauikit-calendar/3.0.2/mauikit-calendar-3.0.2.tar.xz";
-      sha256 = "098d2alw1dnhpqwkdy0wrl6cvanyb6vg8qy5aqmgmsk0hil1s8x1";
-      name = "mauikit-calendar-3.0.2.tar.xz";
+      url = "${mirror}/stable/maui/mauikit-calendar/3.1.0/mauikit-calendar-3.1.0.tar.xz";
+      sha256 = "13hf6z99ibly4cbaf4n4r54qc2vcbmf8i8qjndf35z6kxjc4iwpd";
+      name = "mauikit-calendar-3.1.0.tar.xz";
     };
   };
   mauikit-documents = {
-    version = "3.0.2";
+    version = "3.1.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauikit-documents/3.0.2/mauikit-documents-3.0.2.tar.xz";
-      sha256 = "1ln8nk6n2wcqdjd4l5pzam9291rx52mal7rdxs06f6fwszwifhyr";
-      name = "mauikit-documents-3.0.2.tar.xz";
+      url = "${mirror}/stable/maui/mauikit-documents/3.1.0/mauikit-documents-3.1.0.tar.xz";
+      sha256 = "1v1hbzb84rkva5icmynh87h979xgv8a8da6pfzlf1y7h6syw1wf4";
+      name = "mauikit-documents-3.1.0.tar.xz";
     };
   };
   mauikit-filebrowsing = {
-    version = "3.0.2";
+    version = "3.1.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauikit-filebrowsing/3.0.2/mauikit-filebrowsing-3.0.2.tar.xz";
-      sha256 = "03dcmpw8l19mziswhhsvyiiid07qx0c4ddh8986llsz6xngdnlib";
-      name = "mauikit-filebrowsing-3.0.2.tar.xz";
+      url = "${mirror}/stable/maui/mauikit-filebrowsing/3.1.0/mauikit-filebrowsing-3.1.0.tar.xz";
+      sha256 = "146iflqb4kq25f1azajlbwlbphbk754vvf6w7fzl75pdwhqsbxvp";
+      name = "mauikit-filebrowsing-3.1.0.tar.xz";
     };
   };
   mauikit-imagetools = {
-    version = "3.0.2";
+    version = "3.1.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauikit-imagetools/3.0.2/mauikit-imagetools-3.0.2.tar.xz";
-      sha256 = "1xryms7mc3lq8p67m2h3cxffyd9dk8m738ap30aq9ym62qq76psl";
-      name = "mauikit-imagetools-3.0.2.tar.xz";
+      url = "${mirror}/stable/maui/mauikit-imagetools/3.1.0/mauikit-imagetools-3.1.0.tar.xz";
+      sha256 = "1r7j9lg19s63325xyz6i8hzfn751s14mlpxym533mpzpx6yg784q";
+      name = "mauikit-imagetools-3.1.0.tar.xz";
     };
   };
   mauikit-terminal = {
-    version = "3.0.2";
+    version = "3.1.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauikit-terminal/3.0.2/mauikit-terminal-3.0.2.tar.xz";
-      sha256 = "0abywv56ljxbmsi5y3x9agbgbhvscnkznja9adwjj073pavvaf1g";
-      name = "mauikit-terminal-3.0.2.tar.xz";
+      url = "${mirror}/stable/maui/mauikit-terminal/3.1.0/mauikit-terminal-3.1.0.tar.xz";
+      sha256 = "0q2d8lxzhmncassnl043vrgz9am25yk060v7l7bwm6fp9vv5ix5f";
+      name = "mauikit-terminal-3.1.0.tar.xz";
     };
   };
   mauikit-texteditor = {
-    version = "3.0.2";
+    version = "3.1.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauikit-texteditor/3.0.2/mauikit-texteditor-3.0.2.tar.xz";
-      sha256 = "09wdvjy8c0b5lka0fj28kl99w5y3w0nvz2mnr3ic5kn825ay1wmy";
-      name = "mauikit-texteditor-3.0.2.tar.xz";
+      url = "${mirror}/stable/maui/mauikit-texteditor/3.1.0/mauikit-texteditor-3.1.0.tar.xz";
+      sha256 = "0fsjqfvg2fnfmrsz9hfcw20l5yv0pi5jiww2aqyqqpy09q7jxphv";
+      name = "mauikit-texteditor-3.1.0.tar.xz";
     };
   };
   mauiman = {
-    version = "3.0.2";
+    version = "3.1.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/mauiman/3.0.2/mauiman-3.0.2.tar.xz";
-      sha256 = "0aqzgdkcs6cdlsbsyiyhadambcwwa0xj2q2yj5hv5d42q25ibfs1";
-      name = "mauiman-3.0.2.tar.xz";
+      url = "${mirror}/stable/maui/mauiman/3.1.0/mauiman-3.1.0.tar.xz";
+      sha256 = "1462j8xbla6jra3qpxgp5hi580lk53a6ry4fzmllqpzprwgiyx2w";
+      name = "mauiman-3.1.0.tar.xz";
     };
   };
   nota = {
-    version = "3.0.2";
+    version = "3.1.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/nota/3.0.2/nota-3.0.2.tar.xz";
-      sha256 = "11lqdxwsdvf1vz9y1d9r38vxfsz4jfnin3c1ipsvjl0f0zn1glr6";
-      name = "nota-3.0.2.tar.xz";
+      url = "${mirror}/stable/maui/nota/3.1.0/nota-3.1.0.tar.xz";
+      sha256 = "0x9xaas86rhbqs7wsc7chxc4iijg73wnzj2125dgdwcridmdfxix";
+      name = "nota-3.1.0.tar.xz";
     };
   };
   pix = {
-    version = "3.0.2";
+    version = "3.1.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/pix/3.0.2/pix-3.0.2.tar.xz";
-      sha256 = "0wlpqqbf4j7dlylxhfixrcjz0yz9csni4vnbqv9l5vkxxwf0mq4k";
-      name = "pix-3.0.2.tar.xz";
+      url = "${mirror}/stable/maui/pix/3.1.0/pix-3.1.0.tar.xz";
+      sha256 = "0j3xwdscjqyisv5zn8pb0mqarpfkknz3wxgzd7yl2g1gxdpl502h";
+      name = "pix-3.1.0.tar.xz";
     };
   };
   shelf = {
-    version = "3.0.2";
+    version = "3.1.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/shelf/3.0.2/shelf-3.0.2.tar.xz";
-      sha256 = "1x27grdn9qa7ysxh4fb35h5376crpbl39vpd6hn0a7c3fk74w95q";
-      name = "shelf-3.0.2.tar.xz";
+      url = "${mirror}/stable/maui/shelf/3.1.0/shelf-3.1.0.tar.xz";
+      sha256 = "166l6f5ifv5yz3sgds50bi9swdr3zl7m499myy5x8ph2jw1i2dvq";
+      name = "shelf-3.1.0.tar.xz";
     };
   };
   station = {
-    version = "3.0.2";
+    version = "3.1.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/station/3.0.2/station-3.0.2.tar.xz";
-      sha256 = "14i4z5lkj2rg7p5nkglqpzvrrxmf7b07kf49hh1jdk08753abc76";
-      name = "station-3.0.2.tar.xz";
+      url = "${mirror}/stable/maui/station/3.1.0/station-3.1.0.tar.xz";
+      sha256 = "0skwagzwd4v24ldrww727zs3chzfb1spbynzdjb0yc7pggzxn8nf";
+      name = "station-3.1.0.tar.xz";
     };
   };
   strike = {
-    version = "1.1.2";
+    version = "1.1.3";
     src = fetchurl {
-      url = "${mirror}/stable/maui/strike/1.1.2/strike-1.1.2.tar.xz";
-      sha256 = "01ak3h6n0z3l346nbzfabkgbzwbx1fm3l9g7myiip4518cb2n559";
-      name = "strike-1.1.2.tar.xz";
+      url = "${mirror}/stable/maui/strike/1.1.3/strike-1.1.3.tar.xz";
+      sha256 = "1b0n56mfchcf37j33i3kxp3pd9sc2f1fq5hjfhy1s34dk8gfv947";
+      name = "strike-1.1.3.tar.xz";
     };
   };
   vvave = {
-    version = "3.0.2";
+    version = "3.1.0";
     src = fetchurl {
-      url = "${mirror}/stable/maui/vvave/3.0.2/vvave-3.0.2.tar.xz";
-      sha256 = "1py46ryi57757wyqfvxc2h02x33n11g1v04f0hac0zkjilp5l21k";
-      name = "vvave-3.0.2.tar.xz";
+      url = "${mirror}/stable/maui/vvave/3.1.0/vvave-3.1.0.tar.xz";
+      sha256 = "1ig6vzrqrq4h8y69xm6hxppzspa4vrawpn4rk6rva26j5qm7dh1l";
+      name = "vvave-3.1.0.tar.xz";
     };
   };
 }


### PR DESCRIPTION
Pix fails to build with
```
In file included from /build/pix-3.1.0/src/models/cities/citiesmodel.cpp:3:
/nix/store/yhi8jd368sv19vazm6bg6zhlb4y0izlb-mauikit-imagetools-3.1.0/include/MauiKit3/ImageTools/cities.h:11:10: fatal error: kdtree.hpp: No such file or directory
   11 | #include "kdtree.hpp"
      |          ^~~~~~~~~~~~
compilation terminated.
make[2]: *** [src/CMakeFiles/pix.dir/build.make:316: src/CMakeFiles/pix.dir/models/cities/citiesmodel.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
In file included from /build/pix-3.1.0/src/models/folders/placesmodel.cpp:10:
/nix/store/yhi8jd368sv19vazm6bg6zhlb4y0izlb-mauikit-imagetools-3.1.0/include/MauiKit3/ImageTools/cities.h:11:10: fatal error: kdtree.hpp: No such file or directory
   11 | #include "kdtree.hpp"
      |          ^~~~~~~~~~~~
compilation terminated.
make[2]: *** [src/CMakeFiles/pix.dir/build.make:288: src/CMakeFiles/pix.dir/models/folders/placesmodel.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:265: src/CMakeFiles/pix.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

## Description of changes
https://mauikit.org/blog/maui-release-briefing-5/
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
cc @milahu 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
