### PR TITLE
treewide: Refactor packages to use darwin install binary package

### DIFF
--- a/pkgs/applications/misc/1password/default.nix
+++ b/pkgs/applications/misc/1password/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchurl, fetchzip, autoPatchelfHook, installShellFiles, cpio, xar, _1password, testers }:
+{ lib, stdenvNoCC, fetchurl, fetchzip, autoPatchelfHook, installShellFiles, _1password, testers, darwin }:
 
 let
-  inherit (stdenv.hostPlatform) system;
+  inherit (stdenvNoCC.hostPlatform) system;
   fetch = srcPlatform: hash: extension:
     let
       args = {
@@ -21,49 +21,36 @@ let
     x86_64-darwin = aarch64-darwin;
   };
   platforms = builtins.attrNames sources;
-  mainProgram = "op";
-in
 
-stdenv.mkDerivation {
-  inherit pname version;
   src =
     if (builtins.elem system platforms) then
       sources.${system}
     else
       throw "Source for ${pname} is not available for ${system}";
 
-  nativeBuildInputs = [ installShellFiles ] ++ lib.optional stdenv.isLinux autoPatchelfHook;
-
-  buildInputs = lib.optionals stdenv.isDarwin [ xar cpio ];
-
-  unpackPhase = lib.optionalString stdenv.isDarwin ''
-    xar -xf $src
-    zcat op.pkg/Payload | cpio -i
-  '';
+  nativeBuildInputs = [ installShellFiles ];
 
   installPhase = ''
     runHook preInstall
-    install -D ${mainProgram} $out/bin/${mainProgram}
+    install -D ${meta.mainProgram} $out/bin/${meta.mainProgram}
     runHook postInstall
   '';
 
   postInstall = ''
     HOME=$TMPDIR
-    installShellCompletion --cmd ${mainProgram} \
-      --bash <($out/bin/${mainProgram} completion bash) \
-      --fish <($out/bin/${mainProgram} completion fish) \
-      --zsh <($out/bin/${mainProgram} completion zsh)
+    installShellCompletion --cmd ${meta.mainProgram} \
+      --bash <($out/bin/${meta.mainProgram} completion bash) \
+      --fish <($out/bin/${meta.mainProgram} completion fish) \
+      --zsh <($out/bin/${meta.mainProgram} completion zsh)
   '';
-
-  dontStrip = stdenv.isDarwin;
 
   doInstallCheck = true;
 
   installCheckPhase = ''
-    $out/bin/${mainProgram} --version
+    $out/bin/${meta.mainProgram} --version
   '';
 
-  passthru.tests.version = testers.testVersion {
+  testers' = testers.testVersion {
     package = _1password;
   };
 
@@ -74,6 +61,21 @@ stdenv.mkDerivation {
     maintainers = with maintainers; [ joelburget marsam ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.unfree;
-    inherit mainProgram platforms;
+    mainProgram = "op";
+    inherit platforms;
   };
-}
+
+  linux = stdenvNoCC.mkDerivation {
+    inherit pname version src installPhase postInstall doInstallCheck installCheckPhase meta;
+    nativeBuildInputs = nativeBuildInputs ++ [ autoPatchelfHook ];
+    passthru.tests.version = testers';
+  };
+
+  darwin' = darwin.installBinaryPackage {
+    inherit pname version src nativeBuildInputs installPhase postInstall doInstallCheck installCheckPhase meta;
+    passthru.tests.version = testers';
+  };
+in
+if stdenvNoCC.isDarwin
+then darwin'
+else linux

--- a/pkgs/by-name/ho/hoppscotch/package.nix
+++ b/pkgs/by-name/ho/hoppscotch/package.nix
@@ -1,8 +1,8 @@
 { lib
-, stdenv
+, stdenvNoCC
 , fetchurl
 , appimageTools
-, undmg
+, darwin
 , nix-update-script
 }:
 
@@ -23,7 +23,7 @@ let
       url = "https://github.com/hoppscotch/releases/releases/download/v${version}-1/Hoppscotch_linux_x64.AppImage";
       hash = "sha256-MYQ7SRm+CUPIXROZxejbbZ0/wH+U5DQO4YGbE/HQAj8=";
     };
