### PR TITLE
postgresqlPackages.anonymizer: init at 1.3.1; add me & osnyx to flyingcircus team

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14479,6 +14479,12 @@
     githubId = 111265;
     name = "Ozan Sener";
   };
+  osnyx = {
+    email = "os@flyingcircus.io";
+    github = "osnyx";
+    githubId = 104593071;
+    name = "Oliver Schmidt";
+  };
   ostrolucky = {
     email = "gabriel.ostrolucky@gmail.com";
     github = "ostrolucky";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -302,6 +302,8 @@ with lib.maintainers; {
       dpausp
       frlan
       leona
+      osnyx
+      ma27
     ];
     scope = "Team for Flying Circus employees who collectively maintain packages.";
     shortName = "Flying Circus employees";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -679,6 +679,7 @@ in {
   peering-manager = handleTest ./web-apps/peering-manager.nix {};
   peertube = handleTestOn ["x86_64-linux"] ./web-apps/peertube.nix {};
   peroxide = handleTest ./peroxide.nix {};
+  pg_anonymizer = handleTest ./pg_anonymizer.nix {};
   pgadmin4 = handleTest ./pgadmin4.nix {};
   pgbouncer = handleTest ./pgbouncer.nix {};
   pgjwt = handleTest ./pgjwt.nix {};

--- a/nixos/tests/pg_anonymizer.nix
+++ b/nixos/tests/pg_anonymizer.nix
@@ -2,7 +2,8 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
   name = "pg_anonymizer";
   meta.maintainers = lib.teams.flyingcircus.members;
 
-  nodes.machine = {
+  nodes.machine = { pkgs, ... }: {
+    environment.systemPackages = [ pkgs.pg-dump-anon ];
     services.postgresql = {
       enable = true;
       extraPlugins = ps: [ ps.anonymizer ];
@@ -39,16 +40,55 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
         assert row[1] != original_name, f"Expected first row to have a name other than {original_name}"
         assert not bool(row[2]), "Expected points to be NULL in first row"
 
-    with subtest("Check initial state"):
-        output = get_player_table_contents()
+    def find_xsv_in_dump(dump, sep=','):
+        """
+        Expecting to find a CSV (for pg_dump_anon) or TSV (for pg_dump) structure, looking like
+
+            COPY public.player ...
+            1,Shields,
+            2,Salazar,
+            \.
+
+        in the given dump (the commas are tabs in case of pg_dump).
+              Extract the CSV lines and split by `sep`.
+        """
+
+        try:
+            from itertools import dropwhile, takewhile
+            return [x.split(sep) for x in list(takewhile(
+                lambda x: x != "\\.",
+                dropwhile(
+                    lambda x: not x.startswith("COPY public.player"),
+                    dump.splitlines()
+                )
+            ))[1:]]
+        except:
+            print(f"Dump to process: {dump}")
+            raise
+
+    def check_original_data(output):
         assert output[0] == ['1','Foo','23'], f"Expected first row from player table to be 1,Foo,23; got {output[0]}"
         assert output[1] == ['2','Bar','42'], f"Expected first row from player table to be 2,Bar,42; got {output[1]}"
 
-    with subtest("Anonymize"):
-        machine.succeed("sudo -u postgres psql -d demo --command 'select anon.anonymize_database();'")
-        output = get_player_table_contents()
-
+    def check_anonymized_rows(output):
         check_anonymized_row(output[0], '1', 'Foo')
         check_anonymized_row(output[1], '2', 'Bar')
+
+    with subtest("Check initial state"):
+        check_original_data(get_player_table_contents())
+
+    with subtest("Anonymous dumps"):
+        check_original_data(find_xsv_in_dump(
+            machine.succeed("sudo -u postgres pg_dump demo"),
+            sep='\t'
+        ))
+        check_anonymized_rows(find_xsv_in_dump(
+            machine.succeed("sudo -u postgres pg_dump_anon -U postgres -h /run/postgresql -d demo"),
+            sep=','
+        ))
+
+    with subtest("Anonymize"):
+        machine.succeed("sudo -u postgres psql -d demo --command 'select anon.anonymize_database();'")
+        check_anonymized_rows(get_player_table_contents())
   '';
 })

--- a/nixos/tests/pg_anonymizer.nix
+++ b/nixos/tests/pg_anonymizer.nix
@@ -1,0 +1,54 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "pg_anonymizer";
+  meta.maintainers = lib.teams.flyingcircus.members;
+
+  nodes.machine = {
+    services.postgresql = {
+      enable = true;
+      extraPlugins = ps: [ ps.anonymizer ];
+      settings.shared_preload_libraries = "anon";
+    };
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_for_unit("postgresql.service")
+
+    with subtest("Setup"):
+        machine.succeed("sudo -u postgres psql --command 'create database demo'")
+        machine.succeed(
+            "sudo -u postgres psql -d demo -f ${pkgs.writeText "init.sql" ''
+              create extension anon cascade;
+              select anon.init();
+              create table player(id serial, name text, points int);
+              insert into player(id,name,points) values (1,'Foo', 23);
+              insert into player(id,name,points) values (2,'Bar',42);
+              security label for anon on column player.name is 'MASKED WITH FUNCTION anon.fake_last_name();';
+              security label for anon on column player.points is 'MASKED WITH VALUE NULL';
+            ''}"
+        )
+
+    def get_player_table_contents():
+        return [
+            x.split(',') for x in machine.succeed("sudo -u postgres psql -d demo --csv --command 'select * from player'").splitlines()[1:]
+        ]
+
+    def check_anonymized_row(row, id, original_name):
+        assert row[0] == id, f"Expected first row to have ID {id}, but got {row[0]}"
+        assert row[1] != original_name, f"Expected first row to have a name other than {original_name}"
+        assert not bool(row[2]), "Expected points to be NULL in first row"
+
+    with subtest("Check initial state"):
+        output = get_player_table_contents()
+        assert output[0] == ['1','Foo','23'], f"Expected first row from player table to be 1,Foo,23; got {output[0]}"
+        assert output[1] == ['2','Bar','42'], f"Expected first row from player table to be 2,Bar,42; got {output[1]}"
+
+    with subtest("Anonymize"):
+        machine.succeed("sudo -u postgres psql -d demo --command 'select anon.anonymize_database();'")
+        output = get_player_table_contents()
+
+        check_anonymized_row(output[0], '1', 'Foo')
+        check_anonymized_row(output[1], '2', 'Bar')
+  '';
+})

--- a/pkgs/by-name/pg/pg-dump-anon/package.nix
+++ b/pkgs/by-name/pg/pg-dump-anon/package.nix
@@ -1,0 +1,32 @@
+{ lib, fetchFromGitLab, buildGoModule, nixosTests, postgresql, makeWrapper }:
+
+buildGoModule rec {
+  pname = "pg-dump-anon";
+  version = "1.3.1";
+  src = fetchFromGitLab {
+    owner = "dalibo";
+    repo = "postgresql_anonymizer";
+    rev = version;
+    hash = "sha256-Z5Oz/cIYDxFUZwQijRk4xAOUdOK0LWR+px8WOcs+Rs0=";
+  };
+
+  sourceRoot = "${src.name}/pg_dump_anon";
+
+  vendorHash = "sha256-CwU1zoIayxvfnGL9kPdummPJiV+ECfSz4+q6gZGb8pw=";
+
+  passthru.tests = { inherit (nixosTests) pg_anonymizer; };
+
+  nativeBuildInputs = [ makeWrapper ];
+  postInstall = ''
+    wrapProgram $out/bin/pg_dump_anon \
+      --prefix PATH : ${lib.makeBinPath [ postgresql ]}
+  '';
+
+  meta = with lib; {
+    description = "Export databases with data being anonymized with the anonymizer extension";
+    homepage = "https://postgresql-anonymizer.readthedocs.io/en/stable/";
+    maintainers = teams.flyingcircus.members;
+    license = licenses.postgresql;
+    mainProgram = "pg_dump_anon";
+  };
+}

--- a/pkgs/servers/sql/postgresql/ext/anonymizer.nix
+++ b/pkgs/servers/sql/postgresql/ext/anonymizer.nix
@@ -27,6 +27,6 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = pg-dump-anon.meta // {
-    description = "postgresql_anonymizer is an extension to mask or replace personally identifiable information (PII) or commercially sensitive data from a PostgreSQL database.";
+    description = "Extension to mask or replace personally identifiable information (PII) or commercially sensitive data from a PostgreSQL database";
   };
 })

