### PR TITLE
uboot: 2023.07.02 -> 2024.01

### DIFF
--- a/pkgs/misc/uboot/0001-configs-rpi-allow-for-bigger-kernels.patch
+++ b/pkgs/misc/uboot/0001-configs-rpi-allow-for-bigger-kernels.patch
@@ -1,17 +1,8 @@
-From 3d0ce353cf62efea11aa88f814aa23bf8c04acc9 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?Milan=20P=C3=A4ssler?= <milan@petabyte.dev>
-Date: Mon, 11 Jan 2021 15:13:10 +0100
-Subject: [PATCH] configs/rpi: allow for bigger kernels
-
----
- include/configs/rpi.h | 16 ++++++++--------
- 1 file changed, 8 insertions(+), 8 deletions(-)
-
-diff --git a/include/configs/rpi.h b/include/configs/rpi.h
-index 834f1cd..10ab1e7 100644
---- a/include/configs/rpi.h
-+++ b/include/configs/rpi.h
-@@ -153,20 +153,20 @@
+diff --git a/board/raspberrypi/rpi/rpi.env b/board/raspberrypi/rpi/rpi.env
+index 30228285ed..0327ef74fa 100644
+--- a/board/raspberrypi/rpi/rpi.env
++++ b/board/raspberrypi/rpi/rpi.env
+@@ -55,11 +55,11 @@ dfu_alt_info+=zImage fat 0 1
   * more than ~700M away from the start of the kernel image but this number can
   * be larger OR smaller depending on e.g. the 'vmalloc=xxxM' command line
   * parameter given to the kernel. So reserving memory from low to high
@@ -25,21 +16,20 @@ index 834f1cd..10ab1e7 100644
 + * only 64M, the remaining 8M starting at 0x04800000 should allow reasonably
 + * sized initrds before they start colliding with U-Boot.
   */
- #define ENV_MEM_LAYOUT_SETTINGS \
- 	"fdt_high=" FDT_HIGH "\0" \
- 	"initrd_high=" INITRD_HIGH "\0" \
- 	"kernel_addr_r=0x00080000\0" \
--	"scriptaddr=0x02400000\0" \
--	"pxefile_addr_r=0x02500000\0" \
--	"fdt_addr_r=0x02600000\0" \
--	"ramdisk_addr_r=0x02700000\0"
-+	"scriptaddr=0x04500000\0" \
-+	"pxefile_addr_r=0x04600000\0" \
-+	"fdt_addr_r=0x04700000\0" \
-+	"ramdisk_addr_r=0x04800000\0"
+ #ifdef CONFIG_ARM64
+ fdt_high=ffffffffffffffff
+@@ -69,9 +69,9 @@ fdt_high=ffffffff
+ initrd_high=ffffffff
+ #endif
+ kernel_addr_r=0x00080000
+-scriptaddr=0x02400000
+-pxefile_addr_r=0x02500000
+-fdt_addr_r=0x02600000
+-ramdisk_addr_r=0x02700000
++scriptaddr=0x04500000
++pxefile_addr_r=0x04600000
++fdt_addr_r=0x04700000
++ramdisk_addr_r=0x04800000
  
- #if CONFIG_IS_ENABLED(CMD_MMC)
- 	#define BOOT_TARGET_MMC(func) \
--- 
-2.29.2
+ boot_targets=mmc usb pxe dhcp
 

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -26,10 +26,10 @@
 }:
 
 let
-  defaultVersion = "2023.07.02";
+  defaultVersion = "2024.01";
   defaultSrc = fetchurl {
     url = "https://ftp.denx.de/pub/u-boot/u-boot-${defaultVersion}.tar.bz2";
-    hash = "sha256-a2pIWBwUq7D5W9h8GvTXQJIkBte4AQAqn5Ryf93gIdU=";
+    hash = "sha256-uZYR8e0je/NUG9yENLaMlqbgWWcGH5kkQ8swqr6+9bM=";
   };
 
   # Dependencies for the tools need to be included as either native or cross,


### PR DESCRIPTION
## Description of changes

Bump U-Boot version to v2024.01. This is also helpful in adding support for SBCs that use the RK3588 series of SoCs.

Edit: **This PR depends on #277997.**

## Things done

- Bump U-Boot version to v2024.01
- As a result of version bump, the patch `0001-configs-rpi-allow-for-bigger-kernels.patch` did not apply. Modify the patch by applying the same changes to the v2024.01 tag and saving the output of `git diff` in the patch file again.

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
