### PR TITLE
treewide: remove gst-plugins-good missing libsoup_3 workaround

### DIFF
--- a/pkgs/applications/audio/radiotray-ng/default.nix
+++ b/pkgs/applications/audio/radiotray-ng/default.nix
@@ -19,7 +19,6 @@
 # GStreamer
 , glib-networking
 , gst_all_1
-, libsoup_3
 # User-agent info
 , lsb-release
 # rt2rtng
@@ -100,8 +99,6 @@ stdenv.mkDerivation rec {
   preFixup = ''
     gappsWrapperArgs+=(--suffix PATH : ${lib.makeBinPath [ dbus ]})
     wrapProgram $out/bin/rt2rtng --prefix PYTHONPATH : $PYTHONPATH
-    # for GStreamer
-    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "${lib.getLib libsoup_3}/lib")
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/gl/glide-media-player/package.nix
+++ b/pkgs/by-name/gl/glide-media-player/package.nix
@@ -14,7 +14,6 @@
 , gst_all_1
 , glib-networking
 , darwin
-, libsoup_3
 }:
 
 stdenv.mkDerivation rec {
@@ -68,12 +67,6 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals stdenv.isDarwin [
     darwin.apple_sdk_11_0.frameworks.IOKit
   ];
-
-  # FIXME: gst-plugins-good missing libsoup breaks streaming
-  # (https://github.com/nixos/nixpkgs/issues/271960)
-  preFixup = ''
-    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libsoup_3 ]}")
-  '';
 
   meta = with lib; {
     description = "Linux/macOS media player based on GStreamer and GTK";

--- a/pkgs/by-name/mo/monophony/package.nix
+++ b/pkgs/by-name/mo/monophony/package.nix
@@ -6,7 +6,6 @@
 , gobject-introspection
 , yt-dlp
 , libadwaita
-, libsoup_3
 , glib-networking
 , nix-update-script
 }:
@@ -38,7 +37,6 @@ python3Packages.buildPythonApplication rec {
   buildInputs = [
     libadwaita
     # needed for gstreamer https
-    libsoup_3
     glib-networking
   ] ++ (with gst_all_1; [
     gst-plugins-base
@@ -53,8 +51,6 @@ python3Packages.buildPythonApplication rec {
     gappsWrapperArgs+=(
       --prefix PYTHONPATH : "$program_PYTHONPATH"
       --prefix PATH : "${lib.makeBinPath [yt-dlp]}"
-      # needed for gstreamer https
-      --prefix LD_LIBRARY_PATH : "${lib.getLib libsoup_3}/lib"
     )
   '';
 

--- a/pkgs/by-name/ne/netease-cloud-music-gtk/package.nix
+++ b/pkgs/by-name/ne/netease-cloud-music-gtk/package.nix
@@ -18,7 +18,6 @@
 , libadwaita
 , glib-networking
 , gst_all_1
-, libsoup_3
 }:
 
 stdenv.mkDerivation rec {
@@ -70,12 +69,6 @@ stdenv.mkDerivation rec {
     gst-plugins-bad
     gst-plugins-ugly
   ]);
-
-  # FIXME: gst-plugins-good missing libsoup breaks streaming
-  # (https://github.com/nixos/nixpkgs/issues/271960)
-  preFixup = ''
-    gappsWrapperArgs+=(--prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libsoup_3 ]}")
-  '';
 
   meta = with lib; {
     description = "A Rust + GTK based netease cloud music player";


### PR DESCRIPTION
## Description of changes

As the issue (gst-plugins-good cannot find libsoup_3 with dlopen) is fixed by https://github.com/NixOS/nixpkgs/pull/276408 (The pr already hits nixos-unstable-small).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
