### PR TITLE
python2Packages.wcwidth: fix build

### DIFF
--- a/pkgs/development/python2-modules/wcwidth/default.nix
+++ b/pkgs/development/python2-modules/wcwidth/default.nix
@@ -1,5 +1,6 @@
 { backports-functools-lru-cache
 , wcwidth
+, lib
 }:
 
 wcwidth.overridePythonAttrs(oldAttrs: {
@@ -14,4 +15,10 @@ wcwidth.overridePythonAttrs(oldAttrs: {
       https://github.com/jquast/wcwidth/pull/117#issuecomment-1946609638
   */
   disabled = false;
+
+  meta = oldAttrs.meta // {
+    /** maintainers overridden here for python2; this makes sure that python3
+        maintainers are not blamed for the breakage here. */
+    maintainers = with lib.maintainers; [ bryango ];
+  };
 })

--- a/pkgs/development/python2-modules/wcwidth/default.nix
+++ b/pkgs/development/python2-modules/wcwidth/default.nix
@@ -6,5 +6,12 @@ wcwidth.overridePythonAttrs(oldAttrs: {
   propagatedBuildInputs = oldAttrs.propagatedBuildInputs or [] ++ [
     backports-functools-lru-cache
   ];
-})
 
+  /**
+    As of version 0.2.13 upstream still supports python2. In the future, this
+    package should be dropped or pinned to the last working version after the
+    final release for python2. See:
+      https://github.com/jquast/wcwidth/pull/117#issuecomment-1946609638
+  */
+  disabled = false;
+})


### PR DESCRIPTION
`python2Packages.wcwidth` is disabled in https://github.com/NixOS/nixpkgs/pull/289229/files#diff-e3660b6955728047c993d60ff4af021e2f83ac4b8abd771938015a31141dc913R14. However, as of version 0.2.13 upstream still supports python2, so we re-enabled it in this commit. In the future, this package should be dropped or pinned to the last working version after upstream's final release for python2. See:
- https://github.com/jquast/wcwidth/pull/117#issuecomment-1946609638

Friendly ping @fabaff for comments :wink:

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
