### PR TITLE
libbacktrace: unstable-2023-11-30 → 0-unstable-2024-03-02

### DIFF
--- a/pkgs/development/libraries/libbacktrace/0001-libbacktrace-avoid-libtool-wrapping-tests.patch
+++ b/pkgs/development/libraries/libbacktrace/0001-libbacktrace-avoid-libtool-wrapping-tests.patch
@@ -1,4 +1,4 @@
-From 1cf6b108882669f1b20c18fb5f2d6dff0fc83296 Mon Sep 17 00:00:00 2001
+From eadfee17e7d3a1c1bb2a0ff8585772b40331ebd7 Mon Sep 17 00:00:00 2001
 From: Jan Tojnar <jtojnar@gmail.com>
 Date: Sat, 24 Dec 2022 15:31:51 +0100
 Subject: [PATCH 1/4] libbacktrace: avoid libtool wrapping tests
@@ -21,7 +21,7 @@ https://autotools.info/libtool/wrappers.html
  1 file changed, 23 insertions(+), 5 deletions(-)
 
 diff --git a/Makefile.am b/Makefile.am
-index c53cbae..6eab991 100644
+index 3d67909..06ccf3f 100644
 --- a/Makefile.am
 +++ b/Makefile.am
 @@ -107,6 +107,8 @@ check_DATA =
@@ -90,7 +90,7 @@ index c53cbae..6eab991 100644
  unittest_LDADD = libbacktrace.la
  
  BUILDTESTS += unittest
-@@ -253,7 +263,7 @@ if HAVE_OBJCOPY_DEBUGLINK
+@@ -254,7 +264,7 @@ if HAVE_OBJCOPY_DEBUGLINK
  
  b2test_SOURCES = $(btest_SOURCES)
  b2test_CFLAGS = $(libbacktrace_TEST_CFLAGS)
@@ -99,7 +99,7 @@ index c53cbae..6eab991 100644
  b2test_LDADD = libbacktrace_elf_for_test.la
  
  check_PROGRAMS += b2test
-@@ -263,7 +273,7 @@ if HAVE_DWZ
+@@ -264,7 +274,7 @@ if HAVE_DWZ
  
  b3test_SOURCES = $(btest_SOURCES)
  b3test_CFLAGS = $(libbacktrace_TEST_CFLAGS)
@@ -108,7 +108,7 @@ index c53cbae..6eab991 100644
  b3test_LDADD = libbacktrace_elf_for_test.la
  
  check_PROGRAMS += b3test
-@@ -276,6 +286,7 @@ endif HAVE_ELF
+@@ -278,6 +288,7 @@ endif HAVE_ELF
  
  btest_SOURCES = btest.c testlib.c
  btest_CFLAGS = $(libbacktrace_TEST_CFLAGS) -O
@@ -116,7 +116,7 @@ index c53cbae..6eab991 100644
  btest_LDADD = libbacktrace.la
  
  BUILDTESTS += btest
-@@ -330,6 +341,7 @@ endif HAVE_DWZ
+@@ -332,6 +343,7 @@ endif HAVE_DWZ
  
  stest_SOURCES = stest.c
  stest_CFLAGS = $(libbacktrace_TEST_CFLAGS)
@@ -124,7 +124,7 @@ index c53cbae..6eab991 100644
  stest_LDADD = libbacktrace.la
  
  BUILDTESTS += stest
-@@ -352,6 +364,7 @@ if HAVE_ELF
+@@ -354,6 +366,7 @@ if HAVE_ELF
  
  ztest_SOURCES = ztest.c testlib.c
  ztest_CFLAGS = $(libbacktrace_TEST_CFLAGS) -DSRCDIR=\"$(srcdir)\"
@@ -132,7 +132,7 @@ index c53cbae..6eab991 100644
  ztest_LDADD = libbacktrace.la
  ztest_alloc_LDADD = libbacktrace_alloc.la
  
-@@ -371,6 +384,7 @@ BUILDTESTS += ztest_alloc
+@@ -373,6 +386,7 @@ BUILDTESTS += ztest_alloc
  
  zstdtest_SOURCES = zstdtest.c testlib.c
  zstdtest_CFLAGS = $(libbacktrace_TEST_CFLAGS) -DSRCDIR=\"$(srcdir)\"
@@ -140,7 +140,7 @@ index c53cbae..6eab991 100644
  zstdtest_LDADD = libbacktrace.la
  zstdtest_alloc_LDADD = libbacktrace_alloc.la
  
