### PR TITLE
chromatic: init at 0-unstable-2023-08-05

### DIFF
--- a/pkgs/by-name/ch/chromatic/package.nix
+++ b/pkgs/by-name/ch/chromatic/package.nix
@@ -1,0 +1,69 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, rustPlatform
+, meson
+, ninja
+, pkg-config
+, rustc
+, cargo
+, wrapGAppsHook4
+, desktop-file-utils
+, libxml2
+, libadwaita
+, portaudio
+, libpulseaudio
+}:
+
+stdenv.mkDerivation rec {
+  pname = "chromatic";
+  version = "0-unstable-2023-08-05";
+
+  src = fetchFromGitHub {
+    owner = "nate-xyz";
+    repo = "chromatic";
+    rev = "ffaeb50dcce74bf3ba1b05f98423cf48f205f55e";
+    hash = "sha256-E3v3UoQumBBYDOiXMfCRh5J7bfUCkettHth7SAresCE=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    name = "${pname}-${version}";
+    hash = "sha256-M3UMeGkLf57/I/9BIkyiMpOvjbKQJrOk+axf05vRoW0=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    rustPlatform.cargoSetupHook
+    rustc
+    cargo
+    wrapGAppsHook4
+    desktop-file-utils
+    libxml2.bin # xmllint
+  ];
+
+  buildInputs = [
+    libadwaita
+    portaudio
+    libpulseaudio
+  ];
+
+  meta = with lib; {
+    description = "Fine-tune your instruments";
+    longDescription = ''
+      Fine-tune your instruments with Chromatic. Chromatic
+      detects the frequency of audio input, converts it to
+      a musical note with the correct semitone and octave,
+      and displays the cents error. Cents are displayed on
+      an analog gauge to make tuning more visually intuitive.
+      Requires PulseAudio or PipeWire.
+    '';
+    homepage = "https://github.com/nate-xyz/chromatic";
+    license = licenses.gpl3Plus;
+    mainProgram = "chromatic";
+    maintainers = with maintainers; [ aleksana ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
