### PR TITLE
kana: init at 1.4

### DIFF
--- a/pkgs/by-name/ka/kana/package.nix
+++ b/pkgs/by-name/ka/kana/package.nix
@@ -1,0 +1,74 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, rustPlatform
+, meson
+, ninja
+, pkg-config
+, rustc
+, cargo
+, wrapGAppsHook4
+, desktop-file-utils
+, libadwaita
+, gst_all_1
+, darwin
+}:
+
+stdenv.mkDerivation rec {
+  pname = "kana";
+  version = "1.4";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "fkinoshita";
+    repo = "Kana";
+    rev = "v${version}";
+    hash = "sha256-/Ri723ub8LMlhbPObC83bay63JuWIQpgxAT5UUYuwZI=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "kana-${version}";
+    hash = "sha256-Z7DpPe8/Tt8AcLjCwKbwzQTsLe6YvWBCG7DlDkkklew=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    rustPlatform.cargoSetupHook
+    rustc
+    cargo
+    wrapGAppsHook4
+    desktop-file-utils
+  ];
+
+  buildInputs = [
+    libadwaita
+  ] ++ (with gst_all_1; [
+    gstreamer
+    gst-plugins-base
+    gst-plugins-bad
+    gst-plugins-good
+  ]) ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Foundation
+  ];
+
+  # Workaround for the gettext-sys issue
+  # https://github.com/Koka/gettext-rs/issues/114
+  env.NIX_CFLAGS_COMPILE = lib.optionalString
+    (
+      stdenv.cc.isClang &&
+      lib.versionAtLeast stdenv.cc.version "16"
+    )
+    "-Wno-error=incompatible-function-pointer-types";
+
+  meta = with lib; {
+    description = "Learn Japanese hiragana and katakana characters";
+    homepage = "https://gitlab.gnome.org/fkinoshita/kana";
+    license = licenses.gpl3Plus;
+    mainProgram = "kana";
+    maintainers = with maintainers; [ aleksana ];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

just for fun

![image](https://github.com/NixOS/nixpkgs/assets/42209822/1cfdd4d1-c115-49fd-84c1-0409fcd4c563)

```
./result/
├── bin
│   └── kana
└── share
    ├── applications
    │   └── com.felipekinoshita.Kana.desktop
    ├── glib-2.0
    ├── gsettings-schemas
    │   └── kana-1.4
    │       └── glib-2.0
    │           └── schemas
    │               ├── com.felipekinoshita.Kana.gschema.xml
    │               └── gschemas.compiled
    ├── icons
    │   └── hicolor
    │       ├── scalable
    │       │   └── apps
    │       │       └── com.felipekinoshita.Kana.svg
    │       └── symbolic
    │           └── apps
    │               └── com.felipekinoshita.Kana-symbolic.svg
    ├── kana
    │   └── resources.gresource
    └── metainfo
        └── com.felipekinoshita.Kana.metainfo.xml
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
