### PR TITLE
[23.11] python311Packages.uamqp: add patches for CVE-2024-25110 & CVE-2024-27099

### DIFF
--- a/pkgs/development/python-modules/uamqp/1.6.5-CVE-2024-25110.prerequisite.patch
+++ b/pkgs/development/python-modules/uamqp/1.6.5-CVE-2024-25110.prerequisite.patch
@@ -1,0 +1,26 @@
+Extracted from
+https://github.com/Azure/azure-c-shared-utility/commit/7ddf017f1c08a82688baf08cbe6111ae38e297b8
+(yes, we're two vendored dependencies in at this point) and included
+in-tree because fetchpatch has trouble using extraPrefix with newly
+created files
+
+--- /dev/null
++++ b/src/vendor/azure-uamqp-c/deps/azure-c-shared-utility/inc/azure_c_shared_utility/safe_math.h
+@@ -0,0 +1,17 @@
++// Copyright (c) Microsoft. All rights reserved.
++// Licensed under the MIT license. See LICENSE file in the project root for full license information.
++
++#ifndef SAFE_MATH_H
++#define SAFE_MATH_H
++
++#ifndef SIZE_MAX
++#define SIZE_MAX ((size_t)((size_t)~(size_t)0))
++#endif
++
++#define safe_add_size_t(a, b) ((((size_t)(a)) < ((size_t)(SIZE_MAX - ((size_t)(b))))) ? ((size_t)(a) + (size_t)(b)) : SIZE_MAX)
++
++#define safe_subtract_size_t(a, b) (((a) >= (b)) ? ((size_t)(a) - (size_t)(b)) : SIZE_MAX)
++
++#define safe_multiply_size_t(a, b) (((a) == 0 || (b) == 0) ? 0 : (((SIZE_MAX / (size_t)(a)) >= (size_t)(b)) ? (size_t)(a) * (size_t)(b) : SIZE_MAX))
++
++#endif // SAFE_MATH_H

--- a/pkgs/development/python-modules/uamqp/default.nix
+++ b/pkgs/development/python-modules/uamqp/default.nix
@@ -36,6 +36,24 @@ buildPythonPackage rec {
       extraPrefix = "src/vendor/azure-uamqp-c/";
       hash = "sha256-9o3TNKFeJvZRZeS6qo2Zl+JVFrrqAGYWDQbusz4Ou+g=";
     })
+    ./1.6.5-CVE-2024-25110.prerequisite.patch
+    (fetchpatch {
+      name = "CVE-2024-25110-part-1.patch";
+      url = "https://github.com/Azure/azure-uamqp-c/commit/30865c9ccedaa32ddb036e87a8ebb52c3f18f695.patch";
+      stripLen = 1;
+      extraPrefix = "src/vendor/azure-uamqp-c/";
+      hash = "sha256-igzZqTLUUyuNcpCUbYHI4RXmWxg+7EC/yyD4DBurR2M=";
+    })
+    (fetchpatch {
+      name = "CVE-2024-27099.patch";
+      url = "https://github.com/Azure/azure-uamqp-c/commit/2ca42b6e4e098af2d17e487814a91d05f6ae4987.patch";
+      stripLen = 1;
+      extraPrefix = "src/vendor/azure-uamqp-c/";
+      # other files are just tests which aren't run from the python
+      # builder anyway
+      includes = [ "src/vendor/azure-uamqp-c/src/link.c" ];
+      hash = "sha256-EqDfG1xAz5CG8MssSSrz8Yrje5qwF8ri1Kdw+UUu5ms=";
+    })
     # Fix incompatible function pointer conversion error with clang 16.
     ./clang-fix-incompatible-function-pointer-conversion.patch
   ];


### PR DESCRIPTION
## Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2024-25110
https://nvd.nist.gov/vuln/detail/CVE-2024-27099

Backport from #293035 not quite as simple as I'd hoped - CVE-2024-25110's patch depends on a file in the vendored `azure-uamqp-c`'s vendored `azure-c-shared-utility` which wasn't present in python-uamqp 1.6.5. Ended up having to include the patch adding it in-tree because `fetchpatch` will helpfully add an `extraPrefix` to all paths - including `/dev/null` - meaning the `includes` option won't be able to find files that are _created_ in that patch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
