### PR TITLE
doc & fix: Clean up writers/data.nix file

### DIFF
--- a/pkgs/build-support/writers/data.nix
+++ b/pkgs/build-support/writers/data.nix
@@ -1,28 +1,34 @@
-{ lib, pkgs, formats, runCommand, dasel }:
+{ lib, pkgs, formats, runCommand }:
 let
-  daselBin = lib.getExe dasel;
-
   inherit (lib)
     last
     optionalString
     types
     ;
 in
-rec {
-  # Creates a transformer function that writes input data to disk, transformed
-  # by both the `input` and `output` arguments.
-  #
-  # Type: makeDataWriter :: input -> output -> nameOrPath -> data -> (any -> string) -> string -> string -> any -> derivation
-  #
-  #   input :: T -> string: function that takes the nix data and returns a string
-  #   output :: string: script that takes the $inputFile and write the result into $out
-  #   nameOrPath :: string: if the name contains a / the files gets written to a sub-folder of $out. The derivation name is the basename of this argument.
-  #   data :: T: the data that will be converted.
-  #
-  # Example:
-  #   writeJSON = makeDataWriter { input = builtins.toJSON; output = "cp $inputPath $out"; };
-  #   myConfig = writeJSON "config.json" { hello = "world"; }
-  #
+{
+  /**
+    Creates a transformer function that writes input data to disk, transformed
+    by both the `input` and `output` arguments.
+
+    # Example
+
+    ```nix
+    writeJSON = makeDataWriter { input = builtins.toJSON; output = "cp $inputPath $out"; };
+    myConfig = writeJSON "config.json" { hello = "world"; }
+    ```
+
+    # Type
+
+    ```
+    makeDataWriter :: input -> output -> nameOrPath -> data -> (any -> string) -> string -> string -> any -> derivation
+
+    input :: T -> string: function that takes the nix data and returns a string
+    output :: string: script that takes the $inputFile and write the result into $out
+    nameOrPath :: string: if the name contains a / the files gets written to a sub-folder of $out. The derivation name is the basename of this argument.
+    data :: T: the data that will be converted.
+    ```
+  */
   makeDataWriter = lib.warn "pkgs.writers.makeDataWriter is deprecated. Use pkgs.writeTextFile." ({ input ? lib.id, output ? "cp $inputPath $out" }: nameOrPath: data:
     assert lib.or (types.path.check nameOrPath) (builtins.match "([0-9A-Za-z._])[0-9A-Za-z._-]*" nameOrPath != null);
     let
@@ -44,21 +50,36 @@ rec {
 
   inherit (pkgs) writeText;
 
-  # Writes the content to a JSON file.
-  #
-  # Example:
-  #   writeJSON "data.json" { hello = "world"; }
+  /**
+    Writes the content to a JSON file.
+
+    # Example
+
+    ```nix
+    writeJSON "data.json" { hello = "world"; }
+    ```
+  */
   writeJSON = (pkgs.formats.json {}).generate;
 
-  # Writes the content to a TOML file.
-  #
-  # Example:
-  #   writeTOML "data.toml" { hello = "world"; }
+  /**
+    Writes the content to a TOML file.
+
+    # Example
+
+    ```nix
+    writeTOML "data.toml" { hello = "world"; }
+    ```
+  */
   writeTOML = (pkgs.formats.toml {}).generate;
 
-  # Writes the content to a YAML file.
-  #
-  # Example:
-  #   writeYAML "data.yaml" { hello = "world"; }
+  /**
+    Writes the content to a YAML file.
+
+    # Example
+
+    ```nix
+    writeYAML "data.yaml" { hello = "world"; }
+    ```
+  */
   writeYAML = (pkgs.formats.yaml {}).generate;
 }


### PR DESCRIPTION
## Description of changes

Reformat the comments according to nix doc-comment standard (rfc145).

This is non-critical, as they are not yet part of automatic documentation.

Removes minor ununsed variables and statements

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
