### PR TITLE
minigalaxy: 1.2.2 -> 1.3.0

### DIFF
--- a/pkgs/applications/misc/minigalaxy/default.nix
+++ b/pkgs/applications/misc/minigalaxy/default.nix
@@ -1,14 +1,13 @@
 { lib
 , fetchFromGitHub
-, docutils
-, gettext
 , glibcLocales
 , glib-networking
 , gobject-introspection
 , gtk3
-, python3
+, libnotify
 , python3Packages
 , steam-run
+, substituteAll
 , unzip
 , webkitgtk
 , wrapGAppsHook3
@@ -16,23 +15,29 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "minigalaxy";
-  version = "1.2.2";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "sharkwouter";
-    repo = pname;
+    repo = "minigalaxy";
     rev = "refs/tags/${version}";
-    sha256 = "sha256-bpNtdMYBl2dJ4PQsxkhm/Y+3A0dD/Y2XC0VaUYyRhvM=";
+    hash = "sha256-CMPBKnNrcjHVpsbBjY97FiygEJNG9jKHR/LoVMfuxG4=";
   };
 
-  checkPhase = ''
-    runHook preCheck
-    env HOME=$PWD LC_ALL=en_US.UTF-8 pytest
-    runHook postCheck
+  patches = [
+    (substituteAll {
+      src = ./inject-launcher-steam-run.diff;
+      steamrun = lib.getExe steam-run;
+     })
+  ];
+
+  postPatch = ''
+    substituteInPlace minigalaxy/installer.py \
+      --replace-fail '"unzip"' "\"${lib.getExe unzip}\"" \
+      --replace-fail "'unzip'" "\"${lib.getExe unzip}\""
   '';
 
   nativeBuildInputs = [
-    gettext
     wrapGAppsHook3
     gobject-introspection
   ];
@@ -40,29 +45,29 @@ python3Packages.buildPythonApplication rec {
   buildInputs = [
     glib-networking
     gtk3
+    libnotify
   ];
 
   nativeCheckInputs = with python3Packages; [
     glibcLocales
-    pytest
-    tox
+    pytestCheckHook
+    simplejson
   ];
 
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
   pythonPath = [
-    docutils
-    python3.pkgs.pygobject3
-    python3.pkgs.requests
-    python3.pkgs.setuptools
-    python3.pkgs.simplejson
-    steam-run
-    unzip
+    python3Packages.pygobject3
+    python3Packages.requests
     webkitgtk
   ];
 
-  # Run Linux games using the Steam Runtime by using steam-run in the wrapper
-  # FIXME: not working with makeBinaryWrapper
-  postFixup = ''
-    sed -e 's#exec -a "$0"#exec -a "$0" ${steam-run}/bin/steam-run#' -i $out/bin/minigalaxy
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
 
   meta = with lib; {

--- a/pkgs/applications/misc/minigalaxy/inject-launcher-steam-run.diff
+++ b/pkgs/applications/misc/minigalaxy/inject-launcher-steam-run.diff
@@ -1,0 +1,32 @@
+diff --git a/minigalaxy/launcher.py b/minigalaxy/launcher.py
+index 641db77..712c55b 100644
+--- a/minigalaxy/launcher.py
++++ b/minigalaxy/launcher.py
+@@ -77,6 +77,7 @@ def get_execute_command(game) -> list:
+     if game.get_info("use_mangohud") is True:
+         exe_cmd.insert(0, "mangohud")
+         exe_cmd.insert(1, "--dlsym")
++    exe_cmd.insert(0, "@steamrun@")
+     exe_cmd = get_exe_cmd_with_var_command(game, exe_cmd)
+     logger.info("Launch command for %s: %s", game.name, " ".join(exe_cmd))
+     return exe_cmd
+diff --git a/tests/test_installer.py b/tests/test_installer.py
+index 8e6cb76..a9d9f46 100644
+--- a/tests/test_installer.py
++++ b/tests/test_installer.py
+@@ -296,13 +296,13 @@ def test_get_exec_line(self, mock_list_dir, mock_which):
+         mock_list_dir.return_value = ["data", "docs", "scummvm", "support", "beneath.ini", "gameinfo", "start.sh"]
+ 
+         result1 = installer.get_exec_line(game1)
+-        self.assertEqual(result1, "scummvm -c beneath.ini")
++        self.assertEqual(result1, "@steamrun@ scummvm -c beneath.ini")
+ 
+         game2 = Game("Blocks That Matter", install_dir="/home/test/GOG Games/Blocks That Matter", platform="linux")
+         mock_list_dir.return_value = ["data", "docs", "support", "gameinfo", "start.sh"]
+ 
+         result2 = installer.get_exec_line(game2)
+-        self.assertEqual(result2, "./start.sh")
++        self.assertEqual(result2, "@steamrun@ ./start.sh")
+ 
+     @mock.patch('os.path.getsize')
+     @mock.patch('os.listdir')


### PR DESCRIPTION
## Description of changes

https://github.com/sharkwouter/minigalaxy/blob/1.2.6/CHANGELOG.md

Supersedes https://github.com/NixOS/nixpkgs/pull/282594, adds the missing runtime dependency.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
