### PR TITLE
Remove top level `with lib;` and `with import ...` in `pkgs/top-level/`

### DIFF
--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -2,14 +2,20 @@
 
 { config, lib, ... }:
 
-with lib;
-
 let
+  inherit (lib)
+    literalExpression
+    mapAttrsToList
+    mdDoc
+    mkOption
+    optionals
+    types
+    ;
 
   mkMassRebuild = args: mkOption (builtins.removeAttrs args [ "feature" ] // {
     type = args.type or (types.uniq types.bool);
     default = args.default or false;
-    description = lib.mdDoc ((args.description or ''
+    description = mdDoc ((args.description or ''
       Whether to ${args.feature} while building nixpkgs packages.
     '') + ''
       Changing the default may cause a mass rebuild.
@@ -34,7 +40,7 @@ let
     /* Config options */
 
     warnUndeclaredOptions = mkOption {
-      description = lib.mdDoc "Whether to warn when `config` contains an unrecognized attribute.";
+      description = mdDoc "Whether to warn when `config` contains an unrecognized attribute.";
       type = types.bool;
       default = false;
     };
@@ -66,7 +72,7 @@ let
     allowAliases = mkOption {
       type = types.bool;
       default = true;
-      description = lib.mdDoc ''
+      description = mdDoc ''
         Whether to expose old attribute names for compatibility.
 
         The recommended setting is to enable this, as it
@@ -86,7 +92,7 @@ let
       default = false;
       # getEnv part is in check-meta.nix
       defaultText = literalExpression ''false || builtins.getEnv "NIXPKGS_ALLOW_UNFREE" == "1"'';
-      description = lib.mdDoc ''
+      description = mdDoc ''
         Whether to allow unfree packages.
 
         See [Installing unfree packages](https://nixos.org/manual/nixpkgs/stable/#sec-allow-unfree) in the NixOS manual.
@@ -98,7 +104,7 @@ let
       default = false;
       # getEnv part is in check-meta.nix
       defaultText = literalExpression ''false || builtins.getEnv "NIXPKGS_ALLOW_BROKEN" == "1"'';
-      description = lib.mdDoc ''
+      description = mdDoc ''
         Whether to allow broken packages.
 
         See [Installing broken packages](https://nixos.org/manual/nixpkgs/stable/#sec-allow-broken) in the NixOS manual.
@@ -110,7 +116,7 @@ let
       default = false;
       # getEnv part is in check-meta.nix
       defaultText = literalExpression ''false || builtins.getEnv "NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM" == "1"'';
-      description = lib.mdDoc ''
+      description = mdDoc ''
         Whether to allow unsupported packages.
 
         See [Installing packages on unsupported systems](https://nixos.org/manual/nixpkgs/stable/#sec-allow-unsupported-system) in the NixOS manual.
@@ -132,7 +138,7 @@ let
     showDerivationWarnings = mkOption {
       type = types.listOf (types.enum [ "maintainerless" ]);
       default = [];
-      description = lib.mdDoc ''
+      description = mdDoc ''
         Which warnings to display for potentially dangerous
         or deprecated values passed into `stdenv.mkDerivation`.
 
@@ -147,7 +153,7 @@ let
     checkMeta = mkOption {
       type = types.bool;
       default = false;
-      description = lib.mdDoc ''
+      description = mdDoc ''
         Whether to check that the `meta` attribute of derivations are correct during evaluation time.
       '';
     };
@@ -156,7 +162,7 @@ let
 in {
 
   freeformType =
-    let t = lib.types.lazyAttrsOf lib.types.raw;
+    let t = types.lazyAttrsOf types.raw;
     in t // {
       merge = loc: defs:
         let r = t.merge loc defs;
@@ -166,8 +172,8 @@ in {
   inherit options;
 
   config = {
-    warnings = lib.optionals config.warnUndeclaredOptions (
-      lib.mapAttrsToList (k: v: "undeclared Nixpkgs option set: config.${k}") config._undeclared or {}
+    warnings = optionals config.warnUndeclaredOptions (
+      mapAttrsToList (k: v: "undeclared Nixpkgs option set: config.${k}") config._undeclared or {}
     );
   };
 

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -11,23 +11,7 @@ let
 
   inherit (libretro) fuse genesis-plus-gx mgba nestopia snes9x twenty-fortyeight;
 
-  self = rec {
-
-  addonDir = "/share/kodi/addons";
-  rel = "Nexus";
-
   callPackage = newScope self;
-
-  inherit kodi;
-
-  # Convert derivation to a kodi module. Stolen from ../../../top-level/python-packages.nix
-  toKodiAddon = drv: drv.overrideAttrs (oldAttrs: {
-    # Use passthru in order to prevent rebuilds when possible.
-    passthru = (oldAttrs.passthru or {}) // {
-      kodiAddonFor = kodi;
-      requiredKodiAddons = requiredKodiAddons drv.propagatedBuildInputs;
-    };
-  });
 
   # Check whether a derivation provides a Kodi addon.
   hasKodiAddon = drv: drv ? kodiAddonFor && drv.kodiAddonFor == kodi;
@@ -39,169 +23,185 @@ let
     in
       unique (modules ++ concatLists (catAttrs "requiredKodiAddons" modules));
 
-  # package update scripts
+  self = {
+    addonDir = "/share/kodi/addons";
 
-  addonUpdateScript = callPackage ../applications/video/kodi/addons/addon-update-script { };
+    rel = "Nexus";
 
-  # package builders
+    inherit callPackage kodi hasKodiAddon requiredKodiAddons;
 
-  buildKodiAddon = callPackage ../applications/video/kodi/build-kodi-addon.nix { };
+    # Convert derivation to a kodi module. Stolen from ../../../top-level/python-packages.nix
+    toKodiAddon = drv: drv.overrideAttrs (oldAttrs: {
+      # Use passthru in order to prevent rebuilds when possible.
+      passthru = (oldAttrs.passthru or {}) // {
+        kodiAddonFor = kodi;
+        requiredKodiAddons = requiredKodiAddons drv.propagatedBuildInputs;
+      };
+    });
 
-  buildKodiBinaryAddon = callPackage ../applications/video/kodi/build-kodi-binary-addon.nix { };
+    # package update scripts
 
-  # regular packages
+    addonUpdateScript = callPackage ../applications/video/kodi/addons/addon-update-script { };
 
-  kodi-platform = callPackage ../applications/video/kodi/addons/kodi-platform { };
+    # package builders
 
-  # addon packages
+    buildKodiAddon = callPackage ../applications/video/kodi/build-kodi-addon.nix { };
 
-  a4ksubtitles = callPackage ../applications/video/kodi/addons/a4ksubtitles { };
+    buildKodiBinaryAddon = callPackage ../applications/video/kodi/build-kodi-binary-addon.nix { };
 
-  arteplussept = callPackage ../applications/video/kodi/addons/arteplussept { };
+    # regular packages
 
-  controller-topology-project = callPackage ../applications/video/kodi/addons/controller-topology-project { };
+    kodi-platform = callPackage ../applications/video/kodi/addons/kodi-platform { };
 
-  iagl = callPackage ../applications/video/kodi/addons/iagl { };
+    # addon packages
 
-  invidious = callPackage ../applications/video/kodi/addons/invidious { };
+    a4ksubtitles = callPackage ../applications/video/kodi/addons/a4ksubtitles { };
 
-  libretro = callPackage ../applications/video/kodi/addons/libretro { };
+    arteplussept = callPackage ../applications/video/kodi/addons/arteplussept { };
 
-  libretro-2048 = callPackage ../applications/video/kodi/addons/libretro-2048 { inherit twenty-fortyeight; };
+    controller-topology-project = callPackage ../applications/video/kodi/addons/controller-topology-project { };
 
-  libretro-fuse = callPackage ../applications/video/kodi/addons/libretro-fuse { inherit fuse; };
+    iagl = callPackage ../applications/video/kodi/addons/iagl { };
 
-  libretro-genplus = callPackage ../applications/video/kodi/addons/libretro-genplus { inherit genesis-plus-gx; };
+    invidious = callPackage ../applications/video/kodi/addons/invidious { };
 
-  libretro-mgba = callPackage ../applications/video/kodi/addons/libretro-mgba { inherit mgba; };
+    libretro = callPackage ../applications/video/kodi/addons/libretro { };
 
-  libretro-nestopia = callPackage ../applications/video/kodi/addons/libretro-nestopia { inherit nestopia; };
+    libretro-2048 = callPackage ../applications/video/kodi/addons/libretro-2048 { inherit twenty-fortyeight; };
 
-  libretro-snes9x = callPackage ../applications/video/kodi/addons/libretro-snes9x { inherit snes9x; };
+    libretro-fuse = callPackage ../applications/video/kodi/addons/libretro-fuse { inherit fuse; };
 
-  jellyfin = callPackage ../applications/video/kodi/addons/jellyfin { };
+    libretro-genplus = callPackage ../applications/video/kodi/addons/libretro-genplus { inherit genesis-plus-gx; };
 
-  joystick = callPackage ../applications/video/kodi/addons/joystick { };
+    libretro-mgba = callPackage ../applications/video/kodi/addons/libretro-mgba { inherit mgba; };
 
-  keymap = callPackage ../applications/video/kodi/addons/keymap { };
+    libretro-nestopia = callPackage ../applications/video/kodi/addons/libretro-nestopia { inherit nestopia; };
 
-  mediacccde = callPackage ../applications/video/kodi/addons/mediacccde { };
+    libretro-snes9x = callPackage ../applications/video/kodi/addons/libretro-snes9x { inherit snes9x; };
 
-  mediathekview = callPackage ../applications/video/kodi/addons/mediathekview { };
+    jellyfin = callPackage ../applications/video/kodi/addons/jellyfin { };
 
-  netflix = callPackage ../applications/video/kodi/addons/netflix { };
+    joystick = callPackage ../applications/video/kodi/addons/joystick { };
 
-  orftvthek = callPackage ../applications/video/kodi/addons/orftvthek { };
+    keymap = callPackage ../applications/video/kodi/addons/keymap { };
 
-  radioparadise = callPackage ../applications/video/kodi/addons/radioparadise { };
+    mediacccde = callPackage ../applications/video/kodi/addons/mediacccde { };
 
-  svtplay = callPackage ../applications/video/kodi/addons/svtplay { };
+    mediathekview = callPackage ../applications/video/kodi/addons/mediathekview { };
 
-  steam-controller = callPackage ../applications/video/kodi/addons/steam-controller { };
+    netflix = callPackage ../applications/video/kodi/addons/netflix { };
 
-  steam-launcher = callPackage ../applications/video/kodi/addons/steam-launcher { };
+    orftvthek = callPackage ../applications/video/kodi/addons/orftvthek { };
 
-  steam-library = callPackage ../applications/video/kodi/addons/steam-library { };
+    radioparadise = callPackage ../applications/video/kodi/addons/radioparadise { };
 
-  somafm = callPackage ../applications/video/kodi/addons/somafm { };
+    svtplay = callPackage ../applications/video/kodi/addons/svtplay { };
 
-  pdfreader = callPackage ../applications/video/kodi/addons/pdfreader { };
+    steam-controller = callPackage ../applications/video/kodi/addons/steam-controller { };
 
-  pvr-hts = callPackage ../applications/video/kodi/addons/pvr-hts { };
+    steam-launcher = callPackage ../applications/video/kodi/addons/steam-launcher { };
 
-  pvr-hdhomerun = callPackage ../applications/video/kodi/addons/pvr-hdhomerun { };
+    steam-library = callPackage ../applications/video/kodi/addons/steam-library { };
 
-  pvr-iptvsimple = callPackage ../applications/video/kodi/addons/pvr-iptvsimple { };
+    somafm = callPackage ../applications/video/kodi/addons/somafm { };
 
-  pvr-vdr-vnsi = callPackage ../applications/video/kodi/addons/pvr-vdr-vnsi { };
+    pdfreader = callPackage ../applications/video/kodi/addons/pdfreader { };
 
-  osmc-skin = callPackage ../applications/video/kodi/addons/osmc-skin { };
+    pvr-hts = callPackage ../applications/video/kodi/addons/pvr-hts { };
 
-  vfs-libarchive = callPackage ../applications/video/kodi/addons/vfs-libarchive { };
+    pvr-hdhomerun = callPackage ../applications/video/kodi/addons/pvr-hdhomerun { };
 
-  vfs-rar = callPackage ../applications/video/kodi/addons/vfs-rar { };
+    pvr-iptvsimple = callPackage ../applications/video/kodi/addons/pvr-iptvsimple { };
 
-  vfs-sftp = callPackage ../applications/video/kodi/addons/vfs-sftp { };
+    pvr-vdr-vnsi = callPackage ../applications/video/kodi/addons/pvr-vdr-vnsi { };
 
-  visualization-fishbmc = callPackage ../applications/video/kodi/addons/visualization-fishbmc { };
+    osmc-skin = callPackage ../applications/video/kodi/addons/osmc-skin { };
 
-  visualization-goom = callPackage ../applications/video/kodi/addons/visualization-goom { };
+    vfs-libarchive = callPackage ../applications/video/kodi/addons/vfs-libarchive { };
 
-  visualization-matrix = callPackage ../applications/video/kodi/addons/visualization-matrix { };
+    vfs-rar = callPackage ../applications/video/kodi/addons/vfs-rar { };
 
-  visualization-pictureit = callPackage ../applications/video/kodi/addons/visualization-pictureit { };
+    vfs-sftp = callPackage ../applications/video/kodi/addons/vfs-sftp { };
 
-  visualization-projectm = callPackage ../applications/video/kodi/addons/visualization-projectm { };
+    visualization-fishbmc = callPackage ../applications/video/kodi/addons/visualization-fishbmc { };
 
-  visualization-shadertoy = callPackage ../applications/video/kodi/addons/visualization-shadertoy { };
+    visualization-goom = callPackage ../applications/video/kodi/addons/visualization-goom { };
 
-  visualization-spectrum = callPackage ../applications/video/kodi/addons/visualization-spectrum { };
+    visualization-matrix = callPackage ../applications/video/kodi/addons/visualization-matrix { };
 
-  visualization-starburst = callPackage ../applications/video/kodi/addons/visualization-starburst { };
+    visualization-pictureit = callPackage ../applications/video/kodi/addons/visualization-pictureit { };
 
-  visualization-waveform = callPackage ../applications/video/kodi/addons/visualization-waveform { };
+    visualization-projectm = callPackage ../applications/video/kodi/addons/visualization-projectm { };
 
-  youtube = callPackage ../applications/video/kodi/addons/youtube { };
+    visualization-shadertoy = callPackage ../applications/video/kodi/addons/visualization-shadertoy { };
 
-  # addon packages (dependencies)
+    visualization-spectrum = callPackage ../applications/video/kodi/addons/visualization-spectrum { };
 
-  archive_tool = callPackage ../applications/video/kodi/addons/archive_tool { };
+    visualization-starburst = callPackage ../applications/video/kodi/addons/visualization-starburst { };
 
-  certifi = callPackage ../applications/video/kodi/addons/certifi { };
+    visualization-waveform = callPackage ../applications/video/kodi/addons/visualization-waveform { };
 
-  chardet = callPackage ../applications/video/kodi/addons/chardet { };
+    youtube = callPackage ../applications/video/kodi/addons/youtube { };
 
-  dateutil = callPackage ../applications/video/kodi/addons/dateutil { };
+    # addon packages (dependencies)
 
-  defusedxml = callPackage ../applications/video/kodi/addons/defusedxml { };
+    archive_tool = callPackage ../applications/video/kodi/addons/archive_tool { };
 
-  future = callPackage ../applications/video/kodi/addons/future { };
+    certifi = callPackage ../applications/video/kodi/addons/certifi { };
 
-  idna = callPackage ../applications/video/kodi/addons/idna { };
+    chardet = callPackage ../applications/video/kodi/addons/chardet { };
 
-  infotagger = callPackage ../applications/video/kodi/addons/infotagger { };
+    dateutil = callPackage ../applications/video/kodi/addons/dateutil { };
 
-  inputstream-adaptive = callPackage ../applications/video/kodi/addons/inputstream-adaptive { };
+    defusedxml = callPackage ../applications/video/kodi/addons/defusedxml { };
 
-  inputstream-ffmpegdirect = callPackage ../applications/video/kodi/addons/inputstream-ffmpegdirect { };
+    future = callPackage ../applications/video/kodi/addons/future { };
 
-  inputstream-rtmp = callPackage ../applications/video/kodi/addons/inputstream-rtmp { };
+    idna = callPackage ../applications/video/kodi/addons/idna { };
 
-  inputstreamhelper = callPackage ../applications/video/kodi/addons/inputstreamhelper { };
+    infotagger = callPackage ../applications/video/kodi/addons/infotagger { };
 
-  kodi-six = callPackage ../applications/video/kodi/addons/kodi-six { };
+    inputstream-adaptive = callPackage ../applications/video/kodi/addons/inputstream-adaptive { };
 
-  myconnpy = callPackage ../applications/video/kodi/addons/myconnpy { };
+    inputstream-ffmpegdirect = callPackage ../applications/video/kodi/addons/inputstream-ffmpegdirect { };
 
-  requests = callPackage ../applications/video/kodi/addons/requests { };
+    inputstream-rtmp = callPackage ../applications/video/kodi/addons/inputstream-rtmp { };
 
-  requests-cache = callPackage ../applications/video/kodi/addons/requests-cache { };
+    inputstreamhelper = callPackage ../applications/video/kodi/addons/inputstreamhelper { };
 
-  routing = callPackage ../applications/video/kodi/addons/routing { };
+    kodi-six = callPackage ../applications/video/kodi/addons/kodi-six { };
 
-  sendtokodi = callPackage ../applications/video/kodi/addons/sendtokodi { };
+    myconnpy = callPackage ../applications/video/kodi/addons/myconnpy { };
 
-  signals = callPackage ../applications/video/kodi/addons/signals { };
+    requests = callPackage ../applications/video/kodi/addons/requests { };
 
-  simplejson = callPackage ../applications/video/kodi/addons/simplejson { };
+    requests-cache = callPackage ../applications/video/kodi/addons/requests-cache { };
 
-  six = callPackage ../applications/video/kodi/addons/six { };
+    routing = callPackage ../applications/video/kodi/addons/routing { };
 
-  sponsorblock = callPackage ../applications/video/kodi/addons/sponsorblock { };
+    sendtokodi = callPackage ../applications/video/kodi/addons/sendtokodi { };
 
-  urllib3 = callPackage ../applications/video/kodi/addons/urllib3 { };
+    signals = callPackage ../applications/video/kodi/addons/signals { };
 
-  websocket = callPackage ../applications/video/kodi/addons/websocket { };
+    simplejson = callPackage ../applications/video/kodi/addons/simplejson { };
 
-  xbmcswift2 = callPackage ../applications/video/kodi/addons/xbmcswift2 { };
+    six = callPackage ../applications/video/kodi/addons/six { };
 
-  typing_extensions = callPackage ../applications/video/kodi/addons/typing_extensions { };
+    sponsorblock = callPackage ../applications/video/kodi/addons/sponsorblock { };
 
-  arrow = callPackage ../applications/video/kodi/addons/arrow { };
+    urllib3 = callPackage ../applications/video/kodi/addons/urllib3 { };
 
-  trakt-module = callPackage ../applications/video/kodi/addons/trakt-module { };
+    websocket = callPackage ../applications/video/kodi/addons/websocket { };
 
-  trakt = callPackage ../applications/video/kodi/addons/trakt { };
+    xbmcswift2 = callPackage ../applications/video/kodi/addons/xbmcswift2 { };
+
+    typing_extensions = callPackage ../applications/video/kodi/addons/typing_extensions { };
+
+    arrow = callPackage ../applications/video/kodi/addons/arrow { };
+
+    trakt-module = callPackage ../applications/video/kodi/addons/trakt-module { };
+
+    trakt = callPackage ../applications/video/kodi/addons/trakt { };
 }; in self // optionalAttrs config.allowAliases {
   # deprecated or renamed packages
 

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -1,12 +1,17 @@
 { config, lib, newScope, kodi, libretro }:
 
-with lib;
-
 let
-  inherit (libretro) fuse genesis-plus-gx mgba nestopia snes9x twenty-fortyeight;
-in
+  inherit (lib)
+    catAttrs
+    concatLists
+    filter
+    optionalAttrs
+    unique
+    ;
 
-let self = rec {
+  inherit (libretro) fuse genesis-plus-gx mgba nestopia snes9x twenty-fortyeight;
+
+  self = rec {
 
   addonDir = "/share/kodi/addons";
   rel = "Nexus";
@@ -197,7 +202,7 @@ let self = rec {
   trakt-module = callPackage ../applications/video/kodi/addons/trakt-module { };
 
   trakt = callPackage ../applications/video/kodi/addons/trakt { };
-}; in self // lib.optionalAttrs config.allowAliases {
+}; in self // optionalAttrs config.allowAliases {
   # deprecated or renamed packages
 
   controllers = throw "kodi.packages.controllers has been replaced with kodi.packages.controller-topology-project - a package which contains a large number of controller profiles." { };

--- a/pkgs/top-level/octave-packages.nix
+++ b/pkgs/top-level/octave-packages.nix
@@ -19,7 +19,15 @@
 , octave
 }:
 
-with lib;
+let
+  inherit (lib)
+    catAttrs
+    concatLists
+    filter
+    makeScope
+    unique
+    ;
+in
 
 makeScope newScope (self:
   let

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -20,9 +20,40 @@
   nixpkgsArgs ? { config = { allowUnfree = false; inHydra = true; }; }
 }:
 
-with import ./release-lib.nix { inherit supportedSystems scrubJobs nixpkgsArgs; };
-
 let
+  release-lib = import ./release-lib.nix {
+    inherit supportedSystems scrubJobs nixpkgsArgs;
+  };
+
+  inherit (release-lib)
+    all
+    assertTrue
+    darwin
+    forMatchingSystems
+    hydraJob'
+    linux
+    mapTestOnCross
+    pkgsForCross
+    unix
+    ;
+
+  inherit (release-lib.lib)
+    mapAttrs
+    addMetaAttrs
+    elem
+    getAttrFromPath
+    isDerivation
+    maintainers
+    mapAttrsRecursive
+    mapAttrsRecursiveCond
+    recursiveUpdate
+    systems
+    ;
+
+  inherit (release-lib.lib.attrsets)
+    removeAttrs
+    ;
+
   nativePlatforms = all;
 
   embedded = {
@@ -42,14 +73,14 @@ let
     cargo = nativePlatforms;
   };
 
-  gnuCommon = lib.recursiveUpdate common {
+  gnuCommon = recursiveUpdate common {
     buildPackages.gcc = nativePlatforms;
     coreutils = nativePlatforms;
     haskell.packages.ghcHEAD.hello = nativePlatforms;
     haskellPackages.hello = nativePlatforms;
   };
 
-  linuxCommon = lib.recursiveUpdate gnuCommon {
+  linuxCommon = recursiveUpdate gnuCommon {
     buildPackages.gdb = nativePlatforms;
 
     bison = nativePlatforms;
@@ -60,7 +91,7 @@ let
     patch = nativePlatforms;
   };
 
-  windowsCommon = lib.recursiveUpdate gnuCommon {
+  windowsCommon = recursiveUpdate gnuCommon {
     boehmgc = nativePlatforms;
     guile_1_8 = nativePlatforms;
     libffi = nativePlatforms;
@@ -120,7 +151,7 @@ in
     # good idea lest there be some irrelevant pass-through debug attrs that
     # cause false negatives.
     testEqualOne = path: system: let
-      f = path: crossSystem: system: builtins.toString (lib.getAttrFromPath path (pkgsForCross crossSystem system));
+      f = path: crossSystem: system: toString (getAttrFromPath path (pkgsForCross crossSystem system));
     in assertTrue (
         f path null system
         ==
@@ -129,7 +160,7 @@ in
 
     testEqual = path: systems: forMatchingSystems systems (testEqualOne path);
 
-    mapTestEqual = lib.mapAttrsRecursive testEqual;
+    mapTestEqual = mapAttrsRecursive testEqual;
 
   in mapTestEqual {
     boehmgc = nativePlatforms;
@@ -142,105 +173,107 @@ in
     guile = nativePlatforms;
   };
 
-  crossIphone64 = mapTestOnCross lib.systems.examples.iphone64 darwinCommon;
+  crossIphone64 = mapTestOnCross systems.examples.iphone64 darwinCommon;
 
-  crossIphone32 = mapTestOnCross lib.systems.examples.iphone32 darwinCommon;
+  crossIphone32 = mapTestOnCross systems.examples.iphone32 darwinCommon;
 
   /* Test some cross builds to the Sheevaplug */
-  crossSheevaplugLinux = mapTestOnCross lib.systems.examples.sheevaplug (linuxCommon // {
+  crossSheevaplugLinux = mapTestOnCross systems.examples.sheevaplug (linuxCommon // {
     ubootSheevaplug = nativePlatforms;
   });
 
   /* Test some cross builds on 32 bit mingw-w64 */
-  crossMingw32 = mapTestOnCross lib.systems.examples.mingw32 windowsCommon;
+  crossMingw32 = mapTestOnCross systems.examples.mingw32 windowsCommon;
 
   /* Test some cross builds on 64 bit mingw-w64 */
-  crossMingwW64 = mapTestOnCross lib.systems.examples.mingwW64 windowsCommon;
+  crossMingwW64 = mapTestOnCross systems.examples.mingwW64 windowsCommon;
 
   /* Linux on mipsel */
-  fuloongminipc = mapTestOnCross lib.systems.examples.fuloongminipc linuxCommon;
-  ben-nanonote = mapTestOnCross lib.systems.examples.ben-nanonote linuxCommon;
+  fuloongminipc = mapTestOnCross systems.examples.fuloongminipc linuxCommon;
+  ben-nanonote = mapTestOnCross systems.examples.ben-nanonote linuxCommon;
 
   /* Javacript */
-  ghcjs = mapTestOnCross lib.systems.examples.ghcjs {
+  ghcjs = mapTestOnCross systems.examples.ghcjs {
     haskell.packages.ghcjs.hello = nativePlatforms;
     haskell.packages.native-bignum.ghcHEAD.hello = nativePlatforms;
     haskellPackages.hello = nativePlatforms;
   };
 
   /* Linux on Raspberrypi */
-  rpi = mapTestOnCross lib.systems.examples.raspberryPi rpiCommon;
-  rpi-musl = mapTestOnCross lib.systems.examples.muslpi rpiCommon;
+  rpi = mapTestOnCross systems.examples.raspberryPi rpiCommon;
+  rpi-musl = mapTestOnCross systems.examples.muslpi rpiCommon;
 
   /* Linux on the Remarkable */
-  remarkable1 = mapTestOnCross lib.systems.examples.remarkable1 linuxCommon;
-  remarkable2 = mapTestOnCross lib.systems.examples.remarkable2 linuxCommon;
+  remarkable1 = mapTestOnCross systems.examples.remarkable1 linuxCommon;
+  remarkable2 = mapTestOnCross systems.examples.remarkable2 linuxCommon;
 
   /* Linux on armv7l-hf */
-  armv7l-hf = mapTestOnCross lib.systems.examples.armv7l-hf-multiplatform linuxCommon;
+  armv7l-hf = mapTestOnCross systems.examples.armv7l-hf-multiplatform linuxCommon;
 
-  pogoplug4 = mapTestOnCross lib.systems.examples.pogoplug4 linuxCommon;
+  pogoplug4 = mapTestOnCross systems.examples.pogoplug4 linuxCommon;
 
   /* Linux on aarch64 */
-  aarch64 = mapTestOnCross lib.systems.examples.aarch64-multiplatform linuxCommon;
-  aarch64-musl = mapTestOnCross lib.systems.examples.aarch64-multiplatform-musl linuxCommon;
+  aarch64 = mapTestOnCross systems.examples.aarch64-multiplatform linuxCommon;
+  aarch64-musl = mapTestOnCross systems.examples.aarch64-multiplatform-musl linuxCommon;
 
   /* Linux on RISCV */
-  riscv64 = mapTestOnCross lib.systems.examples.riscv64 linuxCommon;
-  riscv32 = mapTestOnCross lib.systems.examples.riscv32 linuxCommon;
+  riscv64 = mapTestOnCross systems.examples.riscv64 linuxCommon;
+  riscv32 = mapTestOnCross systems.examples.riscv32 linuxCommon;
 
   /* Linux on LoongArch */
-  loongarch64-linux = mapTestOnCross lib.systems.examples.loongarch64-linux linuxCommon;
+  loongarch64-linux = mapTestOnCross systems.examples.loongarch64-linux linuxCommon;
 
-  m68k = mapTestOnCross lib.systems.examples.m68k linuxCommon;
-  s390x = mapTestOnCross lib.systems.examples.s390x linuxCommon;
+  m68k = mapTestOnCross systems.examples.m68k linuxCommon;
+  s390x = mapTestOnCross systems.examples.s390x linuxCommon;
 
   /* (Cross-compiled) Linux on x86 */
-  x86_64-musl = mapTestOnCross lib.systems.examples.musl64 linuxCommon;
-  x86_64-gnu = mapTestOnCross lib.systems.examples.gnu64 linuxCommon;
-  i686-musl = mapTestOnCross lib.systems.examples.musl32 linuxCommon;
-  i686-gnu = mapTestOnCross lib.systems.examples.gnu32 linuxCommon;
+  x86_64-musl = mapTestOnCross systems.examples.musl64 linuxCommon;
+  x86_64-gnu = mapTestOnCross systems.examples.gnu64 linuxCommon;
+  i686-musl = mapTestOnCross systems.examples.musl32 linuxCommon;
+  i686-gnu = mapTestOnCross systems.examples.gnu32 linuxCommon;
 
-  ppc64le = mapTestOnCross lib.systems.examples.powernv linuxCommon;
-  ppc64le-musl = mapTestOnCross lib.systems.examples.musl-power linuxCommon;
+  ppc64le = mapTestOnCross systems.examples.powernv linuxCommon;
+  ppc64le-musl = mapTestOnCross systems.examples.musl-power linuxCommon;
 
-  android64 = mapTestOnCross lib.systems.examples.aarch64-android-prebuilt linuxCommon;
-  android32 = mapTestOnCross lib.systems.examples.armv7a-android-prebuilt linuxCommon;
+  android64 = mapTestOnCross systems.examples.aarch64-android-prebuilt linuxCommon;
+  android32 = mapTestOnCross systems.examples.armv7a-android-prebuilt linuxCommon;
 
-  wasi32 = mapTestOnCross lib.systems.examples.wasi32 wasiCommon;
+  wasi32 = mapTestOnCross systems.examples.wasi32 wasiCommon;
 
-  msp430 = mapTestOnCross lib.systems.examples.msp430 embedded;
-  mmix = mapTestOnCross lib.systems.examples.mmix embedded;
-  vc4 = mapTestOnCross lib.systems.examples.vc4 embedded;
-  or1k = mapTestOnCross lib.systems.examples.or1k embedded;
-  avr = mapTestOnCross lib.systems.examples.avr embedded;
-  arm-embedded = mapTestOnCross lib.systems.examples.arm-embedded embedded;
-  armhf-embedded = mapTestOnCross lib.systems.examples.armhf-embedded embedded;
-  aarch64-embedded = mapTestOnCross lib.systems.examples.aarch64-embedded embedded;
-  aarch64be-embedded = mapTestOnCross lib.systems.examples.aarch64be-embedded embedded;
-  powerpc-embedded = mapTestOnCross lib.systems.examples.ppc-embedded embedded;
-  powerpcle-embedded = mapTestOnCross lib.systems.examples.ppcle-embedded embedded;
-  i686-embedded = mapTestOnCross lib.systems.examples.i686-embedded embedded;
-  x86_64-embedded = mapTestOnCross lib.systems.examples.x86_64-embedded embedded;
-  riscv64-embedded = mapTestOnCross lib.systems.examples.riscv64-embedded embedded;
-  riscv32-embedded = mapTestOnCross lib.systems.examples.riscv32-embedded embedded;
-  rx-embedded = mapTestOnCross lib.systems.examples.rx-embedded embedded;
+  msp430 = mapTestOnCross systems.examples.msp430 embedded;
+  mmix = mapTestOnCross systems.examples.mmix embedded;
+  vc4 = mapTestOnCross systems.examples.vc4 embedded;
+  or1k = mapTestOnCross systems.examples.or1k embedded;
+  avr = mapTestOnCross systems.examples.avr embedded;
+  arm-embedded = mapTestOnCross systems.examples.arm-embedded embedded;
+  armhf-embedded = mapTestOnCross systems.examples.armhf-embedded embedded;
+  aarch64-embedded = mapTestOnCross systems.examples.aarch64-embedded embedded;
+  aarch64be-embedded = mapTestOnCross systems.examples.aarch64be-embedded embedded;
+  powerpc-embedded = mapTestOnCross systems.examples.ppc-embedded embedded;
+  powerpcle-embedded = mapTestOnCross systems.examples.ppcle-embedded embedded;
+  i686-embedded = mapTestOnCross systems.examples.i686-embedded embedded;
+  x86_64-embedded = mapTestOnCross systems.examples.x86_64-embedded embedded;
+  riscv64-embedded = mapTestOnCross systems.examples.riscv64-embedded embedded;
+  riscv32-embedded = mapTestOnCross systems.examples.riscv32-embedded embedded;
+  rx-embedded = mapTestOnCross systems.examples.rx-embedded embedded;
 
-  x86_64-freebsd = mapTestOnCross lib.systems.examples.x86_64-freebsd common;
-  x86_64-netbsd = mapTestOnCross lib.systems.examples.x86_64-netbsd common;
+  x86_64-freebsd = mapTestOnCross systems.examples.x86_64-freebsd common;
+  x86_64-netbsd = mapTestOnCross systems.examples.x86_64-netbsd common;
 
   # we test `embedded` instead of `linuxCommon` because very few packages
   # successfully cross-compile to Redox so far
-  x86_64-redox = mapTestOnCross lib.systems.examples.x86_64-unknown-redox embedded;
+  x86_64-redox = mapTestOnCross systems.examples.x86_64-unknown-redox embedded;
 
   /* Cross-built bootstrap tools for every supported platform */
   bootstrapTools = let
     tools = import ../stdenv/linux/make-bootstrap-tools-cross.nix { system = "x86_64-linux"; };
-    maintainers = [ lib.maintainers.dezgeg ];
+    meta = {
+      maintainers = [ maintainers.dezgeg ];
+    };
     mkBootstrapToolsJob = drv:
-      assert lib.elem drv.system supportedSystems;
-      hydraJob' (lib.addMetaAttrs { inherit maintainers; } drv);
-  in lib.mapAttrsRecursiveCond (as: !lib.isDerivation as) (name: mkBootstrapToolsJob)
+      assert elem drv.system supportedSystems;
+      hydraJob' (addMetaAttrs meta drv);
+  in mapAttrsRecursiveCond (as: !isDerivation as) (name: mkBootstrapToolsJob)
     # The `bootstrapTools.${platform}.bootstrapTools` derivation
     # *unpacks* the bootstrap-files using their own `busybox` binary,
     # so it will fail unless buildPlatform.canExecute hostPlatform.
@@ -248,9 +281,9 @@ in
     # attribute, so there is no way to detect this -- we must add it
     # as a special case.  We filter the "test" attribute (only from
      # *cross*-built bootstrapTools) for the same reason.
-    (builtins.mapAttrs (_: v: builtins.removeAttrs v ["bootstrapTools" "test"]) tools);
+    (mapAttrs (_: v: removeAttrs v ["bootstrapTools" "test"]) tools);
 
   # Cross-built nixStatic for platforms for enabled-but-unsupported platforms
-  mips64el-nixCrossStatic = mapTestOnCross lib.systems.examples.mips64el-linux-gnuabi64 nixCrossStatic;
-  powerpc64le-nixCrossStatic = mapTestOnCross lib.systems.examples.powernv nixCrossStatic;
+  mips64el-nixCrossStatic = mapTestOnCross systems.examples.mips64el-linux-gnuabi64 nixCrossStatic;
+  powerpc64le-nixCrossStatic = mapTestOnCross systems.examples.powernv nixCrossStatic;
 }

--- a/pkgs/top-level/release-cuda.nix
+++ b/pkgs/top-level/release-cuda.nix
@@ -18,10 +18,15 @@
   nixpkgsArgs ? { config = { allowUnfree = true; inHydra = true; }; }
 }:
 
-with import ./release-lib.nix {inherit supportedSystems nixpkgsArgs; };
-with lib;
-
 let
+  release-lib = import ./release-lib.nix {
+    inherit supportedSystems nixpkgsArgs;
+  };
+
+  inherit (release-lib) linux mapTestOn packagePlatforms pkgs;
+
+  inherit (release-lib.lib) genAttrs;
+
   # Package sets to evaluate
   packageSets = [
     "cudaPackages_10_0"

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -7,13 +7,33 @@
 
 let
   lib = import ../../lib;
-in with lib;
 
-rec {
+  inherit (lib)
+    addMetaAttrs
+    any
+    derivations
+    filter
+    flip
+    genAttrs
+    getAttrFromPath
+    hydraJob
+    id
+    isDerivation
+    lists
+    maintainers
+    mapAttrs
+    mapAttrs'
+    mapAttrsRecursive
+    matchAttrs
+    meta
+    nameValuePair
+    platforms
+    recursiveUpdate
+    subtractLists
+    systems
+    ;
 
-  pkgs = packageSet (lib.recursiveUpdate { system = "x86_64-linux"; config.allowUnsupportedSystem = true; } nixpkgsArgs);
-  inherit lib;
-
+  pkgs = packageSet (recursiveUpdate { system = "x86_64-linux"; config.allowUnsupportedSystem = true; } nixpkgsArgs);
 
   hydraJob' = if scrubJobs then hydraJob else id;
 
@@ -57,8 +77,8 @@ rec {
 
   # More poor man's memoisation
   pkgsForCross = let
-    examplesByConfig = lib.flip lib.mapAttrs'
-      lib.systems.examples
+    examplesByConfig = flip mapAttrs'
+      systems.examples
       (_: crossSystem: nameValuePair crossSystem.config {
         inherit crossSystem;
         pkgsFor = mkPkgsFor crossSystem;
@@ -68,7 +88,7 @@ rec {
     candidate = examplesByConfig.${crossSystem.config} or null;
   in if crossSystem == null
       then native
-    else if candidate != null && lib.matchAttrs crossSystem candidate.crossSystem
+    else if candidate != null && matchAttrs crossSystem candidate.crossSystem
       then candidate.pkgsFor
     else mkPkgsFor crossSystem; # uncached fallback
 
@@ -80,12 +100,12 @@ rec {
   # This is written in a funny way so that we only elaborate the systems once.
   supportedMatches = let
       supportedPlatforms = map
-        (system: lib.systems.elaborate { inherit system; })
+        (system: systems.elaborate { inherit system; })
         supportedSystems;
     in metaPatterns: let
       anyMatch = platform:
-        lib.any (lib.meta.platformMatch platform) metaPatterns;
-      matchingPlatforms = lib.filter anyMatch supportedPlatforms;
+        any (meta.platformMatch platform) metaPatterns;
+      matchingPlatforms = filter anyMatch supportedPlatforms;
     in map ({ system, ...}: system) matchingPlatforms;
 
 
@@ -135,7 +155,6 @@ rec {
     (path: metaPatterns: testOnCross crossSystem metaPatterns
       (pkgs: f (getAttrFromPath path pkgs)));
 
-
   /* Similar to the testOn function, but with an additional 'crossSystem'
    * parameter for packageSet', defining the target platform for cross builds,
    * and triggering the build of the host derivation. */
@@ -148,7 +167,7 @@ rec {
   packagePlatforms = mapAttrs (name: value:
       if isDerivation value then
         value.meta.hydraPlatforms
-          or (lib.subtractLists (value.meta.badPlatforms or [])
+          or (subtractLists (value.meta.badPlatforms or [])
                (value.meta.platforms or [ "x86_64-linux" ]))
       else if value.recurseForDerivations or false || value.recurseForRelease or false then
         packagePlatforms value
@@ -156,8 +175,24 @@ rec {
         []
     );
 
-
+in {
   /* Common platform groups on which to test packages. */
   inherit (platforms) unix linux darwin cygwin all mesaPlatforms;
 
+  inherit
+    assertTrue
+    forAllSystems
+    forMatchingSystems
+    hydraJob'
+    lib
+    mapTestOn
+    mapTestOnCross
+    packagePlatforms
+    pkgs
+    pkgsFor
+    pkgsForCross
+    supportedMatches
+    testOn
+    testOnCross
+    ;
 }

--- a/pkgs/top-level/release-python.nix
+++ b/pkgs/top-level/release-python.nix
@@ -21,10 +21,15 @@
   }; }
 }:
 
-with import ./release-lib.nix {inherit supportedSystems nixpkgsArgs; };
-with lib;
-
 let
+  release-lib = import ./release-lib.nix {
+    inherit supportedSystems nixpkgsArgs;
+  };
+
+  inherit (release-lib) mapTestOn pkgs;
+
+  inherit (release-lib.lib) isDerivation mapAttrs optionals;
+
   packagePython = mapAttrs (name: value:
     let res = builtins.tryEval (
       if isDerivation value then
@@ -33,7 +38,7 @@ let
         packagePython value
       else
         []);
-    in lib.optionals res.success res.value
+    in optionals res.success res.value
     );
 
   jobs = {

--- a/pkgs/top-level/release-r.nix
+++ b/pkgs/top-level/release-r.nix
@@ -6,7 +6,13 @@
 */
 { supportedSystems ? [ "x86_64-linux" "aarch64-linux" ] }:
 
-with import ./release-lib.nix { inherit supportedSystems; };
+let
+  inherit (import ./release-lib.nix { inherit supportedSystems; })
+    mapTestOn
+    packagePlatforms
+    pkgs
+    ;
+in
 
 mapTestOn {
   rPackages = packagePlatforms pkgs.rPackages;

--- a/pkgs/top-level/release-small.nix
+++ b/pkgs/top-level/release-small.nix
@@ -7,7 +7,13 @@
   nixpkgsArgs ? { config = { allowUnfree = false; inHydra = true; }; }
 }:
 
-with import ./release-lib.nix { inherit supportedSystems nixpkgsArgs; };
+let
+  release-lib = import ./release-lib.nix {
+    inherit supportedSystems nixpkgsArgs;
+  };
+
+  inherit (release-lib) all linux darwin mapTestOn unix;
+in
 
 {
 

--- a/pkgs/top-level/unixtools.nix
+++ b/pkgs/top-level/unixtools.nix
@@ -10,9 +10,14 @@
 # instance, if your program needs to use "ps", just list it as a build
 # input, not "procps" which requires Linux.
 
-with lib;
-
 let
+  inherit (lib)
+    getBin
+    getOutput
+    mapAttrs
+    platforms
+    ;
+
   version = "1003.1-2008";
 
   singleBinary = cmd: providers: let
@@ -23,7 +28,7 @@ let
       meta = {
         mainProgram = cmd;
         priority = 10;
-        platforms = lib.platforms.${stdenv.hostPlatform.parsed.kernel.name} or lib.platforms.all;
+        platforms = platforms.${stdenv.hostPlatform.parsed.kernel.name} or platforms.all;
       };
       passthru = { inherit provider; };
       preferLocalBuild = true;
@@ -187,7 +192,7 @@ let
 
   # Compatibility derivations
   # Provided for old usage of these commands.
-  compat = with bins; lib.mapAttrs makeCompat {
+  compat = with bins; mapAttrs makeCompat {
     procps = [ ps sysctl top watch ];
     util-linux = [ fsck fdisk getopt hexdump mount
                   script umount whereis write col column ];


### PR DESCRIPTION
## Description of changes

Using `with` at a top-level scope is [an anti-pattern](https://nix.dev/guides/best-practices#with-scopes). The tracking issue is #208242. This is a pure refactor: there is, or ought to be, no functional change contained in this PR, even though https://github.com/NixOS/nixpkgs/pull/293835/commits/83339e48d0fdabc4590507329600195f01e4dcb1 drops a few internal names from `release-lib.nix`.

This PR changes the files that used top-level `with lib;` and `with import ...;` in the `pkgs/top-level/` directory.

Here's what remains:

```
$ rg --sort=path '^with' pkgs/top-level/
pkgs/top-level/aliases.nix
20:with self;

pkgs/top-level/all-packages.nix
11:with pkgs;

pkgs/top-level/emscripten-packages.nix
3:with pkgs;

pkgs/top-level/java-packages.nix
3:with pkgs;

pkgs/top-level/linux-kernels.nix
22:with linuxKernel;

pkgs/top-level/metrics.nix
3:with pkgs;

pkgs/top-level/perl-packages.nix
23:with self; {

pkgs/top-level/python-aliases.nix
3:with self;

pkgs/top-level/python2-packages.nix
7:with self; with super; {
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).