### PR TITLE
python311Packages.approvaltests: 11.0.0 -> 11.1.0

### DIFF
--- a/pkgs/development/python-modules/approvaltests/default.nix
+++ b/pkgs/development/python-modules/approvaltests/default.nix
@@ -15,11 +15,12 @@
 , pythonOlder
 , setuptools
 , testfixtures
+, typing-extensions
 }:
 
 buildPythonPackage rec {
   pname = "approvaltests";
-  version = "11.0.0";
+  version = "11.1.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -28,7 +29,7 @@ buildPythonPackage rec {
     owner = "approvals";
     repo = "ApprovalTests.Python";
     rev = "refs/tags/v${version}";
-    hash = "sha256-Ep95niYin3urtiMFSVY792zpFAcu6MwQN9DA/IJLSQQ=";
+    hash = "sha256-F03qctswG0/y2ZCdHCacHsMiBZFTmEEegYXIIB2UPlc=";
   };
 
   nativeBuildInputs = [
@@ -45,6 +46,7 @@ buildPythonPackage rec {
     pyperclip
     pytest
     testfixtures
+    typing-extensions
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/certauth/default.nix
+++ b/pkgs/development/python-modules/certauth/default.nix
@@ -1,6 +1,7 @@
 { lib
 , buildPythonPackage
 , fetchFromGitHub
+, setuptools
 , pyopenssl
 , tldextract
 , pytestCheckHook
@@ -10,7 +11,7 @@
 buildPythonPackage rec {
   pname = "certauth";
   version = "1.3.0";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -24,8 +25,12 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "--cov certauth " ""
+      --replace-fail "--cov certauth " ""
   '';
+
+  nativeBuildInputs = [
+    setuptools
+  ];
 
   propagatedBuildInputs = [
     pyopenssl
@@ -41,6 +46,9 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
+    # https://github.com/ikreymer/certauth/issues/23
+    "test_ca_cert_in_mem"
+    "test_custom_not_before_not_after"
     # Tests want to download Public Suffix List
     "test_file_wildcard"
     "test_file_wildcard_subdomains"

--- a/pkgs/development/python-modules/mrjob/default.nix
+++ b/pkgs/development/python-modules/mrjob/default.nix
@@ -1,5 +1,6 @@
 { lib
 , buildPythonPackage
+, pythonAtLeast
 , fetchFromGitHub
 
 # propagates
@@ -25,7 +26,9 @@
 buildPythonPackage rec {
   pname = "mrjob";
   version = "0.7.4";
-  format = "setuptools";
+
+  # https://github.com/Yelp/mrjob/issues/2222
+  disabled = pythonAtLeast "3.12";
 
   src = fetchFromGitHub {
     owner = "Yelp";


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/approvals/ApprovalTests.Python/compare/refs/tags/v11.0.0...v11.1.0

Changelog: https://github.com/approvals/ApprovalTests.Python/releases/tag/v11.1.0



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
