### PR TITLE
sbcl: 2.4.1 -> 2.4.2

### DIFF
--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -24,11 +24,11 @@ let
       sha256 = "189gjqzdz10xh3ybiy4ch1r98bsmkcb4hpnrmggd4y2g5kqnyx4y";
     };
 
-    "2.4.0" = {
-      sha256 = "sha256-g9i3TwjSJUxZuXkLwfZp4JCZRXuIRyDs7L9F9LRtF3Y=";
-    };
     "2.4.1" = {
       sha256 = "sha256-2k+UhvrUE9OversbCSaTJf20v/fnuI8hld3udDJjz34=";
+    };
+    "2.4.2" = {
+      sha256 = "sha256-/APLUtEqr+h1nmMoRQogG73fibFwcaToPznoC0Pd7w8=";
     };
   };
   # Collection of pre-built SBCL binaries for platforms that need them for
@@ -96,10 +96,9 @@ stdenv.mkDerivation (self: rec {
   );
   buildInputs = lib.optionals coreCompression [ zstd ];
 
-  patches = [
+  patches = lib.optionals (lib.versionOlder self.version "2.4.2") [
+    # Fixed in 2.4.2
     ./search-for-binaries-in-PATH.patch
-  ] ++ lib.optionals (version == "2.4.0") [
-    ./fix-2.4.0-aarch64-darwin.patch
   ];
 
   # I don’t know why these are failing (on ofBorg), and I’d rather just disable

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25808,17 +25808,17 @@ with pkgs;
   };
 
   # Steel Bank Common Lisp
-  sbcl_2_4_0 = wrapLisp {
-    pkg = callPackage ../development/compilers/sbcl { version = "2.4.0"; };
-    faslExt = "fasl";
-    flags = [ "--dynamic-space-size" "3000" ];
-  };
   sbcl_2_4_1 = wrapLisp {
     pkg = callPackage ../development/compilers/sbcl { version = "2.4.1"; };
     faslExt = "fasl";
     flags = [ "--dynamic-space-size" "3000" ];
   };
-  sbcl = sbcl_2_4_1;
+  sbcl_2_4_2 = wrapLisp {
+    pkg = callPackage ../development/compilers/sbcl { version = "2.4.2"; };
+    faslExt = "fasl";
+    flags = [ "--dynamic-space-size" "3000" ];
+  };
+  sbcl = sbcl_2_4_2;
 
   sbclPackages = recurseIntoAttrs sbcl.pkgs;
 


### PR DESCRIPTION
## Description of changes
SBCL 2.4.2. 

```

changes in sbcl-2.4.2 relative to sbcl-2.4.1:
  * bug fix: restore the ability to inherit from both SEQUENCE and
    SB-MOP:FUNCALLABLE-STANDARD-OBJECT.  (lp#2050088, reported by Christophe
    Junke)
  * bug fix: COERCE will not convert lambda forms to functions if given a type
    naming a (strict) subclass of FUNCTION.
  * bug fix: LOG with a double-float and a ratio argument (in either order) do
    not lose precision through a single-float intermediate argument.
  * bug fix: LOG to the base 2 of integer powers of 2 are more likely to get
    the mathematically precise answer.
  * bug fix: LOG on ratios very near 1 with numerator or denominator being
    near a power of 2 will use log1p and so will lose less precision.
  * bug fix: the utf-8 external format with Unix line-endings updates its
    character size information when taking the fast path for a buffer of ascii
    characters.  (lp#2054169, reported by John Carroll)
  * bug fix: don't print the contents of a possibly no-longer-valid
    dynamic-extent cons in PRINT-OBJECT method for THREAD objects.
    (lp#2026195, reported by Jake Connor)
  * bug fix: place external entry points for functions consistently before any
    local functions.  (lp#2051169, reported by Fedorov Alexander)
  * bug fix: remove unactionable optimization notes for backquoted forms and
    ordinary calls to APPEND at high speed.  (lp#2051401, reported by Robert
    Brown)
  * bug fix: infinite loop in COPY-SEQ on zero-length arrays of element-type
    NIL.  (lp#2051759, reported by Devon Sean McCullough)
  * bug fix: fix compilation of non-top-level struct constructors.
    (lp#2052329, reported by Robert Poitras)
  * bug fixes in SB-SIMD:
    ** improve bounds checking in SB-SIMD.  (lp#2012010, reported by Patrick
       Poitras)
    ** fix SB-SIMD AVX f64.4-reverse (lp#2012986, thanks to Ari Projansky)
    ** fix SB-SIMD shuffles on AVX and SSE2 (lp#2012990, reported by Ari
       Projansky)
    ** fix lifetimes in sse+xmm0 VOPs (lp#2015329, reported by Ari Projansky)
  * optimization: a number of internal tables, particularly those related to
    Unicode support have been converted to use perfect hash mechanisms,
    improving both speed and space.
  * optimization: FIND, POSITION, ASSOC and RASSOC with constant sequence
    arguments containing symbols as keys are compiled to perfect hash lookups.
  * optimization: the compiler runs a jump-to-jump elimination pass on x86-64.
  * system integrity: compiling the system itself on x86-64/linux now produces
    bitwise-identical cross-compiled fasls whether the build host is cmucl,
    ccl, clisp or sbcl itself.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
