### PR TITLE
Update vllm to v0.3.2

### DIFF
--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage rec {
     owner = "vllm-project";
     repo = pname;
     rev = "v${version}";
-    hash = nixpkgs.lib.fakeSha256;
+    hash = "sha256-ZFwlR8Xnen7FFblwzPJm0k+3iEo2p27QhfRaDfzwbOM=";
   };
 
   # Otherwise it tries to enumerate host supported ROCM gfx archs, and that is not possible due to sandboxing.

--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -36,14 +36,14 @@
 
 buildPythonPackage rec {
   pname = "vllm";
-  version = "0.3.1";
+  version = "0.3.2";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "vllm-project";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-hfd4ScU0mkZ7z4+w08BUA1K9bPXSiFThfiO+Ll2MTtg=";
+    hash = nixpkgs.lib.fakeSha256;
   };
 
   # Otherwise it tries to enumerate host supported ROCM gfx archs, and that is not possible due to sandboxing.
@@ -62,11 +62,11 @@ buildPythonPackage rec {
     substituteInPlace requirements.txt \
       --replace "cupy-cuda12x == 12.1.0" "cupy == 12.3.0"
     substituteInPlace requirements-build.txt \
-      --replace "torch==2.1.2" "torch == 2.2.0"
+      --replace "torch==2.1.2" "torch == 2.2.1"
     substituteInPlace pyproject.toml \
-      --replace "torch == 2.1.2" "torch == 2.2.0"
+      --replace "torch == 2.1.2" "torch == 2.2.1"
     substituteInPlace requirements.txt \
-      --replace "torch == 2.1.2" "torch == 2.2.0"
+      --replace "torch == 2.1.2" "torch == 2.2.1"
   '' + lib.optionalString rocmSupport ''
     substituteInPlace setup.py \
       --replace "'hipcc', '--version'" "'${writeShellScript "hipcc-version-stub" "echo HIP version: 0.0"}'"


### PR DESCRIPTION
## Description of changes
vllm updated to 0.3.2.

## Things done
vllm version and commit changed to match v0.3.2
bump torch version from 2.2.0 to 2.2.1

- Built on platform(s)
  - [x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
