### PR TITLE
[backport 23.11] patch2pr: init at 0.22.0 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9302,6 +9302,11 @@
     githubId = 49727155;
     name = "Paul Meyer";
   };
+  katrinafyi = {
+    name = "katrinafyi";
+    github = "katrinafyi";
+    githubId = 39479354;
+  };
   kayhide = {
     email = "kayhide@gmail.com";
     github = "kayhide";

--- a/pkgs/by-name/pa/patch2pr/package.nix
+++ b/pkgs/by-name/pa/patch2pr/package.nix
@@ -1,0 +1,40 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, testers
+, patch2pr
+}:
+
+buildGoModule rec {
+  pname = "patch2pr";
+  version = "0.21.0";
+
+  src = fetchFromGitHub {
+    owner = "bluekeyes";
+    repo = "patch2pr";
+    rev = "v${version}";
+    hash = "sha256-NG6I7tsgmKV5dzBX/f/FxSpfi1pZ5EWMmkIW2l3u6Is=";
+  };
+
+  vendorHash = "sha256-mJ6Gprsh74wCzkqp2zy6F60i7rQusZK8FXLP6Z9XA3Q=";
+
+  ldflags = [
+    "-X main.version=${version}"
+    "-X main.commit=${src.rev}"
+  ];
+
+  passthru.tests.patch2pr-version = testers.testVersion {
+    package = patch2pr;
+    command = "${patch2pr.meta.mainProgram} --version";
+    version = version;
+  };
+
+  meta = with lib; {
+    description = "Create pull requests from patches without cloning the repository";
+    homepage = "https://github.com/bluekeyes/patch2pr";
+    changelog = "https://github.com/bluekeyes/patch2pr/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ katrinafyi ];
+    mainProgram = "patch2pr";
+  };
+}

--- a/pkgs/by-name/pa/patch2pr/package.nix
+++ b/pkgs/by-name/pa/patch2pr/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "patch2pr";
-  version = "0.21.0";
+  version = "0.22.0";
 
   src = fetchFromGitHub {
     owner = "bluekeyes";
     repo = "patch2pr";
     rev = "v${version}";
-    hash = "sha256-NG6I7tsgmKV5dzBX/f/FxSpfi1pZ5EWMmkIW2l3u6Is=";
+    hash = "sha256-tG0pSXmrWT5PCcR25XngbKAS3q9jKdDKqWdPqA62omE=";
   };
 
-  vendorHash = "sha256-mJ6Gprsh74wCzkqp2zy6F60i7rQusZK8FXLP6Z9XA3Q=";
+  vendorHash = "sha256-Z6BHUD7WrEpUmCaLvrFYCQCSbhPhee+gR5ep1oLzqbE=";
 
   ldflags = [
     "-X main.version=${version}"


### PR DESCRIPTION
## Description of changes
backport of #291104 (auto-backport failed at #292179).

this only adds the new patch2pr leaf package. quoted from earlier pr:

> https://github.com/bluekeyes/patch2pr
> 
> _patch2pr_ creates pull requests from patch files. it uses the Github API to create PRs without needing a repo checkout. 
> 
> the package is a fairly simple go package.
> 
> testing functionality will need a GITHUB_TOKEN. assuming you have a nixpkgs fork and a token with write permissions on this fork, you can test this with:
> ```
> wget -O test.patch https://github.com/NixOS/nixpkgs/pull/291104.patch
> GITHUB_TOKEN=github_pat_...   patch2pr -repository NixOS/nixpkgs -fork -patch-base 2ea79083c54ea7a665562c1c41b0e18d9a9ff72e -json -no-pull-request ./test.patch
> ```
> this should make a branch called "patch2pr" in your fork with this pull request applied. with more permissions, you can test without -no-pull-request.
> 
> there is also a simple testVersion:
> ```
> nix build .#patch2pr.tests.patch2pr-version
> ```

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - **and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)**
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
