### PR TITLE
home-assistant-custom-components.tuya-local: init at 2024.2.1

### DIFF
--- a/pkgs/development/python-modules/tinytuya/default.nix
+++ b/pkgs/development/python-modules/tinytuya/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, wheel
+, colorama
+, requests
+, cryptography
+}:
+
+buildPythonPackage rec {
+  pname = "tinytuya";
+  version = "1.13.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jasonacox";
+    repo = "tinytuya";
+    rev = "v${version}";
+    hash = "sha256-3epv2z7WY1VhRLrCjxHkXjcCweJbWIWNRRwMG1xlWaA=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    colorama
+    requests
+    cryptography
+  ];
+
+  pythonImportsCheck = [ "tinytuya" ];
+
+  meta = with lib; {
+    description = "Python API for Tuya WiFi smart devices using a direct local area network (LAN) connection or the cloud (TuyaCloud API";
+    homepage = "https://github.com/jasonacox/tinytuya/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ traxys ];
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -18,5 +18,7 @@
 
   prometheus_sensor = callPackage ./prometheus_sensor {};
 
+  tuya-local = callPackage ./tuya-local {};
+
   waste_collection_schedule = callPackage ./waste_collection_schedule {};
 }

--- a/pkgs/servers/home-assistant/custom-components/tuya-local/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/tuya-local/default.nix
@@ -1,0 +1,29 @@
+{ lib
+, fetchFromGitHub
+, buildHomeAssistantComponent
+, tinytuya
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "make-all";
+  domain = "tuya_local";
+  version = "2024.2.1";
+
+  src = fetchFromGitHub {
+    owner = "make-all";
+    repo = "tuya-local";
+    rev = version;
+    hash = "sha256-mFqx5TlKfyUV1l+2sG3+NxznSwT3MSeFJi+GM3Hgdzw=";
+  };
+
+  propagatedBuildInputs = [
+    tinytuya
+  ];
+
+  meta = with lib; {
+    description = "Local support for Tuya devices in Home Assistant";
+    homepage = "https://github.com/make-all/tuya-local/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ traxys ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14715,6 +14715,8 @@ self: super: with self; {
 
   tinyrecord = callPackage ../development/python-modules/tinyrecord { };
 
+  tinytuya = callPackage ../development/python-modules/tinytuya { };
+
   tissue = callPackage ../development/python-modules/tissue { };
 
   titlecase = callPackage ../development/python-modules/titlecase { };


### PR DESCRIPTION
## Description of changes

While there already exists a component to manage tuya devices (localtuya) both components don't support the same set of devices. In my HA setup I use both of them.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
