### PR TITLE
wrapRustc: wrap rustdoc

### DIFF
--- a/pkgs/build-support/rust/rustc-wrapper/default.nix
+++ b/pkgs/build-support/rust/rustc-wrapper/default.nix
@@ -6,7 +6,6 @@ runCommand "${rustc-unwrapped.pname}-wrapper-${rustc-unwrapped.version}" {
   inherit (rustc-unwrapped) outputs;
 
   env = {
-    prog = "${rustc-unwrapped}/bin/rustc";
     sysroot = lib.optionalString (sysroot != null) "--sysroot ${sysroot}";
 
     # Upstream rustc still assumes that musl = static[1].  The fix for
@@ -42,9 +41,12 @@ runCommand "${rustc-unwrapped.pname}-wrapper-${rustc-unwrapped.version}" {
 } ''
   mkdir -p $out/bin
   ln -s ${rustc-unwrapped}/bin/* $out/bin
-  rm $out/bin/rustc
-  substituteAll ${./rustc-wrapper.sh} $out/bin/rustc
-  chmod +x $out/bin/rustc
+  rm $out/bin/{rustc,rustdoc}
+  prog=${rustc-unwrapped}/bin/rustc extraFlagsVar=NIX_RUSTFLAGS \
+      substituteAll ${./rustc-wrapper.sh} $out/bin/rustc
+  prog=${rustc-unwrapped}/bin/rustdoc extraFlagsVar=NIX_RUSTDOCFLAGS \
+      substituteAll ${./rustc-wrapper.sh} $out/bin/rustdoc
+  chmod +x $out/bin/{rustc,rustdoc}
   ${lib.concatMapStrings (output: "ln -s ${rustc-unwrapped.${output}} \$${output}\n")
     (lib.remove "out" rustc-unwrapped.outputs)}
 ''

--- a/pkgs/build-support/rust/rustc-wrapper/rustc-wrapper.sh
+++ b/pkgs/build-support/rust/rustc-wrapper/rustc-wrapper.sh
@@ -14,7 +14,7 @@ for arg; do
 done
 
 extraBefore=(@defaultArgs@ "${defaultSysroot[@]}")
-extraAfter=($NIX_RUSTFLAGS)
+extraAfter=($@extraFlagsVar@)
 
 # Optionally print debug info.
 if (( "${NIX_DEBUG:-0}" >= 1 )); then

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -175,8 +175,7 @@ in stdenv.mkDerivation (finalAttrs: {
 
     python ./x.py --keep-stage=0 --stage=1 install library/std
     mkdir -v $out/bin $doc $man
-    ln -s ${rustc.unwrapped}/bin/rustc $out/bin
-    makeWrapper ${rustc.unwrapped}/bin/rustdoc $out/bin/rustdoc --add-flags "--sysroot $out"
+    ln -s ${rustc.unwrapped}/bin/{rustc,rustdoc} $out/bin
     ln -s ${rustc.unwrapped}/lib/rustlib/{manifest-rust-std-,}${stdenv.hostPlatform.rust.rustcTargetSpec} $out/lib/rustlib/
     echo rust-std-${stdenv.hostPlatform.rust.rustcTargetSpec} >> $out/lib/rustlib/components
     lndir ${rustc.doc} $doc


### PR DESCRIPTION
## Description of changes

We need to set -crt-static on musl for rustdoc as well, so let's unify the wrappers.  Ideally, rather than wrapping rustdoc, we'd have rustdoc use the wrapped rustc, but that's currently only possible with an unstable option (--test-builder).

The options set by the wrapper, -C target-feature and --sysroot, are supported by both rustdoc and rustc, but other flags maybe not be supported by both, so I've introduced different environment variables (the existing NIX_RUSTFLAGS and a new NIX_RUSTDOCFLAGS) to allow those to be set independently.

This fixes cargo-auditable in pkgsMusl., which broke because its doctests stopped working when -crt-static was moved to the wrapper.

Lesson learned: always run tests.cross.sanity before changing the rustc wrapper.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
