### PR TITLE
nixosTests.bittorrent: Fix pkgs scope

### DIFF
--- a/nixos/tests/bittorrent.nix
+++ b/nixos/tests/bittorrent.nix
@@ -6,163 +6,199 @@
 # which only works if the first client successfully uses the UPnP-IGD
 # protocol to poke a hole in the NAT.
 
-import ./make-test-python.nix ({ pkgs, ... }:
+import ./make-test-python.nix (
+  { pkgs, ... }:
 
-let
+  let
 
-  # Some random file to serve.
-  file = pkgs.hello.src;
+    # Some random file to serve.
+    file = pkgs.hello.src;
 
-  internalRouterAddress = "192.168.3.1";
-  internalClient1Address = "192.168.3.2";
-  externalRouterAddress = "80.100.100.1";
-  externalClient2Address = "80.100.100.2";
-  externalTrackerAddress = "80.100.100.3";
+    internalRouterAddress = "192.168.3.1";
+    internalClient1Address = "192.168.3.2";
+    externalRouterAddress = "80.100.100.1";
+    externalClient2Address = "80.100.100.2";
+    externalTrackerAddress = "80.100.100.3";
 
-  download-dir = "/var/lib/transmission/Downloads";
-  transmissionConfig = { pkgs, ... }: {
-    environment.systemPackages = [ pkgs.transmission_3 ];
-    services.transmission = {
-      enable = true;
-      settings = {
-        dht-enabled = false;
-        message-level = 2;
-        inherit download-dir;
-      };
-    };
-  };
-in
-
-{
-  name = "bittorrent";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ domenkozar rob bobvanderlinden ];
-  };
-
-  nodes = {
-    tracker = { pkgs, ... }: {
-      imports = [ transmissionConfig ];
-
-      virtualisation.vlans = [ 1 ];
-      networking.firewall.enable = false;
-      networking.interfaces.eth1.ipv4.addresses = [
-        { address = externalTrackerAddress; prefixLength = 24; }
-      ];
-
-      # We need Apache on the tracker to serve the torrents.
-      services.httpd = {
-        enable = true;
-        virtualHosts = {
-          "torrentserver.org" = {
-            adminAddr = "foo@example.org";
-            documentRoot = "/tmp";
+    download-dir = "/var/lib/transmission/Downloads";
+    transmissionConfig =
+      { pkgs, ... }:
+      {
+        environment.systemPackages = [ pkgs.transmission_3 ];
+        services.transmission = {
+          enable = true;
+          settings = {
+            dht-enabled = false;
+            message-level = 2;
+            inherit download-dir;
           };
         };
       };
-      services.opentracker.enable = true;
+  in
+
+  {
+    name = "bittorrent";
+    meta = with pkgs.lib.maintainers; {
+      maintainers = [
+        domenkozar
+        rob
+        bobvanderlinden
+      ];
     };
 
-    router = { pkgs, nodes, ... }: {
-      virtualisation.vlans = [ 1 2 ];
-      networking.nat.enable = true;
-      networking.nat.internalInterfaces = [ "eth2" ];
-      networking.nat.externalInterface = "eth1";
-      networking.firewall.enable = true;
-      networking.firewall.trustedInterfaces = [ "eth2" ];
-      networking.interfaces.eth0.ipv4.addresses = [];
-      networking.interfaces.eth1.ipv4.addresses = [
-        { address = externalRouterAddress; prefixLength = 24; }
-      ];
-      networking.interfaces.eth2.ipv4.addresses = [
-        { address = internalRouterAddress; prefixLength = 24; }
-      ];
-      services.miniupnpd = {
-        enable = true;
-        externalInterface = "eth1";
-        internalIPs = [ "eth2" ];
-        appendConfig = ''
-          ext_ip=${externalRouterAddress}
-        '';
-      };
+    nodes = {
+      tracker =
+        { pkgs, ... }:
+        {
+          imports = [ transmissionConfig ];
+
+          virtualisation.vlans = [ 1 ];
+          networking.firewall.enable = false;
+          networking.interfaces.eth1.ipv4.addresses = [
+            {
+              address = externalTrackerAddress;
+              prefixLength = 24;
+            }
+          ];
+
+          # We need Apache on the tracker to serve the torrents.
+          services.httpd = {
+            enable = true;
+            virtualHosts = {
+              "torrentserver.org" = {
+                adminAddr = "foo@example.org";
+                documentRoot = "/tmp";
+              };
+            };
+          };
+          services.opentracker.enable = true;
+        };
+
+      router =
+        { pkgs, nodes, ... }:
+        {
+          virtualisation.vlans = [
+            1
+            2
+          ];
+          networking.nat.enable = true;
+          networking.nat.internalInterfaces = [ "eth2" ];
+          networking.nat.externalInterface = "eth1";
+          networking.firewall.enable = true;
+          networking.firewall.trustedInterfaces = [ "eth2" ];
+          networking.interfaces.eth0.ipv4.addresses = [ ];
+          networking.interfaces.eth1.ipv4.addresses = [
+            {
+              address = externalRouterAddress;
+              prefixLength = 24;
+            }
+          ];
+          networking.interfaces.eth2.ipv4.addresses = [
+            {
+              address = internalRouterAddress;
+              prefixLength = 24;
+            }
+          ];
+          services.miniupnpd = {
+            enable = true;
+            externalInterface = "eth1";
+            internalIPs = [ "eth2" ];
+            appendConfig = ''
+              ext_ip=${externalRouterAddress}
+            '';
+          };
+        };
+
+      client1 =
+        { pkgs, nodes, ... }:
+        {
+          imports = [ transmissionConfig ];
+          environment.systemPackages = [ pkgs.miniupnpc ];
+
+          virtualisation.vlans = [ 2 ];
+          networking.interfaces.eth0.ipv4.addresses = [ ];
+          networking.interfaces.eth1.ipv4.addresses = [
+            {
+              address = internalClient1Address;
+              prefixLength = 24;
+            }
+          ];
+          networking.defaultGateway = internalRouterAddress;
+          networking.firewall.enable = false;
+        };
+
+      client2 =
+        { pkgs, ... }:
+        {
+          imports = [ transmissionConfig ];
+
+          virtualisation.vlans = [ 1 ];
+          networking.interfaces.eth0.ipv4.addresses = [ ];
+          networking.interfaces.eth1.ipv4.addresses = [
+            {
+              address = externalClient2Address;
+              prefixLength = 24;
+            }
+          ];
+          networking.firewall.enable = false;
+        };
     };
 
-    client1 = { pkgs, nodes, ... }: {
-      imports = [ transmissionConfig ];
-      environment.systemPackages = [ pkgs.miniupnpc ];
+    testScript =
+      { nodes, ... }:
+      ''
+        start_all()
 
-      virtualisation.vlans = [ 2 ];
-      networking.interfaces.eth0.ipv4.addresses = [];
-      networking.interfaces.eth1.ipv4.addresses = [
-        { address = internalClient1Address; prefixLength = 24; }
-      ];
-      networking.defaultGateway = internalRouterAddress;
-      networking.firewall.enable = false;
-    };
+        # Wait for network and miniupnpd.
+        router.systemctl("start network-online.target")
+        router.wait_for_unit("network-online.target")
+        router.wait_for_unit("miniupnpd")
 
-    client2 = { pkgs, ... }: {
-      imports = [ transmissionConfig ];
+        # Create the torrent.
+        tracker.succeed("mkdir ${download-dir}/data")
+        tracker.succeed(
+            "cp ${file} ${download-dir}/data/test.tar.bz2"
+        )
+        tracker.succeed(
+            "transmission-create ${download-dir}/data/test.tar.bz2 --private --tracker http://${externalTrackerAddress}:6969/announce --outfile /tmp/test.torrent"
+        )
+        tracker.succeed("chmod 644 /tmp/test.torrent")
 
-      virtualisation.vlans = [ 1 ];
-      networking.interfaces.eth0.ipv4.addresses = [];
-      networking.interfaces.eth1.ipv4.addresses = [
-        { address = externalClient2Address; prefixLength = 24; }
-      ];
-      networking.firewall.enable = false;
-    };
-  };
+        # Start the tracker.  !!! use a less crappy tracker
+        tracker.systemctl("start network-online.target")
+        tracker.wait_for_unit("network-online.target")
+        tracker.wait_for_unit("opentracker.service")
+        tracker.wait_for_open_port(6969)
 
-  testScript = { nodes, ... }: ''
-      start_all()
+        # Start the initial seeder.
+        tracker.succeed(
+            "transmission-remote --add /tmp/test.torrent --no-portmap --no-dht --download-dir ${download-dir}/data"
+        )
 
-      # Wait for network and miniupnpd.
-      router.systemctl("start network-online.target")
-      router.wait_for_unit("network-online.target")
-      router.wait_for_unit("miniupnpd")
+        # Now we should be able to download from the client behind the NAT.
+        tracker.wait_for_unit("httpd")
+        client1.systemctl("start network-online.target")
+        client1.wait_for_unit("network-online.target")
+        client1.succeed("transmission-remote --add http://${externalTrackerAddress}/test.torrent >&2 &")
+        client1.wait_for_file("${download-dir}/test.tar.bz2")
+        client1.succeed(
+            "cmp ${download-dir}/test.tar.bz2 ${file}"
+        )
 
-      # Create the torrent.
-      tracker.succeed("mkdir ${download-dir}/data")
-      tracker.succeed(
-          "cp ${file} ${download-dir}/data/test.tar.bz2"
-      )
-      tracker.succeed(
-          "transmission-create ${download-dir}/data/test.tar.bz2 --private --tracker http://${externalTrackerAddress}:6969/announce --outfile /tmp/test.torrent"
-      )
-      tracker.succeed("chmod 644 /tmp/test.torrent")
+        # Bring down the initial seeder.
+        tracker.stop_job("transmission")
 
-      # Start the tracker.  !!! use a less crappy tracker
-      tracker.systemctl("start network-online.target")
-      tracker.wait_for_unit("network-online.target")
-      tracker.wait_for_unit("opentracker.service")
-      tracker.wait_for_open_port(6969)
-
-      # Start the initial seeder.
-      tracker.succeed(
-          "transmission-remote --add /tmp/test.torrent --no-portmap --no-dht --download-dir ${download-dir}/data"
-      )
-
-      # Now we should be able to download from the client behind the NAT.
-      tracker.wait_for_unit("httpd")
-      client1.systemctl("start network-online.target")
-      client1.wait_for_unit("network-online.target")
-      client1.succeed("transmission-remote --add http://${externalTrackerAddress}/test.torrent >&2 &")
-      client1.wait_for_file("${download-dir}/test.tar.bz2")
-      client1.succeed(
-          "cmp ${download-dir}/test.tar.bz2 ${file}"
-      )
-
-      # Bring down the initial seeder.
-      tracker.stop_job("transmission")
-
-      # Now download from the second client.  This can only succeed if
-      # the first client created a NAT hole in the router.
-      client2.systemctl("start network-online.target")
-      client2.wait_for_unit("network-online.target")
-      client2.succeed(
-          "transmission-remote --add http://${externalTrackerAddress}/test.torrent --no-portmap --no-dht >&2 &"
-      )
-      client2.wait_for_file("${download-dir}/test.tar.bz2")
-      client2.succeed(
-          "cmp ${download-dir}/test.tar.bz2 ${file}"
-      )
-    '';
-})
+        # Now download from the second client.  This can only succeed if
+        # the first client created a NAT hole in the router.
+        client2.systemctl("start network-online.target")
+        client2.wait_for_unit("network-online.target")
+        client2.succeed(
+            "transmission-remote --add http://${externalTrackerAddress}/test.torrent --no-portmap --no-dht >&2 &"
+        )
+        client2.wait_for_file("${download-dir}/test.tar.bz2")
+        client2.succeed(
+            "cmp ${download-dir}/test.tar.bz2 ${file}"
+        )
+      '';
+  }
+)

--- a/nixos/tests/bittorrent.nix
+++ b/nixos/tests/bittorrent.nix
@@ -20,7 +20,7 @@ let
   externalTrackerAddress = "80.100.100.3";
 
   download-dir = "/var/lib/transmission/Downloads";
-  transmissionConfig = { ... }: {
+  transmissionConfig = { pkgs, ... }: {
     environment.systemPackages = [ pkgs.transmission_3 ];
     services.transmission = {
       enable = true;


### PR DESCRIPTION
## Description of changes

This fixes the bittorrent test for all cases where host architecture != guest architecture (e.g. macOS is the host)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
