### PR TITLE
[Backport release-23.11] stdenv: substituteStream: deprecate --replace in favor of --replace-{fail,warn,quiet}

### DIFF
--- a/doc/languages-frameworks/emscripten.section.md
+++ b/doc/languages-frameworks/emscripten.section.md
@@ -86,9 +86,9 @@ One advantage is that when `pkgs.zlib` is updated, it will automatically update 
 
   postPatch = pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
     substituteInPlace configure \
-      --replace '/usr/bin/libtool' 'ar' \
-      --replace 'AR="libtool"' 'AR="ar"' \
-      --replace 'ARFLAGS="-o"' 'ARFLAGS="-r"'
+      --replace-fail '/usr/bin/libtool' 'ar' \
+      --replace-fail 'AR="libtool"' 'AR="ar"' \
+      --replace-fail 'ARFLAGS="-o"' 'ARFLAGS="-r"'
   '';
 })
 ```

--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -700,7 +700,7 @@ with import <nixpkgs> {};
     hello = attrs: lib.optionalAttrs (lib.versionAtLeast attrs.version "1.0")  {
       postPatch = ''
         substituteInPlace lib/zoneinfo.rs \
-          --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
+          --replace-fail "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
       '';
     };
   };

--- a/doc/stdenv/platform-notes.chapter.md
+++ b/doc/stdenv/platform-notes.chapter.md
@@ -54,7 +54,7 @@ Some common issues when packaging software for Darwin:
     # ...
     prePatch = ''
       substituteInPlace Makefile \
-          --replace '/usr/bin/xcrun clang' clang
+          --replace-fail '/usr/bin/xcrun clang' clang
     '';
   }
   ```

--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -230,9 +230,9 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     substituteInPlace $out/bin/solo5-virtio-mkimage \
-      --replace "/usr/lib/syslinux" "${syslinux}/share/syslinux" \
-      --replace "/usr/share/syslinux" "${syslinux}/share/syslinux" \
-      --replace "cp " "cp --no-preserve=mode "
+      --replace-fail "/usr/lib/syslinux" "${syslinux}/share/syslinux" \
+      --replace-fail "/usr/share/syslinux" "${syslinux}/share/syslinux" \
+      --replace-fail "cp " "cp --no-preserve=mode "
 
     wrapProgram $out/bin/solo5-virtio-mkimage \
       --prefix PATH : ${lib.makeBinPath [ dosfstools mtools parted syslinux ]}
@@ -1217,9 +1217,20 @@ postInstall = ''
 
 Performs string substitution on the contents of \<infile\>, writing the result to \<outfile\>. The substitutions in \<subs\> are of the following form:
 
-#### `--replace` \<s1\> \<s2\> {#fun-substitute-replace}
+#### `--replace-fail` \<s1\> \<s2\> {#fun-substitute-replace-fail}
 
 Replace every occurrence of the string \<s1\> by \<s2\>.
+Will error if no change is made.
+
+#### `--replace-warn` \<s1\> \<s2\> {#fun-substitute-replace-warn}
+
+Replace every occurrence of the string \<s1\> by \<s2\>.
+Will print a warning if no change is made.
+
+#### `--replace-quiet` \<s1\> \<s2\> {#fun-substitute-replace-quiet}
+
+Replace every occurrence of the string \<s1\> by \<s2\>.
+Will do nothing if no change can be made.
 
 #### `--subst-var` \<varName\> {#fun-substitute-subst-var}
 
@@ -1233,8 +1244,8 @@ Example:
 
 ```shell
 substitute ./foo.in ./foo.out \
-    --replace /usr/bin/bar $bar/bin/bar \
-    --replace "a string containing spaces" "some other text" \
+    --replace-fail /usr/bin/bar $bar/bin/bar \
+    --replace-fail "a string containing spaces" "some other text" \
     --subst-var someVar
 ```
 

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -816,7 +816,7 @@ fi
 # Textual substitution functions.
 
 # only log once, due to max logging limit on hydra
-_substituteStream_has_warned_replace_deprecation=""
+_substituteStream_has_warned_replace_deprecation=false
 
 substituteStream() {
     local var=$1
@@ -824,24 +824,18 @@ substituteStream() {
     shift 2
 
     while (( "$#" )); do
-        local is_required=1
-        local is_quiet=""
+        local replace_mode="$1"
         case "$1" in
-            --replace-quiet)
-                is_quiet=1
-                ;&
             --replace)
                 # deprecated 2023-11-22
                 # this will either get removed, or switch to the behaviour of --replace-fail in the future
-                if [ -z "$is_quiet" ] && [ -z "$_substituteStream_has_warned_replace_deprecation" ]; then
+                if ! "$_substituteStream_has_warned_replace_deprecation"; then
                     echo "substituteStream(): WARNING: '--replace' is deprecated, use --replace-{fail,warn,quiet}. ($description)" >&2
-                    _substituteStream_has_warned_replace_deprecation=1
+                    _substituteStream_has_warned_replace_deprecation=true
                 fi
+                replace_mode='--replace-warn'
                 ;&
-            --replace-warn)
-                is_required=""
-                ;&
-            --replace-fail)
+            --replace-quiet|--replace-warn|--replace-fail)
                 pattern="$2"
                 replacement="$3"
                 shift 3
