### PR TITLE
rye: 0.27.0 -> 0.28.0

### DIFF
--- a/pkgs/development/tools/rye/Cargo.lock
+++ b/pkgs/development/tools/rye/Cargo.lock
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "rye"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "age",
  "anyhow",

--- a/pkgs/development/tools/rye/default.nix
+++ b/pkgs/development/tools/rye/default.nix
@@ -12,13 +12,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rye";
-  version = "0.27.0";
+  version = "0.28.0";
 
   src = fetchFromGitHub {
     owner = "mitsuhiko";
     repo = "rye";
     rev = "refs/tags/${version}";
-    hash = "sha256-tqwjhA81UYCtZjz6X5tIZ91pDVPe4UU+sTKUIzmOHlM=";
+    hash = "sha256-i40VpPDK991mgBdGtufMFXuQuKuvqr0qIvl7q2KXQrg=";
   };
 
   cargoLock = {
@@ -57,12 +57,15 @@ rustPlatform.buildRustPackage rec {
     # The following require internet access to fetch a python binary
     "--skip=test_add_and_sync_no_auto_sync"
     "--skip=test_add_autosync"
+    "--skip=test_add_explicit_version_or_url"
     "--skip=test_add_flask"
     "--skip=test_add_from_find_links"
+    "--skip=test_autosync_remember"
     "--skip=test_basic_tool_behavior"
     "--skip=test_config_empty"
     "--skip=test_config_get_set_multiple"
     "--skip=test_config_incompatible_format_and_show_path"
+    "--skip=test_config_save_missing_folder"
     "--skip=test_config_show_path"
     "--skip=test_empty_sync"
     "--skip=test_fetch"
@@ -70,6 +73,7 @@ rustPlatform.buildRustPackage rec {
     "--skip=test_init_lib"
     "--skip=test_init_script"
     "--skip=test_lint_and_format"
+    "--skip=test_version"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/mitsuhiko/rye/releases/tag/0.28.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
