### PR TITLE
Remove top level `with lib;` in `maintainers/`

### DIFF
--- a/maintainers/scripts/eval-release.nix
+++ b/maintainers/scripts/eval-release.nix
@@ -1,9 +1,8 @@
-# Evaluate `release.nix' like Hydra would.  Too bad nix-instantiate
-# can't to do this.
-
-with import ../../lib;
+# Evaluate `release.nix' like Hydra would. Too bad nix-instantiate can't to do this.
 
 let
+  inherit (import ../../lib) isDerivation mapAttrs;
+
   trace = if builtins.getEnv "VERBOSE" == "1" then builtins.trace else (x: y: y);
 
   rel = removeAttrs (import ../../pkgs/top-level/release.nix { }) [ "tarball" "unstable" "xbursttools" ];

--- a/maintainers/scripts/find-tarballs.nix
+++ b/maintainers/scripts/find-tarballs.nix
@@ -1,11 +1,22 @@
 # This expression returns a list of all fetchurl calls used by ‘expr’.
 
-with import ../.. { };
-with lib;
-
-{ expr }:
+{ expr, lib ? import ../../lib }:
 
 let
+  inherit (lib)
+    addErrorContext
+    attrNames
+    concatLists
+    const
+    filter
+    genericClosure
+    isAttrs
+    isDerivation
+    isList
+    mapAttrsToList
+    optional
+    optionals
+    ;
 
   root = expr;
 


### PR DESCRIPTION
## Description of changes

Using `with` at a top-level scope is [an anti-pattern](https://nix.dev/guides/best-practices#with-scopes). The tracking issue is #208242. This is a pure refactor: there is, or ought to be, no functional change contained in this PR.

This PR changes the files that used top-level `with lib;` in the `maintainers` directory.

Here's what remains that uses a top-level `with ...;` of a different stripe:

```
$ rg --sort=path '^with' maintainers/
maintainers/scripts/convert-to-import-cargo-lock/default.nix
1:with import ../../../. { };

maintainers/scripts/convert-to-import-cargo-lock/shell.nix
1:with import ../../../. { };

maintainers/scripts/update-octave-shell.nix
3:with nixpkgs;

maintainers/team-list.nix
31:with lib.maintainers; {
```

Each commit notes how testing was done.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).