### PR TITLE
phpPackages.deployer: 6.8.0 -> 7.3.3

### DIFF
--- a/pkgs/development/php-packages/deployer/default.nix
+++ b/pkgs/development/php-packages/deployer/default.nix
@@ -2,16 +2,19 @@
 
 mkDerivation rec {
   pname = "deployer";
-  version = "6.8.0";
+  version = "7.3.3";
 
   src = fetchurl {
-    url = "https://deployer.org/releases/v${version}/${pname}.phar";
-    sha256 = "09mxwfa7yszsiljbkxpsd4sghqngl08cn18v4g1fbsxp3ib3kxi5";
+    url = "https://github.com/deployphp/deployer/releases/download/v${version}/${pname}.phar";
+    hash = "sha256-6F9o7u+BjXsJv1CUawBsCgltIwaeJodVluJjEKbQanY=";
   };
 
   dontUnpack = true;
 
-  nativeBuildInputs = [ makeWrapper installShellFiles ];
+  nativeBuildInputs = [
+    makeWrapper
+    installShellFiles
+  ];
 
   installPhase = ''
     runHook preInstall
@@ -21,15 +24,16 @@ mkDerivation rec {
 
     # fish support currently broken: https://github.com/deployphp/deployer/issues/2527
     installShellCompletion --cmd dep \
-      --bash <($out/bin/dep autocomplete --install) \
-      --zsh <($out/bin/dep autocomplete --install)
+      --bash <($out/bin/dep completion) \
+      --zsh <($out/bin/dep completion)
     runHook postInstall
   '';
 
   meta = with lib; {
+    changelog = "https://github.com/deployphp/deployer/releases/tag/v${version}";
     description = "A deployment tool for PHP";
-    license = licenses.mit;
     homepage = "https://deployer.org/";
+    license = licenses.mit;
     mainProgram = "dep";
     maintainers = with maintainers; teams.php.members;
   };


### PR DESCRIPTION
## Description of changes

Was browsing through Hydra and saw that the build was broken: https://hydra.nixos.org/build/252187553/nixlog/1

Things done:
- Updated the package
- Updated the shell completion command since it changed
- The old page doesn't have the new .phar so updated it to use Github
- Some cleanup

Diff: https://github.com/deployphp/deployer/compare/v6.8.0...v7.3.3

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