--- a/pkgs/servers/sql/postgresql/ext/anonymizer.nix
+++ b/pkgs/servers/sql/postgresql/ext/anonymizer.nix
@@ -1,0 +1,34 @@
+{ lib, stdenv, fetchFromGitLab, postgresql, nixosTests, ... }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "postgresql_anonymizer";
+  version = "1.3.1";
+
+  src = fetchFromGitLab {
+    owner = "dalibo";
+    repo = "postgresql_anonymizer";
+    rev = finalAttrs.version;
+    hash = "sha256-Z5Oz/cIYDxFUZwQijRk4xAOUdOK0LWR+px8WOcs+Rs0=";
+  };
+
+  buildInputs = [ postgresql ];
+  nativeBuildInputs = [ postgresql ] ++ lib.optional postgresql.jitSupport postgresql.llvm;
+
+  strictDeps = true;
+
+  makeFlags = [
+    "BINDIR=${placeholder "out"}/bin"
+    "datadir=${placeholder "out"}/share/postgresql"
+    "pkglibdir=${placeholder "out"}/lib"
+    "DESTDIR="
+  ];
+
+  passthru.tests = { inherit (nixosTests) pg_anonymizer; };
+
+  meta = with lib; {
+    description = "postgresql_anonymizer is an extension to mask or replace personally identifiable information (PII) or commercially sensitive data from a PostgreSQL database.";
+    homepage = "https://postgresql-anonymizer.readthedocs.io/en/stable/";
+    maintainers = teams.flyingcircus.members;
+    license = licenses.postgresql;
+  };
+})

--- a/pkgs/servers/sql/postgresql/packages.nix
+++ b/pkgs/servers/sql/postgresql/packages.nix
@@ -2,6 +2,8 @@ self: super: {
 
     age = super.callPackage ./ext/age.nix { };
 
+    anonymizer = super.callPackage ./ext/anonymizer.nix { };
+
     apache_datasketches = super.callPackage ./ext/apache_datasketches.nix { };
 
     citus = super.callPackage ./ext/citus.nix { };


### PR DESCRIPTION
## Description of changes

* Adds me and @osnyx to the flyingcircus team (we discussed this directly, but please approve here as well for the record :)). Also needs an approval from one of the other team members (cc @dpausp @ctheune @frlan @leona-ya )
* Adds the postgresql extension [pg_anonymizer](https://gitlab.com/dalibo/postgresql_anonymizer).


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
