### PR TITLE
qbe: patch /tmp to ${TMPDIR:-/tmp} on tests and enable parallel building

### DIFF
--- a/pkgs/development/compilers/qbe/001-dont-hardcode-tmp.patch
+++ b/pkgs/development/compilers/qbe/001-dont-hardcode-tmp.patch
@@ -1,0 +1,43 @@
+diff --git a/minic/mcc b/minic/mcc
+index 492947e..5258aac 100755
+--- a/minic/mcc
++++ b/minic/mcc
+@@ -31,9 +31,9 @@ then
+ fi
+ 
+ 
+-$DIR/minic < $file          > /tmp/minic.ssa &&
+-$QBE       < /tmp/minic.ssa > /tmp/minic.s   &&
+-cc /tmp/minic.s $flags
++$DIR/minic < $file          > ${TMPDIR:-/tmp}/minic.ssa &&
++$QBE       < ${TMPDIR:-/tmp}/minic.ssa > ${TMPDIR:-/tmp}/minic.s   &&
++cc ${TMPDIR:-/tmp}/minic.s $flags
+ 
+ if test $? -ne 0
+ then
+diff --git a/tools/cra.sh b/tools/cra.sh
+index 5988267..57a4b34 100755
+--- a/tools/cra.sh
++++ b/tools/cra.sh
+@@ -2,7 +2,7 @@
+ 
+ DIR=`cd $(dirname "$0"); pwd`
+ QBE=$DIR/../qbe
+-BUGF=/tmp/bug.id
++BUGF=${TMPDIR:-/tmp}/bug.id
+ FIND=$1
+ FIND=${FIND:-afl-find}
+ 
+diff --git a/tools/test.sh b/tools/test.sh
+index 23c6663..fb36222 100755
+--- a/tools/test.sh
++++ b/tools/test.sh
+@@ -4,7 +4,7 @@ dir=`dirname "$0"`
+ bin=$dir/../qbe
+ binref=$dir/../qbe.ref
+ 
+-tmp=/tmp/qbe.zzzz
++tmp=${TMPDIR:-/tmp}/qbe.zzzz
+ 
+ drv=$tmp.c
+ asm=$tmp.s

--- a/pkgs/development/compilers/qbe/default.nix
+++ b/pkgs/development/compilers/qbe/default.nix
@@ -16,6 +16,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
+  enableParallelBuilding = true;
+
+  patches = [
+    # Use "${TMPDIR:-/tmp}" instead of the latter directly
+    # see <https://lists.sr.ht/~mpu/qbe/patches/49613>
+    ./001-dont-hardcode-tmp.patch
+  ];
+
   passthru = {
     tests.can-run-hello-world = callPackage ./test-can-run-hello-world.nix { };
   };


### PR DESCRIPTION
## Description of changes

- Fix the tests on darwin because of `/tmp` being hardcode.
- Enable parallel building

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
