### PR TITLE
dosbox-x: 2023.10.06 -> 2024.03.01

### DIFF
--- a/pkgs/applications/emulators/dosbox-x/default.nix
+++ b/pkgs/applications/emulators/dosbox-x/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , alsa-lib
 , AudioUnit
 , autoreconfHook
@@ -28,29 +27,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dosbox-x";
-  version = "2023.10.06";
+  version = "2024.03.01";
 
   src = fetchFromGitHub {
     owner = "joncampbell123";
     repo = "dosbox-x";
     rev = "dosbox-x-v${finalAttrs.version}";
-    hash = "sha256-YNYtYqcpTOx4xS/LXI53h3S+na8JVpn4w8Dhf4fWNBQ=";
+    hash = "sha256-EcAp7KyqXdBACEbPgkM1INoKeGVo7hMDUx97y2RcX+k=";
   };
-
-  patches = [
-    # 2 patches which fix stack smashing when launching Windows 3.0
-    # Remove when version > 2023.10.06
-    (fetchpatch {
-      name = "0001-dosbox-x-Attempt-to-fix-graphical-palette-issues-added-by-TTF-fix.patch";
-      url = "https://github.com/joncampbell123/dosbox-x/commit/40bf135f70376b5c3944fe2e972bdb7143439bcc.patch";
-      hash = "sha256-9whtqBkivYVYaPObyTODtwcfjaoK+rLqhCNZ7zVoiGI=";
-    })
-    (fetchpatch {
-      name = "0002-dosbox-x-Fix-Sid-Meiers-Civ-crash.patch";
-      url = "https://github.com/joncampbell123/dosbox-x/compare/cdcfb554999572e758b81edf85a007d398626b78..ac91760d9353c301e1da382f93e596238cf6d336.patch";
-      hash = "sha256-G7HbUhYEi6JJklN1z3JiOTnWLuWb27bMDyB/iGwywuY=";
-    })
-  ];
 
   strictDeps = true;
 


### PR DESCRIPTION
## Description of changes

Please see [release notes upstream](https://github.com/joncampbell123/dosbox-x/releases/tag/dosbox-x-v2024.03.01)

The patches previously manually applied are listed in the release notes for this version.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
