### PR TITLE
haskellPackages.reflex-gi-gtk: Fix the build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1785,6 +1785,17 @@ self: super: {
   # https://github.com/obsidiansystems/dependent-sum/issues/55
   dependent-sum = doJailbreak super.dependent-sum;
 
+  # 2024-02-03: Jailbreak because pretty much every dependency has
+  # tight bounds, and disable building the example executable because
+  # it's not compatible with Reflex 0.9 (the library itself is
+  # compatible however).
+  # https://gitlab.com/Kritzefitz/reflex-gi-gtk/-/merge_requests/16
+  reflex-gi-gtk = assert super.reflex-gi-gtk.version == "0.2.0.0";
+    overrideCabal (drv: {
+      jailbreak = true;
+      buildTarget = drv.pname;  # just the library
+    }) super.reflex-gi-gtk;
+
   # 2022-06-19: Disable checks because of https://github.com/reflex-frp/reflex/issues/475
   reflex = doJailbreak (dontCheck super.reflex);
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -4591,7 +4591,6 @@ broken-packages:
   - reflex-dom-retractable # failure in job https://hydra.nixos.org/build/233198362 at 2023-09-02
   - reflex-dom-svg # failure in job https://hydra.nixos.org/build/233193544 at 2023-09-02
   - reflex-external-ref # failure in job https://hydra.nixos.org/build/233215834 at 2023-09-02
-  - reflex-gi-gtk # failure in job https://hydra.nixos.org/build/233213103 at 2023-09-02
   - reflex-gloss # failure in job https://hydra.nixos.org/build/234457448 at 2023-09-13
   - reflex-jsx # failure in job https://hydra.nixos.org/build/233207137 at 2023-09-02
   - reflex-orphans # failure in job https://hydra.nixos.org/build/233249128 at 2023-09-02


### PR DESCRIPTION
This is for merging into the `haskell-updates` branch, PR #279413.

It jailbreaks reflex-gi-gtk and disables building of the example executable.