### PR TITLE
python3Packages.django-allauth: 0.60.0 -> 0.61.1

### DIFF
--- a/pkgs/development/python-modules/dj-rest-auth/default.nix
+++ b/pkgs/development/python-modules/dj-rest-auth/default.nix
@@ -5,6 +5,7 @@
 , djangorestframework
 , djangorestframework-simplejwt
 , fetchFromGitHub
+, fetchpatch
 , python
 , pythonOlder
 , responses
@@ -25,6 +26,15 @@ buildPythonPackage rec {
     rev = "refs/tags/${version}";
     hash = "sha256-TqeNpxXn+v89fEiJ4AVNhp8blCfYQKFQfYmZ6/QlRbQ=";
   };
+
+  patches = [
+    # https://github.com/iMerica/dj-rest-auth/pull/597
+    (fetchpatch {
+      name = "disable-email-confirmation-ratelimit-in-tests-to-support-new-allauth.patch";
+      url = "https://github.com/iMerica/dj-rest-auth/commit/c8f19e18a93f4959da875f9c5cdd32f7d9363bba.patch";
+      hash = "sha256-Y/YBjV+c5Gw1wMR5r/4VnyV/ewUVG0z4pjY/MB4ca9Y=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace setup.py \

--- a/pkgs/development/python-modules/django-allauth/default.nix
+++ b/pkgs/development/python-modules/django-allauth/default.nix
@@ -28,7 +28,7 @@
 
 buildPythonPackage rec {
   pname = "django-allauth";
-  version = "0.60.0";
+  version = "0.61.1";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     owner = "pennersr";
     repo = "django-allauth";
     rev = "refs/tags/${version}";
-    hash = "sha256-hkzZl2eZKti6m06LTtBqVXmsj6IFztsV2Of6tPiej+I=";
+    hash = "sha256-C9SYlL1yMnSb+Zpi2opvDw1stxAHuI9/XKHyvkM36Cg=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/pennersr/django-allauth/blob/main/ChangeLog.rst#0610-2024-02-07
https://github.com/pennersr/django-allauth/blob/main/ChangeLog.rst#0611-2024-02-09

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
