### PR TITLE
tinycc: refactor

### DIFF
--- a/pkgs/development/compilers/tinycc/default.nix
+++ b/pkgs/development/compilers/tinycc/default.nix
@@ -1,26 +1,24 @@
 { lib
-, stdenv
-, fetchFromRepoOrCz
 , copyPkgconfigItems
+, fetchFromRepoOrCz
 , makePkgconfigItem
 , perl
+, stdenv
 , texinfo
 , which
 }:
 
-let
-  # avoid "malformed 32-bit x.y.z" error on mac when using clang
-  isCleanVer = version: builtins.match "^[0-9]\\.+[0-9]+\\.[0-9]+" version != null;
-in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tcc";
-  version = "unstable-2022-07-15";
+  version = "0.9.27-unstable-2022-07-15";
 
   src = fetchFromRepoOrCz {
     repo = "tinycc";
     rev = "af1abf1f45d45b34f0b02437f559f4dfdba7d23c";
     hash = "sha256-jY0P2GErmo//YBaz6u4/jj/voOE3C2JaIDRmo0orXN8=";
   };
+
+  outputs = [ "out" "info" "man" ];
 
   nativeBuildInputs = [
     copyPkgconfigItems
@@ -29,23 +27,27 @@ stdenv.mkDerivation rec {
     which
   ];
 
-  pkgconfigItems = [
-    (makePkgconfigItem rec {
+  strictDeps = true;
+
+  pkgconfigItems = let
+    libtcc-pcitem = {
       name = "libtcc";
-      inherit version;
-      cflags = [ "-I${variables.includedir}" ];
+      inherit (finalAttrs) version;
+      cflags = [ "-I${libtcc-pcitem.variables.includedir}" ];
       libs = [
-        "-L${variables.libdir}"
-        "-Wl,--rpath ${variables.libdir}"
+        "-L${libtcc-pcitem.variables.libdir}"
+        "-Wl,--rpath ${libtcc-pcitem.variables.libdir}"
         "-ltcc"
       ];
-      variables = rec {
+      variables = {
         prefix = "${placeholder "out"}";
-        includedir = "${prefix}/include";
-        libdir = "${prefix}/lib";
+        includedir = "${placeholder "dev"}/include";
+        libdir = "${placeholder "lib"}/lib";
       };
       description = "Tiny C compiler backend";
-    })
+    };
+  in [
+    (makePkgconfigItem libtcc-pcitem)
   ];
 
   postPatch = ''
@@ -64,16 +66,18 @@ stdenv.mkDerivation rec {
     "--config-musl"
   ];
 
-  preConfigure = ''
+  preConfigure = let
+    # To avoid "malformed 32-bit x.y.z" error on mac when using clang
+    versionIsClean = version:
+      builtins.match "^[0-9]\\.+[0-9]+\\.[0-9]+" version != null;
+  in ''
     ${
-      if stdenv.isDarwin && ! isCleanVer version
+      if stdenv.isDarwin && ! versionIsClean finalAttrs.version
       then "echo 'not overwriting VERSION since it would upset ld'"
-      else "echo ${version} > VERSION"
+      else "echo ${finalAttrs.version} > VERSION"
     }
     configureFlagsArray+=("--elfinterp=$(< $NIX_CC/nix-support/dynamic-linker)")
   '';
-
-  outputs = [ "out" "info" "man" ];
 
   # Test segfault for static build
   doCheck = !stdenv.hostPlatform.isStatic;
@@ -84,7 +88,7 @@ stdenv.mkDerivation rec {
     rm tests/tests2/{108,114}*
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://repo.or.cz/tinycc.git";
     description = "Small, fast, and embeddable C compiler and interpreter";
     longDescription = ''
@@ -108,13 +112,13 @@ stdenv.mkDerivation rec {
 
       With libtcc, you can use TCC as a backend for dynamic code generation.
     '';
-    license = licenses.lgpl21Only;
-    maintainers = with maintainers; [ joachifm AndersonTorres ];
-    platforms = platforms.unix;
+    license = with lib.licenses; [ lgpl21Only ];
+    mainProgram = "tcc";
+    maintainers = with lib.maintainers; [ joachifm AndersonTorres ];
+    platforms = lib.platforms.unix;
     # https://www.mail-archive.com/tinycc-devel@nongnu.org/msg10199.html
     broken = stdenv.isDarwin && stdenv.isAarch64;
   };
-}
+})
 # TODO: more multiple outputs
 # TODO: self-compilation
-# TODO: provide expression for stable release


### PR DESCRIPTION
- get rid of rec
  - extreme use of recursive rec
- format version string according to commit
  - cb89165fb9a5e80a05356af4d75ed826d7d417e0 (#280312, RFCs 107 and 147)
- strictDeps
- meta.mainProgram

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
