### PR TITLE
nixops_unstable to nixops_unstable_minimal.withPlugins migration + update

### DIFF
--- a/nixos/tests/nixops/default.nix
+++ b/nixos/tests/nixops/default.nix
@@ -9,7 +9,7 @@ let
     #  - Alternatively, blocked on a NixOps 2 release
     #    https://github.com/NixOS/nixops/issues/1242
     # stable = testsLegacyNetwork { nixopsPkg = pkgs.nixops; };
-    unstable = testsForPackage { nixopsPkg = pkgs.nixops_unstable; };
+    unstable = testsForPackage { nixopsPkg = pkgs.nixops_unstable_minimal; };
 
     # inherit testsForPackage;
   };

--- a/nixos/tests/nixops/default.nix
+++ b/nixos/tests/nixops/default.nix
@@ -32,6 +32,7 @@ let
           pkgs.hello
           pkgs.figlet
         ];
+        virtualisation.memorySize = 2048;
 
         # TODO: make this efficient, https://github.com/NixOS/nixpkgs/issues/180529
         system.includeBuildDependencies = true;

--- a/pkgs/applications/networking/cluster/nixops/default.nix
+++ b/pkgs/applications/networking/cluster/nixops/default.nix
@@ -1,4 +1,4 @@
-{ python3 }:
+{ lib, python3 }:
 
 let
   python = python3.override {
@@ -47,6 +47,12 @@ let
         nixos = old.passthru.tests.nixos.passthru.override {
           nixopsPkg = r;
         };
+      }
+      # Make sure we also test with a configuration that's been extended with a plugin.
+      // lib.optionalAttrs (selectedPlugins == []) {
+        withAPlugin =
+          lib.recurseIntoAttrs
+            (withPlugins (ps: with ps; [ nixops-encrypted-links ])).tests;
       };
     };
   }));

--- a/pkgs/applications/networking/cluster/nixops/default.nix
+++ b/pkgs/applications/networking/cluster/nixops/default.nix
@@ -25,10 +25,12 @@ let
     nixopsvbox = nixops-vbox;
   };
 
+  withPlugins = withPlugins' { availablePlugins = plugins python.pkgs; };
+
   # selector is a function mapping pythonPackages to a list of plugins
   # e.g. nixops_unstable.withPlugins (ps: with ps; [ nixops-aws ])
