### PR TITLE
warp-terminal: added passthru update script

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8171,6 +8171,13 @@
     github = "ilyakooo0";
     githubId = 6209627;
   };
+  imadnyc = {
+    email = "me@imad.nyc";
+    github = "imadnyc";
+    githubId = 113966166;
+    name = "Abdullah Imad";
+    matrix = "@dre:imad.nyc";
+  };
   imalison = {
     email = "IvanMalison@gmail.com";
     github = "colonelpanic8";

--- a/pkgs/by-name/wa/warp-terminal/package.nix
+++ b/pkgs/by-name/wa/warp-terminal/package.nix
@@ -17,13 +17,15 @@
 
 let
 pname = "warp-terminal";
-version = "0.2024.02.20.08.01.stable_01";
+versions = lib.importJSON ./versions.json;
+passthru.updateScript = ./update.sh;
 
 linux = stdenv.mkDerivation (finalAttrs:  {
-  inherit pname version meta;
+  inherit pname meta passthru;
+  inherit (versions.linux) version;
   src = fetchurl {
+    inherit (versions.linux) hash;
     url = "https://releases.warp.dev/stable/v${finalAttrs.version}/warp-terminal-v${finalAttrs.version}-1-x86_64.pkg.tar.zst";
-    hash = "sha256-L8alnqSE4crrDozRfPaAAMkLc+5+8d9XBKd5ddsxmD0=";
   };
 
   sourceRoot = ".";
@@ -65,10 +67,11 @@ linux = stdenv.mkDerivation (finalAttrs:  {
 });
 
 darwin = stdenvNoCC.mkDerivation (finalAttrs: {
-  inherit pname version meta;
+  inherit pname meta passthru;
+  inherit (versions.darwin) version;
   src = fetchurl {
+    inherit (versions.darwin) hash;
     url = "https://releases.warp.dev/stable/v${finalAttrs.version}/Warp.dmg";
-    hash = "sha256-tFtoD8URMFfJ3HRkyKStuDStFkoRIV97y9kV4pbDPro=";
   };
 
   sourceRoot = ".";
@@ -90,7 +93,7 @@ meta = with lib; {
   homepage = "https://www.warp.dev";
   license = licenses.unfree;
   sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-  maintainers = with maintainers; [ emilytrau Enzime ];
+  maintainers = with maintainers; [ emilytrau Enzime imadnyc ];
   platforms = platforms.darwin ++ [ "x86_64-linux" ];
 };
 

--- a/pkgs/by-name/wa/warp-terminal/update.sh
+++ b/pkgs/by-name/wa/warp-terminal/update.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq moreutils nix-prefetch
+#shellcheck shell=bash
+set -eu -o pipefail
+
+dirname="$(dirname "$0")"
+
+err() {
+    echo "$*" >&2
+}
+
+json_get() {
+    jq -r "$1" < "$dirname/versions.json"
+}
+
+json_set() {
+    jq --arg x "$2" "$1 = \$x" < "$dirname/versions.json" | sponge "$dirname/versions.json"
+}
+
+resolve_url() {
+    local pkg sfx url
+    local -i i max_redirects
+    case "$1" in
+        darwin)
+            pkg=macos
+            sfx=dmg
+            ;;
+        linux)
+            pkg=pacman
+            sfx=pkg.tar.zst
+            ;;
+        *)
+            err "Unexpected download type: $1"
+            exit 1
+            ;;
+    esac
+    url="https://app.warp.dev/download?package=${pkg}"
+    ((max_redirects = 15))
+    for ((i = 0; i < max_redirects; i++)); do
+        url=$(curl -s -o /dev/null -w '%{redirect_url}' "${url}")
+        [[ ${url} != *.${sfx} ]] || break
+    done
+    ((i < max_redirects)) || { err "too many redirects"; exit 1; }
+    echo "${url}"
+}
+
+get_version() {
+    echo "$1" | grep -oP -m 1 '(?<=/v)[\d.\w]+(?=/)'
+}
+
+for sys in darwin linux; do
+    url=$(resolve_url ${sys})
+    version=$(get_version "${url}")
+    if [[ ${version} != "$(json_get ".${sys}.version")" ]];
+        then
+            sri=$(nix hash to-sri --type sha256 "$(nix-prefetch-url --type sha256 "${url}")")
+            json_set ".${sys}.version" "${version}"
+            json_set ".${sys}.hash" "${sri}"
+    fi
+done

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,0 +1,10 @@
+{
+  "darwin" : {
+    "hash" : "sha256-tFtoD8URMFfJ3HRkyKStuDStFkoRIV97y9kV4pbDPro=",
+    "version" : "0.2024.02.20.08.01.stable_01"
+  },
+  "linux" : {
+    "hash" : "sha256-L8alnqSE4crrDozRfPaAAMkLc+5+8d9XBKd5ddsxmD0=",
+    "version" : "0.2024.02.20.08.01.stable_01"
+  }
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Finally got around to adding a passthru update script. Here, I manually updated the macOS hash because to my understanding `update-source-version` expects a platform+architecture, but doesn't accept a general platform, which warp does with it's `.dmg` (again, to my understanding, I don't have a mac). I also wanted to add myself as a maintainer of this, but I already have that commit in #291443, and didn't want to duplicate the commit. If this is ready to be merged before that, though, I'll remove that one and add it here. 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
