### PR TITLE
transmission_4-qt: support for qt6

### DIFF
--- a/pkgs/applications/networking/p2p/transmission/4.nix
+++ b/pkgs/applications/networking/p2p/transmission/4.nix
@@ -27,8 +27,10 @@
 , gtkmm3
 , xorg
 , wrapGAppsHook
-, enableQt ? false
+, enableQt5 ? false
+, enableQt6 ? false
 , qt5
+, qt6Packages
 , nixosTests
 , enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd
 , enableDaemon ? true
@@ -37,6 +39,24 @@
 , apparmorRulesFromClosure
 }:
 
+let
+  inherit (lib) cmakeBool optionals;
+
+  apparmorRules = apparmorRulesFromClosure { name = "transmission-daemon"; } ([
+    curl
+    libdeflate
+    libevent
+    libnatpmp
+    libpsl
+    miniupnpc
+    openssl
+    pcre
+    zlib
+  ]
+  ++ optionals enableSystemd [ systemd ]
+  ++ optionals stdenv.isLinux [ inotify-tools ]);
+
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "transmission";
   version = "4.0.5";
@@ -51,21 +71,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   outputs = [ "out" "apparmor" ];
 
-  cmakeFlags =
-    let
-      mkFlag = opt: if opt then "ON" else "OFF";
-    in
-    [
-      "-DENABLE_MAC=OFF" # requires xcodebuild
-      "-DENABLE_GTK=${mkFlag enableGTK3}"
-      "-DENABLE_QT=${mkFlag enableQt}"
-      "-DENABLE_DAEMON=${mkFlag enableDaemon}"
-      "-DENABLE_CLI=${mkFlag enableCli}"
-      "-DINSTALL_LIB=${mkFlag installLib}"
-    ] ++ lib.optionals stdenv.isDarwin [
-      # Transmission sets this to 10.13 if not explicitly specified, see https://github.com/transmission/transmission/blob/0be7091eb12f4eb55f6690f313ef70a66795ee72/CMakeLists.txt#L7-L16.
-      "-DCMAKE_OSX_DEPLOYMENT_TARGET=${stdenv.hostPlatform.darwinMinVersion}"
-    ];
+  cmakeFlags = [
+    (cmakeBool "ENABLE_CLI" enableCli)
+    (cmakeBool "ENABLE_DAEMON" enableDaemon)
+    (cmakeBool "ENABLE_GTK" enableGTK3)
+    (cmakeBool "ENABLE_MAC" false) # requires xcodebuild
+    (cmakeBool "ENABLE_QT" (enableQt5 || enableQt6))
+    (cmakeBool "INSTALL_LIB" installLib)
+  ] ++ optionals stdenv.isDarwin [
+    # Transmission sets this to 10.13 if not explicitly specified, see https://github.com/transmission/transmission/blob/0be7091eb12f4eb55f6690f313ef70a66795ee72/CMakeLists.txt#L7-L16.
+    "-DCMAKE_OSX_DEPLOYMENT_TARGET=${stdenv.hostPlatform.darwinMinVersion}"
+  ];
 
   postPatch = ''
     # Clean third-party libraries to ensure system ones are used.
@@ -89,8 +105,9 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     python3
   ]
-  ++ lib.optionals enableGTK3 [ wrapGAppsHook ]
-  ++ lib.optionals enableQt [ qt5.wrapQtAppsHook ]
+  ++ optionals enableGTK3 [ wrapGAppsHook ]
+  ++ optionals enableQt5 [ qt5.wrapQtAppsHook ]
+  ++ optionals enableQt6 [ qt6Packages.wrapQtAppsHook ]
   ;
 
   buildInputs = [
@@ -109,11 +126,12 @@ stdenv.mkDerivation (finalAttrs: {
     utf8cpp
     zlib
   ]
-  ++ lib.optionals enableQt [ qt5.qttools qt5.qtbase ]
-  ++ lib.optionals enableGTK3 [ gtkmm3 xorg.libpthreadstubs ]
-  ++ lib.optionals enableSystemd [ systemd ]
-  ++ lib.optionals stdenv.isLinux [ inotify-tools ]
-  ++ lib.optionals stdenv.isDarwin [ libiconv Foundation ];
+  ++ optionals enableQt5 (with qt5; [ qttools qtbase ])
+  ++ optionals enableQt6 (with qt6Packages; [ qttools qtbase qtsvg ])
+  ++ optionals enableGTK3 [ gtkmm3 xorg.libpthreadstubs ]
+  ++ optionals enableSystemd [ systemd ]
+  ++ optionals stdenv.isLinux [ inotify-tools ]
+  ++ optionals stdenv.isDarwin [ libiconv Foundation ];
 
   postInstall = ''
     mkdir $apparmor
@@ -123,11 +141,7 @@ stdenv.mkDerivation (finalAttrs: {
       include <abstractions/base>
       include <abstractions/nameservice>
       include <abstractions/ssl_certs>
-      include "${apparmorRulesFromClosure { name = "transmission-daemon"; } ([
-        curl libevent openssl pcre zlib libdeflate libpsl libnatpmp miniupnpc
-      ] ++ lib.optionals enableSystemd [ systemd ]
-        ++ lib.optionals stdenv.isLinux [ inotify-tools ]
-      )}"
+      include "${apparmorRules}"
       r @{PROC}/sys/kernel/random/uuid,
       r @{PROC}/sys/vm/overcommit_memory,
       r @{PROC}/@{pid}/environ,
@@ -147,9 +161,9 @@ stdenv.mkDerivation (finalAttrs: {
     smoke-test = nixosTests.bittorrent;
   };
 
-  meta = {
+  meta = with lib; {
     description = "A fast, easy and free BitTorrent client";
-    mainProgram = if enableQt then "transmission-qt" else if enableGTK3 then "transmission-gtk" else "transmission-cli";
+    mainProgram = if (enableQt5 || enableQt6) then "transmission-qt" else if enableGTK3 then "transmission-gtk" else "transmission-cli";
     longDescription = ''
       Transmission is a BitTorrent client which features a simple interface
       on top of a cross-platform back-end.
@@ -161,9 +175,9 @@ stdenv.mkDerivation (finalAttrs: {
         * Bluetack (PeerGuardian) blocklists with automatic updates
         * Full encryption, DHT, and PEX support
     '';
-    homepage = "http://www.transmissionbt.com/";
-    license = with lib.licenses; [ gpl2Plus mit ];
-    maintainers = with lib.maintainers; [ astsmtl ];
-    platforms = lib.platforms.unix;
+    homepage = "https://www.transmissionbt.com/";
+    license = with licenses; [ gpl2Plus mit ];
+    maintainers = with maintainers; [ astsmtl ];
+    platforms = platforms.unix;
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35617,7 +35617,9 @@ with pkgs;
     enableCli = false;
   };
   transmission_4-gtk = transmission_4.override { enableGTK3 = true; };
-  transmission_4-qt = transmission_4.override { enableQt = true; };
+  transmission_4-qt5 = transmission_4.override { enableQt5 = true; };
+  transmission_4-qt6 = transmission_4.override { enableQt6 = true; };
+  transmission_4-qt = transmission_4-qt5;
 
   transmission-remote-gtk = callPackage ../applications/networking/p2p/transmission-remote-gtk { };
 


### PR DESCRIPTION
## Description of changes

Support building with qt6 and some cleanups.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
