### PR TITLE
aiosql: 10.1 → 10.2, run more tests, remove pg8000 from propagatedBuildInputs

### DIFF
--- a/pkgs/development/python-modules/aiosql/default.nix
+++ b/pkgs/development/python-modules/aiosql/default.nix
@@ -3,7 +3,10 @@
   buildPythonPackage,
   fetchFromGitHub,
   pg8000,
+  psycopg,
+  psycopg2,
   pytest-asyncio,
+  pytest-postgresql,
   pytestCheckHook,
   pythonOlder,
   setuptools,
@@ -40,10 +43,12 @@ buildPythonPackage rec {
     sphinxHook
   ];
 
-  propagatedBuildInputs = [ pg8000 ];
-
   nativeCheckInputs = [
+    pg8000
+    psycopg
+    psycopg2
     pytest-asyncio
+    pytest-postgresql
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/aiosql/default.nix
+++ b/pkgs/development/python-modules/aiosql/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "aiosql";
-  version = "10.1";
+  version = "10.2";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     owner = "nackjicholson";
     repo = "aiosql";
     rev = "refs/tags/${version}";
-    hash = "sha256-KlDwvoU0GYCN+ZCp4pp557qf9ChceS4NeA0Yiq+g3YQ=";
+    hash = "sha256-o88pKxvK7fT+ocemiY58yA6fTmgg8+QsztHU3OvcDAo=";
   };
 
   sphinxRoot = "docs/source";


### PR DESCRIPTION
## Description of changes

- Updated from 10.1 to 10.2. See [diff](https://github.com/nackjicholson/aiosql/compare/refs/tags/10.1...10.2) and [10.2 changelog](https://github.com/nackjicholson/aiosql/releases/tag/10.2).
- Made PostgreSQL tests actually. Previously they were skipped because pg8000 was present, but pytest-postgresql was missing. Also, while I was at it, enabled testing with two more backends: psycopg2 and psycopg3.
- Moved pg8000 from propagatedBuildInputs to checkInputs. Like any other backend, it is an optional dependency and does not need to be propagated. Cc @fabaff — if you had a reason to put it there, please let me know.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).