### PR TITLE
libtiff: don't propagate unnecessary build inputs

### DIFF
--- a/pkgs/by-name/li/libappimage/package.nix
+++ b/pkgs/by-name/li/libappimage/package.nix
@@ -16,6 +16,7 @@
   librsvg,
   squashfuse,
   xdg-utils-cxx,
+  xz, # for liblzma
   zlib,
 }:
 stdenv.mkDerivation rec {
@@ -66,6 +67,7 @@ stdenv.mkDerivation rec {
     libarchive
     squashfuse
     xdg-utils-cxx
+    xz
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/by-name/li/libgeotiff/package.nix
+++ b/pkgs/by-name/li/libgeotiff/package.nix
@@ -41,6 +41,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libtiff
     proj
+    zlib
   ];
 
   #hardeningDisable = [ "format" ];

--- a/pkgs/by-name/li/libtiff/package.nix
+++ b/pkgs/by-name/li/libtiff/package.nix
@@ -16,12 +16,10 @@
   zlib,
   zstd,
 
-  # Because lerc is C++ and static libraries don't track dependencies,
-  # that every downstream dependent of libtiff has to link with a C++
-  # compiler, or the C++ standard library won't be linked, resulting
-  # in undefined symbol errors.  Without systematic support for this
-  # in build systems, fixing this would require modifying the build
-  # system of every libtiff user.  Hopefully at some point build
+  # Because lerc is C++ and static libraries don't track dependencies, every downstream dependent of
+  # libtiff has to link with a C++ compiler, or the C++ standard library won't be linked, resulting
+  # in undefined symbol errors. Without systematic support for this in build systems, fixing this
+  # would require modifying the build system of every libtiff user. Hopefully at some point build
   # systems will figure this out, and then we can enable this.
   #
   # See https://github.com/mesonbuild/meson/issues/14234
@@ -84,22 +82,16 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    zstd
-  ]
-  ++ lib.optionals withLerc [
-    lerc
-  ];
-
-  # TODO: opengl support (bogus configure detection)
-  propagatedBuildInputs = [
     libdeflate
     libjpeg
-    # libwebp depends on us; this will cause infinite
-    # recursion otherwise
+    # libwebp depends on us; this will cause infinite recursion otherwise
     (libwebp.override { tiffSupport = false; })
     xz
     zlib
     zstd
+  ]
+  ++ lib.optionals withLerc [
+    lerc
   ];
 
   cmakeFlags = [
@@ -109,6 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = true;
 
   doCheck = true;
+
   # Avoid flakiness like https://gitlab.com/libtiff/libtiff/-/commit/94f6f7315b1
   enableParallelChecking = false;
 
@@ -122,7 +115,9 @@ stdenv.mkDerivation (finalAttrs: {
         openimageio
         freeimage
         ;
+
       inherit (python3Packages) pillow imread;
+
       pkg-config = testers.hasPkgConfigModules {
         package = finalAttrs.finalPackage;
       };


### PR DESCRIPTION
## Description of changes

During a review of #290556 we discovered, that libtiff is unncecessary
propagating some build inputs. This change is solving this issue and is fixing
packages which depended on those propagated dependencies (such as libgeotiff
depending on propagated `zlib`).

- libtiff: don't propagate unnecessary build inputs
- libtiff: adopt package under geospatial team maintenance
- libgeotiff: add missing build dependency

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
