### PR TITLE
bombsquad: init at 1.7.33

### DIFF
--- a/pkgs/by-name/bo/bombsquad/package.nix
+++ b/pkgs/by-name/bo/bombsquad/package.nix
@@ -1,0 +1,100 @@
+{
+  stdenv,
+  lib,
+  python3,
+  SDL2,
+  mesa,
+  libGL,
+  openal,
+  libvorbis,
+  fetchurl,
+  makeWrapper,
+  patchelf,
+  copyDesktopItems,
+  makeDesktopItem
+}:
+let
+  runtimeDependencies = [
+    python3
+    SDL2
+    libvorbis
+    mesa
+    stdenv.cc.cc.lib
+    libGL
+    openal
+  ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  version = "1.7.33";
+  pname = "bombsquad";
+
+  src = fetchurl {
+    url = "http://files.ballistica.net/bombsquad/builds/BombSquad_Linux_x86_64_${finalAttrs.version}.tar.gz";
+    hash = "sha256-pfimBt1s4QP+6buPvTkSdmt5zj2NpXqJUfbxRirfz/o=";
+  };
+
+  sourceRoot = "BombSquad_Linux_x86_64_${finalAttrs.version}";
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [
+    patchelf
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Bombsquad";
+      exec = "bombsquad";
+      icon = fetchurl {
+        url = "https://www.froemling.net/wp-content/uploads/2018/02/icon_clipped-1-150x150.png";
+        hash = "sha256-x08rekyPzHe2FdQzo1EIZ3Rgg/OAcTbWCHoiKuGRBvU=";
+      };
+      comment = finalAttrs.meta.description;
+      desktopName = "Bombsquad";
+      genericName = "Bombsquad";
+      startupWMClass = ".bombsquad-wrapped";
+      categories = [ "Game" ];
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    copyDesktopItems
+    mkdir -p $out/bin
+    cp -r ba_data $out/ba_data
+    install -Dm755 bombsquad -t $out/bin/
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    patchelf \
+      --set-rpath ${lib.makeLibraryPath runtimeDependencies} \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      $out/bin/bombsquad
+    wrapProgram $out/bin/bombsquad --chdir "$out"
+  '';
+
+  meta = with lib; {
+    homepage = "https://ballistica.net/";
+    description = "A party game to blow up your friends in various minigames from CTF to hockey";
+    longDescription = ''
+      Blow up your friends in mini-games ranging from capture-the-flag to hockey!
+      Featuring 8 player local/networked multiplayer, gratuitous explosions,
+      advanced ragdoll face-plant physics, pirates, ninjas, barbarians, insane chefs,
+      and more.
+
+      BombSquad supports touch screens as well as a variety of controllers so all
+      your friends can get in on the action. You can even use phones and tablets
+      as controllers via the free 'BombSquad Remote' app.
+
+      Bombs away!
+    '';
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = [ sourceTypes.binaryNativeCode ];
+    maintainers = with maintainers; [ coffeeispower ];
+    mainProgram = "bombsquad";
+  };
+})


### PR DESCRIPTION
## Description of changes
This pull request adds the bombsquad package.

Bombsquad is a party game where you can blow up your friends in mini-games ranging from capture-the-flag to hockey. Featuring 8 player local/networked multiplayer, gratuitous explosions, advanced ragdoll face-plant physics, pirates, ninjas, barbarians, insane chefs, and more.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
