### PR TITLE
haskellPackages.emanote: Fix the build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2492,7 +2492,7 @@ self: super: {
   # 2023-07-18: https://github.com/srid/ema/issues/156
   ema = doJailbreak super.ema;
 
-  # 2024-03-02: base <=4.18.0.0 - https://github.com/srid/url-slug/issues/1
+  # 2024-03-02: base <=4.18.0.0  https://github.com/srid/url-slug/pull/2
   url-slug = doJailbreak super.url-slug;
 
   glirc = doJailbreak (super.glirc.override {
@@ -2729,9 +2729,35 @@ self: super: {
   # multiple bounds too strict
   snaplet-sqlite-simple = doJailbreak super.snaplet-sqlite-simple;
 
-  emanote = super.emanote.overrideScope (lself: lsuper: {
-    commonmark-extensions = lself.commonmark-extensions_0_2_3_2;
-  });
+  # Test failure https://gitlab.com/lysxia/ap-normalize/-/issues/2
+  ap-normalize = dontCheck super.ap-normalize;
+
+  heist-extra = doJailbreak super.heist-extra;  # base <4.18.0.0.0
+  unionmount = doJailbreak super.unionmount;  # base <4.18
+  path-tree = doJailbreak super.path-tree;  # base <4.18  https://github.com/srid/pathtree/pull/1
+  tailwind = doJailbreak super.tailwind;  # base <=4.17.0.0
+  tagtree = doJailbreak super.tagtree;  # base <=4.17  https://github.com/srid/tagtree/issues/1
+  commonmark-wikilink = doJailbreak super.commonmark-wikilink; # base <4.18.0.0.0
+
+  # 2024-03-02: Apply unreleased changes necessary for compatibility
+  # with commonmark-extensions-0.2.5.3.
+  commonmark-simple = assert super.commonmark-simple.version == "0.1.0.0";
+    appendPatches (map ({ rev, hash }: fetchpatch {
+      name = "commonmark-simple-${lib.substring 0 7 rev}.patch";
+      url = "https://github.com/srid/commonmark-simple/commit/${rev}.patch";
+      includes = [ "src/Commonmark/Simple.hs" ];
+      inherit hash;
+    }) [
+      {
+        rev = "71f5807ed4cbd8da915bf5ba04cd115b49980bcb";
+        hash = "sha256-ibDQbyTd2BoA0V+ldMOr4XYurnqk1nWzbJ15tKizHrM=";
+      }
+      {
+        rev = "fc106c94f781f6a35ef66900880edc08cbe3b034";
+        hash = "sha256-9cpgRNFWhpSuSttAvnwPiLmi1sIoDSYbp0sMwcKWgDQ=";
+      }
+    ])
+      (doJailbreak super.commonmark-simple);
 
   # Test files missing from sdist
   # https://github.com/tweag/webauthn/issues/166

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1623,11 +1623,12 @@ self: super: {
     sha256 = "1c5ck2ibag2gcyag6rjivmlwdlp5k0dmr8nhk7wlkzq2vh7zgw63";
   }) super.splot;
 
-  # Fix build with newer monad-logger: https://github.com/obsidiansystems/monad-logger-extras/pull/5
+  # 2023-07-27: Fix build with newer monad-logger: https://github.com/obsidiansystems/monad-logger-extras/pull/5
+  # 2024-03-02: jailbreak for ansi-terminal <0.12, mtl <2.3
   monad-logger-extras = appendPatch (fetchpatch {
     url = "https://github.com/obsidiansystems/monad-logger-extras/commit/55d414352e740a5ecacf313732074d9b4cf2a6b3.patch";
     sha256 = "sha256-xsQbr/QIrgWR0uwDPtV0NRTbVvP0tR9bY9NMe1JzqOw=";
-  }) super.monad-logger-extras;
+  }) (doJailbreak super.monad-logger-extras);
 
   # Fails with encoding problems, likely needs locale data.
   # Test can be executed by adding which to testToolDepends and
@@ -2490,6 +2491,9 @@ self: super: {
 
   # 2023-07-18: https://github.com/srid/ema/issues/156
   ema = doJailbreak super.ema;
+
+  # 2024-03-02: base <=4.18.0.0 - https://github.com/srid/url-slug/issues/1
+  url-slug = doJailbreak super.url-slug;
 
   glirc = doJailbreak (super.glirc.override {
     vty = self.vty_5_35_1;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -825,7 +825,6 @@ broken-packages:
   - Command # failure in job https://hydra.nixos.org/build/233249718 at 2023-09-02
   - Commando # failure in job https://hydra.nixos.org/build/233248911 at 2023-09-02
   - commodities # failure in job https://hydra.nixos.org/build/233239851 at 2023-09-02
-  - commonmark-simple # failure in job https://hydra.nixos.org/build/245703574 at 2024-01-07
   - Compactable # failure in job https://hydra.nixos.org/build/233227285 at 2023-09-02
   - compactable # failure in job https://hydra.nixos.org/build/233228106 at 2023-09-02
   - compact-list # failure in job https://hydra.nixos.org/build/233241961 at 2023-09-02
@@ -3985,7 +3984,6 @@ broken-packages:
   - pandoc-include-plus # failure in job https://hydra.nixos.org/build/233198059 at 2023-09-02
   - pandoc-lens # failure in job https://hydra.nixos.org/build/233251239 at 2023-09-02
   - pandoc-linear-table # failure in job https://hydra.nixos.org/build/233254813 at 2023-09-02
-  - pandoc-link-context # failure in job https://hydra.nixos.org/build/233254006 at 2023-09-02
   - pandoc-logic-proof # failure in job https://hydra.nixos.org/build/233223409 at 2023-09-02
   - pandoc-markdown-ghci-filter # failure in job https://hydra.nixos.org/build/233213731 at 2023-09-02
   - pandoc-placetable # failure in job https://hydra.nixos.org/build/233243163 at 2023-09-02
@@ -5381,12 +5379,10 @@ broken-packages:
   - tagsoup-megaparsec # failure in job https://hydra.nixos.org/build/233205700 at 2023-09-02
   - tagsoup-parsec # failure in job https://hydra.nixos.org/build/233200887 at 2023-09-02
   - tagsoup-selection # failure in job https://hydra.nixos.org/build/233228969 at 2023-09-02
-  - tagtree # failure in job https://hydra.nixos.org/build/233209409 at 2023-09-02
   - tahoe-capabilities # failure in job https://hydra.nixos.org/build/233253813 at 2023-09-02
   - tahoe-chk # failure in updateAutotoolsGnuConfigScriptsPhase in job https://hydra.nixos.org/build/237298038 at 2023-10-21
   - tai64 # failure in job https://hydra.nixos.org/build/233257422 at 2023-09-02
   - tai # failure in job https://hydra.nixos.org/build/233210483 at 2023-09-02
-  - tailwind # failure in job https://hydra.nixos.org/build/233238757 at 2023-09-02
   - tak # failure in job https://hydra.nixos.org/build/233191188 at 2023-09-02
   - Takusen # failure in job https://hydra.nixos.org/build/233230088 at 2023-09-02
   - takusen-oracle # failure in job https://hydra.nixos.org/build/233197944 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -113,7 +113,6 @@ extra-packages:
   - weeder == 2.2.*                     # 2022-02-21: preserve for GHC 8.10.7
   - weeder == 2.3.*                     # 2022-05-31: preserve for GHC 9.0.2
   - weeder == 2.4.*                     # 2023-02-02: preserve for GHC 9.2.*
-  - commonmark-extensions < 0.2.3.3     # 2022-12-17: required by emanote 1.0.0.0 (to avoid a bug in 0.2.3.3)
   - retrie < 1.2.0.0                    # 2022-12-30: required for hls on ghc < 9.2
   - ghc-tags == 1.5.*                   # 2023-02-18: preserve for ghc-lib == 9.2.*
   - ghc-tags == 1.6.*                   # 2023-02-18: preserve for ghc-lib == 9.4.*

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -1216,7 +1216,6 @@ dont-distribute-packages:
  - emacs-keys
  - email
  - emailparse
- - emanote
  - embroidery
  - emd
  - engine-io-growler


### PR DESCRIPTION
This is for merging into the `haskell-updates` branch, PR #279413.

It fixes the build of `ema` and `emanote`, cc @srid.

There are several jailbreaks due to base <4.18 constraints, covered by the following issues:
- srid/url-slug#1
- srid/pathtree#1
- srid/emanote#518

There is also an unpleasant patching on `commonmark-simple`. This could be removed if there is a new version of this package uploaded to Hackage.