### PR TITLE
qt6.qtbase: search PATH for plugins after search QT_PLUGIN_PATH

### DIFF
--- a/pkgs/development/libraries/qt-6/patches/0011-qtbase-derive-plugin-load-path-from-PATH.patch
+++ b/pkgs/development/libraries/qt-6/patches/0011-qtbase-derive-plugin-load-path-from-PATH.patch
@@ -1,19 +1,19 @@
-From f0c4d3860b75cb064d066045907622d536044096 Mon Sep 17 00:00:00 2001
+From 6f0e6fe1e13ca5844a93d3b97111b7ece7e60f0f Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Milan=20P=C3=A4ssler?= <me@pbb.lc>
 Date: Sun, 10 May 2020 12:47:28 +0200
 Subject: [PATCH 11/11] qtbase: derive plugin load path from PATH
 
 ---
- src/corelib/kernel/qcoreapplication.cpp | 10 ++++++++++
- 1 file changed, 10 insertions(+)
+ src/corelib/kernel/qcoreapplication.cpp | 9 +++++++++
+ 1 file changed, 9 insertions(+)
 
 diff --git a/src/corelib/kernel/qcoreapplication.cpp b/src/corelib/kernel/qcoreapplication.cpp
-index a80efbb5622..8cf9e85da43 100644
+index a80efbb5622..0d41dabeed3 100644
 --- a/src/corelib/kernel/qcoreapplication.cpp
 +++ b/src/corelib/kernel/qcoreapplication.cpp
-@@ -2991,6 +2991,16 @@ QStringList QCoreApplication::libraryPathsLocked()
-         QStringList *app_libpaths = new QStringList;
-         coreappdata()->app_libpaths.reset(app_libpaths);
+@@ -3032,6 +3032,15 @@ QStringList QCoreApplication::libraryPathsLocked()
+                 app_libpaths->append(installPathPlugins);
+         }
  
 +        // Add library paths derived from PATH
 +        const QStringList paths = QFile::decodeName(qgetenv("PATH")).split(QStringLiteral(":"));
@@ -24,10 +24,9 @@ index a80efbb5622..8cf9e85da43 100644
 +            }
 +        }
 +
-+
-         auto setPathsFromEnv = [&](QString libPathEnv) {
-             if (!libPathEnv.isEmpty()) {
-                 QStringList paths = libPathEnv.split(QDir::listSeparator(), Qt::SkipEmptyParts);
+         // If QCoreApplication is not yet instantiated,
+         // make sure we add the application path when we construct the QCoreApplication
+         if (self) self->d_func()->appendApplicationPathToLibraryPaths();
 -- 
-2.42.0
+2.43.1
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
