### PR TITLE
djot-js: 0.2.3 -> 0.3.1

### DIFF
--- a/pkgs/tools/text/djot-js/default.nix
+++ b/pkgs/tools/text/djot-js/default.nix
@@ -1,32 +1,21 @@
 { lib
 , buildNpmPackage
 , fetchFromGitHub
-, fetchpatch
 , installShellFiles
 }:
 
 buildNpmPackage rec {
   pname = "djot-js";
-  version = "0.2.3";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "jgm";
     repo = "djot.js";
     rev = "@djot/djot@${version}";
-    hash = "sha256-W/ZQXJXvFEIgj5PeI+jvw4nIkNP4qa1NyQCOv0unIuA=";
+    hash = "sha256-dQfjI+8cKqn4qLT9eUKfCP++BFCWQ/MmrlQNVRNCFuU=";
   };
 
-  npmDepsHash = "sha256-x/Oc39S6XwZ/ZsS/lmMU9OkHLlKuUxETYmD8pdHAIg8=";
-
-  patches = [
-    # djot.js v0.2.3 doesn't include package-lock.json in the repository
-    # remove at next release
-    (fetchpatch {
-      name = "add-package-lock-json-and-yarn-lock-to-repository.patch";
-      url = "https://github.com/jgm/djot.js/commit/15ed52755b2968932d4a9a80805b9ea6183fe539.patch";
-      hash = "sha256-saNmU7z4IOOG3ptXMFDSNci5uu0d2GiVZ/FAlaNccTc=";
-    })
-  ];
+  npmDepsHash = "sha256-FjrjwhVv2WRjbEga9w37lwz7KYgTTHGsoqt496Uq/0c=";
 
   nativeBuildInputs = [
     installShellFiles


### PR DESCRIPTION
Diff: https://github.com/jgm/djot.js/compare/@djot/djot@0.2.3...@djot/djot@0.3.1

Changelog: https://github.com/jgm/djot.js/blob/@djot/djot@0.3.1/CHANGELOG.md

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
