### PR TITLE
Refactor tailscale nginx-auth module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1164,6 +1164,7 @@
   ./services/networking/syncthing-relay.nix
   ./services/networking/syncthing.nix
   ./services/networking/tailscale.nix
+  ./services/networking/tailscale-auth.nix
   ./services/networking/tayga.nix
   ./services/networking/tcpcrypt.nix
   ./services/networking/teamspeak3.nix

--- a/nixos/modules/services/networking/tailscale-auth.nix
+++ b/nixos/modules/services/networking/tailscale-auth.nix
@@ -1,0 +1,104 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    getExe
+    maintainers
+    mkEnableOption
+    mkPackageOption
+    mkIf
+    mkOption
+    types
+    ;
+  cfg = config.services.tailscaleAuth;
+in
+{
+  options.services.tailscaleAuth = {
+    enable = mkEnableOption "Enable tailscale.nginx-auth, to authenticate users via tailscale.";
+
+    package = mkPackageOption pkgs "tailscale-nginx-auth" {};
+
+    user = mkOption {
+      type = types.str;
+      default = "tailscale-nginx-auth";
+      description = "User which runs tailscale-nginx-auth";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "tailscale-nginx-auth";
+      description = "Group which runs tailscale-nginx-auth";
+    };
+
+    socketPath = mkOption {
+      default = "/run/tailscale-nginx-auth/tailscale-nginx-auth.sock";
+      type = types.path;
+      description = ''
+        Path of the socket listening to authorization requests.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.tailscale.enable = true;
+
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      inherit (cfg) group;
+    };
+    users.groups.${cfg.group} = { };
+
+    systemd.sockets.tailscale-nginx-auth = {
+      description = "Tailscale NGINX Authentication socket";
+      partOf = [ "tailscale-nginx-auth.service" ];
+      wantedBy = [ "sockets.target" ];
+      listenStreams = [ cfg.socketPath ];
+      socketConfig = {
+        SocketMode = "0660";
+        SocketUser = cfg.user;
+        SocketGroup = cfg.group;
+      };
+    };
+
+    systemd.services.tailscale-nginx-auth = {
+      description = "Tailscale NGINX Authentication service";
+      requires = [ "tailscale-nginx-auth.socket" ];
+
+      serviceConfig = {
+        ExecStart = getExe cfg.package;
+        RuntimeDirectory = "tailscale-nginx-auth";
+        User = cfg.user;
+        Group = cfg.group;
+
+        BindPaths = [ "/run/tailscale/tailscaled.sock" ];
+
+        CapabilityBoundingSet = "";
+        DeviceAllow = "";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        PrivateDevices = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        RestrictNamespaces = true;
+        RestrictAddressFamilies = [ "AF_UNIX" ];
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+
+        SystemCallArchitectures = "native";
+        SystemCallErrorNumber = "EPERM";
+        SystemCallFilter = [
+          "@system-service"
+          "~@cpu-emulation" "~@debug" "~@keyring" "~@memlock" "~@obsolete" "~@privileged" "~@setuid"
+        ];
+      };
+    };
+  };
+
+  meta.maintainers = with maintainers; [ dan-theriault phaer ];
+}

--- a/nixos/modules/services/web-servers/nginx/tailscale-auth.nix
+++ b/nixos/modules/services/web-servers/nginx/tailscale-auth.nix
@@ -1,27 +1,28 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
+  inherit (lib)
+    genAttrs
+    maintainers
+    mkAliasOptionModule
+    mkEnableOption
+    mkIf
+    mkOption
+    types
+    ;
   cfg = config.services.nginx.tailscaleAuth;
