### PR TITLE
gamja: init at 1.0.0-beta.9

### DIFF
--- a/pkgs/by-name/ga/gamja/package.nix
+++ b/pkgs/by-name/ga/gamja/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  fetchFromSourcehut,
+  buildNpmPackage,
+  writeText,
+  # https://git.sr.ht/~emersion/gamja/tree/master/doc/config-file.md
+  gamjaConfig ? null,
+}:
+buildNpmPackage rec {
+  pname = "gamja";
+  version = "1.0.0-beta.9";
+
+  src = fetchFromSourcehut {
+    owner = "~emersion";
+    repo = "gamja";
+    rev = "v${version}";
+    hash = "sha256-09rCj9oMzldRrxMGH4rUnQ6wugfhfmJP3rHET5b+NC8=";
+  };
+
+  npmDepsHash = "sha256-LxShwZacCctKAfMNCUMyrSaI1hIVN80Wseq/d8WITkc=";
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r dist $out
+    ${lib.optionalString (gamjaConfig != null) "cp ${writeText "gamja-config" (builtins.toJSON gamjaConfig)} $out/config.json"}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A simple IRC web client";
+    homepage = "https://git.sr.ht/~emersion/gamja";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [motiejus apfelkuchen6];
+  };
+}


### PR DESCRIPTION
gamja is an IRC web client.
Project url: https://git.sr.ht/~emersion/gamja

This is almost a direct copy of #243815 with an updated version. The original PR seems to have stalled, although it was quite complete. I have been using it for a couple of months, let's get this upstream.

Closes #243815

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
