### PR TITLE
zfs: build pyzfs Python module

### DIFF
--- a/pkgs/os-specific/linux/zfs/generic.nix
+++ b/pkgs/os-specific/linux/zfs/generic.nix
@@ -16,7 +16,7 @@ let
       # Userspace dependencies
       zlib,
       libuuid,
-      python3,
+      python3Packages,
       attr,
       openssl,
       libtirpc,
@@ -148,6 +148,14 @@ let
           substituteInPlace ./config/zfs-build.m4 \
             --replace-fail "bashcompletiondir=/etc/bash_completion.d" \
               "bashcompletiondir=$out/share/bash-completion/completions"
+
+          # The contrib/pyzfs module uses dlopen to load the ZFS library. Explicitly
+          # specify the search path, as the shared library is not copied into the
+          # Python package:
+          substituteInPlace ./contrib/pyzfs/libzfs_core/bindings/__init__.py \
+            --replace-fail 'self._ffi.dlopen(self._libname' \
+              'self._ffi.dlopen("'$out'/lib/lib" + self._libname + ".so"'
+
         ''
         + lib.optionalString (lib.versionOlder version "2.4.0") ''
           substituteInPlace ./cmd/arc_summary --replace-fail "/sbin/modinfo" "modinfo"
@@ -172,7 +180,8 @@ let
       ++ optionals buildUser [
         pkg-config
         udevCheckHook
-      ];
+      ]
+      ++ optional (buildUser && enablePython) python3Packages.pythonImportsCheckHook;
       buildInputs =
         optionals buildUser [
           zlib
@@ -183,7 +192,12 @@ let
         ]
         ++ optional buildUser openssl
         ++ optional buildUser curl
-        ++ optional (buildUser && enablePython) python3;
+        ++ optional (buildUser && enablePython) [
+          python3Packages.python
+          python3Packages.packaging
+          python3Packages.setuptools
+        ];
+      propagatedBuildInputs = optional (buildUser && enablePython) python3Packages.cffi;
 
       # for zdb to get the rpath to libgcc_s, needed for pthread_cancel to work
       env.NIX_CFLAGS_LINK = "-lgcc_s";
@@ -197,7 +211,7 @@ let
       configureFlags = [
         "--with-config=${configFile}"
         "--with-tirpc=1"
-        (lib.withFeatureAs (buildUser && enablePython) "python" python3.interpreter)
+        (lib.withFeatureAs (buildUser && enablePython) "python" python3Packages.python.interpreter)
       ]
       ++ optional enableUnsupportedExperimentalKernel "--enable-linux-experimental"
       ++ optionals buildUser [
@@ -212,6 +226,7 @@ let
         "--localstatedir=/var"
         "--enable-systemd"
         "--enable-pam"
+        (lib.optionalString enablePython "--enable-pyzfs")
       ]
       ++ optionals buildKernel (
         [
@@ -232,6 +247,11 @@ let
       ];
 
       preConfigure = ''
+        # Otherwise, the contrib/pyzfs Makefile will attempt to install into the
+        # site-packages in the Python interpreter's derivation:
+        export PYTHON_SITE_PKG="$out/${python3Packages.python.sitePackages}"
+        mkdir -p "$PYTHON_SITE_PKG"
+
         # The kernel module builds some tests during the configurePhase, this envvar controls their parallelism
         export TEST_JOBS=$NIX_BUILD_CORES
         if [ -z "$enableParallelBuilding" ]; then

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8949,6 +8949,18 @@ self: super: with self; {
       }
     )).py;
 
+  libzfs_core_2_3 = toPythonModule (
+    pkgs.zfs_2_3.override {
+      enablePython = true;
+    }
+  );
+
+  libzfs_core_2_4 = toPythonModule (
+    pkgs.zfs_2_4.override {
+      enablePython = true;
+    }
+  );
+
   liccheck = callPackage ../development/python-modules/liccheck { };
 
   license-expression = callPackage ../development/python-modules/license-expression { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This changes the ZFS on Linux derivation to also build the `pyzfs` Python module, which exports the `libzfs_core` bindings. Those bindings are useful to get more direct access to ZFS primitives. For instance, I needed to use this library to resolve some issues around ZFS encryption: https://github.com/openzfs/zfs/issues/12614#issuecomment-1936932729

### Open Questions

I'm not sure whether this is the "correct" approach for packing `pyzfs`. I would prefer to use `buildPythonPackage`, as this currently does not set `PYTHONPATH` correctly, doesn't do import checks, needs to have its `site-packages` install prefix supplied manually, etc.

However, the OpenZFS repository uses autotools to template parts of the Python source, such as the `setup.py` script: https://github.com/openzfs/zfs/blob/8f2f6cd2ac688916adb2caf979daf95365ccb48f/contrib/pyzfs/setup.py.in

I see a couple of potential solutions here, each one of which I'm not sure how well it would work or integrate into the larger Nixpkgs ecosystem:
1. Leave this as is. Its sufficient to be able to use `pyzfs`, provided the `PYTHONPATH` and `LD_LIBRARY_PATH` are amended manually.
2. Try to hack the main ZFS package into behaving like a Python package derivation. I do not know how to do this, and its likely problematic from a maintenance perspective.
3. Only run the `unpack` and `configure` phases of the ZFS derivation, and then use this intermediate result as the source for a new `buildPythonPackage` derivation.
   - Is this easily possible and maintainable?
   - Where do we put this new package? Should it be an attribute on the main ZFS package? Or located under `python3Packages`? For the latter, how do we clearly communicate that this is the `pyzfs` library built specifically for / from the same source as the main ZFS derivation?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
