### PR TITLE
treewide: remove unpackCmd involving 7zz

### DIFF
--- a/pkgs/applications/misc/monitorcontrol/default.nix
+++ b/pkgs/applications/misc/monitorcontrol/default.nix
@@ -14,14 +14,6 @@ stdenv.mkDerivation rec {
   };
 
   # MonitorControl.${version}.dmg is APFS formatted, unpack with 7zz
-  unpackCmd = ''
-    runHook preUnpack
-
-    7zz x $src
-
-    runHook postUnpack
-  '';
-
   nativeBuildInputs = [ _7zz ];
 
   sourceRoot = "MonitorControl.app";

--- a/pkgs/by-name/no/nosql-workbench/package.nix
+++ b/pkgs/by-name/no/nosql-workbench/package.nix
@@ -39,20 +39,12 @@ if stdenv.isDarwin then stdenv.mkDerivation {
 
   sourceRoot = ".";
 
-  nativeBuildInputs = [ _7zz ];
-
-  buildInputs = [ jdk21 ];
-
   # DMG file is using APFS which is unsupported by "undmg".
   # Instead, use "7zz" to extract the contents.
   # "undmg" issue: https://github.com/matthewbauer/undmg/issues/4
-  unpackCmd = ''
-    runHook preUnpack
+  nativeBuildInputs = [ _7zz ];
 
-    7zz x $curSrc
-
-    runHook postUnpack
-  '';
+  buildInputs = [ jdk21 ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/development/libraries/science/math/mkl/default.nix
+++ b/pkgs/development/libraries/science/math/mkl/default.nix
@@ -68,9 +68,7 @@ in stdenvNoCC.mkDerivation ({
 
   dontUnpack = stdenvNoCC.isLinux;
 
-  unpackPhase = if stdenvNoCC.isDarwin then ''
-    7zz x $src
-  '' else null;
+  sourceRoot = if stdenvNoCC.isDarwin then "." else null;
 
   nativeBuildInputs = [ validatePkgConfig ] ++ (if stdenvNoCC.isDarwin
     then

--- a/pkgs/os-specific/darwin/airbuddy/default.nix
+++ b/pkgs/os-specific/darwin/airbuddy/default.nix
@@ -19,16 +19,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   dontBuild = true;
   dontFixup = true;
 
-  nativeBuildInputs = [ _7zz ];
-
   # AirBuddy.dmg is APFS formatted, unpack with 7zz
-  unpackCmd = ''
-    runHook preUnpack
-
-    7zz x $src
-
-    runHook postUnpack
-  '';
+  nativeBuildInputs = [ _7zz ];
 
   sourceRoot = "AirBuddy.app";
 

--- a/pkgs/os-specific/darwin/aldente/default.nix
+++ b/pkgs/os-specific/darwin/aldente/default.nix
@@ -16,16 +16,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   dontBuild = true;
   dontFixup = true;
 
-  nativeBuildInputs = [ _7zz ];
-
   # AlDente.dmg is APFS formatted, unpack with 7zz
-  unpackCmd = ''
-    runHook preUnpack
-
-    7zz x $src
-
-    runHook postUnpack
-  '';
+  nativeBuildInputs = [ _7zz ];
 
   sourceRoot = "AlDente.app";
 

--- a/pkgs/tools/inputmethods/unnaturalscrollwheels/default.nix
+++ b/pkgs/tools/inputmethods/unnaturalscrollwheels/default.nix
@@ -15,7 +15,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   # APFS format is unsupported by undmg
   nativeBuildInputs = [ _7zz ];
-  unpackCmd = "7zz x $curSrc";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/tools/misc/archi/default.nix
+++ b/pkgs/tools/misc/archi/default.nix
@@ -42,9 +42,7 @@ stdenv.mkDerivation rec {
     autoPatchelfHook
   ];
 
-  unpackPhase = if stdenv.hostPlatform.isDarwin then ''
-    7zz x $src
-  '' else null;
+  sourceRoot = if stdenv.isDarwin then "." else null;
 
   installPhase =
     if stdenv.hostPlatform.system == "x86_64-linux" then


### PR DESCRIPTION
## Description of changes

`_7zz` has a setup hook for doing `7zz x $curSrc`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
