### PR TITLE
mysql-workbench: fix build

### DIFF
--- a/pkgs/applications/misc/mysql-workbench/dont-search-for-antlr-jar.patch
+++ b/pkgs/applications/misc/mysql-workbench/dont-search-for-antlr-jar.patch
@@ -1,0 +1,30 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b7320bb..d7169da 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -143,25 +143,6 @@ check_function_exists (strtoull HAVE_STRTOULL)
+ check_function_exists (strtoimax HAVE_STRTOIMAX)
+ check_function_exists (strtoumax HAVE_STRTOUMAX)
+ 
+-set(ANTLR_JAR_FILENAME "antlr-4.11.1-complete.jar")
+-get_filename_component(SOURCE_PARENT_DIR ${CMAKE_SOURCE_DIR} DIRECTORY)
+-set(LINUX_RES_BIN_DIR ${SOURCE_PARENT_DIR}/linux-res/bin)
+-message("WITH_ANTLR_JAR: ${WITH_ANTLR_JAR}")
+-if(WITH_ANTLR_JAR)
+-  get_filename_component(ANTLR_JAR_USER_DIR ${WITH_ANTLR_JAR} DIRECTORY)
+-  find_path(ANTLR_JAR_PATH ${ANTLR_JAR_FILENAME} ${LINUX_RES_BIN_DIR} ${ANTLR_JAR_USER_DIR})
+-else(WITH_ANTLR_JAR)
+-  find_path(ANTLR_JAR_PATH ${ANTLR_JAR_FILENAME} ${LINUX_RES_BIN_DIR})
+-endif(WITH_ANTLR_JAR)
+-
+-if(ANTLR_JAR_PATH AND Java_JAVA_EXECUTABLE) 
+-  set(ANTLR_JAR_PATH ${ANTLR_JAR_PATH}/${ANTLR_JAR_FILENAME})
+-  message(STATUS "ANTLR jar: " ${ANTLR_JAR_PATH})
+-else()
+-  message(WARNING ${ANTLR_JAR_FILENAME} " or java runtime wasn't found which is required if you'd like to rebuild Lexer and Parser files")
+-endif()
+-
+-
+ if (UNIX)
+ 	if (NOT LIB_INSTALL_DIR)
+ 		set(LIB_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib")


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/294060

Because of a recent change to how `antlr4_12.jarLocation` is set we can no longer assume the filename for the jar file (it's now a store path).
To fix this I disabled the directory search logic, and hardcoded a different cmake variable instead. This is much more robust than before.

Another small change I made was that I merged `preConfigure` into `postPatch`


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
