### PR TITLE
clightning: remove failing plugin `clnrest`

### DIFF
--- a/pkgs/applications/blockchains/clightning/default.nix
+++ b/pkgs/applications/blockchains/clightning/default.nix
@@ -44,8 +44,7 @@ stdenv.mkDerivation rec {
       tools/generate-wire.py \
       tools/update-mocks.sh \
       tools/mockup.sh \
-      devtools/sql-rewrite.py \
-      plugins/clnrest/clnrest.py
+      devtools/sql-rewrite.py
   '' else ''
     substituteInPlace external/libwally-core/tools/autogen.sh --replace gsed sed && \
     substituteInPlace external/libwally-core/configure.ac --replace gsed sed
@@ -61,6 +60,11 @@ stdenv.mkDerivation rec {
   # ccan/ccan/fdpass/fdpass.c:16:8: error: variable length array folded to constant array as an extension [-Werror,-Wgnu-folding-constant]
   #                 char buf[CMSG_SPACE(sizeof(fd))];
   env.NIX_CFLAGS_COMPILE = lib.optionalString (stdenv.isDarwin && stdenv.isx86_64) "-Wno-error=gnu-folding-constant";
+
+  # The `clnrest` plugin requires a Python environment to run
+  postInstall = ''
+    rm -r $out/libexec/c-lightning/plugins/clnrest
+  '';
 
   meta = with lib; {
     description = "A Bitcoin Lightning Network implementation in C";


### PR DESCRIPTION
This plugin always got started with clightning but immediately failed due to the missing Python environment.

I'm currently packaging `clnrest` for nix-bitcoin.

cc @prusnak @jonasnick

## Things done

- [x] Built and tested on x86_64-linux