### PR TITLE
mongodb-6_0: add patch to fix broken build

### DIFF
--- a/pkgs/servers/nosql/mongodb/6.0.nix
+++ b/pkgs/servers/nosql/mongodb/6.0.nix
@@ -10,7 +10,6 @@ buildMongoDB {
   sha256 = "sha256-BD3XrTdv4sCa3h37o1A2s3/R0R8zHiR59a4pY0RxLGU=";
   patches = [
     # Patches a bug that it couldn't build MongoDB 6.0 on gcc 13 because a include in ctype.h was missing
-    # PR at https://github.com/NixOS/nixpkgs/pull/293556
     ./fix-gcc-13-ctype-6_0.patch
 
     (fetchpatch {

--- a/pkgs/servers/nosql/mongodb/6.0.nix
+++ b/pkgs/servers/nosql/mongodb/6.0.nix
@@ -9,6 +9,10 @@ buildMongoDB {
   version = "6.0.13";
   sha256 = "sha256-BD3XrTdv4sCa3h37o1A2s3/R0R8zHiR59a4pY0RxLGU=";
   patches = [
+    # Patches a bug that it couldn't build MongoDB 6.0 on gcc 13 because a include in ctype.h was missing
+    # PR at https://github.com/NixOS/nixpkgs/pull/293556
+    ./fix-gcc-13-ctype-6_0.patch
+
     (fetchpatch {
       name = "mongodb-6.1.0-rc-more-specific-cache-alignment-types.patch";
       url = "https://github.com/mongodb/mongo/commit/5435f9585f857f6145beaf6d31daf336453ba86f.patch";

--- a/pkgs/servers/nosql/mongodb/fix-gcc-13-ctype-6_0.patch
+++ b/pkgs/servers/nosql/mongodb/fix-gcc-13-ctype-6_0.patch
@@ -1,0 +1,12 @@
+diff --git a/src/mongo/util/ctype.h b/src/mongo/util/ctype.h
+index a3880e2..78ee57e 100644
+--- a/src/mongo/util/ctype.h
++++ b/src/mongo/util/ctype.h
+@@ -67,6 +67,7 @@
+ #pragma once
+
+ #include <array>
++#include <cstdint>
+
+ namespace mongo::ctype {
+ namespace detail {


### PR DESCRIPTION
## Description of changes
fixes broken build on master for mongodb 6.0:

```
In file included from src/mongo/db/query/analyze_regex.cpp:34:
src/mongo/util/ctype.h:75:15: error: found ‘:’ in nested-name-specifier, expected ‘::’
   75 | enum ClassBit : uint16_t {
      |               ^
      |               ::
src/mongo/util/ctype.h:75:6: error: ‘ClassBit’ has not been declared
   75 | enum ClassBit : uint16_t {
      |      ^~~~~~~~
src/mongo/util/ctype.h:75:26: error: expected unqualified-id before ‘{’ token
   75 | enum ClassBit : uint16_t {
      |                          ^
src/mongo/util/ctype.h:91:11: error: ‘uint16_t’ does not name a type
   91 | constexpr uint16_t calculateClassBits(unsigned char c) {
      |           ^~~~~~~~
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
