### PR TITLE
kdePackages.akonadi: restore mysql backend

### DIFF
--- a/pkgs/kde/gear/akonadi/default.nix
+++ b/pkgs/kde/gear/akonadi/default.nix
@@ -1,16 +1,25 @@
 {
+  lib,
   mkKdeDerivation,
   qttools,
   accounts-qt,
   kaccounts-integration,
   shared-mime-info,
   xz,
+  mariadb,
 }:
 mkKdeDerivation {
   pname = "akonadi";
 
-  # FIXME(later): investigate nixpkgs patches
+  patches = [
+    # Always regenerate MySQL config, as the store paths don't have accurate timestamps
+    ./ignore-mysql-config-timestamp.patch
+  ];
+
+  extraCmakeFlags = [
+    "-DMYSQLD_SCRIPTS_PATH=${lib.getBin mariadb}/bin"
+  ];
 
   extraNativeBuildInputs = [qttools shared-mime-info];
-  extraBuildInputs = [kaccounts-integration accounts-qt xz];
+  extraBuildInputs = [kaccounts-integration accounts-qt xz mariadb];
 }

--- a/pkgs/kde/gear/akonadi/ignore-mysql-config-timestamp.patch
+++ b/pkgs/kde/gear/akonadi/ignore-mysql-config-timestamp.patch
@@ -1,0 +1,12 @@
+--- a/src/server/storage/dbconfigmysql.cpp
++++ b/src/server/storage/dbconfigmysql.cpp
+@@ -241,8 +241,7 @@ bool DbConfigMysql::startInternalServer()
+     bool confUpdate = false;
+     QFile actualFile(actualConfig);
+     // update conf only if either global (or local) is newer than actual
+-    if ((QFileInfo(globalConfig).lastModified() > QFileInfo(actualFile).lastModified())
+-        || (QFileInfo(localConfig).lastModified() > QFileInfo(actualFile).lastModified())) {
++    if (true) {
+         QFile globalFile(globalConfig);
+         QFile localFile(localConfig);
+         if (globalFile.open(QFile::ReadOnly) && actualFile.open(QFile::WriteOnly)) {


### PR DESCRIPTION
I guess we're stuck with it for the time being.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
