### PR TITLE
python-matter-server: 5.7.0b2 -> 5.8.0

### DIFF
--- a/pkgs/development/python-modules/python-matter-server/default.nix
+++ b/pkgs/development/python-modules/python-matter-server/default.nix
@@ -55,7 +55,7 @@ in
 
 buildPythonPackage rec {
   pname = "python-matter-server";
-  version = "5.7.0b2";
+  version = "5.8.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.10";
@@ -64,7 +64,7 @@ buildPythonPackage rec {
     owner = "home-assistant-libs";
     repo = "python-matter-server";
     rev = "refs/tags/${version}";
-    hash = "sha256-fMtvVizHeAzLdou0U1tqbmQATIBLK4w9I7EwMlzB8QA=";
+    hash = "sha256-bpXRay4JUujqdnscGldW732e8FTkcmfShbtwp2YJC60=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/python-matter-server/link-paa-root-certs.patch
+++ b/pkgs/development/python-modules/python-matter-server/link-paa-root-certs.patch
@@ -1,126 +1,45 @@
 diff --git a/matter_server/server/const.py b/matter_server/server/const.py
-index b6cd839..f9f798f 100644
+index 2a6140b..275353a 100644
 --- a/matter_server/server/const.py
 +++ b/matter_server/server/const.py
-@@ -5,14 +5,4 @@ from typing import Final
- # The minimum schema version (of a client) the server can support
- MIN_SCHEMA_VERSION = 5
- 
--# the paa-root-certs path is hardcoded in the sdk at this time
--# and always uses the development subfolder
--# regardless of anything you pass into instantiating the controller
--# revisit this once matter 1.1 is released
+@@ -15,7 +15,8 @@ DATA_MODEL_SCHEMA_VERSION = 6
+ # and always uses the development subfolder
+ # regardless of anything you pass into instantiating the controller
+ # revisit this once matter 1.1 is released
 -PAA_ROOT_CERTS_DIR: Final[pathlib.Path] = (
--    pathlib.Path(__file__)
--    .parent.resolve()
--    .parent.resolve()
--    .parent.resolve()
--    .joinpath("credentials/development/paa-root-certs")
--)
 +PAA_ROOT_CERTS_DIR: Final[pathlib.Path] = pathlib.Path("@paacerts@")
++(
+     pathlib.Path(__file__)
+     .parent.resolve()
+     .parent.resolve()
 diff --git a/matter_server/server/helpers/paa_certificates.py b/matter_server/server/helpers/paa_certificates.py
-index 9ac5a10..25230c1 100644
+index d186be1..d2cef54 100644
 --- a/matter_server/server/helpers/paa_certificates.py
 +++ b/matter_server/server/helpers/paa_certificates.py
-@@ -58,84 +58,14 @@ async def fetch_dcl_certificates(
+@@ -62,6 +62,8 @@ async def fetch_dcl_certificates(
      fetch_production_certificates: bool = True,
  ) -> int:
      """Fetch DCL PAA Certificates."""
--    LOGGER.info("Fetching the latest PAA root certificates from DCL.")
--    if not PAA_ROOT_CERTS_DIR.is_dir():
--        loop = asyncio.get_running_loop()
--        await loop.run_in_executor(None, makedirs, PAA_ROOT_CERTS_DIR)
--    fetch_count: int = 0
--    base_urls = set()
--    # determine which url's need to be queried.
--    # if we're going to fetch both prod and test, do test first
--    # so any duplicates will be overwritten/preferred by the production version
--    # NOTE: While Matter is in BETA we fetch the test certificates by default
--    if fetch_test_certificates:
--        base_urls.add(TEST_URL)
--    if fetch_production_certificates:
--        base_urls.add(PRODUCTION_URL)
- 
--    try:
--        async with ClientSession(raise_for_status=True) as http_session:
--            for url_base in base_urls:
--                # fetch the paa certificates list
--                async with http_session.get(
--                    f"{url_base}/dcl/pki/root-certificates"
--                ) as response:
--                    result = await response.json()
--                paa_list = result["approvedRootCertificates"]["certs"]
--                # grab each certificate
--                for paa in paa_list:
--                    # do not fetch a certificate if we already fetched it
--                    if paa["subjectKeyId"] in LAST_CERT_IDS:
--                        continue
--                    async with http_session.get(
--                        f"{url_base}/dcl/pki/certificates/{paa['subject']}/{paa['subjectKeyId']}"
--                    ) as response:
--                        result = await response.json()
--
--                    certificate_data: dict = result["approvedCertificates"]["certs"][0]
--                    certificate: str = certificate_data["pemCert"]
--                    subject = certificate_data["subjectAsText"]
--                    certificate = certificate.rstrip("\n")
--
--                    await write_paa_root_cert(
--                        certificate,
--                        subject,
--                    )
--                    LAST_CERT_IDS.add(paa["subjectKeyId"])
--                    fetch_count += 1
--    except ClientError as err:
--        LOGGER.warning(
--            "Fetching latest certificates failed: error %s", err, exc_info=err
--        )
--    else:
--        LOGGER.info("Fetched %s PAA root certificates from DCL.", fetch_count)
--
--    return fetch_count
 +    return 0
- 
++
+     LOGGER.info("Fetching the latest PAA root certificates from DCL.")
+     fetch_count: int = 0
+     base_urls = set()
+@@ -121,6 +123,8 @@ async def fetch_dcl_certificates(
  
  async def fetch_git_certificates() -> int:
      """Fetch Git PAA Certificates."""
--    fetch_count = 0
--    LOGGER.info("Fetching the latest PAA root certificates from Git.")
--    try:
--        async with ClientSession(raise_for_status=True) as http_session:
--            for cert in GIT_CERTS:
--                if cert in LAST_CERT_IDS:
--                    continue
- 
--                async with http_session.get(f"{GIT_URL}/{cert}.pem") as response:
--                    certificate = await response.text()
--                await write_paa_root_cert(certificate, cert)
--                LAST_CERT_IDS.add(cert)
--                fetch_count += 1
--    except ClientError as err:
--        LOGGER.warning(
--            "Fetching latest certificates failed: error %s", err, exc_info=err
--        )
--
--    LOGGER.info("Fetched %s PAA root certificates from Git.", fetch_count)
--
--    return fetch_count
 +    return 0
++
+     fetch_count = 0
+     LOGGER.info("Fetching the latest PAA root certificates from Git.")
  
- 
- async def fetch_certificates(
-@@ -144,12 +74,4 @@ async def fetch_certificates(
+@@ -162,6 +166,8 @@ async def fetch_certificates(
+     fetch_production_certificates: bool = True,
  ) -> int:
      """Fetch PAA Certificates."""
- 
--    fetch_count = await fetch_dcl_certificates(
--        fetch_test_certificates=fetch_test_certificates,
--        fetch_production_certificates=fetch_production_certificates,
--    )
--
--    if fetch_test_certificates:
--        fetch_count += await fetch_git_certificates()
--
--    return fetch_count
 +    return 0
-
++
+     loop = asyncio.get_running_loop()
+ 
+     if not PAA_ROOT_CERTS_DIR.is_dir():


### PR DESCRIPTION
## Description of changes

Release notes: https://github.com/home-assistant-libs/python-matter-server/releases/tag/5.8.0

Our patch does not apply cleanly with changes in 5.7.0b2. I refactored it to be less fragile with upstream changes to the function bodies it modifies.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] (In progress) Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).