### PR TITLE
grafana: 10.3.3 -> 10.4.0, explicitly declare subPackages, halve build time, reduce closure size by ~11.5%

### DIFF
--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -32,7 +32,7 @@ let
 in
 buildGoModule rec {
   pname = "grafana";
-  version = "10.3.4";
+  version = "10.4.0";
 
   subPackages = [ "pkg/cmd/grafana" "pkg/cmd/grafana-server" "pkg/cmd/grafana-cli" ];
 
@@ -40,7 +40,7 @@ buildGoModule rec {
     owner = "grafana";
     repo = "grafana";
     rev = "v${version}";
-    hash = "sha256-zogjS8ywNVYF5W2/jCpBXmCu1MEqPbt2e6mCFborP7o=";
+    hash = "sha256-Rp2jGspbmqJFzSbiVy2/5oqQJnAdGG/T+VNBHVsHSwg=";
   };
 
   offlineCache = stdenv.mkDerivation {
@@ -48,7 +48,7 @@ buildGoModule rec {
     inherit src;
     nativeBuildInputs = [
       yarn nodejs cacert
-      jq moreutils
+      jq moreutils python3
     ];
     postPatch = ''
       ${patchAwayGrafanaE2E}
@@ -67,12 +67,12 @@ buildGoModule rec {
     dontInstall = true;
     dontFixup = true;
     outputHashMode = "recursive";
-    outputHash = "sha256-70eMa8E483f/Bz7iy+4Seap1EfIdjD5krnt6W9CUows=";
+    outputHash = "sha256-QdyXSPshzugkDTJoUrJlHNuhPAyR9gae5Cbk8Q8FSl4=";
   };
 
   disallowedRequisites = [ offlineCache ];
 
-  vendorHash = "sha256-PEPk3T/tCfJNZKOn3tL6p8Bnpc5wZMduNeHrv+l8mmU=";
+  vendorHash = "sha256-cNkMVLXp3hPMcW0ilOM0VlrrDX/IsZaze+/6qlTfmRs=";
 
   nativeBuildInputs = [ wire yarn jq moreutils removeReferencesTo python3 ];
 

--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -18,17 +18,6 @@ let
     done
     rm -r packages/grafana-e2e
   '';
-
-  # Injects a `t.Skip()` into a given test since
-  # there's apparently no other way to skip tests here.
-  skipTest = lineOffset: testCase: file:
-    let
-      jumpAndAppend = lib.concatStringsSep ";" (lib.replicate (lineOffset - 1) "n" ++ [ "a" ]);
-    in ''
-      sed -i -e '/${testCase}/{
-      ${jumpAndAppend} t.Skip();
-      }' ${file}
-    '';
 in
 buildGoModule rec {
   pname = "grafana";
@@ -90,35 +79,6 @@ buildGoModule rec {
     GOARCH= CGO_ENABLED=0 go generate ./kinds/gen.go
     GOARCH= CGO_ENABLED=0 go generate ./public/app/plugins/gen.go
     GOARCH= CGO_ENABLED=0 go generate ./pkg/kindsys/report.go
-
-    # Work around `main module (github.com/grafana/grafana) does not contain package github.com/grafana/grafana/pkg/util/xorm`.
-    # Apparently these files confuse the dependency resolution for the go builder implemented here.
-    rm pkg/util/xorm/go.{mod,sum}
-
-    # The testcase makes an API call against grafana.com:
-    #
-    # [...]
-    # grafana> t=2021-12-02T14:24:58+0000 lvl=dbug msg="Failed to get latest.json repo from github.com" logger=update.checker error="Get \"https://raw.githubusercontent.com/grafana/grafana/main/latest.json\": dial tcp: lookup raw.githubusercontent.com on [::1]:53: read udp [::1]:36391->[::1]:53: read: connection refused"
-    # grafana> t=2021-12-02T14:24:58+0000 lvl=dbug msg="Failed to get plugins repo from grafana.com" logger=plugin.manager error="Get \"https://grafana.com/api/plugins/versioncheck?slugIn=&grafanaVersion=\": dial tcp: lookup grafana.com on [::1]:53: read udp [::1]:41796->[::1]:53: read: connection refused"
-    ${skipTest 1 "Request is not forbidden if from an admin" "pkg/tests/api/plugins/api_plugins_test.go"}
-
-    # Skip a flaky test (https://github.com/NixOS/nixpkgs/pull/126928#issuecomment-861424128)
-    ${skipTest 2 "it should change folder successfully and return correct result" "pkg/services/libraryelements/libraryelements_patch_test.go"}
-
-    # Skip flaky tests (https://logs.ofborg.org/?key=nixos/nixpkgs.263185&attempt_id=5b056a17-67a7-4b74-9dc7-888eb1d6c2dd)
-    ${skipTest 1 "TestIntegrationRulerAccess" "pkg/tests/api/alerting/api_alertmanager_test.go"}
-    ${skipTest 1 "TestIntegrationRulePause" "pkg/tests/api/alerting/api_ruler_test.go"}
-
-    # main module (github.com/grafana/grafana) does not contain package github.com/grafana/grafana/scripts/go
-    rm -r scripts/go
-
-    # Requires making API calls against storage.googleapis.com:
-    #
-    # [...]
-    # grafana> 2023/08/24 08:30:23 failed to copy objects, err: Post "https://storage.googleapis.com/upload/storage/v1/b/grafana-testing-repo/o?alt=json&name=test-path%2Fbuild%2FTestCopyLocalDir2194093976%2F001%2Ffile2.txt&prettyPrint=false&projection=full&uploadType=multipart": dial tcp: lookup storage.googleapis.com on [::1]:53: read udp [::1]:36436->[::1]:53: read: connection refused
-    # grafana> panic: test timed out after 10m0s
-    rm pkg/build/gcloud/storage/gsutil_test.go
-
     # Setup node_modules
     export HOME="$(mktemp -d)"
 

--- a/pkgs/servers/monitoring/grafana/default.nix
+++ b/pkgs/servers/monitoring/grafana/default.nix
@@ -34,7 +34,7 @@ buildGoModule rec {
   pname = "grafana";
   version = "10.3.4";
 
-  excludedPackages = [ "alert_webhook_listener" "clean-swagger" "release_publisher" "slow_proxy" "slow_proxy_mac" "macaron" "devenv" "modowners" ];
+  subPackages = [ "pkg/cmd/grafana" "pkg/cmd/grafana-server" "pkg/cmd/grafana-cli" ];
 
   src = fetchFromGitHub {
     owner = "grafana";


### PR DESCRIPTION
## Description of changes
Closes #294020.

The build itself is pretty quick now:

    buildPhase completed in 2 minutes 46 seconds

in contrast to

    buildPhase completed in 5 minutes 22 seconds

before on the same machine (Hetzner AX41 NVMe with AMD Ryzen 5 3600 6-Core Processor and 64GiB RAM).

Downside of that is that no tests are now executed, but I'm inclined to make that sacrifice for now. Especially considering that a fix for that is on the horizon with #284568.

<del>__Note:__ a draft until we have agreed on whether it's OK to ignore the tests (and whether we should proactively remove the test skip code-paths or wait for #284568).</del>
Grafana from this branch works fine and nobody has stepped up so far.

----

Tested on my personal instance and I haven't spotted an issue so far.

This also decreases the runtime closure size from `419.1M` to `371.0M` (~11.5% reduction).
I analyzed this with `diffoscope`. The only file that changed is `bin/grafana`:

```
│ │   --- result/bin/grafana
│ ├── +++ result-old/bin/grafana
│ │ ├── readelf --wide --notes {}
│ │ │ @@ -5,8 +5,8 @@
│ │ │  
│ │ │  Displaying notes found in: .note.ABI-tag
│ │ │    Owner                Data size 	Description
│ │ │    GNU                  0x00000010	NT_GNU_ABI_TAG (ABI version tag)	   OS: Linux, ABI: 3.10.0
│ │ │  
│ │ │  Displaying notes found in: .note.go.buildid
│ │ │    Owner                Data size 	Description
│ │ │ +  Go                   0x00000053	GO BUILDID	  description data: 6a 79 49 37 78 39 63 72 51 52 5f 6d 39 45 6a 51 39 6a 35 45 2f 34 38 65 35 4e 4f 69 57 49 58 6d 74 6d 6b 4d 38 69 64 6a 71 2f 42 69 73 64 78 46 43 46 52 56 6c 66 69 55 63 4b 66 71 37 63 2f 72 47 32 6c 41 33 5f 5a 63 6b 58 38 57 5a 66 54 37 76 65 69 
│ │ │ -  Go                   0x00000053	GO BUILDID	  description data: 6a 79 49 37 78 39 63 72 51 52 5f 6d 39 45 6a 51 39 6a 35 45 2f 34 38 65 35 4e 4f 69 57 49 58 6d 74 6d 6b 4d 38 69 64 6a 71 2f 42 69 73 64 78 46 43 46 52 56 6c 66 69 55 63 4b 66 71 37 63 2f 71 36 38 64 48 79 61 38 4b 32 72 39 70 78 49 77 6b 30 4f 46 
│ │ ├── strings --all --bytes=8 {}
│ │ │ @@ -1,9 +1,9 @@
│ │ │  /nix/store/xmprbk52mlcdsljz66m8yf7cf0xf36n1-glibc-2.38-44/lib/ld-linux-x86-64.so.2
│ │ │ +jyI7x9crQR_m9EjQ9j5E/48e5NOiWIXmtmkM8idjq/BisdxFCFRVlfiUcKfq7c/rG2lA3_ZckX8WZfT7vei
│ │ │ -jyI7x9crQR_m9EjQ9j5E/48e5NOiWIXmtmkM8idjq/BisdxFCFRVlfiUcKfq7c/q68dHya8K2r9pxIwk0OF
│ │ │  __gmon_start__
│ │ │  ftruncate64
│ │ │  getpwuid_r
│ │ │  setreuid
│ │ │  pthread_mutex_lock
│ │ │  localtime
│ │ │  pthread_detach
```

To me this seems like a non-function difference.

Also, the executables `bin/cmd`, `bin/kinds`, `bin/openapi3`, `bin/standalone` are gone now.

* `bin/cmd` seems like a testing tool for a token generator: https://github.com/grafana/grafana/blob/869b89dce45090cd982414479a7e7b3bd7953253/pkg/components/satokengen/cmd/main.go#L33, so should be OK to drop.
* `bin/openapi3` is located in `scripts/` and referenced in upstream's Makefile. I don't expect it to be used in production.
* `bin/standalone` can be one of `pkg/tsdb/azuremonitor/standalone/`, `pkg/tsdb/grafana-testdata-datasource/standalone/` or `pkg/tsdb/parca/standalone/` depending on which is selected first by `getGoDirs`. This seems like a testing thing anyways, but was broken already.
* The only `kinds/*.go` with a `func main` is `kinds/gen.go` which has a `//go:build ignore` at the top, so it doesn't seem needed as well.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
