### PR TITLE
gxml: init at 0.20.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9102,6 +9102,12 @@
     githubId = 8900;
     name = "Johan Magnus Jonsson";
   };
+  jmarmstrong1207 = {
+    name = "James Armstrong";
+    email = "jm.armstrong1207@gmail.com";
+    github = "jmarmstrong1207";
+    githubId = 32995055;
+  };
   jmbaur = {
     email = "jaredbaur@fastmail.com";
     github = "jmbaur";

--- a/pkgs/by-name/gx/gxml/package.nix
+++ b/pkgs/by-name/gx/gxml/package.nix
@@ -1,0 +1,60 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, gobject-introspection
+, meson
+, ninja
+, pkg-config
+, vala
+, glib
+, libgee
+, libxml2
+, gitUpdater
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gxml";
+  version = "0.20.3";
+
+  outputs = [ "out" "dev" "devdoc" ];
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = "gxml";
+    rev = finalAttrs.version;
+    hash = "sha256-GlctGxsLyQ2kPV3oBmusRiouG4PPncBTh3vgxhVaQOo=";
+  };
+
+  nativeBuildInputs = [
+    gobject-introspection
+    meson
+    ninja
+    pkg-config
+    vala
+  ];
+
+  propagatedBuildInputs = [
+    glib
+    libgee
+    libxml2
+  ];
+
+  postPatch = ''
+    # https://gitlab.gnome.org/GNOME/gxml/-/merge_requests/24
+    substituteInPlace gxml/gxml.pc.in \
+      --replace-fail "includedir=@prefix@/include" "includedir=${placeholder "dev"}/include"
+  '';
+
+  doCheck = true;
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = with lib; {
+    description = "GXml provides a GObject API for manipulating XML and a Serializable framework from GObject to XML";
+    homepage = "https://gitlab.gnome.org/GNOME/gxml";
+    license = licenses.lgpl21Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ jmarmstrong1207 ] ++ teams.gnome.members;
+  };
+})


### PR DESCRIPTION
## Description of changes

Init gxml. It provides a GObject API for manipulating XML and a Serializable framework from GObject to XML. It's required for packages such as Planify, where their newest update v4.5 requires gxml. the derivation file has been sourced from the flake.nix in the gxml repository [linked here](https://gitlab.gnome.org/GNOME/gxml/-/blob/master/flake.nix?ref_type=heads)

Closes #194803 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
