### PR TITLE
scion: init at 0.10.0

### DIFF
--- a/pkgs/by-name/sc/scion/package.nix
+++ b/pkgs/by-name/sc/scion/package.nix
@@ -48,6 +48,6 @@ buildGoModule {
     homepage = "https://scion-architecture.net/";
     platforms = platforms.unix;
     license = licenses.asl20;
-    maintainers = with maintainers; [ sarcasticadmin ];
+    maintainers = with maintainers; [ sarcasticadmin matthewcroughan ];
   };
 }

--- a/pkgs/by-name/sc/scion/package.nix
+++ b/pkgs/by-name/sc/scion/package.nix
@@ -1,0 +1,53 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+let
+  version = "0.10.0";
+
+  # Injects a `t.Skip()` into a given test since there's apparently no other way to skip tests here.
+  # ref: https://github.com/NixOS/nixpkgs/blob/047bc33866bf7004d0ce9ed0af78dab5ceddaab0/pkgs/by-name/vi/vikunja/package.nix#L96
+  skipTest = lineOffset: testCase: file:
+    let
+      jumpAndAppend = lib.concatStringsSep ";" (lib.replicate (lineOffset - 1) "n" ++ [ "a" ]);
+    in
+    ''
+      sed -i -e '/${testCase}/{
+      ${jumpAndAppend} t.Skip();
+      }' ${file}
+    '';
+in
+
+buildGoModule {
+  pname = "scion";
+
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "scionproto";
+    repo = "scion";
+    rev = "v${version}";
+    hash = "sha256-8yXjEDo1k0+7O0gx2acAZMrG/r+iePfNCG+FolCSKwI=";
+  };
+
+  vendorHash = "sha256-4nTp6vOyS7qDn8HmNO0NGCNU7wCb8ww8a15Yv3MPEq8=";
+
+  excludedPackages = [ "acceptance" "demo" "tools" "pkg/private/xtest/graphupdater" ];
+
+  # This can be removed in the next release of scion since its fixed upstream
+  # https://github.com/scionproto/scion/pull/4476
+  postConfigure = ''
+    # This test needs docker, so lets skip it
+    ${skipTest 1 "TestOpensslCompatible" "scion-pki/trcs/sign_test.go"}
+  '';
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "A future Internet architecture utilizing path-aware networking";
+    homepage = "https://scion-architecture.net/";
+    platforms = platforms.unix;
+    license = licenses.asl20;
+    maintainers = with maintainers; [ sarcasticadmin ];
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Open-source implementation of [SCION](http://www.scion-architecture.net/) (Scalability, Control and Isolation On next-generation Networks), a future Internet architecture. SCION provides route control, failure isolation, and explicit trust information for end-to-end communication.

This work was originally done as part of a separate flake: https://github.com/ngi-nix/scion/pull/7

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
