### PR TITLE
[backport 23.11] linux-rt_6_6: init at 6.6.15-rt22

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-rt-6.6.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-6.6.nix
@@ -1,0 +1,45 @@
+{ lib, buildLinux, fetchurl
+, kernelPatches ? [ ]
+, structuredExtraConfig ? {}
+, extraMeta ? {}
+, argsOverride ? {}
+, ... } @ args:
+
+let
+  version = "6.6.15-rt22"; # updated by ./update-rt.sh
+  branch = lib.versions.majorMinor version;
+  kversion = builtins.elemAt (lib.splitString "-" version) 0;
+in buildLinux (args // {
+  inherit version;
+
+  # modDirVersion needs a patch number, change X.Y-rtZ to X.Y.0-rtZ.
+  modDirVersion = if (builtins.match "[^.]*[.][^.]*-.*" version) == null then version
+    else lib.replaceStrings ["-"] [".0-"] version;
+
+  src = fetchurl {
+    url = "mirror://kernel/linux/kernel/v6.x/linux-${kversion}.tar.xz";
+    sha256 = "1ajzby6isqji1xlp660m4qj2i2xs003vsjp1jspziwl7hrzhqadb";
+  };
+
+  kernelPatches = let rt-patch = {
+    name = "rt";
+    patch = fetchurl {
+      url = "mirror://kernel/linux/kernel/projects/rt/${branch}/older/patch-${version}.patch.xz";
+      sha256 = "0dr4lb6f95vj8vzhlvy353dk6k694f1s6qfxr10m48hzyyqyaxdy";
+    };
+  }; in [ rt-patch ] ++ kernelPatches;
+
+  structuredExtraConfig = with lib.kernel; {
+    PREEMPT_RT = yes;
+    # Fix error: unused option: PREEMPT_RT.
+    EXPERT = yes; # PREEMPT_RT depends on it (in kernel/Kconfig.preempt)
+    # Fix error: option not set correctly: PREEMPT_VOLUNTARY (wanted 'y', got 'n').
+    PREEMPT_VOLUNTARY = lib.mkForce no; # PREEMPT_RT deselects it.
+    # Fix error: unused option: RT_GROUP_SCHED.
+    RT_GROUP_SCHED = lib.mkForce (option no); # Removed by sched-disable-rt-group-sched-on-rt.patch.
+  } // structuredExtraConfig;
+
+  extraMeta = extraMeta // {
+    inherit branch;
+  };
+} // argsOverride)

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -185,6 +185,14 @@ in {
       ];
     };
 
+    linux_rt_6_6 = callPackage ../os-specific/linux/kernel/linux-rt-6.6.nix {
+      kernelPatches = [
+        kernelPatches.bridge_stp_helper
+        kernelPatches.request_key_helper
+        kernelPatches.export-rt-sched-migrate
+      ];
+    };
+
     linux_6_7 = callPackage ../os-specific/linux/kernel/mainline.nix {
       branch = "6.7";
       kernelPatches = [
@@ -614,6 +622,7 @@ in {
      linux_rt_5_10 = packagesFor kernels.linux_rt_5_10;
      linux_rt_5_15 = packagesFor kernels.linux_rt_5_15;
      linux_rt_6_1 = packagesFor kernels.linux_rt_6_1;
+     linux_rt_6_6 = packagesFor kernels.linux_rt_6_6;
   };
 
   rpiPackages = {
@@ -663,7 +672,7 @@ in {
     linux_latest = packages.linux_6_7;
     linux_mptcp = throw "'linux_mptcp' has been moved to https://github.com/teto/mptcp-flake";
     linux_rt_default = packages.linux_rt_5_4;
-    linux_rt_latest = packages.linux_rt_6_1;
+    linux_rt_latest = packages.linux_rt_6_6;
   };
 
   manualConfig = callPackage ../os-specific/linux/kernel/manual-config.nix {};


### PR DESCRIPTION
## Description of changes

Backporting so automated kernel updates can be auto-backported.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
