### PR TITLE
open-music-kontrollers.mephisto: 0.16.0 -> 0.18.2, fix build

### DIFF
--- a/pkgs/applications/audio/faust/faust2.nix
+++ b/pkgs/applications/audio/faust/faust2.nix
@@ -63,6 +63,14 @@ let
         ncurses_static
       ];
 
+      patches = [
+        (fetchpatch {
+          name = "fix-CsigFFun-API-declaration.patch";
+          url = "https://github.com/grame-cncm/faust/commit/10ce960e91a6237c7bff14a338e770757076ce9e.patch";
+          hash = "sha256-WMFLpLGTZpG7ni3lhI5VJHsmJViWZf4pAFuhYmFVRCE=";
+        })
+      ];
+
       passthru = { inherit wrap wrapWithBuildEnv faust2ApplBase; };
 
       preConfigure = ''

--- a/pkgs/applications/audio/open-music-kontrollers/mephisto.nix
+++ b/pkgs/applications/audio/open-music-kontrollers/mephisto.nix
@@ -1,17 +1,50 @@
-{ callPackage, faust, fontconfig, cmake, libvterm-neovim, libevdev, libglvnd, fira-code, ... } @ args:
+{ stdenv
+, lib
+, fetchFromSourcehut
+, pkg-config
+, cmake
+, meson
+, ninja
+, faust
+, fontconfig
+, glew
+, libvterm-neovim
+, lv2
+, lv2lint
+, sord
+, xorg
+}:
 
-callPackage ./generic.nix (args // rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "mephisto";
-  version = "0.16.0";
+  version = "0.18.2";
 
-  sha256 = "0vgr3rsvdj4w0xpc5iqpvyqilk42wr9zs8bg26sfv3f2wi4hb6gx";
+  src = fetchFromSourcehut {
+    domain = "open-music-kontrollers.ch";
+    owner = "~hp";
+    repo = "mephisto";
+    rev = finalAttrs.version;
+    hash = "sha256-ab6OGt1XVgynKNdszzdXwJ/jVKJSzgSmAv6j1U3/va0=";
+  };
 
-  additionalBuildInputs = [ faust fontconfig cmake libvterm-neovim libevdev libglvnd fira-code ];
+  nativeBuildInputs = [ pkg-config meson ninja fontconfig cmake ];
 
-  # see: https://github.com/OpenMusicKontrollers/mephisto.lv2/issues/6
-  postPatch = ''
-    sed -i 's/llvm-c-dsp/llvm-dsp-c/g' mephisto.c
-  '';
+  buildInputs = [
+    faust
+    libvterm-neovim
+    lv2
+    sord
+    xorg.libX11
+    xorg.libXext
+    glew
+    lv2lint
+  ];
 
-  description = "A Just-in-time FAUST embedded in an LV2 plugin";
+  meta = with lib; {
+    description = "A Just-in-time FAUST embedded in an LV2 plugin";
+    homepage = "https://git.open-music-kontrollers.ch/~hp/mephisto.lv2";
+    license = licenses.artistic2;
+    maintainers = [ maintainers.magnetophon ];
+    platforms = platforms.linux;
+  };
 })

--- a/pkgs/applications/audio/open-music-kontrollers/mephisto.nix
+++ b/pkgs/applications/audio/open-music-kontrollers/mephisto.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromSourcehut {
     domain = "open-music-kontrollers.ch";
     owner = "~hp";
-    repo = "mephisto";
+    repo = "mephisto.lv2";
     rev = finalAttrs.version;
     hash = "sha256-ab6OGt1XVgynKNdszzdXwJ/jVKJSzgSmAv6j1U3/va0=";
   };


### PR DESCRIPTION
## Description of changes

Due to changes in how the upstream project hosts the source code, the [generic.nix](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/audio/open-music-kontrollers/generic.nix) file no longer works.

I had to pull a patch from an as-yet-unreleased Faust version (https://github.com/grame-cncm/faust/pull/997) to fix a build error in that dependency.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).