### PR TITLE
retdec: split outputs, better platform support, and general cleanup. 

### DIFF
--- a/pkgs/by-name/re/retdec/fix-long-double.patch
+++ b/pkgs/by-name/re/retdec/fix-long-double.patch
@@ -1,0 +1,64 @@
+From 93233e79a0b14e6aeeee6b117a1c93feba88577b Mon Sep 17 00:00:00 2001
+From: rina <k@rina.fyi>
+Date: Fri, 8 Mar 2024 17:00:07 +1000
+Subject: [PATCH] fix get10Byte on platforms where long double is >80 bits.
+
+for platforms with a non 80-bit "long double" type, we
+change get10ByteImpl to reduce to double then use the
+language's conversion to long double.
+
+this handles both where long double is smaller and greater
+than 80 bits, though only 64 bits of precision are preserved.
+
+this fixes the tests on aarch64 platforms.
+---
+ src/utils/byte_value_storage.cpp | 7 ++++++-
+ src/utils/system.cpp             | 8 +++++---
+ 2 files changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/src/utils/byte_value_storage.cpp b/src/utils/byte_value_storage.cpp
+index c16e7425e..bc8f6afc3 100644
+--- a/src/utils/byte_value_storage.cpp
++++ b/src/utils/byte_value_storage.cpp
+@@ -1019,7 +1019,12 @@ bool ByteValueStorage::get10ByteImpl(
+ 	{
+ 		std::vector<std::uint8_t> d8;
+ 		double10ToDouble8(d8, data);
+-		memcpy(&res, d8.data(), d8.size());
++
++		double d8res = 0;
++		static_assert(sizeof(double) == 8);
++
++		memcpy(&d8res, d8.data(), d8.size());
++		res = d8res;
+ 	}
+ 
+ 	return true;
+diff --git a/src/utils/system.cpp b/src/utils/system.cpp
+index 669d2d8f0..6721a6821 100644
+--- a/src/utils/system.cpp
++++ b/src/utils/system.cpp
+@@ -7,6 +7,8 @@
+ #include "retdec/utils/os.h"
+ #include "retdec/utils/system.h"
+ 
++#include <cfloat>
++
+ namespace retdec {
+ namespace utils {
+ 
+@@ -22,11 +24,11 @@ bool isLittleEndian() {
+ }
+ 
+ /**
+-* @brief Finds out if the runtime system supports <tt>long double</tt> (at least
+-*        10 bytes long).
++* @brief Finds out if the runtime system supports 80-bit <tt>long double</tt>
++*        (exactly 10 bytes long).
+ */
+ bool systemHasLongDouble() {
+-	return sizeof(long double) >= 10;
++	return sizeof(long double) >= 10 && (LDBL_MANT_DIG == 64);
+ }
+ 
+ } // namespace utils


### PR DESCRIPTION
## Description of changes

the main "out" output is now 300MB uncompressed (down from 1.6GB when it was the only output). "lib" and "dev" outputs are also provided to support retdec's use as a library, available since 5.0.

also restores the retdec/retdec-full split by extracting the static yara patterns into their own output. these are not needed for the majority of use-cases (more comments in nix file). a retdec.full attribute is provided to join this back in.
given their rare use, we also no longer compile these by default. this reduces the patterns output from 1.1GB to 670MB.

```
27M     result-dev/
113M    result-lib/
677M    result-patterns/
334M    result/
```

we support more platforms by working around a lib64 hack that came in through the vendored dependencies.

further, we add support for building with ninja as well as make. this is a touch faster.

### testing

building takes 7 minutes on the fastest laptop i own.

you can test the decompiler with 
```
retdec-decompiler /bin/true -o /tmp/a
```
and inspect the files in /tmp/a*.

you can test the capstone2llvmir tool with 
```
retdec-capstone2llvmir -a arm64 -c '410003AB'
```
this will print an LLVM IR representation of arm's `adds x1, x2, x3` instruction.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
