### PR TITLE
gitignore: ignore tags file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ outputs/
 result-*
 result
 repl-result-*
+tags
 !pkgs/development/python-modules/result
 /doc/NEWS.html
 /doc/NEWS.txt


### PR DESCRIPTION
## Description of changes

It's super useful using `nix-doc tags .` to [generate tags for nixpkgs](https://jade.fyi/blog/finding-functions-in-nixpkgs/), but these should never be checked in. Let's encode that in `.gitignore`.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
