### PR TITLE
Initial RK3588 support in nixpkgs

### DIFF
--- a/pkgs/by-name/rk/rkbin/package.nix
+++ b/pkgs/by-name/rk/rkbin/package.nix
@@ -1,0 +1,34 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+}:
+
+stdenv.mkDerivation {
+  pname = "rkbin";
+  version = "unstable-2024.02.22";
+
+  src = fetchFromGitHub {
+    owner = "rockchip-linux";
+    repo = "rkbin";
+    rev = "a2a0b89b6c8c612dca5ed9ed8a68db8a07f68bc0";
+    hash = "sha256-U/jeUsV7bhqMw3BljmO6SI07NCDAd/+sEp3dZnyXeeA=";
+  };
+
+  installPhase = ''
+    mkdir $out
+    mv bin doc $out/
+  '';
+
+  BL31_RK3568 = "bin/rk35/rk3568_ddr_1056MHz_v1.21.bin";
+  ROCKCHIP_TPL_RK3568 = "bin/rk35/rk3568_ddr_1056MHz_v1.21.bin";
+
+  ROCKCHIP_TPL_RK3588 = "bin/rk35/rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.16.bin";
+
+  meta = with lib; {
+    description = "Rockchip proprietary bootloader blobs";
+    homepage = "https://github.com/rockchip-linux/rkbin";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ thefossguy ];
+    platforms = [ "aarch64-linux" ];
+  };
+}

--- a/pkgs/misc/arm-trusted-firmware/default.nix
+++ b/pkgs/misc/arm-trusted-firmware/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, openssl, pkgsCross, buildPackages
+{ lib, stdenv, fetchFromGitHub, fetchFromGitLab, openssl, pkgsCross, buildPackages
 
 # Warning: this blob (hdcp.bin) runs on the main CPU (not the GPU) at
 # privilege level EL3, which is above both the kernel and the
@@ -149,6 +149,25 @@ in {
     extraMeta.platforms = ["aarch64-linux"];
     filesToInstall = [ "build/${platform}/release/bl31/bl31.elf"];
     platformCanUseHDCPBlob = true;
+  };
+
+  armTrustedFirmwareRK3588 = buildArmTrustedFirmware rec {
+    extraMakeFlags = [ "bl31" ];
+    platform = "rk3588";
+    extraMeta.platforms = ["aarch64-linux"];
+    filesToInstall = [ "build/${platform}/release/bl31/bl31.elf"];
+    platformCanUseHDCPBlob = true;
+
+    # TODO: remove this once the following get merged:
+    # 1: https://review.trustedfirmware.org/c/TF-A/trusted-firmware-a/+/21840
+    # 2: https://review.trustedfirmware.org/c/ci/tf-a-ci-scripts/+/21833
+    src = fetchFromGitLab {
+      domain = "gitlab.collabora.com";
+      owner = "hardware-enablement/rockchip-3588";
+      repo = "trusted-firmware-a";
+      rev = "002d8e85ce5f4f06ebc2c2c52b4923a514bfa701";
+      hash = "sha256-1XOG7ILIgWa3uXUmAh9WTfSGLD/76OsmWrUhIxm/zTg=";
+    };
   };
 
   armTrustedFirmwareS905 = buildArmTrustedFirmware rec {

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -373,6 +373,14 @@ in {
     filesToInstall = ["u-boot-sunxi-with-spl.bin"];
   };
 
+  ubootOrangePi5 = buildUBoot {
+    defconfig = "orangepi-5-rk3588s_defconfig";
+    extraMeta.platforms = ["aarch64-linux"];
+    BL31 = "${armTrustedFirmwareRK3588}/bl31.elf";
+    ROCKCHIP_TPL = "${rkbin}/${rkbin.ROCKCHIP_TPL_RK3588}";
+    filesToInstall = [ "u-boot.itb" "idbloader.img" "u-boot-rockchip.bin" ];
+  };
+
   ubootOrangePiPc = buildUBoot {
     defconfig = "orangepi_pc_defconfig";
     extraMeta.platforms = ["armv7l-linux"];

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -13,6 +13,7 @@
 , meson-tools
 , ncurses
 , openssl
+, rkbin
 , swig
 , which
 , python3
@@ -21,6 +22,7 @@
 , armTrustedFirmwareAllwinnerH616
 , armTrustedFirmwareRK3328
 , armTrustedFirmwareRK3399
+, armTrustedFirmwareRK3588
 , armTrustedFirmwareS905
 , buildPackages
 }:
@@ -513,6 +515,14 @@ in {
     defconfig = "rpi_0_w_defconfig";
     extraMeta.platforms = ["armv6l-linux"];
     filesToInstall = ["u-boot.bin"];
+  };
+
+  ubootRock5ModelB = buildUBoot {
+    defconfig = "rock5b-rk3588_defconfig";
+    extraMeta.platforms = ["aarch64-linux"];
+    BL31 = "${armTrustedFirmwareRK3588}/bl31.elf";
+    ROCKCHIP_TPL = "${rkbin}/${rkbin.ROCKCHIP_TPL_RK3588}";
+    filesToInstall = [ "u-boot.itb" "idbloader.img" "u-boot-rockchip.bin" "u-boot-rockchip-spi.bin" ];
   };
 
   ubootRock64 = buildUBoot {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28418,6 +28418,7 @@ with pkgs;
     ubootRaspberryPi4_32bit
     ubootRaspberryPi4_64bit
     ubootRaspberryPiZero
+    ubootRock5ModelB
     ubootRock64
     ubootRock64v2
     ubootRockPi4

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -28398,6 +28398,7 @@ with pkgs;
     ubootOlimexA64Olinuxino
     ubootOlimexA64Teres1
     ubootOrangePi3
+    ubootOrangePi5
     ubootOrangePiPc
     ubootOrangePiZeroPlus2H5
     ubootOrangePiZero

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27190,6 +27190,7 @@ with pkgs;
     armTrustedFirmwareQemu
     armTrustedFirmwareRK3328
     armTrustedFirmwareRK3399
+    armTrustedFirmwareRK3588
     armTrustedFirmwareS905
     ;
 


### PR DESCRIPTION
## Description of changes

Add initial support for the RK3588 and RK3588s SoCs and the SBCs that use them. I only own the Radxa Rock 5 Model B and Xunlong Orange Pi 5 so that is what I have added support for.

## Things done

1. Add initial support for the RK3588 SoC in arm-trusted-firmware by using the Collabora repository.
2. Introduce package `rkbin` that contains, among other proprietary blobs, the `ROCKCHIP_TPL` blob used to build U-Boot for the SBCs using this SoC.
4. Add U-Boot packages for two SBCs that I own: Radxa Rock 5 Mode B and Xunlong Orange Pi 5.

Tested:
1. Rock 5 Model B: U-Boot flashed to SD and also to the SPI can boot the NixOS ISO*.
2. Orange Pi 5: U-Boot flashed to SD can boot the NixOS ISO*.

*Support for RK3588 in the Linux kernel was added after 6.1 (6.4 IIRC) kernel, so I built a custom ISO with the 6.7.7 kernel and it works.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
