### PR TITLE
fcitx5-configtool: allow building with qt6

### DIFF
--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-configtool.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-configtool.nix
@@ -1,10 +1,14 @@
 { lib
-, mkDerivation
+, stdenv
 , fetchFromGitHub
 , cmake
+, pkg-config
 , extra-cmake-modules
 , fcitx5
 , fcitx5-qt
+, qtbase
+, qtsvg
+, wrapQtAppsHook
 , qtx11extras
 , qtquickcontrols2
 , kwidgetsaddons
@@ -14,12 +18,14 @@
 , xkeyboardconfig
 , libxkbfile
 , libXdmcp
-, plasma5Packages
+, kiconthemes
 , plasma-framework
 , kcmSupport ? true
 }:
 
-mkDerivation rec {
+let
+  isQt6 = lib.versions.major qtbase.version == "6";
+in stdenv.mkDerivation rec {
   pname = "fcitx5-configtool";
   version = "5.1.3";
 
@@ -31,17 +37,22 @@ mkDerivation rec {
   };
 
   cmakeFlags = [
+    (lib.cmakeBool "USE_QT6" isQt6)
     "-DKDE_INSTALL_USE_QT_SYS_PATHS=ON"
   ];
 
   nativeBuildInputs = [
     cmake
+    pkg-config
     extra-cmake-modules
+    wrapQtAppsHook
   ];
 
   buildInputs = [
     fcitx5
     fcitx5-qt
+    qtbase
+    qtsvg
     qtx11extras
     qtquickcontrols2
     kirigami2
@@ -52,7 +63,7 @@ mkDerivation rec {
   ] ++ lib.optionals kcmSupport [
     kdeclarative
     kwidgetsaddons
-    plasma5Packages.kiconthemes
+    kiconthemes
     plasma-framework
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24410,7 +24410,7 @@ with pkgs;
   qt6 = recurseIntoAttrs (callPackage ../development/libraries/qt-6 { });
 
   qt6Packages = recurseIntoAttrs (import ./qt6-packages.nix {
-    inherit lib __splicedPackages makeScopeWithSplicing' generateSplicesForMkScope pkgsHostTarget;
+    inherit lib __splicedPackages makeScopeWithSplicing' generateSplicesForMkScope pkgsHostTarget kdePackages;
     stdenv = if stdenv.isDarwin then darwin.apple_sdk_11_0.stdenv else stdenv;
   });
 

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -10,6 +10,7 @@
 , generateSplicesForMkScope
 , stdenv
 , pkgsHostTarget
+, kdePackages
 }:
 
 let
@@ -33,6 +34,13 @@ makeScopeWithSplicing' {
   appstream-qt = callPackage ../development/libraries/appstream/qt.nix { };
 
   fcitx5-qt = callPackage ../tools/inputmethods/fcitx5/fcitx5-qt.nix { };
+  fcitx5-configtool = kdePackages.callPackage ../tools/inputmethods/fcitx5/fcitx5-configtool.nix {
+    # Adjust for Qt5 -> Qt6 renames
+    kirigami2 = kdePackages.kirigami;
+    plasma-framework = kdePackages.libplasma;
+    qtquickcontrols2 = null;
+    qtx11extras = null;
+  };
 
   kdsoap = callPackage ../development/libraries/kdsoap { };
 


### PR DESCRIPTION
## Description of changes

Allows the KCM to work with Plasma 6. Qt5 version remains default (for now?)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
