### PR TITLE
python311Packages.opentelemetry-api: 1.22.0 -> 1.23.0; python311Packages.opentelemetry-instrumentation: 0.43b0 -> 0.44b0

### DIFF
--- a/pkgs/development/python-modules/chromadb/default.nix
+++ b/pkgs/development/python-modules/chromadb/default.nix
@@ -150,6 +150,8 @@ buildPythonPackage rec {
     "chromadb/test/stress/"
   ];
 
+  __darwinAllowLocalNetworking = true;
+
   meta = with lib; {
     description = "The AI-native open-source embedding database";
     homepage = "https://github.com/chroma-core/chroma";

--- a/pkgs/development/python-modules/opentelemetry-api/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-api/default.nix
@@ -14,30 +14,32 @@
 let
   self = buildPythonPackage rec {
     pname = "opentelemetry-api";
-    version = "1.22.0";
-    disabled = pythonOlder "3.7";
+    version = "1.23.0";
+    pyproject = true;
+
+    disabled = pythonOlder "3.8";
 
     # to avoid breakage, every package in opentelemetry-python must inherit this version, src, and meta
     src = fetchFromGitHub {
       owner = "open-telemetry";
       repo = "opentelemetry-python";
       rev = "refs/tags/v${version}";
-      hash = "sha256-6BmBmooVaH1FOpgXpFlYth0r9XaNtmb9UezeP8hWEok=";
+      hash = "sha256-Ge/DjVG7ajoS0nJLZxtfn4Mmx0SffAE/91dViA5qWAA=";
     };
 
     sourceRoot = "${src.name}/opentelemetry-api";
 
-    format = "pyproject";
-
     nativeBuildInputs = [
-      hatchling
       pythonRelaxDepsHook
     ];
 
-    propagatedBuildInputs = [
+    build-system = [
+      hatchling
+    ];
+
+    dependencies = [
       deprecated
       importlib-metadata
-      setuptools
     ];
 
     pythonRelaxDeps = [

--- a/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-common/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-common/default.nix
@@ -2,10 +2,8 @@
 , buildPythonPackage
 , pythonOlder
 , hatchling
-, backoff
 , opentelemetry-api
 , opentelemetry-proto
-, opentelemetry-sdk
 , opentelemetry-test-utils
 , pytestCheckHook
 }:
@@ -13,19 +11,17 @@
 buildPythonPackage {
   inherit (opentelemetry-api) version src;
   pname = "opentelemetry-exporter-otlp-proto-common";
-  disabled = pythonOlder "3.7";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   sourceRoot = "${opentelemetry-api.src.name}/exporter/opentelemetry-exporter-otlp-proto-common";
 
-  format = "pyproject";
-
-  nativeBuildInputs = [
+  build-system = [
     hatchling
   ];
 
-  propagatedBuildInputs = [
-    backoff
-    opentelemetry-sdk
+  dependencies = [
     opentelemetry-proto
   ];
 

--- a/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-grpc/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-grpc/default.nix
@@ -1,35 +1,37 @@
 { lib
 , buildPythonPackage
 , pythonOlder
-, backoff
+, deprecated
 , googleapis-common-protos
 , grpcio
 , hatchling
 , opentelemetry-api
-, opentelemetry-test-utils
 , opentelemetry-exporter-otlp-proto-common
-, pytest-grpc
+, opentelemetry-proto
+, opentelemetry-test-utils
 , pytestCheckHook
 }:
 
 buildPythonPackage {
   inherit (opentelemetry-api) version src;
   pname = "opentelemetry-exporter-otlp-proto-grpc";
-  disabled = pythonOlder "3.7";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   sourceRoot = "${opentelemetry-api.src.name}/exporter/opentelemetry-exporter-otlp-proto-grpc";
 
-  format = "pyproject";
-
-  nativeBuildInputs = [
+  build-system = [
     hatchling
   ];
 
-  propagatedBuildInputs = [
-    backoff
+  dependencies = [
+    deprecated
     googleapis-common-protos
     grpcio
+    opentelemetry-api
     opentelemetry-exporter-otlp-proto-common
+    opentelemetry-proto
   ];
 
   nativeCheckInputs = [
@@ -42,6 +44,8 @@ buildPythonPackage {
   ];
 
   pythonImportsCheck = [ "opentelemetry.exporter.otlp.proto.grpc" ];
+
+  __darwinAllowLocalNetworking = true;
 
   meta = opentelemetry-api.meta // {
     homepage = "https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter/opentelemetry-exporter-otlp-proto-grpc";

--- a/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-http/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-otlp-proto-http/default.nix
@@ -1,11 +1,13 @@
 { lib
 , buildPythonPackage
 , pythonOlder
-, backoff
+, deprecated
 , googleapis-common-protos
 , hatchling
 , opentelemetry-api
 , opentelemetry-exporter-otlp-proto-common
+, opentelemetry-proto
+, opentelemetry-sdk
 , opentelemetry-test-utils
 , requests
 , responses
@@ -15,20 +17,23 @@
 buildPythonPackage {
   inherit (opentelemetry-api) version src;
   pname = "opentelemetry-exporter-otlp-proto-http";
-  disabled = pythonOlder "3.7";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   sourceRoot = "${opentelemetry-api.src.name}/exporter/opentelemetry-exporter-otlp-proto-http";
 
-  format = "pyproject";
-
-  nativeBuildInputs = [
+  build-system = [
     hatchling
   ];
 
-  propagatedBuildInputs = [
-    backoff
+  dependencies = [
+    deprecated
     googleapis-common-protos
+    opentelemetry-api
     opentelemetry-exporter-otlp-proto-common
+    opentelemetry-proto
+    opentelemetry-sdk
     requests
   ];
 

--- a/pkgs/development/python-modules/opentelemetry-exporter-otlp/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-otlp/default.nix
@@ -1,33 +1,34 @@
 { lib
 , buildPythonPackage
 , pythonOlder
-, backoff
 , hatchling
 , opentelemetry-api
 , opentelemetry-exporter-otlp-proto-grpc
 , opentelemetry-exporter-otlp-proto-http
+, opentelemetry-test-utils
 , pytestCheckHook
 }:
 
 buildPythonPackage {
   inherit (opentelemetry-api) version src;
   pname = "opentelemetry-exporter-otlp";
-  disabled = pythonOlder "3.7";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   sourceRoot = "${opentelemetry-api.src.name}/exporter/opentelemetry-exporter-otlp";
 
-  format = "pyproject";
-
-  nativeBuildInputs = [
+  build-system = [
     hatchling
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     opentelemetry-exporter-otlp-proto-grpc
     opentelemetry-exporter-otlp-proto-http
   ];
 
   nativeCheckInputs = [
+    opentelemetry-test-utils
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/opentelemetry-exporter-prometheus/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-exporter-prometheus/default.nix
@@ -10,19 +10,20 @@
 }:
 
 buildPythonPackage {
-  inherit (opentelemetry-api) version src;
+  inherit (opentelemetry-api) src;
   pname = "opentelemetry-exporter-prometheus";
-  disabled = pythonOlder "3.7";
+  version = "0.44b0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   sourceRoot = "${opentelemetry-api.src.name}/exporter/opentelemetry-exporter-prometheus";
 
-  format = "pyproject";
-
-  nativeBuildInputs = [
+  build-system = [
     hatchling
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     opentelemetry-api
     opentelemetry-sdk
     prometheus-client

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-aiohttp-client/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-aiohttp-client/default.nix
@@ -15,23 +15,23 @@
 buildPythonPackage {
   inherit (opentelemetry-instrumentation) version src;
   pname = "opentelemetry-instrumentation-aiohttp-client";
-  disabled = pythonOlder "3.7";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   sourceRoot = "${opentelemetry-instrumentation.src.name}/instrumentation/opentelemetry-instrumentation-aiohttp-client";
 
-  format = "pyproject";
-
-  nativeBuildInputs = [
+  build-system = [
     hatchling
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
+    aiohttp
     opentelemetry-api
     opentelemetry-instrumentation
     opentelemetry-semantic-conventions
     opentelemetry-util-http
     wrapt
-    aiohttp
   ];
 
   # missing https://github.com/ezequielramos/http-server-mock

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-asgi/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-asgi/default.nix
@@ -14,17 +14,17 @@
 buildPythonPackage {
   inherit (opentelemetry-instrumentation) version src;
   pname = "opentelemetry-instrumentation-asgi";
-  disabled = pythonOlder "3.7";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   sourceRoot = "${opentelemetry-instrumentation.src.name}/instrumentation/opentelemetry-instrumentation-asgi";
 
-  format = "pyproject";
-
-  nativeBuildInputs = [
+  build-system = [
     hatchling
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     asgiref
     opentelemetry-instrumentation
     opentelemetry-api

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-django/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-django/default.nix
@@ -13,33 +13,36 @@
 , pytestCheckHook
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   inherit (opentelemetry-instrumentation) version src;
   pname = "opentelemetry-instrumentation-django";
-  disabled = pythonOlder "3.7";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   sourceRoot = "${opentelemetry-instrumentation.src.name}/instrumentation/opentelemetry-instrumentation-django";
 
-  format = "pyproject";
-
-  nativeBuildInputs = [
+  build-system = [
     hatchling
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     django
     opentelemetry-api
     opentelemetry-instrumentation
-    opentelemetry-instrumentation-asgi
     opentelemetry-instrumentation-wsgi
     opentelemetry-semantic-conventions
     opentelemetry-util-http
   ];
 
+  passthru.optional-dependencies = {
+    asgi = [ opentelemetry-instrumentation-asgi ];
+  };
+
   nativeCheckInputs = [
     opentelemetry-test-utils
     pytestCheckHook
-  ];
+  ] ++ passthru.optional-dependencies.asgi;
 
   pythonImportsCheck = [ "opentelemetry.instrumentation.django" ];
 

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-fastapi/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-fastapi/default.nix
@@ -19,15 +19,15 @@ buildPythonPackage {
   pname = "opentelemetry-instrumentation-fastapi";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   sourceRoot = "${opentelemetry-instrumentation.src.name}/instrumentation/opentelemetry-instrumentation-fastapi";
 
-  nativeBuildInputs = [
+  build-system = [
     hatchling
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     fastapi
     opentelemetry-api
     opentelemetry-instrumentation

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-flask/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-flask/default.nix
@@ -7,6 +7,7 @@
 , opentelemetry-semantic-conventions
 , opentelemetry-test-utils
 , opentelemetry-util-http
+, packaging
 , pytestCheckHook
 , pythonOlder
 }:
@@ -14,21 +15,22 @@
 buildPythonPackage {
   inherit (opentelemetry-instrumentation) version src;
   pname = "opentelemetry-instrumentation-flask";
-  disabled = pythonOlder "3.7";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   sourceRoot = "${opentelemetry-instrumentation.src.name}/instrumentation/opentelemetry-instrumentation-flask";
 
-  format = "pyproject";
+  build-system = [ hatchling ];
 
-  nativeBuildInputs = [ hatchling ];
-
-  propagatedBuildInputs = [
+  dependencies = [
     flask
     opentelemetry-api
     opentelemetry-instrumentation
     opentelemetry-instrumentation-wsgi
     opentelemetry-semantic-conventions
     opentelemetry-util-http
+    packaging
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-grpc/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-grpc/default.nix
@@ -1,4 +1,5 @@
 { lib
+, stdenv
 , buildPythonPackage
 , pythonOlder
 , hatchling
@@ -15,17 +16,17 @@
 buildPythonPackage {
   inherit (opentelemetry-instrumentation) version src;
   pname = "opentelemetry-instrumentation-grpc";
-  disabled = pythonOlder "3.7";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   sourceRoot = "${opentelemetry-instrumentation.src.name}/instrumentation/opentelemetry-instrumentation-grpc";
 
-  format = "pyproject";
-
-  nativeBuildInputs = [
+  build-system = [
     hatchling
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     opentelemetry-api
     opentelemetry-instrumentation
     opentelemetry-sdk
@@ -43,7 +44,14 @@ buildPythonPackage {
     pytestCheckHook
   ];
 
+  disabledTests = lib.optionals stdenv.isDarwin [
+    # RuntimeError: Failed to bind to address
+    "TestOpenTelemetryServerInterceptorUnix"
+  ];
+
   pythonImportsCheck = [ "opentelemetry.instrumentation.grpc" ];
+
+  __darwinAllowLocalNetworking = true;
 
   meta = opentelemetry-instrumentation.meta // {
     homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-grpc";

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-wsgi/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-wsgi/default.nix
@@ -13,17 +13,17 @@
 buildPythonPackage {
   inherit (opentelemetry-instrumentation) version src;
   pname = "opentelemetry-instrumentation-wsgi";
-  disabled = pythonOlder "3.7";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   sourceRoot = "${opentelemetry-instrumentation.src.name}/instrumentation/opentelemetry-instrumentation-wsgi";
 
-  format = "pyproject";
-
-  nativeBuildInputs = [
+  build-system = [
     hatchling
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     opentelemetry-instrumentation
     opentelemetry-api
     opentelemetry-semantic-conventions

--- a/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation/default.nix
@@ -4,7 +4,6 @@
 , fetchFromGitHub
 , hatchling
 , opentelemetry-api
-, opentelemetry-sdk
 , opentelemetry-test-utils
 , setuptools
 , wrapt
@@ -13,28 +12,27 @@
 
 buildPythonPackage rec {
   pname = "opentelemetry-instrumentation";
-  version = "0.43b0";
-  disabled = pythonOlder "3.7";
+  version = "0.44b0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   # to avoid breakage, every package in opentelemetry-python-contrib must inherit this version, src, and meta
   src = fetchFromGitHub {
     owner = "open-telemetry";
     repo = "opentelemetry-python-contrib";
     rev = "refs/tags/v${version}";
-    hash = "sha256-fUyA3cPXAxO506usEWxOUX9xiapc8Ocnbx73LP6ghRE=";
+    hash = "sha256-r+k/YdK7YqYme8nKoy3ig3krvZjxYRKgLBkcdEtFy3k=";
   };
 
   sourceRoot = "${src.name}/opentelemetry-instrumentation";
 
-  format = "pyproject";
-
-  nativeBuildInputs = [
+  build-system = [
     hatchling
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     opentelemetry-api
-    opentelemetry-sdk
     setuptools
     wrapt
   ];

--- a/pkgs/development/python-modules/opentelemetry-proto/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-proto/default.nix
@@ -10,17 +10,17 @@
 buildPythonPackage {
   inherit (opentelemetry-api) version src;
   pname = "opentelemetry-proto";
-  disabled = pythonOlder "3.7";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   sourceRoot = "${opentelemetry-api.src.name}/opentelemetry-proto";
 
-  format = "pyproject";
-
-  nativeBuildInputs = [
+  build-system = [
     hatchling
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     protobuf
   ];
 

--- a/pkgs/development/python-modules/opentelemetry-sdk/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-sdk/default.nix
@@ -15,20 +15,19 @@ let
   self = buildPythonPackage {
     inherit (opentelemetry-api) version src;
     pname = "opentelemetry-sdk";
-    disabled = pythonOlder "3.7";
+    pyproject = true;
+
+    disabled = pythonOlder "3.8";
 
     sourceRoot = "${opentelemetry-api.src.name}/opentelemetry-sdk";
 
-    format = "pyproject";
-
-    nativeBuildInputs = [
+    build-system = [
       hatchling
     ];
 
-    propagatedBuildInputs = [
+    dependencies = [
       opentelemetry-api
       opentelemetry-semantic-conventions
-      setuptools
       typing-extensions
     ];
 

--- a/pkgs/development/python-modules/opentelemetry-semantic-conventions/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-semantic-conventions/default.nix
@@ -7,15 +7,16 @@
 }:
 
 buildPythonPackage {
-  inherit (opentelemetry-api) version src;
+  inherit (opentelemetry-api) src;
   pname = "opentelemetry-semantic-conventions";
-  disabled = pythonOlder "3.7";
+  version = "0.44b0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   sourceRoot = "${opentelemetry-api.src.name}/opentelemetry-semantic-conventions";
 
-  format = "pyproject";
-
-  nativeBuildInputs = [
+  build-system = [
     hatchling
   ];
 

--- a/pkgs/development/python-modules/opentelemetry-test-utils/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-test-utils/default.nix
@@ -1,5 +1,4 @@
 { lib
-, callPackage
 , buildPythonPackage
 , pythonOlder
 , asgiref
@@ -9,19 +8,20 @@
 }:
 
 buildPythonPackage {
-  inherit (opentelemetry-api) version src;
+  inherit (opentelemetry-api) src;
   pname = "opentelemetry-test-utils";
-  disabled = pythonOlder "3.7";
+  version = "0.44b0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   sourceRoot = "${opentelemetry-api.src.name}/tests/opentelemetry-test-utils";
 
-  format = "pyproject";
-
-  nativeBuildInputs = [
+  build-system = [
     hatchling
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     asgiref
     opentelemetry-api
     opentelemetry-sdk

--- a/pkgs/development/python-modules/opentelemetry-util-http/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-util-http/default.nix
@@ -3,8 +3,6 @@
 , pythonOlder
 , hatchling
 , opentelemetry-instrumentation
-, opentelemetry-sdk
-, opentelemetry-semantic-conventions
 , opentelemetry-test-utils
 , pytestCheckHook
 }:
@@ -12,23 +10,18 @@
 buildPythonPackage {
   inherit (opentelemetry-instrumentation) version src;
   pname = "opentelemetry-util-http";
-  disabled = pythonOlder "3.7";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   sourceRoot = "${opentelemetry-instrumentation.src.name}/util/opentelemetry-util-http";
 
-  format = "pyproject";
-
-  nativeBuildInputs = [
+  build-system = [
     hatchling
   ];
 
-  propagatedBuildInputs = [
-    opentelemetry-instrumentation
-    opentelemetry-sdk
-    opentelemetry-semantic-conventions
-  ];
-
   nativeCheckInputs = [
+    opentelemetry-instrumentation
     opentelemetry-test-utils
     pytestCheckHook
   ];
@@ -40,6 +33,8 @@ buildPythonPackage {
   ];
 
   pythonImportsCheck = [ "opentelemetry.util.http" ];
+
+  __darwinAllowLocalNetworking = true;
 
   meta = opentelemetry-instrumentation.meta // {
     homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/util/opentelemetry-util-http";


### PR DESCRIPTION
## Description of changes

Diff: https://github.com/open-telemetry/opentelemetry-python/compare/refs/tags/v1.22.0...v1.23.0
Changelog: https://github.com/open-telemetry/opentelemetry-python/releases/tag/refs/tags/v1.23.0

Diff: https://github.com/open-telemetry/opentelemetry-python-contrib/compare/refs/tags/v0.43b0...v0.44b0
Changelog: https://github.com/open-telemetry/opentelemetry-python-contrib/releases/tag/refs/tags/v0.44b0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
