### PR TITLE
[Backport release-23.11]: Rust 1.75.0

### DIFF
--- a/pkgs/development/compilers/rust/1_75.nix
+++ b/pkgs/development/compilers/rust/1_75.nix
@@ -1,0 +1,60 @@
+# New rust versions should first go to staging.
+# Things to check after updating:
+# 1. Rustc should produce rust binaries on x86_64-linux, aarch64-linux and x86_64-darwin:
+#    i.e. nix-shell -p fd or @GrahamcOfBorg build fd on github
+#    This testing can be also done by other volunteers as part of the pull
+#    request review, in case platforms cannot be covered.
+# 2. The LLVM version used for building should match with rust upstream.
+#    Check the version number in the src/llvm-project git submodule in:
+#    https://github.com/rust-lang/rust/blob/<version-tag>/.gitmodules
+# 3. Firefox and Thunderbird should still build on x86_64-linux.
+
+{ stdenv, lib
+, buildPackages
+, targetPackages
+, newScope, callPackage
+, CoreFoundation, Security, SystemConfiguration
+, pkgsBuildTarget, pkgsBuildBuild, pkgsBuildHost
+, makeRustPlatform
+, llvmPackages_17, llvm_17
+} @ args:
+
+import ./default.nix {
+  rustcVersion = "1.75.0";
+  rustcSha256 = "sha256-W3OfRbydNB4tHFcNZdI3VZHiLC0j71uKN3EaA4arwIg=";
+
+  llvmSharedForBuild = pkgsBuildBuild.llvmPackages_17.libllvm.override { enableSharedLibraries = true; };
+  llvmSharedForHost = pkgsBuildHost.llvmPackages_17.libllvm.override { enableSharedLibraries = true; };
+  llvmSharedForTarget = pkgsBuildTarget.llvmPackages_17.libllvm.override { enableSharedLibraries = true; };
+
+  # For use at runtime
+  llvmShared = llvm_17.override { enableSharedLibraries = true; };
+
+  # Expose llvmPackages used for rustc from rustc via passthru for LTO in Firefox
+  llvmPackages = llvmPackages_17;
+
+  # Note: the version MUST be one version prior to the version we're
+  # building
+  bootstrapVersion = "1.74.1";
+
+  # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
+  bootstrapHashes = {
+    i686-unknown-linux-gnu = "b883b98372c91bc6aa9dc6ebb2b4e02e7dacbbc2ac1ebe55923dc37134df70a4";
+    x86_64-unknown-linux-gnu = "d206888a2a9d55113940151ba16117ce2456d7de021bab18cfcb06dc48d3157c";
+    x86_64-unknown-linux-musl = "5af3115a1f16431630f288821bd7f3be8cf7e08a7611b3c3bce3976774aa6cd2";
+    arm-unknown-linux-gnueabihf = "1dd7d835af4afe9adb7f785046c907090ace66f1c975cfe9e8886847310d8ec9";
+    armv7-unknown-linux-gnueabihf = "a5038ae004bf86eed64ef67329f7ba047bb4d188663bfd260320d53a2fed33c4";
+    aarch64-unknown-linux-gnu = "0dbdfce647f3c7d9ff00a7aa5d6dbbd7010486f803a9749cff46189f5ecb438c";
+    aarch64-unknown-linux-musl = "02674b8e4311780464313c5773d43606fbf6880d5c4512930d59b6d5d369f0de";
+    x86_64-apple-darwin = "54e1ef01d73f6031fbee36bbecd9af4209eb682dea478696e8282ca64d5792e5";
+    aarch64-apple-darwin = "af6a982cbed85807fb8e5c4ba85b8a76162b58945f4787e0a7dec32e901e8b3b";
+    powerpc64le-unknown-linux-gnu = "bb1c9f0ab1016a2817afe8f72c03f8f1787fe44d0f9999669e0c1957a08e6213";
+    riscv64gc-unknown-linux-gnu = "86561a8d630f634fdd7cb5899d40027103c907d9763a32770b7e2fd57dbd8473";
+  };
+
+  selectRustPackage = pkgs: pkgs.rust_1_75;
+
+  rustcPatches = [ ];
+}
+
+(builtins.removeAttrs args [ "pkgsBuildTarget" "pkgsBuildHost" "llvmPackages_17" "llvm_17"])

--- a/pkgs/development/compilers/rust/1_75.nix
+++ b/pkgs/development/compilers/rust/1_75.nix
@@ -9,52 +9,78 @@
 #    https://github.com/rust-lang/rust/blob/<version-tag>/.gitmodules
 # 3. Firefox and Thunderbird should still build on x86_64-linux.
 
