### PR TITLE
dotnet: add publish and web tests

### DIFF
--- a/pkgs/development/compilers/dotnet/common.nix
+++ b/pkgs/development/compilers/dotnet/common.nix
@@ -4,6 +4,8 @@
 , writeText
 , testers
 , runCommand
+, expect
+, curl
 }: type: args: stdenv.mkDerivation (finalAttrs: args // {
   doInstallCheck = true;
 
@@ -27,37 +29,97 @@
 
 } // lib.optionalAttrs (type == "sdk") {
   passthru = {
-    tests = {
+    tests = let
+      mkDotnetTest =
+        {
+          name,
+          template,
+          usePackageSource ? false,
+          build,
+          # TODO: use correct runtimes instead of sdk
+          runtime ? finalAttrs.finalPackage,
+          runInputs ? [],
+          run ? null,
+        }:
+        let
+          built = runCommand "dotnet-test-${name}" { buildInputs = [ finalAttrs.finalPackage ]; } (''
+            HOME=$PWD/.home
+            dotnet new nugetconfig
+            dotnet nuget disable source nuget
+          '' + lib.optionalString usePackageSource ''
+            dotnet nuget add source ${finalAttrs.finalPackage.packages}
+          '' + ''
+            dotnet new ${template} -n test -o .
+          '' + build);
+        in
+          if run == null
+            then build
+          else
+            runCommand "${built.name}-run" { src = built; nativeBuildInputs = runInputs; } (
+              lib.optionalString (runtime != null) ''
+                # TODO: use runtime here
+                export DOTNET_ROOT=${runtime}
+              '' + run);
+
+      checkConsoleOutput = command: ''
+        output="$(${command})"
+        # yes, older SDKs omit the comma
+        [[ "$output" =~ Hello,?\ World! ]] && touch "$out"
+      '';
+
+    in {
       version = testers.testVersion {
         package = finalAttrs.finalPackage;
       };
 
-      console = runCommand "dotnet-test-console" {
-        nativeBuildInputs = [ finalAttrs.finalPackage ];
-      } ''
-        HOME=$(pwd)/fake-home
-        dotnet new nugetconfig
-        dotnet nuget disable source nuget
-        dotnet new console -n test -o .
-        output="$(dotnet run)"
-        # yes, older SDKs omit the comma
-        [[ "$output" =~ Hello,?\ World! ]] && touch "$out"
-      '';
+      console = mkDotnetTest {
+        name = "console";
+        template = "console";
+        build = checkConsoleOutput "dotnet run";
+      };
 
-      single-file = let build = runCommand "dotnet-test-build-single-file" {
-        nativeBuildInputs = [ finalAttrs.finalPackage ];
-      } ''
-        HOME=$(pwd)/fake-home
-        dotnet new nugetconfig
-        dotnet nuget disable source nuget
-        dotnet nuget add source ${finalAttrs.finalPackage.packages}
-        dotnet new console -n test -o .
-        dotnet publish --use-current-runtime -p:PublishSingleFile=true -o $out
-      ''; in runCommand "dotnet-test-run-single-file" {} ''
-        output="$(${build}/test)"
-        # yes, older SDKs omit the comma
-        [[ "$output" =~ Hello,?\ World! ]] && touch "$out"
-      '';
+      publish = mkDotnetTest {
+        name = "publish";
+        template = "console";
+        build = "dotnet publish -o $out";
+        run = checkConsoleOutput "$src/test";
+      };
+
+      single-file = mkDotnetTest {
+        name = "single-file";
+        template = "console";
+        usePackageSource = true;
+        build = "dotnet publish --use-current-runtime -p:PublishSingleFile=true -o $out";
+        runtime = null;
+        run = checkConsoleOutput "$src/test";
+      };
+
+      web = mkDotnetTest {
+        name = "publish";
+        template = "web";
+        build = "dotnet publish -o $out";
+        runInputs = [ expect curl ];
+        run = ''
+          expect <<"EOF"
+            set status 1
+            spawn $env(src)/test
+            expect_before default abort
+            expect -re {Now listening on: ([^\r]+)\r} {
+              set url $expect_out(1,string)
+            }
+            expect "Application started. Press Ctrl+C to shut down."
+            set output [exec curl -sSf $url]
+            if {$output != "Hello World!"} {
+              send_error "Unexpected output: $output\n"
+              exit 1
+            }
+            send \x03
+            catch wait result
+            exit [lindex $result 3]
+          EOF
+          touch $out
+        '';
+      };
     } // args.passthru.tests or {};
   } // args.passthru or {};
 })


### PR DESCRIPTION
This adds a helper for creating dotnet tests, and adds tests for:

- normal publish and run via wrapper
- aspnetcore web app

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

FYI @NixOS/dotnet 

@ofborg build dotnet-sdk_6.tests dotnet-sdk_7.tests dotnet-sdk_8.tests dotnetCorePackages.dotnet_8.tests