### PR TITLE
python311Packages.pandas-stubs: 2.1.4.231227 -> 2.2.0.240218

### DIFF
--- a/pkgs/development/python-modules/pandas-stubs/default.nix
+++ b/pkgs/development/python-modules/pandas-stubs/default.nix
@@ -27,7 +27,7 @@
 
 buildPythonPackage rec {
   pname = "pandas-stubs";
-  version = "2.1.4.231227";
+  version = "2.2.0.240218";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     owner = "pandas-dev";
     repo = "pandas-stubs";
     rev = "refs/tags/v${version}";
-    hash = "sha256-AkgMesDesKkVkwxNnGYG71IuIgF3G+BecpfWNWVucC8=";
+    hash = "sha256-416vyaHcSfTfkSNKZ05edozfsMmNKcpOZAoPenCLFzQ=";
   };
 
   nativeBuildInputs = [
@@ -70,55 +70,11 @@ buildPythonPackage rec {
 
   disabledTests = [
     # AttributeErrors, missing dependencies, error and warning checks
-    "test_aggregate_frame_combinations"
-    "test_aggregate_series_combinations"
-    "test_all_read_without_lxml_dtype_backend"
-    "test_arrow_dtype"
-    "test_attribute_conflict_warning"
-    "test_categorical_conversion_warning"
-    "test_clipboard_iterator"
-    "test_clipboard"
-    "test_closed_file_error"
-    "test_compare_150_changes"
-    "test_crosstab_args"
-    "test_css_warning"
-    "test_data_error"
-    "test_database_error"
-    "test_dummies"
-    "test_from_dummies_args"
-    "test_hdf_context_manager"
-    "test_hdfstore"
-    "test_incompatibility_warning"
-    "test_index_astype"
-    "test_indexing_error"
-    "test_invalid_column_name"
-    "test_isetframe"
-    "test_join"
-    "test_numexpr_clobbering_error"
-    "test_orc_buffer"
-    "test_orc_bytes"
-    "test_orc_columns"
-    "test_orc_path"
+    "test_types_groupby"
+    "test_frame_groupby_resample"
     "test_orc"
-    "test_possible_data_loss_error"
-    "test_possible_precision_loss"
-    "test_pyperclip_exception"
-    "test_quantile_150_changes"
-    "test_read_hdf_iterator"
-    "test_read_sql_via_sqlalchemy_connection"
-    "test_read_sql_via_sqlalchemy_engine"
-    "test_resample_150_changes"
-    "test_reset_index_150_changes"
-    "test_reset_index"
-    "test_rolling_step_method"
-    "test_setting_with_copy_error"
-    "test_setting_with_copy_warning"
+    "test_all_read_without_lxml_dtype_backend"
     "test_show_version"
-    "test_specification_error"
-    "test_types_assert_series_equal"
-    "test_types_rank"
-    "test_undefined_variable_error"
-    "test_value_label_type_mismatch"
   ] ++ lib.optionals stdenv.isDarwin [
     "test_plotting" # Fatal Python error: Illegal instruction
   ];


### PR DESCRIPTION
Diff: https://github.com/pandas-dev/pandas-stubs/compare/refs/tags/v2.1.4.231227...v2.2.0.240218

## Description of changes
Fix build ()
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
