### PR TITLE
container-diff: init at 0.19.0

### DIFF
--- a/pkgs/by-name/co/container-diff/package.nix
+++ b/pkgs/by-name/co/container-diff/package.nix
@@ -1,0 +1,52 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, buildGoModule
+, installShellFiles
+, testers
+, container-diff
+}:
+
+buildGoModule rec {
+  pname = "container-diff";
+  version = "0.19.0";
+
+  src = fetchFromGitHub {
+    owner = "GoogleContainerTools";
+    repo = "container-diff";
+    rev = "v${version}";
+    hash = "sha256-oihyH4anPDV3vMna7ZKg+5cn9QQVgrUw4qUi2qcyv0w=";
+  };
+
+  vendorHash = "sha256-aHF1y8/aoXQ73TwSPymj4yngfeyMB48u6/2Kz4JV/qk=";
+
+  ldflags = [
+    "-s" "-w"
+    "-X github.com/GoogleContainerTools/container-diff/pkg/version.version=${version}"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  doCheck = false; # uses network
+
+  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+    for shell in bash fish zsh; do
+      $out/bin/container-diff completion $shell > container-diff.$shell
+      installShellCompletion container-diff.$shell
+    done
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = container-diff;
+    version = "v${version}";
+    command = "${container-diff}/bin/container-diff version";
+  };
+
+  meta = {
+    description = "A tool to diff your Docker containers.";
+    homepage = "https://github.com/GoogleContainerTools/container-diff";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ layus ]; # feel free to take ownership ;)
+  };
+}


### PR DESCRIPTION
## Description of changes

container-diff is a Google tool to analyse and compare docker containers.

See https://github.com/GoogleContainerTools/container-diff.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
