### PR TITLE
nwg-displays: Default to enabled hyprland support

### DIFF
--- a/pkgs/applications/misc/nwg-displays/default.nix
+++ b/pkgs/applications/misc/nwg-displays/default.nix
@@ -8,7 +8,7 @@
 , pango
 , python310Packages
 , wrapGAppsHook
-, hyprlandSupport ? false
+, hyprlandSupport ? true
 , wlr-randr
 }:
 


### PR DESCRIPTION
``nix-shell -p nwg-displays`` fails on systems using hyprland if support is not enabled. To fix this the default was changed to enable support for hyprland. If users wish to disable it they still can do that.
