### PR TITLE
python3Packages.email-validator: 2.1.0 -> 2.1.1

### DIFF
--- a/pkgs/development/python-modules/email-validator/default.nix
+++ b/pkgs/development/python-modules/email-validator/default.nix
@@ -1,7 +1,7 @@
 { lib
 , buildPythonPackage
 , dnspython
-, fetchFromGitHub
+, fetchurl
 , idna
 , pytestCheckHook
 , pythonOlder
@@ -9,16 +9,17 @@
 
 buildPythonPackage rec {
   pname = "email-validator";
-  version = "2.1.0";
+  version = "2.1.1";
   format = "setuptools";
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
-  src = fetchFromGitHub {
-    owner = "JoshData";
-    repo = "python-${pname}";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-58DuQslADM7glrnlSSP6TtIDTlwuS0/GK8+izatqDxI=";
+  # Upstream has a bad habit of re-issuing release tarballs and
+  # force-pushing over public release tags.
+  # Archive new release tarballs at: https://web.archive.org/save
+  src = fetchurl {
+    url = "http://web.archive.org/web/20240306093519/https://github.com/JoshData/python-email-validator/archive/refs/tags/v${version}.tar.gz";
+    hash = "sha256-BR/a+YJjvpr6UtzVC2vFkXCGVLa1mLR+SkCAIFpxf8E=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
## Description of changes

https://github.com/JoshData/python-email-validator/releases/tag/v2.1.1

Upstream reissued their 2.1.0 tarball, breaking non-cache fetches. May as well move to the new release.

Closes #291925

CC Maintainer: @langston-barrett 

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