-@@ -392,6 +406,7 @@ endif HAVE_ELF
+@@ -394,6 +408,7 @@ endif HAVE_ELF
  
  edtest_SOURCES = edtest.c edtest2_build.c testlib.c
  edtest_CFLAGS = $(libbacktrace_TEST_CFLAGS)
@@ -148,7 +148,7 @@ index c53cbae..6eab991 100644
  edtest_LDADD = libbacktrace.la
  
  BUILDTESTS += edtest
-@@ -422,6 +437,7 @@ BUILDTESTS += ttest
+@@ -424,6 +439,7 @@ BUILDTESTS += ttest
  
  ttest_SOURCES = ttest.c testlib.c
  ttest_CFLAGS = $(libbacktrace_TEST_CFLAGS) -pthread
@@ -156,7 +156,7 @@ index c53cbae..6eab991 100644
  ttest_LDADD = libbacktrace.la
  
  if USE_DSYMUTIL
-@@ -460,12 +476,12 @@ if HAVE_COMPRESSED_DEBUG
+@@ -472,12 +488,12 @@ if HAVE_COMPRESSED_DEBUG
  
  ctestg_SOURCES = btest.c testlib.c
  ctestg_CFLAGS = $(libbacktrace_TEST_CFLAGS)
@@ -171,7 +171,7 @@ index c53cbae..6eab991 100644
  ctesta_LDADD = libbacktrace.la
  
  BUILDTESTS += ctestg ctesta
-@@ -474,7 +490,7 @@ if HAVE_COMPRESSED_DEBUG_ZSTD
+@@ -486,7 +502,7 @@ if HAVE_COMPRESSED_DEBUG_ZSTD
  
  ctestzstd_SOURCES = btest.c testlib.c
  ctestzstd_CFLAGS = $(libbacktrace_TEST_CFLAGS)
@@ -180,7 +180,7 @@ index c53cbae..6eab991 100644
  ctestzstd_LDADD = libbacktrace.la
  
  BUILDTESTS += ctestzstd
-@@ -521,6 +537,7 @@ endif
+@@ -533,6 +549,7 @@ endif
  
  mtest_SOURCES = mtest.c testlib.c
  mtest_CFLAGS = $(libbacktrace_TEST_CFLAGS) -O
@@ -188,7 +188,7 @@ index c53cbae..6eab991 100644
  mtest_LDADD = libbacktrace.la
  
  BUILDTESTS += mtest
-@@ -553,6 +570,7 @@ if HAVE_ELF
+@@ -565,6 +582,7 @@ if HAVE_ELF
  
  xztest_SOURCES = xztest.c testlib.c
  xztest_CFLAGS = $(libbacktrace_TEST_CFLAGS) -DSRCDIR=\"$(srcdir)\"
@@ -197,5 +197,5 @@ index c53cbae..6eab991 100644
  
  xztest_alloc_SOURCES = $(xztest_SOURCES)
 -- 
-2.38.1
+2.43.1
 

--- a/pkgs/development/libraries/libbacktrace/0002-libbacktrace-Allow-configuring-debug-dir.patch
+++ b/pkgs/development/libraries/libbacktrace/0002-libbacktrace-Allow-configuring-debug-dir.patch
@@ -1,4 +1,4 @@
-From f409ee343fe6cdc059bb411746f27a515aec66a8 Mon Sep 17 00:00:00 2001
+From 2ceaa9bc8a9a0c8a02806a92e19bd21b3fccf3a0 Mon Sep 17 00:00:00 2001
 From: Jan Tojnar <jtojnar@gmail.com>
 Date: Sat, 24 Dec 2022 16:46:18 +0100
 Subject: [PATCH 2/4] libbacktrace: Allow configuring debug dir
@@ -14,13 +14,13 @@ the path can be changed. The same flag is supported by gdb:
 
 https://github.com/bminor/binutils-gdb/blob/095f84c7e3cf85cd68c657c46b80be078f336bc9/gdb/configure.ac#L113-L115
 ---
- Makefile.am  | 11 ++++++-----
+ Makefile.am  | 13 +++++++------
  configure.ac |  8 ++++++++
  elf.c        |  4 ++--
- 3 files changed, 16 insertions(+), 7 deletions(-)
+ 3 files changed, 17 insertions(+), 8 deletions(-)
 
 diff --git a/Makefile.am b/Makefile.am
