### PR TITLE
fcitx5-rose-pine: init at 0-unstable-2024-03-01

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16582,6 +16582,11 @@
       fingerprint = "1401 1B63 393D 16C1 AA9C  C521 8526 B757 4A53 6236";
     }];
   };
+  RoseHobgoblin = {
+    name = "J. L. Bowden";
+    github = "rosehobgoblin";
+    githubId = 84164410;
+  };
   rossabaker = {
     name = "Ross A. Baker";
     email = "ross@rossabaker.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16582,7 +16582,7 @@
       fingerprint = "1401 1B63 393D 16C1 AA9C  C521 8526 B757 4A53 6236";
     }];
   };
-  RoseHobgoblin = {
+  rosehobgoblin = {
     name = "J. L. Bowden";
     github = "rosehobgoblin";
     githubId = 84164410;

--- a/pkgs/by-name/fc/fcitx5-rose-pine/package.nix
+++ b/pkgs/by-name/fc/fcitx5-rose-pine/package.nix
@@ -1,0 +1,34 @@
+{ stdenvNoCC
+, fetchFromGitHub
+, lib
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "fcitx5-rose-pine";
+  version = "0-unstable-2024-03-01";
+
+  src = fetchFromGitHub {
+    owner = "rose-pine";
+    repo = "fcitx5";
+    rev = "148de09929c2e2f948376bb23bc25d72006403bc";
+    hash = "sha256-SpQ5ylHSDF5KCwKttAlXgrte3GA1cCCy/0OKNT1a3D8=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -pv $out/share/fcitx5/themes/
+    cp -rv rose-pine* $out/share/fcitx5/themes/
+
+    runHook postInstall
+  '';
+
+
+  meta = {
+    description = "Fcitx5 themes based on Rosé Pine";
+    homepage = "https://github.com/rose-pine/fcitx5";
+    maintainers = with lib.maintainers; [ rosehobgoblin ];
+    platforms = lib.platforms.all;
+    license = lib.licenses.unfree;
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds three rose-pine themes for fcitx5
https://github.com/rose-pine/fcitx5

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
