### PR TITLE
maintainers/bootstrap-files: fix two typos in README.md

### DIFF
--- a/maintainers/scripts/bootstrap-files/README.md
+++ b/maintainers/scripts/bootstrap-files/README.md
@@ -39,7 +39,7 @@ target:
    ```
 
    To validate cross-targets `binfmt` `NixOS` helper can be useful.
-   For `riscv64-unknown-linux-gnu` the `/etc/nixox/configuraqtion.nix`
+   For `riscv64-unknown-linux-gnu` the `/etc/nixos/configuration.nix`
    entry would be `boot.binfmt.emulatedSystems = [ "riscv64-linux" ]`.
 
 3. Propose the commit as a PR to update bootstrap tarballs, tag people


### PR DESCRIPTION
## Description of changes

Just two fixing two typos I noticed while reading this file.

## Things done

- [x] Fixed typos `nixox` => `nixos` and `configuraqtion` => `configuration`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).