### PR TITLE
opengist: init at 1.6.1

### DIFF
--- a/pkgs/by-name/op/opengist/package.nix
+++ b/pkgs/by-name/op/opengist/package.nix
@@ -1,0 +1,70 @@
+{ lib, buildGoModule, buildNpmPackage, fetchFromGitHub, moreutils, jq, git }:
+let
+  # finalAttrs when 🥺 (buildGoModule does not support them)
+  # https://github.com/NixOS/nixpkgs/issues/273815
+  version = "1.6.1";
+  src = fetchFromGitHub {
+    owner = "thomiceli";
+    repo = "opengist";
+    rev = "v${version}";
+    hash = "sha256-rJ8oiH08kSSFNgPHKGo68Oi1i3L1SEJyHuzoxKMOZME=";
+  };
+
+  frontend = buildNpmPackage {
+    pname = "opengist-frontend";
+    inherit version src;
+
+    nativeBuildInputs = [ moreutils jq ];
+
+    # npm complains of "invalid package". shrug. we can give it a version.
+    preBuild = ''
+      jq '.version = "${version}"' package.json | sponge package.json
+    '';
+
+    # copy pasta from the Makefile upstream, seems to be a workaround of sass
+    # issues, unsure why it is not done in vite:
+    # https://github.com/thomiceli/opengist/blob/05eccfa8e728335514a40476cd8116cfd1ca61dd/Makefile#L16-L19
+    postBuild = ''
+      EMBED=1 npx postcss 'public/assets/embed-*.css' -c public/postcss.config.js --replace
+    '';
+
+    installPhase = ''
+      mkdir -p $out
+      cp -R public $out
+    '';
+
+    npmDepsHash = "sha256-Sy321tIQOOrypk+EOGGixEzrPdhA9U8Hak+DOS+d00A=";
+  };
+in
+buildGoModule {
+  pname = "opengist";
+  inherit version src;
+  vendorHash = "sha256-IorqXJKzUTUL5zfKRipZaJtRlwVOmTwolJXFG/34Ais=";
+  tags = [
+    "fs_embed"
+  ];
+
+  # required for tests
+  nativeCheckInputs = [
+    git
+  ];
+
+  # required for tests to not try to write into $HOME and fail
+  preCheck = ''
+    export OG_OPENGIST_HOME=$(mktemp -d)
+  '';
+
+  postPatch = ''
+    cp -R ${frontend}/public/{manifest.json,assets} public/
+  '';
+
+  passthru.frontend = frontend;
+
+  meta = {
+    description = "Self-hosted pastebin powered by Git";
+    homepage = "https://github.com/thomiceli/opengist";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ lf- ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is a clone of github gist, with 100% more open source and 100% more self hosted.

https://github.com/thomiceli/opengist

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
