### PR TITLE
skawarePackages: add manpages to their respective packages

### DIFF
--- a/pkgs/development/skaware-packages/default.nix
+++ b/pkgs/development/skaware-packages/default.nix
@@ -10,7 +10,6 @@ lib.makeScope pkgs.newScope (self:
 
   # execline
   execline = callPackage ./execline { };
-  execline-man-pages = callPackage ./execline-man-pages { };
 
   # servers & tools
   mdevd = callPackage ./mdevd { };
@@ -32,8 +31,10 @@ lib.makeScope pkgs.newScope (self:
   s6-portable-utils = callPackage ./s6-portable-utils { };
   s6-rc = callPackage ./s6-rc { };
 
-  s6-man-pages = callPackage ./s6-man-pages { };
-  s6-networking-man-pages = callPackage ./s6-networking-man-pages { };
-  s6-portable-utils-man-pages = callPackage ./s6-portable-utils-man-pages { };
-  s6-rc-man-pages = callPackage ./s6-rc-man-pages { };
+  # manpages (DEPRECATED, they are added directly to the packages now)
+  execline-man-pages = self.execline.passthru.manpages;
+  s6-man-pages = self.s6.passthru.manpages;
+  s6-networking-man-pages = self.s6-networking.passthru.manpages;
+  s6-portable-utils-man-pages = self.s6-portable-utils.passthru.manpages;
+  s6-rc-man-pages = self.s6-rc.passthru.manpages;
 })

--- a/pkgs/development/skaware-packages/execline-man-pages/default.nix
+++ b/pkgs/development/skaware-packages/execline-man-pages/default.nix
@@ -1,9 +1,0 @@
-{ lib, buildManPages }:
-
-buildManPages {
-  pname = "execline-man-pages";
-  version = "2.9.3.0.5";
-  sha256 = "0fcjrj4xp7y7n1c55k45rxr5m7zpv6cbhrkxlxymd4j603i9jh6d";
-  description = "Port of the documentation for the execline suite to mdoc";
-  maintainers = [ lib.maintainers.sternenseemann ];
-}

--- a/pkgs/development/skaware-packages/execline/default.nix
+++ b/pkgs/development/skaware-packages/execline/default.nix
@@ -1,29 +1,30 @@
-{ fetchFromGitHub, skawarePackages }:
+{ lib, fetchFromGitHub, skawarePackages, skalibs }:
 
-with skawarePackages;
 let
   version = "2.9.4.0";
