### PR TITLE
doc: lib.asserts migrate to doc-comments

### DIFF
--- a/lib/asserts.nix
+++ b/lib/asserts.nix
@@ -2,47 +2,87 @@
 
 rec {
 
-  /* Throw if pred is false, else return pred.
-     Intended to be used to augment asserts with helpful error messages.
+  /**
+    Throw if pred is false, else return pred.
+    Intended to be used to augment asserts with helpful error messages.
 
-     Example:
-       assertMsg false "nope"
-       stderr> error: nope
+    # Inputs
 
-       assert assertMsg ("foo" == "bar") "foo is not bar, silly"; ""
-       stderr> error: foo is not bar, silly
+    `pred`
 
-     Type:
-       assertMsg :: Bool -> String -> Bool
+    : Predicate that needs to succeed, otherwise `msg` is thrown
+
+    `msg`
+
+    : Message to throw in case `pred` fails
+
+    # Type
+
+    ```
+    assertMsg :: Bool -> String -> Bool
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.asserts.assertMsg` usage example
+
+    ```nix
+    assertMsg false "nope"
+    stderr> error: nope
+    assert assertMsg ("foo" == "bar") "foo is not bar, silly"; ""
+    stderr> error: foo is not bar, silly
+    ```
+
+    :::
   */
   # TODO(Profpatsch): add tests that check stderr
   assertMsg =
-    # Predicate that needs to succeed, otherwise `msg` is thrown
     pred:
-    # Message to throw in case `pred` fails
     msg:
     pred || builtins.throw msg;
 
-  /* Specialized `assertMsg` for checking if `val` is one of the elements
-     of the list `xs`. Useful for checking enums.
+  /**
+    Specialized `assertMsg` for checking if `val` is one of the elements
+    of the list `xs`. Useful for checking enums.
 
-     Example:
-       let sslLibrary = "libressl";
-       in assertOneOf "sslLibrary" sslLibrary [ "openssl" "bearssl" ]
-       stderr> error: sslLibrary must be one of [
-       stderr>   "openssl"
-       stderr>   "bearssl"
-       stderr> ], but is: "libressl"
+    # Inputs
 
-     Type:
-       assertOneOf :: String -> ComparableVal -> List ComparableVal -> Bool
+    `name`
+
+    : The name of the variable the user entered `val` into, for inclusion in the error message
+
+    `val`
+
+    : The value of what the user provided, to be compared against the values in `xs`
+
+    `xs`
+
+    : The list of valid values
+
+    # Type
+
+    ```
+    assertOneOf :: String -> ComparableVal -> List ComparableVal -> Bool
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.asserts.assertOneOf` usage example
+
+    ```nix
+    let sslLibrary = "libressl";
+    in assertOneOf "sslLibrary" sslLibrary [ "openssl" "bearssl" ]
+    stderr> error: sslLibrary must be one of [
+    stderr>   "openssl"
+    stderr>   "bearssl"
+    stderr> ], but is: "libressl"
+    ```
+
+    :::
   */
   assertOneOf =
-    # The name of the variable the user entered `val` into, for inclusion in the error message
     name:
-    # The value of what the user provided, to be compared against the values in `xs`
     val:
-    # The list of valid values
     xs:
     assertMsg
     (lib.elem val xs)
@@ -50,29 +90,51 @@ rec {
       lib.generators.toPretty {} xs}, but is: ${
         lib.generators.toPretty {} val}";
 
-  /* Specialized `assertMsg` for checking if every one of `vals` is one of the elements
-     of the list `xs`. Useful for checking lists of supported attributes.
+  /**
+    Specialized `assertMsg` for checking if every one of `vals` is one of the elements
+    of the list `xs`. Useful for checking lists of supported attributes.
 
-     Example:
-       let sslLibraries = [ "libressl" "bearssl" ];
-       in assertEachOneOf "sslLibraries" sslLibraries [ "openssl" "bearssl" ]
-       stderr> error: each element in sslLibraries must be one of [
-       stderr>   "openssl"
-       stderr>   "bearssl"
-       stderr> ], but is: [
-       stderr>   "libressl"
-       stderr>   "bearssl"
-       stderr> ]
+    # Inputs
 
-     Type:
-       assertEachOneOf :: String -> List ComparableVal -> List ComparableVal -> Bool
+    `name`
+
+    : The name of the variable the user entered `val` into, for inclusion in the error message
+
+    `vals`
+
+    : The list of values of what the user provided, to be compared against the values in `xs`
+
+    `xs`
+
+    : The list of valid values
+
+    # Type
+
+    ```
+    assertEachOneOf :: String -> List ComparableVal -> List ComparableVal -> Bool
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.asserts.assertEachOneOf` usage example
+
+    ```nix
+    let sslLibraries = [ "libressl" "bearssl" ];
+    in assertEachOneOf "sslLibraries" sslLibraries [ "openssl" "bearssl" ]
+    stderr> error: each element in sslLibraries must be one of [
+    stderr>   "openssl"
+    stderr>   "bearssl"
+    stderr> ], but is: [
+    stderr>   "libressl"
+    stderr>   "bearssl"
+    stderr> ]
+    ```
+
+    :::
   */
   assertEachOneOf =
-    # The name of the variable the user entered `val` into, for inclusion in the error message
     name:
-    # The list of values of what the user provided, to be compared against the values in `xs`
     vals:
-    # The list of valid values
     xs:
     assertMsg
     (lib.all (val: lib.elem val xs) vals)


### PR DESCRIPTION
## Description of changes

Migrate deprecated nixdoc comments to official doc-comment format. (see rfc45) 

I choose lib.asserts, as this is a relatively small set that allows us to gradually figure out what parts are missing / should work better.

Manual still renders nicely. The only thing i realized is that examples are not counted by nixos render docs anymore. We could change nixos-render docs, to count markdown headings, instead of json fields to fix this.

@DanielSidhion  Not sure if this is a blocker, that we need to resolve beforehand.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
