### PR TITLE
linux: enable CONFIG_BLK_DEV_ZONED

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -846,6 +846,7 @@ let
       AIC94XX_DEBUG = no;
 
       BLK_DEV_INTEGRITY       = yes;
+      BLK_DEV_ZONED           = yes;
 
       BLK_SED_OPAL = yes;
 


### PR DESCRIPTION
## Description of changes

This enables support for [ZAC/ZBC/ZNS host-managed and host-aware zoned block devices](https://zonedstorage.io/docs/linux/config#zoned-block-devices-core-support). It also enables zone features in various filesystems including BTRFS and F2FS, and other relative subsystems like nvme and virtio-blk.

It seems to be available [since 3.10](https://www.kernelconfig.io/config_blk_dev_zoned) which is earlier  than the earliest version we support. It is also enabled by default for [Arch Linux](https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/blob/373c484546bfeba30a4a2134dc9c5cbeb4415217/config#L985) (since 4.19.arch1-1, or 5 years ago) and [Fedora 40](https://src.fedoraproject.org/rpms/kernel/blob/f40/f/kernel-x86_64-fedora.config#_629).

## Things done

I'm using the latest mainline kernel (`linuxPackages_testing`) on x86_64 for about one month and have not seen any issue. ~~I havn't built each kernel version in nixpkgs yet since my computer is not beefy enough. Is there any way to quick test the config validity for different kernel versions in nixpkgs?~~

**EDIT: Okay the kernel versions are less than I expected. After a whole night of building, all kernel versions that evaluates currently are successfully built. See the comment below for the script.**

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
