### PR TITLE
python3Packages.flask-seasurf: fix with werkzeug update and powerdns-admin: 0.4.1 -> 0.4.2

### DIFF
--- a/pkgs/applications/networking/powerdns-admin/default.nix
+++ b/pkgs/applications/networking/powerdns-admin/default.nix
@@ -1,12 +1,12 @@
 { lib, stdenv, fetchFromGitHub, fetchYarnDeps, mkYarnPackage, nixosTests, writeText, python3 }:
 
 let
-  version = "0.4.1";
+  version = "0.4.2";
   src = fetchFromGitHub {
     owner = "PowerDNS-Admin";
     repo = "PowerDNS-Admin";
     rev = "v${version}";
-    hash = "sha256-AwqEcAPD1SF1Ma3wtH03mXlTywM0Q19hciCmTtlr3gk=";
+    hash = "sha256-q9mt8wjSNFb452Xsg+qhNOWa03KJkYVGAeCWVSzZCyk=";
   };
 
   python = python3;
@@ -29,7 +29,7 @@ let
 
     offlineCache = fetchYarnDeps {
       yarnLock = "${src}/yarn.lock";
-      hash = "sha256-3ebT19LrbYuypdJaoB3tClVVP0Fi8tHx3Xi6ge/DpA4=";
+      hash = "sha256-rXIts+dgOuZQGyiSke1NIG7b4lFlR/Gfu3J6T3wP3aY=";
     };
 
     # Copied from package.json, see also

--- a/pkgs/development/python-modules/flask-seasurf/0001-Fix-with-new-dependency-versions.patch
+++ b/pkgs/development/python-modules/flask-seasurf/0001-Fix-with-new-dependency-versions.patch
@@ -1,17 +1,17 @@
-From 001549503eed364d4baaa5804242f67c6236f6c2 Mon Sep 17 00:00:00 2001
+From d3aed2c18cc3a1c88a8052af1f34d7f81f1be11a Mon Sep 17 00:00:00 2001
 From: Flakebi <flakebi@t-online.de>
-Date: Sat, 2 Dec 2023 16:55:05 +0100
+Date: Wed, 28 Feb 2024 23:24:14 +0100
 Subject: [PATCH] Fix with new dependency versions
 
 - cookie_jar is private in werkzeug 2.3, so recreate the client instead
 - set_cookie does not take a hostname argument anymore, use domain instead
 - Headers need to specify a content type
 ---
- test_seasurf.py | 63 ++++++++++++++++++++++++-------------------------
- 1 file changed, 31 insertions(+), 32 deletions(-)
+ test_seasurf.py | 71 ++++++++++++++++++++++++-------------------------
+ 1 file changed, 35 insertions(+), 36 deletions(-)
 
 diff --git a/test_seasurf.py b/test_seasurf.py
-index 517b2d7..501f82d 100644
+index 517b2d7..f940b91 100644
 --- a/test_seasurf.py
 +++ b/test_seasurf.py
 @@ -71,18 +71,18 @@ class SeaSurfTestCase(BaseTestCase):
@@ -37,6 +37,15 @@ index 517b2d7..501f82d 100644
          self.assertIn(b('403 Forbidden'), rv.data)
  
      def test_json_token_validation_bad(self):
+@@ -93,7 +93,7 @@ class SeaSurfTestCase(BaseTestCase):
+         with self.app.test_client() as client:
+             with client.session_transaction() as sess:
+                 sess[self.csrf._csrf_name] = tokenA
+-                client.set_cookie('www.example.com', self.csrf._csrf_name, tokenB)
++                client.set_cookie(self.csrf._csrf_name, tokenB, domain='www.example.com')
+ 
+             rv = client.post('/bar', data=data)
+             self.assertEqual(rv.status_code, 403, rv)
 @@ -107,7 +107,7 @@ class SeaSurfTestCase(BaseTestCase):
          data = {'_csrf_token': token}
          with self.app.test_client() as client:
@@ -55,7 +64,7 @@ index 517b2d7..501f82d 100644
                  sess[self.csrf._csrf_name] = token
  
              # once this is reached the session was stored
-@@ -144,7 +144,7 @@ class SeaSurfTestCase(BaseTestCase):
+@@ -144,18 +144,18 @@ class SeaSurfTestCase(BaseTestCase):
              with client.session_transaction() as sess:
                  token = self.csrf._generate_token()
  
@@ -64,6 +73,19 @@ index 517b2d7..501f82d 100644
                  sess[self.csrf._csrf_name] = token
  
              # once this is reached the session was stored
+-            rv = client.post('/bar',
++            rv = client.post('/bar', content_type='application/json',
+                 data={self.csrf._csrf_name: token},
+                 base_url='https://www.example.com',
+                 headers={'Referer': 'https://www.example.com/foobar'})
+ 
+             self.assertEqual(rv.status_code, 200)
+ 
+-            rv = client.post(u'/bar/\xf8',
++            rv = client.post(u'/bar/\xf8', content_type='application/json',
+                 data={self.csrf._csrf_name: token},
+                 base_url='https://www.example.com',
+                 headers={'Referer': 'https://www.example.com/foobar\xf8'})
 @@ -167,7 +167,7 @@ class SeaSurfTestCase(BaseTestCase):
              with client.session_transaction() as sess:
                  token = self.csrf._generate_token()
@@ -252,6 +274,15 @@ index 517b2d7..501f82d 100644
              self.assertEqual(res2.status_code, 200)
  
      def test_header_set_cookie_samesite(self):
+@@ -789,7 +788,7 @@ class SeaSurfTestCaseGenerateNewToken(BaseTestCase):
+             client.get('/foo')
+             tokenA = self.csrf._get_token()
+ 
+-            client.set_cookie('www.example.com', self.csrf._csrf_name, tokenA)
++            client.set_cookie(self.csrf._csrf_name, tokenA, domain='www.example.com')
+             with client.session_transaction() as sess:
+                 sess[self.csrf._csrf_name] = tokenA
+ 
 -- 
-2.42.0
+2.43.0
 


### PR DESCRIPTION
## Description of changes
Fix flask-seasurf tests and update powerdns-admin to 0.4.2.
https://github.com/PowerDNS-Admin/PowerDNS-Admin/releases/tag/v0.4.2

The flask-seasurf fix repairs the powerdns-admin build.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
