### PR TITLE
testers.nixosTest: Deprecate

### DIFF
--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -239,6 +239,12 @@ pkgs.testers.runNixOSTest ({ lib, ... }: {
 
 ## `nixosTest` {#tester-nixosTest}
 
+This function is deprecated in favor of [`runNixOSTest`](#tester-runNixOSTest). The reason why it's bad is that when you pass it a function, it is invoked via `callPackage`. This is somewhat incompatible with the module system and running cross-platform:
+  - The choice of packages is ambiguous when the VM host platform is not Linux. `nixosTest` could in theory pick either:
+    - `hostPkgs` for packages to run on the VM host
+    - or `config.node.pkgs` for packages that run in one of the VMs
+  - The return value of the passed function should have been a module, but `nixosTest` does not actually allow that.
+
 Run a NixOS VM network test using this evaluation of Nixpkgs.
 
 NOTE: This function is primarily for external use. NixOS itself uses `make-test-python.nix` directly. Packages defined in Nixpkgs [reuse NixOS tests via `nixosTests`, plural](#ssec-nixos-tests-linking).

--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -239,12 +239,16 @@ pkgs.testers.runNixOSTest ({ lib, ... }: {
 
 ## `nixosTest` {#tester-nixosTest}
 
-This function is deprecated in favor of [`runNixOSTest`](#tester-runNixOSTest). The reason why it's bad is that when you pass it a function, it is invoked via `callPackage`. This is somewhat incompatible with the module system and running cross-platform:
-  - The choice of packages is ambiguous when the VM host platform is not Linux. `nixosTest` could in theory pick either:
+:::{.warning}
+This function is deprecated in favor of [`runNixOSTest`](#tester-runNixOSTest).
+The reason why it's bad is that when you pass it a function, it is invoked via `callPackage`.
+This is somewhat incompatible with the module system and running cross-platform:
+  - The choice of packages is ambiguous when the VM host platform is not Linux.
+    `nixosTest` could in theory pick either:
     - `hostPkgs` for packages to run on the VM host
     - or `config.node.pkgs` for packages that run in one of the VMs
   - The return value of the passed function should have been a module, but `nixosTest` does not actually allow that.
-
+:::
 Run a NixOS VM network test using this evaluation of Nixpkgs.
 
 NOTE: This function is primarily for external use. NixOS itself uses `make-test-python.nix` directly. Packages defined in Nixpkgs [reuse NixOS tests via `nixosTests`, plural](#ssec-nixos-tests-linking).

--- a/nixos/lib/testing/legacy.nix
+++ b/nixos/lib/testing/legacy.nix
@@ -19,7 +19,7 @@ in
   config = {
     nodes = mkIf options.machine.isDefined (
       lib.warn
-        "In test `${config.name}': The `machine' attribute in NixOS tests (pkgs.nixosTest / make-test-python.nix / testing-python.nix / makeTest) is deprecated. Please set the equivalent `nodes.machine'."
+        "In test `${config.name}': The `machine' attribute in NixOS tests is deprecated. Please set the equivalent `nodes.machine'."
         { inherit (config) machine; }
     );
   };

--- a/nixos/lib/testing/nixos-test-base.nix
+++ b/nixos/lib/testing/nixos-test-base.nix
@@ -14,7 +14,7 @@ in
       key = "no-revision";
       # Make the revision metadata constant, in order to avoid needless retesting.
       # The human version (e.g. 21.05-pre) is left as is, because it is useful
-      # for external modules that test with e.g. testers.nixosTest and rely on that
+      # for external modules that test with e.g. testers.runNixOSTest and rely on that
       # version number.
       config.system.nixos = {
         revision = mkForce "constant-nixos-revision";

--- a/nixos/tests/nixops/default.nix
+++ b/nixos/tests/nixops/default.nix
@@ -1,3 +1,9 @@
+/*
+  These tests may be run with:
+
+      nix-build -A nixosTests.nixops
+
+*/
 { pkgs, ... }:
 let
   inherit (pkgs) lib;
@@ -19,7 +25,7 @@ let
     passthru.override = args': testsForPackage (args // args');
   };
 
-  testLegacyNetwork = { nixopsPkg, ... }: pkgs.testers.nixosTest ({
+  testLegacyNetwork = { nixopsPkg, ... }: pkgs.testers.runNixOSTest ({
     name = "nixops-legacy-network";
     nodes = {
       deployer = { config, lib, nodes, pkgs, ... }: {

--- a/nixos/tests/nixos-test-driver/lib-extend.nix
+++ b/nixos/tests/nixos-test-driver/lib-extend.nix
@@ -1,3 +1,9 @@
+/*
+  These tests may be run with:
+
+      nix-build -A nixosTests.nixos-test-driver.lib-extend
+
+ */
 { pkgs, ... }:
 
 let
@@ -22,10 +28,8 @@ let
     testScript = "";
   };
 
-  inherit (patchedPkgs.testers) nixosTest runNixOSTest;
-  evaluationNixosTest = nixosTest testBody;
+  inherit (patchedPkgs.testers) runNixOSTest;
   evaluationRunNixOSTest = runNixOSTest testBody;
 in {
-  nixosTest = evaluationNixosTest.driver.nodes.machine.system.build.toplevel;
   runNixOSTest = evaluationRunNixOSTest.driver.nodes.machine.system.build.toplevel;
 }

--- a/nixos/tests/spark/default.nix
+++ b/nixos/tests/spark/default.nix
@@ -10,7 +10,7 @@ let
     sparkCluster = testSparkCluster args;
     passthru.override = args': testsForPackage (args // args');
   };
-  testSparkCluster = { sparkPackage, ... }: pkgs.testers.nixosTest ({
+  testSparkCluster = { sparkPackage, ... }: pkgs.testers.runNixOSTest ({
     name = "spark";
 
     nodes = {

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -118,6 +118,7 @@
        * make sense for this evaluation of Nixpkgs.
        */
       nixosTesting =
+        lib.warn "testers.nixosTest is deprecated. Use testers.runNixOSTest instead."
         (import ../../../nixos/lib/testing-python.nix {
           inherit (stdenv.hostPlatform) system;
           inherit pkgs;

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -118,7 +118,6 @@
        * make sense for this evaluation of Nixpkgs.
        */
       nixosTesting =
-        lib.warn "testers.nixosTest is deprecated. Use testers.runNixOSTest instead."
         (import ../../../nixos/lib/testing-python.nix {
           inherit (stdenv.hostPlatform) system;
           inherit pkgs;
@@ -136,6 +135,7 @@
             else test;
           calledTest = lib.toFunction loadedTest pkgs;
         in
+          lib.warn "testers.nixosTest is deprecated. Use testers.runNixOSTest instead. See https://nixos.org/manual/nixpkgs/unstable/#tester-runNixOSTest"
           nixosTesting.simpleTest calledTest;
 
   hasPkgConfigModule =

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, pkgsLinux, buildPackages, lib, callPackage, runCommand, stdenv, substituteAll, testers }:
+{ config, pkgs, pkgsLinux, buildPackages, lib, callPackage, runCommand, stdenv, substituteAll, testers }:
 # Documentation is in doc/builders/testers.chapter.md
 {
   # See https://nixos.org/manual/nixpkgs/unstable/#tester-testBuildFailure
@@ -112,7 +112,7 @@
 
   # See doc/builders/testers.chapter.md or
   # https://nixos.org/manual/nixpkgs/unstable/#tester-invalidateFetcherByDrvHash
-  nixosTest =
+  ${if config.allowAliases then "nixosTest" else null} =
     let
       /* The nixos/lib/testing-python.nix module, preapplied with arguments that
        * make sense for this evaluation of Nixpkgs.

--- a/pkgs/build-support/testers/test/default.nix
+++ b/pkgs/build-support/testers/test/default.nix
@@ -1,4 +1,4 @@
-{ testers, lib, pkgs, hello, runCommand, ... }:
+{ config, testers, lib, pkgs, hello, runCommand, ... }:
 let
   pkgs-with-overlay = pkgs.extend(final: prev: {
     proof-of-overlay-hello = prev.hello;
@@ -27,7 +27,7 @@ lib.recurseIntoAttrs {
 
   # Check that the wiring of nixosTest is correct.
   # Correct operation of the NixOS test driver should be asserted elsewhere.
-  nixosTest-example = pkgs-with-overlay.testers.nixosTest ({ lib, ... }: {
+  ${if config.allowAliases then "nixosTest-example" else null} = pkgs-with-overlay.testers.nixosTest ({ lib, ... }: {
     name = "nixosTest-test";
     nodes.machine = { pkgs, ... }: {
       system.nixos = dummyVersioning;

--- a/pkgs/build-support/trivial-builders/test/references/default.nix
+++ b/pkgs/build-support/trivial-builders/test/references/default.nix
@@ -93,7 +93,7 @@ let
     };
   });
 in
-testers.nixosTest {
+testers.runNixOSTest {
   name = "nixpkgs-trivial-builders";
   nodes.machine = { ... }: {
     virtualisation.writableStore = true;

--- a/pkgs/test/nixos-functions/default.nix
+++ b/pkgs/test/nixos-functions/default.nix
@@ -1,9 +1,5 @@
 /*
 
-This file is a test that makes sure that the `pkgs.nixos` and
-`pkgs.testers.nixosTest` functions work. It's far from a perfect test suite,
-but better than not checking them at all on hydra.
-
 To run this test:
 
     nixpkgs$ nix-build -A tests.nixos-functions


### PR DESCRIPTION
## Description of changes

It's time to migrate.
`runNixOSTest` is a better alternative, that supports modules properly, as well as running on macOS.
At this point, the existence of `nixosTest` leads to uncertainty, and its users are missing out on the new features.

:rocket: 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
