### PR TITLE
nixos/mautrix-telegram: hardening flags, package option, dataDir option

### DIFF
--- a/nixos/modules/services/matrix/mautrix-telegram.nix
+++ b/nixos/modules/services/matrix/mautrix-telegram.nix
@@ -3,9 +3,11 @@
 with lib;
 
 let
-  dataDir = "/var/lib/mautrix-telegram";
-  registrationFile = "${dataDir}/telegram-registration.yaml";
   cfg = config.services.mautrix-telegram;
+  fullDataDir = "/var/lib/${cfg.dataDir}";
+  relativeDataDir = cfg.dataDir;
+  pkg = cfg.package;
+  registrationFile = "${fullDataDir}/telegram-registration.yaml";
   settingsFormat = pkgs.formats.json {};
   settingsFile =
     settingsFormat.generate "mautrix-telegram-config.json" cfg.settings;
@@ -14,6 +16,17 @@ in {
   options = {
     services.mautrix-telegram = {
       enable = mkEnableOption (lib.mdDoc "Mautrix-Telegram, a Matrix-Telegram hybrid puppeting/relaybot bridge");
+
+      package = mkPackageOption pkgs "mautrix-telegram" {};
+
+      dataDir = mkOption {
+        type = types.string;
+        default =  "mautrix-telegram";
+        description = mdDoc ''
+          Path to the directory with database, registration, and other data for the bridge service.
+          This path is relative to `/var/lib`, it cannot start with `../` (it cannot be outside of `/var/lib`).
+        '';
+      };
 
       settings = mkOption rec {
         apply = recursiveUpdate default;
@@ -24,11 +37,11 @@ in {
           };
 
           appservice = rec {
-            database = "sqlite:///${dataDir}/mautrix-telegram.db";
+            database = "sqlite:///${fullDataDir}/mautrix-telegram.db";
             database_opts = {};
             hostname = "0.0.0.0";
             port = 8080;
-            address = "http://localhost:${toString port}";
+            address = "http://localhost:${toString cfg.settings.appservice.port}";
           };
 
           bridge = {
@@ -64,6 +77,52 @@ in {
             };
           };
         };
+        defaultText = options.literalExpression ''
+          homeserver = {
+            software = "standard";
+          };
+
+          appservice = rec {
+            database = "sqlite:///var/lib/''${config.services.mautrix-telegram.dataDir}/mautrix-telegram.db";
+            database_opts = {};
+            hostname = "0.0.0.0";
+            port = 8080;
+            address = "http://localhost:''${toString config.service.mautrix-telegram.settings.appservice.port}";
+          };
+
+          bridge = {
+            permissions."*" = "relaybot";
+            relaybot.whitelist = [ ];
+            double_puppet_server_map = {};
+            login_shared_secret_map = {};
+          };
+
+          logging = {
+            version = 1;
+
+            formatters.precise.format = "[%(levelname)s@%(name)s] %(message)s";
+
+            handlers.console = {
+              class = "logging.StreamHandler";
+              formatter = "precise";
+            };
+
+            loggers = {
+              mau.level = "INFO";
+              telethon.level = "INFO";
+
+              # prevent tokens from leaking in the logs:
+              # https://github.com/tulir/mautrix-telegram/issues/351
+              aiohttp.level = "WARNING";
+            };
+
+            # log to console/systemd instead of file
+            root = {
+              level = "INFO";
+              handlers = [ "console" ];
+            };
+          };
+        '';
         example = literalExpression ''
           {
             homeserver = {
@@ -134,6 +193,7 @@ in {
   };
 
   config = mkIf cfg.enable {
+
     systemd.services.mautrix-telegram = {
       description = "Mautrix-Telegram, a Matrix-Telegram hybrid puppeting/relaybot bridge.";
 
@@ -152,40 +212,51 @@ in {
       #  File "python3.10/pathlib.py", line 1440, in expanduser
       #    raise RuntimeError("Could not determine home directory.")
       # RuntimeError: Could not determine home directory.
-      environment.HOME = dataDir;
+      environment.HOME = fullDataDir;
 
       preStart = ''
         # generate the appservice's registration file if absent
         if [ ! -f '${registrationFile}' ]; then
-          ${pkgs.mautrix-telegram}/bin/mautrix-telegram \
+          ${pkg}/bin/mautrix-telegram \
             --generate-registration \
             --config='${settingsFile}' \
             --registration='${registrationFile}'
         fi
-      '' + lib.optionalString (pkgs.mautrix-telegram ? alembic) ''
-        # run automatic database init and migration scripts
-        ${pkgs.mautrix-telegram.alembic}/bin/alembic -x config='${settingsFile}' upgrade head
       '';
 
       serviceConfig = {
         Type = "simple";
-        Restart = "always";
 
-        ProtectSystem = "strict";
-        ProtectHome = true;
-        ProtectKernelTunables = true;
-        ProtectKernelModules = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        ProtectClock = true;
         ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectSystem = "strict";
+        Restart = "on-failure";
+        RestartSec = "30s";
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallErrorNumber = "EPERM";
+        SystemCallFilter = ["@system-service"];
+        UMask = 0027;
 
         DynamicUser = true;
-        PrivateTmp = true;
-        WorkingDirectory = pkgs.mautrix-telegram; # necessary for the database migration scripts to be found
-        StateDirectory = baseNameOf dataDir;
-        UMask = "0027";
+        WorkingDirectory = pkg; # necessary for the database migration scripts to be found
+        ReadWritePaths = fullDataDir;
+        StateDirectory = relativeDataDir;
         EnvironmentFile = cfg.environmentFile;
 
         ExecStart = ''
-          ${pkgs.mautrix-telegram}/bin/mautrix-telegram \
+          ${pkg}/bin/mautrix-telegram \
             --config='${settingsFile}'
         '';
       };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Implements #292780 partially as agreed with maintainer. + some extras.

Things changed in the mautrix-telegram package:
- Made package configurable
- Made dataDir configurable
- Added some systemd hardening flags, based mainly on mautrix-whatsapp service config
- Removed alembic execution as alembic is no longer user with mautrix-telegram [see changelog](https://github.com/mautrix/telegram/blob/150bf5e3389dd256ed2e2e8913df5866e8cd91f4/CHANGELOG.md?plain=1#L326)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
