### PR TITLE
go_1_21: 1.21.7 -> 1.21.8

### DIFF
--- a/pkgs/development/compilers/go/1.21.nix
+++ b/pkgs/development/compilers/go/1.21.nix
@@ -46,11 +46,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "go";
-  version = "1.21.7";
+  version = "1.21.8";
 
   src = fetchurl {
     url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
-    hash = "sha256-ABl6sg8zgTgyv/Yv2TzKHEKgjMaJoypmcspJWRlZv/Y=";
+    hash = "sha256-3IBs91qH4UFLW0w9y53T6cyY9M/M7EK3r2F9WmWKPEM=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
## Description of changes

> These minor releases include 5 security fixes following the [security policy](https://go.dev/security):
> 
> crypto/x509: Verify panics on certificates with an unknown public key algorithm
> 
> Verifying a certificate chain which contains a certificate with an unknown public
> key algorithm will cause Certificate.Verify to panic.
> 
> This affects all crypto/tls clients, and servers that set Config.ClientAuth to
> VerifyClientCertIfGiven or RequireAndVerifyClientCert. The default behavior is
> for TLS servers to not verify client certificates.
> 
> Thanks to John Howard (Google) for reporting this issue.
> 
> This is CVE-2024-24783 and Go issue https://go.dev/issue/65390.
> 
> net/http: memory exhaustion in Request.ParseMultipartForm
> 
> When parsing a multipart form (either explicitly with Request.ParseMultipartForm or implicitly with Request.FormValue, Request.PostFormValue, or Request.FormFile), limits on the total size of the parsed form were not applied to the memory consumed while reading a single form line. This permitted a maliciously crafted input containing very long lines to cause allocation of arbitrarily large amounts of memory, potentially leading to memory exhaustion.
> 
> ParseMultipartForm now correctly limits the maximum size of form lines.
> 
> Thanks to Bartek Nowotarski for reporting this issue.
> 
> This is CVE-2023-45290 and Go issue https://go.dev/issue/65383.
> 
> net/http, net/http/cookiejar: incorrect forwarding of sensitive headers and cookies on HTTP redirect
> 
> When following an HTTP redirect to a domain which is not a subdomain match or exact match of the initial domain, an http.Client does not forward sensitive headers such as "Authorization" or "Cookie". For example, a redirect from [foo.com](http://foo.com/) to [www.foo.com](http://www.foo.com/) will forward the Authorization header, but a redirect to [bar.com](http://bar.com/) will not.
> 
> A maliciously crafted HTTP redirect could cause sensitive headers to be unexpectedly forwarded.
> 
> Thanks to Juho Nurminen of Mattermost for reporting this issue.
> 
> This is CVE-2023-45289 and Go issue https://go.dev/issue/65065.
> 
> html/template: errors returned from MarshalJSON methods may break template escaping
> 
> If errors returned from MarshalJSON methods contain user controlled data, they
> may be used to break the contextual auto-escaping behavior of the html/template
> package, allowing for subsequent actions to inject unexpected content into
> templates.
> 
> Thanks to RyotaK (https://ryotak.net/) for reporting this issue.
> 
> This is CVE-2024-24785 and Go issue https://go.dev/issue/65697.
> 
> net/mail: comments in display names are incorrectly handled
> 
> The ParseAddressList function incorrectly handles comments (text within parentheses) within display names. Since this is a misalignment with conforming address parsers, it can result in different trust decisions being made by programs using different parsers.
> 
> Thanks to Juho Nurminen of Mattermost and Slonser (https://github.com/Slonser) for reporting this issue.
> 
> This is CVE-2024-24784 and Go issue https://go.dev/issue/65083.

https://groups.google.com/g/golang-announce/c/5pwGVUPoMbg/m/46oA5yPABQAJ?utm_medium=email&utm_source=footer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
