### PR TITLE
lib.lazyDerivation: Support multi-output derivations

### DIFF
--- a/lib/derivations.nix
+++ b/lib/derivations.nix
@@ -1,7 +1,20 @@
 { lib }:
 
 let
-  inherit (lib) throwIfNot;
+  inherit (lib)
+    genAttrs
+    isString
+    throwIfNot
+    ;
+
+  showMaybeAttrPosPre = prefix: attrName: v:
+    let pos = builtins.unsafeGetAttrPos attrName v;
+    in if pos == null then "" else "${prefix}${pos.file}:${toString pos.line}:${toString pos.column}";
+
+  showMaybePackagePosPre = prefix: pkg:
+    if pkg?meta.position && isString pkg.meta.position
+    then "${prefix}${pkg.meta.position}"
+    else "";
 in
 {
   /*
@@ -64,6 +77,11 @@ in
       #
       # This can be used for adding package attributes, such as `tests`.
       passthru ? { }
+    , # Optional list of assumed outputs. Default: ["out"]
+      #
+      # This must match the set of outputs that the returned derivation has.
+      # You must use this when the derivation has multiple outputs.
+      outputs ? [ "out" ]
     }:
     let
       # These checks are strict in `drv` and some `drv` attributes, but the
@@ -71,11 +89,40 @@ in
       # Instead, the individual derivation attributes do depend on it.
       checked =
         throwIfNot (derivation.type or null == "derivation")
-          "lazySimpleDerivation: input must be a derivation."
+          "lazyDerivation: input must be a derivation."
           throwIfNot
-          (derivation.outputs == [ "out" ])
-          # Supporting multiple outputs should be a matter of inheriting more attrs.
-          "The derivation ${derivation.name or "<unknown>"} has multiple outputs. This is not supported by lazySimpleDerivation yet. Support could be added, and be useful as long as the set of outputs is known in advance, without evaluating the actual derivation."
+          # NOTE: Technically we could require our outputs to be a subset of the
+          # actual ones, or even leave them unchecked and fail on a lazy basis.
+          # However, consider the case where an output is added in the underlying
+          # derivation, such as dev. lazyDerivation would remove it and cause it
+          # to fail as a buildInputs item, without any indication as to what
+          # happened. Hence the more stringent condition. We could consider
+          # adding a flag to control this behavior if there's a valid case for it,
+          # but the documentation must have a note like this.
+          (derivation.outputs == outputs)
+          ''
+            lib.lazyDerivation: The derivation ${derivation.name or "<unknown>"} has outputs that don't match the assumed outputs.
+
+            Assumed outputs passed to lazyDerivation${showMaybeAttrPosPre ",\n    at " "outputs" args}:
+                ${lib.generators.toPretty { multiline = false; } outputs};
+
+            Actual outputs of the derivation${showMaybePackagePosPre ",\n    defined at " derivation}:
+                ${lib.generators.toPretty { multiline = false; } derivation.outputs}
+
+            If the outputs are known ahead of evaluating the derivation,
+            then update the lazyDerivation call to match the actual outputs, in the same order.
+            If lazyDerivation is passed a literal value, just change it to the actual outputs.
+            As a result it will work as before / as intended.
+
+            Otherwise, when the outputs are dynamic and can't be known ahead of time, it won't
+            be possible to add laziness, but lib.lazyDerivation may still be useful for trimming
+            the attributes.
+            If you want to keep trimming the attributes, make sure that the package is in a
+            variable (don't evaluate it twice!) and pass the variable and its outputs attribute
+            to lib.lazyDerivation. This largely defeats laziness, but keeps the trimming.
+            If none of the above works for you, replace the lib.lazyDerivation call by the
+            expression in the derivation argument.
+          ''
           derivation;
     in
     {
@@ -92,12 +139,15 @@ in
       # A fixed set of derivation values, so that `lazyDerivation` can return
       # its attrset before evaluating `derivation`.
       # This must only list attributes that are available on _all_ derivations.
-      inherit (checked) outputs out outPath outputName drvPath name system;
+      inherit (checked) outPath outputName drvPath name system;
+      inherit outputs;
 
       # The meta attribute can either be taken from the derivation, or if the
       # `lazyDerivation` caller knew a shortcut, be taken from there.
       meta = args.meta or checked.meta;
-    } // passthru;
+    }
+    // genAttrs outputs (outputName: checked.${outputName})
+    // passthru;
 
   /* Conditionally set a derivation attribute.
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -1973,6 +1973,24 @@ runTests {
     }).drvPath;
   };
 
+  testLazyDerivationMultiOutputReturnsDerivationAttrs = let
+    derivation = {
+      type = "derivation";
+      outputs = ["out" "dev"];
+      dev = "test dev";
+      out = "test out";
+      outPath = "test outPath";
+      outputName = "out";
+      drvPath = "test drvPath";
+      name = "test name";
+      system = "test system";
+      meta.position = "/hi:23";
+    };
+  in {
+    expr = lazyDerivation { inherit derivation; outputs = ["out" "dev"]; passthru.meta.position = "/hi:23"; };
+    expected = derivation;
+  };
+
   testTypeDescriptionInt = {
     expr = (with types; int).description;
     expected = "signed integer";


### PR DESCRIPTION
## Description of changes

Add laziness to all derivations.
Well, not literally all of them. I'm too lazy for that, and it's not always applicable, useful, and pleasant to work with.

Details are in the diff. It feels more like a bugfix than a feature to me.
A lot of it is explanations for a smooth as possible UX.

## Context

Needed in #292099, to make the custom overriding lazy; only instantiate the final config.
(It's custom in order to keep the overriding coherent, which is next to impossible without a "big" fixpoint like that) 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
