### PR TITLE
[Backport release-23.11] rsmangler: init at 1.5-unstable-2019-07-24

### DIFF
--- a/pkgs/by-name/rs/rsmangler/package.nix
+++ b/pkgs/by-name/rs/rsmangler/package.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenvNoCC
+, fetchFromGitHub
+, testers
+, ruby
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "rsmangler";
+  version = "1.5-unstable-2019-07-24";
+
+  src = fetchFromGitHub {
+    owner = "digininja";
+    repo = "RSMangler";
+    rev = "e85da7d4a6e6241a92389aecf376077adc7544c3";
+    hash = "sha256-DN20XzrlkunLyk4nkgytUJEtCOlFjWUUUAQ416l3Aug=";
+  };
+
+  buildInputs = [ ruby ];
+
+  postPatch = ''
+    substituteInPlace rsmangler.rb \
+      --replace ./rsmangler.rb rsmangler \
+      --replace rsmangler.rb rsmangler
+  '';
+
+  postInstall = ''
+    install -Dm555 rsmangler.rb $out/bin/rsmangler
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "rsmangler --help";
+    version = "rsmangler v ${lib.versions.majorMinor finalAttrs.version}";
+  };
+
+  meta = with lib; {
+    description = "Perform various manipulations on the wordlists";
+    homepage = "https://github.com/digininja/RSMangler";
+    license = licenses.cc-by-sa-20;
+    mainProgram = "rsmangler";
+    maintainers = with maintainers; [ d3vil0p3r ];
+    platforms = ruby.meta.platforms;
+  };
+})


### PR DESCRIPTION
## Description of changes
It solves https://github.com/NixOS/nixpkgs/pull/293091 by replacing `--replace-quiet` to `--replace`.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
