### PR TITLE
knock: init at 0.0.2

### DIFF
--- a/pkgs/tools/networking/knock/package.nix
+++ b/pkgs/tools/networking/knock/package.nix
@@ -1,4 +1,8 @@
-{ lib, buildGoModule, installShellFiles, fetchFromGitHub }:
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+}:
 
 buildGoModule rec {
   pname = "knock";

--- a/pkgs/tools/networking/knock/package.nix
+++ b/pkgs/tools/networking/knock/package.nix
@@ -1,0 +1,31 @@
+{ lib, buildGoModule, installShellFiles, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "knock";
+  version = "0.0.2";
+
+  src = fetchFromGitHub {
+    owner = "nat-418";
+    repo = pname;
+    rev = "a3749685381cae178bb5836c67645e0fce7aa1d0";
+    hash = "sha256-VXrWphfBDGDNsz4iuUdwwd46oqnmhJ9i3TtzMqHoSJk=";
+  };
+
+  vendorHash = "sha256-wkSXdIgfkHbVJYsgm/hLAeKA9geof92U3mzSzt7eJE8=";
+
+  outputs = [ "out" "man" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installManPage man/man1/knock.1
+  '';
+
+  meta = with lib; {
+    description = "A simple CLI network reachability tester";
+    homepage = "https://github.com/nat-418/knock";
+    license = licenses.bsd0;
+    changelog = "https://github.com/nat-418/knock/blob/${version}/CHANGELOG.md";
+    maintainers = with maintainers; [ nat-418 ];
+  };
+}

--- a/pkgs/tools/networking/knock/package.nix
+++ b/pkgs/tools/networking/knock/package.nix
@@ -11,7 +11,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "nat-418";
     repo ="knock";
-    rev = "a3749685381cae178bb5836c67645e0fce7aa1d0";
+    rev = "refs/tags/v${version}";
     hash = "sha256-VXrWphfBDGDNsz4iuUdwwd46oqnmhJ9i3TtzMqHoSJk=";
   };
 

--- a/pkgs/tools/networking/knock/package.nix
+++ b/pkgs/tools/networking/knock/package.nix
@@ -6,7 +6,7 @@ buildGoModule rec {
 
   src = fetchFromGitHub {
     owner = "nat-418";
-    repo = pname;
+    repo ="knock";
     rev = "a3749685381cae178bb5836c67645e0fce7aa1d0";
     hash = "sha256-VXrWphfBDGDNsz4iuUdwwd46oqnmhJ9i3TtzMqHoSJk=";
   };


### PR DESCRIPTION
## Description of changes

`knock` is a simple, command-line network reachability tester.

Homepage: https://github.com/nat-418/knock