### PR TITLE
haskellPackages.dhall-lsp-server: use latest revision from git

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -93,8 +93,8 @@ extra-packages:
   - language-docker == 11.0.0           # required by hadolint 2.12.0, 2022-11-16
   - language-javascript == 0.7.0.0      # required by purescript
   - lens-aeson < 1.2                    # 2022-12-17: For aeson < 2.0 compat
-  - lsp == 1.4.0.0                      # 2022-09-18: need for dhall-lsp-server 1.1.2
-  - lsp-types == 1.4.0.1                # 2022-09-18: need for dhall-lsp-server 1.1.2
+  - lsp == 2.1.0.0                      # 2024-02-28: need for dhall-lsp-server unstable
+  - lsp-types == 2.0.2.0                # 2024-02-28: need for dhall-lsp-server unstable
   - mmorph == 1.1.3                     # Newest working version of mmorph on ghc 8.6.5. needed for hls
   - network == 2.6.3.1                  # required by pkgs/games/hedgewars/default.nix, 2020-11-15
   - optparse-applicative < 0.16         # needed for niv-0.2.19


### PR DESCRIPTION
This is for merging into the `haskell-updates` branch, PR #279413.

It fixes the build of dhall-lsp-server by using an unreleased revision from git main branch.

cc: @dalpd @Gabriella439

See also: dhall-lang/dhall-haskell#2566
