### PR TITLE
museum: init at 0-unstable-2024-03-02

### DIFF
--- a/pkgs/by-name/mu/museum/package.nix
+++ b/pkgs/by-name/mu/museum/package.nix
@@ -1,0 +1,53 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+, libsodium
+, pkg-config
+}:
+
+buildGoModule rec {
+  pname = "museum";
+  version = "0-unstable-2024-03-02";
+
+  src = fetchFromGitHub {
+    owner = "ente-io";
+    repo = "ente";
+    sparseCheckout = [ "server" ];
+    rev = "44eb8353a289710ad7dc35a4abfa93feecfe40ac";
+    hash = "sha256-IZZ9cxpV55i8AA1POuidAZ7HjhXlr+xwKD/OqOeVpLk=";
+  };
+  sourceRoot = "${src.name}/server";
+
+  postPatch = ''
+    # otherwise go wants us to run "go mod tidy"
+    substituteInPlace go.mod \
+      --replace-fail "go 1.20" "go 1.21"
+  '';
+
+  # "go: inconsistent vendoring in /build/source/server"
+  proxyVendor = true;
+  vendorHash = "sha256-/1F7ClVQOKDxSauyMHS4EyoTh/3mAcULLrPzDfArNM4=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libsodium ];
+
+  # fatal: "Not running tests in non-test environment"
+  doCheck = false;
+
+  postInstall = ''
+    mkdir -p $out/share/museum
+    cp -R configurations \
+      migrations \
+      mail-templates \
+      $out/share/museum
+  '';
+
+  meta = with lib; {
+    description = "API server for ente.io";
+    homepage = "https://github.com/ente-io/ente/tree/main/server";
+    license = licenses.agpl3Only;
+    maintainers = with maintainers; [ surfaceflinger ];
+    mainProgram = "museum";
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

https://github.com/NixOS/nixpkgs/issues/292641

for now untested. will need to package client and write a module.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