-  withPlugins = selector: let
-   selected = selector (plugins python.pkgs);
+  withPlugins' = { availablePlugins }: selector: let
+   selected = selector availablePlugins;
    r = python.pkgs.toPythonApplication (python.pkgs.nixops.overridePythonAttrs (old: {
     propagatedBuildInputs = old.propagatedBuildInputs ++ selected;
 
@@ -39,7 +41,7 @@ let
     '';
 
     passthru = old.passthru // {
-      plugins = plugins python.pkgs;
+      plugins = availablePlugins;
       inherit withPlugins python;
       tests = old.passthru.tests // {
         nixos = old.passthru.tests.nixos.passthru.override {

--- a/pkgs/applications/networking/cluster/nixops/default.nix
+++ b/pkgs/applications/networking/cluster/nixops/default.nix
@@ -41,7 +41,7 @@ let
     '';
 
     passthru = old.passthru // {
-      plugins = availablePlugins;
+      inherit availablePlugins;
       inherit withPlugins python;
       tests = old.passthru.tests // {
         nixos = old.passthru.tests.nixos.passthru.override {

--- a/pkgs/applications/networking/cluster/nixops/default.nix
+++ b/pkgs/applications/networking/cluster/nixops/default.nix
@@ -43,14 +43,20 @@ let
       inherit withPlugins python;
     };
   }));
-in withPlugins (ps: [
-  ps.nixops-aws
-  ps.nixops-digitalocean
-  ps.nixops-encrypted-links
-  ps.nixops-gce
-  ps.nixops-hercules-ci
-  ps.nixops-hetzner
-  ps.nixops-hetznercloud
-  ps.nixops-libvirtd
-  ps.nixops-vbox
-])
+
+in {
+  nixops_unstable_minimal = withPlugins (ps: []);
+
+  # Not recommended; too fragile.
+  nixops_unstable_full = withPlugins (ps: [
+    ps.nixops-aws
+    ps.nixops-digitalocean
+    ps.nixops-encrypted-links
+    ps.nixops-gce
+    ps.nixops-hercules-ci
+    ps.nixops-hetzner
+    ps.nixops-hetznercloud
+    ps.nixops-libvirtd
+    ps.nixops-vbox
+  ]);
+}

--- a/pkgs/applications/networking/cluster/nixops/default.nix
+++ b/pkgs/applications/networking/cluster/nixops/default.nix
@@ -41,7 +41,7 @@ let
     '';
 
     passthru = old.passthru // {
-      inherit availablePlugins;
+      inherit availablePlugins selectedPlugins;
       inherit withPlugins python;
       tests = old.passthru.tests // {
         nixos = old.passthru.tests.nixos.passthru.override {

--- a/pkgs/applications/networking/cluster/nixops/default.nix
+++ b/pkgs/applications/networking/cluster/nixops/default.nix
@@ -30,9 +30,9 @@ let
   # selector is a function mapping pythonPackages to a list of plugins
   # e.g. nixops_unstable.withPlugins (ps: with ps; [ nixops-aws ])
   withPlugins' = { availablePlugins }: selector: let
-   selected = selector availablePlugins;
+   selectedPlugins = selector availablePlugins;
    r = python.pkgs.toPythonApplication (python.pkgs.nixops.overridePythonAttrs (old: {
-    propagatedBuildInputs = old.propagatedBuildInputs ++ selected;
+    propagatedBuildInputs = old.propagatedBuildInputs ++ selectedPlugins;
 
     # Propagating dependencies leaks them through $PYTHONPATH which causes issues
     # when used in nix-shell.

--- a/pkgs/applications/networking/cluster/nixops/default.nix
+++ b/pkgs/applications/networking/cluster/nixops/default.nix
@@ -1,4 +1,4 @@
-{ lib, python3 }:
+{ lib, python3, emptyFile }:
 
 let
   inherit (lib) extends;
@@ -64,6 +64,13 @@ let
         nixos = this.rawPackage.tests.nixos.passthru.override {
           nixopsPkg = this.rawPackage;
         };
+        commutative_addAvailablePlugins_withPlugins =
+          assert
+            (this.public.addAvailablePlugins (self: super: { inherit emptyFile; })).withPlugins (ps: [ emptyFile ])
+            ==
+            # Note that this value proves that the package is not instantiated until the end, where it's valid again.
+            (this.public.withPlugins (ps: [ emptyFile ])).addAvailablePlugins (self: super: { inherit emptyFile; });
+          emptyFile;
       }
         # Make sure we also test with a configuration that's been extended with a plugin.
         // lib.optionalAttrs (this.selectedPlugins == [ ]) {

--- a/pkgs/applications/networking/cluster/nixops/default.nix
+++ b/pkgs/applications/networking/cluster/nixops/default.nix
@@ -90,6 +90,9 @@ let
       addAvailablePlugins = newPlugins: this.extend (finalThis: oldThis: {
         plugins = lib.composeExtensions oldThis.plugins newPlugins;
       });
+
+      # For those who need or dare.
+      internals = this;
     };
 
     package = lib.lazyDerivation { outputs = [ "out" "dist" ]; derivation = this.rawPackage; } // this.extraPackageAttrs;

--- a/pkgs/applications/networking/cluster/nixops/default.nix
+++ b/pkgs/applications/networking/cluster/nixops/default.nix
@@ -35,13 +35,13 @@ let
       nixopsvbox = nixops-vbox;
     };
 
-    withPlugins = this.withPlugins' { availablePlugins = this.plugins this.python.pkgs; };
+    availablePlugins = this.plugins this.python.pkgs;
 
     # selector is a function mapping pythonPackages to a list of plugins
     # e.g. nixops_unstable.withPlugins (ps: with ps; [ nixops-aws ])
-    withPlugins' = { availablePlugins }: selector:
+    withPlugins = selector:
       let
-        selectedPlugins = selector availablePlugins;
+        selectedPlugins = selector this.availablePlugins;
         r = this.python.pkgs.toPythonApplication (this.python.pkgs.nixops.overridePythonAttrs (old: {
           propagatedBuildInputs = old.propagatedBuildInputs ++ selectedPlugins;
 
@@ -52,8 +52,8 @@ let
           '';
 
           passthru = old.passthru // {
-            inherit availablePlugins selectedPlugins;
-            inherit (this) withPlugins python;
+            inherit selectedPlugins;
+            inherit (this) availablePlugins withPlugins python;
             tests = old.passthru.tests // {
               nixos = old.passthru.tests.nixos.passthru.override {
                 nixopsPkg = r;

--- a/pkgs/applications/networking/cluster/nixops/plugins/nixops-aws.nix
+++ b/pkgs/applications/networking/cluster/nixops/plugins/nixops-aws.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage {
   pname = "nixops-aws";
-  version = "unstable-2023-08-09";
+  version = "unstable-2024-02-29";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "NixOS";
     repo = "nixops-aws";
-    rev = "8802d1cda9004ec1362815292c2a8ab95e6d64e8";
-    hash = "sha256-i0KjFrwpDHRch9jorccdVwnjAQiORClDUqm2R2xvwuU=";
+    rev = "d173b2f14ec767d782ceab45fb22b32fe3b5a1f7";
+    hash = "sha256-ocTtc7POt1bugb9Bki2ew2Eh5uc933GftNw1twoOJsc=";
   };
 
   postPatch = ''

--- a/pkgs/applications/networking/cluster/nixops/unwrapped.nix
+++ b/pkgs/applications/networking/cluster/nixops/unwrapped.nix
@@ -13,14 +13,14 @@
 
 buildPythonApplication rec {
   pname = "nixops";
-  version = "unstable-2023-12-17";
+  version = "unstable-2024-02-28";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "NixOS";
     repo = "nixops";
-    rev = "053668e849bb369973cf265b7e8f38e66ef70138";
-    hash = "sha256-Kus1Ls1tT8fVGLX0NakRXmjuz5/J/tfqU4TLOkiZqvo=";
+    rev = "08feccb14074c5434f3e483d19a7f7d9bfcdb669";
+    hash = "sha256-yWeF5apQJdChjYVSOyH6LYjJYGa1RL68LRHrSgZ9l8U=";
   };
 
   postPatch = ''

--- a/pkgs/applications/networking/cluster/nixops/unwrapped.nix
+++ b/pkgs/applications/networking/cluster/nixops/unwrapped.nix
@@ -50,7 +50,7 @@ buildPythonApplication rec {
   pythonImportsCheck = [ "nixops" ];
 
   passthru = {
-    tests.nixops = nixosTests.nixops.unstable;
+    tests.nixos = nixosTests.nixops.unstable;
     updateScript = unstableGitUpdater {};
   };
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -782,8 +782,12 @@ mapAliases ({
   nix_2_4 = nixVersions.nix_2_4;
   nix_2_5 = nixVersions.nix_2_5;
   nix_2_6 = nixVersions.nix_2_6;
-  nixops = throw "'nixops' has been removed. Please use 'nixops_unstable' for the time being."; # Added 2023-10-26
+  nixops = throw "'nixops' has been removed. Please use 'nixops_unstable_minimal' for the time being. E.g. nixops_unstable_minimal.withPlugins (ps: [ ps.nixops-gce ])"; # Added 2023-10-26
   nixopsUnstable = nixops_unstable; # Added 2022-03-03
+
+  # When the nixops_unstable alias is removed, nixops_unstable_minimal can be renamed to nixops_unstable.
+  nixops_unstable = throw "nixops_unstable has been replaced. Please use for example 'nixops_unstable_minimal.withPlugins (ps: [ ps.nixops-gce ps.nixops-encrypted-links ])' instead"; # Added 2024-02-28
+
   nixosTest = testers.nixosTest; # Added 2022-05-05
   nmap-unfree = nmap; # Added 2021-04-06
   nodejs_14 = throw "nodejs_14 has been removed as it is EOL."; # Added 2023-10-30

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40211,6 +40211,9 @@ with pkgs;
     # Not recommended; too fragile
     nixops_unstable_full;
 
+  # Useful with ofborg, e.g. commit prefix `nixops_unstablePlugins.nixops-aws: ...` to trigger automatically.
+  nixops_unstablePlugins = recurseIntoAttrs nixops_unstable_minimal.availablePlugins;
+
   /*
     Evaluate a NixOS configuration using this evaluation of Nixpkgs.
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -40205,7 +40205,11 @@ with pkgs;
 
   nixStatic = pkgsStatic.nix;
 
-  nixops_unstable = callPackage ../applications/networking/cluster/nixops { };
+  inherit (callPackages ../applications/networking/cluster/nixops { })
+    nixops_unstable_minimal
+
+    # Not recommended; too fragile
+    nixops_unstable_full;
 
   /*
     Evaluate a NixOS configuration using this evaluation of Nixpkgs.


### PR DESCRIPTION
## Description of changes

- Update `nixops_unstable` using the `updateScript`.

- UX and DX improvements, especially for plugin repos that want to use this method of packaging.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
