### PR TITLE
rizinPlugins.sigdb: 2023-02-13 -> 2023-08-13

### DIFF
--- a/pkgs/development/tools/analysis/rizin/sigdb.nix
+++ b/pkgs/development/tools/analysis/rizin/sigdb.nix
@@ -3,17 +3,17 @@
 , stdenvNoCC
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "rizin-sigdb";
-  version = "unstable-2023-02-13";
+  version = "unstable-2023-08-13";
 
   src = fetchFromGitHub {
     owner = "rizinorg";
     # sigdb-source: source files (.pat and etc), around 2.5gb total
     # sigdb: built and deflated .sig files, around 50mb total
     repo = "sigdb";
-    rev = "829baf835e3515923266898fd597f7f75046ebd2";
-    hash = "sha256-zvGna2CEsDctc9P7hWTaz7kdtxAtPsXHNWOrRQ9ocdc=";
+    rev = "4addbed50cd3b50eeef5a41d72533d079ebbfbf8";
+    hash = "sha256-Fy92MTuLswEgQ/XEUExqdU1Z4a5MP2Ahzi/gGxd5BtA=";
   };
 
   buildPhase = ''
@@ -29,8 +29,8 @@ stdenvNoCC.mkDerivation rec {
 
   meta = with lib; {
     description = "Rizin FLIRT Signature Database";
-    homepage = src.meta.homepage;
+    homepage = finalAttrs.src.meta.homepage;
     license = licenses.lgpl3;
     maintainers = with lib.maintainers; [ chayleaf ];
   };
-}
+})


### PR DESCRIPTION
## Description of changes

https://github.com/rizinorg/sigdb/compare/829baf835e3515923266898fd597f7f75046ebd2...4addbed50cd3b50eeef5a41d72533d079ebbfbf8

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc