### PR TITLE
rizinPlugins.jsdec: 0.6.0 -> 0.7.0

### DIFF
--- a/pkgs/development/tools/analysis/rizin/jsdec.nix
+++ b/pkgs/development/tools/analysis/rizin/jsdec.nix
@@ -8,28 +8,41 @@
 , openssl
 }:
 
-stdenv.mkDerivation rec {
+let
+  libquickjs = fetchFromGitHub {
+    owner = "frida";
+    repo = "quickjs";
+    rev = "c81f05c9859cea5f83a80057416a0c7affe9b876";
+    hash = "sha256-nAws0ae9kAwvCFcw/yR7XRMwU8EbHoq7kp7iBFpZEZc=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
   pname = "jsdec";
-  version = "0.6.0";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "rizinorg";
     repo = "jsdec";
-    rev = "v${version}";
-    hash = "sha256-iVaxxPBIJRhZrmejAOL/Fb4k66mGsZOBs7UikgMj5WA=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-UuFA0YKH+0n4Ec3CTiSUFlKXMY4k+tooaEFJYrj6Law=";
   };
 
-  nativeBuildInputs = [ meson ninja pkg-config ];
-  preConfigure = ''
-    cd p
+  postUnpack = ''
+    cp -r --no-preserve=mode ${libquickjs} $sourceRoot/subprojects/libquickjs
   '';
-  mesonFlags = [ "-Djsc_folder=.." ];
+
+  postPatch = ''
+    cp subprojects/packagefiles/libquickjs/* subprojects/libquickjs
+  '';
+
+  nativeBuildInputs = [ meson ninja pkg-config ];
   buildInputs = [ openssl rizin ];
 
   meta = with lib; {
     description = "Simple decompiler for Rizin";
-    homepage = src.meta.homepage;
+    homepage = finalAttrs.src.meta.homepage;
+    changelog = "${finalAttrs.src.meta.homepage}/releases/tag/${finalAttrs.src.rev}";
     license = with licenses; [ asl20 bsd3 mit ];
     maintainers = with maintainers; [ chayleaf ];
   };
-}
+})


### PR DESCRIPTION
## Description of changes

https://github.com/rizinorg/jsdec/compare/v0.6.0...v0.7.0

Depends on #293264

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc