### PR TITLE
trilium-{desktop,server}: 0.62.5 -> 0.63.3

### DIFF
--- a/pkgs/applications/office/trilium/0001-Use-console-logger-instead-of-rolling-files.patch
+++ b/pkgs/applications/office/trilium/0001-Use-console-logger-instead-of-rolling-files.patch
@@ -6,8 +6,8 @@ index a141eae14..094b9381b 100644
  "use strict";
  
 -const fs = require('fs');
--const dataDir = require('./data_dir');
- const cls = require('./cls');
+-const dataDir = require('./data_dir.js');
+ const cls = require('./cls.js');
  
 -if (!fs.existsSync(dataDir.LOG_DIR)) {
 -    fs.mkdirSync(dataDir.LOG_DIR, 0o700);

--- a/pkgs/applications/office/trilium/desktop.nix
+++ b/pkgs/applications/office/trilium/desktop.nix
@@ -7,13 +7,13 @@
 
 let
   pname = "trilium-desktop";
-  version = "0.62.5";
+  version = "0.63.3";
 
   linuxSource.url = "https://github.com/zadam/trilium/releases/download/v${version}/trilium-linux-x64-${version}.tar.xz";
-  linuxSource.sha256 = "1f2f8nvj1gx9i797mck5aazgz821sjcs06538py9za4m532i66pj";
+  linuxSource.sha256 = "1dcq7s4lcp9bc0p4ylzxyfc020xvj7scrlsddzwcnp8mqz5ckik9";
 
   darwinSource.url = "https://github.com/zadam/trilium/releases/download/v${version}/trilium-mac-x64-${version}.zip";
-  darwinSource.sha256 = "19zny4akf3hxqjqayiz4s47vdblbrn4kgwg3nykljv4lpqnqkyn3";
+  darwinSource.sha256 = "0m9m68f9jg10nfn719q6wahwvi13lpc2hmandw7ddxfslylwq29s";
 
   meta = metaCommon // {
     mainProgram = "trilium";

--- a/pkgs/applications/office/trilium/server.nix
+++ b/pkgs/applications/office/trilium/server.nix
@@ -3,8 +3,8 @@
 
 let
   serverSource.url = "https://github.com/zadam/trilium/releases/download/v${version}/trilium-linux-x64-server-${version}.tar.xz";
-  serverSource.sha256 = "1s0pfb3virhxsh5kkgq4yfhdnv1lq2z0zdcikilnayzp0lpjskhb";
-  version = "0.62.5";
+  serverSource.sha256 = "1pnxss85lz313r5l1qpgm9msyfr87h54nbfc7d89dbj0wgsjwk0n";
+  version = "0.63.3";
 in stdenv.mkDerivation {
   pname = "trilium-server";
   inherit version;


### PR DESCRIPTION
## Description of changes

https://github.com/zadam/trilium/releases/tag/v0.62.6
https://github.com/zadam/trilium/releases/tag/v0.63.3

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
