### PR TITLE
dialect: 2.1.1 -> 2.2.0

### DIFF
--- a/pkgs/applications/misc/dialect/default.nix
+++ b/pkgs/applications/misc/dialect/default.nix
@@ -13,23 +13,32 @@
 , gobject-introspection
 , gst_all_1
 , libsoup_3
+, glib-networking
 , libadwaita
 , nix-update-script
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "dialect";
-  version = "2.1.1";
+  version = "2.2.0";
 
   format = "other";
 
   src = fetchFromGitHub {
     owner = "dialect-app";
-    repo = pname;
+    repo = "dialect";
     rev = version;
     fetchSubmodules = true;
-    hash = "sha256-ytZnolQTOj0dpv+ouN1N7sypr1LxSN/Uhp7qP0ZOTHE=";
+    hash = "sha256-+0qA+jFYrK3K3mJNvxTvnT/3q4c51H0KgEMjzvV34Zs=";
   };
+
+  # FIXME: remove in next release
+  postPatch = ''
+    substituteInPlace dialect/providers/lingva.py \
+      --replace-fail 'lingva.ml' 'lingva.dialectapp.org'
+    substituteInPlace dialect/providers/libretrans.py \
+      --replace-fail 'libretranslate.de' 'lt.dialectapp.org'
+  '';
 
   nativeBuildInputs = [
     appstream-glib
@@ -47,7 +56,9 @@ python3.pkgs.buildPythonApplication rec {
     glib
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
     libsoup_3
+    glib-networking
     libadwaita
   ];
 
@@ -55,6 +66,7 @@ python3.pkgs.buildPythonApplication rec {
     dbus-python
     gtts
     pygobject3
+    beautifulsoup4
   ];
 
   # Prevent double wrapping, let the Python wrapper use the args in preFixup.
@@ -76,6 +88,7 @@ python3.pkgs.buildPythonApplication rec {
     description = "A translation app for GNOME";
     maintainers = with maintainers; [ linsui ];
     license = licenses.gpl3Plus;
+    mainProgram = "dialect";
     platforms = platforms.linux;
   };
 }

--- a/pkgs/applications/misc/dialect/default.nix
+++ b/pkgs/applications/misc/dialect/default.nix
@@ -86,7 +86,7 @@ python3.pkgs.buildPythonApplication rec {
   meta = with lib; {
     homepage = "https://github.com/dialect-app/dialect";
     description = "A translation app for GNOME";
-    maintainers = with maintainers; [ linsui aleksana ];
+    maintainers = with maintainers; [ aleksana ];
     license = licenses.gpl3Plus;
     mainProgram = "dialect";
     platforms = platforms.linux;

--- a/pkgs/applications/misc/dialect/default.nix
+++ b/pkgs/applications/misc/dialect/default.nix
@@ -86,7 +86,7 @@ python3.pkgs.buildPythonApplication rec {
   meta = with lib; {
     homepage = "https://github.com/dialect-app/dialect";
     description = "A translation app for GNOME";
-    maintainers = with maintainers; [ linsui ];
+    maintainers = with maintainers; [ linsui aleksana ];
     license = licenses.gpl3Plus;
     mainProgram = "dialect";
     platforms = platforms.linux;


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes https://github.com/NixOS/nixpkgs/issues/285091

~~Known issue: libretrans and lingva are broken (also broken in the last release, not sure if it's network reason)~~
Fixed. The upstream changed to their own provider addresses. I've done a quick replacing on the code. The relevant code has been significantly modified, making it inconvenient to use patch directly.

Known issue: Bing translate cannot work in China.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
