### PR TITLE
 bt-migrate: init at 0-unstable-2023-08-17 

### DIFF
--- a/pkgs/by-name/bt/bt-migrate/package.nix
+++ b/pkgs/by-name/bt/bt-migrate/package.nix
@@ -1,0 +1,65 @@
+{ lib
+, boost
+, cmake
+, cxxopts
+, digestpp
+, fetchFromGitHub
+, fmt
+, jsoncons
+, pugixml
+, sqlite
+, sqlite_orm
+, stdenv
+}:
+stdenv.mkDerivation {
+  pname = "bt-migrate";
+  version = "0-unstable-2023-08-17";
+
+  src = fetchFromGitHub {
+    owner = "mikedld";
+    repo = "bt-migrate";
+    rev = "e15a489c0c76f98355586ebbee08223af4e9bf50";
+    hash = "sha256-kA6yxhbIh3ThmgF8Zyoe3I79giLVmdNr9IIrw5Xx4s0=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    boost
+    cxxopts
+    fmt
+    jsoncons
+    pugixml
+    sqlite_orm
+  ];
+
+  cmakeFlags = [
+    (lib.strings.cmakeBool "USE_VCPKG" false)
+    # NOTE: digestpp does not have proper CMake packaging (yet?)
+    (lib.strings.cmakeBool "USE_FETCHCONTENT" true)
+    (lib.strings.cmakeFeature "FETCHCONTENT_SOURCE_DIR_DIGESTPP" "${digestpp}/include/digestpp")
+  ];
+
+  # NOTE: no install target in CMake...
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp BtMigrate $out/bin
+
+    runHook postInstall
+  '';
+
+  strictDeps = true;
+
+  meta = with lib; {
+    description = "Torrent state migration tool";
+    homepage = "https://github.com/mikedld/bt-migrate?tab=readme-ov-file";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ ambroisie ];
+    mainProgram = "BtMigrate";
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/by-name/di/digestpp/package.nix
+++ b/pkgs/by-name/di/digestpp/package.nix
@@ -1,0 +1,32 @@
+{ lib
+, fetchFromGitHub
+, stdenvNoCC
+}:
+stdenvNoCC.mkDerivation {
+  pname = "digestpp";
+  version = "0-unstable-2023-11-07";
+
+  src = fetchFromGitHub {
+    owner = "kerukuro";
+    repo = "digestpp";
+    rev = "ebb699402c244e22c3aff61d2239bcb2e87b8ef8";
+    hash = "sha256-9X/P7DgZB6bSYjQWRli4iAXEFjhmACOVv3EYQrXuH5c=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/include/digestpp
+    cp -r *.hpp algorithm/ detail/ $out/include/digestpp
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "C++11 header-only message digest library";
+    homepage = "https://github.com/kerukuro/digestpp";
+    license = licenses.unlicense;
+    maintainers = with maintainers; [ ambroisie ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/by-name/sq/sqlite_orm/package.nix
+++ b/pkgs/by-name/sq/sqlite_orm/package.nix
@@ -1,0 +1,35 @@
+{ lib
+, cmake
+, fetchFromGitHub
+, sqlite
+, stdenv
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sqlite_orm";
+  version = "1.8.2";
+
+  src = fetchFromGitHub {
+    owner = "fnc12";
+    repo = "sqlite_orm";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-KqphGFcnR1Y11KqL7sxODSv7lEvcURdF6kLd3cg84kc=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  propagatedBuildInputs = [
+    sqlite
+  ];
+
+  strictDeps = true;
+
+  meta = with lib; {
+    description = "Light header only SQLite ORM";
+    homepage = "https://sqliteorm.com/";
+    license = licenses.agpl3Only; # MIT license is commercial
+    maintainers = with maintainers; [ ambroisie ];
+    platforms = platforms.all;
+  };
+})


### PR DESCRIPTION
## Description of changes

Not a big fan of the new `unstable` naming...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
