### PR TITLE
blender: cleanup

### DIFF
--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -12,7 +12,7 @@
   cmake,
   colladaSupport ? true,
   config,
-  cudaPackages ? { },
+  cudaPackages,
   cudaSupport ? config.cudaSupport,
   dbus,
   embree,

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -68,7 +68,7 @@
   pkg-config,
   potrace,
   pugixml,
-  python310Packages,
+  python310Packages, # must use instead of python3.pkgs, see https://github.com/NixOS/nixpkgs/issues/211340
   rocmPackages, # comes with a significantly larger closure size
   runCommand,
   spaceNavSupport ? stdenv.isLinux,

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -1,41 +1,104 @@
-{ config, stdenv, lib, fetchurl, fetchzip, fetchpatch, boost, cmake, ffmpeg, gettext, glew
-, libepoxy, libXi, libX11, libXext, libXrender
-, libjpeg, libpng, libsamplerate, libsndfile
-, libtiff, libwebp, libGLU, libGL, openal, opencolorio, openexr, openimagedenoise, openimageio, openjpeg, python310Packages
-, openvdb, libXxf86vm, tbb, alembic
-, zlib, zstd, fftw, fftwFloat, opensubdiv, freetype, jemalloc, ocl-icd, addOpenGLRunpath
-, jackaudioSupport ? false, libjack2
-, cudaSupport ? config.cudaSupport, cudaPackages ? { }
-, hipSupport ? false, rocmPackages # comes with a significantly larger closure size
-, colladaSupport ? true, opencollada
-, spaceNavSupport ? stdenv.isLinux, libspnav
-, makeWrapper
-, pugixml, llvmPackages, SDL, Cocoa, CoreGraphics, ForceFeedback, OpenAL, OpenGL
-, waylandSupport ? stdenv.isLinux, pkg-config, wayland, wayland-protocols, libffi, libdecor, libxkbcommon, dbus
-, potrace
-, openxr-loader
-, embree, gmp, libharu
-, openpgl
-, mesa
-, runCommand
-, callPackage
+{
+  Cocoa,
+  CoreGraphics,
+  ForceFeedback,
+  OpenAL,
+  OpenGL,
+  SDL,
+  addOpenGLRunpath,
+  alembic,
+  boost,
+  callPackage,
+  cmake,
+  colladaSupport ? true,
+  config,
+  cudaPackages ? { },
+  cudaSupport ? config.cudaSupport,
+  dbus,
+  embree,
+  fetchpatch,
+  fetchurl,
+  fetchzip,
+  ffmpeg,
+  fftw,
+  fftwFloat,
+  freetype,
+  gettext,
+  glew,
+  gmp,
+  hipSupport ? false,
+  jackaudioSupport ? false,
+  jemalloc,
+  lib,
+  libGL,
+  libGLU,
+  libX11,
+  libXext,
+  libXi,
+  libXrender,
+  libXxf86vm,
+  libdecor,
+  libepoxy,
+  libffi,
+  libharu,
+  libjack2,
+  libjpeg,
+  libpng,
+  libsamplerate,
+  libsndfile,
+  libspnav,
+  libtiff,
+  libwebp,
+  libxkbcommon,
+  llvmPackages,
+  makeWrapper,
+  mesa,
+  ocl-icd,
+  openal,
+  opencollada,
+  opencolorio,
+  openexr,
+  openimagedenoise,
+  openimageio,
+  openjpeg,
+  openpgl,
+  opensubdiv,
+  openvdb,
+  openxr-loader,
+  pkg-config,
+  potrace,
+  pugixml,
+  python310Packages,
+  rocmPackages, # comes with a significantly larger closure size
+  runCommand,
+  spaceNavSupport ? stdenv.isLinux,
+  stdenv,
+  tbb,
+  wayland,
+  wayland-protocols,
+  waylandSupport ? stdenv.isLinux,
+  zlib,
+  zstd,
 }:
 
 let
   pythonPackages = python310Packages;
   inherit (pythonPackages) python;
-  buildEnv = callPackage ./wrapper.nix {};
-  optix = fetchzip {
-    # url taken from the archlinux blender PKGBUILD
-    url = "https://developer.download.nvidia.com/redist/optix/v7.3/OptiX-7.3.0-Include.zip";
-    sha256 = "0max1j4822mchj0xpz9lqzh91zkmvsn4py0r174cvqfz8z8ykjk8";
-  };
+
+  buildEnv = callPackage ./wrapper.nix { };
+
   libdecor' = libdecor.overrideAttrs (old: {
     # Blender uses private APIs, need to patch to expose them
     patches = (old.patches or [ ]) ++ [ ./libdecor.patch ];
   });
 
+  optix = fetchzip {
+    # url taken from the archlinux blender PKGBUILD
+    url = "https://developer.download.nvidia.com/redist/optix/v7.3/OptiX-7.3.0-Include.zip";
+    sha256 = "0max1j4822mchj0xpz9lqzh91zkmvsn4py0r174cvqfz8z8ykjk8";
+  };
 in
