### PR TITLE
arpwatch: init at 3.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13459,6 +13459,12 @@
     githubId = 1009523;
     name = "Ashijit Pramanik";
   };
+  nalves599 = {
+    name = "Nuno Alves";
+    email = "me@nalves.pt";
+    github = "nalves599";
+    githubId = 50085568;
+  };
   name-snrl = {
     github = "name-snrl";
     githubId = 72071763;

--- a/pkgs/by-name/ar/arpwatch/package.nix
+++ b/pkgs/by-name/ar/arpwatch/package.nix
@@ -1,0 +1,38 @@
+{ fetchurl
+, lib
+, libpcap
+, stdenv
+, system-sendmail
+, ...
+}:
+stdenv.mkDerivation rec {
+  pname = "arpwatch";
+  version = "3.6";
+
+  src = fetchurl {
+    url = "https://ee.lbl.gov/downloads/${pname}/${pname}-${version}.tar.gz";
+    hash = "sha256-+GUp/lf9taL/VBO8E8JFBj+Zs790JCH9MTMnIXW+gVY=";
+  };
+
+  patchPhase = ''
+    sed -i '1i#include <time.h>' report.c
+  '';
+
+  preInstall = ''
+    install -d -m 0755 $out/bin
+    install -d -m 0755 $out/etc/rc.d
+    install -d -m 0755 $out/share/man/man8
+  '';
+
+  configureFlags = [ "--sbindir=${placeholder "out"}/bin" ];
+
+  buildInputs = [ libpcap system-sendmail ];
+
+  meta = with lib; {
+    description = "Arpwatch tracks ethernet MAC addresses with their associated IP";
+    homepage = "https://ee.lbl.gov/";
+    license = licenses.bsd3;
+    mainProgram = "arpwatch";
+    maintainers = with maintainers; [ nalves599 ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Arpwatch maintains a database of Ethernet MAC addresses seen on the network, with their associated IP pairs. Alerts the system administrator via e-mail if any change happens, such as new station/activity, flip-flops, changed and re-used old addresses.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
