### PR TITLE
python311Packages.crate: 0.34.0 -> 0.35.2

### DIFF
--- a/pkgs/development/python-modules/crate/default.nix
+++ b/pkgs/development/python-modules/crate/default.nix
@@ -1,9 +1,12 @@
 { lib
 , fetchPypi
 , buildPythonPackage
+, fetchpatch
 , dask
 , urllib3
 , geojson
+, verlib2
+, pueblo
 , pandas
 , pythonOlder
 , sqlalchemy
@@ -13,20 +16,35 @@
 
 buildPythonPackage rec {
   pname = "crate";
-  version = "0.34.0";
+  version = "0.35.2";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-nEWrfCd2MQCcIM6dLkVYc/cWT5wcT/pvYaY2V3wfuto=";
+    hash = "sha256-4hGACtsK71hvcn8L9ggID7zR+umtTwvskBxSHBpLyME=";
   };
+  patches = [
+    # Fix a pandas issue https://github.com/crate/crate-python/commit/db7ba4d0e1f4f4087739a8f9ebe1d71946333979
+    (fetchpatch {
+      url = "https://github.com/crate/crate-python/commit/db7ba4d0e1f4f4087739a8f9ebe1d71946333979.patch";
+      hash = "sha256-20g8T0t5gPMbK6kRJ2bzc4BNbB1Dg4hvngXNUPvxi5I=";
+      name = "python-crate-fix-pandas-error.patch";
+      # Patch doesn't apply due to other changes to these files
+      excludes = [
+        "setup.py"
+        "docs/by-example/sqlalchemy/dataframe.rst"
+      ];
+    })
+  ];
 
   propagatedBuildInputs = [
     urllib3
     sqlalchemy
     geojson
+    verlib2
+    pueblo
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/pueblo/default.nix
+++ b/pkgs/development/python-modules/pueblo/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools
+, versioningit
+, platformdirs
+}:
+
+buildPythonPackage rec {
+  pname = "pueblo";
+  version = "0.0.8";
+  pyproject = true;
+
+  # This tarball doesn't include tests unfortuneatly, and the GitHub tarball
+  # could have been an alternative, but versioningit fails to detect the
+  # version of it correctly, even with setuptools-scm and
+  # SETUPTOOLS_SCM_PRETEND_VERSION = version added. Since this is a pure Python
+  # package, we can rely on upstream to run the tests before releasing, and it
+  # should work for us as well.
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-iM8Ea2ym7ZM0wInkCZ76yUjvOPRF5MVbT4WhpWz70UU=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    versioningit
+  ];
+
+  propagatedBuildInputs = [
+  #  contextlib-chdir
+  #  importlib-metadata
+    platformdirs
+  ];
+
+  pythonImportsCheck = [ "pueblo" ];
+
+  meta = with lib; {
+    description = "Pueblo - a Python toolbox library";
+    homepage = "https://pypi.org/project/pueblo/";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/development/python-modules/verlib2/default.nix
+++ b/pkgs/development/python-modules/verlib2/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools
+, versioningit
+}:
+
+buildPythonPackage rec {
+  pname = "verlib2";
+  version = "0.2.0";
+  pyproject = true;
+
+  # This tarball doesn't include tests unfortuneatly, and the GitHub tarball
+  # could have been an alternative, but versioningit fails to detect the
+  # version of it correctly, even with setuptools-scm and
+  # SETUPTOOLS_SCM_PRETEND_VERSION = version added. Since this is a pure Python
+  # package, we can rely on upstream to run the tests before releasing, and it
+  # should work for us as well.
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-CrlAh8CU4nFjlI36gXyY1itr3QEibM5RiPjMPNaDRbk=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    versioningit
+  ];
+
+  pythonImportsCheck = [ "verlib2" ];
+
+  meta = with lib; {
+    description = "A standalone variant of packaging.version, without anything else";
+    homepage = "https://pypi.org/project/verlib2/";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ doronbehar ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16144,6 +16144,8 @@ self: super: with self; {
 
   verboselogs = callPackage ../development/python-modules/verboselogs { };
 
+  verlib2 = callPackage ../development/python-modules/verlib2 { };
+
   versioneer = callPackage ../development/python-modules/versioneer { };
 
   versionfinder = callPackage ../development/python-modules/versionfinder { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1310,6 +1310,8 @@ self: super: with self; {
 
   paddlepaddle = callPackage ../development/python-modules/paddlepaddle { };
 
+  pueblo = callPackage ../development/python-modules/pueblo { };
+
   pulumi = callPackage ../development/python-modules/pulumi { inherit (pkgs) pulumi; };
 
   pulumi-aws = callPackage ../development/python-modules/pulumi-aws { };


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
