### PR TITLE
Yuzu: Only compile with -msse4.1 if on x64

### DIFF
--- a/pkgs/applications/emulators/yuzu/mainline.nix
+++ b/pkgs/applications/emulators/yuzu/mainline.nix
@@ -131,7 +131,7 @@ stdenv.mkDerivation(finalAttrs: {
   ];
 
   # Does some handrolled SIMD
-  env.NIX_CFLAGS_COMPILE = "-msse4.1";
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isx86_64 "-msse4.1";
 
   # Fixes vulkan detection.
   # FIXME: patchelf --add-rpath corrupts the binary for some reason, investigate
@@ -174,7 +174,7 @@ stdenv.mkDerivation(finalAttrs: {
       Using the early-access branch is recommended if you would like to try out experimental features, with a cost of stability.
     '';
     mainProgram = "yuzu";
-    platforms = [ "x86_64-linux" ];
+    platforms = [ "aarch64-linux" "x86_64-linux" ];
     license = with licenses; [
       gpl3Plus
       # Icons


### PR DESCRIPTION
## Description of changes

This make Yuzu compatible with aarch64.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

