### PR TITLE
chawan: init at 0-unstable-2024-03-01

### DIFF
--- a/pkgs/by-name/ch/chawan/mancha-augment-path.diff
+++ b/pkgs/by-name/ch/chawan/mancha-augment-path.diff
@@ -1,0 +1,15 @@
+Add the -m option to man's command line to augment the list of paths
+searched by man. The string "OUT" must be substituted with chawan's $out
+path after patching.
+The required -m option is only available in the mandoc implementation.
+--- a/adapter/protocol/man
++++ b/adapter/protocol/man
+@@ -75,7 +75,7 @@ EOF
+ 
+   $section =~ s:([^-\w\200-\377.,])::g;
+   $man =~ s:([^-\w\200-\377.,])::g;
+-  open(F, "GROFF_NO_SGR=1 MAN_KEEP_FORMATTING=1 $MAN $section $man 2> /dev/null |");
++  open(F, "GROFF_NO_SGR=1 MAN_KEEP_FORMATTING=1 $MAN -m OUT/share/man $section $man 2> /dev/null |");
+ }
+ 
+ $ok = 0;

--- a/pkgs/by-name/ch/chawan/package.nix
+++ b/pkgs/by-name/ch/chawan/package.nix
@@ -1,0 +1,76 @@
+{ lib
+, stdenv
+, fetchFromSourcehut
+, makeBinaryWrapper
+, curlMinimal
+, mandoc
+, ncurses
+, nim
+, pandoc
+, perl
+, pkg-config
+, zlib
+}:
+
+stdenv.mkDerivation {
+  pname = "chawan";
+  version = "0-unstable-2024-03-01";
+
+  src = fetchFromSourcehut {
+    owner = "~bptato";
+    repo = "chawan";
+    rev = "87ba9a87be15abbe06837f1519cfb76f4bf759f3";
+    hash = "sha256-Xs+Mxe5/uoxPMf4FuelpO+bRJ1KdfASVI7rWqtboJZw=";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    # Include chawan's man pages in mancha's search path
+    ./mancha-augment-path.diff
+  ];
+
+  env.NIX_CFLAGS_COMPILE = toString (
+    lib.optional stdenv.cc.isClang "-Wno-error=implicit-function-declaration"
+  );
+
+  buildInputs = [ curlMinimal ncurses perl zlib ];
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    nim
+    pandoc
+    pkg-config
+  ];
+
+  postPatch = ''
+    substituteInPlace adapter/protocol/man \
+      --replace-fail "OUT" $out
+  '';
+
+  buildFlags = [ "all" "manpage" ];
+  installFlags = [
+    "DESTDIR=$(out)"
+    "PREFIX=/"
+  ];
+
+  postInstall =
+  let
+    makeWrapperArgs = ''
+      --set MANCHA_CHA $out/bin/cha \
+      --set MANCHA_MAN ${mandoc}/bin/man
+    '';
+  in
+  ''
+    wrapProgram $out/bin/cha ${makeWrapperArgs}
+    wrapProgram $out/bin/mancha ${makeWrapperArgs}
+  '';
+
+  meta = {
+    description = "Lightweight and featureful terminal web browser";
+    homepage = "https://sr.ht/~bptato/chawan/";
+    license = lib.licenses.publicDomain;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ jtbx ];
+    mainProgram = "cha";
+    broken = stdenv.isDarwin; # pending PR #292043
+  };
+}


### PR DESCRIPTION
## Description of changes

Lightweight, pretty web browser that runs in your terminal.

https://sr.ht/~bptato/chawan/

Unlike most Nim software, Chawan uses make rather than nimble, which means I can't use `buildNimPackage`.

A few workarounds were employed to ensure both the `cha` and `mancha` utilities work as expected. `mancha` uses Chawan to display system man pages and so to make this work properly I had to use a wrapper to make sure it gets the correct path to all man pages as well as the path to its own man page. `cha` can also display man pages given a `man:` URL, so I had to wrap it with the same arguments as `mancha` is wrapped with.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
