### PR TITLE
Implement runtime-substitution JSON format

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -75,7 +75,9 @@ let
       info showWarnings nixpkgsVersion version isInOldestRelease
       mod compare splitByAndCompare
       functionArgs setFunctionArgs isFunction toFunction mirrorFunctionArgs
-      toHexString toBaseDigits inPureEvalMode;
+      toHexString toBaseDigits inPureEvalMode
+      stringFromRuntimeFile stringFromSystemdCredential
+    ;
     inherit (self.fixedPoints) fix fix' converge extends composeExtensions
       composeManyExtensions makeExtensible makeExtensibleWithCustomName;
     inherit (self.attrsets) attrByPath hasAttrByPath setAttrByPath

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -546,4 +546,8 @@ in {
       assert (base >= 2);
       assert (i >= 0);
       lib.reverseList (go i);
+
+  /* For use with pkgs.formats.jsonWithRuntimeSubstitution and potentially future other related formats. */
+  stringFromRuntimeFile = path: {_runtimeSource.file = path;};
+  stringFromSystemdCredential = name: {_runtimeSource.systemdCredential = name;};
 }


### PR DESCRIPTION
## Description of changes

This format allows an elegant and robust definition of settings which
are to be read from files or systemd credentials at runtime. Previous
solutions based on envsubst or similar brittle tooling had escaping
problems and no awareness of structured data.

We also apply this new format to make hedgedoc's configuration nicer, as an example.

## Things done

- [x] Built hedgedoc test on x86_64-linux
- [ ] Agree on what to call the formats and functions (the naming is definitely worth discussing)
- [ ] Work out a placement of the lib functions that makes sense (trivial.nix _probably_ isn't the right place?)
- [ ] Write release notes entry to explain the breakage in hedgedoc
- [ ] Write format tests and docs
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).