+  cfgAuth = config.services.tailscaleAuth;
 in
 {
+  imports = [
+    (mkAliasOptionModule [ "services" "nginx" "tailscaleAuth" "package" ] [ "services" "tailscaleAuth" "package" ])
+    (mkAliasOptionModule [ "services" "nginx" "tailscaleAuth" "user" ] [ "services" "tailscaleAuth" "user" ])
+    (mkAliasOptionModule [ "services" "nginx" "tailscaleAuth" "group" ] [ "services" "tailscaleAuth" "group" ])
+    (mkAliasOptionModule [ "services" "nginx" "tailscaleAuth" "socketPath" ] [ "services" "tailscaleAuth" "socketPath" ])
+  ];
+
   options.services.nginx.tailscaleAuth = {
     enable = mkEnableOption "Enable tailscale.nginx-auth, to authenticate nginx users via tailscale.";
-
-    package = lib.mkPackageOptionMD pkgs "tailscale-nginx-auth" {};
-
-    user = mkOption {
-      type = types.str;
-      default = "tailscale-nginx-auth";
-      description = "User which runs tailscale-nginx-auth";
-    };
-
-    group = mkOption {
-      type = types.str;
-      default = "tailscale-nginx-auth";
-      description = "Group which runs tailscale-nginx-auth";
-    };
 
     expectedTailnet = mkOption {
       default = "";
@@ -30,14 +31,6 @@ in
       description = ''
         If you want to prevent node sharing from allowing users to access services
         across tailnets, declare your expected tailnets domain here.
-      '';
-    };
-
-    socketPath = mkOption {
-      default = "/run/tailscale-nginx-auth/tailscale-nginx-auth.sock";
-      type = types.path;
-      description = ''
-        Path of the socket listening to nginx authorization requests.
       '';
     };
 
@@ -51,67 +44,14 @@ in
   };
 
   config = mkIf cfg.enable {
-    services.tailscale.enable = true;
+    services.tailscaleAuth.enable = true;
     services.nginx.enable = true;
 
-    users.users.${cfg.user} = {
-      isSystemUser = true;
-      inherit (cfg) group;
-    };
-    users.groups.${cfg.group} = { };
-    users.users.${config.services.nginx.user}.extraGroups = [ cfg.group ];
-    systemd.sockets.tailscale-nginx-auth = {
-      description = "Tailscale NGINX Authentication socket";
-      partOf = [ "tailscale-nginx-auth.service" ];
-      wantedBy = [ "sockets.target" ];
-      listenStreams = [ cfg.socketPath ];
-      socketConfig = {
-        SocketMode = "0660";
-        SocketUser = cfg.user;
-        SocketGroup = cfg.group;
-      };
-    };
-
+    users.users.${config.services.nginx.user}.extraGroups = [ cfgAuth.group ];
 
     systemd.services.tailscale-nginx-auth = {
-      description = "Tailscale NGINX Authentication service";
       after = [ "nginx.service" ];
       wants = [ "nginx.service" ];
-      requires = [ "tailscale-nginx-auth.socket" ];
-
-      serviceConfig = {
-        ExecStart = "${lib.getExe cfg.package}";
-        RuntimeDirectory = "tailscale-nginx-auth";
-        User = cfg.user;
-        Group = cfg.group;
-
-        BindPaths = [ "/run/tailscale/tailscaled.sock" ];
-
-        CapabilityBoundingSet = "";
-        DeviceAllow = "";
-        LockPersonality = true;
-        MemoryDenyWriteExecute = true;
-        PrivateDevices = true;
-        PrivateUsers = true;
-        ProtectClock = true;
-        ProtectControlGroups = true;
-        ProtectHome = true;
-        ProtectHostname = true;
-        ProtectKernelLogs = true;
-        ProtectKernelModules = true;
-        ProtectKernelTunables = true;
-        RestrictNamespaces = true;
-        RestrictAddressFamilies = [ "AF_UNIX" ];
-        RestrictRealtime = true;
-        RestrictSUIDSGID = true;
-
-        SystemCallArchitectures = "native";
-        SystemCallErrorNumber = "EPERM";
-        SystemCallFilter = [
-          "@system-service"
-          "~@cpu-emulation" "~@debug" "~@keyring" "~@memlock" "~@obsolete" "~@privileged" "~@setuid"
-        ];
-      };
     };
 
     services.nginx.virtualHosts = genAttrs
@@ -121,7 +61,7 @@ in
           extraConfig = ''
             internal;
 
-            proxy_pass http://unix:${cfg.socketPath};
+            proxy_pass http://unix:${cfgAuth.socketPath};
             proxy_pass_request_body off;
 
             # Upstream uses $http_host here, but we are using gixy to check nginx configurations


### PR DESCRIPTION
## Description of changes

Tailscale's nginx-auth proxy, despite the name, actually works just fine with caddy and traefik (see tailscale/tailscale#4680). However, the current nixos module is closely coupled with nginx. This change breaks that coupling.

All options of the existing module except `virtualHosts` (which is nginx-specific) have been moved to a new module without any nginx coupling. The options remain exposed on the nginx-specific module as aliases.

closes #290353 

@phaer 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
