### PR TITLE
python311Packages.types-lxml: init at 2024.02.09

### DIFF
--- a/pkgs/development/python-modules/types-lxml/default.nix
+++ b/pkgs/development/python-modules/types-lxml/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, lxml
+, pyright
+, pytestCheckHook
+, pythonOlder
+, setuptools
+, setuptools-scm
+, typeguard
+, types-beautifulsoup4
+, typing-extensions
+}:
+
+buildPythonPackage rec {
+  pname = "types-lxml";
+  version = "2024.02.09";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "abelcheung";
+    repo = "types-lxml";
+    rev = "refs/tags/${version}";
+    hash = "sha256-vmRbzfwlGGxd64KX8j4B3O9c7kg7hXSsCEYq3WAFdmk=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    types-beautifulsoup4
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    lxml
+    pyright
+    pytestCheckHook
+    typeguard
+  ];
+
+  pythonImportsCheck = [
+    "lxml-stubs"
+  ];
+
+  disabledTests = [
+    # AttributeError: 'bytes' object has no attribute 'find_class'
+    # https://github.com/abelcheung/types-lxml/issues/34
+    "test_bad_methodfunc"
+    "test_find_class"
+    "test_find_rel_links"
+    "test_iterlinks"
+    "test_make_links_absolute"
+    "test_resolve_base_href"
+    "test_rewrite_links"
+  ];
+
+  meta = with lib; {
+    description = "Complete lxml external type annotation";
+    homepage = "https://github.com/abelcheung/types-lxml";
+    changelog = "https://github.com/abelcheung/types-lxml/releases/tag/${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15746,6 +15746,8 @@ self: super: with self; {
 
   types-ipaddress = callPackage ../development/python-modules/types-ipaddress { };
 
+  types-lxml = callPackage ../development/python-modules/types-lxml { };
+
   types-markdown = callPackage ../development/python-modules/types-markdown { };
 
   types-mock = callPackage ../development/python-modules/types-mock { };


### PR DESCRIPTION
## Description of changes

Complete lxml external type annotation

https://github.com/abelcheung/types-lxml

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
