### PR TITLE
nixos/cosmic-greeter: init; nixos/cosmic: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -546,6 +546,7 @@
   ./services/development/rstudio-server/default.nix
   ./services/development/zammad.nix
   ./services/display-managers/default.nix
+  ./services/display-managers/cosmic-greeter.nix
   ./services/display-managers/greetd.nix
   ./services/display-managers/sddm.nix
   ./services/display-managers/ly.nix

--- a/nixos/modules/services/desktop-managers/cosmic.nix
+++ b/nixos/modules/services/desktop-managers/cosmic.nix
@@ -1,0 +1,162 @@
+{
+  config,
+  pkgs,
+  lib,
+  utils,
+  ...
+}:
+
+let
+  cfg = config.services.desktopManager.cosmic;
+in
+{
+  meta.maintainers = with lib.maintainers; [ nyanbinary ];
+
+  options = {
+    services.desktopManager.cosmic = {
+      enable = lib.mkEnableOption (lib.mdDoc "COSMIC desktop environment");
+
+      xwayland.enable = lib.mkEnableOption "Xwayland support for cosmic-comp" // {
+        default = true;
+      };
+    };
+
+    environment.cosmic.excludePackages = lib.mkOption {
+      description = lib.mdDoc "List of COSMIC packages to exclude from the default environment";
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      example = lib.literalExpression "[ pkgs.cosmic-edit ]";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # seed configuration in nixos-generate-config
+    system.nixos-generate-config.desktopConfiguration = [
+      ''
+        # Enable the COSMIC Desktop Environment.
+        services.displayManager.cosmic-greeter.enable = true;
+        services.desktopManager.cosmic.enable = true;
+      ''
+    ];
+
+    # environment packages
+    environment.pathsToLink = [ "/share/cosmic" ];
+    environment.systemPackages = utils.removePackagesByName (
+      with pkgs;
+      (
+        if lib.versionAtLeast lib.version "24.11" then
+          [
+            adwaita-icon-theme
+          ]
+        else
+          [
+            gnome.adwaita-icon-theme
+          ]
+      )
+      ++ [
+        alsa-utils
+        cosmic-applets
+        cosmic-applibrary
+        cosmic-bg
+        (cosmic-comp.override {
+          useXWayland = config.services.desktopManager.cosmic.xwayland.enable;
+        })
+        cosmic-edit
+        cosmic-files
+        cosmic-greeter
+        cosmic-icons
+        cosmic-launcher
+        cosmic-notifications
+        cosmic-osd
+        cosmic-panel
+        cosmic-randr
+        cosmic-screenshot
+        cosmic-session
+        cosmic-settings
+        cosmic-settings-daemon
+        cosmic-term
+        cosmic-workspaces-epoch
+        hicolor-icon-theme
+        playerctl
+        pop-icon-theme
+        pop-launcher
+      ]
+      ++ lib.optionals config.services.flatpak.enable [
+        cosmic-store
+      ]
+    ) config.environment.cosmic.excludePackages;
+
+    # xdg portal packages and config
+    xdg.portal = {
+      enable = true;
+      extraPortals =
+        with pkgs;
+        [
+          xdg-desktop-portal-cosmic
+        ]
+        # Workaround for conflicting xdg-desktop-portal-gtk
+        # see https://github.com/lilyinstarlight/nixos-cosmic/issues/17
+        ++ lib.optional (
+          !(
+            config.services.xserver.desktopManager.gnome.enable
+            || config.services.xserver.desktopManager.deepin.enable
+            || config.services.xserver.desktopManager.cinnamon.enable
+            || config.services.xserver.desktopManager.phosh.enable
+          )
+        ) pkgs.xdg-desktop-portal-gtk;
+      configPackages = lib.mkDefault (
+        with pkgs;
+        [
+          xdg-desktop-portal-cosmic
+        ]
+      );
+    };
+
+    # fonts
+    fonts.packages = utils.removePackagesByName (with pkgs; [
+      fira
+    ]) config.environment.cosmic.excludePackages;
+
+    # required features
+    hardware.${if lib.versionAtLeast lib.version "24.11" then "graphics" else "opengl"}.enable = true;
+    services.libinput.enable = true;
+    xdg.mime.enable = true;
+    xdg.icons.enable = true;
+
+    # optional features
+    hardware.bluetooth.enable = lib.mkDefault true;
+    services.acpid.enable = lib.mkDefault true;
+    services.pipewire = {
+      enable = lib.mkDefault true;
+      alsa.enable = lib.mkDefault true;
+      pulse.enable = lib.mkDefault true;
+    };
+    services.gvfs.enable = lib.mkDefault true;
+    networking.networkmanager.enable = lib.mkDefault true;
+    services.gnome.gnome-keyring.enable = lib.mkDefault true;
+
+    # general graphical session features
+    programs.dconf.enable = lib.mkDefault true;
+
+    # required dbus services
+    services.accounts-daemon.enable = true;
+    services.upower.enable = true;
+    services.power-profiles-daemon.enable = lib.mkDefault (
+      !config.hardware.system76.power-daemon.enable
+    );
+    security.polkit.enable = true;
+    security.rtkit.enable = true;
+
+    # session packages
+    services.displayManager.sessionPackages = with pkgs; [ cosmic-session ];
+    systemd.packages = with pkgs; [ cosmic-session ];
+    # TODO: remove when upstream has XDG autostart support
+    systemd.user.targets.cosmic-session = {
+      wants = [ "xdg-desktop-autostart.target" ];
+      before = [ "xdg-desktop-autostart.target" ];
+    };
+
+    # required for screen locker
+    security.pam.services.cosmic-greeter = { };
+  };
+}

