### PR TITLE
linux: Enable P2P DMA, NVMe Target Passthrough, Fabrics In-Band Auth and TCP TLS.

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -1053,6 +1053,17 @@ let
 
       NVME_MULTIPATH = yes;
 
+      NVME_AUTH = whenAtLeast "6.0" yes;
+      NVME_HOST_AUTH = whenAtLeast "6.7" yes;
+      NVME_TCP_TLS = whenAtLeast "6.7" yes;
+
+      NVME_TARGET = module;
+      NVME_TARGET_PASSTHROUGH = whenAtLeast "5.1" yes;
+      NVME_TARGET_AUTH = whenAtLeast "6.0" yes;
+      NVME_TARGET_TCP_TLS = whenAtLeast "6.7" yes;
+
+      PCI_P2PDMA = mkIf stdenv.hostPlatform.is64bit yes;
+
       PSI = whenAtLeast "4.20" yes;
 
       MOUSE_ELAN_I2C_SMBUS = yes;


### PR DESCRIPTION
## Description of changes

These changes enable the following:
- P2PDMA: Allows devices to DMA to another device without round-trip through the CPU if possible. Mainly useful for RDMA and NVMe Target, but I saw uses in AMDGPU and the Intel Xe driver as well.

- NVMe Target Passthrough allows bypassing the block layer and thus more efficient when exposing an existing NVMe device directly, especially in combination with P2PDMA and RDMA/RoCE NICs.

- NVMe over Fabrics In-Band Auth allows challange-response authentication. Enabled it for both client and target.
- NVMe over Fabrics TCP TLS support - with the help of ktls-utils, TLS encrypted sessions are possible. This, in combination with In-Band Auth, enables secure storage transport.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
