### PR TITLE
hare: enable cross-compilation

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -152,6 +152,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - `services.homepage-dashboard` now takes it's configuration using native Nix expressions, rather than dumping templated configurations into `/var/lib/homepage-dashboard` where they were previously managed manually. There are now new options which allow the configuration of bookmarks, services, widgets and custom CSS/JS natively in Nix.
 
+- `hare` may now be cross-compiled. For that to work, however, `haredoc` needed to stop being built together with it. Thus, the latter is now its own package with the name of `haredoc`.
+
 - The legacy and long deprecated systemd target `network-interfaces.target` has been removed. Use `network.target` instead.
 
 - `services.frp.settings` now generates the frp configuration file in TOML format as [recommended by upstream](https://github.com/fatedier/frp#configuration-files), instead of the legacy INI format. This has also introduced other changes in the configuration file structure and options.

--- a/pkgs/by-name/ha/hare/002-dont-build-haredoc.patch
+++ b/pkgs/by-name/ha/hare/002-dont-build-haredoc.patch
@@ -1,0 +1,43 @@
+diff --git a/Makefile b/Makefile
+index 2482be1f..9d58bc81 100644
+--- a/Makefile
++++ b/Makefile
+@@ -5,7 +5,7 @@ all:
+ include config.mk
+ include makefiles/$(PLATFORM).$(ARCH).mk
+ 
+-all: $(BINOUT)/hare $(BINOUT)/haredoc docs
++all: $(BINOUT)/hare docs
+ 
+ HARE_DEFINES = \
+ 	-D PLATFORM:str='"$(PLATFORM)"' \
+@@ -79,11 +79,10 @@ docs: \
+ 	docs/haredoc.1 \
+ 	docs/hare-run.1 \
+ 	docs/hare-test.1 \
+-	docs/haredoc.5 \
+ 	docs/hare-module.5
+ 
+-MAN1 = hare hare-build hare-cache hare-deps haredoc hare-run hare-test
+-MAN5 = haredoc hare-module
++MAN1 = hare hare-build hare-cache hare-deps hare-run hare-test
++MAN5 = hare-module
+ 
+ bootstrap:
+ 	@BINOUT=$(BINOUT) ./scripts/genbootstrap
+@@ -104,7 +103,6 @@ install-cmd:
+ 		'$(DESTDIR)$(BINDIR)' '$(DESTDIR)$(MANDIR)/man1' \
+ 		'$(DESTDIR)$(BINDIR)' '$(DESTDIR)$(MANDIR)/man5'
+ 	install -m755 '$(BINOUT)/hare' '$(DESTDIR)$(BINDIR)/hare'
+-	install -m755 '$(BINOUT)/haredoc' '$(DESTDIR)$(BINDIR)/haredoc'
+ 	for i in $(MAN1); do install -m644 docs/$$i.1 '$(DESTDIR)$(MANDIR)'/man1/$$i.1; done
+ 	for i in $(MAN5); do install -m644 docs/$$i.5 '$(DESTDIR)$(MANDIR)'/man5/$$i.5; done
+ 
+@@ -115,7 +113,6 @@ install-mods:
+ 
+ uninstall:
+ 	rm -- '$(DESTDIR)$(BINDIR)/hare'
+-	rm -- '$(DESTDIR)$(BINDIR)/haredoc'
+ 	for i in $(MAN1); do rm -- '$(DESTDIR)$(MANDIR)'/man1/$$i.1; done
+ 	for i in $(MAN5); do rm -- '$(DESTDIR)$(MANDIR)'/man5/$$i.5; done
+ 	rm -r -- '$(DESTDIR)$(STDLIB)'

--- a/pkgs/by-name/ha/harec/package.nix
+++ b/pkgs/by-name/ha/harec/package.nix
@@ -7,6 +7,11 @@
 let
   platform = lib.toLower stdenv.hostPlatform.uname.system;
   arch = stdenv.hostPlatform.uname.processor;
+  qbePlatform = {
+    x86_64 = "amd64_sysv";
+    aarch64 = "arm64";
+    riscv64 = "rv64";
+  }.${arch};
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "harec";
@@ -31,6 +36,10 @@ stdenv.mkDerivation (finalAttrs: {
     "PREFIX=${builtins.placeholder "out"}"
     "ARCH=${arch}"
     "VERSION=${finalAttrs.version}-nixpkgs"
+    "QBEFLAGS=-t${qbePlatform}"
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "AS=${stdenv.cc.targetPrefix}as"
+    "LD=${stdenv.cc.targetPrefix}ld"
   ];
 
   strictDeps = true;

--- a/pkgs/by-name/ha/haredoc/package.nix
+++ b/pkgs/by-name/ha/haredoc/package.nix
@@ -1,0 +1,55 @@
+{ lib
+, stdenv
+, scdoc
+, hare
+}:
+let
+  arch = stdenv.hostPlatform.uname.processor;
+in
+stdenv.mkDerivation {
+  pname = "haredoc";
+  outputs = [ "out" "man" ];
+  inherit (hare) version src;
+
+  strictDeps = true;
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    scdoc
+    hare
+  ];
+
+  preBuild = ''
+    HARECACHE="$(mktemp -d)"
+    export HARECACHE
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    hare build -qR -a ${arch} -o haredoc ./cmd/haredoc
+    scdoc <docs/haredoc.1.scd >haredoc.1
+    scdoc <docs/haredoc.5.scd >haredoc.5
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm0755 ./haredoc $out/bin/haredoc
+    install -Dm0644 ./haredoc.1 $out/share/man/man1/haredoc.1
+    install -Dm0644 ./haredoc.5 $out/share/man/man5/haredoc.5
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://harelang.org/";
+    description = "Hare's documentation tool";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ onemoresuza ];
+    mainProgram = "haredoc";
+    inherit (hare.meta) platforms badPlatforms;
+  };
+}

--- a/pkgs/development/compilers/qbe/default.nix
+++ b/pkgs/development/compilers/qbe/default.nix
@@ -12,7 +12,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-UgtJnZF/YtD54OBy9HzGRAEHx5tC9Wo2YcUidGwrv+s=";
   };
 
-  makeFlags = [ "PREFIX=$(out)" ];
+  makeFlags = [
+    "PREFIX=$(out)"
+    "CC=${stdenv.cc.targetPrefix}cc"
+  ];
 
   doCheck = true;
 


### PR DESCRIPTION
## Description of changes

- **qbe: enable cross-compilation**
- **harec: enable cross-compilation**
- **hare: enable cross-compilation**
- **haredoc: init at 0.24.0**
- Add mention to 24.05 release notes about the split of `hare` and `haredoc`.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## Note for reviewers

To test this PR:

```bash
git clone --filter=blob:none --depth=1 -b hare-crosscomp https://github.com/onemoresuza/nixpkgs.git hare-crosscomp
cd hare-crosscomp
nix-build -E '
    let
        pkgs = import ./. {};
        x86_64 = builtins.attrValues {
            inherit (pkgs.pkgsCross.gnu64) qbe harec hare haredoc;
        };
        aarch64 = builtins.attrValues {
            inherit (pkgs.pkgsCross.aarch64-multiplatform) qbe harec hare haredoc;
        };
    in
        aarch64 ++ x86_64
'
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
