### PR TITLE
nixos/eintopf: init; eintopf: init at 0.13.16

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -19,6 +19,8 @@
 
 - [Flood](https://flood.js.org/), a beautiful WebUI for various torrent clients. Available as [services.flood](options.html#opt-services.flood).
 
+- [Eintopf](https://eintopf.info), community event and calendar web application. Available as [services.eintopf](options.html#opt-services.eintopf).
+
 - [Renovate](https://github.com/renovatebot/renovate), a dependency updating tool for various git forges and language ecosystems. Available as [services.renovate](#opt-services.renovate.enable).
 
 - [wg-access-server](https://github.com/freifunkMUC/wg-access-server/), an all-in-one WireGuard VPN solution with a web ui for connecting devices. Available at [services.wg-access-server](#opt-services.wg-access-server.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1370,6 +1370,7 @@
   ./services/web-apps/documize.nix
   ./services/web-apps/dokuwiki.nix
   ./services/web-apps/dolibarr.nix
+  ./services/web-apps/eintopf.nix
   ./services/web-apps/engelsystem.nix
   ./services/web-apps/ethercalc.nix
   ./services/web-apps/filesender.nix

--- a/nixos/modules/services/web-apps/eintopf.nix
+++ b/nixos/modules/services/web-apps/eintopf.nix
@@ -1,0 +1,92 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+
+  cfg = config.services.eintopf;
+
+in {
+  options.services.eintopf = {
+
+    enable = mkEnableOption "Eintopf community event calendar web app";
+
+    settings = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      description = ''
+        Settings to configure web service. See
+        <https://codeberg.org/Klasse-Methode/eintopf/src/branch/main/DEPLOYMENT.md>
+        for available options.
+      '';
+      example = literalExpression ''
+        {
+          EINTOPF_ADDR = ":1234";
+          EINTOPF_ADMIN_EMAIL = "admin@example.org";
+          EINTOPF_TIMEZONE = "Europe/Berlin";
+        }
+      '';
+    };
+
+    secrets = lib.mkOption {
+      type = with types; listOf path;
+      description = ''
+        A list of files containing the various secrets. Should be in the
+        format expected by systemd's `EnvironmentFile` directory.
+      '';
+      default = [ ];
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+
+    systemd.services.eintopf = {
+      description = "Community event calendar web app";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      environment = cfg.settings;
+      serviceConfig = {
+        ExecStart = "${pkgs.eintopf}/bin/eintopf";
+        WorkingDirectory = "/var/lib/eintopf";
+        StateDirectory = "eintopf" ;
+        EnvironmentFile = [ cfg.secrets ];
+
+        # hardening
+        AmbientCapabilities = "";
+        CapabilityBoundingSet = "" ;
+        DevicePolicy = "closed";
+        DynamicUser = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [ "@system-service" "~@privileged" ];
+        UMask = "0077";
+      };
+    };
+
+  };
+
+  meta.maintainers = with lib.maintainers; [ onny ];
+
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -280,6 +280,7 @@ in {
   ecryptfs = handleTest ./ecryptfs.nix {};
   fscrypt = handleTest ./fscrypt.nix {};
   fastnetmon-advanced = runTest ./fastnetmon-advanced.nix;
+  eintopf = handleTest ./eintopf.nix {};
   ejabberd = handleTest ./xmpp/ejabberd.nix {};
   elk = handleTestOn ["x86_64-linux"] ./elk.nix {};
   emacs-daemon = handleTest ./emacs-daemon.nix {};

--- a/nixos/tests/eintopf.nix
+++ b/nixos/tests/eintopf.nix
@@ -1,0 +1,21 @@
+import ./make-test-python.nix ({ pkgs, ...} : {
+  name = "eintopf";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ onny ];
+  };
+
+  nodes = {
+    eintopf = { config, pkgs, ... }: {
+      services.eintopf = {
+        enable = true;
+      };
+    };
+  };
+
+  testScript = ''
+    eintopf.start
+    eintopf.wait_for_unit("eintopf.service")
+    eintopf.wait_for_open_port(3333)
+    eintopf.succeed("curl -sSfL http://eintopf:3333 | grep 'Es sind keine Veranstaltungen eingetragen'")
+  '';
+})

--- a/pkgs/by-name/ei/eintopf/frontend.nix
+++ b/pkgs/by-name/ei/eintopf/frontend.nix
@@ -1,0 +1,64 @@
+{ lib
+, stdenv
+, fetchYarnDeps
+, fixup-yarn-lock
+, yarn
+, fetchFromGitea
+, src
+, version
+, nodejs
+, eintopf
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "eintopf";
+  inherit version src;
+
+  sourceRoot = "${finalAttrs.src.name}/backstage";
+
+  offlineCache = fetchYarnDeps {
+    yarnLock = "${finalAttrs.src}/yarn.lock";
+    hash = "sha256-Z/Pkk/qCWwr99g11DjEgnisPfxOhfD8+OCn6otxJtfI=";
+  };
+
+  nativeBuildInputs = [
+    fixup-yarn-lock
+    nodejs
+    yarn
+  ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    export HOME=$(mktemp -d)
+    yarn config --offline set yarn-offline-mirror $offlineCache
+    fixup-yarn-lock yarn.lock
+    yarn --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive install
+    patchShebangs node_modules
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    yarn --offline build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    yarn --offline --production install
+
+    mkdir -p "$out"
+    cp -r . $out/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    inherit (eintopf.meta) homepage description license maintainers;
+  };
+})

--- a/pkgs/by-name/ei/eintopf/package.nix
+++ b/pkgs/by-name/ei/eintopf/package.nix
@@ -1,0 +1,57 @@
+{ lib
+, buildGoModule
+, fetchFromGitea
+, callPackage
+, nixosTests
+}:
+
+let
+  version = "0.13.16";
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "Klasse-Methode";
+    repo = "eintopf";
+    rev = "v${version}";
+    hash = "sha256-ex5bpO60ousJcgZGdviqWrCyihycW+JT+EYFvdooUDw=";
+  };
+  frontend = callPackage ./frontend.nix { inherit src version; };
+in
+
+buildGoModule rec {
+  pname = "eintopf";
+  inherit version src;
+
+  vendorHash = "sha256-dBxI6cUGc16lg89x8b+hSLcv5y/MLf6vDIvqdMBUz3I=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+    "-X main.revision=${src.rev}"
+  ];
+
+  preConfigure = ''
+    cp -R ${frontend}/. backstage/
+  '';
+
+  preCheck = ''
+    # Disable test, requires running Docker daemon
+    rm cmd/eintopf/main_test.go
+    rm service/email/email_test.go
+  '';
+
+  passthru.tests = {
+    inherit (nixosTests) eintopf;
+  };
+
+  meta = with lib; {
+    description = "A calendar for Stuttgart, showing events, groups and places";
+    homepage = "https://codeberg.org/Klasse-Methode/eintopf";
+    # License is going to change back to AGPL in the next release
+    # https://codeberg.org/Klasse-Methode/eintopf/issues/351#issuecomment-2076870
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ onny ];
+    platforms = platforms.unix;
+  };
+}
+


### PR DESCRIPTION
## Description of changes

Packaging the community event and calendar web app [Eintopf](https://codeberg.org/Klasse-Methode/eintopf), including module for the web app server

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
