### PR TITLE
agda: Remove `--local-interfaces` workaround

### DIFF
--- a/nixos/tests/agda.nix
+++ b/nixos/tests/agda.nix
@@ -25,13 +25,6 @@ in
   };
 
   testScript = ''
-    assert (
-        "${pkgs.agdaPackages.lib.interfaceFile "Everything.agda"}" == "Everything.agdai"
-    ), "wrong interface file for Everything.agda"
-    assert (
-        "${pkgs.agdaPackages.lib.interfaceFile "tmp/Everything.agda.md"}" == "tmp/Everything.agdai"
-    ), "wrong interface file for tmp/Everything.agda.md"
-
     # Minimal script that typechecks
     machine.succeed("touch TestEmpty.agda")
     machine.succeed("agda TestEmpty.agda")

--- a/pkgs/build-support/agda/default.nix
+++ b/pkgs/build-support/agda/default.nix
@@ -31,10 +31,9 @@ let
     mkdir -p $out/bin
     makeWrapper ${Agda}/bin/agda $out/bin/agda \
       --add-flags "--with-compiler=${ghc}/bin/ghc" \
-      --add-flags "--library-file=${library-file}" \
-      --add-flags "--local-interfaces"
+      --add-flags "--library-file=${library-file}"
     ln -s ${Agda}/bin/agda-mode $out/bin/agda-mode
-    ''; # Local interfaces has been added for now: See https://github.com/agda/agda/issues/4526
+    '';
 
   withPackages = arg: if builtins.isAttrs arg then withPackages' arg else withPackages' { pkgs = arg; };
 
@@ -82,7 +81,7 @@ let
         installPhase = if installPhase != null then installPhase else ''
           runHook preInstall
           mkdir -p $out
-          find -not \( -path ${everythingFile} -or -path ${lib.interfaceFile everythingFile} \) -and \( ${concatMapStringsSep " -or " (p: "-name '*.${p}'") (extensions ++ extraExtensions)} \) -exec cp -p --parents -t "$out" {} +
+          find -not \( -path ${everythingFile} -or -path ${lib.interfaceFile Agda.version everythingFile} \) -and \( ${concatMapStringsSep " -or " (p: "-name '*.${p}'") (extensions ++ extraExtensions)} \) -exec cp -p --parents -t "$out" {} +
           runHook postInstall
         '';
 

--- a/pkgs/build-support/agda/default.nix
+++ b/pkgs/build-support/agda/default.nix
@@ -75,13 +75,14 @@ let
         buildPhase = if buildPhase != null then buildPhase else ''
           runHook preBuild
           agda ${includePathArgs} ${everythingFile}
+          rm ${everythingFile} ${lib.interfaceFile Agda.version everythingFile}
           runHook postBuild
         '';
 
         installPhase = if installPhase != null then installPhase else ''
           runHook preInstall
           mkdir -p $out
-          find -not \( -path ${everythingFile} -or -path ${lib.interfaceFile Agda.version everythingFile} \) -and \( ${concatMapStringsSep " -or " (p: "-name '*.${p}'") (extensions ++ extraExtensions)} \) -exec cp -p --parents -t "$out" {} +
+          find \( ${concatMapStringsSep " -or " (p: "-name '*.${p}'") (extensions ++ extraExtensions)} \) -exec cp -p --parents -t "$out" {} +
           runHook postInstall
         '';
 

--- a/pkgs/build-support/agda/lib.nix
+++ b/pkgs/build-support/agda/lib.nix
@@ -3,10 +3,10 @@
   /* Returns the Agda interface file to a given Agda file.
   *
   * Examples:
-  * interfaceFile "Everything.agda" == "Everything.agdai"
-  * interfaceFile "src/Everything.lagda.tex" == "src/Everything.agdai"
+  * interfaceFile pkgs.agda.version "./Everything.agda" == "./_build/2.6.4.3/agda/Everything.agdai"
+  * interfaceFile pkgs.agda.version "./src/Everything.lagda.tex" == "./_build/2.6.4.3/agda/src/Everything.agdai"
   */
-  interfaceFile = agdaFile: lib.head (builtins.match ''(.*\.)l?agda(\.(md|org|rst|tex|typ))?'' agdaFile) + "agdai";
+  interfaceFile = agdaVersion: agdaFile: "./_build/" + agdaVersion + "/agda/" + lib.head (builtins.match ''./(.*\.)l?agda(\.(md|org|rst|tex|typ))?'' agdaFile) + "agdai";
 
   /* Takes an arbitrary derivation and says whether it is an agda library package
   *  that is not marked as broken.

--- a/pkgs/build-support/agda/lib.nix
+++ b/pkgs/build-support/agda/lib.nix
@@ -2,11 +2,13 @@
 {
   /* Returns the Agda interface file to a given Agda file.
   *
+  * The resulting path may not be normalized.
+  *
   * Examples:
-  * interfaceFile pkgs.agda.version "./Everything.agda" == "./_build/2.6.4.3/agda/Everything.agdai"
-  * interfaceFile pkgs.agda.version "./src/Everything.lagda.tex" == "./_build/2.6.4.3/agda/src/Everything.agdai"
+  * interfaceFile pkgs.agda.version "./Everything.agda" == "_build/2.6.4.3/agda/./Everything.agdai"
+  * interfaceFile pkgs.agda.version "src/Everything.lagda.tex" == "_build/2.6.4.3/agda/src/Everything.agdai"
   */
-  interfaceFile = agdaVersion: agdaFile: "./_build/" + agdaVersion + "/agda/" + lib.head (builtins.match ''./(.*\.)l?agda(\.(md|org|rst|tex|typ))?'' agdaFile) + "agdai";
+  interfaceFile = agdaVersion: agdaFile: "_build/" + agdaVersion + "/agda/" + lib.head (builtins.match ''(.*\.)l?agda(\.(md|org|rst|tex|typ))?'' agdaFile) + "agdai";
 
   /* Takes an arbitrary derivation and says whether it is an agda library package
   *  that is not marked as broken.


### PR DESCRIPTION
## Description of changes

Remove the `--local-interfaces` flag which was a workaround for https://github.com/agda/agda/issues/4613 and https://github.com/agda/agda/issues/4526.
Changelog making this change possible: https://github.com/agda/agda/blob/master/doc/release-notes/2.6.4.2.md
Relevant upstream PR which also fixes #83864: https://github.com/agda/agda/pull/6988

This is currently a draft because I manually changed `pkgs/development/haskell-modules/hackage-packages.nix` to update to the latest Agda release. As far as I know the usual process is to wait until Agda is updated by an automatic script updating `pkgs/development/haskell-modules/hackage-packages.nix`. As soon as the new Agda version is in nixpkgs, I will remove the second commit and then this PR can be merged.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  I  haven't got `nixpkgs-review` to work (not enough memory).
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
