### PR TITLE
python311Packages.home-assistant-chip-{core,clusters}: 2024.1.0 -> 2024.2.1; python-matter-server: 5.5.3 -> 5.7.0b1

### DIFF
--- a/pkgs/development/python-modules/home-assistant-chip-clusters/default.nix
+++ b/pkgs/development/python-modules/home-assistant-chip-clusters/default.nix
@@ -7,7 +7,7 @@
 
 buildPythonPackage rec {
   pname = "home-assistant-chip-clusters";
-  version = "2024.1.0";
+  version = "2024.2.1";
   format = "wheel";
 
   src = fetchPypi {
@@ -15,7 +15,7 @@ buildPythonPackage rec {
     pname = "home_assistant_chip_clusters";
     dist = "py3";
     python = "py3";
-    hash = "sha256-4btkqAHbwAsyGV1LjngEoeTT5qyI8dtqFVTp0lIFwmg=";
+    hash = "sha256-QMsfs9gUWeaz1LfMZF5J2OFVCPnuckZvvF9x5bQ5uZY=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/home-assistant-chip-core/default.nix
+++ b/pkgs/development/python-modules/home-assistant-chip-core/default.nix
@@ -10,7 +10,6 @@
 # runtime
 , glib
 , libnl
-, openssl_1_1
 
 # propagates
 , aenum
@@ -29,7 +28,7 @@
 
 buildPythonPackage rec {
   pname = "home-assistant-chip-core";
-  version = "2024.1.0";
+  version = "2024.2.1";
   format = "wheel";
 
   disabled = pythonOlder "3.7";
@@ -38,11 +37,11 @@ buildPythonPackage rec {
     system = {
       "aarch64-linux" = {
         name = "aarch64";
-        hash = "sha256-UiikZ2DVhTqX6WYfiE8sp2e52BMlyoQnDjLap/efmNc=";
+        hash = "sha256-gHnTuiyCD9A9Ru8xhniNEpCyn+W9zYnCAoTJeGOW7TI=";
       };
       "x86_64-linux" = {
         name = "x86_64";
-        hash = "sha256-/+gegUMd2n7MpJvdilS5VWefXc0tuRcLrXBBXSH35b0=";
+        hash = "sha256-gKZKcCXQ8PvZAPV2QRQl+u+r95CVLBDDDgtC0MT7xw4=";
       };
     }.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
   in fetchPypi {
@@ -62,7 +61,6 @@ buildPythonPackage rec {
   buildInputs = [
     glib
     libnl
-    openssl_1_1
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/python-matter-server/default.nix
+++ b/pkgs/development/python-modules/python-matter-server/default.nix
@@ -5,6 +5,7 @@
 
 # build
 , setuptools
+, pythonRelaxDepsHook
 
 # propagates
 , aiohttp
@@ -29,7 +30,7 @@
 
 buildPythonPackage rec {
   pname = "python-matter-server";
-  version = "5.5.3";
+  version = "5.7.0b1";
   format = "pyproject";
 
   disabled = pythonOlder "3.10";
@@ -38,16 +39,22 @@ buildPythonPackage rec {
     owner = "home-assistant-libs";
     repo = "python-matter-server";
     rev = "refs/tags/${version}";
-    hash = "sha256-8daAABR5l8ZEX+PR4XrxRHlLllgnOVE4Q9yY/7UQXHw=";
+    hash = "sha256-icWp5DiUoTn1l0wNFk83jCpbVsb6MN2qM3QvI6uZaic=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace 'version = "0.0.0"' 'version = "${version}"'
+      --replace 'version = "0.0.0"' 'version = "${version}"' \
+      --replace '--cov' ""
   '';
 
   nativeBuildInputs = [
     setuptools
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [
+    "home-assistant-chip-clusters"
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
https://github.com/home-assistant-libs/chip-wheels/releases/tag/2024.2.0
https://github.com/home-assistant-libs/chip-wheels/releases/tag/2024.2.1

Replaces our `openssl_1_1` with their vendored boringssl :smiling_face_with_tear: 

cc https://github.com/NixOS/nixpkgs/issues/269713

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
