### PR TITLE
Plasma 6.0.1.1

### DIFF
--- a/pkgs/kde/generated/sources/plasma.json
+++ b/pkgs/kde/generated/sources/plasma.json
@@ -15,14 +15,14 @@
     "hash": "sha256-iI1vzXZ+j97dqgq/Uze81TSpeu+RqKXkf6oZcmdNguM="
   },
   "breeze-gtk": {
-    "version": "6.0.1",
-    "url": "mirror://kde/stable/plasma/6.0.1/breeze-gtk-6.0.1.tar.xz",
-    "hash": "sha256-MmInFnKHzR4PHzIfm7UFQsQAa/x53lehSNSaHL8gYqU="
+    "version": "6.0.1.1",
+    "url": "mirror://kde/stable/plasma/6.0.1/breeze-gtk-6.0.1.1.tar.xz",
+    "hash": "sha256-I8qWYBzJv/AENPf7/jkB+8uSNi0XUaMcCFIPtMESRhA="
   },
   "breeze-plymouth": {
-    "version": "6.0.1",
-    "url": "mirror://kde/stable/plasma/6.0.1/breeze-plymouth-6.0.1.tar.xz",
-    "hash": "sha256-TlPrMhAYMWCf8dGyzxP1PjS8JMQHb1ec0JysuXtx8ZM="
+    "version": "6.0.1.1",
+    "url": "mirror://kde/stable/plasma/6.0.1/breeze-plymouth-6.0.1.1.tar.xz",
+    "hash": "sha256-Xk/enHtV4kwK4inPSrct34g1nvewvSrnFbuH4eDx94I="
   },
   "discover": {
     "version": "6.0.1",
@@ -85,9 +85,9 @@
     "hash": "sha256-9wZA2Q88JbE5NFM5UDwAGax0Oy8ldd+d+Ywn0URcdiQ="
   },
   "kpipewire": {
-    "version": "6.0.1",
-    "url": "mirror://kde/stable/plasma/6.0.1/kpipewire-6.0.1.tar.xz",
-    "hash": "sha256-CfahfSldlHT0ecVrzYuL5pCl1RCHAdDcICJ+84Udvjk="
+    "version": "6.0.1.1",
+    "url": "mirror://kde/stable/plasma/6.0.1/kpipewire-6.0.1.1.tar.xz",
+    "hash": "sha256-GQLzlJBS/xq12nnGMJWG8+EaKcfASgRPc7P2rJglHEo="
   },
   "kscreen": {
     "version": "6.0.1",

--- a/pkgs/kde/plasma/breeze-gtk/default.nix
+++ b/pkgs/kde/plasma/breeze-gtk/default.nix
@@ -10,10 +10,5 @@ mkKdeDerivation {
   # FIXME(later): upstream
   patches = [./0001-fix-add-executable-bit.patch];
 
-  # FIXME: hack to fix build, remove for 6.0.2
-  postPatch = ''
-    substituteInPlace CMakeLists.txt --replace-fail "ECM 6.0.1" "ECM 6.0.0"
-  '';
-
   extraNativeBuildInputs = [sass python3 python3Packages.pycairo];
 }

--- a/pkgs/kde/plasma/breeze-plymouth/default.nix
+++ b/pkgs/kde/plasma/breeze-plymouth/default.nix
@@ -41,9 +41,6 @@ in
       postPatch =
         ''
           substituteInPlace cmake/FindPlymouth.cmake --subst-var out
-
-          # FIXME: hack to fix build, remove for 6.0.2
-          substituteInPlace CMakeLists.txt --replace-fail "ECM 6.0.1" "ECM 6.0.0"
         ''
         + lib.optionalString (logoFile != null) ''
           cp ${logoFile} breeze/images/${resolvedLogoName}.logo.png

--- a/pkgs/kde/plasma/kpipewire/default.nix
+++ b/pkgs/kde/plasma/kpipewire/default.nix
@@ -1,6 +1,5 @@
 {
   mkKdeDerivation,
-  fetchpatch,
   qtquick3d,
   pkg-config,
   pipewire,
@@ -10,14 +9,6 @@
 }:
 mkKdeDerivation {
   pname = "kpipewire";
-
-  # FIXME: backport to fix build, remove for 6.0.2
-  patches = [
-    (fetchpatch {
-      url = "https://invent.kde.org/plasma/kpipewire/-/commit/df052bfa3c66d24109f40f18266ee057d1838b9b.patch";
-      hash = "sha256-69ftUUz5cvG/CmCw3hHFeU8XKhZPJjnx1raJCCay38g=";
-    })
-  ];
 
   extraNativeBuildInputs = [pkg-config];
   extraBuildInputs = [qtquick3d pipewire ffmpeg mesa libva];


### PR DESCRIPTION
## Description of changes

Tarball respins from upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
