### PR TITLE
hyprland: 0.35.0 -> 0.36.0;  hyprlandPlugins.hy3: 0.35.0 -> unstable-2024-02-23 

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hyprland/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland/default.nix
@@ -9,6 +9,7 @@
 , cairo
 , git
 , hyprland-protocols
+, hyprlang
 , jq
 , libGL
 , libdrm
@@ -31,7 +32,7 @@
 , debug ? false
 , enableXWayland ? true
 , legacyRenderer ? false
-, withSystemd ? true
+, withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd
 , wrapRuntimeDeps ? true
   # deprecated flags
 , nvidiaPatches ? false
@@ -43,13 +44,13 @@ assert lib.assertMsg (!enableNvidiaPatches) "The option `enableNvidiaPatches` ha
 assert lib.assertMsg (!hidpiXWayland) "The option `hidpiXWayland` has been removed. Please refer https://wiki.hyprland.org/Configuring/XWayland";
 stdenv.mkDerivation (finalAttrs: {
   pname = "hyprland" + lib.optionalString debug "-debug";
-  version = "0.35.0";
+  version = "0.36.0";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = finalAttrs.pname;
     rev = "v${finalAttrs.version}";
-    hash = "sha256-dU5m6Cd4+WQZal2ICDVf1kww/dNzo1YUWRxWeCctEig=";
+    hash = "sha256-oZe4k6jtO/0govmERGcbeyvE9EfTvXY5bnyIs6AsL9U=";
   };
 
   patches = [
@@ -92,6 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
       cairo
       git
       hyprland-protocols
+      hyprlang
       libGL
       libdrm
       libinput
@@ -116,10 +118,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   mesonAutoFeatures = "disabled";
 
-  mesonFlags = builtins.concatLists [
-    (lib.optional enableXWayland "-Dxwayland=enabled")
-    (lib.optional legacyRenderer "-Dlegacy_renderer=enabled")
-    (lib.optional withSystemd "-Dsystemd=enabled")
+  mesonFlags = [
+    (lib.mesonEnable "xwayland" enableXWayland)
+    (lib.mesonEnable "legacy_renderer" legacyRenderer)
+    (lib.mesonEnable "systemd" withSystemd)
   ];
 
   postInstall = ''

--- a/pkgs/applications/window-managers/hyprwm/hyprland/plugins.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland/plugins.nix
@@ -24,13 +24,13 @@ let
     hy3 = { fetchFromGitHub, cmake, hyprland }:
       mkHyprlandPlugin rec {
         pluginName = "hy3";
-        version = "0.35.0";
+        version = "unstable-2024-02-23";
 
         src = fetchFromGitHub {
           owner = "outfoxxed";
           repo = "hy3";
-          rev = "hl${version}";
-          hash = "sha256-lFe7Lf0K5ePTh4gflnvBohOGH4ayGDtNkbg/XtoNqRo=";
+          rev = "029a2001361d2a4cbbe7447968dee5d1b1880298";
+          hash = "sha256-8LKCXwNU6wA8o6O7s9T2sLWbYNHaI1tYU4YMjHkNLZQ=";
         };
 
         nativeBuildInputs = [ cmake ];

--- a/pkgs/applications/window-managers/hyprwm/hyprland/wlroots.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland/wlroots.nix
@@ -9,8 +9,8 @@ wlroots.overrideAttrs
       domain = "gitlab.freedesktop.org";
       owner = "wlroots";
       repo = "wlroots";
-      rev = "00b869c1a96f300a8f25da95d624524895e0ddf2";
-      hash = "sha256-5HUTG0p+nCJv3cn73AmFHRZdfRV5AD5N43g8xAePSKM=";
+      rev = "0cb091f1a2d345f37d2ee445f4ffd04f7f4ec9e5";
+      hash = "sha256-Mz6hCtommq7RQfcPnxLINigO4RYSNt23HeJHC6mVmWI=";
     };
 
     patches = [ ]; # don't inherit old.patches


### PR DESCRIPTION
## Description of changes
https://github.com/hyprwm/Hyprland/releases/tag/v0.36.0

closes: https://github.com/NixOS/nixpkgs/issues/292270
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
