### PR TITLE
pangolin_0_6: init at 0.6

### DIFF
--- a/pkgs/by-name/pa/pangolin_0_6/cstdint.patch
+++ b/pkgs/by-name/pa/pangolin_0_6/cstdint.patch
@@ -1,0 +1,23 @@
+diff --git a/include/pangolin/log/packetstream_tags.h b/include/pangolin/log/packetstream_tags.h
+index 13216f3d..66a5bd61 100644
+--- a/include/pangolin/log/packetstream_tags.h
++++ b/include/pangolin/log/packetstream_tags.h
+@@ -1,6 +1,7 @@
+ #pragma once
+ 
+ #include <string>
++#include <cstdint>
+ 
+ namespace pangolin {
+ 
+diff --git a/src/image/image_io_jpg.cpp b/src/image/image_io_jpg.cpp
+index cfa110a1..9b1b98df 100644
+--- a/src/image/image_io_jpg.cpp
++++ b/src/image/image_io_jpg.cpp
+@@ -1,5 +1,6 @@
+ #include <algorithm>
+ #include <fstream>
++#include <cstdint>
+ 
+ 
+ #include <pangolin/platform.h>

--- a/pkgs/by-name/pa/pangolin_0_6/package.nix
+++ b/pkgs/by-name/pa/pangolin_0_6/package.nix
@@ -1,0 +1,64 @@
+{ stdenv, lib, fetchFromGitHub, cmake, pkg-config, doxygen, glew
+, xorg, ffmpeg_4, libjpeg, libpng, libtiff, eigen
+, Carbon ? null, Cocoa ? null
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pangolin";
+
+  version = "v0.6";
+
+  src = fetchFromGitHub {
+    owner = "stevenlovegrove";
+    repo = "Pangolin";
+    rev = finalAttrs.version;
+    hash = "sha256-SPJh/mKHSaMH8tBKnW8JAbmJOMmqRqil8oLRI7tUcik=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    doxygen
+  ];
+
+  buildInputs = [
+    glew
+    xorg.libX11
+    ffmpeg_4
+    libjpeg
+    libpng
+    libtiff
+    eigen
+  ]
+  ++ lib.optionals stdenv.isDarwin [ Carbon Cocoa ];
+
+  # The tests use cmake's findPackage to find the installed version of
+  # pangolin, which isn't what we want (or available).
+  doCheck = false;
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_TESTS" false)
+  ];
+
+  patches = [
+    ./cstdint.patch
+  ];
+
+  meta = {
+    description = "A lightweight portable rapid development library for managing OpenGL display / interaction and abstracting video input";
+    longDescription = ''
+      Pangolin is a lightweight portable rapid development library for managing
+      OpenGL display / interaction and abstracting video input. At its heart is
+      a simple OpenGl viewport manager which can help to modularise 3D
+      visualisation without adding to its complexity, and offers an advanced
+      but intuitive 3D navigation handler. Pangolin also provides a mechanism
+      for manipulating program variables through config files and ui
+      integration, and has a flexible real-time plotter for visualising
+      graphical data.
+    '';
+    homepage = "https://github.com/stevenlovegrove/Pangolin";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ expipiplus1 locochoco ];
+    platforms = lib.platforms.all;
+  };
+})
+


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
[Pangolin](https://github.com/stevenlovegrove/Pangolin) is a lightweight portable rapid development library for managing OpenGL display / interaction and abstracting video input. 

This is the [0.6 version](https://github.com/stevenlovegrove/Pangolin/tree/v0.6) of the [pangolin package](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/libraries/pangolin/default.nix) that is already in nixpkgs.
While some newer programs would use the up to date pangolin, some "older" computer vision libraries (like [basalt](https://gitlab.freedesktop.org/mateosss/basalt)) use the 0.6 version, so it would be nice to have this as a separated package for packaging them.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
