### PR TITLE
ioq3-scion init at unstable-2024-03-03

### DIFF
--- a/pkgs/by-name/io/ioq3-scion/package.nix
+++ b/pkgs/by-name/io/ioq3-scion/package.nix
@@ -1,0 +1,19 @@
+{ ioquake3, fetchFromGitHub, pan-bindings, libsodium, lib }:
+ioquake3.overrideAttrs (old: {
+  pname = "ioq3-scion";
+  version = "unstable-2024-03-03";
+  buildInputs = old.buildInputs ++ [
+    pan-bindings
+    libsodium
+  ];
+  src = fetchFromGitHub {
+    owner = "lschulz";
+    repo = "ioq3-scion";
+    rev = "9f06abd5030c51cd4582ba3d24ba87531e3eadbc";
+    hash = "sha256-+zoSlNT+oqozQFnhA26PiMo1NnzJJY/r4tcm2wOCBP0=";
+  };
+  meta = {
+    description = "ioquake3 with support for path aware networking";
+    maintainers = with lib.maintainers; [ matthewcroughan ];
+  };
+})

--- a/pkgs/by-name/pa/pan-bindings/package.nix
+++ b/pkgs/by-name/pa/pan-bindings/package.nix
@@ -1,0 +1,61 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, buildGo122Module
+, cmake
+, ncurses
+, asio
+}:
+
+let
+  version = "unstable-2024-03-03";
+  src = fetchFromGitHub {
+    owner = "lschulz";
+    repo = "pan-bindings";
+    rev = "4361d30f1c5145a70651c259f2d56369725b0d15";
+    hash = "sha256-0WxrgXTCM+BwGcjjWBBKiZawje2yxB5RRac6Sk5t3qc=";
+  };
+  goDeps = (buildGo122Module {
+    name = "pan-bindings-goDeps";
+    inherit src version;
+    modRoot = "go";
+    vendorHash = "sha256-7EitdEJTRtiM29qmVnZUM6w68vCBI8mxZhCA7SnAxLA=";
+  });
+in
+
+stdenv.mkDerivation {
+  name = "pan-bindings";
+
+  inherit src version;
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=1"
+    "-DBUILD_EXAMPLES=0"
+  ];
+
+  patchPhase = ''
+    runHook prePatch
+    export HOME=$TMP
+    cp -r --reflink=auto ${goDeps.goModules} go/vendor
+    runHook postPatch
+  '';
+
+  buildInputs = [
+    ncurses
+    asio
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    goDeps.go
+  ];
+
+  meta = with lib; {
+    description = "SCION PAN Bindings for C, C++, and Python";
+    homepage = "https://github.com/lschulz/pan-bindings";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ matthewcroughan ];
+    mainProgram = "pan-bindings";
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds a fork of ioquake3 capable of using the [SCION internet architecture](https://scion-architecture.net/), which depends upon pan-bindings (path aware networking.

~This is pending a GO version bump, which is incidentally in this PR https://github.com/lschulz/pan-bindings/pull/2, but the Rust code in this PR is a WIP and so I'll mark this PR as a draft until there's an upstream version bump.~

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
