### PR TITLE
python311Packages.pydmd: 0.4.0post2302 -> 1.0.0

### DIFF
--- a/pkgs/development/python-modules/pydmd/default.nix
+++ b/pkgs/development/python-modules/pydmd/default.nix
@@ -2,57 +2,68 @@
 , stdenv
 , buildPythonPackage
 , fetchFromGitHub
+, setuptools
 , future
 , matplotlib
 , numpy
 , pytestCheckHook
+, pytest-mock
 , pythonOlder
 , scipy
 , ezyrb
 }:
 
-buildPythonPackage rec {
-  pname = "pydmd";
-  version = "0.4.0.post2302";
-  format = "setuptools";
+let
+  self = buildPythonPackage rec {
+    pname = "pydmd";
+    version = "1.0.0";
+    pyproject = true;
 
-  disabled = pythonOlder "3.6";
+    disabled = pythonOlder "3.6";
 
-  src = fetchFromGitHub {
-    owner = "mathLab";
-    repo = "PyDMD";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-EYVmaxwOxje3KVrNbvsjwRqQBD7Rje/JK+qB1F7EqA0=";
+    src = fetchFromGitHub {
+      owner = "PyDMD";
+      repo = "PyDMD";
+      rev = "refs/tags/v${version}";
+      hash = "sha256-vprvq3sl/eNtu4cqg0A4XV96dzUt0nOtPmfwEv0h+PI=";
+    };
+
+    build-system = [
+      setuptools
+  ];
+
+    propagatedBuildInputs = [
+      future
+      matplotlib
+      numpy
+      scipy
+      ezyrb
+    ];
+
+    nativeCheckInputs = [
+      pytestCheckHook
+      pytest-mock
+    ];
+
+    pytestFlagsArray = [
+      "tests/test_dmdbase.py"
+    ];
+
+    pythonImportsCheck = [
+      "pydmd"
+    ];
+
+    passthru.tests = self.overrideAttrs (old: {
+      pytestFlagsArray = [];
+    });
+
+    meta = with lib; {
+      description = "Python Dynamic Mode Decomposition";
+      homepage = "https://pydmd.github.io/PyDMD/";
+      changelog = "https://github.com/PyDMD/PyDMD/releases/tag/v${version}";
+      license = licenses.mit;
+      maintainers = with maintainers; [ yl3dy ];
+      broken = stdenv.hostPlatform.isAarch64;
+    };
   };
-
-  propagatedBuildInputs = [
-    future
-    matplotlib
-    numpy
-    scipy
-    ezyrb
-  ];
-
-  nativeCheckInputs = [
-    pytestCheckHook
-  ];
-
-  pytestFlagsArray = [
-    # test suite takes over 100 vCPU hours, just run small subset of it.
-    # TODO: Add a passthru.tests with all tests
-    "tests/test_dmdbase.py"
-  ];
-
-  pythonImportsCheck = [
-    "pydmd"
-  ];
-
-  meta = with lib; {
-    description = "Python Dynamic Mode Decomposition";
-    homepage = "https://mathlab.github.io/PyDMD/";
-    changelog = "https://github.com/mathLab/PyDMD/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ yl3dy ];
-    broken = stdenv.hostPlatform.isAarch64;
-  };
-}
+in self


### PR DESCRIPTION
## Description of changes

Updated to 1.0.0, updated links and added full tests via passthru.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
