### PR TITLE
nixosTests.networking: refactor and add NetworkManager support

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -232,10 +232,12 @@ pkgs/development/python-modules/buildcatrust/ @ajs124 @lukegb @mweinelt
 /nixos/modules/services/networking/babeld.nix @mweinelt
 /nixos/modules/services/networking/kea.nix @mweinelt
 /nixos/modules/services/networking/knot.nix @mweinelt
+nixos/modules/services/networking/networkmanager.nix @Janik-Haag
 /nixos/modules/services/monitoring/prometheus/exporters/kea.nix @mweinelt
 /nixos/tests/babeld.nix @mweinelt
 /nixos/tests/kea.nix @mweinelt
 /nixos/tests/knot.nix @mweinelt
+/nixos/tests/networking/* @Janik-Haag
 
 # Web servers
 /doc/packages/nginx.section.md @raitobezarius

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -581,6 +581,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - The `hardware.pulseaudio` module now sets permission of pulse user home directory to 755 when running in "systemWide" mode. It fixes [issue 114399](https://github.com/NixOS/nixpkgs/issues/114399).
 
+- The `services.networkmanager.extraConfig` was renamed to `services.networkmanager.settings` and was changed to use the ini type instead of using a multiline string.
+
 - The module `services.github-runner` has been removed. To configure a single GitHub Actions Runner refer to `services.github-runners.*`. Note that this will trigger a new runner registration.
 
 - The `services.slskd` has been refactored to include more configuation options in

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -598,6 +598,7 @@ in {
   netdata = handleTest ./netdata.nix {};
   networking.scripted = handleTest ./networking/networkd-and-scripted.nix { networkd = false; };
   networking.networkd = handleTest ./networking/networkd-and-scripted.nix { networkd = true; };
+  networking.networkmanager = handleTest ./networking/networkmanager.nix {};
   netbox_3_6 = handleTest ./web-apps/netbox.nix { netbox = pkgs.netbox_3_6; };
   netbox_3_7 = handleTest ./web-apps/netbox.nix { netbox = pkgs.netbox_3_7; };
   netbox-upgrade = handleTest ./web-apps/netbox-upgrade.nix {};

--- a/nixos/tests/networking/networkmanager.nix
+++ b/nixos/tests/networking/networkmanager.nix
@@ -1,0 +1,169 @@
+{ system ? builtins.currentSystem
+, config ? {}
+, pkgs ? import ../.. { inherit system config; }
+}:
+
+with import ../../lib/testing-python.nix { inherit system pkgs; };
+
+let
+  lib = pkgs.lib;
+  # this is intended as a client test since you shouldn't use NetworkManager for a router or server
+  # so using systemd-networkd for the router vm is fine in these tests.
+  router = import ./router.nix { networkd = true; };
+  qemu-common = import ../../lib/qemu-common.nix { inherit (pkgs) lib pkgs; };
+  clientConfig = extraConfig: lib.recursiveUpdate {
+    networking.useDHCP = false;
+
+    # Make sure that only NetworkManager configures the interface
+    networking.interfaces = lib.mkForce {
+      eth1 = {};
+    };
+    networking.networkmanager = {
+      enable = true;
+      # this is needed so NM doesn't generate 'Wired Connection' profiles and instead uses the default one
+      settings.main.no-auto-default = "*";
+      ensureProfiles.profiles.default = {
+        connection = {
+          id = "default";
+          type = "ethernet";
+          interface-name = "eth1";
+          autoconnect = true;
+        };
+      };
+    };
+  } extraConfig;
+  testCases = {
+    static = {
+      name = "static";
+      nodes = {
+        inherit router;
+        client = clientConfig {
+          networking.networkmanager.ensureProfiles.profiles.default = {
+            ipv4.method = "manual";
+            ipv4.addresses = "192.168.1.42/24";
+            ipv4.gateway = "192.168.1.1";
+            ipv6.method = "manual";
+            ipv6.addresses = "fd00:1234:5678:1::42/64";
+            ipv6.gateway = "fd00:1234:5678:1::1";
+          };
+        };
+      };
+      testScript = ''
+        start_all()
+        router.wait_for_unit("network-online.target")
+        client.wait_for_unit("NetworkManager.service")
+
+        with subtest("Wait until we have an ip address on each interface"):
+            client.wait_until_succeeds("ip addr show dev eth1 | grep -q '192.168.1'")
+            client.wait_until_succeeds("ip addr show dev eth1 | grep -q 'fd00:1234:5678:1:'")
+
+        with subtest("Test if icmp echo works"):
+            client.wait_until_succeeds("ping -c 1 192.168.3.1")
+            client.wait_until_succeeds("ping -c 1 fd00:1234:5678:3::1")
+            router.wait_until_succeeds("ping -c 1 192.168.1.42")
+            router.wait_until_succeeds("ping -c 1 fd00:1234:5678:1::42")
+      '';
+    };
+    auto = {
+      name = "auto";
+      nodes = {
+        inherit router;
+        client = clientConfig {
+          networking.networkmanager.ensureProfiles.profiles.default = {
+            ipv4.method = "auto";
+            ipv6.method = "auto";
+          };
+        };
+      };
+      testScript = ''
+        start_all()
+        router.wait_for_unit("network-online.target")
+        client.wait_for_unit("NetworkManager.service")
+
+        with subtest("Wait until we have an ip address on each interface"):
+            client.wait_until_succeeds("ip addr show dev eth1 | grep -q '192.168.1'")
+            client.wait_until_succeeds("ip addr show dev eth1 | grep -q 'fd00:1234:5678:1:'")
+
+        with subtest("Test if icmp echo works"):
+            client.wait_until_succeeds("ping -c 1 192.168.1.1")
+            client.wait_until_succeeds("ping -c 1 fd00:1234:5678:1::1")
+            router.wait_until_succeeds("ping -c 1 192.168.1.2")
+            router.wait_until_succeeds("ping -c 1 fd00:1234:5678:1::2")
+      '';
+    };
+    dns = {
+      name = "dns";
+      nodes = {
+        inherit router;
+        dynamic = clientConfig {
+          networking.networkmanager.ensureProfiles.profiles.default = {
+            ipv4.method = "auto";
+          };
+        };
+        static = clientConfig {
+          networking.networkmanager.ensureProfiles.profiles.default = {
+            ipv4 = {
+              method = "auto";
+              ignore-auto-dns = "true";
+              dns = "10.10.10.10";
+              dns-search = "";
+            };
+          };
+        };
+      };
+      testScript = ''
+        start_all()
+        router.wait_for_unit("network-online.target")
+        dynamic.wait_for_unit("NetworkManager.service")
+        static.wait_for_unit("NetworkManager.service")
+
+        dynamic.wait_until_succeeds("cat /etc/resolv.conf | grep -q '192.168.1.1'")
+        static.wait_until_succeeds("cat /etc/resolv.conf | grep -q '10.10.10.10'")
+        static.wait_until_fails("cat /etc/resolv.conf | grep -q '192.168.1.1'")
+      '';
+    };
+    dispatcherScripts = {
+      name = "dispatcherScripts";
+      nodes.client = clientConfig {
+        networking.networkmanager.dispatcherScripts = [{
+          type = "pre-up";
+          source = pkgs.writeText "testHook" ''
+            touch /tmp/dispatcher-scripts-are-working
+          '';
+        }];
+      };
+      testScript = ''
+        start_all()
+        client.wait_for_unit("NetworkManager.service")
+        client.wait_until_succeeds("stat /tmp/dispatcher-scripts-are-working")
+      '';
+    };
+    envsubst = {
+      name = "envsubst";
+      nodes.client = let
+        # you should never write secrets in to your nixos configuration, please use tools like sops-nix or agenix
+        secretFile = pkgs.writeText "my-secret.env" ''
+          MY_SECRET_IP=fd00:1234:5678:1::23/64
+        '';
+      in clientConfig {
+        networking.networkmanager.ensureProfiles.environmentFiles = [ secretFile ];
+        networking.networkmanager.ensureProfiles.profiles.default = {
+          ipv6.method = "manual";
+          ipv6.addresses = "$MY_SECRET_IP";
+        };
+      };
+      testScript = ''
+        start_all()
+        client.wait_for_unit("NetworkManager.service")
+        client.wait_until_succeeds("ip addr show dev eth1 | grep -q 'fd00:1234:5678:1:'")
+        client.wait_until_succeeds("ping -c 1 fd00:1234:5678:1::23")
+      '';
+    };
+  };
+in lib.mapAttrs (lib.const (attrs: makeTest (attrs // {
+  name = "${attrs.name}-Networking-NetworkManager";
+  meta = {
+    maintainers = with lib.maintainers; [ janik ];
+  };
+
+}))) testCases

--- a/nixos/tests/networking/networkmanager.nix
+++ b/nixos/tests/networking/networkmanager.nix
@@ -50,6 +50,7 @@ let
       };
       testScript = ''
         start_all()
+        router.systemctl("start network-online.target")
         router.wait_for_unit("network-online.target")
         client.wait_for_unit("NetworkManager.service")
 
@@ -77,6 +78,7 @@ let
       };
       testScript = ''
         start_all()
+        router.systemctl("start network-online.target")
         router.wait_for_unit("network-online.target")
         client.wait_for_unit("NetworkManager.service")
 
@@ -113,6 +115,7 @@ let
       };
       testScript = ''
         start_all()
+        router.systemctl("start network-online.target")
         router.wait_for_unit("network-online.target")
         dynamic.wait_for_unit("NetworkManager.service")
         static.wait_for_unit("NetworkManager.service")

--- a/pkgs/tools/networking/networkmanager/default.nix
+++ b/pkgs/tools/networking/networkmanager/default.nix
@@ -50,6 +50,7 @@
 , mobile-broadband-provider-info
 , runtimeShell
 , buildPackages
+, nixosTests
 }:
 
 let
@@ -202,6 +203,9 @@ stdenv.mkDerivation rec {
       packageName = "NetworkManager";
       attrPath = "networkmanager";
       versionPolicy = "odd-unstable";
+    };
+    tests = {
+      inherit (nixosTests.networking) networkmanager;
     };
   };
 


### PR DESCRIPTION
## Description of changes

This adds nixos vm tests for NetworkManager and simplifies the existing  networking tests for systemd-networkd and scripted networking. There is still a lot of todo's and this is a early-ish draft for now.

Fixes #71151

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
