### PR TITLE
daytona-bin: init at 0.9.0

### DIFF
--- a/pkgs/by-name/da/daytona-bin/package.nix
+++ b/pkgs/by-name/da/daytona-bin/package.nix
@@ -1,0 +1,55 @@
+{ stdenvNoCC
+, lib
+, fetchurl
+, makeWrapper
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "daytona-bin";
+  version = "0.9.0";
+
+  src =
+    let
+      urls = {
+        "x86_64-linux" = {
+          url = "https://download.daytona.io/daytona/v${finalAttrs.version}/daytona-linux-amd64";
+          hash = "sha256-vJVGFmaGP9oCCzdvhuAPsoTaxzGvdDKDupMYuepRUCA=";
+        };
+        "x86_64-darwin" = {
+          url = "https://download.daytona.io/daytona/v${finalAttrs.version}/daytona-darwin-amd64";
+          hash = "sha256-R63AQVt5DudzJub+TYcJiHkBGVeOhjvgJZgnqvJb8t0=";
+        };
+        "aarch64-linux" = {
+          url = "https://download.daytona.io/daytona/v${finalAttrs.version}/daytona-linux-arm64";
+          hash = "sha256-98OEhJ1gakPTVO73M9WW0QuSDgR42gNjoioEkkNbf6w=";
+        };
+        "aarch64-darwin" = {
+          url = "https://download.daytona.io/daytona/v${finalAttrs.version}/daytona-darwin-arm64";
+          hash = "sha256-YmLyioFueEfi/2Q+JwINDhkwo617/KUZrimz9CibdA8=";
+        };
+      };
+    in
+    fetchurl urls."${stdenvNoCC.hostPlatform.system}";
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 $src $out/bin/daytona
+    runHook postInstall
+  '';
+
+  meta = {
+    changelog = "https://github.com/daytonaio/daytona/releases/tag/v${finalAttrs.version}";
+    description = "The Open Source Dev Environment Manager";
+    homepage = "https://github.com/daytonaio/daytona";
+    license = lib.licenses.asl20;
+    mainProgram = "daytona";
+    maintainers = with lib.maintainers; [ ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
More info: https://github.com/daytonaio/daytona/

It is possible to build this package via the sources, however, the licence and trademark of the tool prevent anybody to re-use the name `Daytona`. Therefore, building a binary through Nix is forbidden, unless we name it differently (like `Iceweasel` vs `Firefox` see: https://en.wikipedia.org/wiki/Debian%E2%80%93Mozilla_trademark_dispute).

CC @Tpuljak @idagelic

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
