### PR TITLE
Lomiri shell package, modules & tests: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -74,6 +74,8 @@ Use `services.pipewire.extraConfig` or `services.pipewire.configPackages` for Pi
 
 - Plasma 6 is now available and can be installed with `services.xserver.desktopManager.plasma6.enable = true;`. Plasma 5 will likely be deprecated in the next release (24.11). Note that Plasma 6 runs as Wayland by default, and the X11 session needs to be explicitly selected if necessary.
 
+- The desktop mode of Lomiri (formerly known as Unity8), using Mir 2.x to function as a Wayland compositor, is now available and can be installed with `services.desktopManager.lomiri.enable = true`. Note that some core applications, services and indicators have yet to be packaged, and some functions may remain incomplete, but the base experience should be there.
+
 ## New Services {#sec-release-24.05-new-services}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -1,0 +1,165 @@
+{ config, pkgs, lib, ... }:
+
+let
+  cfg = config.services.desktopManager.lomiri;
+in {
+  options.services.desktopManager.lomiri = {
+    enable = lib.mkEnableOption ''
+      the Lomiri graphical shell (formerly known as Unity8)
+    '';
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment = {
+      systemPackages = (with pkgs; [
+        glib # XDG MIME-related tools identify it as GNOME, add gio for MIME identification to work
+        libayatana-common
+        ubports-click
+      ]) ++ (with pkgs.lomiri; [
+        content-hub
+        hfd-service
+        history-service
+        libusermetrics
+        lomiri
+        lomiri-download-manager
+        lomiri-schemas # exposes some required dbus interfaces
+        lomiri-session # wrappers to properly launch the session
+        lomiri-sounds
+        lomiri-system-settings
+        lomiri-terminal-app
+        lomiri-thumbnailer
+        lomiri-url-dispatcher
+        lomiri-wallpapers
+        mediascanner2 # TODO possibly needs to be kicked off by graphical-session.target
+        morph-browser
+        qtmir # not having its desktop file for Xwayland available causes any X11 application to crash the session
+        suru-icon-theme
+        telephony-service
+      ]);
+    };
+
+    systemd.packages = with pkgs.lomiri; [
+      hfd-service
+      lomiri-download-manager
+    ];
+
+    services.dbus.packages = with pkgs.lomiri; [
+      hfd-service
+      libusermetrics
+      lomiri-download-manager
+    ];
+
+    fonts.packages = with pkgs; [
+      # Applications tend to default to Ubuntu font
+      ubuntu_font_family
+    ];
+
+    # Copy-pasted basic stuff
+    hardware.opengl.enable = lib.mkDefault true;
+    fonts.enableDefaultPackages = lib.mkDefault true;
+    programs.dconf.enable = lib.mkDefault true;
+
+    # Xwayland is partly hardcoded in Mir so it can't really be fully turned off, and it must be on PATH for X11 apps *and Lomiri's web browser* to work.
+    # Until Mir/Lomiri can be properly used without it, force it on so everything behaves as expected.
+    programs.xwayland.enable = lib.mkForce true;
+
+    services.accounts-daemon.enable = true;
+
+    services.ayatana-indicators = {
+      enable = true;
+      packages = (with pkgs; [
+        ayatana-indicator-datetime
+        ayatana-indicator-messages
+        ayatana-indicator-session
+      ]) ++ (with pkgs.lomiri; [
+        telephony-service
+      ]);
+    };
+
+    services.udisks2.enable = true;
+    services.upower.enable = true;
+    services.geoclue2.enable = true;
+
+    services.gnome.evolution-data-server = {
+      enable = true;
+      plugins = with pkgs; [
+        # TODO: lomiri.address-book-service
+      ];
+    };
+
+    services.telepathy.enable = true;
+
+    services.displayManager = {
+      defaultSession = lib.mkDefault "lomiri";
+      sessionPackages = with pkgs.lomiri; [ lomiri-session ];
+    };
+
+    services.xserver = {
+      enable = lib.mkDefault true;
+      displayManager.lightdm = {
+        enable = lib.mkDefault true;
+        greeters.lomiri.enable = lib.mkDefault true;
+      };
+    };
+
+    environment.pathsToLink = [
+      # Configs for inter-app data exchange system
+      "/share/content-hub/peers"
+      # Configs for inter-app URL requests
+      "/share/lomiri-url-dispatcher/urls"
+      # Splash screens & other images for desktop apps launched via lomiri-app-launch
+      "/share/lomiri-app-launch"
+      # TODO Try to get maliit stuff working
+      "/share/maliit/plugins"
+      # Data
+      "/share/locale" # TODO LUITK hardcoded default locale path, fix individual apps to not rely on it
+      "/share/sounds"
+      "/share/wallpapers"
+    ];
+
+    systemd.user.services = {
+      # Unconditionally run service that collects system-installed URL handlers before LUD
+      # TODO also run user-installed one?
+      "lomiri-url-dispatcher-update-system-dir" = {
+        description = "Lomiri URL dispatcher system directory updater";
+        wantedBy = [ "lomiri-url-dispatcher.service" ];
+        before = [ "lomiri-url-dispatcher.service" ];
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = "${pkgs.lomiri.lomiri-url-dispatcher}/libexec/lomiri-url-dispatcher/lomiri-update-directory /run/current-system/sw/share/lomiri-url-dispatcher/urls/";
+        };
+      };
+    };
+
+    systemd.services = {
+      "dbus-com.lomiri.UserMetrics" = {
+        serviceConfig = {
+          Type = "dbus";
+          BusName = "com.lomiri.UserMetrics";
+          User = "usermetrics";
+          StandardOutput = "syslog";
+          SyslogIdentifier = "com.lomiri.UserMetrics";
+          ExecStart = "${pkgs.lomiri.libusermetrics}/libexec/libusermetrics/usermetricsservice";
+        } // lib.optionalAttrs (!config.security.apparmor.enable) {
+          # Due to https://gitlab.com/ubports/development/core/libusermetrics/-/issues/8, auth must be disabled when not using AppArmor, lest the next database usage breaks
+          Environment = "USERMETRICS_NO_AUTH=1";
+        };
+      };
+    };
+
+    users.users.usermetrics = {
+      group = "usermetrics";
+      home = "/var/lib/usermetrics";
+      createHome = true;
+      isSystemUser = true;
+    };
+
+    users.groups.usermetrics = { };
+
+    # TODO content-hub cannot pass files between applications without asking AA for permissions. And alot of the Lomiri stack is designed with AA availability in mind. This might be a requirement to be closer to upstream?
+    # But content-hub currently fails to pass files between applications even with AA enabled, and we can get away without AA in many places. Let's see how this develops before requiring this for good.
+    # security.apparmor.enable = true;
+  };
+
+  meta.maintainers = lib.teams.lomiri.members;
+}

