### PR TITLE
sway/hyprland: cross compilation fixes

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hyprland/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland/default.nix
@@ -77,6 +77,11 @@ stdenv.mkDerivation (finalAttrs: {
       --replace "@DIRTY@" ""
   '';
 
+  depsBuildBuild = [
+    # to find wayland-scanner when cross-compiling
+    pkg-config
+  ];
+
   nativeBuildInputs = [
     jq
     makeWrapper

--- a/pkgs/by-name/wa/waybar/package.nix
+++ b/pkgs/by-name/wa/waybar/package.nix
@@ -40,10 +40,12 @@
 , udev
 , upower
 , wayland
+, wayland-scanner
 , wireplumber
 , wrapGAppsHook
 
 , cavaSupport ? true
+, enableManpages ? stdenv.buildPlatform.canExecute stdenv.hostPlatform
 , evdevSupport ? true
 , experimentalPatches ? true
 , hyprlandSupport ? true
@@ -55,7 +57,7 @@
 , pipewireSupport ? true
 , pulseSupport ? true
 , rfkillSupport ? true
-, runTests ? true
+, runTests ? stdenv.buildPlatform.canExecute stdenv.hostPlatform
 , sndioSupport ? true
 , swaySupport ? true
 , traySupport ? true
@@ -97,17 +99,16 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     pkg-config
-    scdoc
+    wayland-scanner
     wrapGAppsHook
-  ] ++ lib.optional withMediaPlayer gobject-introspection;
+  ] ++ lib.optional withMediaPlayer gobject-introspection
+    ++ lib.optional enableManpages scdoc;
 
   propagatedBuildInputs = lib.optionals withMediaPlayer [
     glib
     playerctl
     python3.pkgs.pygobject3
   ];
-
-  strictDeps = false;
 
   buildInputs = [
     gtk-layer-shell
@@ -154,7 +155,7 @@ stdenv.mkDerivation (finalAttrs: {
     "libinput" = inputSupport;
     "libnl" = nlSupport;
     "libudev" = udevSupport;
-    "man-pages" = true;
+    "man-pages" = enableManpages;
     "mpd" = mpdSupport;
     "mpris" = mprisSupport;
     "pipewire" = pipewireSupport;

--- a/pkgs/development/libraries/wlroots/default.nix
+++ b/pkgs/development/libraries/wlroots/default.nix
@@ -127,9 +127,11 @@ rec {
   wlroots_0_17 = generic {
     version = "0.17.3";
     hash = "sha256-jth6BKci3sVDC86o+gSHKyDWnibVcNmipm7nn0S6LTg=";
+    extraNativeBuildInputs = [
+      hwdata
+    ];
     extraBuildInputs = [
       ffmpeg
-      hwdata
       libliftoff
       libdisplay-info
     ];


### PR DESCRIPTION
## Description of changes
- fixes cross compilation for `wlroots`, `hyprland` and `waybar`.
- `sway` cross compiles w/o intervention now that its dependencies cross compile.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (and cross-compiled via `pkgsCross.aarch64-multiplatform.{hyprland,sway,waybar}`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
