### PR TITLE
glfw: 3.3.10 -> 3.4

### DIFF
--- a/pkgs/development/libraries/glfw/3.x.nix
+++ b/pkgs/development/libraries/glfw/3.x.nix
@@ -2,18 +2,18 @@
 , libGL, libXrandr, libXinerama, libXcursor, libX11, libXi, libXext
 , Carbon, Cocoa, Kernel, OpenGL, fixDarwinDylibNames
 , waylandSupport ? false, extra-cmake-modules, wayland
-, wayland-protocols, libxkbcommon
+, wayland-scanner, wayland-protocols, libxkbcommon
 }:
 
 stdenv.mkDerivation rec {
-  version = "3.3.10";
+  version = "3.4";
   pname = "glfw";
 
   src = fetchFromGitHub {
     owner = "glfw";
     repo = "GLFW";
     rev = version;
-    sha256 = "sha256-kTRXsfQ+9PFurG3ffz0lwnITAYAXtNl3h/3O6FSny5o=";
+    sha256 = "sha256-FcnQPDeNHgov1Z07gjFze0VMz2diOrpbKZCsI96ngz0=";
   };
 
   # Fix linkage issues on X11 (https://github.com/NixOS/nixpkgs/issues/142583)
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ]
     ++ lib.optional stdenv.isDarwin fixDarwinDylibNames
-    ++ lib.optional waylandSupport extra-cmake-modules;
+    ++ lib.optionals waylandSupport [ extra-cmake-modules wayland-scanner ];
 
   buildInputs =
     lib.optionals stdenv.isDarwin [ Carbon Cocoa Kernel ]
@@ -37,8 +37,10 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (!stdenv.isDarwin && !stdenv.hostPlatform.isWindows) [
     "-DCMAKE_C_FLAGS=-D_GLFW_GLX_LIBRARY='\"${lib.getLib libGL}/lib/libGL.so.1\"'"
   ] ++ lib.optionals waylandSupport [
-    "-DGLFW_USE_WAYLAND=ON"
+    "-DGLFW_BUILD_X11=OFF"
     "-DCMAKE_C_FLAGS=-D_GLFW_EGL_LIBRARY='\"${lib.getLib libGL}/lib/libEGL.so.1\"'"
+  ] ++ lib.optionals (!waylandSupport) [
+    "-DGLFW_BUILD_WAYLAND=OFF"
   ];
 
   postPatch = lib.optionalString waylandSupport ''

--- a/pkgs/development/libraries/glfw/3.x.nix
+++ b/pkgs/development/libraries/glfw/3.x.nix
@@ -1,7 +1,7 @@
 { stdenv, lib, fetchFromGitHub, cmake
 , libGL, libXrandr, libXinerama, libXcursor, libX11, libXi, libXext
 , Carbon, Cocoa, Kernel, OpenGL, fixDarwinDylibNames
-, waylandSupport ? false, extra-cmake-modules, wayland
+, extra-cmake-modules, wayland
 , wayland-scanner, wayland-protocols, libxkbcommon
 }:
 
@@ -17,33 +17,38 @@ stdenv.mkDerivation rec {
   };
 
   # Fix linkage issues on X11 (https://github.com/NixOS/nixpkgs/issues/142583)
-  patches = lib.optional (!waylandSupport) ./x11.patch;
+  patches = ./x11.patch;
 
   propagatedBuildInputs =
     lib.optionals stdenv.isDarwin [ OpenGL ]
     ++ lib.optionals stdenv.isLinux [ libGL ];
 
-  nativeBuildInputs = [ cmake ]
+  nativeBuildInputs = [ cmake extra-cmake-modules ]
     ++ lib.optional stdenv.isDarwin fixDarwinDylibNames
-    ++ lib.optionals waylandSupport [ extra-cmake-modules wayland-scanner ];
+    ++ lib.optionals stdenv.isLinux [ wayland-scanner ];
 
   buildInputs =
     lib.optionals stdenv.isDarwin [ Carbon Cocoa Kernel ]
