### PR TITLE
chromium: fix ANGLE vulkan backend on NixOS

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -479,6 +479,10 @@ let
       for chromiumBinary in "$libExecPath/$packageName" "$libExecPath/libGLESv2.so"; do
         patchelf --set-rpath "${lib.makeLibraryPath [ libGL vulkan-loader pciutils ]}:$(patchelf --print-rpath "$chromiumBinary")" "$chromiumBinary"
       done
+
+      # replace bundled vulkan-loader
+      rm "$libExecPath/libvulkan.so.1"
+      ln -s -t "$libExecPath" "${lib.getLib vulkan-loader}/lib/libvulkan.so.1"
     '';
 
     passthru = {

--- a/pkgs/development/tools/electron/binary/generic.nix
+++ b/pkgs/development/tools/electron/binary/generic.nix
@@ -13,6 +13,7 @@
 , libxkbcommon
 , libxshmfence
 , libGL
+, vulkan-loader
 , alsa-lib
 , cairo
 , cups
@@ -102,7 +103,7 @@ let
     ++ lib.optionals (lib.versionOlder version "10.0.0") [ libXScrnSaver ]
     ++ lib.optionals (lib.versionAtLeast version "11.0.0") [ libxkbcommon ]
     ++ lib.optionals (lib.versionAtLeast version "12.0.0") [ libxshmfence ]
-    ++ lib.optionals (lib.versionAtLeast version "17.0.0") [ libGL ]
+    ++ lib.optionals (lib.versionAtLeast version "17.0.0") [ libGL vulkan-loader ]
   );
 
   linux = {
@@ -133,8 +134,12 @@ let
 
       # patch libANGLE
       patchelf \
-        --set-rpath "${lib.makeLibraryPath [ libGL pciutils ]}" \
+        --set-rpath "${lib.makeLibraryPath [ libGL pciutils vulkan-loader ]}" \
         $out/libexec/electron/lib*GL*
+
+      # replace bundled vulkan-loader
+      rm "$out/libexec/electron/libvulkan.so.1"
+      ln -s -t "$out/libexec/electron" "${lib.getLib vulkan-loader}/lib/libvulkan.so.1"
     '';
   };
 


### PR DESCRIPTION
## Description of changes

libANGLE includes an unpatched copy of `libvulkan.so.1`, so on NixOS it is unable to locate the runtime icds.
By replacing this copy with a symlink to our own version of `vulkan-loader`, it now correctly loads the system icds.

Output of `VK_LOADER_DEBUG=driver` before change:
```console
...
DRIVER:               Found no files
ERROR | DRIVER:    vkCreateInstance: Found no drivers!
...
DRIVER | LAYER:    vkCreateDevice layer callstack setup to:
DRIVER | LAYER:       <Application>
DRIVER | LAYER:         ||
DRIVER | LAYER:       <Loader>
DRIVER | LAYER:         ||
DRIVER | LAYER:       <Device>
DRIVER | LAYER:           Using "SwiftShader Device (Subzero)" with driver: "/nix/store/byiqfj6ays9jazj4b71akvvgklww3q26-electron-unwrapped-28.2.2/libexec/electron/././libvk_swiftshader.so"
```

Output of `VK_LOADER_DEBUG=driver` after change:
```console
...
DRIVER:               Found the following files:
DRIVER:                  /run/opengl-driver/share/vulkan/icd.d/dzn_icd.x86_64.json
DRIVER:                  /run/opengl-driver/share/vulkan/icd.d/intel_hasvk_icd.x86_64.json
DRIVER:                  /run/opengl-driver/share/vulkan/icd.d/intel_icd.x86_64.json
DRIVER:                  /run/opengl-driver/share/vulkan/icd.d/lvp_icd.x86_64.json
DRIVER:                  /run/opengl-driver/share/vulkan/icd.d/nvidia_icd.x86_64.json
DRIVER:                  /run/opengl-driver/share/vulkan/icd.d/radeon_icd.x86_64.json
DRIVER:                  /run/opengl-driver/share/vulkan/icd.d/virtio_icd.x86_64.json
...
DRIVER | LAYER:    vkCreateDevice layer callstack setup to:
DRIVER | LAYER:       <Application>
DRIVER | LAYER:         ||
DRIVER | LAYER:       <Loader>
DRIVER | LAYER:         ||
DRIVER | LAYER:       <Device>
DRIVER | LAYER:           Using "NVIDIA GeForce RTX 3060" with driver: "/nix/store/d0j0ppbwzkpyhpi8mrgdcqb4x45sry5g-nvidia-x11-545.29.02-6.6.1/lib/libGLX_nvidia.so.0"
```

The only concern is the fallback behavior if there is no working vulkan driver installed. Chromium bundled its own icd at `$out/libexec/<app>/vk_swiftshader_icd.json`. We might be able to fix this by setting the `VK_ADD_DRIVER_FILES` env variable in the wrapper.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
