### PR TITLE
av1an: init at 0.4.2

### DIFF
--- a/pkgs/by-name/av/av1an-unwrapped/package.nix
+++ b/pkgs/by-name/av/av1an-unwrapped/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  ffmpeg,
+  nasm,
+  vapoursynth,
+  libaom,
+  rav1e,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "av1an-unwrapped";
+  version = "0.4.2";
+
+  src = fetchFromGitHub {
+    owner = "master-of-zen";
+    repo = "av1an";
+    rev = version;
+    hash = "sha256-A4/1UdM8N5CHP44PBNB+ZH2Gcl84rcpUBwQRSnubBGc=";
+  };
+
+  cargoHash = "sha256-ahoiCAUREtXgXLNrWVQ2Gc65bWMo4pIJXP9xjnQAlaI=";
+
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+    pkg-config
+    nasm
+  ];
+
+  buildInputs = [
+    ffmpeg
+    vapoursynth
+  ];
+
+  nativeCheckInputs = [
+    libaom
+    rav1e
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Cross-platform command-line encoding framework";
+    longDescription = ''
+      Cross-platform command-line AV1 / VP9 / HEVC / H264 encoding framework with per scene quality encoding.
+      It can increase your encoding speed and improve cpu utilization by running multiple encoder processes in parallel.
+    '';
+    homepage = "https://github.com/master-of-zen/Av1an";
+    changelog = "https://github.com/master-of-zen/Av1an/releases/tag/${src.rev}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ getchoo ];
+    mainProgram = "av1an";
+  };
+}

--- a/pkgs/by-name/av/av1an/package.nix
+++ b/pkgs/by-name/av/av1an/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  symlinkJoin,
+  makeBinaryWrapper,
+  testers,
+  av1an-unwrapped,
+  ffmpeg,
+  python3Packages,
+  libaom,
+  svt-av1,
+  rav1e,
+  libvpx,
+  x264,
+  x265,
+  libvmaf,
+  withAom ? true, # AV1 reference encoder
+  withSvtav1 ? false, # AV1 encoder/decoder (focused on speed and correctness)
+  withRav1e ? false, # AV1 encoder (focused on speed and safety)
+  withVpx ? true, # VP8 & VP9 de/encoding
+  withX264 ? true, # H.264/AVC encoder
+  withX265 ? true, # H.265/HEVC encoder
+  withVmaf ? false, # Perceptual video quality assessment algorithm
+}:
+# av1an requires at least one encoder
+assert lib.assertMsg (lib.elem true [
+  withAom
+  withSvtav1
+  withRav1e
+  withVpx
+  withX264
+  withX265
+]) "At least one encoder is required!";
+symlinkJoin {
+  name = "av1an-${av1an-unwrapped.version}";
+
+  paths = [ av1an-unwrapped ];
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  postBuild =
+    let
+      runtimePrograms =
+        [ (ffmpeg.override { inherit withVmaf; }) ]
+        ++ lib.optional withAom libaom
+        ++ lib.optional withSvtav1 svt-av1
+        ++ lib.optional withRav1e rav1e
+        ++ lib.optional withVpx libvpx
+        ++ lib.optional withX264 x264
+        ++ lib.optional withX265 x265
+        ++ lib.optional withVmaf libvmaf;
+    in
+    ''
+      wrapProgram $out/bin/av1an \
+        --prefix PATH : ${lib.makeBinPath runtimePrograms} \
+        --prefix PYTHONPATH : ${python3Packages.makePythonPath [ python3Packages.vapoursynth ]}
+    '';
+
+  passthru = {
+    # TODO: uncomment when upstream actually bumps CARGO_PKG_VERSION
+    #tests.version = testers.testVersion {
+    #  package = av1an;
+    #  inherit (av1an-unwrapped) version;
+    #};
+  };
+
+  meta = {
+    inherit (av1an-unwrapped.meta)
+      description
+      longDescription
+      homepage
+      changelog
+      license
+      maintainers
+      mainProgram
+      ;
+  };
+}


### PR DESCRIPTION
## Description of changes

[av1an](https://github.com/master-of-zen/Av1an) a cross-platform command-line AV1 / VP9 / HEVC / H264 encoding framework with per scene quality encoding

Fixes #255427

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
