### PR TITLE
python3Packages.hurry-filesize: init at 0.9

### DIFF
--- a/pkgs/development/python-modules/hurry-filesize/default.nix
+++ b/pkgs/development/python-modules/hurry-filesize/default.nix
@@ -1,0 +1,39 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+
+, pythonOlder
+
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "hurry-filesize";
+  version = "0.9";
+  pyproject = true;
+
+  disabled = pythonOlder "3.3";
+
+  src = fetchPypi {
+    pname = "hurry.filesize";
+    inherit version;
+    hash = "sha256-9TaDKa2++GrM07yUkFIjQLt5JgRVromxpCwQ9jgBuaY=";
+  };
+
+  # project has no repo...
+  # fix implicit namespaces (PEP 420) warning
+  patches = [ ./use-pep-420-implicit-namespace-package.patch ];
+
+  build-system = [
+    setuptools
+  ];
+
+  pythonImportsCheck = [ "hurry.filesize" ];
+
+  meta = with lib; {
+    description = "A simple Python library for human readable file sizes (or anything sized in bytes)";
+    homepage = "https://pypi.org/project/hurry.filesize/";
+    license = licenses.zpl21;
+    maintainers = with maintainers; [ vizid ];
+  };
+}

--- a/pkgs/development/python-modules/hurry-filesize/use-pep-420-implicit-namespace-package.patch
+++ b/pkgs/development/python-modules/hurry-filesize/use-pep-420-implicit-namespace-package.patch
@@ -1,0 +1,24 @@
+diff --git a/setup.py b/setup.py
+index 9ec6f2e..607b680 100644
+--- a/setup.py
++++ b/setup.py
+@@ -29,7 +29,6 @@ setup(
+     license='ZPL 2.1',
+     packages=find_packages('src'),
+     package_dir= {'':'src'},
+-    namespace_packages=['hurry'],
+     include_package_data=True,
+     zip_safe=False,
+     install_requires=[
+diff --git a/src/hurry/__init__.py b/src/hurry/__init__.py
+index 2e2033b..e69de29 100644
+--- a/src/hurry/__init__.py
++++ b/src/hurry/__init__.py
+@@ -1,7 +0,0 @@
+-# this is a namespace package
+-try:
+-    import pkg_resources
+-    pkg_resources.declare_namespace(__name__)
+-except ImportError:
+-    import pkgutil
+-    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5418,6 +5418,8 @@ self: super: with self; {
 
   hupper = callPackage ../development/python-modules/hupper { };
 
+  hurry-filesize = callPackage ../development/python-modules/hurry-filesize { };
+
   huum = callPackage ../development/python-modules/huum { };
 
   hvac = callPackage ../development/python-modules/hvac { };


### PR DESCRIPTION
## Description of changes
A simple Python library for human readable file sizes (or anything sized in bytes)
https://pypi.org/project/hurry.filesize/

Project has no repo. I did patch for fix PEP 420: implicit namespace package deprecation warning

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
