### PR TITLE
lv2lint: fix build and update to libelf

### DIFF
--- a/pkgs/applications/audio/lv2lint/default.nix
+++ b/pkgs/applications/audio/lv2lint/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.16.2";
 
   src = fetchFromSourcehut {
-    domain = "git.open-music-kontrollers.ch";
+    domain = "open-music-kontrollers.ch";
     owner = "~hp";
     repo = "lv2lint";
     rev = finalAttrs.version;

--- a/pkgs/applications/audio/lv2lint/default.nix
+++ b/pkgs/applications/audio/lv2lint/default.nix
@@ -1,23 +1,33 @@
-{ stdenv, lib, fetchurl, pkg-config, meson, ninja, lv2, lilv, curl, libelf }:
+{ stdenv, lib, fetchFromSourcehut, pkg-config, meson, ninja, lv2, lilv, curl, elfutils, xorg }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lv2lint";
   version = "0.16.2";
 
-  src = fetchurl {
-    url = "https://git.open-music-kontrollers.ch/lv2/${pname}/snapshot/${pname}-${version}.tar.xz";
-    sha256 = "sha256-sjgQVx8uGNPWcUwKzGUhChpfzXj/8D8cggVTpcHEXPQ=";
+  src = fetchFromSourcehut {
+    domain = "git.open-music-kontrollers.ch";
+    owner = "~hp";
+    repo = "lv2lint";
+    rev = finalAttrs.version;
+    hash = "sha256-NkzbKteLZ+P+Py+CMOYYipvu6psDslWnM1MAV1XB0TM=";
   };
 
   nativeBuildInputs = [ pkg-config meson ninja ];
-  buildInputs = [ lv2 lilv curl libelf ];
+
+  buildInputs = [ lv2 lilv curl elfutils xorg.libX11 ];
+
+  mesonFlags = [
+    (lib.mesonEnable "online-tests" true)
+    (lib.mesonEnable "elf-tests" true)
+    (lib.mesonEnable "x11-tests" true)
+  ];
 
   meta = with lib; {
     description = "Check whether a given LV2 plugin is up to the specification";
-    homepage = "https://open-music-kontrollers.ch/lv2/${pname}:";
+    homepage = "https://git.open-music-kontrollers.ch/~hp/lv2lint";
     license = licenses.artistic2;
     maintainers = [ maintainers.magnetophon ];
-    platforms = platforms.all;
+    platforms = platforms.linux;
     mainProgram = "lv2lint";
   };
-}
+})


### PR DESCRIPTION
## Description of changes

1. The homepage and source had rotted. Update to the new ones.
1. Use the `finalAttrs` pattern instead of `rec`.
1. The package didn't (and to the best of my trying, won't) build on Darwin, so mark it as `platforms = platforms.linux;`
1. The appropriate Meson flags for turning on the possible lint tests weren't set. Set them and enable the features if possible.
1. Switch from using unmaintained `libelf` to `elfutils` (#271473). 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).