### PR TITLE
[23.11] zabbix40: unblock evaluation and fetching

### DIFF
--- a/pkgs/servers/monitoring/zabbix/agent.nix
+++ b/pkgs/servers/monitoring/zabbix/agent.nix
@@ -1,13 +1,12 @@
 { lib, stdenv, fetchurl, pkg-config, libiconv, openssl, pcre }:
 
-import ./versions.nix ({ version, hash, ... }:
+import ./versions.nix ({ version, url, hash, ... }:
   stdenv.mkDerivation {
     pname = "zabbix-agent";
     inherit version;
 
     src = fetchurl {
-      url = "https://cdn.zabbix.com/zabbix/sources/stable/${lib.versions.majorMinor version}/zabbix-${version}.tar.gz";
-      inherit hash;
+      inherit url hash;
     };
 
     nativeBuildInputs = [ pkg-config ];

--- a/pkgs/servers/monitoring/zabbix/agent2.nix
+++ b/pkgs/servers/monitoring/zabbix/agent2.nix
@@ -1,13 +1,12 @@
 { lib, buildGoModule, fetchurl, autoreconfHook, pkg-config, libiconv, openssl, pcre, zlib }:
 
-import ./versions.nix ({ version, hash, vendorHash ? throw "unsupported version ${version} for zabbix-agent2", ... }:
+import ./versions.nix ({ version, url, hash, vendorHash ? throw "unsupported version ${version} for zabbix-agent2", ... }:
   buildGoModule {
     pname = "zabbix-agent2";
     inherit version;
 
     src = fetchurl {
-      url = "https://cdn.zabbix.com/zabbix/sources/stable/${lib.versions.majorMinor version}/zabbix-${version}.tar.gz";
-      inherit hash;
+      inherit url hash;
     };
 
     modRoot = "src/go";

--- a/pkgs/servers/monitoring/zabbix/proxy.nix
+++ b/pkgs/servers/monitoring/zabbix/proxy.nix
@@ -15,14 +15,13 @@ assert sqliteSupport -> !mysqlSupport && !postgresqlSupport;
 let
   inherit (lib) optional optionalString;
 in
-  import ./versions.nix ({ version, hash, ... }:
+  import ./versions.nix ({ version, url, hash, ... }:
     stdenv.mkDerivation {
       pname = "zabbix-proxy";
       inherit version;
 
       src = fetchurl {
-        url = "https://cdn.zabbix.com/zabbix/sources/stable/${lib.versions.majorMinor version}/zabbix-${version}.tar.gz";
-        inherit hash;
+        inherit url hash;
       };
 
       nativeBuildInputs = [ pkg-config ];

--- a/pkgs/servers/monitoring/zabbix/server.nix
+++ b/pkgs/servers/monitoring/zabbix/server.nix
@@ -16,13 +16,13 @@ assert postgresqlSupport -> !mysqlSupport;
 let
   inherit (lib) optional optionalString;
 in
-  import ./versions.nix ({ version, hash, ... }:
+  import ./versions.nix ({ version, hash, srcdir ? "stable", ... }:
     stdenv.mkDerivation {
       pname = "zabbix-server";
       inherit version;
 
       src = fetchurl {
-        url = "https://cdn.zabbix.com/zabbix/sources/stable/${lib.versions.majorMinor version}/zabbix-${version}.tar.gz";
+        url = "https://cdn.zabbix.com/zabbix/sources/${srcdir}/${lib.versions.majorMinor version}/zabbix-${version}.tar.gz";
         inherit hash;
       };
 

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -13,6 +13,6 @@ generic: {
 
   v40 = generic {
     version = "4.0.48";
-    sha256 = "sha256-WK8Zzkd/s9M7N5Qr2kejtp/f/n1wb5zRSfh0RiI2K+Q=";
+    hash = "sha256-WK8Zzkd/s9M7N5Qr2kejtp/f/n1wb5zRSfh0RiI2K+Q=";
   };
 }

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -1,18 +1,21 @@
 generic: {
-  v60 = generic {
+  v60 = generic rec {
     version = "6.0.26";
     hash = "sha256-MIOKe5hqfDecB1oWZKzbFmJCsQLuAGtp21l2WxxVG+g=";
     vendorHash = null;
+    url = "https://cdn.zabbix.com/zabbix/sources/stable/6.0/zabbix-${version}.tar.gz";
   };
 
-  v50 = generic {
+  v50 = generic rec {
     version = "5.0.41";
     hash = "sha256-pPvw0lPoK1IpsXc5c8Qu9zFhx2oHJz2bwiX80vrYa58=";
     vendorHash = "sha256-qLDoNnEFiSrWXbLtYlmQaqY8Rv6JaG8WbMYBlry5Evc=";
+    url = "https://cdn.zabbix.com/zabbix/sources/stable/5.0/zabbix-${version}.tar.gz";
   };
 
-  v40 = generic {
+  v40 = generic rec {
     version = "4.0.48";
     hash = "sha256-WK8Zzkd/s9M7N5Qr2kejtp/f/n1wb5zRSfh0RiI2K+Q=";
+    url = "https://cdn.zabbix.com/zabbix/sources/oldstable/4.0/zabbix-${version}.tar.gz";
   };
 }

--- a/pkgs/servers/monitoring/zabbix/web.nix
+++ b/pkgs/servers/monitoring/zabbix/web.nix
@@ -1,13 +1,12 @@
 { lib, stdenv, fetchurl, writeText }:
 
-import ./versions.nix ({ version, hash, ... }:
+import ./versions.nix ({ version, url, hash, ... }:
   stdenv.mkDerivation rec {
     pname = "zabbix-web";
     inherit version;
 
     src = fetchurl {
-      url = "https://cdn.zabbix.com/zabbix/sources/stable/${lib.versions.majorMinor version}/zabbix-${version}.tar.gz";
-      inherit hash;
+      inherit url hash;
     };
 
     phpConfig = writeText "zabbix.conf.php" ''


### PR DESCRIPTION

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
