### PR TITLE
python311Packages.mahotas: remove freeimage dependency

### DIFF
--- a/pkgs/development/python-modules/mahotas/default.nix
+++ b/pkgs/development/python-modules/mahotas/default.nix
@@ -6,7 +6,6 @@
 , numpy
 , pytestCheckHook
 , imread
-, freeimage
 , lib
 , stdenv
 }:
@@ -24,7 +23,6 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
-    freeimage
     imread
     numpy
     pillow
@@ -33,11 +31,6 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  postPatch = ''
-    substituteInPlace mahotas/io/freeimage.py \
-      --replace "ctypes.util.find_library('freeimage')" 'True' \
-      --replace 'ctypes.CDLL(libname)' 'np.ctypeslib.load_library("libfreeimage", "${freeimage}/lib")'
-  '';
 
   # mahotas/_morph.cpp:864:10: error: no member named 'random_shuffle' in namespace 'std'
   env = lib.optionalAttrs stdenv.cc.isClang {
@@ -59,7 +52,6 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [
     "mahotas"
-    "mahotas.freeimage"
   ];
 
   disabled = stdenv.isi686; # Failing tests


### PR DESCRIPTION
The library will work without it (unless the user explicitly imports the freeimage subpackage, which is a very specialized usage)

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)

