### PR TITLE
Improve error messages by removing `checkDependencyList` in `stdenv.mkDerivation`

### DIFF
--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -261,12 +261,6 @@ let
     else subtractLists hardeningDisable' (defaultHardeningFlags ++ hardeningEnable);
   # hardeningDisable additionally supports "all".
   erroneousHardeningFlags = subtractLists knownHardeningFlags (hardeningEnable ++ remove "all" hardeningDisable);
-
-  checkDependencyList = checkDependencyList' [];
-  checkDependencyList' = positions: name: deps: flip imap1 deps (index: dep:
-    if isDerivation dep || dep == null || builtins.isString dep || builtins.isPath dep then dep
-    else if isList dep then checkDependencyList' ([index] ++ positions) name dep
-    else throw "Dependency is not of a valid type: ${concatMapStrings (ix: "element ${toString ix} of ") ([index] ++ positions)}${name} for ${attrs.name or attrs.pname}");
 in if builtins.length erroneousHardeningFlags != 0
 then abort ("mkDerivation was called with unsupported hardening flags: " + lib.generators.toPretty {} {
   inherit erroneousHardeningFlags hardeningDisable hardeningEnable knownHardeningFlags;
@@ -290,30 +284,30 @@ else let
 
   dependencies = map (map chooseDevOutputs) [
     [
-      (map (drv: drv.__spliced.buildBuild or drv) (checkDependencyList "depsBuildBuild" depsBuildBuild))
-      (map (drv: drv.__spliced.buildHost or drv) (checkDependencyList "nativeBuildInputs" nativeBuildInputs'))
-      (map (drv: drv.__spliced.buildTarget or drv) (checkDependencyList "depsBuildTarget" depsBuildTarget))
+      (map (drv: drv.__spliced.buildBuild or drv) depsBuildBuild)
+      (map (drv: drv.__spliced.buildHost or drv) nativeBuildInputs')
+      (map (drv: drv.__spliced.buildTarget or drv) depsBuildTarget)
     ]
     [
-      (map (drv: drv.__spliced.hostHost or drv) (checkDependencyList "depsHostHost" depsHostHost))
-      (map (drv: drv.__spliced.hostTarget or drv) (checkDependencyList "buildInputs" buildInputs'))
+      (map (drv: drv.__spliced.hostHost or drv) depsHostHost)
+      (map (drv: drv.__spliced.hostTarget or drv) buildInputs')
     ]
     [
-      (map (drv: drv.__spliced.targetTarget or drv) (checkDependencyList "depsTargetTarget" depsTargetTarget))
+      (map (drv: drv.__spliced.targetTarget or drv) depsTargetTarget)
     ]
   ];
   propagatedDependencies = map (map chooseDevOutputs) [
     [
-      (map (drv: drv.__spliced.buildBuild or drv) (checkDependencyList "depsBuildBuildPropagated" depsBuildBuildPropagated))
-      (map (drv: drv.__spliced.buildHost or drv) (checkDependencyList "propagatedNativeBuildInputs" propagatedNativeBuildInputs))
-      (map (drv: drv.__spliced.buildTarget or drv) (checkDependencyList "depsBuildTargetPropagated" depsBuildTargetPropagated))
+      (map (drv: drv.__spliced.buildBuild or drv) depsBuildBuildPropagated)
+      (map (drv: drv.__spliced.buildHost or drv) propagatedNativeBuildInputs)
+      (map (drv: drv.__spliced.buildTarget or drv) depsBuildTargetPropagated)
     ]
     [
-      (map (drv: drv.__spliced.hostHost or drv) (checkDependencyList "depsHostHostPropagated" depsHostHostPropagated))
-      (map (drv: drv.__spliced.hostTarget or drv) (checkDependencyList "propagatedBuildInputs" propagatedBuildInputs))
+      (map (drv: drv.__spliced.hostHost or drv) depsHostHostPropagated)
+      (map (drv: drv.__spliced.hostTarget or drv) propagatedBuildInputs)
     ]
     [
-      (map (drv: drv.__spliced.targetTarget or drv) (checkDependencyList "depsTargetTargetPropagated" depsTargetTargetPropagated))
+      (map (drv: drv.__spliced.targetTarget or drv) depsTargetTargetPropagated)
     ]
   ];
 


### PR DESCRIPTION
I recently encountered this error attempting to build a derivation:

```
error:
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'infra-shell'
         whose name attribute is located at /nix/store/ppm74s0slima7385piksmdcnvcawgs1x-source/pkgs/stdenv/generic/make-derivation.nix:353:7

       … while evaluating attribute 'nativeBuildInputs' of derivation 'infra-shell'

         at /nix/store/ppm74s0slima7385piksmdcnvcawgs1x-source/pkgs/stdenv/generic/make-derivation.nix:397:7:

          396|       depsBuildBuild              = elemAt (elemAt dependencies 0) 0;
          397|       nativeBuildInputs           = elemAt (elemAt dependencies 0) 1;
             |       ^
          398|       depsBuildTarget             = elemAt (elemAt dependencies 0) 2;

       error: Dependency is not of a valid type: element 23 of nativeBuildInputs for infra-shell
```

This isn't very helpful; it doesn't tell me what the type of the dependency is. I'm also not directly constructing `stdenv.mkDerivation { nativeBuildInputs = [...]; }`, so it's not obvious what "element 23" would be (the derivation is constructed through several layers of helpers, like many derivations in nixpkgs are).

Ultimately, element 23 was a function, which surfaces another issue:

```
nix-repl> throw "Dependency is not of a valid type: ${a: a}"
error:
       … while evaluating a path segment

         at «string»:1:43:

            1| throw "Dependency is not of a valid type: ${a: a}"
             |                                           ^

       error: cannot coerce a function to a string
```

(`builtins.toString` produces similar results.) The Nix language doesn't provide a safe value printing function, so we can't really construct a good error message here.

The good news is that we can remove this error checking code from nixpkgs entirely without losing usability. Here's the error message on Nix 2.19.3:

```
error:
       … while calling the 'derivationStrict' builtin

         at /derivation-internal.nix:9:12:

            8|
            9|   strict = derivationStrict drvAttrs;
             |            ^
           10|

       … while evaluating derivation 'my-derivation'
         whose name attribute is located at /Users/wiggles/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:347:7

       … while evaluating attribute 'nativeBuildInputs' of derivation 'my-derivation'

         at /Users/wiggles/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:391:7:

          390|       depsBuildBuild              = elemAt (elemAt dependencies 0) 0;
          391|       nativeBuildInputs           = elemAt (elemAt dependencies 0) 1;
             |       ^
          392|       depsBuildTarget             = elemAt (elemAt dependencies 0) 2;

       error: cannot coerce a function to a string
```

Thanks to PRs like https://github.com/NixOS/nix/pull/9754, these error messages will improve in coming Nix releases:

```
       … while evaluating attribute 'nativeBuildInputs' of derivation 'my-derivation'
         at /Users/wiggles/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:391:7:
          390|       depsBuildBuild              = elemAt (elemAt dependencies 0) 0;
          391|       nativeBuildInputs           = elemAt (elemAt dependencies 0) 1;
             |       ^
          392|       depsBuildTarget             = elemAt (elemAt dependencies 0) 2;

       … while evaluating one element of the list

       error: cannot coerce a function to a string: «lambda @ /Users/wiggles/nixpkgs/xxx-derivation.nix:7:28»
```

(This shows the exact location of the failing value!)

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
