### PR TITLE
linuxPackages.scst: init at 3.8

### DIFF
--- a/pkgs/os-specific/linux/scst/default.nix
+++ b/pkgs/os-specific/linux/scst/default.nix
@@ -1,0 +1,61 @@
+{ lib, stdenv, bash, fetchFromGitHub, kernel }:
+
+stdenv.mkDerivation rec {
+  version = "3.8";
+  name = "scst-${version}-${kernel.version}";
+
+  src = fetchFromGitHub {
+    owner = "SCST-project";
+    repo = "scst";
+    rev = "v${version}";
+    hash = "sha256-pXpnf8oBwELPGB8aZtgD5X9nV8IZB+cQHZvAfoB71yA=";
+  };
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  hardeningDisable = [ "pic" ];
+
+  outputs = [ "out" "bin" ];
+
+  postPatch = ''
+    shopt -s globstar
+    substituteInPlace \
+      **/Makefile \
+      scripts/list-source-files \
+      scripts/sign-modules \
+      --replace-quiet "/bin/bash" "${lib.getExe bash}"
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    export KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build
+    export BUILD_2X_MODULE=y CONFIG_SCSI_QLA_FC=y CONFIG_SCSI_QLA2XXX_TARGET=y
+
+    make 2release
+    for d in scst fcst iscsi-scst qla2x00t-32gbit/qla2x00-target scst_local srpt; do
+      make -C $d
+    done
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    for d in scst fcst iscsi-scst qla2x00t-32gbit/qla2x00-target scst_local srpt; do
+      make PREFIX="" DESTDIR=$bin INSTALL_MOD_PATH=$out -C $d install
+    done
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "SCST SCSI target subsystem and QLogic Fibre Channel HBA kernel modules";
+    homepage = "https://scst.sourceforge.net";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ titanous ];
+    platforms = platforms.linux;
+    outputsToInstall = [ "out" "bin" ];
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -492,6 +492,8 @@ in {
 
     rr-zen_workaround = callPackage ../development/tools/analysis/rr/zen_workaround.nix { };
 
+    scst = callPackage ../os-specific/linux/scst {};
+
     shufflecake = callPackage ../os-specific/linux/shufflecake {};
 
     sysdig = callPackage ../os-specific/linux/sysdig {};


### PR DESCRIPTION
## Description of changes

Adds `scst` kernel module which provides access to SCSI devices via QLogic Fibre Channel cards.

The build targets and flags are taken from the [upstream RPM spec](https://github.com/SCST-project/scst/blob/7bec05916c37e4d28f1d9ad55dd962ffef1ef9a7/scst.spec.in#L136-L140).

Tested with a QLogic QLE2564 card and kernel 6.7.7.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
