### PR TITLE
homepage-dashboard: allow server read hostname from environment

### DIFF
--- a/pkgs/servers/homepage-dashboard/allow_env_hostname.patch
+++ b/pkgs/servers/homepage-dashboard/allow_env_hostname.patch
@@ -1,0 +1,30 @@
+--- a/server.js
++++ b/server.js
+@@ -24,14 +24,16 @@ const server = http.createServer(async (req, res) => {
+   }
+ })
+ const currentPort = parseInt(process.env.PORT, 10) || 3000
++const hostname = process.env.HOSTNAME || 'localhost'
++const listenIP = process.env.LISTEN_IP || '0.0.0.0'
+ 
+-server.listen(currentPort, (err) => {
++server.listen(currentPort, listenIP, (err) => {
+   if (err) {
+     console.error("Failed to start server", err)
+     process.exit(1)
+   }
+   const nextServer = new NextServer({
+-    hostname: 'localhost',
++    hostname,
+     port: currentPort,
+     dir: path.join(__dirname),
+     dev: false,
+@@ -40,6 +42,5 @@ server.listen(currentPort, (err) => {
+   })
+   handler = nextServer.getRequestHandler()
+ 
+-  console.log("Listening on port", currentPort)
++  console.log(`Listening on ${listenIP}:${currentPort}`)
+ })
+-    
+\ No newline at end of file

--- a/pkgs/servers/homepage-dashboard/default.nix
+++ b/pkgs/servers/homepage-dashboard/default.nix
@@ -44,6 +44,8 @@ buildNpmPackage rec {
   '';
 
   postBuild = ''
+    # Allow standalone program read HOSTNAME from env
+    patch -p1 .next/standalone/server.js -i ${./allow_env_hostname.patch}
     # Add a shebang to the server js file, then patch the shebang.
     sed -i '1s|^|#!/usr/bin/env node\n|' .next/standalone/server.js
     patchShebangs .next/standalone/server.js


### PR DESCRIPTION
## Description of changes
Allow homepage listen to specific IP address.
Default it listens to all interfaces.

Set `HOSTNAME` to set hostname of NextServer (implemented in newer version of NextJS but not work at all).
Set `LISTEN_IP` to set listen IP of httpserver.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