-{ stdenv, lib
+{ stdenv
+, lib
 , buildPackages
 , targetPackages
-, newScope, callPackage
-, CoreFoundation, Security, SystemConfiguration
-, pkgsBuildTarget, pkgsBuildBuild, pkgsBuildHost
+, newScope
+, callPackage
+, CoreFoundation
+, Security
+, SystemConfiguration
+, pkgsBuildTarget
+, pkgsBuildBuild
+, pkgsBuildHost
 , makeRustPlatform
-, llvmPackages_17, llvm_17
+, llvmPackages_17
+, llvm_17
 } @ args:
 
-import ./default.nix {
-  rustcVersion = "1.75.0";
-  rustcSha256 = "sha256-W3OfRbydNB4tHFcNZdI3VZHiLC0j71uKN3EaA4arwIg=";
+let
+  toolchain = import ./default.nix
+    {
+      rustcVersion = "1.75.0";
+      rustcSha256 = "sha256-W3OfRbydNB4tHFcNZdI3VZHiLC0j71uKN3EaA4arwIg=";
 
-  llvmSharedForBuild = pkgsBuildBuild.llvmPackages_17.libllvm.override { enableSharedLibraries = true; };
-  llvmSharedForHost = pkgsBuildHost.llvmPackages_17.libllvm.override { enableSharedLibraries = true; };
-  llvmSharedForTarget = pkgsBuildTarget.llvmPackages_17.libllvm.override { enableSharedLibraries = true; };
+      llvmSharedForBuild = pkgsBuildBuild.llvmPackages_17.libllvm.override { enableSharedLibraries = true; };
+      llvmSharedForHost = pkgsBuildHost.llvmPackages_17.libllvm.override { enableSharedLibraries = true; };
+      llvmSharedForTarget = pkgsBuildTarget.llvmPackages_17.libllvm.override { enableSharedLibraries = true; };
 
-  # For use at runtime
-  llvmShared = llvm_17.override { enableSharedLibraries = true; };
+      # For use at runtime
+      llvmShared = llvm_17.override { enableSharedLibraries = true; };
 
-  # Expose llvmPackages used for rustc from rustc via passthru for LTO in Firefox
-  llvmPackages = llvmPackages_17;
+      # Expose llvmPackages used for rustc from rustc via passthru for LTO in Firefox
+      llvmPackages = llvmPackages_17;
 
-  # Note: the version MUST be one version prior to the version we're
-  # building
-  bootstrapVersion = "1.74.1";
+      # Note: the version MUST be one version prior to the version we're
+      # building
+      bootstrapVersion = "1.74.1";
 
-  # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
-  bootstrapHashes = {
-    i686-unknown-linux-gnu = "b883b98372c91bc6aa9dc6ebb2b4e02e7dacbbc2ac1ebe55923dc37134df70a4";
-    x86_64-unknown-linux-gnu = "d206888a2a9d55113940151ba16117ce2456d7de021bab18cfcb06dc48d3157c";
-    x86_64-unknown-linux-musl = "5af3115a1f16431630f288821bd7f3be8cf7e08a7611b3c3bce3976774aa6cd2";
-    arm-unknown-linux-gnueabihf = "1dd7d835af4afe9adb7f785046c907090ace66f1c975cfe9e8886847310d8ec9";
-    armv7-unknown-linux-gnueabihf = "a5038ae004bf86eed64ef67329f7ba047bb4d188663bfd260320d53a2fed33c4";
-    aarch64-unknown-linux-gnu = "0dbdfce647f3c7d9ff00a7aa5d6dbbd7010486f803a9749cff46189f5ecb438c";
-    aarch64-unknown-linux-musl = "02674b8e4311780464313c5773d43606fbf6880d5c4512930d59b6d5d369f0de";
-    x86_64-apple-darwin = "54e1ef01d73f6031fbee36bbecd9af4209eb682dea478696e8282ca64d5792e5";
-    aarch64-apple-darwin = "af6a982cbed85807fb8e5c4ba85b8a76162b58945f4787e0a7dec32e901e8b3b";
-    powerpc64le-unknown-linux-gnu = "bb1c9f0ab1016a2817afe8f72c03f8f1787fe44d0f9999669e0c1957a08e6213";
-    riscv64gc-unknown-linux-gnu = "86561a8d630f634fdd7cb5899d40027103c907d9763a32770b7e2fd57dbd8473";
-  };
+      # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
+      bootstrapHashes = {
+        i686-unknown-linux-gnu = "b883b98372c91bc6aa9dc6ebb2b4e02e7dacbbc2ac1ebe55923dc37134df70a4";
+        x86_64-unknown-linux-gnu = "d206888a2a9d55113940151ba16117ce2456d7de021bab18cfcb06dc48d3157c";
+        x86_64-unknown-linux-musl = "5af3115a1f16431630f288821bd7f3be8cf7e08a7611b3c3bce3976774aa6cd2";
+        arm-unknown-linux-gnueabihf = "1dd7d835af4afe9adb7f785046c907090ace66f1c975cfe9e8886847310d8ec9";
+        armv7-unknown-linux-gnueabihf = "a5038ae004bf86eed64ef67329f7ba047bb4d188663bfd260320d53a2fed33c4";
+        aarch64-unknown-linux-gnu = "0dbdfce647f3c7d9ff00a7aa5d6dbbd7010486f803a9749cff46189f5ecb438c";
+        aarch64-unknown-linux-musl = "02674b8e4311780464313c5773d43606fbf6880d5c4512930d59b6d5d369f0de";
+        x86_64-apple-darwin = "54e1ef01d73f6031fbee36bbecd9af4209eb682dea478696e8282ca64d5792e5";
+        aarch64-apple-darwin = "af6a982cbed85807fb8e5c4ba85b8a76162b58945f4787e0a7dec32e901e8b3b";
+        powerpc64le-unknown-linux-gnu = "bb1c9f0ab1016a2817afe8f72c03f8f1787fe44d0f9999669e0c1957a08e6213";
+        riscv64gc-unknown-linux-gnu = "86561a8d630f634fdd7cb5899d40027103c907d9763a32770b7e2fd57dbd8473";
+      };
 
-  selectRustPackage = pkgs: pkgs.rust_1_75;
+      selectRustPackage = pkgs: pkgs.rust_1_75;
 
-  rustcPatches = [ ];
+      rustcPatches = [ ];
+    }
+    (builtins.removeAttrs args [
+      "pkgsBuildTarget"
+      "pkgsBuildHost"
+      "llvmPackages_17"
+      "llvm_17"
+    ]);
+
+    # patch the output of the rustc.nix expression
+    # with changes for the rust_1_75 expression from e9ca6038eb5f4398fc57feb4084b7df4afaa6d7d
+    overwrittenRustc =
+      toolchain.packages.stable.rustc.overrideAttrs (previousAttrs: {
+        configureFlags =
+          [ "--sysconfdir=${placeholder "out"}/etc" ] ++ previousAttrs.configureFlags;
+        postConfigure = null;
+      });
+in
+lib.attrsets.recursiveUpdate toolchain {
+  packages.stable.rustc = overwrittenRustc;
 }
-
-(builtins.removeAttrs args [ "pkgsBuildTarget" "pkgsBuildHost" "llvmPackages_17" "llvm_17"])

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16944,6 +16944,10 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
     llvm_16 = llvmPackages_16.libllvm;
   };
+  rust_1_75 = callPackage ../development/compilers/rust/1_75.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
+    llvm_17 = llvmPackages_17.libllvm;
+  };
   rust = rust_1_73;
 
   mrustc = callPackage ../development/compilers/mrustc { };