-index 6eab991..da443c1 100644
+index 06ccf3f..6304faa 100644
 --- a/Makefile.am
 +++ b/Makefile.am
 @@ -33,7 +33,8 @@ ACLOCAL_AMFLAGS = -I config
@@ -53,7 +53,7 @@ index 6eab991..da443c1 100644
  	$(SED) "s%$$SEARCH%$$REPLACE%" \
  		$< \
  		> $@.tmp
-@@ -468,7 +469,7 @@ endif HAVE_OBJCOPY_DEBUGLINK
+@@ -474,13 +475,13 @@ endif HAVE_OBJCOPY_DEBUGLINK
  
  %_buildid: %
  	./install-debuginfo-for-buildid.sh \
@@ -62,8 +62,15 @@ index 6eab991..da443c1 100644
  	  $<
  	$(OBJCOPY) --strip-debug $< $@
  
+ %_buildidfull: %
+ 	./install-debuginfo-for-buildid.sh \
+-	  "$(TEST_BUILD_ID_DIR)" \
++	  "$(TEST_DEBUG_DIR)/.build-id" \
+ 	  $<
+ 	$(OBJCOPY) --strip-all $< $@
+ 
 diff --git a/configure.ac b/configure.ac
-index 7f122cb..bb590ab 100644
+index 69304ea..aeb2ee9 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -67,6 +67,14 @@ AM_MAINTAINER_MODE
@@ -82,7 +89,7 @@ index 7f122cb..bb590ab 100644
  # the wrong, non-multilib-adjusted value will be used in multilibs.
  # As a side effect, we have to subst CFLAGS ourselves.
 diff --git a/elf.c b/elf.c
