### PR TITLE
ondsel: init at 2024.1.0

### DIFF
--- a/pkgs/applications/graphics/freecad/default.nix
+++ b/pkgs/applications/graphics/freecad/default.nix
@@ -116,6 +116,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-Wno-dev" # turns off warnings which otherwise makes it hard to see what is going on
+    "-DINSTALL_TO_SITEPACKAGES=OFF" # https://github.com/FreeCAD/FreeCAD/pull/11885
     "-DBUILD_FLAT_MESH:BOOL=ON"
     "-DBUILD_QT5=ON"
     "-DSHIBOKEN_INCLUDE_DIR=${shiboken2}/include"

--- a/pkgs/applications/graphics/freecad/ondsel.nix
+++ b/pkgs/applications/graphics/freecad/ondsel.nix
@@ -1,0 +1,43 @@
+{ lib
+, cmake
+, fetchFromGitHub
+, freecad
+, gfortran
+, makeDesktopItem
+, ninja
+, pkg-config
+, yaml-cpp
+}:
+let
+  ondsel = freecad.overrideAttrs (finalAttrs: previousAttrs: {
+
+    pname = "ondsel";
+    version = "2024.1.0";
+
+    src = fetchFromGitHub {
+      owner = "Ondsel-Development";
+      repo = "FreeCAD";
+      rev = finalAttrs.version;
+      hash = "sha256-1Xyj2ta9ukBzP/Be0qivm0nv4/s4GGPwV+O3Ukd/5mE=";
+      fetchSubmodules = true;
+    };
+
+    nativeBuildInputs = previousAttrs.nativeBuildInputs ++ [
+      cmake
+      ninja
+      pkg-config
+      gfortran
+      yaml-cpp
+    ];
+
+    meta = with lib; {
+      # mainProgram = "freecad";
+      homepage = "https://ondsel.com/";
+      description = "General purpose Open Source 3D CAD/MCAD/CAx/CAE/PLM modeler (Fork of FreeCAD)";
+      license = lib.licenses.lgpl2Plus;
+      maintainers = with lib.maintainers; [ viric gebner AndersonTorres pinpox ];
+      platforms = platforms.linux;
+    };
+  });
+in
+ondsel

--- a/pkgs/applications/graphics/freecad/ondsel.nix
+++ b/pkgs/applications/graphics/freecad/ondsel.nix
@@ -30,6 +30,12 @@ let
       yaml-cpp
     ];
 
+    postPatch = ''
+      substituteInPlace src/3rdParty/OndselSolver/OndselSolver.pc.in \
+        --replace-fail "\''${exec_prefix}/@CMAKE_INSTALL_LIBDIR@" "@CMAKE_INSTALL_FULL_LIBDIR@" \
+        --replace-fail "\''${prefix}/@CMAKE_INSTALL_INCLUDEDIR@" "@CMAKE_INSTALL_FULL_INCLUDEDIR@"
+    '';
+
     meta = with lib; {
       # mainProgram = "freecad";
       homepage = "https://ondsel.com/";

--- a/pkgs/applications/graphics/freecad/ondsel.nix
+++ b/pkgs/applications/graphics/freecad/ondsel.nix
@@ -36,6 +36,25 @@ let
         --replace-fail "\''${prefix}/@CMAKE_INSTALL_INCLUDEDIR@" "@CMAKE_INSTALL_FULL_INCLUDEDIR@"
     '';
 
+    postFixup =
+      let
+        feedstock = fetchFromGitHub {
+          owner = "Ondsel-Development";
+          repo = "freecad-feedstock";
+          rev = "386fab80c8aaa3bb1b9454aee8695c959d642bac";
+          hash = "sha256-H5LbcK5iXS+QFhMayvCDSfXk2ulc6BJXWVwv97nPH9o=";
+          fetchSubmodules = true;
+        };
+      in
+      ''
+        cp ${feedstock}/recipe/branding/branding.xml $out/bin
+        cp -r ${feedstock}/recipe/branding $out/share/Gui/Ondsel
+
+        mv $out/share/doc $out
+        ln -s $out/bin/FreeCAD $out/bin/freecad
+        ln -s $out/bin/FreeCADCmd $out/bin/freecadcmd
+      '';
+
     meta = with lib; {
       # mainProgram = "freecad";
       homepage = "https://ondsel.com/";

--- a/pkgs/applications/graphics/freecad/ondsel.nix
+++ b/pkgs/applications/graphics/freecad/ondsel.nix
@@ -7,6 +7,7 @@
 , ninja
 , pkg-config
 , yaml-cpp
+, requests
 }:
 let
   ondsel = freecad.overrideAttrs (finalAttrs: previousAttrs: {
@@ -28,6 +29,7 @@ let
       pkg-config
       gfortran
       yaml-cpp
+      requests
     ];
 
     postPatch = ''

--- a/pkgs/applications/graphics/freecad/ondsel.nix
+++ b/pkgs/applications/graphics/freecad/ondsel.nix
@@ -42,7 +42,7 @@ let
       let
         feedstock = fetchFromGitHub {
           owner = "Ondsel-Development";
-          repo = "freecad-feedstock";
+          repo = "ondsel-es-feedstock";
           rev = "386fab80c8aaa3bb1b9454aee8695c959d642bac";
           hash = "sha256-H5LbcK5iXS+QFhMayvCDSfXk2ulc6BJXWVwv97nPH9o=";
           fetchSubmodules = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31688,6 +31688,8 @@ with pkgs;
       shiboken2;
   };
 
+  ondsel = callPackage ../applications/graphics/freecad/ondsel.nix {};
+
   freedv = callPackage ../applications/radio/freedv {
     inherit (darwin.apple_sdk.frameworks) AppKit AVFoundation Cocoa CoreMedia;
     codec2 = codec2.override {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31685,7 +31685,8 @@ with pkgs;
       python
       pyyaml
       scipy
-      shiboken2;
+      shiboken2
+      requests;
   };
 
   ondsel = callPackage ../applications/graphics/freecad/ondsel.nix {};


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Alternative build for https://github.com/NixOS/nixpkgs/pull/284996
This PR builds ondsel from source instead of using the appimage.

I added the package next to freecad since it is a fork and shares most of its derivation.

Fixes: https://github.com/NixOS/nixpkgs/issues/284524

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
