### PR TITLE
ut1999: init at 469d

### DIFF
--- a/pkgs/by-name/ut/ut1999/package.nix
+++ b/pkgs/by-name/ut/ut1999/package.nix
@@ -1,0 +1,98 @@
+{ lib, stdenv, requireFile, autoPatchelfHook, fetchurl, makeDesktopItem, copyDesktopItems, imagemagick
+, runCommand, libgcc, wxGTK32, innoextract, libGL, SDL2, openal, libmpg123, libxmp }:
+
+let
+  unpackGog = runCommand "ut1999-gog" {
+    src = requireFile rec {
+      name = "setup_ut_goty_2.0.0.5.exe";
+      sha256 = "00v8jbqhgb1fry7jvr0i3mb5jscc19niigzjc989qrcp9pamghjc";
+      message = ''
+        Unreal Tournament 1999 requires the official GOG package, version 2.0.0.5.
+
+        Once you download the file, run the following command:
+
+        nix-prefetch-url file://\$PWD/${name}
+      '';
+    };
+
+    buildInputs = [ innoextract ];
+  } ''
+    innoextract --extract --exclude-temp "$src"
+    mkdir $out
+    cp -r app/* $out
+  '';
+in stdenv.mkDerivation rec {
+  name = "ut1999";
+  version = "469d";
+  sourceRoot = ".";
+  src = fetchurl {
+    url = "https://github.com/OldUnreal/UnrealTournamentPatches/releases/download/v${version}/OldUnreal-UTPatch${version}-Linux-amd64.tar.bz2";
+    hash = "sha256-aoGzWuakwN/OL4+xUq8WEpd2c1rrNN/DkffI2vDVGjs=";
+  };
+
+  buildInputs = [
+    libgcc
+    wxGTK32
+    SDL2
+    libGL
+    openal
+    libmpg123
+    libxmp
+    stdenv.cc.cc
+  ];
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    autoPatchelfHook
+    imagemagick
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -r ./* $out
+
+    # Remove bundled libraries to use native versions instead
+    rm $out/System64/libmpg123.so* \
+      $out/System64/libopenal.so* \
+      $out/System64/libSDL2* \
+      $out/System64/libxmp.so*
+
+    chmod -R 755 $out
+
+    ln -s ${unpackGog}/Music $out
+    ln -s ${unpackGog}/Sounds $out
+    cp -n ${unpackGog}/Textures/* $out/Textures || true
+    ln -s ${unpackGog}/Maps $out
+    cp -n ${unpackGog}/System/*.{u,int} $out/System || true
+
+    ln -s "$out/System64/ut-bin" "$out/bin/ut1999"
+    ln -s "$out/System64/ucc-bin" "$out/bin/ut1999-ucc"
+
+    convert "${unpackGog}/gfw_high.ico" "ut1999.png"
+    install -D ut1999-5.png "$out/share/icons/hicolor/256x256/apps/ut1999.png"
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "ut1999";
+      desktopName = "Unreal Tournament GOTY (1999)";
+      exec = "ut1999";
+      icon = "ut1999";
+      comment = "Unreal Tournament GOTY (1999) with the OldUnreal patch.";
+      categories = [ "Game" ];
+    })
+  ];
+
+  meta = with lib; {
+    description = "Unreal Tournament GOTY (1999) with the OldUnreal patch.";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ eliandoran ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "ut1999";
+  };
+}


### PR DESCRIPTION
## Description of changes

This introduces the classic game Unreal Tournament 1999 to NixOS. The way it's achieved is heavily inspired by [gog-unreal-tournament-goty](https://aur.archlinux.org/packages/gog-unreal-tournament-goty) from AUR.

The way it works is:

- It downloads the [OldUnreal](https://github.com/OldUnreal/UnrealTournamentPatches) patch.
- It expects the user to provide the GOG version 2.0.0.5 of the game.
- Applies the OldUnreal patch according to the instructions of its README.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
