### PR TITLE
[staging-next] libmicrohttpd: Refactor to inherit

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -23009,11 +23009,21 @@ with pkgs;
 
   libmemcached = callPackage ../development/libraries/libmemcached { };
 
-  libmicrohttpd_0_9_69 = callPackage ../development/libraries/libmicrohttpd/0.9.69.nix { };
-  libmicrohttpd_0_9_71 = callPackage ../development/libraries/libmicrohttpd/0.9.71.nix { };
-  libmicrohttpd_0_9_72 = callPackage ../development/libraries/libmicrohttpd/0.9.72.nix { };
-  libmicrohttpd_0_9_74 = callPackage ../development/libraries/libmicrohttpd/0.9.74.nix { };
-  libmicrohttpd_0_9_77 = callPackage ../development/libraries/libmicrohttpd/0.9.77.nix { };
+  inherit
+    ({
+      libmicrohttpd_0_9_69 = callPackage ../development/libraries/libmicrohttpd/0.9.69.nix { };
+      libmicrohttpd_0_9_71 = callPackage ../development/libraries/libmicrohttpd/0.9.71.nix { };
+      libmicrohttpd_0_9_72 = callPackage ../development/libraries/libmicrohttpd/0.9.72.nix { };
+      libmicrohttpd_0_9_74 = callPackage ../development/libraries/libmicrohttpd/0.9.74.nix { };
+      libmicrohttpd_0_9_77 = callPackage ../development/libraries/libmicrohttpd/0.9.77.nix { };
+    })
+    libmicrohttpd_0_9_69
+    libmicrohttpd_0_9_71
+    libmicrohttpd_0_9_72
+    libmicrohttpd_0_9_74
+    libmicrohttpd_0_9_77
+    ;
+
   libmicrohttpd = libmicrohttpd_0_9_77;
 
   libmikmod = callPackage ../development/libraries/libmikmod {


### PR DESCRIPTION
## Description of changes

The `pkgs/by-name` check currently fails on the staging-next merge into master (https://github.com/NixOS/nixpkgs/actions/runs/8110296543/job/22167262748) because it contains the changes of https://github.com/NixOS/nixpkgs/pull/278920, which introduced a "new" package using `callPackage` but not using `pkgs/by-name`.

This was never noticed in that PR because CI last ran almosts 2 months ago, which is before the check for new packages was introduced.

This wouldn't be a problem normally, it's only become a problem because of the staging-next merge into master, which effectively PRs the same change again (and the `pkgs/by-name` check doesn't try to distinguish between branches).

The fix for this is a bit special because it's not actually a "new" package, but rather just a new version of an existing package. The `pkgs/by-name` check can't distinguish between such cases though.

So instead we make sure that the `pkgs/by-name` check doesn't think of it as a package using `callPackage` by using the recommendation for multi-versioned packages from
https://github.com/NixOS/nixpkgs/pull/292214.

Ping @vcunat @mweinelt 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
