### PR TITLE
nixos/jellyfin: pin uid/gid of jellyfin to 330

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -253,6 +253,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 - `services.avahi.nssmdns` got split into `services.avahi.nssmdns4` and `services.avahi.nssmdns6` which enable the mDNS NSS switch for IPv4 and IPv6 respectively.
   Since most mDNS responders only register IPv4 addresses, most users want to keep the IPv6 support disabled to avoid long timeouts.
 
+- `services.jellyfin` now has jellyfin user gid/uid pinned to 330. It's necessary to manually re-apply permission for files used by jellyfin. ([#292327](https://github.com/NixOS/nixpkgs/pull/292327))
+
 - A warning has been added for services that are
   `after = [ "network-online.target" ]` but do not depend on it (e.g. using
   `wants`), because the dependency that `multi-user.target` has on

--- a/nixos/modules/misc/ids.nix
+++ b/nixos/modules/misc/ids.nix
@@ -356,6 +356,7 @@ in
       rstudio-server = 324;
       localtimed = 325;
       automatic-timezoned = 326;
+      jellyfin = 330;
 
       # When adding a uid, make sure it doesn't match an existing gid. And don't use uids above 399!
 
@@ -666,6 +667,7 @@ in
       rstudio-server = 324;
       localtimed = 325;
       automatic-timezoned = 326;
+      jellyfin = 330;
 
       # When adding a gid, make sure it doesn't match an existing
       # uid. Users and groups with the same name should have equal

--- a/nixos/modules/services/misc/jellyfin.nix
+++ b/nixos/modules/services/misc/jellyfin.nix
@@ -145,11 +145,14 @@ in
       jellyfin = {
         inherit (cfg) group;
         isSystemUser = true;
+        uid = config.ids.uids.jellyfin;
       };
     };
 
     users.groups = mkIf (cfg.group == "jellyfin") {
-      jellyfin = {};
+      jellyfin = {
+        gid = config.ids.gids.jellyfin;
+      };
     };
 
     networking.firewall = mkIf cfg.openFirewall {


### PR DESCRIPTION
nixos/jellyfin: pin uid/gid of jellyfin to 330

I have used this to sync jellyfin uid/gid in multiple hosts.