### PR TITLE
dell-command-configure: 4.8.0-494 -> 4.11.0-6

### DIFF
--- a/pkgs/tools/system/dell-command-configure/default.nix
+++ b/pkgs/tools/system/dell-command-configure/default.nix
@@ -17,18 +17,20 @@
 # the dependencies from other pkgs.
 
 let
-  version = "4.8.0-494";
+  version = "4.11.0-6";
 
   unpacked = stdenv.mkDerivation rec {
     inherit version;
     pname = "dell-command-configure-unpacked";
 
     src = fetchurl {
-      url =
-        "https://dl.dell.com/FOLDER08911312M/1/command-configure_${version}.ubuntu20_amd64.tar.gz";
+      urls = [
+        "https://dl.dell.com/FOLDER10469726M/1/command-configure_${version}.ubuntu22_amd64.tar.gz"
+        "https://web.archive.org/web/20240228233129/https://dl.dell.com/FOLDER10469726M/1/command-configure_4.11.0-6.ubuntu22_amd64.tar.gz"
+      ];
       # The CDN blocks the Curl user-agent, so set to blank instead.
       curlOpts = ''-A=""'';
-      hash = "sha256-l5oHgDkFBF6llNsHufTmuDzjkhGmXHYXlOJ4hvZfRoE=";
+      hash = "sha256-Bwa4sYguYwEBKEJSP3wzHhzjuDeaGQN8fKeooWHX18E=";
     };
 
     dontBuild = true;
@@ -37,7 +39,7 @@ let
 
     unpackPhase = ''
       tar -xzf ${src}
-      dpkg-deb -x command-configure_${version}.ubuntu20_amd64.deb command-configure
+      dpkg-deb -x command-configure_${version}.ubuntu22_amd64.deb command-configure
       dpkg-deb -x srvadmin-hapi_9.5.0_amd64.deb srvadmin-hapi
     '';
 


### PR DESCRIPTION
## Description of changes

https://www.dell.com/support/home/en-us/drivers/DriversDetails?driverId=42VJ8

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
