### PR TITLE
sshd-openpgp-auth: init at 0.3.0

### DIFF
--- a/pkgs/by-name/ss/ssh-openpgp-auth/daemon.nix
+++ b/pkgs/by-name/ss/ssh-openpgp-auth/daemon.nix
@@ -1,0 +1,14 @@
+# Ideally, this file would have been placed in
+# pkgs/by-name/ss/sshd-openpgp-auth/package.nix, but since `./generic.nix` is
+# outside of the directory, the nixpkgs-check-by-name test will fail the CI. So
+# we call this file in all-packages.nix like in the old days.
+{ callPackage }:
+
+callPackage ./generic.nix {
+  pname = "sshd-openpgp-auth";
+  version = "0.3.0";
+  srcHash = "sha256-IV0Nhdqyn12HDOp1jaKz3sKTI3ktFd5b6qybCLWt27I=";
+  cargoHash = "sha256-/+lZkVMeFUMRD7NQ/MHDU5f3rkKDx1kDv5tjA41RExc=";
+  metaDescription =
+    "Command-line tool for creating and managing OpenPGP based trust anchors for SSH host keys";
+}

--- a/pkgs/by-name/ss/ssh-openpgp-auth/generic.nix
+++ b/pkgs/by-name/ss/ssh-openpgp-auth/generic.nix
@@ -1,0 +1,82 @@
+# This file is based upon upstream's package.nix shared among both
+# "ssh-openpgp-auth" and "sshd-openpgpg-auth"
+{ lib
+, rustPlatform
+, fetchFromGitea
+, pkg-config
+, just
+, rust-script
+, installShellFiles
+, bzip2
+, nettle
+, openssl
+, sqlite
+, stdenv
+, darwin
+, openssh
+# Arguments not supplied by callPackage
+, pname , version , srcHash , cargoHash, metaDescription
+}:
+
+rustPlatform.buildRustPackage {
+  inherit pname version;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "wiktor";
+    repo = "ssh-openpgp-auth";
+    # See also: https://codeberg.org/wiktor/ssh-openpgp-auth/pulls/92#issuecomment-1635274
+    rev = "${pname}/${version}";
+    hash = srcHash;
+  };
+  buildAndTestSubdir = pname;
+  inherit cargoHash;
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+    just
+    rust-script
+    installShellFiles
+  ];
+  # Otherwise just's build, check and install phases take precedence over
+  # buildRustPackage's phases.
+  dontUseJustBuild = true;
+  dontUseJustCheck = true;
+  dontUseJustInstall = true;
+
+  postInstall = ''
+    export HOME=$(mktemp -d)
+    just generate manpages ${pname} $out/share/man/man1
+    just generate shell_completions ${pname} shell_completions
+    installShellCompletion --cmd ${pname} \
+      --bash shell_completions/${pname}.bash \
+      --fish shell_completions/${pname}.fish \
+      --zsh  shell_completions/_${pname}
+  '';
+
+
+  buildInputs = [
+    nettle
+    openssl
+    sqlite
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk_11_0.frameworks.CoreFoundation
+    darwin.apple_sdk_11_0.frameworks.IOKit
+    darwin.apple_sdk_11_0.frameworks.Security
+    darwin.apple_sdk_11_0.frameworks.SystemConfiguration
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    openssh
+  ];
+
+  meta = with lib; {
+    description = metaDescription;
+    homepage = "https://codeberg.org/wiktor/ssh-openpgp-auth";
+    license = with licenses; [ mit /* or */ asl20 ];
+    maintainers = with maintainers; [ doronbehar ];
+    mainProgram = pname;
+  };
+}

--- a/pkgs/by-name/ss/ssh-openpgp-auth/package.nix
+++ b/pkgs/by-name/ss/ssh-openpgp-auth/package.nix
@@ -1,0 +1,10 @@
+{ callPackage }:
+
+callPackage ./generic.nix {
+  pname = "ssh-openpgp-auth";
+  version = "0.2.2";
+  srcHash = "sha256-5ew6jT6Zr54QYaWFQIGYXd8sqC3yHHZjPfoaCossm8o=";
+  cargoHash = "sha256-/k/XAp7PHIJaJWf4Oa1JC1mMSR5pyeM4SSPCcr77cAg=";
+  metaDescription =
+    "Command-line tool that provides client-side functionality to transparently verify the identity of remote SSH hosts";
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11643,6 +11643,8 @@ with pkgs;
 
   ssh-copy-id = callPackage ../tools/networking/openssh/copyid.nix { };
 
+  sshd-openpgp-auth = callPackage ../by-name/ss/ssh-openpgp-auth/daemon.nix { };
+
   opensp = callPackage ../tools/text/sgml/opensp { };
 
   opentofu = callPackage ../applications/networking/cluster/opentofu { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
