### PR TITLE
python311Packages.imread: Fix testing

### DIFF
--- a/pkgs/development/python-modules/imread/default.nix
+++ b/pkgs/development/python-modules/imread/default.nix
@@ -1,8 +1,9 @@
 { lib
 , buildPythonPackage
 , fetchPypi
-, nose
+, pytestCheckHook
 , pkg-config
+, setuptools
 , libjpeg
 , libpng
 , libtiff
@@ -13,17 +14,47 @@
 buildPythonPackage rec {
   pname = "python-imread";
   version = "0.7.5";
+  pyproject = true;
 
   src = fetchPypi {
     inherit version;
     pname = "imread";
-    sha256 = "sha256-GiWpA128GuLlbBW1CQQHHVVeoZfu9Yyh2RFzSdtHDbc=";
+    hash = "sha256-GiWpA128GuLlbBW1CQQHHVVeoZfu9Yyh2RFzSdtHDbc=";
   };
 
+  nativeBuildInputs = [
+    pkg-config
+    setuptools
+  ];
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ nose libjpeg libpng libtiff libwebp ];
+  buildInputs = [
+    libjpeg
+    libpng
+    libtiff
+    libwebp
+  ];
+
   propagatedBuildInputs = [ numpy ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    # verbose build outputs needed to debug hard-to-reproduce hydra failures
+    "-v"
+    "--pyargs" "imread"
+  ];
+
+  pythonImportsCheck = [
+    "imread"
+  ];
+
+  preCheck = ''
+    cd $TMPDIR
+    export HOME=$TMPDIR
+    export OMP_NUM_THREADS=1
+  '';
 
   meta = with lib; {
     description = "Python package to load images as numpy arrays";


### PR DESCRIPTION

## Description of changes

Use pytestCheckHook to fix tests in `pythonPackages.imread`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