@@ -850,11 +844,9 @@ substituteStream() {
                 eval "$var"'=${'"$var"'//"$pattern"/"$replacement"}'
                 if [ "$pattern" != "$replacement" ]; then
                     if [ "${!var}" == "$savedvar" ]; then
-                        if [ -z "$is_required" ]; then
-                            if [ -z "$is_quiet" ]; then
-                                printf "substituteStream(): WARNING: pattern %q doesn't match anything in %s\n" "$pattern" "$description" >&2
-                            fi
-                        else
+                        if [ "$replace_mode" == --replace-warn ]; then
+                            printf "substituteStream(): WARNING: pattern %q doesn't match anything in %s\n" "$pattern" "$description" >&2
+                        elif [ "$replace_mode" == --replace-fail ]; then
                             printf "substituteStream(): ERROR: pattern %q doesn't match anything in %s\n" "$pattern" "$description" >&2
                             return 1
                         fi

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -815,9 +815,6 @@ fi
 ######################################################################
 # Textual substitution functions.
 
-# only log once, due to max logging limit on hydra
-_substituteStream_has_warned_replace_deprecation=false
-
 substituteStream() {
     local var=$1
     local description=$2
@@ -827,12 +824,6 @@ substituteStream() {
         local replace_mode="$1"
         case "$1" in
             --replace)
-                # deprecated 2023-11-22
-                # this will either get removed, or switch to the behaviour of --replace-fail in the future
-                if ! "$_substituteStream_has_warned_replace_deprecation"; then
-                    echo "substituteStream(): WARNING: '--replace' is deprecated, use --replace-{fail,warn,quiet}. ($description)" >&2
-                    _substituteStream_has_warned_replace_deprecation=true
-                fi
                 replace_mode='--replace-warn'
                 ;&
             --replace-quiet|--replace-warn|--replace-fail)

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -815,6 +815,8 @@ fi
 ######################################################################
 # Textual substitution functions.
 
+# only log once, due to max logging limit on hydra
+_substituteStream_has_warned_replace_deprecation=""
 
 substituteStream() {
     local var=$1
@@ -822,8 +824,24 @@ substituteStream() {
     shift 2
 
     while (( "$#" )); do
+        local is_required=1
+        local is_quiet=""
         case "$1" in
+            --replace-quiet)
+                is_quiet=1
+                ;&
             --replace)
+                # deprecated 2023-11-22
+                # this will either get removed, or switch to the behaviour of --replace-fail in the future
+                if [ -z "$_substituteStream_has_warned_replace_deprecation" ]; then
+                    echo "substituteStream(): WARNING: '--replace' is deprecated, use --replace-{fail,warn,quiet}. ($description)" >&2
+                    _substituteStream_has_warned_replace_deprecation=1
+                fi
+                ;&
+            --replace-warn)
+                is_required=""
+                ;&
+            --replace-fail)
                 pattern="$2"
                 replacement="$3"
                 shift 3
@@ -832,7 +850,14 @@ substituteStream() {
                 eval "$var"'=${'"$var"'//"$pattern"/"$replacement"}'
                 if [ "$pattern" != "$replacement" ]; then
                     if [ "${!var}" == "$savedvar" ]; then
-                        echo "substituteStream(): WARNING: pattern '$pattern' doesn't match anything in $description" >&2
+                        if [ -z "$is_required" ]; then
+                            if [ -z "$is_quiet" ]; then
+                                echo "substituteStream(): WARNING: pattern '$pattern' doesn't match anything in $description" >&2
+                            fi
+                        else
+                            echo "substituteStream(): ERROR: pattern '$pattern' doesn't match anything in $description" >&2
+                            return 1
+                        fi
                     fi
                 fi
                 ;;

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -852,10 +852,10 @@ substituteStream() {
                     if [ "${!var}" == "$savedvar" ]; then
                         if [ -z "$is_required" ]; then
                             if [ -z "$is_quiet" ]; then
-                                echo "substituteStream(): WARNING: pattern '$pattern' doesn't match anything in $description" >&2
+                                printf "substituteStream(): WARNING: pattern %q doesn't match anything in %s\n" "$pattern" "$description" >&2
                             fi
                         else
-                            echo "substituteStream(): ERROR: pattern '$pattern' doesn't match anything in $description" >&2
+                            printf "substituteStream(): ERROR: pattern %q doesn't match anything in %s\n" "$pattern" "$description" >&2
                             return 1
                         fi
                     fi

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -833,7 +833,7 @@ substituteStream() {
             --replace)
                 # deprecated 2023-11-22
                 # this will either get removed, or switch to the behaviour of --replace-fail in the future
-                if [ -z "$_substituteStream_has_warned_replace_deprecation" ]; then
+                if [ -z "$is_quiet" ] && [ -z "$_substituteStream_has_warned_replace_deprecation" ]; then
                     echo "substituteStream(): WARNING: '--replace' is deprecated, use --replace-{fail,warn,quiet}. ($description)" >&2
                     _substituteStream_has_warned_replace_deprecation=1
                 fi


### PR DESCRIPTION
## Description of changes
Backport the following changes:
https://github.com/NixOS/nixpkgs/pull/260776
https://github.com/NixOS/nixpkgs/pull/286526
https://github.com/NixOS/nixpkgs/pull/287111

This should allow backporting changes like this: https://github.com/NixOS/nixpkgs/pull/292041

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
