### PR TITLE
python311Packages.microsoft-kiota-http: init at 1.3.0, python311Packages.microsoft-kiota-authentication-azure: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/microsoft-kiota-abstractions/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-abstractions/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flit-core
+, opentelemetry-api
+, opentelemetry-sdk
+, pytest-asyncio
+, pytest-mock
+, pytestCheckHook
+, pythonOlder
+, std-uritemplate
+}:
+
+buildPythonPackage rec {
+  pname = "microsoft-kiota-abstractions";
+  version = "1.2.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "kiota-abstractions-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-ubDbpQhrqoyiBNne15nlO44lXg2wG+wrL8EJasMUocc=";
+  };
+
+  nativeBuildInputs = [
+    flit-core
+  ];
+
+  propagatedBuildInputs = [
+    opentelemetry-api
+    opentelemetry-sdk
+    std-uritemplate
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "kiota_abstractions"
+  ];
+
+  meta = with lib; {
+    description = "Abstractions library for Kiota generated Python clients";
+    homepage = "https://github.com/microsoft/kiota-abstractions-python";
+    changelog = "https://github.com/microsoft/kiota-abstractions-python/blob/${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/microsoft-kiota-authentication-azure/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-authentication-azure/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, aiohttp
+, azure-core
+, buildPythonPackage
+, fetchFromGitHub
+, flit-core
+, microsoft-kiota-abstractions
+, opentelemetry-api
+, opentelemetry-sdk
+, pytest-asyncio
+, pytest-mock
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "microsoft-kiota-authentication-azure";
+  version = "1.0.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "kiota-authentication-azure-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-RA0BbIwDs3cXiH4tQsvCGUO1OAg+DWjEeWd7MEVIC8E=";
+  };
+
+  nativeBuildInputs = [
+    flit-core
+  ];
+
+  propagatedBuildInputs = [
+    aiohttp
+    azure-core
+    microsoft-kiota-abstractions
+    opentelemetry-api
+    opentelemetry-sdk
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "kiota_authentication_azure"
+  ];
+
+  meta = with lib; {
+    description = "Kiota Azure authentication provider";
+    homepage = "https://github.com/microsoft/kiota-authentication-azure-python";
+    changelog = "https://github.com/microsoft/kiota-authentication-azure-python/blob/${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/microsoft-kiota-http/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-http/default.nix
@@ -1,0 +1,59 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flit-core
+, httpx
+, microsoft-kiota-abstractions
+, opentelemetry-api
+, opentelemetry-sdk
+, pytest-asyncio
+, pytest-mock
+, pytestCheckHook
+, pythonOlder
+, urllib3
+}:
+
+buildPythonPackage rec {
+  pname = "microsoft-kiota-http";
+  version = "1.3.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "kiota-http-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-N3+oAH3yWgrl0v2fm4xdCxzj7u/0fbQI3xHFht39vzA=";
+  };
+
+  nativeBuildInputs = [
+    flit-core
+  ];
+
+  propagatedBuildInputs = [
+    httpx
+    microsoft-kiota-abstractions
+    opentelemetry-api
+    opentelemetry-sdk
+  ] ++ httpx.optional-dependencies.http2;
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-mock
+    pytestCheckHook
+    urllib3
+  ];
+
+  pythonImportsCheck = [
+    "kiota_http"
+  ];
+
+  meta = with lib; {
+    description = "HTTP request adapter implementation for Kiota clients for Python";
+    homepage = "https://github.com/microsoft/kiota-http-python";
+    changelog = "https://github.com/microsoft/kiota-http-python/blob/${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/microsoft-kiota-serialization-json/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-serialization-json/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flit-core
+, microsoft-kiota-abstractions
+, pendulum
+, pytest-asyncio
+, pytest-mock
+, pytestCheckHook
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "kiota-serialization-json";
+  version = "1.0.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "kiota-serialization-json-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-DhuDIRTm6xATnXpQ+xLpMuaBcWxZHdr8dO1Rl8OvCKQ=";
+  };
+
+  nativeBuildInputs = [
+    flit-core
+  ];
+
+  propagatedBuildInputs = [
+    microsoft-kiota-abstractions
+    pendulum
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "kiota_serialization_json"
+  ];
+
+  disabledTests = [
+    # Test compare an output format
+    "test_parse_union_type_complex_property1"
+  ];
+
+  meta = with lib; {
+    description = "JSON serialization implementation for Kiota clients in Python";
+    homepage = "https://github.com/microsoft/kiota-serialization-json-python";
+    changelog = "https://github.com/microsoft/kiota-serialization-json-python/blob/${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/microsoft-kiota-serialization-text/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-serialization-text/default.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, flit-core
+, microsoft-kiota-abstractions
+, pytest-asyncio
+, pytest-mock
+, pytestCheckHook
+, python-dateutil
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "kiota-serialization-text";
+  version = "1.0.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "kiota-serialization-text-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-jPuRfvqO4n5/PjSOS5NMCawaYRhXmrZtfg6LgYFCv7o=";
+  };
+
+  nativeBuildInputs = [
+    flit-core
+  ];
+
+  propagatedBuildInputs = [
+    microsoft-kiota-abstractions
+    python-dateutil
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "kiota_serialization_text"
+  ];
+
+  meta = with lib; {
+    description = "Text serialization implementation for Kiota generated clients in Python";
+    homepage = "https://github.com/microsoft/kiota-serialization-text-python";
+    changelog = "https://github.com/microsoft/kiota-serialization-text-python/blob/${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7180,6 +7180,8 @@ self: super: with self; {
 
   microdata = callPackage ../development/python-modules/microdata { };
 
+  microsoft-kiota-abstractions = callPackage ../development/python-modules/microsoft-kiota-abstractions { };
+
   midiutil = callPackage ../development/python-modules/midiutil { };
 
   mido = callPackage ../development/python-modules/mido { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7182,6 +7182,8 @@ self: super: with self; {
 
   microsoft-kiota-abstractions = callPackage ../development/python-modules/microsoft-kiota-abstractions { };
 
+  microsoft-kiota-authentication-azure = callPackage ../development/python-modules/microsoft-kiota-authentication-azure { };
+
   midiutil = callPackage ../development/python-modules/midiutil { };
 
   mido = callPackage ../development/python-modules/mido { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7188,6 +7188,8 @@ self: super: with self; {
 
   microsoft-kiota-serialization-json = callPackage ../development/python-modules/microsoft-kiota-serialization-json { };
 
+  microsoft-kiota-serialization-text = callPackage ../development/python-modules/microsoft-kiota-serialization-text { };
+
   midiutil = callPackage ../development/python-modules/midiutil { };
 
   mido = callPackage ../development/python-modules/mido { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7186,6 +7186,8 @@ self: super: with self; {
 
   microsoft-kiota-http = callPackage ../development/python-modules/microsoft-kiota-http { };
 
+  microsoft-kiota-serialization-json = callPackage ../development/python-modules/microsoft-kiota-serialization-json { };
+
   midiutil = callPackage ../development/python-modules/midiutil { };
 
   mido = callPackage ../development/python-modules/mido { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7184,6 +7184,8 @@ self: super: with self; {
 
   microsoft-kiota-authentication-azure = callPackage ../development/python-modules/microsoft-kiota-authentication-azure { };
 
+  microsoft-kiota-http = callPackage ../development/python-modules/microsoft-kiota-http { };
+
   midiutil = callPackage ../development/python-modules/midiutil { };
 
   mido = callPackage ../development/python-modules/mido { };


### PR DESCRIPTION
## Description of changes
Dependencies for msgraph-sdk
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
