### PR TITLE
krr: init at 1.7.0

### DIFF
--- a/pkgs/by-name/kr/krr/package.nix
+++ b/pkgs/by-name/kr/krr/package.nix
@@ -1,0 +1,68 @@
+{ lib
+, python3
+, fetchFromGitHub
+, testers
+, krr
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "krr";
+  version = "1.7.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "robusta-dev";
+    repo = "krr";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-8K97v/8lsLqr88MSOT3peOy0GZp1so9GaipG/t2uR88=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'aiostream = "^0.4.5"' 'aiostream = "*"' \
+      --replace-fail 'kubernetes = "^26.1.0"' 'kubernetes = "*"' \
+      --replace-fail 'pydantic = "1.10.7"' 'pydantic = "*"' \
+      --replace-fail 'typer = { extras = ["all"], version = "^0.7.0" }' 'typer = { extras = ["all"], version = "*" }'
+  '';
+
+  propagatedBuildInputs = with python3.pkgs; [
+    aiostream
+    alive-progress
+    kubernetes
+    numpy
+    poetry-core
+    prometheus-api-client
+    prometrix
+    pydantic_1
+    slack-sdk
+    typer
+  ] ++ typer.optional-dependencies.all;
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "robusta_krr"
+  ];
+
+  passthru.tests.version = testers.testVersion {
+    package = krr;
+    command = "krr version";
+  };
+
+  meta = with lib; {
+    description = "Prometheus-based Kubernetes resource recommendations";
+    longDescription = ''
+      Robusta KRR (Kubernetes Resource Recommender) is a CLI tool for optimizing
+      resource allocation in Kubernetes clusters. It gathers Pod usage data from
+      Prometheus and recommends requests and limits for CPU and memory. This
+      reduces costs and improves performance.
+    '';
+    homepage = "https://github.com/robusta-dev/krr";
+    changelog = "https://github.com/robusta-dev/krr/releases/tag/v${src.rev}";
+    license = licenses.mit;
+    maintainers = with lib.maintainers; [ azahi ];
+    mainProgram = "krr";
+  };
+}

--- a/pkgs/development/python-modules/prometheus-api-client/default.nix
+++ b/pkgs/development/python-modules/prometheus-api-client/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, dateparser
+, httmock
+, matplotlib
+, numpy
+, pandas
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "prometheus-api-client";
+  version = "0.5.5";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "4n4nd";
+    repo = "prometheus-api-client-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-tUu0+ZUOFxBCj//lHhNm88rhFbS01j1x508+nqIkCfQ=";
+  };
+
+  propagatedBuildInputs = [
+    dateparser
+    matplotlib
+    numpy
+    pandas
+    requests
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  checkInputs = [
+    httmock
+  ];
+
+  disabledTestPaths = [
+    "tests/test_prometheus_connect.py"
+  ];
+
+  pythonImportsCheck = [
+    "prometheus_api_client"
+  ];
+
+
+  meta = with lib; {
+    description = "A Python wrapper for the Prometheus HTTP API";
+    longDescription = ''
+      The prometheus-api-client library consists of multiple modules which
+      assist in connecting to a Prometheus host, fetching the required metrics
+      and performing various aggregation operations on the time series data.
+    '';
+    homepage = "https://github.com/4n4nd/prometheus-api-client-python";
+    changelog = "https://github.com/4n4nd/prometheus-api-client-python/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ azahi ];
+  };
+}

--- a/pkgs/development/python-modules/prometrix/default.nix
+++ b/pkgs/development/python-modules/prometrix/default.nix
@@ -1,0 +1,62 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, boto3
+, botocore
+, dateparser
+, matplotlib
+, numpy
+, pandas
+, poetry-core
+, prometheus-api-client
+, pydantic_1
+, requests
+}:
+
+buildPythonPackage rec {
+  pname = "prometrix";
+  version = "unstable-2024-02-20";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "robusta-dev";
+    repo = "prometrix";
+    rev = "ab2dad2192ed3df91c1a25446a4f54b8f2f6742f";
+    hash = "sha256-/72Qkd2BojYgiQi5rq7dVsEje7M0aQQXhenvIM7lSy4=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'pydantic = "^1.8.1"' 'pydantic = "*"'
+  '';
+
+  propagatedBuildInputs = [
+    boto3
+    botocore
+    dateparser
+    matplotlib
+    numpy
+    pandas
+    prometheus-api-client
+    pydantic_1
+    requests
+  ];
+
+  nativeBuildInputs = [
+    poetry-core
+  ];
+
+  pythonImportsCheck = [
+    "prometrix"
+  ];
+
+  meta = with lib; {
+    description = "Unified Prometheus client";
+    longDescription = ''
+      This Python package provides a unified Prometheus client that can be used
+      to connect to and query various types of Prometheus instances.
+    '';
+    license = licenses.mit;
+    maintainers = with maintainers; [ azahi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10041,6 +10041,8 @@ self: super: with self; {
 
   prometheus-flask-exporter = callPackage ../development/python-modules/prometheus-flask-exporter { };
 
+  prometrix = callPackage ../development/python-modules/prometrix { };
+
   promise = callPackage ../development/python-modules/promise { };
 
   prompt-toolkit = callPackage ../development/python-modules/prompt-toolkit { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10035,6 +10035,8 @@ self: super: with self; {
 
   progress = callPackage ../development/python-modules/progress { };
 
+  prometheus-api-client = callPackage ../development/python-modules/prometheus-api-client { };
+
   prometheus-client = callPackage ../development/python-modules/prometheus-client { };
 
   prometheus-flask-exporter = callPackage ../development/python-modules/prometheus-flask-exporter { };


### PR DESCRIPTION
## Description of changes

Robusta KRR (Kubernetes Resource Recommender) is a CLI tool for optimizing
resource allocation in Kubernetes clusters. It gathers pod usage data from
Prometheus and recommends requests and limits for CPU and memory. This reduces
costs and improves performance.

https://github.com/robusta-dev/krr

Also add its dependencies:
- **prometheus-api-client: init at 0.5.5**
- **prometrix: init at unstable-2024-02-20**

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
