### PR TITLE
fetchFromGitHub: re-fetch upon version changes

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -165,6 +165,10 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
   "mysecret"` becomes `services.aria2.rpcSecretFile = "/path/to/secret_file"`
   where the file `secret_file` contains the string `mysecret`.
 
+- `fetchFromGitHub`'s default `name` is now dependent to `rev`. This ensures that the result FOD is always re-fetced for each new version, and makes irrelevent hashes more discoverable.
+
+  This also means that the default `name` is no longer `"source"`. Packages must adhere to the [Nixpkgs specification about `sourceRoot`](https://nixos.org/manual/nixpkgs/unstable/#var-stdenv-sourceRoot) and specify `sourceRoot = "${src.name}/subdir"` instead of `sourceRoot = "source/subdir"`, or the build will fail.
+
 - Invidious has changed its default database username from `kemal` to `invidious`. Setups involving an externally provisioned database (i.e. `services.invidious.database.createLocally == false`) should adjust their configuration accordingly. The old `kemal` user will not be removed automatically even when the database is provisioned automatically.(https://github.com/NixOS/nixpkgs/pull/265857)
 
 - `inetutils` now has a lower priority to avoid shadowing the commonly used `util-linux`. If one wishes to restore the default priority, simply use `lib.setPrio 5 inetutils` or override with `meta.priority = 5`.

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -27,6 +27,7 @@ lib.makeOverridable (
 , # Impure env vars (https://nixos.org/nix/manual/#sec-advanced-attributes)
   # needed for netrcPhase
   netrcImpureEnvVars ? []
+, passthru ? {}
 , meta ? {}
 , allowedRequisites ? null
 }:
@@ -103,7 +104,7 @@ stdenvNoCC.mkDerivation {
 
   inherit preferLocalBuild meta allowedRequisites;
 
-  passthru = {
+  passthru = passthru // {
     gitRepoUrl = url;
   };
 }

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -6,6 +6,7 @@ lib.makeOverridable (
 , deepClone ? false, private ? false, forceFetchGit ? false
 , sparseCheckout ? []
 , githubBase ? "github.com", varPrefix ? null
+, passthru ? { }
 , meta ? { }
 , ... # For hash agility
 }@args:
@@ -17,6 +18,9 @@ let
     else builtins.unsafeGetAttrPos "rev" args
   );
   baseUrl = "https://${githubBase}/${owner}/${repo}";
+  newPassthru = passthru // {
+    inherit rev owner repo;
+  };
   newMeta = meta // {
     homepage = meta.homepage or baseUrl;
   } // lib.optionalAttrs (position != null) {
@@ -53,16 +57,19 @@ let
   fetcherArgs = (if useFetchGit
     then {
       inherit rev deepClone fetchSubmodules sparseCheckout; url = gitRepoUrl;
+      passthru = newPassthru;
     } // lib.optionalAttrs (leaveDotGit != null) { inherit leaveDotGit; }
     else {
       url = "${baseUrl}/archive/${rev}.tar.gz";
 
-      passthru = {
+      passthru = newPassthru // {
         inherit gitRepoUrl;
       };
     }
   ) // privateAttrs // passthruAttrs // { inherit name; };
 in
 
-fetcher fetcherArgs // { meta = newMeta; inherit rev owner repo; }
+(fetcher fetcherArgs).overrideAttrs (finalAttrs: previousAttrs: {
+  meta = newMeta;
+})
 )

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -1,7 +1,9 @@
 { lib, fetchgit, fetchzip }:
 
 lib.makeOverridable (
-{ owner, repo, rev, name ? "source"
+{ owner, repo, rev
+, name ? null # Override with nullbto use the default value
+, pname ? "source-${owner}-${repo}"
 , fetchSubmodules ? false, leaveDotGit ? null
 , deepClone ? false, private ? false, forceFetchGit ? false
 , sparseCheckout ? []
@@ -12,6 +14,8 @@ lib.makeOverridable (
 }@args:
 
 let
+  name = if args.name or null != null then args.name
+  else "${pname}-${rev}";
 
   position = (if args.meta.description or null != null
     then builtins.unsafeGetAttrPos "description" args.meta


### PR DESCRIPTION
## Description of changes

This PR mitigates the development issue of irrelevent FOD hashes after version bump/version overriding, by making `rev` part of the store path through the default value of the `name` attribute.

Depends on #294329 and #294334. Once they're merged, there will be only one commit and two changed files (including the release note) in this PR.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