+
 stdenv.mkDerivation (finalAttrs: rec {
   pname = "blender";
   version = "4.0.2";
@@ -53,101 +116,62 @@ stdenv.mkDerivation (finalAttrs: rec {
     })
   ] ++ lib.optional stdenv.isDarwin ./darwin.patch;
 
-  nativeBuildInputs =
-    [ cmake makeWrapper python310Packages.wrapPython llvmPackages.llvm.dev
-    ]
-    ++ lib.optionals cudaSupport [
-      addOpenGLRunpath
-      cudaPackages.cuda_nvcc
-    ]
-    ++ lib.optionals waylandSupport [ pkg-config ];
-  buildInputs =
-    [ boost ffmpeg gettext glew
-      freetype libjpeg libpng libsamplerate libsndfile libtiff libwebp
-      opencolorio openexr openimageio openjpeg python zlib zstd fftw fftwFloat jemalloc
-      alembic
-      (opensubdiv.override { inherit cudaSupport; })
-      tbb
-      gmp
-      pugixml
-      potrace
-      libharu
-      libepoxy
-      openpgl
-    ]
-    ++ lib.optionals waylandSupport [
-      wayland wayland-protocols libffi libdecor' libxkbcommon dbus
-    ]
-    ++ lib.optionals (!stdenv.isAarch64) [
-      openimagedenoise
-      embree
-    ]
-    ++ (if (!stdenv.isDarwin) then [
-      libXi libX11 libXext libXrender
-      libGLU libGL openal
-      libXxf86vm
-      openxr-loader
-      # OpenVDB currently doesn't build on darwin
-      openvdb
-    ]
-    else [
-      llvmPackages.openmp SDL Cocoa CoreGraphics ForceFeedback OpenAL OpenGL
-    ])
-    ++ lib.optional jackaudioSupport libjack2
-    ++ lib.optionals cudaSupport [ cudaPackages.cuda_cudart ]
-    ++ lib.optional colladaSupport opencollada
-    ++ lib.optional spaceNavSupport libspnav;
-  pythonPath = with python310Packages; [ numpy requests zstandard ];
-
-  postPatch = ''
-  '' +
-    (if stdenv.isDarwin then ''
-      : > build_files/cmake/platform/platform_apple_xcode.cmake
-      substituteInPlace source/creator/CMakeLists.txt \
-        --replace '${"$"}{LIBDIR}/python' \
-                  '${python}'
-      substituteInPlace build_files/cmake/platform/platform_apple.cmake \
-        --replace '${"$"}{LIBDIR}/python' \
-                  '${python}' \
-        --replace '${"$"}{LIBDIR}/opencollada' \
-                  '${opencollada}' \
-        --replace '${"$"}{PYTHON_LIBPATH}/site-packages/numpy' \
-                  '${python310Packages.numpy}/${python.sitePackages}/numpy'
-    '' else ''
-      substituteInPlace extern/clew/src/clew.c --replace '"libOpenCL.so"' '"${ocl-icd}/lib/libOpenCL.so"'
-    '') +
-    (lib.optionalString hipSupport ''
+  postPatch =
+    (
+      if stdenv.isDarwin then
+        ''
+          : > build_files/cmake/platform/platform_apple_xcode.cmake
+          substituteInPlace source/creator/CMakeLists.txt \
+            --replace '${"$"}{LIBDIR}/python' \
+                      '${python}'
+          substituteInPlace build_files/cmake/platform/platform_apple.cmake \
+            --replace '${"$"}{LIBDIR}/python' \
+                      '${python}' \
+            --replace '${"$"}{LIBDIR}/opencollada' \
+                      '${opencollada}' \
+            --replace '${"$"}{PYTHON_LIBPATH}/site-packages/numpy' \
+                      '${python310Packages.numpy}/${python.sitePackages}/numpy'
+        ''
+      else
+        ''
+          substituteInPlace extern/clew/src/clew.c --replace '"libOpenCL.so"' '"${ocl-icd}/lib/libOpenCL.so"'
+        ''
+    )
+    + (lib.optionalString hipSupport ''
       substituteInPlace extern/hipew/src/hipew.c --replace '"/opt/rocm/hip/lib/libamdhip64.so"' '"${rocmPackages.clr}/lib/libamdhip64.so"'
       substituteInPlace extern/hipew/src/hipew.c --replace '"opt/rocm/hip/bin"' '"${rocmPackages.clr}/bin"'
     '');
 
+  env.NIX_CFLAGS_COMPILE = "-I${python}/include/${python.libPrefix}";
+
   cmakeFlags =
     [
+      "-DPYTHON_INCLUDE_DIR=${python}/include/${python.libPrefix}"
+      "-DPYTHON_LIBPATH=${python}/lib"
+      "-DPYTHON_LIBRARY=${python.libPrefix}"
+      "-DPYTHON_NUMPY_INCLUDE_DIRS=${python310Packages.numpy}/${python.sitePackages}/numpy/core/include"
+      "-DPYTHON_NUMPY_PATH=${python310Packages.numpy}/${python.sitePackages}"
+      "-DPYTHON_VERSION=${python.pythonVersion}"
       "-DWITH_ALEMBIC=ON"
+      "-DWITH_CODEC_FFMPEG=ON"
+      "-DWITH_CODEC_SNDFILE=ON"
+      "-DWITH_FFTW3=ON"
+      "-DWITH_IMAGE_OPENJPEG=ON"
+      "-DWITH_INSTALL_PORTABLE=OFF"
+      "-DWITH_MOD_OCEANSIM=ON"
+      "-DWITH_OPENCOLLADA=${if colladaSupport then "ON" else "OFF"}"
+      "-DWITH_OPENCOLORIO=ON"
+      "-DWITH_OPENSUBDIV=ON"
+      "-DWITH_OPENVDB=ON"
+      "-DWITH_PYTHON_INSTALL=OFF"
+      "-DWITH_PYTHON_INSTALL_NUMPY=OFF"
+      "-DWITH_PYTHON_INSTALL_REQUESTS=OFF"
+      "-DWITH_SDL=OFF"
+      "-DWITH_TBB=ON"
+
       # Blender supplies its own FindAlembic.cmake (incompatible with the Alembic-supplied config file)
       "-DALEMBIC_INCLUDE_DIR=${lib.getDev alembic}/include"
       "-DALEMBIC_LIBRARY=${lib.getLib alembic}/lib/libAlembic.so"
-      "-DWITH_MOD_OCEANSIM=ON"
-      "-DWITH_CODEC_FFMPEG=ON"
-      "-DWITH_CODEC_SNDFILE=ON"
-      "-DWITH_INSTALL_PORTABLE=OFF"
-      "-DWITH_FFTW3=ON"
-      "-DWITH_SDL=OFF"
-      "-DWITH_OPENCOLORIO=ON"
-      "-DWITH_OPENSUBDIV=ON"
-      "-DPYTHON_LIBRARY=${python.libPrefix}"
-      "-DPYTHON_LIBPATH=${python}/lib"
-      "-DPYTHON_INCLUDE_DIR=${python}/include/${python.libPrefix}"
-      "-DPYTHON_VERSION=${python.pythonVersion}"
-      "-DWITH_PYTHON_INSTALL=OFF"
-      "-DWITH_PYTHON_INSTALL_NUMPY=OFF"
-      "-DPYTHON_NUMPY_PATH=${python310Packages.numpy}/${python.sitePackages}"
-      "-DPYTHON_NUMPY_INCLUDE_DIRS=${python310Packages.numpy}/${python.sitePackages}/numpy/core/include"
-      "-DWITH_PYTHON_INSTALL_REQUESTS=OFF"
-      "-DWITH_OPENVDB=ON"
-      "-DWITH_TBB=ON"
-      "-DWITH_IMAGE_OPENJPEG=ON"
-      "-DWITH_OPENCOLLADA=${if colladaSupport then "ON" else "OFF"}"
     ]
     ++ lib.optionals waylandSupport [
       "-DWITH_GHOST_WAYLAND=ON"
@@ -155,43 +179,135 @@ stdenv.mkDerivation (finalAttrs: rec {
       "-DWITH_GHOST_WAYLAND_DYNLOAD=OFF"
       "-DWITH_GHOST_WAYLAND_LIBDECOR=ON"
     ]
-    ++ lib.optionals stdenv.hostPlatform.isAarch64 [
-      "-DWITH_CYCLES_EMBREE=OFF"
-    ]
+    ++ lib.optionals stdenv.hostPlatform.isAarch64 [ "-DWITH_CYCLES_EMBREE=OFF" ]
     ++ lib.optionals stdenv.isDarwin [
+      "-DLIBDIR=/does-not-exist"
       "-DWITH_CYCLES_OSL=OFF" # requires LLVM
       "-DWITH_OPENVDB=OFF" # OpenVDB currently doesn't build on darwin
-
-      "-DLIBDIR=/does-not-exist"
     ]
-    # Clang doesn't support "-export-dynamic"
-    ++ lib.optional stdenv.cc.isClang "-DPYTHON_LINKFLAGS="
+    ++ lib.optional stdenv.cc.isClang "-DPYTHON_LINKFLAGS=" # Clang doesn't support "-export-dynamic"
     ++ lib.optional jackaudioSupport "-DWITH_JACK=ON"
     ++ lib.optionals cudaSupport [
+      "-DOPTIX_ROOT_DIR=${optix}"
       "-DWITH_CYCLES_CUDA_BINARIES=ON"
       "-DWITH_CYCLES_DEVICE_OPTIX=ON"
-      "-DOPTIX_ROOT_DIR=${optix}"
     ];
 
-  env.NIX_CFLAGS_COMPILE = "-I${python}/include/${python.libPrefix}";
+  nativeBuildInputs =
+    [
+      cmake
+      llvmPackages.llvm.dev
+      makeWrapper
+      python310Packages.wrapPython
+    ]
+    ++ lib.optionals cudaSupport [
+      addOpenGLRunpath
+      cudaPackages.cuda_nvcc
+    ]
+    ++ lib.optionals waylandSupport [ pkg-config ];
+
+  buildInputs =
+    [
+      alembic
+      boost
+      ffmpeg
+      fftw
+      fftwFloat
+      freetype
+      gettext
+      glew
+      gmp
+      jemalloc
+      libepoxy
+      libharu
+      libjpeg
+      libpng
+      libsamplerate
+      libsndfile
+      libtiff
+      libwebp
+      opencolorio
+      openexr
+      openimageio
+      openjpeg
+      openpgl
+      (opensubdiv.override { inherit cudaSupport; })
+      potrace
+      pugixml
+      python
+      tbb
+      zlib
+      zstd
+    ]
+    ++ lib.optionals (!stdenv.isAarch64) [
+      embree
+      openimagedenoise
+    ]
+    ++ (
+      if (!stdenv.isDarwin) then
+        [
+          libGL
+          libGLU
+          libX11
+          libXext
+          libXi
+          libXrender
+          libXxf86vm
+          openal
+          openvdb # OpenVDB currently doesn't build on darwin
+          openxr-loader
+        ]
+      else
+        [
+          Cocoa
+          CoreGraphics
+          ForceFeedback
+          OpenAL
+          OpenGL
+          SDL
+          llvmPackages.openmp
+        ]
+    )
+    ++ lib.optionals cudaSupport [ cudaPackages.cuda_cudart ]
+    ++ lib.optionals waylandSupport [
+      dbus
+      libdecor'
+      libffi
+      libxkbcommon
+      wayland
+      wayland-protocols
+    ]
+    ++ lib.optional colladaSupport opencollada
+    ++ lib.optional jackaudioSupport libjack2
+    ++ lib.optional spaceNavSupport libspnav;
+
+  pythonPath = with python310Packages; [
+    numpy
+    requests
+    zstandard
+  ];
 
   # Since some dependencies are built with gcc 6, we need gcc 6's
   # libstdc++ in our RPATH. Sigh.
   NIX_LDFLAGS = lib.optionalString cudaSupport "-rpath ${stdenv.cc.cc.lib}/lib";
 
   blenderExecutable =
-    placeholder "out" + (if stdenv.isDarwin then "/Applications/Blender.app/Contents/MacOS/Blender" else "/bin/blender");
-  postInstall = lib.optionalString stdenv.isDarwin ''
-    mkdir $out/Applications
-    mv $out/Blender.app $out/Applications
-  '' + ''
-    mv $out/share/blender/${lib.versions.majorMinor version}/python{,-ext}
-    buildPythonPath "$pythonPath"
-    wrapProgram $blenderExecutable \
-      --prefix PATH : $program_PATH \
-      --prefix PYTHONPATH : "$program_PYTHONPATH" \
-      --add-flags '--python-use-system-env'
-  '';
+    placeholder "out"
+    + (if stdenv.isDarwin then "/Applications/Blender.app/Contents/MacOS/Blender" else "/bin/blender");
+
+  postInstall =
+    lib.optionalString stdenv.isDarwin ''
+      mkdir $out/Applications
+      mv $out/Blender.app $out/Applications
+    ''
+    + ''
+      mv $out/share/blender/${lib.versions.majorMinor version}/python{,-ext}
+      buildPythonPath "$pythonPath"
+      wrapProgram $blenderExecutable \
+        --prefix PATH : $program_PATH \
+        --prefix PYTHONPATH : "$program_PYTHONPATH" \
+        --add-flags '--python-use-system-env'
+    '';
 
   # Set RUNPATH so that libcuda and libnvrtc in /run/opengl-driver(-32)/lib can be
   # found. See the explanation in libglvnd.
@@ -205,7 +321,15 @@ stdenv.mkDerivation (finalAttrs: rec {
   passthru = {
     inherit python pythonPackages;
 
-    withPackages = f: let packages = f pythonPackages; in buildEnv.override { blender = finalAttrs.finalPackage; extraModules = packages; };
+    withPackages =
+      f:
+      let
+        packages = f pythonPackages;
+      in
+      buildEnv.override {
+        blender = finalAttrs.finalPackage;
+        extraModules = packages;
+      };
 
     tests = {
       render = runCommand "${pname}-test" { } ''
@@ -251,9 +375,16 @@ stdenv.mkDerivation (finalAttrs: rec {
     # say: "We've decided to cancel the BL offering for an indefinite period."
     # OptiX, enabled with cudaSupport, is non-free.
     license = with licenses; [ gpl2Plus ] ++ optional cudaSupport unfree;
-    platforms = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" ];
+    platforms = [
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
     broken = stdenv.isDarwin;
-    maintainers = with maintainers; [ goibhniu veprbl ];
+    maintainers = with maintainers; [
+      goibhniu
+      veprbl
+    ];
     mainProgram = "blender";
   };
 })

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -91,9 +91,9 @@ let
   });
 
   optix = fetchzip {
-    # url taken from the archlinux blender PKGBUILD
+    # URL from https://gitlab.archlinux.org/archlinux/packaging/packages/blender/-/commit/333add667b43255dcb011215a2d2af48281e83cf#9b9baac1eb9b72790eef5540a1685306fc43fd6c_30_30
     url = "https://developer.download.nvidia.com/redist/optix/v7.3/OptiX-7.3.0-Include.zip";
-    sha256 = "0max1j4822mchj0xpz9lqzh91zkmvsn4py0r174cvqfz8z8ykjk8";
+    hash = "sha256-aMrp0Uff4c3ICRn4S6zedf6Q4Mc0/duBhKwKgYgMXVU=";
   };
 in
 

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -281,11 +281,15 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional jackaudioSupport libjack2
     ++ lib.optional spaceNavSupport libspnav;
 
-  pythonPath = with pythonPackages; [
-    numpy
-    requests
-    zstandard
-  ];
+  pythonPath =
+    let
+      ps = pythonPackages;
+    in
+    [
+      ps.numpy
+      ps.requests
+      ps.zstandard
+    ];
 
   # Since some dependencies are built with gcc 6, we need gcc 6's
   # libstdc++ in our RPATH. Sigh.
@@ -368,20 +372,20 @@ stdenv.mkDerivation (finalAttrs: {
     };
   };
 
-  meta = with lib; {
+  meta = {
     description = "3D Creation/Animation/Publishing System";
     homepage = "https://www.blender.org";
     # They comment two licenses: GPLv2 and Blender License, but they
     # say: "We've decided to cancel the BL offering for an indefinite period."
     # OptiX, enabled with cudaSupport, is non-free.
-    license = with licenses; [ gpl2Plus ] ++ optional cudaSupport unfree;
+    license = with lib.licenses; [ gpl2Plus ] ++ lib.optional cudaSupport unfree;
     platforms = [
       "aarch64-linux"
       "x86_64-darwin"
       "x86_64-linux"
     ];
     broken = stdenv.isDarwin;
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       goibhniu
       veprbl
     ];

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -130,7 +130,7 @@ stdenv.mkDerivation (finalAttrs: rec {
             --replace '${"$"}{LIBDIR}/opencollada' \
                       '${opencollada}' \
             --replace '${"$"}{PYTHON_LIBPATH}/site-packages/numpy' \
-                      '${python310Packages.numpy}/${python.sitePackages}/numpy'
+                      '${pythonPackages.numpy}/${python.sitePackages}/numpy'
         ''
       else
         ''
@@ -149,8 +149,8 @@ stdenv.mkDerivation (finalAttrs: rec {
       "-DPYTHON_INCLUDE_DIR=${python}/include/${python.libPrefix}"
       "-DPYTHON_LIBPATH=${python}/lib"
       "-DPYTHON_LIBRARY=${python.libPrefix}"
-      "-DPYTHON_NUMPY_INCLUDE_DIRS=${python310Packages.numpy}/${python.sitePackages}/numpy/core/include"
-      "-DPYTHON_NUMPY_PATH=${python310Packages.numpy}/${python.sitePackages}"
+      "-DPYTHON_NUMPY_INCLUDE_DIRS=${pythonPackages.numpy}/${python.sitePackages}/numpy/core/include"
+      "-DPYTHON_NUMPY_PATH=${pythonPackages.numpy}/${python.sitePackages}"
       "-DPYTHON_VERSION=${python.pythonVersion}"
       "-DWITH_ALEMBIC=ON"
       "-DWITH_CODEC_FFMPEG=ON"
@@ -198,7 +198,7 @@ stdenv.mkDerivation (finalAttrs: rec {
       cmake
       llvmPackages.llvm.dev
       makeWrapper
-      python310Packages.wrapPython
+      pythonPackages.wrapPython
     ]
     ++ lib.optionals cudaSupport [
       addOpenGLRunpath
@@ -281,7 +281,7 @@ stdenv.mkDerivation (finalAttrs: rec {
     ++ lib.optional jackaudioSupport libjack2
     ++ lib.optional spaceNavSupport libspnav;
 
-  pythonPath = with python310Packages; [
+  pythonPath = with pythonPackages; [
     numpy
     requests
     zstandard

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -99,12 +99,12 @@ let
   };
 in
 
-stdenv.mkDerivation (finalAttrs: rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "blender";
   version = "4.0.2";
 
   src = fetchurl {
-    url = "https://download.blender.org/source/${pname}-${version}.tar.xz";
+    url = "https://download.blender.org/source/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
     hash = "sha256-qqDnKdp1kc+/RXcq92NFl32qp7EaCvNdmPkxPiRgd6M=";
   };
 
@@ -301,7 +301,7 @@ stdenv.mkDerivation (finalAttrs: rec {
       mv $out/Blender.app $out/Applications
     ''
     + ''
-      mv $out/share/blender/${lib.versions.majorMinor version}/python{,-ext}
+      mv $out/share/blender/${lib.versions.majorMinor finalAttrs.version}/python{,-ext}
       buildPythonPath "$pythonPath"
       wrapProgram $blenderExecutable \
         --prefix PATH : $program_PATH \
@@ -332,7 +332,7 @@ stdenv.mkDerivation (finalAttrs: rec {
       };
 
     tests = {
-      render = runCommand "${pname}-test" { } ''
+      render = runCommand "${finalAttrs.pname}-test" { } ''
         set -euo pipefail
 
         export LIBGL_DRIVERS_PATH=${mesa.drivers}/lib/dri

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -291,10 +291,6 @@ stdenv.mkDerivation (finalAttrs: {
       ps.zstandard
     ];
 
-  # Since some dependencies are built with gcc 6, we need gcc 6's
-  # libstdc++ in our RPATH. Sigh.
-  NIX_LDFLAGS = lib.optionalString cudaSupport "-rpath ${stdenv.cc.cc.lib}/lib";
-
   blenderExecutable =
     placeholder "out"
     + (if stdenv.isDarwin then "/Applications/Blender.app/Contents/MacOS/Blender" else "/bin/blender");

--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -85,8 +85,6 @@ let
   pythonPackages = python310Packages;
   inherit (pythonPackages) python;
 
-  buildEnv = callPackage ./wrapper.nix { };
-
   libdecor' = libdecor.overrideAttrs (old: {
     # Blender uses private APIs, need to patch to expose them
     patches = (old.patches or [ ]) ++ [ ./libdecor.patch ];
@@ -323,12 +321,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     withPackages =
       f:
-      let
-        packages = f pythonPackages;
-      in
-      buildEnv.override {
+      (callPackage ./wrapper.nix { }).override {
         blender = finalAttrs.finalPackage;
-        extraModules = packages;
+        extraModules = (f pythonPackages);
       };
 
     tests = {


### PR DESCRIPTION
## Description of changes

Intention here is no functional changes (though the derivation itself does change due to reordering in lists). Motivation is to make it easier to contribute future changes to blender without having to undergo piecemeal cleanups to align with more modern nixpkgs style, while also producing more compact, obvious diffs.

Incorporated some feedback from stalled draft PR https://github.com/NixOS/nixpkgs/pull/257780.


## Things done

Have verified the only difference between the generated derivations before-and-after is inconsequential reordering (e.g. of buildInputs; as is expected).

<details>
<summary>nix-diff, etc. output</summary>

```
- /nix/store/2mkq73y45g2laph9sb6adrnhjs8273h1-blender-4.0.2:{out}
+ ./result/:{out}
• The environments do not match:
    - NIX_LDFLAGS=
    buildInputs=''
    /nix/store/jr04j43vj4msihyr04qpzbaxzv81dvqa-alembic-1.8.6-dev /nix/store/6d5sjqmrm93jncsmgzlgb7jqi1gwrgag-boost-1.81.0-dev /nix/store/yglspjlx9g2ggrb14k74d1ic7v85n4sv-ffmpeg-6.1-dev /nix/store/lf16l9l7254q7n2dpdvb7v8sm52ipj58-fftw-double-3.3.10-dev /nix/store/xgkz2q9v4hd88pqzga39xxz0wqssj0ha-fftw-single-3.3.10-dev /nix/store/0bkz0x8vsb92kcr3inkgs0ba2dqlla5a-freetype-2.13.2-dev /nix/store/zd1a9i36yqs6bfamfqa3hbxf7a2si2vq-gettext-0.21.1 /nix/store/q9afqp2563dxlnj11sp1jm1wqqs9qxmv-glew-2.2.0-dev /nix/store/0bkz0x8vsb92kcr3inkgs0ba2dqlla5a-freetype-2.13.2-dev/nix/store/ngn2dcks7bhn1lf6aw3i87vxz57bzzbm-gmp-with-cxx-6.3.0-dev /nix/store/2rh1ria0y4h6axmc7lc4rnf7pmxq9h9g-jemalloc-5.3.0 /nix/store/44crpysa5xmp87kp8f3szkvwzgb3m94j-libepoxy-1.5.10-dev /nix/store/m0hagrpa8qs039xmy3qv9l8b0lfr44bj-libharu-2.4.4 /nix/store/r2z54nm9xkrz7z6cv09a0g3j3am5chaj-libjpeg-turbo-3.0.2-dev /nix/store/831hplq82ppf633fv1qchlrsihhkryz4-libpng-apng-1.6.40-dev /nix/store/mnzw9pdgbp4jwsnrhphg32ksx4szw5bi-libsamplerate-0.1.9-dev /nix/store/i9s5cznrzcm06dlwzy1lff1y36rll1dj-libsndfile-1.2.2-dev /nix/store/b1a4g7a7cxh1sl0y4rzbqyc4nmxhi874-libtiff-4.6.0-dev /nix/store/lbli5mw15jd163vllb2kkh6h1aw2n799-libwebp-1.3.2 /nix/store/kz0bb6n4bwhqigxkny8y8cak5d5656w8-opencolorio-2.3.0 /nix/store/r2mskmdpay21drxzypxqy45vwn9xlf4y-openexr-3.2.2-dev /nix/store/f9snhaffkl80j7biwhawv4jpqwrk1q71-openimageio-2.5.5.0-dev /nix/store/0d9iwk3fvy1sg2ymsyy024n1ac85324k-openjpeg-2.5.0-dev /nix/store/rys6l2skqj995pin7h5221yg0y80xyql-openpgl-0.5.0 /nix/store/zwfs2v6shid5ww6ixj8lv52pbdcn2152-opensubdiv-3.5.1-dev /nix/store/14ar275f6rznjc6vi3v4pm0gj4zl10gy-potrace-1.16 /nix/store/lyk7g1vy6sq3ri8wmlwq930ahpip85gs-pugixml-1.13 /nix/store/9x6kjq8z5dwcg145l7k2r5lvvb24kckp-python3-3.10.13 /nix/store/by6afz91dmy4l9s9rvwjsx32hqxl8wbd-tbb-2020.3-dev /nix/store/hwlm6akqm83lapl79y8r9r2vw741sppd-zlib-1.3.1-dev /nix/store/s88sksxns15dhwr6dp0pwy0qz5sr7gq3-zstd-1.5.5-dev /nix/store/lf16l9l7254q7n2dpdvb7v8sm52ipj58-fftw-double-3.3.10-dev /nix/store/xgkz2q9v4hd88pqzga39xxz0wqssj0ha-fftw-single-3.3.10-dev /nix/store/2rh1ria0y4h6axmc7lc4rnf7pmxq9h9g-jemalloc-5.3.0 /nix/store/jr04j43vj4msihyr04qpzbaxzv81dvqa-alembic-1.8.6-dev /nix/store/zwfs2v6shid5ww6ixj8lv52pbdcn2152-opensubdiv-3.5.1-dev /nix/store/by6afz91dmy4l9s9rvwjsx32hqxl8wbd-tbb-2020.3-dev /nix/store/ngn2dcks7bhn1lf6aw3i87vxz57bzzbm-gmp-with-cxx-6.3.0-dev /nix/store/lyk7g1vy6sq3ri8wmlwq930ahpip85gs-pugixml-1.13 /nix/store/14ar275f6rznjc6vi3v4pm0gj4zl10gy-potrace-1.16 /nix/store/m0hagrpa8qs039xmy3qv9l8b0lfr44bj-libharu-2.4.4 /nix/store/44crpysa5xmp87kp8f3szkvwzgb3m94j-libepoxy-1.5.10-dev /nix/store/rys6l2skqj995pin7h5221yg0y80xyql-openpgl-0.5.0 /nix/store/13ay8131gj00mjz9vmg37ypqyb5pppms-wayland-1.22.0-dev /nix/store/2rnny7gvwn2mdrmiaysb5z5pdgjl4rly-wayland-protocols-1.33 /nix/store/7sg7d748qf9lc8cq0ywhs1y2qbxain3n-libffi-3.4.4-dev /nix/store/v30711i60lvw47fr2760pzf98kqq68d1-libdecor-0.2.2-dev /nix/store/14j5m65bpz50sqczkni59vrma4vlwhd8-libxkbcommon-1.5.0-dev /nix/store/s3gyml9g2x7124zbghvnzrfifbkhyfnq-dbus-1.14.10-dev/nix/store/787fcyzlvydspiidg53cka2f0k549bc1-embree-3.13.5 /nix/store/8rvlxa4gz91nmi68p18abd5qva24w7m6-openimagedenoise-1.4.3 /nix/store/787fcyzlvydspiidg53cka2f0k549bc1-embree-3.13.5/nix/store/477xpc7ffpkds6a20v4gdx9hkq2y08kx-libGL-1.7.0-dev /nix/store/bpq2ax3jks7cam3h3s75xz2jk90ni3f9-libXi-1.8.1-dev/nix/store/cdy1knbqwfy8wd3sj5c8vwj0nnzyjvgk-glu-9.0.3-dev /nix/store/pirdcrf04q6qm2yq8w6w4gam0ax1vlnd-libX11-1.8.7-dev /nix/store/drz4r0b20cl5r4lsw600h9l59jsanvr6-libXext-1.3.6-dev /nix/store/bpq2ax3jks7cam3h3s75xz2jk90ni3f9-libXi-1.8.1-dev /nix/store/13m2njz5m4wwrmf4n74zmfpcczi6kk8s-libXrender-0.9.11-dev /nix/store/cdy1knbqwfy8wd3sj5c8vwj0nnzyjvgk-glu-9.0.3-dev /nix/store/477xpc7ffpkds6a20v4gdx9hkq2y08kx-libGL-1.7.0-dev/nix/store/g96kg0flgdkq9aqyymyhp8vqzlgpdn6x-libXxf86vm-1.1.5-dev /nix/store/dsdfn1k9hnxzdwvzirx2smfinziqc8bz-openal-soft-1.23.1 /nix/store/g96kg0flgdkq9aqyymyhp8vqzlgpdn6x-libXxf86vm-1.1.5-dev/nix/store/7yz6zxzcn5z6rhqxa23cv5767px1p3di-openvdb-11.0.0-dev /nix/store/v0vcw2id0vvprix0jrdr792rg791n726-openxr-loader-1.0.33-dev /nix/store/7yz6zxzcn5z6rhqxa23cv5767px1p3di-openvdb-11.0.0-dev/nix/store/s3gyml9g2x7124zbghvnzrfifbkhyfnq-dbus-1.14.10-dev /nix/store/v30711i60lvw47fr2760pzf98kqq68d1-libdecor-0.2.2-dev /nix/store/7sg7d748qf9lc8cq0ywhs1y2qbxain3n-libffi-3.4.4-dev /nix/store/14j5m65bpz50sqczkni59vrma4vlwhd8-libxkbcommon-1.5.0-dev /nix/store/13ay8131gj00mjz9vmg37ypqyb5pppms-wayland-1.22.0-dev /nix/store/2rnny7gvwn2mdrmiaysb5z5pdgjl4rly-wayland-protocols-1.33 /nix/store/nb93wgvkix9k7q4mcpd3dz00g1k6bdrf-opencollada-1.6.68 /nix/store/x006cp8b1pqpikdllr2rmc8ikywmr7rn-libspnav-0.2.3
''
    cmakeFlags=''
    -DPYTHON_INCLUDE_DIR=/nix/store/9x6kjq8z5dwcg145l7k2r5lvvb24kckp-python3-3.10.13/include/python3.10 -DPYTHON_LIBPATH=/nix/store/9x6kjq8z5dwcg145l7k2r5lvvb24kckp-python3-3.10.13/lib -DPYTHON_LIBRARY=python3.10 -DPYTHON_NUMPY_INCLUDE_DIRS=/nix/store/zikqyh7a8sx211br3zh7zmsgbvg7vqpj-python3.10-numpy-1.26.4/lib/python3.10/site-packages/numpy/core/include -DPYTHON_NUMPY_PATH=/nix/store/zikqyh7a8sx211br3zh7zmsgbvg7vqpj-python3.10-numpy-1.26.4/lib/python3.10/site-packages -DPYTHON_VERSION=3.10 -DWITH_ALEMBIC=ON -DALEMBIC_INCLUDE_DIR=/nix/store/jr04j43vj4msihyr04qpzbaxzv81dvqa-alembic-1.8.6-dev/include -DALEMBIC_LIBRARY=/nix/store/8vh9nfb8mgsdgb3yv6zpj6wcg7905cp2-alembic-1.8.6-lib/lib/libAlembic.so -DWITH_MOD_OCEANSIM=ON -DWITH_CODEC_FFMPEG=ON -DWITH_CODEC_SNDFILE=ON -DWITH_FFTW3=ON -DWITH_IMAGE_OPENJPEG=ON -DWITH_INSTALL_PORTABLE=OFF -DWITH_FFTW3=ON-DWITH_MOD_OCEANSIM=ON -DWITH_SDL=OFF-DWITH_OPENCOLLADA=ON -DWITH_OPENCOLORIO=ON -DWITH_OPENSUBDIV=ON -DPYTHON_LIBRARY=python3.10 -DPYTHON_LIBPATH=/nix/store/9x6kjq8z5dwcg145l7k2r5lvvb24kckp-python3-3.10.13/lib -DPYTHON_INCLUDE_DIR=/nix/store/9x6kjq8z5dwcg145l7k2r5lvvb24kckp-python3-3.10.13/include/python3.10 -DPYTHON_VERSION=3.10-DWITH_OPENVDB=ON -DWITH_PYTHON_INSTALL=OFF -DWITH_PYTHON_INSTALL_NUMPY=OFF -DPYTHON_NUMPY_PATH=/nix/store/zikqyh7a8sx211br3zh7zmsgbvg7vqpj-python3.10-numpy-1.26.4/lib/python3.10/site-packages -DPYTHON_NUMPY_INCLUDE_DIRS=/nix/store/zikqyh7a8sx211br3zh7zmsgbvg7vqpj-python3.10-numpy-1.26.4/lib/python3.10/site-packages/numpy/core/include -DWITH_PYTHON_INSTALL_REQUESTS=OFF -DWITH_OPENVDB=ON-DWITH_SDL=OFF -DWITH_TBB=ON -DWITH_IMAGE_OPENJPEG=ON-DALEMBIC_INCLUDE_DIR=/nix/store/jr04j43vj4msihyr04qpzbaxzv81dvqa-alembic-1.8.6-dev/include -DWITH_OPENCOLLADA=ON-DALEMBIC_LIBRARY=/nix/store/8vh9nfb8mgsdgb3yv6zpj6wcg7905cp2-alembic-1.8.6-lib/lib/libAlembic.so -DWITH_GHOST_WAYLAND=ON -DWITH_GHOST_WAYLAND_DBUS=ON -DWITH_GHOST_WAYLAND_DYNLOAD=OFF -DWITH_GHOST_WAYLAND_LIBDECOR=ON
''
    nativeBuildInputs=''
    /nix/store/paxnwg89pdx4car5fj84mmiprg952459-cmake-3.28.2 /nix/store/mz5rqlnmfyq18dvlqkdzi6dm5l9kjpjp-llvm-16.0.6-dev /nix/store/qyh61bhf3s7jgmczpmdq5ps72xqizsnq-make-shell-wrapper-hook /nix/store/ib8hjl1ya45q4glrix483crc6184qz8f-wrap-python-hook /nix/store/mz5rqlnmfyq18dvlqkdzi6dm5l9kjpjp-llvm-16.0.6-dev /nix/store/492n7ylp2f9zn0k3vghv1snypgkzznc5-pkg-config-wrapper-0.29.2
''
```

```
diff -u \
  <(nix derivation show /nix/store/2mkq73y45g2laph9sb6adrnhjs8273h1-blender-4.0.2 | jq -r '.[].env.cmakeFlags' | tr ' ' "\n" | sort) \
  <(nix derivation show ./result | jq -r '.[].env.cmakeFlags' | tr ' ' "\n" | sort)
# empty diff

diff -u \
  <(nix derivation show /nix/store/2mkq73y45g2laph9sb6adrnhjs8273h1-blender-4.0.2 | jq -r '.[].env.buildInputs' | tr ' ' "\n" | sort) \
  <(nix derivation show ./result | jq -r '.[].env.buildInputs' | tr ' ' "\n" | sort)
# empty diff

diff -u \
  <(nix derivation show /nix/store/2mkq73y45g2laph9sb6adrnhjs8273h1-blender-4.0.2 | jq -r '.[].env.nativeBuildInputs' | tr ' ' "\n" | sort) \
  <(nix derivation show ./result | jq -r '.[].env.nativeBuildInputs' | tr ' ' "\n" | sort)
# empty diff
```

</details>

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