+
+in skawarePackages.buildPackage {
+  inherit version;
+
+  pname = "execline";
+  # ATTN: also check whether there is a new manpages version
+  sha256 = "mrVdVhU536dv9Kl5BvqZX8SiiOPeUiXLGp2PqenrxJs=";
 
   # Maintainer of manpages uses following versioning scheme: for every
   # upstream $version he tags manpages release as ${version}.1, and,
   # in case of extra fixes to manpages, new tags in form ${version}.2,
   # ${version}.3 and so on are created.
-  manpages = fetchFromGitHub {
-    owner = "flexibeast";
-    repo = "execline-man-pages";
-    rev = "v2.9.1.0.1";
-    sha256 = "nZzzQFMUPmIgPS3aAIgcORr/TSpaLf8UtzBUFD7blt8=";
+  manpages = skawarePackages.buildManPages {
+    pname = "execline-man-pages";
+    version = "2.9.3.0.5";
+    sha256 = "0fcjrj4xp7y7n1c55k45rxr5m7zpv6cbhrkxlxymd4j603i9jh6d";
+    description = "Port of the documentation for the execline suite to mdoc";
+    maintainers = [ lib.maintainers.sternenseemann ];
   };
-
-in buildPackage {
-  inherit version;
-
-  pname = "execline";
-  sha256 = "mrVdVhU536dv9Kl5BvqZX8SiiOPeUiXLGp2PqenrxJs=";
 
   description = "A small scripting language, to be used in place of a shell in non-interactive scripts";
 
-  outputs = [ "bin" "man" "lib" "dev" "doc" "out" ];
+  outputs = [ "bin" "lib" "dev" "doc" "out" ];
 
   # TODO: nsss support
   configureFlags = [
@@ -62,7 +63,5 @@ in buildPackage {
       -o "$bin/bin/execlineb" \
       ${./execlineb-wrapper.c} \
       -lskarnet
-    mkdir -p $man/share/
-    cp -vr ${manpages}/man* $man/share
   '';
 }

--- a/pkgs/development/skaware-packages/mdevd/default.nix
+++ b/pkgs/development/skaware-packages/mdevd/default.nix
@@ -1,8 +1,6 @@
-{ lib, skawarePackages }:
+{ lib, skawarePackages, skalibs }:
 
-with skawarePackages;
-
-buildPackage {
+skawarePackages.buildPackage {
   pname = "mdevd";
   version = "0.1.6.3";
   sha256 = "9uzw73zUjQTvx1rLLa2WfYULyIFb2wCY8cnvBDOU1DA=";

--- a/pkgs/development/skaware-packages/nsss/default.nix
+++ b/pkgs/development/skaware-packages/nsss/default.nix
@@ -1,8 +1,6 @@
-{ skawarePackages }:
+{ skawarePackages, skalibs }:
 
-with skawarePackages;
-
-buildPackage {
+skawarePackages.buildPackage {
   pname = "nsss";
   version = "0.2.0.4";
   sha256 = "ObUE+FvY9rUj0zTlz6YsAqOV2zWZG3XyBt8Ku9Z2Gq0=";

--- a/pkgs/development/skaware-packages/s6-dns/default.nix
+++ b/pkgs/development/skaware-packages/s6-dns/default.nix
@@ -1,8 +1,6 @@
-{ skawarePackages }:
+{ skawarePackages, skalibs }:
 
-with skawarePackages;
-
-buildPackage {
+skawarePackages.buildPackage {
   pname = "s6-dns";
   version = "2.3.7.1";
   sha256 = "zwJYV07H1itlTgwq14r0x9Z6xMnLN/eBSA9ZflSzD20=";

--- a/pkgs/development/skaware-packages/s6-linux-init/default.nix
+++ b/pkgs/development/skaware-packages/s6-linux-init/default.nix
@@ -1,8 +1,6 @@
-{ lib, skawarePackages }:
+{ lib, skawarePackages, skalibs, execline, s6 }:
 
-with skawarePackages;
-
-buildPackage {
+skawarePackages.buildPackage {
   pname = "s6-linux-init";
   version = "1.1.2.0";
   sha256 = "sha256-Ea4I0KZiELXla2uu4Pa5sbafvtsF/aEoWxFaMcpGx38=";

--- a/pkgs/development/skaware-packages/s6-linux-utils/default.nix
+++ b/pkgs/development/skaware-packages/s6-linux-utils/default.nix
@@ -1,8 +1,6 @@
-{ lib, skawarePackages }:
+{ lib, skawarePackages, skalibs }:
 
-with skawarePackages;
-
-buildPackage {
+skawarePackages.buildPackage {
   pname = "s6-linux-utils";
   version = "2.6.2.0";
   sha256 = "j5RGM8qH09I+DwPJw4PRUC1QjJusFtOMP79yOl6rK7c=";

--- a/pkgs/development/skaware-packages/s6-man-pages/default.nix
+++ b/pkgs/development/skaware-packages/s6-man-pages/default.nix
@@ -1,9 +1,0 @@
-{ lib, buildManPages }:
-
-buildManPages {
-  pname = "s6-man-pages";
-  version = "2.12.0.2.1";
-  sha256 = "sha256-fFU+cRwXb4SwHsI/r0ghuzCf6hEK/muPPp2XMvD8VtQ=";
-  description = "Port of the documentation for the s6 supervision suite to mdoc";
-  maintainers = [ lib.maintainers.sternenseemann ];
-}

--- a/pkgs/development/skaware-packages/s6-networking-man-pages/default.nix
+++ b/pkgs/development/skaware-packages/s6-networking-man-pages/default.nix
@@ -1,9 +1,0 @@
-{ lib, buildManPages }:
-
-buildManPages {
-  pname = "s6-networking-man-pages";
-  version = "2.5.1.3.3";
-  sha256 = "02ba5jyfpbib402mfl42pbbdxyjy2vhpiz1b2qdg4ax58yr4jzqk";
-  description = "Port of the documentation for the s6-networking suite to mdoc";
-  maintainers = [ lib.maintainers.sternenseemann ];
-}

--- a/pkgs/development/skaware-packages/s6-networking/default.nix
+++ b/pkgs/development/skaware-packages/s6-networking/default.nix
@@ -1,11 +1,10 @@
-{ lib, skawarePackages
+{ lib, skawarePackages, skalibs, execline, s6, s6-dns
 
 # Whether to build the TLS/SSL tools and what library to use
 # acceptable values: "bearssl", "libressl", false
 , sslSupport ? "bearssl" , libressl, bearssl
 }:
 
-with skawarePackages;
 let
   sslSupportEnabled = sslSupport != false;
   sslLibs = {
@@ -17,10 +16,18 @@ in
 assert sslSupportEnabled -> sslLibs ? ${sslSupport};
 
 
-buildPackage {
+skawarePackages.buildPackage {
   pname = "s6-networking";
   version = "2.7.0.2";
   sha256 = "wzxvGyvhb4miGvlGz9BiQqEvmBhMiYt1XdskM4ZxzrE=";
+
+  manpages = skawarePackages.buildManPages {
+    pname = "s6-networking-man-pages";
+    version = "2.5.1.3.3";
+    sha256 = "02ba5jyfpbib402mfl42pbbdxyjy2vhpiz1b2qdg4ax58yr4jzqk";
+    description = "Port of the documentation for the s6-networking suite to mdoc";
+    maintainers = [ lib.maintainers.sternenseemann ];
+  };
 
   description = "A suite of small networking utilities for Unix systems";
 

--- a/pkgs/development/skaware-packages/s6-portable-utils-man-pages/default.nix
+++ b/pkgs/development/skaware-packages/s6-portable-utils-man-pages/default.nix
@@ -1,9 +1,0 @@
-{ lib, buildManPages }:
-
-buildManPages {
-  pname = "s6-portable-utils-man-pages";
-  version = "2.3.0.2.2";
-  sha256 = "0zbxr6jqrx53z1gzfr31nm78wjfmyjvjx7216l527nxl9zn8nnv1";
-  description = "Port of the documentation for the s6-portable-utils suite to mdoc";
-  maintainers = [ lib.maintainers.somasis ];
-}

--- a/pkgs/development/skaware-packages/s6-portable-utils/default.nix
+++ b/pkgs/development/skaware-packages/s6-portable-utils/default.nix
@@ -1,11 +1,17 @@
-{ skawarePackages }:
+{ lib, skawarePackages, skalibs }:
 
-with skawarePackages;
-
-buildPackage {
+skawarePackages.buildPackage {
   pname = "s6-portable-utils";
   version = "2.3.0.3";
   sha256 = "PkSSBV0WDCX7kBU/DvwnfX1Sv5gbvj6i6d/lHEk1Yf8=";
+
+  manpages = skawarePackages.buildManPages {
+    pname = "s6-portable-utils-man-pages";
+    version = "2.3.0.2.2";
+    sha256 = "0zbxr6jqrx53z1gzfr31nm78wjfmyjvjx7216l527nxl9zn8nnv1";
+    description = "Port of the documentation for the s6-portable-utils suite to mdoc";
+    maintainers = [ lib.maintainers.somasis ];
+  };
 
   description = "A set of tiny general Unix utilities optimized for simplicity and small size";
 

--- a/pkgs/development/skaware-packages/s6-rc-man-pages/default.nix
+++ b/pkgs/development/skaware-packages/s6-rc-man-pages/default.nix
@@ -1,9 +1,0 @@
-{ lib, buildManPages }:
-
-buildManPages {
-  pname = "s6-rc-man-pages";
-  version = "0.5.4.2.1";
-  sha256 = "Ywke3FG/xhhUd934auDB+iFRDCvy8IJs6IkirP6O/As=";
-  description = "mdoc(7) versions of the documentation for the s6-rc service manager";
-  maintainers = [ lib.maintainers.qyliss ];
-}

--- a/pkgs/development/skaware-packages/s6-rc/default.nix
+++ b/pkgs/development/skaware-packages/s6-rc/default.nix
@@ -1,11 +1,17 @@
-{ lib, stdenv, skawarePackages, targetPackages }:
+{ lib, stdenv, skawarePackages, targetPackages, skalibs, execline, s6 }:
 
-with skawarePackages;
-
-buildPackage {
+skawarePackages.buildPackage {
   pname = "s6-rc";
   version = "0.5.4.2";
   sha256 = "AL36WW+nFhUS6XLskoKiq9j9DjHwkXe616K8PY8oOYI=";
+
+  manpages = skawarePackages.buildManPages {
+    pname = "s6-rc-man-pages";
+    version = "0.5.4.2.1";
+    sha256 = "Ywke3FG/xhhUd934auDB+iFRDCvy8IJs6IkirP6O/As=";
+    description = "mdoc(7) versions of the documentation for the s6-rc service manager";
+    maintainers = [ lib.maintainers.qyliss ];
+  };
 
   description = "A service manager for s6-based systems";
   platforms = lib.platforms.unix;

--- a/pkgs/development/skaware-packages/s6/default.nix
+++ b/pkgs/development/skaware-packages/s6/default.nix
@@ -1,11 +1,17 @@
-{ skawarePackages }:
+{ lib, skawarePackages, skalibs, execline }:
 
-with skawarePackages;
-
-buildPackage {
+skawarePackages.buildPackage {
   pname = "s6";
   version = "2.12.0.3";
   sha256 = "gA0xIm9sJc3T7AtlJA+AtWzl7BNzQdCo0VTndjjlgQM=";
+
+  manpages = skawarePackages.buildManPages {
+    pname = "s6-man-pages";
+    version = "2.12.0.2.1";
+    sha256 = "sha256-fFU+cRwXb4SwHsI/r0ghuzCf6hEK/muPPp2XMvD8VtQ=";
+    description = "Port of the documentation for the s6 supervision suite to mdoc";
+    maintainers = [ lib.maintainers.sternenseemann ];
+  };
 
   description = "skarnet.org's small & secure supervision software suite";
 

--- a/pkgs/development/skaware-packages/sdnotify-wrapper/default.nix
+++ b/pkgs/development/skaware-packages/sdnotify-wrapper/default.nix
@@ -1,6 +1,4 @@
-{ stdenv, lib, runCommandCC, skawarePackages }:
-
-with skawarePackages;
+{ stdenv, lib, runCommandCC, skawarePackages, skalibs }:
 
 let
   # From https://skarnet.org/software/misc/sdnotify-wrapper.c,

--- a/pkgs/development/skaware-packages/skalibs/default.nix
+++ b/pkgs/development/skaware-packages/skalibs/default.nix
@@ -4,9 +4,7 @@
 , pkgs
 }:
 
-with skawarePackages;
-
-buildPackage {
+skawarePackages.buildPackage {
   pname = "skalibs";
   version = "2.14.1.1";
   sha256 = "trebgW9LoLaAFnaw7UF5tZyMeAnu/+JttnLkBGNr78M=";

--- a/pkgs/development/skaware-packages/tipidee/default.nix
+++ b/pkgs/development/skaware-packages/tipidee/default.nix
@@ -1,8 +1,6 @@
-{ skawarePackages }:
+{ skawarePackages, skalibs }:
 
-with skawarePackages;
-
-buildPackage {
+skawarePackages.buildPackage {
   pname = "tipidee";
   version = "0.0.3.0";
   sha256 = "0dk6k86UKgJ2ioX5H2Xoga9S+SwMy9NFrK2KEKoNxCA=";

--- a/pkgs/development/skaware-packages/utmps/default.nix
+++ b/pkgs/development/skaware-packages/utmps/default.nix
@@ -1,8 +1,6 @@
-{ skawarePackages }:
+{ skawarePackages, skalibs }:
 
-with skawarePackages;
-
-buildPackage {
+skawarePackages.buildPackage {
   pname = "utmps";
   version = "0.1.2.2";
   sha256 = "sha256-9/+jcUxllzu5X7zxUBwG/AR42TpRzqGzc+xoEcJCX1I=";


### PR DESCRIPTION
For a while now, we’ve had these separate derivations for the skaware manpages.

That was fine in the beginning, because it was not entirely clear whether the manpage project would be long-lived. Given that the collection of third-party manpages is now extensive and updated regularly, plus it is sanctioned by skarnet, we can remove this additional hurdle to using skaware.

The buildManPage structure is kept, instead of building them in a separate `default.nix`, we add a field `manpages` to `skawarePackages.buildPackage`, which adds the `"man"` output and copies everything from the manpages output.

For backwards-compat, the manpage derivation is exposed in the `passthru` and referenced by the `*-man-pages` attributes.

The `with skawarePackages;` scope is removed from all packages, and used explicitly for all functions, while packages get added to the package import header.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
