### PR TITLE
wechat-uos: init at 1.0.0.238

### DIFF
--- a/pkgs/by-name/we/wechat-uos/package.nix
+++ b/pkgs/by-name/we/wechat-uos/package.nix
@@ -1,0 +1,248 @@
+{ stdenvNoCC
+, stdenv
+, lib
+, fetchurl
+, requireFile
+, dpkg
+, nss
+, nspr
+, xorg
+, pango
+, zlib
+, atkmm
+, libdrm
+, libxkbcommon
+, xcbutilwm
+, xcbutilimage
+, xcbutilkeysyms
+, xcbutilrenderutil
+, mesa
+, alsa-lib
+, wayland
+, openssl_1_1
+, atk
+, qt6
+, at-spi2-atk
+, at-spi2-core
+, dbus
+, cups
+, gtk3
+, libxml2
+, cairo
+, freetype
+, fontconfig
+, vulkan-loader
+, gdk-pixbuf
+, libexif
+, ffmpeg
+, pulseaudio
+, systemd
+, libuuid
+, expat
+, bzip2
+, glib
+, libva
+, libGL
+, libnotify
+, buildFHSEnv
+, writeShellScript
+, /**
+  License for wechat-uos, packed in a gz archive named "license.tar.gz".
+  It should have the following files:
+  license.tar.gz
+  ├── etc
+  │   ├── lsb-release
+  │   └── os-release
+  └── var
+      ├── lib
+      │   └── uos-license
+      │       └── .license.json
+      └── uos
+          └── .license.key
+  */
+  uosLicense ? requireFile {
+    name = "license.tar.gz";
+    url = "https://www.uniontech.com";
+    sha256 = "53760079c1a5b58f2fa3d5effe1ed35239590b288841d812229ef4e55b2dbd69";
+  }
+}:
+let
+  wechat-uos-env = stdenvNoCC.mkDerivation {
+    meta.priority = 1;
+    name = "wechat-uos-env";
+    buildCommand = ''
+      mkdir -p $out/etc
+      mkdir -p $out/lib/license
+      mkdir -p $out/usr/bin
+      mkdir -p $out/usr/share
+      mkdir -p $out/opt
+      mkdir -p $out/var
+
+      ln -s ${wechat}/opt/* $out/opt/
+      ln -s ${wechat}/usr/lib/wechat-uos/license/etc/os-release  $out/etc/os-release
+      ln -s ${wechat}/usr/lib/wechat-uos/license/etc/lsb-release  $out/etc/lsb-release
+      ln -s ${wechat}/usr/lib/wechat-uos/license/var/*  $out/var/
+      ln -s ${wechat}/usr/lib/wechat-uos/license/libuosdevicea.so $out/lib/license/
+    '';
+    preferLocalBuild = true;
+  };
+
+  wechat-uos-runtime = with xorg; [
+    stdenv.cc.cc
+    stdenv.cc.libc
+    pango
+    zlib
+    xcbutilwm
+    xcbutilimage
+    xcbutilkeysyms
+    xcbutilrenderutil
+    libX11
+    libXt
+    libXext
+    libSM
+    libICE
+    libxcb
+    libxkbcommon
+    libxshmfence
+    libXi
+    libXft
+    libXcursor
+    libXfixes
+    libXScrnSaver
+    libXcomposite
+    libXdamage
+    libXtst
+    libXrandr
+    libnotify
+    atk
+    atkmm
+    cairo
+    at-spi2-atk
+    at-spi2-core
+    alsa-lib
+    dbus
+    cups
+    gtk3
+    gdk-pixbuf
+    libexif
+    ffmpeg
+    libva
+    freetype
+    fontconfig
+    libXrender
+    libuuid
+    expat
+    glib
+    nss
+    nspr
+    libGL
+    libxml2
+    pango
+    libdrm
+    mesa
+    vulkan-loader
+    systemd
+    wayland
+    pulseaudio
+    qt6.qt5compat
+    openssl_1_1
+    bzip2
+  ];
+
+  wechat = stdenvNoCC.mkDerivation
+    rec {
+      pname = "wechat-uos";
+      version = "1.0.0.238";
+
+      src = {
+        x86_64-linux = fetchurl {
+          url = "https://pro-store-packages.uniontech.com/appstore/pool/appstore/c/com.tencent.wechat/com.tencent.wechat_${version}_amd64.deb";
+          hash = "sha256-NxAmZ526JaAzAjtAd9xScFnZBuwD6i2wX2/AEqtAyWs=";
+        };
+        aarch64-linux = fetchurl {
+          url = "https://pro-store-packages.uniontech.com/appstore/pool/appstore/c/com.tencent.wechat/com.tencent.wechat_${version}_arm64.deb";
+          hash = "sha256-3ru6KyBYXiuAlZuWhyyvtQCWbOJhGYzker3FS0788RE=";
+        };
+        loongarch64-linux = fetchurl {
+          url = "https://pro-store-packages.uniontech.com/appstore/pool/appstore/c/com.tencent.wechat/com.tencent.wechat_${version}_loongarch64.deb";
+          hash = "sha256-iuJeLMKD6v8J8iKw3+cyODN7PZQrLpi9p0//mkI0ujE=";
+        };
+      }.${stdenv.system} or (throw "${pname}-${version}: ${stdenv.system} is unsupported.");
+
+      # Don't blame about this. WeChat requires some binary from here to work properly
+      uosSrc = {
+        x86_64-linux = fetchurl {
+          url = "https://pro-store-packages.uniontech.com/appstore/pool/appstore/c/com.tencent.weixin/com.tencent.weixin_2.1.5_amd64.deb";
+          hash = "sha256-vVN7w+oPXNTMJ/g1Rpw/AVLIytMXI+gLieNuddyyIYE=";
+        };
+        aarch64-linux = fetchurl {
+          url = "https://pro-store-packages.uniontech.com/appstore/pool/appstore/c/com.tencent.weixin/com.tencent.weixin_2.1.5_arm64.deb";
+          hash = "sha256-XvGFPYJlsYPqRyDycrBGzQdXn/5Da1AJP5LgRVY1pzI=";
+        };
+        loongarch64-linux = fetchurl {
+          url = "https://pro-store-packages.uniontech.com/appstore/pool/appstore/c/com.tencent.weixin/com.tencent.weixin_2.1.5_loongarch64.deb";
+          hash = "sha256-oa6rLE6QXMCPlbebto9Tv7xT3fFqYIlXL6WHpB2U35s=";
+        };
+      }.${stdenv.system} or (throw "${pname}-${version}: ${stdenv.system} is unsupported.");
+
+      inherit uosLicense;
+
+      nativeBuildInputs = [ dpkg ];
+
+      unpackPhase = ''
+        runHook preUnpack
+
+        dpkg -x $src ./wechat-uos
+        dpkg -x $uosSrc ./wechat-uos-old-source
+
+        tar -xvf $uosLicense
+
+        runHook postUnpack
+      '';
+
+      installPhase = ''
+        runHook preInstall
+        mkdir -p $out
+
+        cp -r wechat-uos/* $out
+
+        mkdir -pv $out/usr/lib/wechat-uos/license
+        cp -r license/* $out/usr/lib/wechat-uos/license
+        cp -r wechat-uos-old-source/usr/lib/license/libuosdevicea.so $out/usr/lib/wechat-uos/license/
+
+        runHook postInstall
+      '';
+
+      meta = with lib; {
+        description = "Messaging app";
+        homepage = "https://weixin.qq.com/";
+        license = licenses.unfree;
+        platforms = [ "x86_64-linux" "aarch64-linux" "loongarch64-linux" ];
+        sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+        maintainers = with maintainers; [ pokon548 ];
+        mainProgram = "wechat-uos";
+      };
+    };
+in
+buildFHSEnv {
+  inherit (wechat) name meta;
+  runScript = writeShellScript "wechat-uos-launcher" ''
+    export QT_QPA_PLATFORM=xcb
+    export LD_LIBRARY_PATH=${lib.makeLibraryPath wechat-uos-runtime}
+    ${wechat.outPath}/opt/apps/com.tencent.wechat/files/wechat
+  '';
+  extraInstallCommands = ''
+    mkdir -p $out/share/applications
+    mkdir -p $out/share/icons
+    cp -r ${wechat.outPath}/opt/apps/com.tencent.wechat/entries/applications/com.tencent.wechat.desktop $out/share/applications
+    cp -r ${wechat.outPath}/opt/apps/com.tencent.wechat/entries/icons/* $out/share/icons/
+
+    mv $out/bin/$name $out/bin/wechat-uos
+
+    substituteInPlace $out/share/applications/com.tencent.wechat.desktop \
+      --replace-quiet 'Exec=/usr/bin/wechat' "Exec=$out/bin/wechat-uos --"
+  '';
+  targetPkgs = pkgs: [ wechat-uos-env ];
+
+  extraOutputsToInstall = [ "usr" "var/lib/uos" "var/uos" "etc" ];
+}


### PR DESCRIPTION
## Description of changes
Introduce official `WeChat` app. 
**Due to the possible legal reason, `license.tar.gz` is not provided by default. You need to find it for yourself.**

~~Currently, `WeChatAppEx` will coredump without useful logs. So you are not able to use:~~
~~- Mini Apps~~
~~- Subscriptions~~
~~- Image Viewer~~
~~- etc.~~

~~Still looking for a way to fix that.~~ Fixed.

If you find `WeChat hangout` cannot detect your microphone and speaker, please make sure:
1. You are using `PipeWire` with [PulseAudio emulation](https://search.nixos.org/options?channel=unstable&show=services.pipewire.pulse.enable&from=0&size=50&sort=relevance&type=packages&query=pipewire+pulse) enabled.
2. **OR**, you are using `PulseAudio`.

Warning: This app use `openssl_1_1`, which is EOL and possibly introduce security risks. Proceed with cautions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
