### PR TITLE
dropbear: fix pkgsStatic build

### DIFF
--- a/pkgs/tools/networking/dropbear/default.nix
+++ b/pkgs/tools/networking/dropbear/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, glibc, zlib, libxcrypt
+{ lib, stdenv, fetchurl, zlib, libxcrypt
 , enableStatic ? stdenv.hostPlatform.isStatic
 , enableSCP ? false
 , sftpPath ? "/run/current-system/sw/libexec/sftp-server"
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     ./pass-path.patch
   ];
 
-  buildInputs = [ zlib libxcrypt ] ++ lib.optionals enableStatic [ glibc.static zlib.static ];
+  buildInputs = [ zlib libxcrypt ];
 
   meta = with lib; {
     description = "A small footprint implementation of the SSH 2 protocol";

--- a/pkgs/tools/networking/dropbear/default.nix
+++ b/pkgs/tools/networking/dropbear/default.nix
@@ -1,5 +1,4 @@
 { lib, stdenv, fetchurl, zlib, libxcrypt
-, enableStatic ? stdenv.hostPlatform.isStatic
 , enableSCP ? false
 , sftpPath ? "/run/current-system/sw/libexec/sftp-server"
 }:
@@ -22,9 +21,6 @@ stdenv.mkDerivation rec {
     url = "https://matt.ucc.asn.au/dropbear/releases/dropbear-${version}.tar.bz2";
     sha256 = "sha256-vFoSH/vJS1FxrV6+Ab5CdG1Qqnl8lUmkY5iUoWdJRDs=";
   };
-
-  dontDisableStatic = enableStatic;
-  configureFlags = lib.optional enableStatic "LDFLAGS=-static";
 
   CFLAGS = lib.pipe (lib.attrNames dflags) [
     (builtins.map (name: "-D${name}=\\\"${dflags.${name}}\\\""))


### PR DESCRIPTION
## Description of changes

This prevents the glibc.static dependency's build failing with
```
if test -r /build/build/csu/abi-tag.h.new; then mv -f /build/build/csu/abi-tag.h.new /build/build/csu/abi-tag.h; \
else echo >&2 'This configuration not matched in ../abi-tags'; exit 1;
fi
```
---

The dependencies this PR removes were added in 3507da085f6373302385c0c44f7370d095ab5d83 (dropbear: fix static build). Since nixpkg's cross build architecture presumably has vastly changed since then (afaict), removing those should be the right thing todo (?).

---

Fixes #292147

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
    - [x] ".#pkgsStatic.dropbear"
    - [x] ".#pkgsCross.aarch64-multiplatform.dropbear"
    - [x] ".#pkgsCross.aarch64-multiplatform.pkgsStatic.dropbear"
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
