### PR TITLE
principia: unstable-2023-03-21 -> 2024.02.29

### DIFF
--- a/pkgs/games/principia/default.nix
+++ b/pkgs/games/principia/default.nix
@@ -1,13 +1,14 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, autoreconfHook
+, cmake
 , pkg-config
+, wrapGAppsHook
 
 , curl
 , freetype
 , glew
-, gtk2
+, gtk3
 , libGL
 , libjpeg
 , libpng
@@ -18,27 +19,28 @@
 , SDL2_ttf
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "principia";
-  version = "unstable-2023-03-21";
+  version = "2024.02.29";
 
   src = fetchFromGitHub {
     owner = "Bithack";
     repo = "principia";
-    rev = "af2cfda21b6ce4c0725700e2a01b0597a97dbeff";
-    hash = "sha256-jBWdXzbPpk23elHcs5sWkxXfkekj+aa24VvEHzid8KE=";
+    rev = finalAttrs.version;
+    hash = "sha256-L37H261IGCcH2K7RhX8iTdHRkle83vKhgpyssRmSKN0=";
   };
 
   nativeBuildInputs = [
-    autoreconfHook
+    cmake
     pkg-config
+    wrapGAppsHook
   ];
 
   buildInputs = [
     curl
     freetype
     glew
-    gtk2
+    gtk3
     libGL
     libjpeg
     libpng
@@ -49,45 +51,13 @@ stdenv.mkDerivation {
     SDL2_ttf
   ];
 
-  preAutoreconf = ''
-    cd build-linux
-  '';
-
-  # Since we bypass the "build-linux/go" wrapper script so we can use nixpkgs'
-  # autotools/make integration, set the release flags manually.
-  # https://github.com/Bithack/principia/issues/98
-  preBuild = ''
-    RELEASE_SHARED="-ffast-math -DNDEBUG=1 -s -fomit-frame-pointer -fvisibility=hidden -fdata-sections -ffunction-sections"
-    makeFlagsArray+=(
-      CFLAGS="$RELEASE_SHARED -O1"
-      CXXFLAGS="$RELEASE_SHARED -O2 -fvisibility-inlines-hidden -fno-rtti"
-      LDFLAGS="-Wl,-O,-s,--gc-sections"
-    )
-  '';
-
-  # `make install` only installs the binary, and the binary looks for data
-  # files in its same directory, so we override installPhase, install the
-  # binary in $out/share, and link to it from $out/bin
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/bin
-    mkdir -p $out/share/principia
-    install -Dm755 principia $out/share/principia/principia
-    ln -s $out/share/principia/principia $out/bin/principia
-
-    cp -r --dereference data-pc data-shared $out/share/principia/
-    install -Dm644 principia.desktop $out/share/applications/principia.desktop
-    install -Dm644 principia-url-handler.desktop $out/share/applications/principia-url-handler.desktop
-    install -Dm644 principia.png $out/share/pixmaps/principia.png
-
-    runHook postInstall
-  '';
-
-  # The actual binary is here, see comment above installPhase
-  stripDebugList = [ "share/principia" ];
+  cmakeFlags = [
+    # Remove when https://github.com/NixOS/nixpkgs/issues/144170 is fixed
+    (lib.cmakeFeature "CMAKE_INSTALL_BINDIR" "bin")
+  ];
 
   meta = with lib; {
+    changelog = "https://principia-web.se/wiki/Changelog#${lib.replaceStrings ["."] ["-"] finalAttrs.version}";
     description = "Physics-based sandbox game";
     homepage = "https://principia-web.se/";
     downloadPage = "https://principia-web.se/download";
@@ -95,4 +65,4 @@ stdenv.mkDerivation {
     maintainers = [ maintainers.fgaz ];
     platforms = platforms.linux;
   };
-}
+})


### PR DESCRIPTION


## Description of changes

Diff: https://github.com/Bithack/principia/compare/af2cfda21b6ce4c0725700e2a01b0597a97dbeff...2024.02.29
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