-  }.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
+  }.${stdenvNoCC.system} or (throw "Unsupported system: ${stdenvNoCC.system}");
 
   meta = {
     description = "Open source API development ecosystem";
@@ -34,22 +34,12 @@ let
     maintainers = with lib.maintainers; [ DataHearth ];
   };
 in
-if stdenv.isDarwin then stdenv.mkDerivation
+if stdenvNoCC.isDarwin then darwin.installBinaryPackage
 {
   inherit pname version src meta;
 
-  sourceRoot = ".";
-
-  nativeBuildInputs = [ undmg ];
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p "$out/Applications"
-    mv Hoppscotch.app $out/Applications/
-
-    runHook postInstall
-  '';
+  sourceRoot = "Hoppscotch";
+  appName = "Hoppscotch.app";
 }
 else appimageTools.wrapType2 {
   inherit pname version src meta;

--- a/pkgs/by-name/ii/iina/package.nix
+++ b/pkgs/by-name/ii/iina/package.nix
@@ -1,11 +1,11 @@
 { lib
 , fetchurl
-, stdenv
-, undmg
+, stdenvNoCC
+, darwin
 , nix-update-script
 }:
 
-stdenv.mkDerivation rec {
+darwin.installBinaryPackage rec {
   pname = "iina";
   version = "1.3.4";
 
@@ -14,14 +14,12 @@ stdenv.mkDerivation rec {
     hash = "sha256-feUPWtSi/Vsnv1mjGyBgB0wFMxx6r6UzrUratlAo14w=";
   };
 
-  nativeBuildInputs = [ undmg ];
+  appName = "IINA.app";
+  sourceRoot = "IINA";
 
-  sourceRoot = "IINA.app";
-
-  installPhase = ''
-    mkdir -p $out/{bin,Applications/IINA.app}
-    cp -R . "$out/Applications/IINA.app"
-    ln -s "$out/Applications/IINA.app/Contents/MacOS/iina-cli" "$out/bin/iina"
+  postInstall = ''
+    mkdir -p $out/bin
+    ln -s $out/Applications/IINA.app/Contents/MacOS/${meta.mainProgram} $out/bin/${meta.mainProgram}
   '';
 
   passthru.updateScript = nix-update-script { };
@@ -29,10 +27,8 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://iina.io/";
     description = "The modern media player for macOS";
-    platforms = platforms.darwin;
     license = licenses.gpl3;
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    mainProgram = "iina";
+    mainProgram = "iina-cli";
     maintainers = with maintainers; [ arkivm stepbrobd ];
   };
 }

--- a/pkgs/by-name/no/nosql-workbench/package.nix
+++ b/pkgs/by-name/no/nosql-workbench/package.nix
@@ -1,10 +1,9 @@
-{
-  appimageTools,
-  lib,
-  fetchurl,
-  jdk21,
-  stdenv,
-  _7zz
+{ lib
+, appimageTools
+, fetchurl
+, jdk21
+, stdenvNoCC
+, darwin
 }:
 let
   pname = "nosql-workbench";
@@ -23,7 +22,7 @@ let
       url = "https://s3.amazonaws.com/nosql-workbench/NoSQL%20Workbench-linux-${version}.AppImage";
       hash = "sha256-cDOSbhAEFBHvAluxTxqVpva1GJSlFhiozzRfuM4MK5c=";
     };
-  }.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
+  }.${stdenvNoCC.system} or (throw "Unsupported system: ${stdenvNoCC.system}");
 
   meta = {
     description = "Visual tool that provides data modeling, data visualization, and query development features to help you design, create, query, and manage DynamoDB tables";
@@ -34,27 +33,10 @@ let
     platforms = [ "aarch64-darwin" "x86_64-darwin" "x86_64-linux" ];
   };
 in
