### PR TITLE
linux-rpi: 6.1.63-stable_20231123 -> 6.6.31-stable_20240529;  raspberrypifw: stable_20231123 -> 1.20240529;  raspberrypiWirelessFirmware: unstable-2023-11-15 -> unstable-2024-02-26

### DIFF
--- a/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
@@ -2,22 +2,22 @@
 
 stdenvNoCC.mkDerivation {
   pname = "raspberrypi-wireless-firmware";
-  version = "unstable-2023-11-15";
+  version = "unstable-2024-02-26";
 
   srcs = [
     (fetchFromGitHub {
       name = "bluez-firmware";
       owner = "RPi-Distro";
       repo = "bluez-firmware";
-      rev = "d9d4741caba7314d6500f588b1eaa5ab387a4ff5";
-      hash = "sha256-CjbZ3t3TW/iJ3+t9QKEtM9NdQU7SwcUCDYuTmFEwvhU=";
+      rev = "78d6a07730e2d20c035899521ab67726dc028e1c";
+      hash = "sha256-KakKnOBeWxh0exu44beZ7cbr5ni4RA9vkWYb9sGMb8Q=";
     })
     (fetchFromGitHub {
       name = "firmware-nonfree";
       owner = "RPi-Distro";
       repo = "firmware-nonfree";
-      rev = "88aa085bfa1a4650e1ccd88896f8343c22a24055";
-      hash = "sha256-Yynww79LPPkau4YDSLI6IMOjH64nMpHUdGjnCfIR2+M=";
+      rev = "223ccf3a3ddb11b3ea829749fbbba4d65b380897";
+      hash = "sha256-BGq0+cr+xBRwQM/LqiQuRWuZpQsKM5jfcrNCqWMuVzM=";
     })
   ];
 

--- a/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
@@ -3,16 +3,13 @@
 stdenvNoCC.mkDerivation rec {
   # NOTE: this should be updated with linux_rpi
   pname = "raspberrypi-firmware";
-  # raspberrypi/firmware no longers tag the releases. However, since each commit
-  # on the stable branch corresponds to a tag in raspberrypi/linux repo, we
-  # assume they are cut together.
-  version = "stable_20231123";
+  version = "1.20240529";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "firmware";
-    rev = "524247ac6d8b1f4ddd53730e978a70c76a320bd6";
-    hash = "sha256-rESwkR7pc5MTwIZ8PaMUPXuzxfv+jVpdRp8ijvxHGcg=";
+    rev = version;
+    hash = "sha256-KsCo7ZG6vKstxRyFljZtbQvnDSqiAPdUza32xTY/tlA=";
   };
 
   installPhase = ''

--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -2,8 +2,8 @@
 
 let
   # NOTE: raspberrypifw & raspberryPiWirelessFirmware should be updated with this
-  modDirVersion = "6.1.63";
-  tag = "stable_20231123";
+  modDirVersion = "6.6.31";
+  tag = "stable_20240529";
 in
 lib.overrideDerivation (buildLinux (args // {
   version = "${modDirVersion}-${tag}";
@@ -14,7 +14,7 @@ lib.overrideDerivation (buildLinux (args // {
     owner = "raspberrypi";
     repo = "linux";
     rev = tag;
-    hash = "sha256-4Rc57y70LmRFwDnOD4rHoHGmfxD9zYEAwYm9Wvyb3no=";
+    hash = "sha256-UWUTeCpEN7dlFSQjog6S3HyEWCCnaqiUqV5KxCjYink=";
   };
 
   defconfig = {
@@ -24,32 +24,33 @@ lib.overrideDerivation (buildLinux (args // {
     "4" = "bcm2711_defconfig";
   }.${toString rpiVersion};
 
+  structuredExtraConfig = (args.structuredExtraConfig or {}) // (with lib.kernel; {
+    # Workaround https://github.com/raspberrypi/linux/issues/6198
+    # Needed because NixOS 24.05+ sets DRM_SIMPLEDRM=y which pulls in
+    # DRM_KMS_HELPER=y.
+    BACKLIGHT_CLASS_DEVICE = yes;
+  });
+
   features = {
     efiBootStub = false;
   } // (args.features or {});
 
   kernelPatches = (args.kernelPatches or []) ++ [
-    # Fix "WARNING: unmet direct dependencies detected for MFD_RP1", and
-    # subsequent build failure.
-    # https://github.com/NixOS/nixpkgs/pull/268280#issuecomment-1911839809
-    # https://github.com/raspberrypi/linux/pull/5900
+    # Fix compilation errors due to incomplete patch backport.
+    # https://github.com/raspberrypi/linux/pull/6223
     {
-      name = "drm-rp1-depends-on-instead-of-select-MFD_RP1.patch";
+      name = "gpio-pwm_-_pwm_apply_might_sleep.patch";
       patch = fetchpatch {
-        url = "https://github.com/peat-psuwit/rpi-linux/commit/6de0bb51929cd3ad4fa27b2a421a2af12e6468f5.patch";
-        hash = "sha256-9pHcbgWTiztu48SBaLPVroUnxnXMKeCGt5vEo9V8WGw=";
+        url = "https://github.com/peat-psuwit/rpi-linux/commit/879f34b88c60dd59765caa30576cb5bfb8e73c56.patch";
+        hash = "sha256-HlOkM9EFmlzOebCGoj7lNV5hc0wMjhaBFFZvaRCI0lI=";
       };
     }
 
-    # Fix `ERROR: modpost: missing MODULE_LICENSE() in <...>/bcm2712-iommu.o`
-    # by preventing such code from being built as module.
-    # https://github.com/NixOS/nixpkgs/pull/284035#issuecomment-1913015802
-    # https://github.com/raspberrypi/linux/pull/5910
     {
-      name = "iommu-bcm2712-don-t-allow-building-as-module.patch";
+      name = "ir-rx51_-_pwm_apply_might_sleep.patch";
       patch = fetchpatch {
-        url = "https://github.com/peat-psuwit/rpi-linux/commit/693a5e69bddbcbe1d1b796ebc7581c3597685b1b.patch";
-        hash = "sha256-8BYYQDM5By8cTk48ASYKJhGVQnZBIK4PXtV70UtfS+A=";
+        url = "https://github.com/peat-psuwit/rpi-linux/commit/23431052d2dce8084b72e399fce82b05d86b847f.patch";
+        hash = "sha256-UDX/BJCJG0WVndP/6PbPK+AZsfU3vVxDCrpn1kb1kqE=";
       };
     }
   ];


### PR DESCRIPTION
## Description of changes

- linux-rpi is upgrade from 6.1.63 to 6.6.31. [This forum thread](https://forums.raspberrypi.com/viewtopic.php?t=361116) discuses the jump from 6.1.y to 6.6.y. Additional upstream 6.6.y versions and downstream patches are added since then.
- raspberrypi-firmware are binary blobs which are updated together with linux-rpi. [The latest commit](https://github.com/raspberrypi/firmware/compare/524247ac6d8b1f4ddd53730e978a70c76a320bd6...1.20240529) doesn't seem to do anything more that updating prebuilt kernels, but included here for completeness.
- [bluez-firmware](https://github.com/RPi-Distro/bluez-firmware/compare/d9d4741caba7314d6500f588b1eaa5ab387a4ff5...78d6a07730e2d20c035899521ab67726dc028e1c) and [firmware-nonfree](https://github.com/RPi-Distro/firmware-nonfree/compare/88aa085bfa1a4650e1ccd88896f8343c22a24055...223ccf3a3ddb11b3ea829749fbbba4d65b380897) are updated so that they use a "generic" firmware so that WPA3-SAE works - not sure what that means. Firmware-nonfree also see Debian packaging merge & additional firmware, however since we don't use those we can safely ignore them.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux (cross-compiled, I promised I tested both linux-rpi3 and linux-rpi4 this time)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