-    ++ lib.optionals (stdenv.isLinux && waylandSupport) [ wayland wayland-protocols libxkbcommon ]
-    ++ lib.optionals (stdenv.isLinux && !waylandSupport) [ libX11 libXrandr libXinerama libXcursor libXi libXext ];
+    ++ lib.optionals stdenv.isLinux [
+      wayland
+      wayland-protocols
+      libxkbcommon
+      libX11
+      libXrandr
+      libXinerama
+      libXcursor
+      libXi
+      libXext
+    ];
 
   cmakeFlags = [
     "-DBUILD_SHARED_LIBS=ON"
   ] ++ lib.optionals (!stdenv.isDarwin && !stdenv.hostPlatform.isWindows) [
     "-DCMAKE_C_FLAGS=-D_GLFW_GLX_LIBRARY='\"${lib.getLib libGL}/lib/libGL.so.1\"'"
-  ] ++ lib.optionals waylandSupport [
-    "-DGLFW_BUILD_X11=OFF"
     "-DCMAKE_C_FLAGS=-D_GLFW_EGL_LIBRARY='\"${lib.getLib libGL}/lib/libEGL.so.1\"'"
-  ] ++ lib.optionals (!waylandSupport) [
-    "-DGLFW_BUILD_WAYLAND=OFF"
   ];
 
-  postPatch = lib.optionalString waylandSupport ''
+  postPatch = lib.optionalString stdenv.isLinux ''
     substituteInPlace src/wl_init.c \
       --replace "libxkbcommon.so.0" "${lib.getLib libxkbcommon}/lib/libxkbcommon.so.0"
   '';

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -355,6 +355,7 @@ mapAliases ({
 
   gitter = throw "gitter has been removed since the client has been abandoned by upstream with the backend migration to Matrix"; # Added 2023-09-18
   glide = throw "'glide' has been removed as it is unmaintained, please use Go modules instead"; # Added 2023-12-26
+  glfw-wayland = glfw; # Added 2024-04-19
   gmailieer = lieer; # Added 2020-04-19
   gmic-qt-krita = throw "gmic-qt-krita was removed as it's no longer supported upstream."; # Converted to throw 2023-02-02
   gnatboot11 = gnat-bootstrap11;

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1168,6 +1168,7 @@ mapAliases ({
   virtmanager-qt = throw "'virtmanager-qt' has been renamed to/replaced by 'virt-manager-qt'"; # Converted to throw 2023-09-10
   vivaldi-widevine = throw "'vivaldi-widevine' has been renamed to/replaced by 'widevine-cdm'"; # Added 2023-02-25
   vkBasalt = vkbasalt; # Added 2022-11-22
+  vkdt-wayland = vkdt; # Added 2024-04-19
   vsmtp = throw "'vsmtp' has been removed, upstream gone"; # Added 2023-12-18
   vte_290 = throw "'vte_290' has been renamed to/replaced by 'vte'"; # Added 2023-01-05
   varnish72 = throw "varnish 7.2 is EOL. Either use the LTS or upgrade."; # Added 2023-10-09

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21347,9 +21347,6 @@ with pkgs;
   };
 
   glfw = glfw3;
-  glfw-wayland = glfw.override {
-    waylandSupport = true;
-  };
   glfw-wayland-minecraft = callPackage ../development/libraries/glfw/3.x-wayland-minecraft.nix {};
   glfw2 = callPackage ../development/libraries/glfw/2.x.nix { };
   glfw3 = callPackage ../development/libraries/glfw/3.x.nix {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25211,8 +25211,6 @@ with pkgs;
 
   vkdt = callPackage ../applications/graphics/vkdt { };
 
-  vkdt-wayland = callPackage ../applications/graphics/vkdt { glfw = glfw-wayland; };
-
   vlock = callPackage ../misc/screensavers/vlock { };
 
   virtualpg = callPackage ../development/libraries/virtualpg { };


### PR DESCRIPTION
## Description of changes

Release notes: https://github.com/glfw/glfw/releases/tag/3.4
Diff: https://github.com/glfw/GLFW/compare/3.3.10...3.4

Notable changes include better Wayland support, and the [deprecation](https://github.com/glfw/glfw/blob/3.4/CMakeLists.txt#L32) of `GLFW_USE_WAYLAND`.

I would also suggest following upstream here and enabling both X11 and Wayland on supported platforms (which is done by default), removing the need for the `glfw-wayland` package; this hasn't been implemented for now though as I wanted to get some feedback.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