--- a/nixos/modules/services/x11/desktop-managers/default.nix
+++ b/nixos/modules/services/x11/desktop-managers/default.nix
@@ -21,7 +21,7 @@ in
     ./none.nix ./xterm.nix ./phosh.nix ./xfce.nix ./plasma5.nix ../../desktop-managers/plasma6.nix ./lumina.nix
     ./lxqt.nix ./enlightenment.nix ./gnome.nix ./retroarch.nix ./kodi.nix
     ./mate.nix ./pantheon.nix ./surf-display.nix ./cde.nix
-    ./cinnamon.nix ./budgie.nix ./deepin.nix
+    ./cinnamon.nix ./budgie.nix ./deepin.nix ../../desktop-managers/lomiri.nix
   ];
 
   options = {

--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/lomiri.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/lomiri.nix
@@ -1,0 +1,34 @@
+{ config, lib, pkgs, ... }:
+
+let
+
+  dmcfg = config.services.displayManager;
+  ldmcfg = config.services.xserver.displayManager.lightdm;
+  cfg = ldmcfg.greeters.lomiri;
+
+in
+{
+  meta.maintainers = lib.teams.lomiri.members;
+
+  options = {
+    services.xserver.displayManager.lightdm.greeters.lomiri = {
+      enable = lib.mkEnableOption "lomiri's greeter as the lightdm greeter";
+    };
+  };
+
+  config = lib.mkIf (ldmcfg.enable && cfg.enable) {
+    services.xserver.displayManager.lightdm.greeters.gtk.enable = false;
+
+    services.xserver.displayManager.lightdm.greeter = lib.mkDefault {
+      package = pkgs.lomiri.lomiri.greeter;
+      name = "lomiri-greeter";
+    };
+
+    # Greeter needs to be run through its wrapper
+    # Greeter doesn't work with our set-session.py script, need to set default user-session
+    services.xserver.displayManager.lightdm.extraSeatDefaults = ''
+      greeter-wrapper = ${lib.getExe' pkgs.lomiri.lomiri "lomiri-greeter-wrapper"}
+      user-session = ${dmcfg.defaultSession}
+    '';
+  };
+}

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -81,6 +81,7 @@ in
     ./lightdm-greeters/mini.nix
     ./lightdm-greeters/enso-os.nix
     ./lightdm-greeters/pantheon.nix
+    ./lightdm-greeters/lomiri.nix
     ./lightdm-greeters/tiny.nix
     ./lightdm-greeters/slick.nix
     ./lightdm-greeters/mobile.nix

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -503,6 +503,7 @@ in {
   lxd = pkgs.recurseIntoAttrs (handleTest ./lxd { inherit handleTestOn; });
   lxd-image-server = handleTest ./lxd-image-server.nix {};
   #logstash = handleTest ./logstash.nix {};
+  lomiri = handleTest ./lomiri.nix {};
   lomiri-system-settings = handleTest ./lomiri-system-settings.nix {};
   lorri = handleTest ./lorri/default.nix {};
   maddy = discoverTests (import ./maddy { inherit handleTest; });

--- a/nixos/tests/lomiri.nix
+++ b/nixos/tests/lomiri.nix
@@ -1,0 +1,281 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: let
+  # Just to make sure everything is the same, need it for OCR & navigating greeter
+  user = "alice";
+  description = "Alice Foobar";
+  password = "foobar";
+in {
+  name = "lomiri";
+
+  meta = {
+    maintainers = lib.teams.lomiri.members;
+  };
+
+  nodes.machine = { config, ... }: {
+    imports = [
+      ./common/user-account.nix
+    ];
+
+    users.users.${user} = {
+      inherit description password;
+    };
+
+    services.desktopManager.lomiri.enable = lib.mkForce true;
+    services.displayManager.defaultSession = lib.mkForce "lomiri";
+
+    fonts.packages = [ pkgs.inconsolata ];
+
+    environment = {
+      # Help with OCR
+      etc."xdg/alacritty/alacritty.yml".text = lib.generators.toYAML { } {
+        font = rec {
+          normal.family = "Inconsolata";
+          bold.family = normal.family;
+          italic.family = normal.family;
+          bold_italic.family = normal.family;
+          size = 16;
+        };
+        colors = rec {
+          primary = {
+            foreground = "0x000000";
+            background = "0xffffff";
+          };
+          normal = {
+            green = primary.foreground;
+          };
+        };
+      };
+
+      variables = {
+        # So we can test what content-hub is working behind the scenes
+        CONTENT_HUB_LOGGING_LEVEL = "2";
+      };
+
+      systemPackages = with pkgs; [
+        # For a convenient way of kicking off content-hub peer collection
+        lomiri.content-hub.examples
+
+        # Forcing alacritty to run as an X11 app when opened from the starter menu
+        (symlinkJoin {
+          name = "x11-${alacritty.name}";
+
+          paths = [ alacritty ];
+
+          nativeBuildInputs = [ makeWrapper ];
+
+          postBuild = ''
+            wrapProgram $out/bin/alacritty \
+              --set WINIT_UNIX_BACKEND x11 \
+              --set WAYLAND_DISPLAY ""
+          '';
+
+          inherit (alacritty) meta;
+        })
+      ];
+    };
+
+    # Help with OCR
+    systemd.tmpfiles.settings = let
+      white = "255, 255, 255";
+      black = "0, 0, 0";
+      colorSection = color: {
+        Color = color;
+        Bold = true;
+        Transparency = false;
+      };
+      terminalColors = pkgs.writeText "customized.colorscheme" (lib.generators.toINI {} {
+        Background = colorSection white;
+        Foreground = colorSection black;
+        Color2 = colorSection black;
+        Color2Intense = colorSection black;
+      });
+      terminalConfig = pkgs.writeText "terminal.ubports.conf" (lib.generators.toINI {} {
+        General = {
+          colorScheme = "customized";
+          fontSize = "16";
+          fontStyle = "Inconsolata";
+        };
+      });
+      confBase = "${config.users.users.${user}.home}/.config";
+      userDirArgs = {
+        mode = "0700";
+        user = user;
+        group = "users";
+      };
+    in {
+      "10-lomiri-test-setup" = {
+        "${confBase}".d = userDirArgs;
+        "${confBase}/terminal.ubports".d = userDirArgs;
+        "${confBase}/terminal.ubports/customized.colorscheme".L.argument = "${terminalColors}";
+        "${confBase}/terminal.ubports/terminal.ubports.conf".L.argument = "${terminalConfig}";
+      };
+    };
+  };
+
+  enableOCR = true;
+
+  testScript = { nodes, ... }: ''
+    def open_starter():
+        """
+        Open the starter, and ensure it's opened.
+        """
+        machine.send_key("meta_l-a")
+        # Look for any of the default apps
+        machine.wait_for_text(r"(Search|System|Settings|Morph|Browser|Terminal|Alacritty)")
+
+    def toggle_maximise():
+        """
+        Send the keybind to maximise the current window.
+        """
+        machine.send_key("ctrl-meta_l-up")
+
+        # For some reason, Lomiri in these VM tests very frequently opens the starter menu a few seconds after sending the above.
+        # Because this isn't 100% reproducible all the time, and there is no command to await when OCR doesn't pick up some text,
+        # the best we can do is send some Escape input after waiting some arbitrary time and hope that it works out fine.
+        machine.sleep(5)
+        machine.send_key("esc")
+        machine.sleep(5)
+
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+
+    # Lomiri in greeter mode should work & be able to start a session
+    with subtest("lomiri greeter works"):
+        machine.wait_for_unit("display-manager.service")
+        # Start page shows current tie
+        machine.wait_for_text(r"(AM|PM)")
+        machine.screenshot("lomiri_greeter_launched")
+
+        # Advance to login part
+        machine.send_key("ret")
+        machine.wait_for_text("${description}")
+        machine.screenshot("lomiri_greeter_login")
+
+        # Login
+        machine.send_chars("${password}\n")
+        # Best way I can think of to differenciate "Lomiri in LightDM greeter mode" from "Lomiri in user shell mode"
+        machine.wait_until_succeeds("pgrep -u ${user} -f 'lomiri --mode=full-shell'")
+
+    # The session should start, and not be stuck in i.e. a crash loop
+    with subtest("lomiri starts"):
+        # Output rendering from Lomiri has started when it starts printing performance diagnostics
+        machine.wait_for_console_text("Last frame took")
+        # Look for datetime's clock, one of the last elements to load
+        machine.wait_for_text(r"(AM|PM)")
+        machine.screenshot("lomiri_launched")
+
+    # Working terminal keybind is good
+    with subtest("terminal keybind works"):
+        machine.send_key("ctrl-alt-t")
+        machine.wait_for_text(r"(${user}|machine)")
+        machine.screenshot("terminal_opens")
+
+        # lomiri-terminal-app has a separate VM test to test its basic functionality
+
+        # for the LSS content-hub test to work reliably, we need to kick off peer collecting
+        machine.send_chars("content-hub-test-importer\n")
+        machine.wait_for_text(r"(/build/source|hub.cpp|handler.cpp|void|virtual|const)") # awaiting log messages from content-hub
+        machine.send_key("ctrl-c")
+
+        machine.send_key("alt-f4")
+
+    # We want the ability to launch applications
+    with subtest("starter menu works"):
+        open_starter()
+        machine.screenshot("starter_opens")
+
+        # Just try the terminal again, we know that it should work
+        machine.send_chars("Terminal\n")
+        machine.wait_for_text(r"(${user}|machine)")
+        machine.send_key("alt-f4")
+
+    # We want support for X11 apps
+    with subtest("xwayland support works"):
+        open_starter()
+        machine.send_chars("Alacritty\n")
+        machine.wait_for_text(r"(${user}|machine)")
+        machine.screenshot("alacritty_opens")
+        machine.send_key("alt-f4")
+
+    # LSS provides DE settings
+    with subtest("system settings open"):
+        open_starter()
+        machine.send_chars("System Settings\n")
+        machine.wait_for_text("Rotation Lock")
+        machine.screenshot("settings_open")
+
+        # lomiri-system-settings has a separate VM test, only test Lomiri-specific content-hub functionalities here
+
+        # Make fullscreen, can't navigate to Background plugin via keyboard unless window has non-phone-like aspect ratio
+        toggle_maximise()
+
+        # Load Background plugin
+        machine.send_key("tab")
+        machine.send_key("tab")
+        machine.send_key("tab")
+        machine.send_key("tab")
+        machine.send_key("tab")
+        machine.send_key("tab")
+        machine.send_key("ret")
+        machine.wait_for_text("Background image")
+
+        # Try to load custom background
+        machine.send_key("shift-tab")
+        machine.send_key("shift-tab")
+        machine.send_key("shift-tab")
+        machine.send_key("shift-tab")
+        machine.send_key("shift-tab")
+        machine.send_key("shift-tab")
+        machine.send_key("ret")
+
+        # Peers should be loaded
+        machine.wait_for_text("Morph") # or Gallery, but Morph is already packaged
+        machine.screenshot("settings_content-hub_peers")
+
+        # Sadly, it doesn't seem possible to actually select a peer and attempt a content-hub data exchange with just the keyboard
+
+        machine.send_key("alt-f4")
+
+    # Morph is how we go online
+    with subtest("morph browser works"):
+        open_starter()
+        machine.send_chars("Morph\n")
+        machine.wait_for_text(r"(Bookmarks|address|site|visited any)")
+        machine.screenshot("morph_open")
+
+        # morph-browser has a separate VM test, there isn't anything new we could test here
+
+        machine.send_key("alt-f4")
+
+    # The ayatana indicators are an important part of the experience, and they hold the only graphical way of exiting the session.
+    # Reaching them via the intended way requires wayland mouse control, but ydotool lacks a module for its daemon:
+    # https://github.com/NixOS/nixpkgs/issues/183659
+    # Luckily, there's a test app that also displays their contents, but it's abit inconsistent. Hopefully this is *good-enough*.
+    with subtest("ayatana indicators work"):
+        open_starter()
+        machine.send_chars("Indicators\n")
+        machine.wait_for_text(r"(Indicators|Client|List|datetime|session)")
+        machine.screenshot("indicators_open")
+
+        # Element tab order within the indicator menus is not fully deterministic
+        # Only check that the indicators are listed & their items load
+
+        with subtest("ayatana indicator datetime works"):
+            # Select ayatana-indicator-datetime
+            machine.send_key("tab")
+            machine.send_key("ret")
+            machine.wait_for_text("Time and Date Settings")
+            machine.screenshot("indicators_timedate")
+
+        machine.send_key("shift-tab")
+        machine.send_key("ret")
+        machine.wait_for_text(r"(Indicators|Client|List|datetime|session)")
+
+        with subtest("ayatana indicator session works"):
+            # Select ayatana-indicator-session
+            machine.send_key("tab")
+            machine.send_key("down")
+            machine.send_key("ret")
+            machine.wait_for_text("Log Out")
+            machine.screenshot("indicators_session")
+  '';
+})

--- a/pkgs/by-name/ay/ayatana-indicator-messages/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-messages/package.nix
@@ -119,6 +119,15 @@ stdenv.mkDerivation (finalAttrs: {
     chmod +w doc/reference/html/*
   '';
 
+  # Indicators that talk to it may issue requests to parse desktop files, which needs binaries in Exec on PATH
+  # messaging_menu_app_set_desktop_id -> g_desktop_app_info_new -...-> g_desktop_app_info_load_from_keyfile -> g_find_program_for_path
+  # When launched via systemd, PATH is very narrow
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --suffix PATH : '/run/current-system/sw/bin'
+    )
+  '';
+
   passthru = {
     ayatana-indicators = [
       "ayatana-indicator-messages"

--- a/pkgs/desktops/lomiri/applications/lomiri-system-settings/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-system-settings/default.nix
@@ -125,6 +125,11 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace plugins/language/{PageComponent,SpellChecking,ThemeValues}.qml plugins/language/onscreenkeyboard-plugin.cpp plugins/sound/PageComponent.qml \
       --replace-fail 'com.lomiri.keyboard.maliit' 'org.maliit.keyboard.maliit'
 
+    # Gets list of available localisations from current system, but later drops any language that doesn't cover LSS
+    # So just give it its own prefix
+    substituteInPlace plugins/language/language-plugin.cpp \
+      --replace-fail '/usr/share/locale' '${placeholder "out"}/share/locale'
+
     # Decide which entries should be visible based on the current system
     substituteInPlace plugins/*/*.settings \
       --replace-warn '/etc' '/run/current-system/sw/etc'

--- a/pkgs/desktops/lomiri/applications/lomiri/9901-lomiri-Disable-Wizard.patch
+++ b/pkgs/desktops/lomiri/applications/lomiri/9901-lomiri-Disable-Wizard.patch
@@ -1,0 +1,30 @@
+From b7757a71bbce18b4718474cab6a7ff7b613f8c86 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Sun, 19 Nov 2023 13:25:55 +0100
+Subject: [PATCH] lomiri: Disable Wizard
+
+NixOS does all of this configuration statically at generation build & setup time. For us this just ends up being series of screens
+re-confirming abunch of things set in your configuration, so pointless.
+---
+ plugins/Wizard/System.cpp | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/plugins/Wizard/System.cpp b/plugins/Wizard/System.cpp
+index aee8184a8..06c867023 100644
+--- a/plugins/Wizard/System.cpp
++++ b/plugins/Wizard/System.cpp
+@@ -69,10 +69,7 @@ bool System::wizardPathExists() {
+ 
+ bool System::wizardEnabled() const
+ {
+-    if (!wizardPathExists()) {
+-        return true;
+-    }
+-    return isUpdate();
++    return false;
+ }
+ 
+ QString System::readCurrentFramework()
+-- 
+2.40.1
+

--- a/pkgs/desktops/lomiri/applications/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri/default.nix
@@ -5,6 +5,7 @@
 , fetchpatch2
 , gitUpdater
 , linkFarm
+, nixosTests
 , ayatana-indicator-datetime
 , bash
 , biometryd
@@ -262,6 +263,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
+    tests.lomiri = nixosTests.lomiri;
     updateScript = gitUpdater { };
     greeter = linkFarm "lomiri-greeter" [{
       path = "${finalAttrs.finalPackage}/share/lightdm/greeters/lomiri-greeter.desktop";

--- a/pkgs/desktops/lomiri/applications/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri/default.nix
@@ -1,0 +1,287 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, fetchpatch
+, fetchpatch2
+, gitUpdater
+, linkFarm
+, ayatana-indicator-datetime
+, bash
+, biometryd
+, boost
+, cmake
+, cmake-extras
+, coreutils
+, dbus
+, dbus-test-runner
+, deviceinfo
+, geonames
+, glib
+, glm
+, gnome-desktop
+, gsettings-qt
+, gtk3
+, hfd-service
+, libevdev
+, libqtdbustest
+, libqtdbusmock
+, libusermetrics
+, libuuid
+, lightdm_qt
+, lomiri-api
+, lomiri-app-launch
+, lomiri-download-manager
+, lomiri-indicator-network
+, lomiri-ui-toolkit
+, lomiri-settings-components
+, lomiri-system-settings-unwrapped
+, lomiri-schemas
+, lomiri-notifications
+, lomiri-thumbnailer
+, maliit-keyboard
+, mir
+, nixos-icons
+, pam
+, pkg-config
+, properties-cpp
+, protobuf
+, python3
+, qmenumodel
+, qtbase
+, qtdeclarative
+, qtmir
+, qtmultimedia
+, qtsvg
+, telephony-service
+, wrapGAppsHook
+, wrapQtAppsHook
+, xwayland
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "lomiri";
+  version = "0.2.1";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lomiri";
+    rev = finalAttrs.version;
+    hash = "sha256-V5Lt870eHgmJ63OF8bTiNFLAFrxdgNihkd7aodSO3v8=";
+  };
+
+  patches = [
+    # Remove when version > 0.2.1
+    (fetchpatch {
+      name = "0001-lomiri-Fix-overwriting-INCLUDE_DIRECTORIES-variable.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri/-/commit/53190bf2f03c8a35491efb26222b8d67ff6caa34.patch";
+      hash = "sha256-sbwqOqpTf5OlEB4NZZZTFNXyKq4rTQAxJ6U8YP/DT5s=";
+    })
+
+    # fetchpatch2 for renames
+    # Use GNUInstallDirs variables better, replace more /usr references
+    # Remove when https://gitlab.com/ubports/development/core/lomiri/-/merge_requests/137 merged & in release
+    (fetchpatch2 {
+      name = "0002-lomiri-Make-less-FHS-assumptions.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri/-/commit/817ae1d8ed927e661fbc006851163ba99c46ae13.patch";
+      hash = "sha256-NLvpzI2MtjKcGrgTn6PbLXSy3/Jg8KxdSvVYO9KYu9g=";
+    })
+
+    # Fix greeter & related settings
+    # These patches are seemingly not submitted upstream yet
+    (fetchpatch {
+      name = "1000-lomiri-QT_IM_MODULE-maliit.patch";
+      url = "https://salsa.debian.org/ubports-team/lomiri/-/raw/ebbe0f3f568bd145bb58a2e47f7112442328a0a5/debian/patches/2003_maliit-not-maliitphablet-as-im-module-namespace.patch";
+      hash = "sha256-5HEMl0x1S9Hb7spxPRgu8OBebmpaLa6zko2uVEYtBmY=";
+    })
+    (fetchpatch {
+      name = "1001-lomiri-QT_QPA_PLATFORM-wayland.patch";
+      url = "https://salsa.debian.org/ubports-team/lomiri/-/raw/ebbe0f3f568bd145bb58a2e47f7112442328a0a5/debian/patches/2004_qt-qpa-platform-is-wayland.patch";
+      hash = "sha256-4C6X2TW+yjZhqYPIcQ3GJeTKbz785i7p/DpT+vX1DSQ=";
+    })
+    (fetchpatch {
+      name = "1002-lomiri-Fix-Lomiri-greeter.patch";
+      url = "https://salsa.debian.org/ubports-team/lomiri/-/raw/ebbe0f3f568bd145bb58a2e47f7112442328a0a5/debian/patches/1008_lomiri-greeter-wayland.patch";
+      excludes = [ "data/lomiri-greeter.desktop.in.in" ]; # conflict with GNUInstallDirs patch
+      hash = "sha256-XSSxf06Su8PMoqYwqevN034b/li8G/cNXjrqOXyhTRg=";
+    })
+    (fetchpatch {
+      name = "1003-lomiri-Hide-launcher-in-greeter-mode.patch";
+      url = "https://salsa.debian.org/ubports-team/lomiri/-/raw/ebbe0f3f568bd145bb58a2e47f7112442328a0a5/debian/patches/0002_qml-shell-hide-and-disallow-launcher-in-greeter-only-mode.patch";
+      hash = "sha256-R0aMlb7N7XACCthML4SQSd0LvbadADfdQJqrYFhmujk=";
+    })
+    (fetchpatch {
+      name = "1004-lomiri-Dont-reset-OSK-setting.patch";
+      url = "https://salsa.debian.org/ubports-team/lomiri/-/raw/ebbe0f3f568bd145bb58a2e47f7112442328a0a5/debian/patches/2005_dont-reset-alwaysShowOsk-to-system-defaults-on-login.patch";
+      hash = "sha256-guq/Ykcq4WcuXxNKO1eA4sJFyGSpZo0gtyFTdeK/GeE=";
+    })
+
+    ./9901-lomiri-Disable-Wizard.patch
+  ];
+
+  postPatch = ''
+    # Part of greeter fix, applies separately due to merge conflicts
+    substituteInPlace data/lomiri-greeter.desktop.in.in \
+      --replace-fail '@CMAKE_INSTALL_FULL_BINDIR@/lomiri-greeter-wrapper @CMAKE_INSTALL_FULL_BINDIR@/lomiri --mode=greeter' '@CMAKE_INSTALL_FULL_BINDIR@/lomiri --mode=greeter' \
+      --replace-fail 'X-LightDM-Session-Type=mir' 'X-LightDM-Session-Type=wayland'
+
+    # Need to replace prefix
+    substituteInPlace data/systemd-user/CMakeLists.txt \
+      --replace-fail 'pkg_get_variable(SYSTEMD_USERUNITDIR systemd systemduserunitdir)' 'pkg_get_variable(SYSTEMD_USERUNITDIR systemd systemduserunitdir DEFINE_VARIABLES prefix=''${CMAKE_INSTALL_PREFIX})'
+
+    # Don't embed full paths into regular desktop files (but do embed them into lightdm greeter one)
+    substituteInPlace data/{indicators-client,lomiri}.desktop.in.in \
+      --replace-fail '@CMAKE_INSTALL_FULL_BINDIR@/' ""
+
+    # Exclude tests that don't compile (Mir headers these relied on were removed in mir 2.9)
+    # fatal error: mirtest/mir/test/doubles/stub_surface.h: No such file or directory
+    substituteInPlace tests/mocks/CMakeLists.txt \
+      --replace-fail 'add_subdirectory(QtMir/Application)' ""
+
+    #substituteInPlace plugins/AccountsService/CMakeLists.txt \
+    #  --replace-fail 'CMAKE_INSTALL_DATADIR' 'CMAKE_INSTALL_FULL_DATADIR'
+
+    # NixOS-ify
+
+    # Use Nix flake instead of Canonical's Ubuntu logo
+    rm qml/Launcher/graphics/home.svg
+    ln -s ${nixos-icons}/share/icons/hicolor/scalable/apps/nix-snowflake-white.svg qml/Launcher/graphics/home.svg
+
+    # Look up default wallpaper in current system
+    substituteInPlace plugins/Utils/constants.cpp \
+      --replace-fail '/usr/share/backgrounds' '/run/current-system/sw/share/wallpapers'
+  '' + lib.optionalString finalAttrs.finalPackage.doCheck ''
+    patchShebangs tests/whitespace/check_whitespace.py
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    glib # populates GSETTINGS_SCHEMAS_PATH
+    pkg-config
+    wrapGAppsHook # XDG_DATA_DIRS wrapper flags for schemas
+    wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    ayatana-indicator-datetime
+    bash
+    boost
+    cmake-extras
+    dbus
+    dbus-test-runner
+    deviceinfo
+    geonames
+    glib
+    glm
+    gnome-desktop
+    gsettings-qt
+    gtk3
+    libevdev
+    libusermetrics
+    libuuid
+    lightdm_qt
+    lomiri-api
+    lomiri-app-launch
+    lomiri-download-manager
+    lomiri-indicator-network
+    lomiri-schemas
+    lomiri-system-settings-unwrapped
+    lomiri-ui-toolkit
+    maliit-keyboard
+    mir
+    pam
+    properties-cpp
+    protobuf
+    qmenumodel
+    qtbase
+    qtdeclarative
+    qtmir
+    qtsvg
+
+    # QML import path
+    biometryd
+    hfd-service
+    lomiri-notifications
+    lomiri-settings-components
+    lomiri-thumbnailer
+    qtmultimedia
+    telephony-service
+  ];
+
+  nativeCheckInputs = [
+    (python3.withPackages (ps: with ps; [
+      python-dbusmock
+    ]))
+  ];
+
+  checkInputs = [
+    libqtdbustest
+    libqtdbusmock
+  ];
+
+  # Need its flags
+  dontWrapGApps = true;
+
+  # Manually calling, to avoid double & unnecessary wrapping
+  dontWrapQtApps = true;
+
+  cmakeFlags = [
+    (lib.cmakeBool "NO_TESTS" (!finalAttrs.finalPackage.doCheck))
+  ];
+
+  postInstall = ''
+    install -Dm755 ../data/lomiri-greeter-wrapper $out/bin/lomiri-greeter-wrapper
+  '';
+
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  preCheck = ''
+    export QT_PLUGIN_PATH=${lib.getBin qtbase}/${qtbase.qtPluginPrefix}
+    export XDG_DATA_DIRS=${libqtdbusmock}/share
+  '';
+
+  preFixup = ''
+    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  postFixup = ''
+    wrapQtApp $out/bin/lomiri
+    wrapQtApp $out/bin/indicators-client
+    wrapQtApp $out/bin/lomiri-mock-indicator-service
+
+    wrapProgram $out/bin/lomiri-greeter-wrapper \
+      --prefix PATH : ${lib.makeBinPath [ coreutils dbus deviceinfo glib ]} \
+      --set LOMIRI_BINARY "$out/bin/lomiri"
+
+    wrapProgram $out/libexec/Xwayland.lomiri \
+      --prefix PATH : ${lib.makeBinPath [ deviceinfo ]}
+
+    wrapProgram $out/libexec/lomiri-systemd-wrapper \
+      --prefix PATH : ${lib.makeBinPath [ dbus ]}
+  '';
+
+  passthru = {
+    updateScript = gitUpdater { };
+    greeter = linkFarm "lomiri-greeter" [{
+      path = "${finalAttrs.finalPackage}/share/lightdm/greeters/lomiri-greeter.desktop";
+      name = "lomiri-greeter.desktop";
+    }];
+  };
+
+  meta = with lib; {
+    description = "Shell of the Lomiri Operating environment";
+    longDescription = ''
+      Shell of the Lomiri Operating environment optimized for touch based human-machine interaction, but also supporting
+      convergence (i.e. switching between tablet/phone and desktop mode).
+
+      Lomiri is the user shell driving Ubuntu Touch based mobile devices.
+    '';
+    homepage = "https://lomiri.com/";
+    changelog = "https://gitlab.com/ubports/development/core/lomiri/-/blob/${finalAttrs.version}/ChangeLog";
+    license = licenses.gpl3Only;
+    mainProgram = "lomiri";
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/desktops/lomiri/data/lomiri-session/default.nix
+++ b/pkgs/desktops/lomiri/data/lomiri-session/default.nix
@@ -1,0 +1,196 @@
+{ stdenvNoCC
+, lib
+, fetchFromGitLab
+, fetchpatch
+, fetchpatch2
+, gitUpdater
+, bash
+, cmake
+, dbus
+, deviceinfo
+, inotify-tools
+, lomiri
+, makeWrapper
+, pkg-config
+, runtimeShell
+, systemd
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "lomiri-session";
+  version = "0.2";
+
+  src = fetchFromGitLab {
+    owner = "ubports";
+    repo = "development/core/lomiri-session";
+    rev = finalAttrs.version;
+    hash = "sha256-1ZpAn1tFtlXIfeejG0TnrJBRjf3tyz7CD+riWo+sd0s=";
+  };
+
+  patches = [
+    # Properly gate of UBtouch-specific code
+    # Otherwise session won't launch, errors out on a removed Mir setting
+    # Remove when version > 0.2
+    (fetchpatch {
+      name = "0001-lomiri-session-Properly-differentiate-between-Ubuntu-Touch-and-Lomiri-Desktop-session.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-session/-/commit/780c19d8b4f18ce24ceb64b8abfae70018579dce.patch";
+      hash = "sha256-eFiagFEpH43WpVGA6xkI1IiQ99HHizonhXYg1wYAhwU=";
+    })
+
+    # Export Lomiri-prefixed stop envvar
+    # Remove when version > 0.2
+    (fetchpatch {
+      name = "0002-lomiri-session-Use-LOMIRI_MIR_EMITS_SIGSTOP.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-session/-/commit/452e38b489b5893aac3481410d708f4397b1fa1c.patch";
+      hash = "sha256-w/kifBLfDm8+CBliVjm4o8JtjaOByHf97XyPhVk6Gho=";
+    })
+
+    # Removes broken first-time wizard check
+    # Remove when version > 0.2
+    (fetchpatch {
+      name = "0003-lomiri-session-Drop-old-wizard-has-run-check.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-session/-/commit/c16ae87d8848f9909850072f7728c03c894b1a47.patch";
+      hash = "sha256-AIwgztFOGwG2zUsaUen/Z3Mes9m7VgbvNKWp/qYp4g4=";
+    })
+
+    # Fix quoting on ps check
+    # Remove when version > 0.2
+    (fetchpatch {
+      name = "0004-lomiri-session-Put-evaluation-of-ps-call-in-quotes.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-session/-/commit/2d7368eae99f07200c814c840636206b9eaa485d.patch";
+      hash = "sha256-6LqurJqi/I+Qw64hWTrvA8uA/EIRZbcS6TRRXK+9s1s=";
+    })
+
+    # Check for Xwayland presense to determine X11 support
+    # Remove when version > 0.2
+    (fetchpatch {
+      name = "0005-lomiri-session-Check-for-Xwayland-presence.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-session/-/commit/707e43d3b1a6200535b7682e63817265a8e4ee7e.patch";
+      hash = "sha256-sI00P31QVF7ZKdwNep2r+0MetNGg/bbrd2YfEzZPLFI=";
+    })
+
+    # Fix systemd service startup things, drop upstart hacks
+    # Remove when https://gitlab.com/ubports/development/core/lomiri-session/-/merge_requests/13 merged & in release
+    (fetchpatch {
+      name = "0100-lomiri-session-Drop-Before-Wants-for-App-Indicator-targets.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-session/-/commit/ccebdc1c47d7411a9cf4ad2e529471fb0403433a.patch";
+      hash = "sha256-vGFvcCjbwcuLrAUIsL5y/QmoOR5i0560LNv01ZT9OOg=";
+    })
+    (fetchpatch {
+      name = "0101-lomiri-session-Start-lal-application-end.target-on-stop-restart.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-session/-/commit/9a945b09feff0c1d2b3203caaf3cec5230481e80.patch";
+      hash = "sha256-1vD+I5YDEh2wF7UDn6ZxPTBRrdUvwWVXt5x5QdkIAkY=";
+    })
+    (fetchpatch {
+      name = "0102-lomiri-session-Drop-manual-Xwayland-start-logic.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-session/-/commit/6aee0d6cfd76ab1904876f4166621f9f6d833056.patch";
+      hash = "sha256-iW/Ko+Xm2ZuJuNE7ATeuMTSHby0fXD+D5nWjX6LLLwU=";
+    })
+    (fetchpatch {
+      name = "0103-lomiri-session-Set-SyslogIdentifier.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-session/-/commit/09d378728685411a04333040279cdaef487dedc8.patch";
+      hash = "sha256-minJSxrn2d0+FBlf7bdN3ddSvsn6YWdeH6ZuCW7qbII=";
+    })
+    (fetchpatch {
+      name = "0104-lomiri-session-Use-LOMIRI_AS_SYSTEMD_UNIT-to-launch-session.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-session/-/commit/9bd2552c2638c139a0abff527fda99f2ef94cc42.patch";
+      hash = "sha256-7ipsGrQRJ98uVSRp2e0U4q3iTuyeUalqZIohbxXpT9k=";
+    })
+    (fetchpatch {
+      name = "0105-lomiri-session-Allow-sd_notify-calls-for-NOTIFY_SOCKET.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-session/-/commit/2157bfc472f2d35e7c81002a924a1f6aa85f7395.patch";
+      hash = "sha256-qtArOG4gysFWGnXbz3KpXEppaZ1PGDQKEGqnJvU6/RE=";
+    })
+    (fetchpatch {
+      name = "0106-lomiri-session-Change-envvar-for-1-time-binary.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-session/-/commit/0cd1dbd30f3d5c6e50bce79146e8511e0ee56153.patch";
+      hash = "sha256-b8/Mrs36JPJE6l6/Dc/PN+zNV8Oq37HOFx+zMQvWPBY=";
+    })
+    (fetchpatch {
+      name = "0107-lomiri-session-Drag-lomiri-process-under-umbrella-of-wrapper-script.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-session/-/commit/d8212b1862924eb283fd1ee7ea390a144d5ee97e.patch";
+      hash = "sha256-UJzV0pYEBBrXSpYxdFoBoMRzPeIQtvtPzDW2/Ljz+uI=";
+    })
+    (fetchpatch {
+      name = "0108-lomiri-session-Dont-hide-exit-code-from-systemd.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-session/-/commit/9ac78d736caa891a4923be8d040fe8224e335215.patch";
+      hash = "sha256-yPg1K0IfaGYKqg9536i9AFCLTcAENlsJNdHjrElSeZ4=";
+    })
+
+    # Don't require a C & C++ compiler, nothing to compile
+    # Remove when https://gitlab.com/ubports/development/core/lomiri-session/-/merge_requests/14 merged & in release
+    (fetchpatch {
+      name = "0200-lomiri-session-Dont-require-a-compiler.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-session/-/commit/6915a5678e09e5dbcb26d29a8e5585d032a19186.patch";
+      hash = "sha256-2SWiOLDLsdTjRHaJcnZe/WKcFMFmHtpZsuj7bQCtB4A=";
+    })
+
+    # Use GNUInstallDirs for install locations, find_program() for locations of used binaries
+    # fetchpatch2 due to renames, need to resolve merge conflict manually in postPatch
+    # Remove when https://gitlab.com/ubports/development/core/lomiri-session/-/merge_requests/15 merged & in release
+    (fetchpatch2 {
+      name = "0201-lomiri-session-Hardcode-less-locations.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-session/-/commit/d5b93ecaf08ba776a79c69e8a9dd05d0b6181947.patch";
+      excludes = [ "systemd/lomiri.service" ];
+      hash = "sha256-BICb6ZwU/sUBzmM4udsOndIgw1A03I/UEG000YvMZ9Y=";
+    })
+  ];
+
+  postPatch = ''
+    # Resolving merge conflict
+    mv systemd/lomiri.service{,.in}
+    substituteInPlace systemd/lomiri.service.in \
+      --replace-fail '/usr/bin/lomiri-session' '@CMAKE_INSTALL_FULL_BINDIR@/lomiri-session' \
+      --replace-fail '/usr/bin/dbus-update-activation-environment' '@DUAE_BIN@'
+
+    substituteInPlace lomiri-session \
+      --replace-fail '/usr/libexec/Xwayland.lomiri' '${lib.getBin lomiri}/libexec/Xwayland.lomiri'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    bash
+    deviceinfo
+    dbus
+    inotify-tools
+    lomiri
+    systemd
+  ];
+
+  cmakeFlags = [
+    # Requires lomiri-system-compositor -> not ported to Mir 2.x yet
+    (lib.cmakeBool "ENABLE_TOUCH_SESSION" false)
+  ];
+
+  postInstall = ''
+    patchShebangs $out/bin/lomiri-session
+    wrapProgram $out/bin/lomiri-session \
+      --prefix PATH : ${lib.makeBinPath [ deviceinfo inotify-tools lomiri ]}
+  '';
+
+  passthru = {
+    providedSessions = [
+      "lomiri"
+      # not packaged/working yet
+      # "lomiri-touch"
+    ];
+    updateScript = gitUpdater { };
+  };
+
+  meta = with lib; {
+    description = "Integrates Lomiri desktop/touch sessions into display / session managers";
+    homepage = "https://gitlab.com/ubports/development/core/lomiri-session";
+    changelog = "https://gitlab.com/ubports/development/core/lomiri-session/-/blob/${finalAttrs.version}/ChangeLog";
+    license = licenses.gpl3Only;
+    mainProgram = "lomiri-session";
+    maintainers = teams.lomiri.members;
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/desktops/lomiri/data/lomiri-session/default.nix
+++ b/pkgs/desktops/lomiri/data/lomiri-session/default.nix
@@ -4,6 +4,7 @@
 , fetchpatch
 , fetchpatch2
 , gitUpdater
+, nixosTests
 , bash
 , cmake
 , dbus
@@ -181,6 +182,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       # not packaged/working yet
       # "lomiri-touch"
     ];
+    tests.lomiri = nixosTests.lomiri;
     updateScript = gitUpdater { };
   };
 

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -8,6 +8,7 @@ let
     inherit (self) callPackage;
   in {
     #### Core Apps
+    lomiri = callPackage ./applications/lomiri { };
     lomiri-system-settings-unwrapped = callPackage ./applications/lomiri-system-settings { };
     lomiri-system-settings-security-privacy = callPackage ./applications/lomiri-system-settings/plugins/lomiri-system-settings-security-privacy.nix { };
     lomiri-system-settings = callPackage ./applications/lomiri-system-settings/wrapper.nix { };

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -17,6 +17,7 @@ let
 
     #### Data
     lomiri-schemas = callPackage ./data/lomiri-schemas { };
+    lomiri-session = callPackage ./data/lomiri-session { };
     lomiri-sounds = callPackage ./data/lomiri-sounds { };
     lomiri-wallpapers = callPackage ./data/lomiri-wallpapers { };
     suru-icon-theme = callPackage ./data/suru-icon-theme { };

--- a/pkgs/desktops/lomiri/development/libusermetrics/2002-Launch-module-created-systemd-service.patch
+++ b/pkgs/desktops/lomiri/development/libusermetrics/2002-Launch-module-created-systemd-service.patch
@@ -1,0 +1,21 @@
+From cf8ba54d22f5ac839004c0d984fb402bde82b527 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Mon, 8 Apr 2024 15:22:55 +0200
+Subject: [PATCH] Launch module-created systemd service
+
+---
+ data/com.lomiri.UserMetrics.service.in | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/data/com.lomiri.UserMetrics.service.in b/data/com.lomiri.UserMetrics.service.in
+index c2e6ae1..212e24f 100644
+--- a/data/com.lomiri.UserMetrics.service.in
++++ b/data/com.lomiri.UserMetrics.service.in
+@@ -3,3 +3,4 @@ Name=com.lomiri.UserMetrics
+ Exec=@CMAKE_INSTALL_FULL_LIBEXECDIR@/libusermetrics/usermetricsservice
+ User=usermetrics
+ StandardOutput=syslog
++SystemdService=dbus-com.lomiri.UserMetrics.service
+-- 
+2.42.0
+

--- a/pkgs/desktops/lomiri/development/libusermetrics/default.nix
+++ b/pkgs/desktops/lomiri/development/libusermetrics/default.nix
@@ -43,6 +43,10 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # Not submitted yet, waiting for decision on how CMake testing should be handled
     ./2001-Remove-custom-check-target.patch
+
+    # Due to https://gitlab.com/ubports/development/core/libusermetrics/-/issues/8, we require knowledge about AppArmor availability at launch time
+    # Custom patch to launch a module-defined service that can handle this
+    ./2002-Launch-module-created-systemd-service.patch
   ];
 
   postPatch = ''
@@ -91,6 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "GSETTINGS_LOCALINSTALL" true)
     (lib.cmakeBool "GSETTINGS_COMPILE" true)
+    (lib.cmakeBool "ENABLE_CLICK" true)
     (lib.cmakeBool "ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
     (lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" (lib.concatStringsSep ";" [
       # Exclude tests

--- a/pkgs/desktops/lomiri/services/content-hub/default.nix
+++ b/pkgs/desktops/lomiri/services/content-hub/default.nix
@@ -161,6 +161,7 @@ stdenv.mkDerivation (finalAttrs: {
       moveToOutput share/applications/$exampleExe.desktop $examples
     done
     moveToOutput share/icons $examples
+    moveToOutput share/content-hub/peers $examples
   '';
 
   postFixup = ''

--- a/pkgs/desktops/lomiri/services/telephony-service/default.nix
+++ b/pkgs/desktops/lomiri/services/telephony-service/default.nix
@@ -176,6 +176,10 @@ stdenv.mkDerivation (finalAttrs: {
       sed -i $out/lib/systemd/user/"$service".service \
         -e '/ofono-setup.service/d'
     done
+
+    # Parses the call & SMS indicator desktop files & tries to find its own executable in PATH
+    wrapProgram $out/bin/telephony-service-indicator \
+      --prefix PATH : "$out/bin"
   '';
 
   passthru = {


### PR DESCRIPTION
## Description of changes

Working towards #99090.

Inits:

- [`lomiri.lomiri`](https://gitlab.com/ubports/development/core/lomiri), the [Lomiri Shell](https://lomiri.com/)
- [`lomiri.lomiri-session`](https://gitlab.com/ubports/development/core/lomiri-session), scripts & data files for starting a Lomiri session
- A module for enabling the Lomiri DE
- A test to check if
  - Lomiri launches
  - Basic app expectations work
  - Basic inter-app behaviour works
  - Ayatana Indicators are usable

And various fixes to Lomiri components, now that a test can be run for them.

<details>
  <summary>Some pictures, after installing it on spare hardware</summary>

![screenshot20240411_134047572](https://github.com/NixOS/nixpkgs/assets/23431373/f16117c6-e8fe-41e8-a7c3-db194949043a)
![screenshot20240411_163943601](https://github.com/NixOS/nixpkgs/assets/23431373/e9841514-e2ee-4427-9866-9dac56766d96)

</details>

Checklist:
- [x] Submit some patches upstream
- [x] Decide if we should disable the first time wizard in general (i'm not sure if it's of much use for us)
  - Decision: Will just patch it out, it mostly just asks the stuff that should be set up by the system config already.
- [x] Decide where the nixos module should be put (there might be an ongoing effort to start moving those outside of `services.xserver`: https://github.com/NixOS/nixpkgs/pull/292141)
  - ~~Decision: For now, `services.xserver.desktopManager.lomiri` is prolly fine. If there's any developments on the linked PR, then I might change it to `services.desktopManager.lomiri` (although we'd also need a display technology agnostic `services.displayManager.lightdm` for the Wayland `services.displayManager.lightdm.greeters.lomiri`).~~
  - Decision: With #291913 merged, names are now `services.desktopManager.lomiri` (no longer implying X11) and `services.xserver.displayManager.lightdm.greeter.lomiri` (`lightdm` is yet to be moved out of `services.xserver`)
- [x] Clean up the module, check what's really necessary, resolve leftover errors
  - Left some TODOs for myself when further stuff gets upstreamed, rest looks fine to me.
- [x] Apparently, Debian got the lomiri greeter working? Check if we can get that working too
  - Got the greeter working
- [x] Release notes entry about Lomiri availability
  - Entry has been written, sprinkling in some details about what it & our state of it is. Not sure if it's too much, happy about feedback on it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
