### PR TITLE
python3Packages.gradio: 4.9.1 -> 4.19.2, gradio-client: 0.7.3 -> 0.10.1

### DIFF
--- a/pkgs/development/python-modules/gradio/client.nix
+++ b/pkgs/development/python-modules/gradio/client.nix
@@ -27,7 +27,7 @@
 
 buildPythonPackage rec {
   pname = "gradio-client";
-  version = "0.7.3";
+  version = "0.10.1";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -36,10 +36,9 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "gradio-app";
     repo = "gradio";
-    #rev = "refs/tags/v${gradio.version}";
-    rev = "dc131b64f05062447643217819ca630e483a11df"; # v4.9.1 is not tagged...
+    rev = "refs/tags/gradio_client@${version}";
     sparseCheckout = [ "client/python" ];
-    hash = "sha256-Zp1Zl53Va0pyyZEHDUpnldi4dtH2uss7PZQD+Le8+cA=";
+    hash = "sha256-cRsYqNMmzuybJI823lpUOmNcTdcTO8dJkp3cpjATZQU=";
   };
   prePatch = ''
     cd client/python

--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -57,7 +57,7 @@
 
 buildPythonPackage rec {
   pname = "gradio";
-  version = "4.9.1";
+  version = "4.19.2";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -66,7 +66,7 @@ buildPythonPackage rec {
   # and upstream has stopped tagging releases since 3.41.0
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-KosxlmU5pYvuy5zysscuWM25IGXin7RLGEM9V2xPQrU=";
+    hash = "sha256-b+WBW7Tfru0fx0Ijv/2R2nChtGMVivjF4D0BuwkGih0=";
   };
 
   # fix packaging.ParserSyntaxError, which can't handle comments
@@ -79,6 +79,12 @@ buildPythonPackage rec {
 
   pythonRelaxDeps = [
     "tomlkit"
+  ];
+
+  pythonRemoveDeps = [
+    # our package is presented as a binary, not a python lib - and
+    # this isn't a real runtime dependency
+    "ruff"
   ];
 
   nativeBuildInputs = [
@@ -164,6 +170,9 @@ buildPythonPackage rec {
 
     # shap is too often broken in nixpkgs
     "test_shapley_text"
+
+    # fails without network
+    "test_download_if_url_correct_parse"
   ];
   disabledTestPaths = [
     # 100% touches network
@@ -193,7 +202,6 @@ buildPythonPackage rec {
       gradio-pdf = null;
     })).overridePythonAttrs (old: {
       pname = old.pname + "-sans-client";
-      nativeBuildInputs = (old.nativeBuildInputs or []) ++ [ pythonRelaxDepsHook ];
       pythonRemoveDeps = (old.pythonRemoveDeps or []) ++ [ "gradio-client" ];
       doInstallCheck = false;
       doCheck = false;


### PR DESCRIPTION
## Description of changes

CVE-2023-51449
Also possibly addressing CVE-2024-0964, though I have to confirm this with the reporter.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
