### PR TITLE
libidn & libidn2: add meta.mainProgram

### DIFF
--- a/pkgs/development/libraries/libidn/default.nix
+++ b/pkgs/development/libraries/libidn/default.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
       included.
     '';
 
+    mainProgram = "idn";
     license = lib.licenses.lgpl2Plus;
     pkgConfigModules = [ "libidn" ];
     platforms = lib.platforms.all;

--- a/pkgs/development/libraries/libidn2/default.nix
+++ b/pkgs/development/libraries/libidn2/default.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
       detailed information.
     '';
 
+    mainProgram = "idn2";
     license = with lib.licenses; [ lgpl3Plus gpl2Plus gpl3Plus ];
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ fpletz ];

--- a/pkgs/development/libraries/libidn2/no-bootstrap-reference.nix
+++ b/pkgs/development/libraries/libidn2/no-bootstrap-reference.nix
@@ -8,6 +8,7 @@ runCommandLocal
     passthru = {
       inherit (libidn2) out info devdoc; # no need to touch these store paths
     };
+    inherit (libidn2) meta;
   }
   ''
     cp -r '${libidn2.bin}' "$bin"


### PR DESCRIPTION
## Description of changes

This adds `meta.mainProgram` information to both `libidn` and `libidn2` (their executables being `idn` and `idn2`, respectively), so that `lib.getExe` will give the correct result.

For `libidn2`, it also adds an `inherit` in the non-bootstrap version's wrapper script to preserve meta information, which is only set on the bootstrap version, which (apart from preventing `meta.mainProgram` to work) currently also means meta information for that package gets lost and is missing on e.g. https://search.nixos.org/packages?query=libidn2.

(actual derivation-wise, this is a no-op)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
