### PR TITLE
lib: use explicit name imports in `lib/generators.nix`

### DIFF
--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -16,8 +16,6 @@
 { lib }:
 with (lib).trivial;
 let
-  libAttr = lib.attrsets;
-
   inherit (builtins)
     addErrorContext
     attrNames
@@ -143,7 +141,7 @@ rec {
       mkLines = if listsAsDuplicateKeys
         then k: v: map (mkLine k) (if isList v then v else [v])
         else k: v: [ (mkLine k v) ];
-  in attrs: concatStrings (concatLists (libAttr.mapAttrsToList mkLines attrs));
+  in attrs: concatStrings (concatLists (mapAttrsToList mkLines attrs));
 
 
   /* Generate an INI-style config file from an
@@ -178,7 +176,7 @@ rec {
         # map function to string for each key val
         mapAttrsToStringsSep = sep: mapFn: attrs:
           concatStringsSep sep
-            (libAttr.mapAttrsToList mapFn attrs);
+            (mapAttrsToList mapFn attrs);
         mkSection = sectName: sectValues: ''
           [${mkSectionName sectName}]
         '' + toKeyValue { inherit mkKeyValue listsAsDuplicateKeys; } sectValues;
@@ -399,7 +397,7 @@ rec {
         + outroSpace + "]"
     else if isFunction v then
       let fna = functionArgs v;
-          showFnas = concatStringsSep ", " (libAttr.mapAttrsToList
+          showFnas = concatStringsSep ", " (mapAttrsToList
                        (name: hasDefVal: if hasDefVal then name + "?" else name)
                        fna);
       in if fna == {}    then "<function>"
@@ -412,7 +410,7 @@ rec {
       else if v ? type && v.type == "derivation" then
         "<derivation ${v.name or "???"}>"
       else "{" + introSpace
-          + concatStringsSep introSpace (libAttr.mapAttrsToList
+          + concatStringsSep introSpace (mapAttrsToList
               (name: value:
                 "${escapeNixIdentifier name} = ${
                   addErrorContext "while evaluating an attribute `${name}`"
@@ -574,7 +572,7 @@ ${expr "" v}
           "(${v.expr})"
         else if v == { } then
           "{}"
-        else if libAttr.isDerivation v then
+        else if isDerivation v then
           ''"${toString v}"''
         else
           "{${introSpace}${concatItems (

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -16,67 +16,55 @@
 { lib }:
 
 let
-  inherit (builtins)
+  inherit (lib)
     addErrorContext
+    assertMsg
     attrNames
     concatLists
+    concatMapStringsSep
+    concatStrings
     concatStringsSep
+    const
     elem
+    escape
     filter
+    flatten
+    foldl
+    functionArgs  # Note: not the builtin; considers `__functor` in attrsets.
+    gvariant
+    hasInfix
     head
+    id
+    init
     isAttrs
     isBool
+    isDerivation
     isFloat
+    isFunction    # Note: not the builtin; considers `__functor` in attrsets.
     isInt
     isList
     isPath
     isString
+    last
     length
     mapAttrs
-    match
-    replaceStrings
-    split
-    tail
-    toJSON
-    typeOf
-    ;
-
-  inherit (lib.attrsets)
-    isDerivation
     mapAttrsToList
-    recursiveUpdate
-    ;
-
-  inherit (lib.lists)
-    init
-    flatten
-    foldl
-    last
     optionals
+    recursiveUpdate
+    replaceStrings
     reverseList
+    splitString
+    tail
     toList
     ;
 
   inherit (lib.strings)
-    concatMapStringsSep
-    concatStrings
-    escape
     escapeNixIdentifier
     floatToString
-    hasInfix
-    splitString
-    ;
-
-  inherit (lib.trivial)
-    const
-    id
-    isFunction    # Note: not the builtin, considers `__functor` in attrsets.
-    functionArgs  # Note: not the builtin; considers `__functor` in attrsets.
-    ;
-
-  inherit (lib)
-    assertMsg
-    gvariant
+    match
+    split
+    toJSON
+    typeOf
     ;
 
   ## -- HELPER FUNCTIONS & DEFAULTS --

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -14,7 +14,7 @@
  * Documentation in the manual, #sec-generators
  */
 { lib }:
-with (lib).trivial;
+
 let
   inherit (builtins)
     addErrorContext
@@ -25,6 +25,7 @@ let
     filter
     head
     isAttrs
+    isBool
     isFloat
     isInt
     isList
@@ -36,6 +37,7 @@ let
     replaceStrings
     split
     tail
+    typeOf
     ;
 
   inherit (lib.attrsets)
@@ -65,6 +67,8 @@ let
     ;
 
   inherit (lib.trivial)
+    const
+    id
     isFunction    # Note: not the builtin, considers `__functor` in attrsets.
     functionArgs  # Note: not the builtin; considers `__functor` in attrsets.
     ;


### PR DESCRIPTION
## Description of changes

Using `with` at a top-level scope is [an anti-pattern](https://nix.dev/guides/best-practices#with-scopes). The tracking issue is https://github.com/NixOS/nixpkgs/issues/208242. This is a pure refactor: there is, or ought to be, no functional change contained in this PR.

This PR is best reviewed commit-by-commit.

Related: 
- https://github.com/NixOS/nixpkgs/pull/293901
- https://github.com/NixOS/nixpkgs/pull/295374

## Things done

- [x] Tested, as applicable:
  - [x] `nix-instantiate --strict --eval lib/tests/misc.nix`
  - [x] `lib/tests/modules.sh`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).