### PR TITLE
python312Packages.pytest-examples: fix disable failing tests

### DIFF
--- a/pkgs/development/python-modules/pytest-examples/default.nix
+++ b/pkgs/development/python-modules/pytest-examples/default.nix
@@ -2,6 +2,7 @@
 , black
 , buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , hatchling
 , pytest
 , pytestCheckHook
@@ -23,6 +24,17 @@ buildPythonPackage rec {
     rev = "refs/tags/v${version}";
     hash = "sha256-jCxOGDJlFkMH9VtaaPsE5zt+p3Z/mrVzhdNSI51/nVM=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/pydantic/pytest-examples/commit/551ba911713c2859caabc91b664723dd6bc800c5.patch";
+      hash = "sha256-Y3OU4fNyLADhBQGwX2jY0gagVV2q2dcn3kJRLUyCtZI=";
+    })
+    (fetchpatch {
+      url = "https://github.com/pydantic/pytest-examples/commit/3bef5d644fe3fdb076270833768e4c6df9148530.patch";
+      hash = "sha256-pf+WKzZNqgjbJiblMMLHWk23kjg4W9nm+KBmC8rG8Lw=";
+    })
+  ];
 
   postPatch = ''
     # ruff binary is used directly, the ruff Python package is not needed


### PR DESCRIPTION
## Description of changes

Some tests fail as they use functions deperecated in python3.12. This prevents this package from being build so I disabled the tests for now. The affected tests where already fixed upstream but not packaged in a release yet.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
