### PR TITLE
systemd-repart: improve overridability of image builder

### DIFF
--- a/nixos/modules/image/repart-image.nix
+++ b/nixos/modules/image/repart-image.nix
@@ -3,6 +3,7 @@
 
 { lib
 , runCommand
+, runCommandLocal
 , python3
 , black
 , ruff
@@ -50,6 +51,11 @@ let
     mypy --strict $out
   '';
 
+  amendedRepartDefinitions = runCommandLocal "amended-repart.d" {} ''
+    definitions=$(${amendRepartDefinitions} ${partitions} ${definitionsDirectory})
+    cp -r $definitions $out
+  '';
+
   fileSystemToolMapping = {
     "vfat" = [ dosfstools mtools ];
     "ext4" = [ e2fsprogs.bin ];
@@ -74,28 +80,37 @@ in
 
 runCommand imageFileBasename
 {
+  __structuredAttrs = true;
+
   nativeBuildInputs = [
     systemd
     fakeroot
     util-linux
     compressionPkg
   ] ++ fileSystemTools;
-} ''
-  amendedRepartDefinitions=$(${amendRepartDefinitions} ${partitions} ${definitionsDirectory})
 
+  systemdRepartFlags = [
+    "--dry-run=no"
+    "--empty=create"
+    "--size=auto"
+    "--seed=${seed}"
+    "--definitions=${amendedRepartDefinitions}"
+    "--split=${lib.boolToString split}"
+    "--json=pretty"
+  ] ++ lib.optionals (sectorSize != null) [
+    "--sector-size=${toString sectorSize}"
+  ];
+
+  passthru = {
+    inherit amendRepartDefinitions amendedRepartDefinitions;
+  };
+} ''
   mkdir -p $out
   cd $out
 
   echo "Building image with systemd-repart..."
   unshare --map-root-user fakeroot systemd-repart \
-    --dry-run=no \
-    --empty=create \
-    --size=auto \
-    --seed="${seed}" \
-    --definitions="$amendedRepartDefinitions" \
-    --split="${lib.boolToString split}" \
-    --json=pretty \
-    ${lib.optionalString (sectorSize != null) "--sector-size=${toString sectorSize}"} \
+    ''${systemdRepartFlags[@]} \
     ${imageFileBasename}.raw \
     | tee repart-output.json
 

--- a/nixos/modules/image/repart-image.nix
+++ b/nixos/modules/image/repart-image.nix
@@ -34,6 +34,7 @@
 , seed
 , definitionsDirectory
 , sectorSize
+, mkfsEnv ? {}
 }:
 
 let
@@ -88,6 +89,8 @@ runCommand imageFileBasename
     util-linux
     compressionPkg
   ] ++ fileSystemTools;
+
+  env = mkfsEnv;
 
   systemdRepartFlags = [
     "--dry-run=no"


### PR DESCRIPTION
## Description of changes

Parameters passed to systemd-repart are now passed to the build script
via environment variable, which is defined as a list of strings in
combination with `__structuredAttrs = true`. This should make it easier
to customize the image build using `overrideAttrs`.

Both the script used to amend the repart definitions and the amended
definitions are now available via passthru.

The new option `image.repart.mkfsOptions` makes it easier to specify extra mkfs parameters for the
systemd-repart builder.
See https://github.com/systemd/systemd/blob/v255/docs/ENVIRONMENT.md?plain=1#L575-L577

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---