### PR TITLE
pixi: 0.13.0 -> 0.15.2

### DIFF
--- a/pkgs/by-name/pi/pixi/package.nix
+++ b/pkgs/by-name/pi/pixi/package.nix
@@ -12,16 +12,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "pixi";
-  version = "0.13.0";
+  version = "0.15.2";
 
   src = fetchFromGitHub {
     owner = "prefix-dev";
     repo = "pixi";
     rev = "v${version}";
-    hash = "sha256-4EKJwHXNDUGhwlSSZFoPHdG5WBDoHFAQncG+CpD2sik=";
+    hash = "sha256-bh8Uu6Q2AND50Qzivc6k1Z8JWudkHC2i4YW1Hxa69SM=";
   };
 
-  cargoHash = "sha256-s1ODwuYv1x5/iP8yHS5FRk5MacrW81LaXI7/J+qtPNM=";
+  cargoHash = "sha256-yMIcPwnuN7F2ZrOtJw8T+nxeSzLsYn+iC34bYeWpi/w=";
 
   nativeBuildInputs = [
     pkg-config
@@ -35,6 +35,13 @@ rustPlatform.buildRustPackage rec {
     with darwin.apple_sdk_11_0.frameworks; [ CoreFoundation IOKit SystemConfiguration Security ]
   );
 
+  # There are some CI failures with Rattler. Tests on Aarch64 has been skipped.
+  # See https://github.com/prefix-dev/pixi/pull/241.
+  doCheck = !stdenv.isAarch64;
+
+  preCheck = ''
+    export HOME="$(mktemp -d)"
+  '';
 
   checkFlags = [
     # Skip tests requiring network
@@ -49,7 +56,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   postInstall = ''
-    installShellCompletion --cmd pix \
+    installShellCompletion --cmd pixi \
       --bash <($out/bin/pixi completion --shell bash) \
       --fish <($out/bin/pixi completion --shell fish) \
       --zsh <($out/bin/pixi completion --shell zsh)


### PR DESCRIPTION
## Description of changes

https://github.com/prefix-dev/pixi/releases/tag/v0.14.0

https://github.com/prefix-dev/pixi/releases/tag/v0.15.0

Closes #289845

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
