### PR TITLE
marge-bot: init at 0.10.1

### DIFF
--- a/pkgs/by-name/ma/marge-bot/package.nix
+++ b/pkgs/by-name/ma/marge-bot/package.nix
@@ -1,0 +1,50 @@
+{ lib
+, python3
+, fetchFromGitLab
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "marge-bot";
+  version = "0.10.1";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    owner = "marge-org";
+    repo = "marge-bot";
+    rev = version;
+    hash = "sha256-2L7c/NEKyjscwpyf/5GtWXr7Ig14IQlRR5IbDYxp8jA=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.cfg --replace "--flake8 --pylint --cov=marge" ""
+  '';
+
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    configargparse
+    maya
+    pyyaml
+    requests
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [ pytestCheckHook ];
+  disabledTests = [
+    # test broken when run under Nix:
+    #   "unittest.mock.InvalidSpecError: Cannot spec a Mock object."
+    "test_get_mr_ci_status"
+  ];
+
+  pythonImportsCheck = [ "marge" ];
+
+  meta = with lib; {
+    description = "A merge bot for GitLab";
+    homepage = "https://gitlab.com/marge-org/marge-bot";
+    changelog = "https://gitlab.com/marge-org/marge-bot/-/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ bcdarwin ];
+    mainProgram = "marge.app";
+  };
+}


### PR DESCRIPTION
## Description of changes

Init `marge-bot`, a Python application for automating GitLab MR workflows.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
