### PR TITLE
nng: 1.7.2 -> 1.7.3

### DIFF
--- a/pkgs/development/libraries/nng/default.nix
+++ b/pkgs/development/libraries/nng/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "nng";
-  version = "1.7.2";
+  version = "1.7.3";
 
   src = fetchFromGitHub {
     owner = "nanomsg";
     repo = "nng";
     rev = "v${version}";
-    hash = "sha256-CG6Gw/Qrbi96koF2VxKMYPMPT2Zj9U97vNk2JdrfRro=";
+    hash = "sha256-oP7hO3wCXNPW7877wK+HpGsw7j+U0q4i8aTRVi1v0r0=";
   };
 
   nativeBuildInputs = [ cmake ninja ]


### PR DESCRIPTION
## Description of changes

Updating to 1.7.3:
- https://github.com/nanomsg/nng/releases/tag/v1.7.3

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
