### PR TITLE
nixos/arpwatch: Add service

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13459,6 +13459,12 @@
     githubId = 1009523;
     name = "Ashijit Pramanik";
   };
+  nalves599 = {
+    name = "Nuno Alves";
+    email = "me@nalves.pt";
+    github = "nalves599";
+    githubId = 50085568;
+  };
   name-snrl = {
     github = "name-snrl";
     githubId = 72071763;

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -58,6 +58,8 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- [arpwatch](https://salsa.debian.org/pkg-security-team/arpwatch), maintains a database of Ethernet MAC addresses seen on the network, with their associated IP pairs. Alerts the system administrator via e-mail if any change happens, such as new station/activity, flip-flops, changed and re-used old addresses.
+
 - [Handheld Daemon](https://github.com/hhd-dev/hhd), support for gaming handhelds like the Legion Go, ROG Ally, and GPD Win. Available as [services.handheld-daemon](#opt-services.handheld-daemon.enable).
 
 - [Guix](https://guix.gnu.org), a functional package manager inspired by Nix. Available as [services.guix](#opt-services.guix.enable).

--- a/nixos/modules/services/networking/arpwatch.nix
+++ b/nixos/modules/services/networking/arpwatch.nix
@@ -1,0 +1,160 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.arpwatch;
+
+  interfaces = filterAttrs (_: v: v.enable) cfg.interfaces;
+  defaultUser = "arpwatch";
+  defaultGroup = "arpwatch";
+  capabilities = [ "CAP_NET_RAW" ];
+
+  interfaceOptions = { config, name, ... }: {
+    options = {
+      enable = mkOption {
+        type = types.bool;
+        description = lib.mdDoc "Whether to enable arpwatch instance.";
+        default = cfg.enable;
+      };
+
+      package = mkOption {
+        type = types.package;
+        description = lib.mdDoc "arpwatch package.";
+        default = cfg.package;
+      };
+
+      interface = mkOption {
+        type = types.str;
+        description = lib.mdDoc "Name of the interface to watch.";
+        default = name;
+      };
+
+      datafile = mkOption {
+        type = types.path;
+        description = lib.mdDoc "Path to the datafile.";
+        default = cfg.stateDir + "/arpwatch.${config.interface}.dat";
+      };
+
+      targetEmail = mkOption {
+        type = types.nullOr types.str;
+        description = lib.mdDoc "Target address to send the email reports.";
+        default = cfg.targetEmail;
+      };
+
+      fromEmail = mkOption {
+        type = types.nullOr types.str;
+        description = lib.mdDoc "From address to send the email reports.";
+        default = cfg.fromEmail;
+      };
+
+      flags = mkOption {
+        type = types.listOf types.str;
+        description = lib.mdDoc "Arguments to use for executing arpwatch.";
+        default = [
+          "-i '${config.interface}'"
+          "-f '${config.datafile}'"
+          (optionalString (config.targetEmail != null) "-w '${config.targetEmail}'")
+          (optionalString (config.fromEmail != null) "-W '${config.fromEmail}'")
+        ] ++ config.extraFlags;
+      };
+
+      extraFlags = mkOption {
+        type = types.listOf types.str;
+        description = lib.mdDoc "Extra arguments to use for executing arpwatch.";
+        default = cfg.extraFlags;
+      };
+    };
+  };
+
+in
+{
+  options.services.arpwatch = {
+    enable = mkEnableOption (lib.mdDoc "Arpwatch, keep track of ethernet/ip address pairings");
+
+    package = mkPackageOption pkgs "arpwatch" { };
+
+    interfaces = mkOption {
+      type = types.attrsOf (types.submodule interfaceOptions);
+      description = lib.mdDoc "Set of interfaces to monitor.";
+      default = { };
+    };
+
+    user = mkOption {
+      type = types.str;
+      description = lib.mdDoc "The user to run arpwatch as.";
+      default = "arpwatch";
+    };
+
+    group = mkOption {
+      type = types.str;
+      description = lib.mdDoc "The group to run arpwatch under.";
+      default = "arpwatch";
+    };
+
+    stateDir = mkOption {
+      type = types.path;
+      description = lib.mdDoc "The path to the arpwatch state directory.";
+      default = "/var/lib/arpwatch";
+    };
+
+    targetEmail = mkOption {
+      type = types.nullOr types.str;
+      description = lib.mdDoc "Target address to send the email reports.";
+      default = null;
+    };
+
+    fromEmail = mkOption {
+      type = types.nullOr types.str;
+      description = lib.mdDoc "From address to send the email reports.";
+      default = "arpwatch@${config.networking.fqdn}";
+    };
+
+    extraFlags = mkOption {
+      type = types.listOf types.str;
+      description = lib.mdDoc "Global extra arguments to use for executing arpwatch.";
+      default = [ "-N" "-p" ];
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services = mapAttrs'
+      (n: v: {
+        name = "arpwatch-${v.interface}";
+        value = {
+          description = "Watch ARP on interface ${v.interface}";
+          after = [ "network.target" ];
+          serviceConfig = {
+            Type = "forking";
+            User = cfg.user;
+            Group = cfg.group;
+            WorkingDirectory = cfg.stateDir;
+            ExecStartPre = "${pkgs.coreutils}/bin/touch ${v.datafile}";
+            ExecStart = "${pkgs.arpwatch}/bin/arpwatch " + (concatStringsSep " " v.flags);
+            Restart = "on-failure";
+            RestartSec = 15;
+            AmbientCapabilities = capabilities;
+            CapabilityBoundingSet = capabilities;
+          };
+        };
+      })
+      interfaces;
+
+    systemd.tmpfiles.rules = [ "d '${cfg.stateDir}' 0750 ${cfg.user} ${cfg.group} - -" ];
+
+    users.users = mkIf (cfg.user == defaultUser) {
+      arpwatch = {
+        home = "${cfg.stateDir}";
+        isSystemUser = true;
+        group = cfg.group;
+      };
+    };
+    users.groups = mkIf (cfg.group == defaultGroup) {
+      arpwatch = { };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ nalves599 ];
+}
+
+

--- a/pkgs/by-name/ar/arpwatch/package.nix
+++ b/pkgs/by-name/ar/arpwatch/package.nix
@@ -1,0 +1,38 @@
+{ fetchurl
+, lib
+, libpcap
+, stdenv
+, system-sendmail
+, ...
+}:
+stdenv.mkDerivation rec {
+  pname = "arpwatch";
+  version = "3.6";
+
+  src = fetchurl {
+    url = "https://ee.lbl.gov/downloads/${pname}/${pname}-${version}.tar.gz";
+    sha256 = "sha256-+GUp/lf9taL/VBO8E8JFBj+Zs790JCH9MTMnIXW+gVY=";
+  };
+
+  patchPhase = ''
+    sed -i '1i#include <time.h>' report.c
+  '';
+
+  preInstall = ''
+    install -d -m 0755 $out/bin
+    install -d -m 0755 $out/etc/rc.d
+    install -d -m 0755 $out/share/man/man8
+  '';
+
+  configureFlags = [ "--sbindir=${placeholder "out"}/bin" ];
+
+  buildInputs = [ libpcap system-sendmail ];
+
+  meta = with lib; {
+    description = "Arpwatch tracks ethernet MAC addresses with their associated IP";
+    homepage = "https://ee.lbl.gov/";
+    license = licenses.bsd3;
+    mainProgram = "arpwatch";
+    maintainers = [ maintainers.nalves599 ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Add arpwatch service.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Depends on #293208

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
