### PR TITLE
rizinPlugins.rz-ghidra: 0.6.0 -> 0.7.0

### DIFF
--- a/pkgs/development/tools/analysis/rizin/rz-ghidra.nix
+++ b/pkgs/development/tools/analysis/rizin/rz-ghidra.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , cmake
 # buildInputs
 , rizin
@@ -15,24 +14,17 @@
 , qtsvg
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rz-ghidra";
-  version = "0.6.0";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "rizinorg";
     repo = "rz-ghidra";
-    rev = "v${version}";
-    hash = "sha256-tQAurouRr6fP1tbIkfd0a9UfeYcwiU1BpjOTcooXkT0=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-W9VcKrDAh7GNRbE4eyWbtHlsYLmrjBBgVvWNyMUhlDk=";
     fetchSubmodules = true;
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/rizinorg/rz-ghidra/pull/327/commits/eba20e2c743ed3dfc5d1be090a5018f7267baa49.patch";
-      hash = "sha256-aoXFClXZBcOnHl+6lLYrnui7sRb3cRJQhQfNDLxHtcs=";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [
@@ -59,9 +51,10 @@ stdenv.mkDerivation rec {
     # errors out with undefined symbols from Cutter
     broken = enableCutterPlugin && stdenv.isDarwin;
     description = "Deep ghidra decompiler and sleigh disassembler integration for rizin";
-    homepage = src.meta.homepage;
+    homepage = finalAttrs.src.meta.homepage;
+    changelog = "${finalAttrs.src.meta.homepage}/releases/tag/${finalAttrs.src.rev}";
     license = licenses.lgpl3;
     maintainers = with maintainers; [ chayleaf ];
     inherit (rizin.meta) platforms;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

https://github.com/rizinorg/rz-ghidra/compare/v0.6.0...v0.7.0

Depends on #293264

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc