### PR TITLE
New option to apply device tree overlays at runtime.

### DIFF
--- a/nixos/modules/hardware/device-tree.nix
+++ b/nixos/modules/hardware/device-tree.nix
@@ -195,6 +195,20 @@ in
           '';
         };
 
+        runtimeOverlays = mkOption {
+          default = [];
+          example = literalExpression ''
+            [
+              "rockchip/overlay/rk3588-disable-led.dtbo"
+              "rockchip/overlay/rk3588-wifi-ap6275p.dtbo"
+            ]
+          '';
+          type = types.listOf types.str;
+          description = lib.mdDoc ''
+            List of overlays to apply at runtime, relative to the dtb base.
+          '';
+        };
+
         package = mkOption {
           default = null;
           type = types.nullOr types.path;
@@ -222,5 +236,9 @@ in
     hardware.deviceTree.package = if (cfg.overlays != [])
       then pkgs.deviceTree.applyOverlays filteredDTBs (withDTBOs cfg.overlays)
       else filteredDTBs;
+
+      system.extraSystemBuilderCmds = ''
+        echo ${builtins.concatStringsSep " " config.hardware.deviceTree.runtimeOverlays} > $out/devicetree-overlays
+      '';
   };
 }

--- a/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.sh
+++ b/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.sh
@@ -103,6 +103,10 @@ addEntry() {
         return
     fi
 
+    if [ -f "$path/devicetree-overlays" ]; then
+        local dtbOverlays="$(cat $path/devicetree-overlays)"
+    fi
+
     if [ -d "$dtbDir" ]; then
         # if a dtbName was specified explicitly, use that, else use FDTDIR
         if [ -n "$dtbName" ]; then
@@ -110,9 +114,21 @@ addEntry() {
         else
             echo "  FDTDIR ../nixos/$(basename $dtbs)"
         fi
+
+        if [ -n "$dtbOverlays" ]; then
+            echo -n "  FDTOVERLAYS"
+            for overlay in $dtbOverlays; do
+                echo -n " ../nixos/$(basename $dtbs)/${overlay}"
+            done
+            echo
+        fi
     else
         if [ -n "$dtbName" ]; then
             echo "Explicitly requested dtbName $dtbName, but there's no FDTDIR - bailing out." >&2
+            exit 1
+        fi
+        if [ -n "$dtbOverlays" ]; then
+            echo "Requested overlays $dtbOverlays, but there's no FDTDIR - bailing out." >&2
             exit 1
         fi
     fi


### PR DESCRIPTION
## Description of changes

NixOS can apply device tree overlays by means of the `hardware.deviceTree.overlays` option. However, it is very useful to be able to apply pre-built overlays in runtime, without recompiling the whole device tree. This PR introduces a new option `hardware.deviceTree.runtimeOverlays` you can use to specify the overlays you want to apply at runtime. The list of overlays is handled by the extlinux config generator and ends up in the `FDTOVERLAYS` option. This option is understood by u-boot, which applies the requested overlays to the device tree.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