--- a/nixos/modules/services/display-managers/cosmic-greeter.nix
+++ b/nixos/modules/services/display-managers/cosmic-greeter.nix
@@ -1,0 +1,68 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.displayManager.cosmic-greeter;
+in
+{
+  meta.maintainers = with lib.maintainers; [ nyanbinary ];
+
+  options.services.displayManager.cosmic-greeter = {
+    enable = lib.mkEnableOption (lib.mdDoc "COSMIC greeter");
+  };
+
+  config = lib.mkIf cfg.enable {
+    # greetd config
+    services.greetd = {
+      enable = true;
+      settings = {
+        default_session = {
+          user = "cosmic-greeter";
+          command = ''${pkgs.coreutils}/bin/env XCURSOR_THEME="''${XCURSOR_THEME:-Pop}" systemd-cat -t cosmic-greeter ${pkgs.cosmic-comp}/bin/cosmic-comp ${pkgs.cosmic-greeter}/bin/cosmic-greeter'';
+        };
+      };
+    };
+
+    # daemon for querying background state and such
+    systemd.services.cosmic-greeter-daemon = {
+      wantedBy = [ "multi-user.target" ];
+      before = [ "greetd.service" ];
+      serviceConfig = {
+        Type = "dbus";
+        BusName = "com.system76.CosmicGreeter";
+        ExecStart = "${pkgs.cosmic-greeter}/bin/cosmic-greeter-daemon";
+        Restart = "on-failure";
+      };
+    };
+
+    # greeter user (hardcoded in cosmic-greeter)
+    systemd.tmpfiles.rules = [
+      "d '/var/lib/cosmic-greeter' - cosmic-greeter cosmic-greeter - -"
+    ];
+
+    users.users.cosmic-greeter = {
+      isSystemUser = true;
+      home = "/var/lib/cosmic-greeter";
+      group = "cosmic-greeter";
+    };
+
+    users.groups.cosmic-greeter = { };
+
+    # required features
+    hardware.${if lib.versionAtLeast lib.version "24.11" then "graphics" else "opengl"}.enable = true;
+    services.libinput.enable = true;
+
+    # required dbus services
+    services.accounts-daemon.enable = true;
+
+    # required for authentication
+    security.pam.services.cosmic-greeter = { };
+
+    # dbus definitions
+    services.dbus.packages = with pkgs; [ cosmic-greeter ];
+  };
+}

--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -20,7 +20,7 @@ in
     ./none.nix ./xterm.nix ./phosh.nix ./xfce.nix ./plasma5.nix ../../desktop-managers/plasma6.nix ./lumina.nix
     ./lxqt.nix ./enlightenment.nix ./gnome.nix ./retroarch.nix ./kodi.nix
     ./mate.nix ./pantheon.nix ./surf-display.nix ./cde.nix
-    ./cinnamon.nix ./budgie.nix ./deepin.nix ../../desktop-managers/lomiri.nix
+    ./cinnamon.nix ./budgie.nix ./deepin.nix ../../desktop-managers/lomiri.nix ../../desktop-managers/cosmic.nix
   ];
 
   options = {


### PR DESCRIPTION
## Description of changes
- Adds a cosmic-greeter module for the COSMIC greeter
- Adds a cosmic module for the COSMIC DE
- Huge thanks to @lilyinstarlight for which this work is based from ([nixos-cosmic](https://github.com/lilyinstarlight/nixos-cosmic))
- Depends on #339287
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
