### PR TITLE
python311Packages.gymnasium: temporarily disable pygame-related tests

### DIFF
--- a/pkgs/development/python-modules/gymnasium/default.nix
+++ b/pkgs/development/python-modules/gymnasium/default.nix
@@ -55,7 +55,10 @@ buildPythonPackage rec {
     moviepy
     opencv4
     pybox2d
-    pygame
+    # Currently broken
+    # TODO: uncomment when pygame is fixed
+    # See https://github.com/NixOS/nixpkgs/issues/293186
+    # pygame
     pytestCheckHook
     scipy
   ];
@@ -69,6 +72,32 @@ buildPythonPackage rec {
     "tests/utils/test_save_video.py"
     "tests/wrappers/test_record_video.py"
     "tests/wrappers/test_video_recorder.py"
+
+    # Currently broken
+    # TODO: remove when pygame is fixed
+    # See https://github.com/NixOS/nixpkgs/issues/293186
+    "tests/envs/test_env_implementation.py"
+    "tests/utils/test_play.py"
+  ];
+
+  # Currently broken
+  # TODO: remove when pygame is fixed
+  # See https://github.com/NixOS/nixpkgs/issues/293186
+  disabledTests = [
+    "test_call_async_vector_env"
+    "test_call_sync_vector_env"
+    "test_frame_stack"
+    "test_gray_scale_observation"
+    "test_human_rendering"
+    "test_invalid_input"
+    "test_make_human_rendering"
+    "test_make_render_collection"
+    "test_no_error_warnings"
+    "test_order_enforcing"
+    "test_render_modes"
+    "test_resize_observation"
+    "test_resize_shapes"
+    "test_vector_wrapper_equivalence"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

[pygame is currently broken](https://github.com/NixOS/nixpkgs/issues/293186) which causes `gymnasium` to fail.
As it is not a core dependency of gymnasium (only used for testing) I suggest to temporarily disable those tests.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
