### PR TITLE
technitium-dns-server: init at 12.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6177,6 +6177,12 @@
     githubId = 303897;
     name = "Fabián Heredia Montiel";
   };
+  fabianrig = {
+    email = "fabianrig@posteo.de";
+    github = "fabianrig";
+    githubId = 88741530;
+    name = "Fabian Rigoll";
+  };
   fadenb = {
     email = "tristan.helmich+nixos@gmail.com";
     github = "fadenb";

--- a/pkgs/by-name/te/technitium-dns-server/package.nix
+++ b/pkgs/by-name/te/technitium-dns-server/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  makeWrapper,
+  dotnet-sdk_8,
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "technitium-dns-server";
+  version = "12.1";
+
+  src = fetchurl {
+    url = "https://download.technitium.com/dns/archive/${version}/DnsServerPortable.tar.gz";
+    hash = "sha256-G0M2xuYBZA3XXXaPs4pLrJmzAMbVJhiqISAvuCw3iZo=";
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share/${pname}-${version}}
+    cp -r * $out/share/${pname}-${version}/.
+    rm $out/share/${pname}-${version}/start.{sh,bat}
+    rm $out/share/${pname}-${version}/DnsServerApp.exe
+    rm $out/share/${pname}-${version}/env-vars
+    # Remove systemd.service in favor of a separate module (including firewall configuration).
+    rm $out/share/${pname}-${version}/systemd.service
+
+    makeWrapper "${dotnet-sdk_8}/bin/dotnet" $out/bin/technitium-dns-server \
+      --add-flags "$out/share/${pname}-${version}/DnsServerApp.dll"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    changelog = "https://github.com/TechnitiumSoftware/DnsServer/blob/master/CHANGELOG.md";
+    description = "Authorative and Recursive DNS server for Privacy and Security";
+    homepage = "https://github.com/TechnitiumSoftware/DnsServer";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "technitium-dns-server";
+    maintainers = with lib.maintainers; [ fabianrig ];
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Created a new package for Technitium DNS Server which is an authorative and recursive DNS server.
Homepage: https://technitium.com/dns/ 
GitHub: https://github.com/TechnitiumSoftware/DnsServer

Added myself as maintainer.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).