### PR TITLE
prometheus-kafka-adapter: init at 1.9.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -836,6 +836,7 @@
   ./services/monitoring/opentelemetry-collector.nix
   ./services/monitoring/osquery.nix
   ./services/monitoring/parsedmarc.nix
+  ./services/monitoring/prometheus-kafka-adapter.nix
   ./services/monitoring/prometheus/alertmanager-irc-relay.nix
   ./services/monitoring/prometheus/alertmanager.nix
   ./services/monitoring/prometheus/default.nix

--- a/nixos/modules/services/monitoring/prometheus-kafka-adapter.nix
+++ b/nixos/modules/services/monitoring/prometheus-kafka-adapter.nix
@@ -1,0 +1,70 @@
+{ config, pkgs, lib, ... }:
+let
+  cfg = config.services.prometheus-kafka-adapter;
+  inherit (lib) mkOption types mkPackageOption concatStringsSep mkIf mkEnableOption;
+in {
+  options.services.prometheus-kafka-adapter = with types; {
+    enable = mkEnableOption "prometheus kafka adapter";
+    package = mkPackageOption pkgs "prometheus-kafka-adapter" { };
+    brokers = mkOption {
+      type = listOf str;
+      description = "List of kafka brokers";
+      example = [ "kafka-1.internal" "kafka-2.internal" "kafka-3.internal" ];
+    };
+    topic = mkOption {
+      type = str;
+      description = "Kafka topic to write to";
+      example = "cluster1.prometehus";
+    };
+    compression = mkOption {
+      type = str;
+      default = "none";
+      description = "Compression type to be used, such as gzip, snappy, lz4";
+      example = "zstd";
+    };
+    logLevel = mkOption {
+      type = enum [ "debug" "info" "warn" "error" "fatal" "panic" ];
+      default = "warn";
+      description = "Log level for logrus";
+    };
+    port = mkOption {
+      type = port;
+      description = "Port to listen on";
+      default = 8080;
+    };
+    openFirewall = mkOption {
+      type = bool;
+      default = false;
+      description = "Whether to open the port in firewall";
+    };
+    extraEnvironment = mkOption {
+      type = attrsOf str;
+      description = "Additional environment variables to pass to prometheus kafka adapter";
+      default = { };
+      example = {
+        SERIALIZATION_FORMAT = "json";
+        GIN_MODE = "debug";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.prometheus-kafka-adapter = {
+      wantedBy = [ "multi-user.target" ];
+      script = lib.getExe cfg.package;
+      environment = {
+        GIN_MODE = "release";
+        KAFKA_BROKER_LIST = concatStringsSep "," cfg.brokers;
+        KAFKA_TOPIC = cfg.topic;
+        KAFKA_COMPRESSION = cfg.compression;
+        LOG_LEVEL = cfg.logLevel;
+        PORT = toString cfg.port;
+      } // cfg.extraEnvironment;
+      serviceConfig = {
+        User = "prom-kafka-adapter";
+        DynamicUser = true;
+      };
+    };
+    networking.firewall.allowedTCPPorts = [ cfg.port ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -730,6 +730,7 @@ in {
   privoxy = handleTest ./privoxy.nix {};
   prometheus = handleTest ./prometheus.nix {};
   prometheus-exporters = handleTest ./prometheus-exporters.nix {};
+  prometheus-kafka-adapter = handleTestOn ["x86_64-linux"] ./prometheus-kafka-adapter.nix {};
   prosody = handleTest ./xmpp/prosody.nix {};
   prosody-mysql = handleTest ./xmpp/prosody-mysql.nix {};
   proxy = handleTest ./proxy.nix {};

--- a/nixos/tests/prometheus-kafka-adapter.nix
+++ b/nixos/tests/prometheus-kafka-adapter.nix
@@ -1,0 +1,66 @@
+{ system ? builtins.currentSystem
+, config ? {}
+, pkgs ? import ../.. { inherit system config; }
+}:
+
+import ./make-test-python.nix {
+  name = "prometheus-kafka-adapter";
+
+  nodes.n = { connfig, lib, ... }: {
+    services = {
+      apache-kafka = {
+        enable = true;
+        settings = {
+          "log.dirs" = [
+            "/var/lib/kafka/logdir1"
+            "/var/lib/kafka/logdir2"
+          ];
+          "offsets.topic.replication.factor" = 1;
+          "zookeeper.connect" = [ "localhost:2181" ];
+          "zookeeper.session.timeout.ms" = 600000;
+        };
+      };
+      zookeeper.enable = true;
+      prometheus-kafka-adapter = {
+        enable = true;
+        brokers = [ "localhost" ];
+        topic = "testtopic";
+        # zookeeper binds 8080
+        port = 8081;
+      };
+      prometheus = {
+        enable = true;
+        remoteWrite = [ {url = "http://localhost:8081/receive";} ];
+        scrapeConfigs = lib.singleton {
+          job_name = "prometheus";
+          static_configs = lib.singleton {
+            targets = [ "localhost:9090" ];
+          };
+        };
+      };
+    };
+  };
+  testScript = let
+    kafkaPackage = pkgs.apacheKafka;
+  in ''
+    start_all()
+
+    n.wait_for_unit("zookeeper.service")
+    n.wait_for_open_port(2181)
+
+    n.wait_for_unit("apache-kafka.service")
+    n.wait_for_open_port(9092)
+
+    n.wait_until_succeeds(
+      "${kafkaPackage}/bin/kafka-topics.sh --create "
+      + "--bootstrap-server localhost:9092 --partitions 1 "
+      + "--replication-factor 1 --topic testtopic"
+    )
+
+    assert '"job":"prometheus"' in n.succeed(
+      "${kafkaPackage}/bin/kafka-console-consumer.sh "
+      + "--bootstrap-server localhost:9092 --topic testtopic "
+      + "--from-beginning --max-messages 1"
+    )
+  '';
+}

--- a/pkgs/by-name/pr/prometheus-kafka-adapter/package.nix
+++ b/pkgs/by-name/pr/prometheus-kafka-adapter/package.nix
@@ -17,6 +17,8 @@ buildGoModule rec {
 
   vendorHash = null;
 
+  passthru.tests.default = nixosTests.prometheus-kafka-adapter;
+
   meta = with lib; {
     description = "Prometheus remote write adapter for Apache Kafka";
     homepage = "https://github.com/Telefonica/prometheus-kafka-adapter";

--- a/pkgs/by-name/pr/prometheus-kafka-adapter/package.nix
+++ b/pkgs/by-name/pr/prometheus-kafka-adapter/package.nix
@@ -1,0 +1,29 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, nixosTests
+}:
+
+buildGoModule rec {
+  pname = "prometheus-kafka-adapter";
+  version = "1.9.0";
+
+  src = fetchFromGitHub {
+    owner = "Telefonica";
+    repo = "prometheus-kafka-adapter";
+    rev = version;
+    hash = "sha256-nL6NSLG2POgnIvaQ7JWahKCnnOh3/ZatM22kxZ6CNTQ=";
+  };
+
+  vendorHash = null;
+
+  meta = with lib; {
+    description = "Prometheus remote write adapter for Apache Kafka";
+    homepage = "https://github.com/Telefonica/prometheus-kafka-adapter";
+    changelog = "https://github.com/Telefonica/prometheus-kafka-adapter/releases/tag/${src.rev}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ illustris ];
+    mainProgram = pname;
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Prometheus-kafka-adapter is a service which receives Prometheus metrics through remote_write, marshal into JSON and sends them into Kafka.

https://github.com/Telefonica/prometheus-kafka-adapter

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