@@ -16953,6 +16957,7 @@ with pkgs;
   };
 
   rustPackages_1_73 = rust_1_73.packages.stable;
+  rustPackages_1_75 = rust_1_75.packages.stable;
   rustPackages = rustPackages_1_73;
 
   inherit (rustPackages) cargo cargo-auditable cargo-auditable-cargo-wrapper clippy rustc rustPlatform;


### PR DESCRIPTION
## Description of changes

This packages the rust toolchain for 1.75.0 for the stable channel.

Rationale is that I'd like to see a fair number of packages being backported to the stable nixos release, though they do not build with older rust toolchains, for example:

* https://github.com/NixOS/nixpkgs/pull/292569
* https://github.com/NixOS/nixpkgs/pull/291580
* https://github.com/NixOS/nixpkgs/pull/291071
* https://github.com/NixOS/nixpkgs/pull/290447
* https://github.com/NixOS/nixpkgs/pull/289518
* https://github.com/NixOS/nixpkgs/pull/288298

The idea here is to package 1.75.0, then backport the packages and modify them to be built with that newer version of the rust toolchain.
The idea is _not_ to alter the default rust toolchain on stable.

---

If this gets rejected for whatever reason (please tell tho), I am fine with that, since I learned a lot writing these patches :laughing: 

---

FWIW, the `rust_1_75.packages.stable.rustc` attribute has been test-built by me on `x86_64-linux`.
I also tried to backport https://github.com/NixOS/nixpkgs/pull/290447 and modify it to build with that newer toolchain, but for whatever reason I did not yet understand it tries to rebuild the toolchain (although it has been built already) and then fails with

```
       > error: the argument '--jobs <JOBS>' cannot be used multiple times
       >
       > Usage: x.py build [OPTIONS] [PATHS]... [-- <ARGS>...]
       >
       > For more information, try '--help'.
       > Build completed unsuccessfully in 0:00:12
       > make: *** [Makefile:19: all] Error 1
```

:eyes: 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