-if stdenv.isDarwin then stdenv.mkDerivation {
+if stdenvNoCC.isDarwin then darwin.installBinaryPackage {
   inherit pname version src meta;
-
-  sourceRoot = ".";
-
-  # DMG file is using APFS which is unsupported by "undmg".
-  # Instead, use "7zz" to extract the contents.
-  # "undmg" issue: https://github.com/matthewbauer/undmg/issues/4
-  nativeBuildInputs = [ _7zz ];
-
+  appName = "NoSQL Workbench.app";
   buildInputs = [ jdk21 ];
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p "$out/Applications"
-    mv NoSQL\ Workbench.app $out/Applications/
-
-    runHook postInstall
-  '';
-
 } else appimageTools.wrapType2 {
   inherit pname version src meta;
 

--- a/pkgs/by-name/st/stats/package.nix
+++ b/pkgs/by-name/st/stats/package.nix
@@ -1,36 +1,23 @@
 { lib
 , stdenvNoCC
 , fetchurl
-, undmg
+, darwin
 }:
 
-stdenvNoCC.mkDerivation (finalAttrs: {
+darwin.installBinaryPackage rec {
   pname = "stats";
   version = "2.10.3";
 
   src = fetchurl {
-    url = "https://github.com/exelban/stats/releases/download/v${finalAttrs.version}/Stats.dmg";
+    url = "https://github.com/exelban/stats/releases/download/v${version}/Stats.dmg";
     hash = "sha256-PSRK9YihiIHKHade3XE/OnAleBhmu71CNFyzJ/Upx/A=";
   };
-  sourceRoot = ".";
-
-  nativeBuildInputs = [ undmg ];
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/Applications
-    cp -r *.app $out/Applications
-
-    runHook postInstall
-  '';
+  sourceRoot = "Stats";
 
   meta = with lib; {
     description = "macOS system monitor in your menu bar";
     homepage = "https://github.com/exelban/stats";
     license = licenses.mit;
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     maintainers = with maintainers; [ emilytrau Enzime ];
-    platforms = platforms.darwin;
   };
-})
+}

--- a/pkgs/os-specific/darwin/apparency/default.nix
+++ b/pkgs/os-specific/darwin/apparency/default.nix
@@ -1,39 +1,30 @@
-{ lib
-, fetchurl
-, stdenv
-, undmg
-}:
+{ lib, fetchurl, darwin }:
 
-stdenv.mkDerivation {
+darwin.installBinaryPackage rec {
   pname = "apparency";
-  version = "1.5.1";
+  version = "1.8.1";
 
   src = fetchurl {
-    url = "https://web.archive.org/web/20230815073821/https://www.mothersruin.com/software/downloads/Apparency.dmg";
-    hash = "sha256-JpaBdlt8kTNFzK/yZVZ+ZFJ3DnPQbogJC7QBmtSVkoQ=";
+    # Use externally archived download URL because
+    # upstream does not provide stable URLs for versioned releases
+    url = "https://web.archive.org/web/20240304101835/https://www.mothersruin.com/software/downloads/Apparency.dmg";
+    hash = "sha256-hxbAtIy7RdhDrsFIvm9CEr04uUTbWi4KmrzJIcU1YVA=";
   };
 
-  nativeBuildInputs = [ undmg ];
+  appName = "Apparency.app";
+  sourceRoot = "Apparency ${version}";
 
-  sourceRoot = "Apparency.app";
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/Applications/Apparency.app $out/bin
-    cp -R . $out/Applications/Apparency.app
-    ln -s ../Applications/Apparency.app/Contents/MacOS/appy $out/bin
-
-    runHook postInstall
+  postInstall = ''
+    mkdir -p $out/bin
+    ln -s ../Applications/${appName}/Contents/MacOS/${meta.mainProgram} $out/bin
   '';
 
   meta = {
     description = "The App That Opens Apps";
     homepage = "https://www.mothersruin.com/software/Apparency/";
+    downloadPage = "https://www.mothersruin.com/software/Apparency/get.html";
     license = lib.licenses.unfreeRedistributable;
     maintainers = with lib.maintainers; [ Enzime ];
     mainProgram = "appy";
-    platforms = lib.platforms.darwin;
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 }

--- a/pkgs/os-specific/darwin/bartender/default.nix
+++ b/pkgs/os-specific/darwin/bartender/default.nix
@@ -1,48 +1,31 @@
 { lib
-, stdenvNoCC
 , fetchurl
-, _7zz
+, darwin
 }:
 
-stdenvNoCC.mkDerivation (finalAttrs: {
+darwin.installBinaryPackage rec {
   pname = "bartender";
   version = "5.0.49";
 
   src = fetchurl {
-    name = "Bartender ${lib.versions.major finalAttrs.version}.dmg";
-    url = "https://www.macbartender.com/B2/updates/${builtins.replaceStrings [ "." ] [ "-" ] finalAttrs.version}/Bartender%20${lib.versions.major finalAttrs.version}.dmg";
+    url = "https://www.macbartender.com/B2/updates/${builtins.replaceStrings [ "." ] [ "-" ] version}/Bartender%20${lib.versions.major version}.dmg";
     hash = "sha256-DOQLtdbwYFyRri3GBdjLfFNII65QJMvAQu9Be4ATBx0=";
   };
 
-  dontPatch = true;
-  dontConfigure = true;
-  dontBuild = true;
-  dontFixup = true;
-
-  nativeBuildInputs = [ _7zz ];
-
-  sourceRoot = "Bartender ${lib.versions.major finalAttrs.version}.app";
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p "$out/Applications/${finalAttrs.sourceRoot}"
-    cp -R . "$out/Applications/${finalAttrs.sourceRoot}"
-
-    runHook postInstall
-  '';
+  appName = "Bartender ${lib.versions.major version}.app";
 
   meta = with lib; {
     description = "Take control of your menu bar";
     longDescription = ''
-      Bartender is an award-winning app for macOS that superpowers your menu bar, giving you total control over your menu bar items, what's displayed, and when, with menu bar items only showing when you need them.
-      Bartender improves your workflow with quick reveal, search, custom hotkeys and triggers, and lots more.
+      Bartender is an award-winning app for macOS that superpowers your menu
+      bar, giving you total control over your menu bar items, what's displayed,
+      and when, with menu bar items only showing when you need them.
+      Bartender improves your workflow with quick reveal, search, custom
+      hotkeys and triggers, and lots more.
     '';
     homepage = "https://www.macbartender.com";
-    changelog = "https://www.macbartender.com/Bartender${lib.versions.major finalAttrs.version}/release_notes/";
+    changelog = "https://www.macbartender.com/Bartender${lib.versions.major version}/release_notes/";
     license = with licenses; [ unfree ];
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     maintainers = with maintainers; [ stepbrobd ];
-    platforms = [ "aarch64-darwin" "x86_64-darwin" ];
   };
-})
+}

--- a/pkgs/os-specific/darwin/install-binary-package/default.nix
+++ b/pkgs/os-specific/darwin/install-binary-package/default.nix
@@ -1,0 +1,52 @@
+{ lib, stdenvNoCC, makeSetupHook, _7zz, libarchive }:
+
+{ pname
+, version
+, src
+, buildInputs ? []
+, nativeBuildInputs ? []
+, propagatedBuildInputs ? []
+, postInstall ? null
+, appName ? "."
+, sourceRoot ? "."
+, ...
+}@args:
+
+let
+  unpackDmgPkg = makeSetupHook {
+    name = "unpack-dmg-pkg";
+    propagatedBuildInputs = [ _7zz libarchive ];
+  } ./unpack-dmg-pkg.sh;
+in
+stdenvNoCC.mkDerivation (args // {
+  inherit pname appName src buildInputs propagatedBuildInputs postInstall;
+
+  dontMakeSourcesWritable = args.dontMakeSourcesWritable or true;
+  dontPatch = args.dontPatch or true;
+  dontConfigure = args.dontConfigure or true;
+  dontBuild = args.dontBuild or true;
+  dontStrip = args.dontStrip or true;
+  dontFixup = args.dontFixup or true;
+  dontCheck = args.dontCheck or true;
+  doInstallCheck = args.doInstallCheck or false;
+
+  sourceRoot = "${pname}/${sourceRoot}";
+
+  nativeBuildInputs = [ unpackDmgPkg ] ++ nativeBuildInputs;
+
+  installPhase = (args.installPhase or ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -R "${appName}" $out/Applications
+
+    runHook postInstall
+  '');
+
+  installCheckPhase = args.installCheckPhase or null;
+
+  meta = {
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = lib.platforms.darwin;
+  } // ( args.meta or {} );
+})

--- a/pkgs/os-specific/darwin/install-binary-package/unpack-dmg-pkg.sh
+++ b/pkgs/os-specific/darwin/install-binary-package/unpack-dmg-pkg.sh
@@ -1,0 +1,29 @@
+# shellcheck shell=bash
+unpackCmdHooks+=(unpackDmgPkg)
+unpackDmgPkg() {
+    case "$curSrc" in
+        *.dmg) unpackDmg "$curSrc";;
+        *.pkg) unpackPkg "$curSrc";;
+        *) return 1
+    esac
+}
+
+unpackDmg() {
+    _unpack "$1" "${2:-$pname}"
+}
+
+unpackPkg() {
+    _unpack "$1" "${2:-$pname}"
+    pushd "${2:-$pname}"
+    # Extract files from Payload or Payload~ file contained in given pkg if any
+    find . -name 'Payload*' -maxdepth 1 -print0 | xargs -0 -t -I % bsdtar -xf %
+    popd
+}
+
+_unpack() {
+    # Exclude */Applications files from extraction as they may
+    # contain a dangerous link path, causing 7zz to error.
+    # Exclude *com.apple.provenance xattr files from extraction as they
+    # break the an application's signature and notarization.
+    7zz x -bd -o"$2" -xr'!*/Applications' -xr'!*com.apple.provenance' "$1"
+}

