### PR TITLE
citra: use lib.cmakeBool

### DIFF
--- a/pkgs/applications/emulators/citra/generic.nix
+++ b/pkgs/applications/emulators/citra/generic.nix
@@ -34,7 +34,7 @@
 , enableQtTranslation ? enableQt, qttools
 , enableWebService ? true
 , enableCubeb ? true, cubeb
-, useDiscordRichPresence ? true, rapidjson
+, useDiscordRichPresence ? false, rapidjson
 }:
 stdenv.mkDerivation {
   inherit pname version src;

--- a/pkgs/applications/emulators/citra/generic.nix
+++ b/pkgs/applications/emulators/citra/generic.nix
@@ -72,23 +72,25 @@ stdenv.mkDerivation {
     ++ lib.optional useDiscordRichPresence rapidjson;
 
   cmakeFlags = [
-    "-DUSE_SYSTEM_LIBS=ON"
+    (lib.cmakeBool "USE_SYSTEM_LIBS" true)
 
-    "-DDISABLE_SYSTEM_DYNARMIC=ON"
-    "-DDISABLE_SYSTEM_GLSLANG=ON" # The following imported targets are referenced, but are missing: SPIRV-Tools-opt
-    "-DDISABLE_SYSTEM_LODEPNG=ON" # Not packaged in nixpkgs
-    "-DDISABLE_SYSTEM_VMA=ON"
-    "-DDISABLE_SYSTEM_XBYAK=ON"
+    (lib.cmakeBool "DISABLE_SYSTEM_DYNARMIC" true)
+    (lib.cmakeBool "DISABLE_SYSTEM_GLSLANG" true) # The following imported targets are referenced, but are missing: SPIRV-Tools-opt
+    (lib.cmakeBool "DISABLE_SYSTEM_LODEPNG" true) # Not packaged in nixpkgs
+    (lib.cmakeBool "DISABLE_SYSTEM_VMA" true)
+    (lib.cmakeBool "DISABLE_SYSTEM_XBYAK" true)
 
     # We don't want to bother upstream with potentially outdated compat reports
-    "-DCITRA_ENABLE_COMPATIBILITY_REPORTING=ON"
-    "-DENABLE_COMPATIBILITY_LIST_DOWNLOAD=OFF" # We provide this deterministically
-  ] ++ lib.optional (!enableSdl2Frontend) "-DENABLE_SDL2_FRONTEND=OFF"
-    ++ lib.optional (!enableQt) "-DENABLE_QT=OFF"
-    ++ lib.optional enableQtTranslation "-DENABLE_QT_TRANSLATION=ON"
-    ++ lib.optional (!enableWebService) "-DENABLE_WEB_SERVICE=OFF"
-    ++ lib.optional (!enableCubeb) "-DENABLE_CUBEB=OFF"
-    ++ lib.optional useDiscordRichPresence "-DUSE_DISCORD_PRESENCE=ON";
+    (lib.cmakeBool "CITRA_ENABLE_COMPATIBILITY_REPORTING" true)
+    (lib.cmakeBool "ENABLE_COMPATIBILITY_LIST_DOWNLOAD" false) # We provide this deterministically
+
+    (lib.cmakeBool "ENABLE_SDL2_FRONTEND" enableSdl2Frontend)
+    (lib.cmakeBool "ENABLE_QT" enableQt)
+    (lib.cmakeBool "ENABLE_QT_TRANSLATION" enableQtTranslation)
+    (lib.cmakeBool "ENABLE_WEB_SERVICE" enableWebService)
+    (lib.cmakeBool "ENABLE_CUBEB" enableCubeb)
+    (lib.cmakeBool "USE_DISCORD_PRESENCE" useDiscordRichPresence)
+  ];
 
   # causes redefinition of _FORTIFY_SOURCE
   hardeningDisable = [ "fortify3" ];


### PR DESCRIPTION
## Description of changes

Improve readability.
It was kinda ugly to not set some variables if they were already set to the default. (Especially in the eventuality that the default upstream changes, no one makes notices to make changes here, and confusion arises.)

BTW, should I also default Discord RPC to false, considering the feedback of https://github.com/NixOS/nixpkgs/pull/288890#discussion_r1490254944? (@AndersonTorres)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
