### PR TITLE
doc: actually document `lib.customisation.makeScope`

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -321,7 +321,12 @@ rec {
     2. `f` (`AttrSet -> AttrSet`)
 
        A function that takes an attribute set as returned by `makeScope newScope f` (a "scope") and returns any attribute set.
+
        This function is used to compute the fixpoint of the resulting scope using `callPackage`.
+       Its argument is the lazily evaluated reference to the value of that fixpoint, and is typically called `self` or `final`.
+
+       See [](#ex-makeScope) for how to use it.
+       See [](#sec-functions-library-fixedPoints) for details on fixpoint computation.
 
     # Output
 

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -342,7 +342,7 @@ rec {
 
     1. `newScope` (`AttrSet -> ((AttrSet -> a) | Path) -> AttrSet -> a`)
 
-       A function that Takes an attribute set `attrs` and returns what ends up as `callPackage` in the output.
+       A function that takes an attribute set `attrs` and returns what ends up as `callPackage` in the output.
 
        Typical values are `callPackageWith` or `(makeScope callPackageWith f).newScope`.
 

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -308,35 +308,7 @@ rec {
 
   /**
     Make an attribute set (a "scope") from functions that take arguments from that same attribute set.
-
-    :::{#ex-makeScope .example}
-    # Create an interdependent package set based on the scope of `pkgs`
-
-    The functions in `foo.nix` and `bar.nix` can depend on each other, in the sense that `foo.nix` can contain a function that expects `bar` as an attribute in its argument.
-
-    ```nix
-    let
-      pkgs = import <nixpkgs> { };
-    in
-    pkgs.lib.makeScope pkgs.newScope (self: {
-      foo = self.callPackage ./foo.nix { };
-      bar = self.callPackage ./bar.nix { };
-    })
-    ```
-
-    evaluates to
-
-    ```nix
-    {
-      callPackage = «lambda»;
-      newScope = «lambda»;
-      overrideScope = «lambda»;
-      packages = «lambda»;
-      foo = «derivation»;
-      bar = «derivation»;
-    }
-    ```
-    :::
+    See [](#ex-makeScope) for how to use it.
 
     # Inputs
 
@@ -344,7 +316,7 @@ rec {
 
        A function that takes an attribute set `attrs` and returns what ends up as `callPackage` in the output.
 
-       Typical values are `callPackageWith` or `(makeScope callPackageWith f).newScope`.
+       Typical values are `callPackageWith` or the output attribute `newScope`.
 
     2. `f` (`AttrSet -> AttrSet`)
 
@@ -374,6 +346,8 @@ rec {
 
       All such functions `p` will be called with the same value for `attrs`.
 
+      See [](#ex-makeScope-callPackage) for how to use it.
+
     - `newScope` (`AttrSet -> scope`)
 
       Takes an attribute set `attrs` and returns a scope that extends the original scope.
@@ -390,6 +364,37 @@ rec {
     - final attributes
 
       The final values returned by `f`.
+
+    # Examples
+
+    :::{#ex-makeScope .example}
+    # Create an interdependent package set on top of `pkgs`
+
+    The functions in `foo.nix` and `bar.nix` can depend on each other, in the sense that `foo.nix` can contain a function that expects `bar` as an attribute in its argument.
+
+    ```nix
+    let
+      pkgs = import <nixpkgs> { };
+    in
+    pkgs.lib.makeScope pkgs.newScope (self: {
+      foo = self.callPackage ./foo.nix { };
+      bar = self.callPackage ./bar.nix { };
+    })
+    ```
+
+    evaluates to
+
+    ```nix
+    {
+      callPackage = «lambda»;
+      newScope = «lambda»;
+      overrideScope = «lambda»;
+      packages = «lambda»;
+      foo = «derivation»;
+      bar = «derivation»;
+    }
+    ```
+    :::
 
     :::{#ex-makeScope-callPackage .example}
     # Using `callPackage` from a scope

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -336,7 +336,7 @@ rec {
     scope :: {
       callPackage :: ((AttrSet -> a) | Path) -> AttrSet -> a
       newScope = AttrSet -> scope
-      overrideScope = (AttrSet -> AttrSet) -> scope
+      overrideScope = (scope -> scope -> AttrSet) -> scope
       packages :: AttrSet -> AttrSet
     }
     ```
@@ -357,10 +357,12 @@ rec {
 
       Takes an attribute set `attrs` and returns a scope that extends the original scope.
 
-    - `overrideScope` (`(AttrSet -> AttrSet) -> scope`)
+    - `overrideScope` (`(scope -> scope -> AttrSet) -> scope`)
 
-      Takes a function `g` like the argument `f` to `makeScope`, and returns a new scope where values returned by the original `f` are overriddne with values returned by `g`.
-      This allows subsequent modification of the final attribute set in a consistent way, i.e. all functions `p` invoked with `callPackage` will be called with the overridden values.
+      Takes a function `g` of the form `final: prev: { # attributes }` to act as an overlay on `f`, and returns a new scope with values determined by `extends g f`.
+      See [](https://nixos.org/manual/nixpkgs/unstable/#function-library-lib.fixedPoints.extends) for details.
+
+      This allows subsequent modification of the final attribute set in a consistent way, i.e. all functions `p` invoked with `callPackage` will be called with the modified values.
 
     - `packages` (`AttrSet -> AttrSet`)
 


### PR DESCRIPTION
## Description of changes

Added interface documentation to `makeScope` that hopefully reduces confusion rather than creating more. Took some parts from https://github.com/NixOS/nixpkgs/pull/270696 by @9999years.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc