### PR TITLE
gpustat: init at 0.1.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1532,6 +1532,12 @@
     githubId = 160646;
     name = "Patrick Jackson";
   };
+  arduano = {
+    email = "leonid.shchurov@gmail.com";
+    github = "arduano";
+    githubId = 13347712;
+    name = "Leo Shchurov";
+  };
   ardumont = {
     email = "eniotna.t@gmail.com";
     github = "ardumont";

--- a/pkgs/by-name/gp/gpustat/package.nix
+++ b/pkgs/by-name/gp/gpustat/package.nix
@@ -1,0 +1,71 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, fontconfig
+, libGL
+, libX11
+, libXcursor
+, libXi
+, libXrandr
+, cmake
+, libxkbcommon
+, wayland
+, makeWrapper
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "gpustat";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "arduano";
+    repo = "gpustat";
+    rev = "v${version}";
+    sha256 = "sha256-M9P/qfw/tp9ogkNOE3b2fD2rGFnii1/VwmqJHqXb7Mg=";
+  };
+
+  cargoSha256 = "sha256-po/pEMZEtySZnz7l2FI7Wqbmp2CiWBijchKGkqlIMPU=";
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    fontconfig
+    libGL
+    libX11
+    libXcursor
+    libXi
+    libXrandr
+    libxkbcommon
+    wayland
+  ];
+
+  postInstall = ''
+    mkdir -p $out/share/applications $out/share/pixmaps
+
+    cp assets/gpustat.desktop $out/share/applications
+    cp assets/gpustat_icon_* $out/share/pixmaps
+  '';
+
+  # Wrap the program in a script that sets the LD_LIBRARY_PATH environment variable
+  # so that it can find the shared libraries it depends on. This is currently a
+  # requirement for running Rust programs that depend on `egui` within a Nix environment.
+  # https://github.com/emilk/egui/issues/2486
+  postFixup = ''
+    wrapProgram $out/bin/gpustat \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath buildInputs}:/run/opengl-driver/lib"
+  '';
+
+  meta = with lib; {
+    description = "A simple utility for viewing GPU utilization";
+    homepage = "https://github.com/arduano/gpustat";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ arduano ];
+    mainProgram = "gpustat";
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`gpustat` is a simple GPU monitoring program, currently only supporting Nvidia and only running as a GUI app, but in the future a terminal UI is planned, as well as further GPU support. 

A screenshot and more details can be found in the readme: https://github.com/arduano/gpustat

For testing, run this application on any NixOS machine with a Nvidia GPU attached.

Also, this is my first contribution here, please be gentle :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
