### PR TITLE
[23.11] zoom-us: 5.16.6.24664 -> 5.17.5.2543

### DIFF
--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -48,23 +48,23 @@ let
   # and often with different versions.  We write them on three lines
   # like this (rather than using {}) so that the updater script can
   # find where to edit them.
-  versions.aarch64-darwin = "5.17.1.27701";
-  versions.x86_64-darwin = "5.17.1.27701";
-  versions.x86_64-linux = "5.17.1.1840";
+  versions.aarch64-darwin = "5.17.5.29101";
+  versions.x86_64-darwin = "5.17.5.29101";
+  versions.x86_64-linux = "5.17.5.2543";
 
   srcs = {
     aarch64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.aarch64-darwin}/zoomusInstallerFull.pkg?archType=arm64";
       name = "zoomusInstallerFull.pkg";
-      hash = "sha256-r+TCbpvdiZd+oPglJ8D1dgZhlu4nJiAgeihQMBFFydA=";
+      hash = "sha256-Zq/8r4Ny9m+Ym6YMm49iMoITvkGO9q1DxQ0IqHC/7Us=";
     };
     x86_64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-darwin}/zoomusInstallerFull.pkg";
-      hash = "sha256-ofCJ1K2u/jlNjiHa/zhV2n5v1I540KqTbDjdfZRmcAo=";
+      hash = "sha256-/GTBPIswV+YSvnbrSYefrLfcv5eXsRCe3vaTDGmptl8=";
     };
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-linux}/zoom_x86_64.pkg.tar.xz";
-      hash = "sha256-nuYyTAZ3J6i6gpoRJxhskWfBCf/SWmU0lfEvPSSWXR4=";
+      hash = "sha256-R8LHyL5ojnaLBk00W997PtnKzDwMaADIpYClKDYkJcQ=";
     };
   };
 

--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -48,23 +48,23 @@ let
   # and often with different versions.  We write them on three lines
   # like this (rather than using {}) so that the updater script can
   # find where to edit them.
-  versions.aarch64-darwin = "5.16.10.25689";
-  versions.x86_64-darwin = "5.16.10.25689";
-  versions.x86_64-linux = "5.16.10.668";
+  versions.aarch64-darwin = "5.17.1.27701";
+  versions.x86_64-darwin = "5.17.1.27701";
+  versions.x86_64-linux = "5.17.1.1840";
 
   srcs = {
     aarch64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.aarch64-darwin}/zoomusInstallerFull.pkg?archType=arm64";
       name = "zoomusInstallerFull.pkg";
-      hash = "sha256-FIvUDbK1dwOdF8Y70Y3PHTxM/Kl5BMkmvNwcqbV+pog=";
+      hash = "sha256-r+TCbpvdiZd+oPglJ8D1dgZhlu4nJiAgeihQMBFFydA=";
     };
     x86_64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-darwin}/zoomusInstallerFull.pkg";
-      hash = "sha256-z8nDNaJtSUtb/KeoxiSgU3HU/VY7JxGp9Ug5roD0y3U=";
+      hash = "sha256-ofCJ1K2u/jlNjiHa/zhV2n5v1I540KqTbDjdfZRmcAo=";
     };
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-linux}/zoom_x86_64.pkg.tar.xz";
-      hash = "sha256-dZQHbpvU8uNafmHtGoPhj6WsDhO20Dma/XwY6oa3Xes=";
+      hash = "sha256-nuYyTAZ3J6i6gpoRJxhskWfBCf/SWmU0lfEvPSSWXR4=";
     };
   };
 

--- a/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
+++ b/pkgs/applications/networking/instant-messengers/zoom-us/default.nix
@@ -48,23 +48,23 @@ let
   # and often with different versions.  We write them on three lines
   # like this (rather than using {}) so that the updater script can
   # find where to edit them.
-  versions.aarch64-darwin = "5.16.6.24664";
-  versions.x86_64-darwin = "5.16.6.24664";
-  versions.x86_64-linux = "5.16.6.382";
+  versions.aarch64-darwin = "5.16.10.25689";
+  versions.x86_64-darwin = "5.16.10.25689";
+  versions.x86_64-linux = "5.16.10.668";
 
   srcs = {
     aarch64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.aarch64-darwin}/zoomusInstallerFull.pkg?archType=arm64";
       name = "zoomusInstallerFull.pkg";
-      hash = "sha256-5xccYYisVRZw7tJ6uri52BuaeURadaHypse4vjwPQIY=";
+      hash = "sha256-FIvUDbK1dwOdF8Y70Y3PHTxM/Kl5BMkmvNwcqbV+pog=";
     };
     x86_64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-darwin}/zoomusInstallerFull.pkg";
-      hash = "sha256-N3jzvxoRY3W5fw1Fs0qevgHC+7cLLYvoGA/ZYiE71JA=";
+      hash = "sha256-z8nDNaJtSUtb/KeoxiSgU3HU/VY7JxGp9Ug5roD0y3U=";
     };
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-linux}/zoom_x86_64.pkg.tar.xz";
-      hash = "sha256-2O8jGQHGyF5XLQUxHUWA3h9K792lRQmOC2mS0rTukSw=";
+      hash = "sha256-dZQHbpvU8uNafmHtGoPhj6WsDhO20Dma/XwY6oa3Xes=";
     };
   };
 


### PR DESCRIPTION
## Description of changes

Backport `zoom-us` changes from `master`.
I was not able to connect to some of our company meetings until I've upgraded to Zoom 5.17.
Was not able to use `5.17` from `unstable` as it has some versioning issue in the graphical libraries.  Zoom starts, but shows a blank window.

Backporting automatic updates:
```
> git log --oneline origin/release-23.11..origin/master pkgs/applications/networking/instant-messengers/zoom-us/
09c1e9 zoom-us: 5.17.1.1840 -> 5.17.5.2543
3753ca9 zoom-us: 5.16.10.668 -> 5.17.1.1840
40d826c zoom-us: 5.16.6.24664 -> 5.16.10.25689
```

## Things done

- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
