### PR TITLE
zephyr-sdk: init at 0.16.5-1

### DIFF
--- a/pkgs/by-name/ze/zephyr-sdk/package.nix
+++ b/pkgs/by-name/ze/zephyr-sdk/package.nix
@@ -1,0 +1,46 @@
+{ lib
+, stdenv
+, fetchurl
+, python3
+, autoPatchelfHook
+, callPackage
+}:
+
+let
+  srcjson = builtins.fromJSON (builtins.readFile ./src.json);
+in stdenv.mkDerivation (finalAttrs: {
+  pname = "zephyr-sdk";
+  inherit (srcjson) version;
+
+  src = fetchurl (srcjson.tar.${stdenv.hostPlatform.system});
+
+  nativeBuildInputs = [
+    stdenv.cc.cc
+    python3
+  ] ++ lib.optional stdenv.isLinux autoPatchelfHook;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    cp -r . $out
+    runHook postInstall
+  '';
+
+  passthru.updateScript = callPackage ./update.nix { };
+
+  meta = with lib; {
+    homepage = "https://github.com/zephyrproject-rtos/sdk-ng";
+    description = "Collection of compilers and tools for the Zephyr RTOS";
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    # dont build on hydra, big binary distribution
+    hydraPlatforms = [ ];
+    maintainers = with maintainers; [ mib ];
+    sourceProvenance = with sourceTypes; [
+      binaryFirmware
+      binaryNativeCode
+    ];
+  };
+})

--- a/pkgs/by-name/ze/zephyr-sdk/src.json
+++ b/pkgs/by-name/ze/zephyr-sdk/src.json
@@ -1,0 +1,21 @@
+{
+  "version": "0.16.5-1",
+  "tar": {
+    "x86_64-linux": {
+      "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.5-1/zephyr-sdk-0.16.5-1_linux-x86_64.tar.xz",
+      "hash": "sha512-qk6qY7xAenAgbgbf3atHtuzLfph5iZ7L/MB3L+JsfKdfgJBKn2QI5II82AKVnwgM6h0a7vXm1M0P6dPGsOObjA=="
+    },
+    "aarch64-linux": {
+      "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.5-1/zephyr-sdk-0.16.5-1_linux-aarch64.tar.xz",
+      "hash": "sha512-A3eXKM5q/7E+ZiizI7D5jfz1dy96MotLvfhru7FxNvwH6EwuF+vdTbEwEJN8iWzvep1LVOGFmGXxVOs7JIwNPw=="
+    },
+    "x86_64-darwin": {
+      "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.5-1/zephyr-sdk-0.16.5-1_macos-x86_64.tar.xz",
+      "hash": "sha512-yJu/2g2HYl+alpG64jTc1pRzNVqzBL4JB6N4wWeEdFLklmXqLQWgkKkNzjOfHmVQUnl4OyNotFlgkl1ap1XIcg=="
+    },
+    "aarch64-darwin": {
+      "url": "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.5-1/zephyr-sdk-0.16.5-1_macos-aarch64.tar.xz",
+      "hash": "sha512-E9fGPW0MbsWza4hjnZY/u9WjYbUJwsU+/7Nmm5ROvcoo6DRT6ReFldhq9yOPww9LsEDYOlqfcIlQnu5jpOvMbg=="
+    }
+  }
+}

--- a/pkgs/by-name/ze/zephyr-sdk/update.nix
+++ b/pkgs/by-name/ze/zephyr-sdk/update.nix
@@ -1,0 +1,50 @@
+{ writeScript, lib, curl, runtimeShell, jq, coreutils, moreutils, nix, gnused }:
+
+writeScript "update-zephyr-sdk" ''
+  #!${runtimeShell}
+  PATH=${lib.makeBinPath [ jq curl nix coreutils moreutils gnused ]}
+
+  set -euo pipefail
+  set -x
+
+  tmpDir=$(mktemp -d)
+  srcJson=pkgs/by-name/ze/zephyr-sdk/src.json
+  jsonPath="$tmpDir"/latest
+
+  oldVersion=$(jq -r .version < "$srcJson")
+
+  curl https://api.github.com/repos/zephyrproject-rtos/sdk-ng/releases/latest > "$jsonPath"
+
+  newVersion=$(cat "$jsonPath" | jq -r .tag_name | sed s/^v//)
+
+  if [[ "$oldVersion" == "$newVersion" ]]; then
+    echo "version did not change"
+    exit 0
+  fi
+
+  function getDownloadUrl() {
+    platform=$1
+    cat $jsonPath | jq -r ".assets[] | select(.name==\"zephyr-sdk-''${newVersion}_''${platform}.tar.xz\") | .browser_download_url"
+  }
+
+  function setJsonKey() {
+    jq "$1 = \"$2\"" "$srcJson" | sponge "$srcJson"
+  }
+
+  function updatePlatform() {
+    nixPlatform="$1"
+    upstreamPlatform="$2"
+    url=$(getDownloadUrl $upstreamPlatform)
+    hash=$(nix-prefetch-url "$url" --type sha512)
+    sriHash=$(nix hash to-sri --type sha512 $hash)
+    setJsonKey .tar[\""$nixPlatform"\"].url "$url"
+    setJsonKey .tar[\""$nixPlatform"\"].hash "$sriHash"
+  }
+
+  updatePlatform x86_64-linux linux-x86_64
+  updatePlatform aarch64-linux linux-aarch64
+  updatePlatform x86_64-darwin macos-x86_64
+  updatePlatform aarch64-darwin macos-aarch64
+  setJsonKey .version "$newVersion"
+  echo "Updated to $newVersion"
+''


### PR DESCRIPTION
## Description of changes

Updated and add auto update script to https://github.com/NixOS/nixpkgs/pull/255017

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