--- a/pkgs/os-specific/darwin/karabiner-elements/default.nix
+++ b/pkgs/os-specific/darwin/karabiner-elements/default.nix
@@ -1,43 +1,39 @@
-{ lib, stdenv, fetchurl, cpio, xar, undmg }:
+{ lib, stdenvNoCC, fetchurl, darwin }:
 
-stdenv.mkDerivation rec {
+darwin.installBinaryPackage rec {
   pname = "karabiner-elements";
   version = "14.13.0";
 
   src = fetchurl {
     url = "https://github.com/pqrs-org/Karabiner-Elements/releases/download/v${version}/Karabiner-Elements-${version}.dmg";
-    sha256 = "sha256-gmJwoht/Tfm5qMecmq1N6PSAIfWOqsvuHU8VDJY8bLw=";
+    hash = "sha256-gmJwoht/Tfm5qMecmq1N6PSAIfWOqsvuHU8VDJY8bLw=";
   };
 
   outputs = [ "out" "driver" ];
 
-  nativeBuildInputs = [ cpio xar undmg ];
-
-  unpackPhase = ''
-    undmg $src
-    xar -xf Karabiner-Elements.pkg
-    cd Installer.pkg
-    zcat Payload | cpio -i
-    cd ../Karabiner-DriverKit-VirtualHIDDevice.pkg
-    zcat Payload | cpio -i
-    cd ..
+  postUnpack = ''
+    pushd ''${sourceRoot}
+    unpackPkg Karabiner-Elements-${version}/Karabiner-Elements.pkg .
+    bsdtar -xf Installer.pkg/Payload -C Installer.pkg
+    bsdtar -xf Karabiner-DriverKit-VirtualHIDDevice.pkg/Payload -C Karabiner-DriverKit-VirtualHIDDevice.pkg
+    popd
   '';
 
-  sourceRoot = ".";
-
+  dontPatch = false;
   postPatch = ''
     for f in *.pkg/Library/Launch{Agents,Daemons}/*.plist; do
       substituteInPlace $f \
-        --replace "/Library/" "$out/Library/"
+        --replace-fail "/Library/" "$out/Library/"
     done
   '';
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out $driver
     cp -R Installer.pkg/Applications Installer.pkg/Library $out
     cp -R Karabiner-DriverKit-VirtualHIDDevice.pkg/Applications Karabiner-DriverKit-VirtualHIDDevice.pkg/Library $driver
-
     cp "$out/Library/Application Support/org.pqrs/Karabiner-Elements/package-version" "$out/Library/Application Support/org.pqrs/Karabiner-Elements/version"
+    runHook postInstall
   '';
 
   passthru.updateScript = ./updater.sh;
@@ -45,7 +41,6 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Karabiner-Elements is a powerful utility for keyboard customization on macOS Sierra (10.12) or later.";
     homepage = "https://karabiner-elements.pqrs.org/";
-    platforms = platforms.darwin;
     maintainers = with maintainers; [ Enzime ];
     license = licenses.unlicense;
   };

--- a/pkgs/os-specific/darwin/monitorcontrol/default.nix
+++ b/pkgs/os-specific/darwin/monitorcontrol/default.nix
@@ -1,9 +1,9 @@
-{ lib, fetchurl, stdenv, _7zz }:
+{ lib, fetchurl, darwin }:
 
 # This cannot be built from source due to the problematic nature of XCode - so
 # this is what it's like when doves cry?
 
-stdenv.mkDerivation rec {
+darwin.installBinaryPackage rec {
   pname = "MonitorControl";
   version = "4.2.0";
 
@@ -13,15 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "Q96uK6wVe1D2uLvWL+pFR6LcmrU7cgmr2Y5tPvvTDgI=";
   };
 
-  # MonitorControl.${version}.dmg is APFS formatted, unpack with 7zz
-  nativeBuildInputs = [ _7zz ];
-
-  sourceRoot = "MonitorControl.app";
-
-  installPhase = ''
-    mkdir -p "$out/Applications/MonitorControl.app"
-    cp -R . "$out/Applications/MonitorControl.app"
-  '';
+  appName = "MonitorControl.app";
 
   meta = with lib; {
     description = "A macOS system extension to control brightness and volume of external displays with native OSD";
@@ -29,6 +21,5 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/MonitorControl/MonitorControl#readme";
     license = licenses.mit;
     maintainers = with maintainers; [ cbleslie cottand ];
-    platforms = platforms.darwin;
   };
 }

--- a/pkgs/os-specific/darwin/utm/default.nix
+++ b/pkgs/os-specific/darwin/utm/default.nix
@@ -1,11 +1,11 @@
 { lib
-, undmg
 , makeWrapper
 , fetchurl
 , stdenvNoCC
+, darwin
 }:
 
-stdenvNoCC.mkDerivation rec {
+darwin.installBinaryPackage rec {
   pname = "utm";
   version = "4.4.5";
 
@@ -14,23 +14,18 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-FlIPSWqY2V1akd/InS6BPEBfc8pomJ8jgDns7wvaOm8=";
   };
 
-  nativeBuildInputs = [ undmg makeWrapper ];
+  nativeBuildInputs = [ makeWrapper ];
 
-  sourceRoot = ".";
-  installPhase = ''
-    runHook preInstall
+  appName = "UTM.app";
+  sourceRoot = "UTM";
 
-    mkdir -p $out/Applications
-    cp -r *.app $out/Applications
-
+  postaInstall = ''
     mkdir -p $out/bin
     for bin in $out/Applications/UTM.app/Contents/MacOS/*; do
       # Symlinking `UTM` doesn't work; seems to look for files in the wrong
       # place
       makeWrapper $bin "$out/bin/$(basename $bin)"
     done
-
-    runHook postInstall
   '';
 
   meta = with lib; {
@@ -57,11 +52,10 @@ stdenvNoCC.mkDerivation rec {
       See https://docs.getutm.app/ for more information.
     '';
     homepage = "https://mac.getutm.app/";
-    changelog = "https://github.com/utmapp/${pname}/releases/tag/v${version}";
+    changelog = "https://github.com/utmapp/utm/releases/tag/v${version}";
     mainProgram = "UTM";
     license = licenses.asl20;
     platforms = platforms.darwin; # 11.3 is the minimum supported version as of UTM 4.
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     maintainers = with maintainers; [ rrbutani wegank ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -33367,8 +33367,6 @@ with pkgs;
 
   mod-distortion = callPackage ../applications/audio/mod-distortion { };
 
-  monitorcontrol = callPackage ../applications/misc/monitorcontrol { };
-
   xmr-stak = callPackage ../applications/misc/xmr-stak { };
 
   xmrig = darwin.apple_sdk_11_0.callPackage ../applications/misc/xmrig { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27325,8 +27325,6 @@ with pkgs;
   ath9k-htc-blobless-firmware-unstable =
     callPackage ../os-specific/linux/firmware/ath9k { enableUnstable = true; };
 
-  bartender = callPackage ../os-specific/darwin/bartender { };
-
   b43Firmware_5_1_138 = callPackage ../os-specific/linux/firmware/b43-firmware/5.1.138.nix { };
 
   b43Firmware_6_30_163_46 = callPackage ../os-specific/linux/firmware/b43-firmware/6.30.163.46.nix { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -27288,8 +27288,6 @@ with pkgs;
     fftw = fftwFloat;
   };
 
-  apparency = callPackage ../os-specific/darwin/apparency { };
-
   arm-trusted-firmware = callPackage ../misc/arm-trusted-firmware { };
   inherit (arm-trusted-firmware)
     buildArmTrustedFirmware

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35702,8 +35702,6 @@ with pkgs;
 
   uwimap = callPackage ../tools/networking/uwimap { };
 
-  utm = callPackage ../os-specific/darwin/utm { };
-
   utox = callPackage ../applications/networking/instant-messengers/utox { };
 
   valentina = libsForQt5.callPackage ../applications/misc/valentina { };

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -192,6 +192,8 @@ impure-cmds // appleSourcePackages // chooseLibs // {
 
   trash = callPackage ../os-specific/darwin/trash { };
 
+  utm = callPackage ../os-specific/darwin/utm { };
+
   xattr = pkgs.python3Packages.callPackage ../os-specific/darwin/xattr { };
 
   inherit (pkgs.callPackages ../os-specific/darwin/xcode { })

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -80,6 +80,8 @@ impure-cmds // appleSourcePackages // chooseLibs // {
     extraBuildInputs = [];
   };
 
+  apparency = callPackage ../os-specific/darwin/apparency { };
+
   bartender = callPackage ../os-specific/darwin/bartender { };
 
   binutils-unwrapped = callPackage ../os-specific/darwin/binutils {

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -80,6 +80,8 @@ impure-cmds // appleSourcePackages // chooseLibs // {
     extraBuildInputs = [];
   };
 
+  bartender = callPackage ../os-specific/darwin/bartender { };
+
   binutils-unwrapped = callPackage ../os-specific/darwin/binutils {
     inherit (pkgs) binutils-unwrapped;
     inherit (pkgs.llvmPackages) llvm clang-unwrapped;

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -142,6 +142,8 @@ impure-cmds // appleSourcePackages // chooseLibs // {
     propagatedBuildInputs = [ pkgs.darwin.print-reexports ];
   } ../os-specific/darwin/print-reexports/setup-hook.sh;
 
+  installBinaryPackage = callPackage ../os-specific/darwin/install-binary-package { };
+
   sigtool = callPackage ../os-specific/darwin/sigtool { };
 
   signingUtils = callPackage ../os-specific/darwin/signing-utils { };

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -182,6 +182,8 @@ impure-cmds // appleSourcePackages // chooseLibs // {
     inherit (pkgs.darwin) cctools sigtool;
   };
 
+  monitorcontrol = callPackage ../os-specific/darwin/monitorcontrol { };
+
   opencflite = callPackage ../os-specific/darwin/opencflite { };
 
   openwith = pkgs.darwin.apple_sdk_11_0.callPackage ../os-specific/darwin/openwith {


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

ℹ️ This is a companion PR that builds upon #293498.
Because this PR targets master as the base branch the changes from #293498 as also included in this PR. Here's the [diff to what changes to #293498](https://github.com/NixOS/nixpkgs/compare/c42449435d1d5a753f892475e54437144bf9ec67..8b89c2cbbd1de539370cfd02b08ef3d019ba7523).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
