### PR TITLE
ytdownloader: init at 3.17.3

### DIFF
--- a/pkgs/by-name/yt/ytdownloader/package.nix
+++ b/pkgs/by-name/yt/ytdownloader/package.nix
@@ -1,0 +1,66 @@
+{ lib
+, buildNpmPackage
+, fetchFromGitHub
+, makeWrapper
+, ffmpeg
+, yt-dlp
+, makeDesktopItem
+, electron
+}:
+
+buildNpmPackage rec {
+  pname = "ytDownloader";
+  version = "3.17.3";
+
+  src = fetchFromGitHub {
+    owner = "aandrew-me";
+    repo = "ytDownloader";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-aqQGOqPLKKTBjWjL3KyRD4paBGCQLhCBjXwVVhoHDSk=";
+  };
+
+  npmDepsHash = "sha256-lhFyiWy9dgnxxaElavzqA4YpRm7cVC23pvL5Kwve58E=";
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ ffmpeg yt-dlp ];
+
+  desktopItem = makeDesktopItem {
+    name = "YTDownloader";
+    exec = "ytdownloader %U";
+    icon = "ytdownloader";
+    desktopName = "YT Downloader";
+    comment = "A modern GUI video and audio downloader";
+    categories = [ "Utility" ];
+    startupWMClass = "YTDownloader";
+  };
+
+  ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  dontNpmBuild = true;
+
+  # Replace hardcoded ffmpeg and ytdlp paths
+  # Also stop it from downloading ytdlp
+  postPatch = ''
+    substituteInPlace src/renderer.js \
+      --replace-fail $\{__dirname}/../ffmpeg '${lib.getExe ffmpeg}' \
+      --replace-fail 'path.join(os.homedir(), ".ytDownloader", "ytdlp")' '`${lib.getExe yt-dlp}`' \
+      --replace-fail '!!localStorage.getItem("fullYtdlpBinPresent")' 'true'
+  '';
+
+  postInstall = ''
+    makeWrapper ${electron}/bin/electron $out/bin/ytdownloader \
+        --add-flags $out/lib/node_modules/ytdownloader/main.js
+
+    install -Dm444 assets/images/icon.png $out/share/pixmaps/ytdownloader.png
+    install -Dm444 "${desktopItem}/share/applications/"* -t $out/share/applications
+  '';
+
+  meta = {
+    description = "A modern GUI video and audio downloader";
+    homepage = "https://github.com/aandrew-me/ytDownloader";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ chewblacka ];
+    platforms = lib.platforms.all;
+    mainProgram = "ytdownloader";
+  };
+}


### PR DESCRIPTION
## Description of changes
ytDownloader - A modern GUI video and audio downloader (utilizes yt-dlp and ffmpeg on the backend)
https://github.com/aandrew-me/ytDownloader
Init at 3.17.3

Closes https://github.com/NixOS/nixpkgs/issues/293327

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
