### PR TITLE
python312Packages.clickhouse-driver: 0.2.5 -> 0.2.7, add support for python 3.12

### DIFF
--- a/pkgs/development/python-modules/clickhouse-cityhash/default.nix
+++ b/pkgs/development/python-modules/clickhouse-cityhash/default.nix
@@ -1,14 +1,15 @@
 { lib
 , buildPythonPackage
+, cython_3
 , fetchPypi
-, setuptools
 , pythonOlder
+, setuptools
 }:
 
 buildPythonPackage rec {
   pname = "clickhouse-cityhash";
   version = "1.0.2.4";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -17,7 +18,8 @@ buildPythonPackage rec {
     hash = "sha256-ezEl19CqE8LMTnWDqWWmv7CqlqEhMUdbRCVSustV9Pg=";
   };
 
-  propagatedBuildInputs = [
+  nativeBuildInputs = [
+    cython_3
     setuptools
   ];
 

--- a/pkgs/development/python-modules/clickhouse-driver/default.nix
+++ b/pkgs/development/python-modules/clickhouse-driver/default.nix
@@ -1,22 +1,23 @@
 { lib
 , buildPythonPackage
-, fetchFromGitHub
-, setuptools
-, pytz
-, tzlocal
 , clickhouse-cityhash
-, zstd
-, lz4
+, cython_3
+, fetchFromGitHub
 , freezegun
+, lz4
 , mock
 , nose
 , pytestCheckHook
 , pytest-xdist
+, pytz
+, setuptools
+, tzlocal
+, zstd
 }:
 
 buildPythonPackage rec {
   pname = "clickhouse-driver";
-  version = "0.2.5";
+  version = "0.2.7";
   format = "setuptools";
 
   # pypi source doesn't contain tests
@@ -24,16 +25,20 @@ buildPythonPackage rec {
     owner = "mymarilyn";
     repo = "clickhouse-driver";
     rev = version;
-    hash = "sha256-o5v37jPKmvUW4GFVD742nHSdO0g0z2FA4FkacbaRfNA=";
+    hash = "sha256-l0YHWY25PMHgZG/sAZjtGhwmcxWdA8k96zlm9hbKcek=";
   };
 
-  propagatedBuildInputs = [
+  nativeBuildInputs = [
+    cython_3
     setuptools
+  ];
+
+  propagatedBuildInputs = [
+    clickhouse-cityhash
+    lz4
     pytz
     tzlocal
-    clickhouse-cityhash
     zstd
-    lz4
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
## Description of changes

clickhouse-driver didn't build in python 3.12 because cython was missing.
This PR need to be merged after https://github.com/NixOS/nixpkgs/pull/294018 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
