### PR TITLE
ags: init at 1.8.0

### DIFF
--- a/pkgs/by-name/ag/ags/package.nix
+++ b/pkgs/by-name/ag/ags/package.nix
@@ -1,0 +1,74 @@
+{ lib
+, buildNpmPackage
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, gobject-introspection
+, gjs
+, glib-networking
+, gnome
+, gtk-layer-shell
+, libpulseaudio
+, libsoup_3
+, networkmanager
+, upower
+, typescript
+, wrapGAppsHook
+, linux-pam
+}:
+
+buildNpmPackage rec {
+  pname = "ags";
+  version = "1.8.0";
+
+  src = fetchFromGitHub {
+    owner = "Aylur";
+    repo = "ags";
+    rev = "v${version}";
+    hash = "sha256-+0us1/lawDXp6RXn4ev95a99VgpsVPi2A4jwNS2O1Uo=";
+    fetchSubmodules = true;
+  };
+
+  npmDepsHash = "sha256-ucWdADdMqAdLXQYKGOXHNRNM9bhjKX4vkMcQ8q/GZ20=";
+
+  mesonFlags = [
+    (lib.mesonBool "build_types" true)
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gjs
+    gobject-introspection
+    typescript
+    wrapGAppsHook
+  ];
+
+  # Most of the build inputs here are basically needed for their typelibs.
+  buildInputs = [
+    gjs
+    glib-networking
+    gnome.gnome-bluetooth
+    gtk-layer-shell
+    libpulseaudio
+    libsoup_3
+    linux-pam
+    networkmanager
+    upower
+  ];
+
+  postPatch = ''
+    chmod u+x ./post_install.sh && patchShebangs ./post_install.sh
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/Aylur/ags";
+    description = "A EWW-inspired widget system as a GJS library";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ foo-dogsquared ];
+    mainProgram = "ags";
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes


Add [ags](https://github.com/Aylur/ags), a GJS library for defining widgets.

cc @Alyur
I'm aware that there is a Nix package from upstream but I would prefer to fetch it from nixpkgs repo altogether. I just want to know if the author is cool with it.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