-index e82ecc5..8b1189c 100644
+index 3ef07bb..21fbe4f 100644
 --- a/elf.c
 +++ b/elf.c
 @@ -856,7 +856,7 @@ elf_readlink (struct backtrace_state *state, const char *filename,
@@ -104,5 +111,5 @@ index e82ecc5..8b1189c 100644
    const char * const suffix = ".debug";
    const size_t suffix_len = strlen (suffix);
 -- 
-2.38.1
+2.43.1
 

--- a/pkgs/development/libraries/libbacktrace/0003-libbacktrace-Support-multiple-build-id-directories.patch
+++ b/pkgs/development/libraries/libbacktrace/0003-libbacktrace-Support-multiple-build-id-directories.patch
@@ -1,4 +1,4 @@
-From de122af5382d8017cae63bdee946206c6c6c23ab Mon Sep 17 00:00:00 2001
+From 47c3503938c863d55c835463d8815b5fa4ab8326 Mon Sep 17 00:00:00 2001
 From: Jan Tojnar <jtojnar@gmail.com>
 Date: Sat, 24 Dec 2022 20:19:27 +0100
 Subject: [PATCH 3/4] libbacktrace: Support multiple build id directories
@@ -16,7 +16,7 @@ to debug data installed using distribution’s package manager.
  1 file changed, 36 insertions(+), 21 deletions(-)
 
 diff --git a/elf.c b/elf.c
-index 8b1189c..65c647a 100644
+index 21fbe4f..ccffa95 100644
 --- a/elf.c
 +++ b/elf.c
 @@ -865,12 +865,12 @@ elf_readlink (struct backtrace_state *state, const char *filename,
@@ -34,7 +34,7 @@ index 8b1189c..65c647a 100644
    const size_t prefix_len = strlen (prefix);
    const char * const suffix = ".debug";
    const size_t suffix_len = strlen (suffix);
-@@ -6936,27 +6936,42 @@ elf_add (struct backtrace_state *state, const char *filename, int descriptor,
+@@ -6947,27 +6947,42 @@ elf_add (struct backtrace_state *state, const char *filename, int descriptor,
    if (buildid_data != NULL)
      {
        int d;
@@ -53,9 +53,9 @@ index 8b1189c..65c647a 100644
 -	    elf_release_view (state, &debuglink_view, error_callback, data);
 -	  if (debugaltlink_view_valid)
 -	    elf_release_view (state, &debugaltlink_view, error_callback, data);
--	  ret = elf_add (state, "", d, NULL, 0, base_address, error_callback,
--			 data, fileline_fn, found_sym, found_dwarf, NULL, 0,
--			 1, NULL, 0);
+-	  ret = elf_add (state, "", d, NULL, 0, base_address, opd,
+-			 error_callback, data, fileline_fn, found_sym,
+-			 found_dwarf, NULL, 0, 1, NULL, 0);
 -	  if (ret < 0)
 -	    backtrace_close (d, error_callback, data);
 -	  else if (descriptor >= 0)
@@ -81,9 +81,9 @@ index 8b1189c..65c647a 100644
 +              elf_release_view (state, &debuglink_view, error_callback, data);
 +            if (debugaltlink_view_valid)
 +              elf_release_view (state, &debugaltlink_view, error_callback, data);
-+            ret = elf_add (state, "", d, NULL, 0, base_address, error_callback,
-+                           data, fileline_fn, found_sym, found_dwarf, NULL, 0,
-+                           1, NULL, 0);
++            ret = elf_add (state, "", d, NULL, 0, base_address, opd,
++                           error_callback, data, fileline_fn, found_sym,
++                           found_dwarf, NULL, 0, 1, NULL, 0);
 +            if (ret < 0)
 +              backtrace_close (d, error_callback, data);
 +            else if (descriptor >= 0)
@@ -97,5 +97,5 @@ index 8b1189c..65c647a 100644
  
    if (buildid_view_valid)
 -- 
-2.38.1
+2.43.1
 

--- a/pkgs/development/libraries/libbacktrace/0004-libbacktrace-Support-NIX_DEBUG_INFO_DIRS-environment.patch
+++ b/pkgs/development/libraries/libbacktrace/0004-libbacktrace-Support-NIX_DEBUG_INFO_DIRS-environment.patch
@@ -1,4 +1,4 @@
-From a3b7510e4c9e7201a4301f2a45d8569b06354607 Mon Sep 17 00:00:00 2001
+From 884ef7c843be906d62e4240c2a0e885dcd5a5726 Mon Sep 17 00:00:00 2001
 From: Jan Tojnar <jtojnar@gmail.com>
 Date: Sat, 24 Dec 2022 20:30:22 +0100
 Subject: [PATCH 4/4] libbacktrace: Support NIX_DEBUG_INFO_DIRS environment
@@ -13,10 +13,10 @@ Let’s make debug data lookup work on NixOS just like in gdb.
  1 file changed, 9 insertions(+), 2 deletions(-)
 
 diff --git a/elf.c b/elf.c
-index 65c647a..5c8abc0 100644
+index ccffa95..e86950d 100644
 --- a/elf.c
 +++ b/elf.c
-@@ -6935,11 +6935,18 @@ elf_add (struct backtrace_state *state, const char *filename, int descriptor,
+@@ -6946,11 +6946,18 @@ elf_add (struct backtrace_state *state, const char *filename, int descriptor,
  
    if (buildid_data != NULL)
      {
@@ -38,5 +38,5 @@ index 65c647a..5c8abc0 100644
        debug_dir = strtok (debug_directories, ":");
        while (debug_dir != NULL)
 -- 
-2.38.1
+2.43.1
 

--- a/pkgs/development/libraries/libbacktrace/default.nix
+++ b/pkgs/development/libraries/libbacktrace/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation {
   pname = "libbacktrace";
-  version = "unstable-2023-11-30";
+  version = "0-unstable-2024-03-02";
 
   src = fetchFromGitHub {
     owner = "ianlancetaylor";
     repo = "libbacktrace";
-    rev = "14818b7783eeb9a56c3f0fca78cefd3143f8c5f6";
-    sha256 = "DQZQsqzeQ/0v87bfqs6sXqS2M5Tunc1OydTWRSB3PCw=";
+    rev = "28824f2cc9069e3fdc39d3702acdf753e35c41b4";
+    sha256 = "1k1O1GT22hZAWPF8NYP0y4qe+e3pGfzT9Mz2TH+H/v4=";
   };
 
   patches = [
@@ -40,10 +40,6 @@ stdenv.mkDerivation {
     (lib.enableFeature enableStatic "static")
     (lib.enableFeature enableShared "shared")
   ];
-
-  # Workaround upstream testsuite failure in multithreaded setup:
-  #   https://github.com/ianlancetaylor/libbacktrace/issues/118#issuecomment-1974850483
-  env.XZ_OPT = "--threads=1";
 
   doCheck = stdenv.isLinux && !stdenv.hostPlatform.isMusl;
 


### PR DESCRIPTION
## Description of changes

https://github.com/ianlancetaylor/libbacktrace/compare/14818b7783eeb9a56c3f0fca78cefd3143f8c5f6...28824f2cc9069e3fdc39d3702acdf753e35c41b4

Follow up to https://github.com/NixOS/nixpkgs/pull/292828#

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
