### PR TITLE
lzip: fix mingw regression

### DIFF
--- a/pkgs/tools/compression/lzip/default.nix
+++ b/pkgs/tools/compression/lzip/default.nix
@@ -17,6 +17,9 @@ stdenv.mkDerivation rec {
 
   patches = lib.optionals stdenv.hostPlatform.isMinGW [
     ./mingw-install-exe-file.patch
+    # https://lists.nongnu.org/archive/html/lzip-bug/2024-02/msg00015.html
+    # patch provided by upstream, to be removed in the next release
+    ./mingw-mkdir-one-argument.patch
   ];
 
   configureFlags = [

--- a/pkgs/tools/compression/lzip/mingw-mkdir-one-argument.patch
+++ b/pkgs/tools/compression/lzip/mingw-mkdir-one-argument.patch
@@ -1,0 +1,13 @@
+--- lzip-1.24/main.cc     2024-01-26 00:08:47.000000000 +0100
++++ lzip-1.24.1/src/main.cc   2024-02-06 16:04:00.000000000 +0100
+@@ -42,8 +42,10 @@
+ #if defined __MSVCRT__ || defined __OS2__ || defined __DJGPP__
+ #include <io.h>
+ #if defined __MSVCRT__
++#include <direct.h>
+ #define fchmod(x,y) 0
+ #define fchown(x,y,z) 0
++#define mkdir(name,mode) _mkdir(name)
+ #define strtoull std::strtoul
+ #define SIGHUP SIGTERM
+ #define S_ISSOCK(x) 0


### PR DESCRIPTION
## Description of changes
fix mingw regression
https://github.com/NixOS/nixpkgs/pull/284905 broke the mingw build
relevant for https://github.com/NixOS/nixpkgs/issues/274274
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
