### PR TITLE
home-assistant: migrate to python 3.12

### DIFF
--- a/pkgs/development/python-modules/aiobotocore/default.nix
+++ b/pkgs/development/python-modules/aiobotocore/default.nix
@@ -13,6 +13,7 @@
 , setuptools
 , pytest-asyncio
 , pytestCheckHook
+, pythonAtLeast
 , pythonOlder
 , wrapt
 }:
@@ -96,6 +97,10 @@ buildPythonPackage rec {
     "test_required_config_not_set"
     "test_sso_cred_fetcher_raises_helpful_message_on_unauthorized_exception"
     "test_sso_credential_fetcher_can_fetch_credentials"
+  ] ++ lib.optionals (pythonAtLeast "3.12.") [
+    # AttributeError: 'called_with' is not a valid assertion. Use a spec for the mock if 'called_with' is meant to be an attribute.
+    "test_max_rate_updated_on_success_response"
+    "test_max_rate_cant_exceed_20_percent_max"
   ];
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/python-modules/arcam-fmj/default.nix
+++ b/pkgs/development/python-modules/arcam-fmj/default.nix
@@ -1,5 +1,6 @@
 { lib
 , buildPythonPackage
+, pythonAtLeast
 , pythonOlder
 , fetchFromGitHub
 , aiohttp
@@ -34,6 +35,18 @@ buildPythonPackage rec {
     pytest-aiohttp
     pytest-mock
     pytestCheckHook
+  ];
+
+  disabledTests = lib.optionals (pythonAtLeast "3.12") [
+    # stuck on EpollSelector.poll()
+    "test_power"
+    "test_multiple"
+    "test_invalid_command"
+    "test_state"
+    "test_silent_server_request"
+    "test_silent_server_disconnect"
+    "test_heartbeat"
+    "test_cancellation"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/pyatv/default.nix
+++ b/pkgs/development/python-modules/pyatv/default.nix
@@ -18,6 +18,7 @@
 , pytest-timeout
 , pytestCheckHook
 , pythonRelaxDepsHook
+, pythonAtLeast
 , pythonOlder
 , requests
 , setuptools
@@ -95,6 +96,9 @@ buildPythonPackage rec {
   disabledTests = [
     # https://github.com/postlund/pyatv/issues/2307
     "test_zeroconf_service_published"
+  ] ++ lib.optionals (pythonAtLeast "3.12") [
+    # https://github.com/postlund/pyatv/issues/2365
+    "test_simple_dispatch"
   ] ++ lib.optionals (stdenv.isDarwin) [
     # tests/protocols/raop/test_raop_functional.py::test_stream_retransmission[raop_properties2-2-True] - assert False
     "test_stream_retransmission"

--- a/pkgs/development/python-modules/pykaleidescape/default.nix
+++ b/pkgs/development/python-modules/pykaleidescape/default.nix
@@ -5,6 +5,7 @@
 , fetchFromGitHub
 , pytest-asyncio
 , pytestCheckHook
+, pythonAtLeast
 , pythonOlder
 }:
 
@@ -39,6 +40,10 @@ buildPythonPackage rec {
   disabledTests = [
     # Test requires network access
     "test_resolve_succeeds"
+  ] ++ lib.optionals (pythonAtLeast "3.12") [
+    # stuck in EpollSelector.poll()
+    "test_manual_disconnect"
+    "test_concurrency"
   ];
 
   meta = with lib; {

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -4,7 +4,7 @@
 , fetchFromGitHub
 , fetchPypi
 , fetchpatch
-, python311
+, python312
 , substituteAll
 , ffmpeg-headless
 , inetutils
@@ -375,6 +375,9 @@ let
           inherit version;
           hash = "sha256-6xjnunJoqIC/HM/pLlNOlqs04Dl/KNy8s/wNpPaltr0=";
         };
+        pytestFlagsArray = [
+          "-W" "ignore::DeprecationWarning"
+        ];
       });
 
       voluptuous = super.voluptuous.overridePythonAttrs (oldAttrs: rec {
@@ -444,7 +447,7 @@ let
     })
   ];
 
-  python = python311.override {
+  python = python312.override {
     packageOverrides = lib.composeManyExtensions (defaultOverrides ++ [ packageOverrides ]);
   };
 
@@ -496,6 +499,7 @@ in python.pkgs.buildPythonApplication rec {
 
   pythonRelaxDeps = [
     "attrs"
+    "bcrypt"
     "ciso8601"
     "orjson"
     "pyopenssl"


### PR DESCRIPTION
## Description of changes

Everything is in place for home assistant to run on Python 3.12.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
