### PR TITLE
monado: upstream missing tooling

### DIFF
--- a/pkgs/applications/graphics/monado/default.nix
+++ b/pkgs/applications/graphics/monado/default.nix
@@ -2,16 +2,10 @@
 , stdenv
 , fetchFromGitLab
 , writeText
-, clang
 , cmake
-, cmake-format
 , cjson
 , doxygen
-, git
 , glslang
-, gradle
-, gradle-completion
-, ninja
 , pkg-config
 , python3
 , SDL2
@@ -55,6 +49,12 @@
 , libdrm
 , zlib
 , zstd
+, clang
+, cmake-format
+, git
+, gradle
+, gradle-completion
+, ninja
 , nixosTests
 # Set as 'false' to build monado without service support, i.e. allow VR
 # applications linking against libopenxr_monado.so to use OpenXR standalone
@@ -76,15 +76,9 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [
-    clang
     cmake
-    cmake-format
     doxygen
-    git
     glslang
-    gradle
-    gradle-completion
-    ninja
     pkg-config
     python3
   ];
@@ -152,6 +146,15 @@ stdenv.mkDerivation {
   patches = [
     # We don't have $HOME/.steam when building
     ./force-enable-steamvr_lh.patch
+  ];
+
+  passthru.devTools = [
+    clang
+    cmake-format
+    git
+    gradle
+    gradle-completion
+    ninja
   ];
 
   passthru.tests = {

--- a/pkgs/applications/graphics/monado/default.nix
+++ b/pkgs/applications/graphics/monado/default.nix
@@ -2,10 +2,16 @@
 , stdenv
 , fetchFromGitLab
 , writeText
+, clang
 , cmake
+, cmake-format
 , cjson
 , doxygen
+, git
 , glslang
+, gradle
+, gradle-completion
+, ninja
 , pkg-config
 , python3
 , SDL2
@@ -70,9 +76,15 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [
+    clang
     cmake
+    cmake-format
     doxygen
+    git
     glslang
+    gradle
+    gradle-completion
+    ninja
     pkg-config
     python3
   ];

--- a/pkgs/applications/graphics/monado/default.nix
+++ b/pkgs/applications/graphics/monado/default.nix
@@ -76,12 +76,9 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [
-    clang
     cmake
     doxygen
     glslang
-    gradle
-    ninja
     pkg-config
     python3
   ];
@@ -152,9 +149,12 @@ stdenv.mkDerivation {
   ];
 
   passthru.devTools = [
+    clang
     cmake-format
     git
+    gradle
     gradle-completion
+    ninja
   ];
 
   passthru.tests = {

--- a/pkgs/applications/graphics/monado/default.nix
+++ b/pkgs/applications/graphics/monado/default.nix
@@ -76,9 +76,12 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [
+    clang
     cmake
     doxygen
     glslang
+    gradle
+    ninja
     pkg-config
     python3
   ];
@@ -149,12 +152,9 @@ stdenv.mkDerivation {
   ];
 
   passthru.devTools = [
-    clang
     cmake-format
     git
-    gradle
     gradle-completion
-    ninja
   ];
 
   passthru.tests = {


### PR DESCRIPTION
## Description of changes

My understanding is that tooling that is required for development should be placed in `nativeBuildInputs`, even if it doesn't impact the build.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
