### PR TITLE
cloudcompare: creation of .desktop entry

### DIFF
--- a/pkgs/applications/graphics/cloudcompare/default.nix
+++ b/pkgs/applications/graphics/cloudcompare/default.nix
@@ -143,6 +143,7 @@ mkDerivation rec {
     homepage = "https://cloudcompare.org";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ nh2 ];
+    mainProgram = "CloudCompare";
     platforms = with platforms; linux; # only tested here; might work on others
   };
 }

--- a/pkgs/applications/graphics/cloudcompare/default.nix
+++ b/pkgs/applications/graphics/cloudcompare/default.nix
@@ -2,6 +2,8 @@
 , stdenv
 , mkDerivation
 , fetchFromGitHub
+, makeDesktopItem
+, copyDesktopItems
 , cmake
 , boost
 , cgal
@@ -37,6 +39,7 @@ mkDerivation rec {
     cmake
     eigen # header-only
     wrapGAppsHook
+    copyDesktopItems
   ];
 
   buildInputs = [
@@ -96,18 +99,44 @@ mkDerivation rec {
   dontWrapGApps = true;
 
   postInstall = ''
-    install -Dm444 $src/snap/gui/{ccViewer,cloudcompare}.png -t $out/share/icons/hicolor/256x256/apps
-    install -Dm444 $src/snap/gui/{ccViewer,cloudcompare}.desktop -t $out/share/applications
-    substituteInPlace $out/share/applications/{ccViewer,cloudcompare}.desktop \
-      --replace 'Exec=cloudcompare.' 'Exec=' \
-      --replace 'Icon=''${SNAP}/meta/gui/' 'Icon=' \
-      --replace '.png' ""
+    install -Dm444 $src/qCC/images/icon/cc_icon_16.png $out/share/icons/hicolor/16x16/apps/CloudCompare.png
+    install -Dm444 $src/qCC/images/icon/cc_icon_32.png $out/share/icons/hicolor/32x32/apps/CloudCompare.png
+    install -Dm444 $src/qCC/images/icon/cc_icon_64.png $out/share/icons/hicolor/64x64/apps/CloudCompare.png
+    install -Dm444 $src/qCC/images/icon/cc_icon_256.png $out/share/icons/hicolor/256x256/apps/CloudCompare.png
+
+    install -Dm444 $src/qCC/images/icon/cc_viewer_icon_16.png $out/share/icons/hicolor/16x16/apps/ccViewer.png
+    install -Dm444 $src/qCC/images/icon/cc_viewer_icon_32.png $out/share/icons/hicolor/32x32/apps/ccViewer.png
+    install -Dm444 $src/qCC/images/icon/cc_viewer_icon_64.png $out/share/icons/hicolor/64x64/apps/ccViewer.png
+    install -Dm444 $src/qCC/images/icon/cc_viewer_icon_256.png $out/share/icons/hicolor/256x256/apps/ccViewer.png
   '';
 
   # fix file dialogs crashing on non-NixOS (and avoid double wrapping)
   preFixup = ''
     qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "CloudCompare";
+      desktopName = "CloudCompare";
+      comment = "3D point cloud and mesh processing software";
+      exec = "CloudCompare";
+      terminal = false;
+      categories = [ "Graphics" "3DGraphics" "Viewer" ];
+      keywords = [ "3d" "processing" ];
+      icon = "CloudCompare";
+    })
+    (makeDesktopItem {
+      name = "ccViewer";
+      desktopName = "CloudCompare Viewer";
+      comment = "3D point cloud and mesh processing software";
+      exec = "ccViewer";
+      terminal = false;
+      categories = [ "Graphics" "3DGraphics" "Viewer" ];
+      keywords = [ "3d" "viewer" ];
+      icon = "ccViewer";
+    })
+  ];
 
   meta = with lib; {
     description = "3D point cloud and mesh processing software";

--- a/pkgs/applications/graphics/cloudcompare/default.nix
+++ b/pkgs/applications/graphics/cloudcompare/default.nix
@@ -25,13 +25,13 @@
 
 mkDerivation rec {
   pname = "cloudcompare";
-  version = "2.13";
+  version = "2.13.1";
 
   src = fetchFromGitHub {
     owner = "CloudCompare";
     repo = "CloudCompare";
     rev = "v${version}";
-    hash = "sha256-tCmIdajizaTT1tvPA7YQoklfz7pYVKS0lJXrxV2fidg=";
+    hash = "sha256-QQwQt63tXxJnGaBLu+GvWkEazumYPhXnDe+giSu7wjk=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
CloudCompare no longer provides snap directory with images and .desktop entry since they removed snap builds support. https://github.com/CloudCompare/CloudCompare/commit/6e6e3f13d76e5bf44a3938642e8035942d994d26
Those files where used during the nix package build to create a .desktop entry. Since they no longer exists the build fails : https://hydra.nixos.org/build/251747046/nixlog/1/tail


## Description of changes

To solve the issue, the build of the desktop entry added in [efdec26090fe6c61327b67d933e39d694da36bc2](https://github.com/NixOS/nixpkgs/commit/efdec26090fe6c61327b67d933e39d694da36bc2#diff-6806a6534f483e9dc42cf06ae8e134523a589d38f7a8621a43db9c2cc4258de2) has been removed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
