### PR TITLE
Fixed certipy-ad package CLI

### DIFF
--- a/pkgs/development/python-modules/certipy-ad/default.nix
+++ b/pkgs/development/python-modules/certipy-ad/default.nix
@@ -14,6 +14,7 @@
 , requests
 , requests-ntlm
 , unicrypto
+, setuptools
 }:
 
 buildPythonPackage rec {
@@ -49,6 +50,7 @@ buildPythonPackage rec {
     requests
     requests-ntlm
     unicrypto
+    setuptools
   ];
 
   # Project has no tests


### PR DESCRIPTION
Added `setuptools` in `propagatedBuildInputs`.

## Description of changes

When running `certipy` from the CLI we obtain this error:
```
Traceback (most recent call last):
  File "/nix/store/z3dizn39rrgivb9a93x2k5ldhrhnk1kw-python3.11-certipy-ad-4.8.2/bin/.certipy-wrapped", line 6, in <module>
    from certipy.entry import main
  File "/nix/store/z3dizn39rrgivb9a93x2k5ldhrhnk1kw-python3.11-certipy-ad-4.8.2/lib/python3.11/site-packages/certipy/entry.py", line 6, in <module>
    from certipy import version
  File "/nix/store/z3dizn39rrgivb9a93x2k5ldhrhnk1kw-python3.11-certipy-ad-4.8.2/lib/python3.11/site-packages/certipy/version.py", line 1, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

In order to get rid of this we need to add `setuptools` to `propagatedBuildInputs`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
