### PR TITLE
sentry-native: 0.6.7 -> 0.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4247,6 +4247,12 @@
     githubId = 49398;
     name = "Daniël de Kok";
   };
+  daniel-fahey = {
+    name = "Daniel Fahey";
+    email = "daniel.fahey+nixpkgs@pm.me";
+    github = "daniel-fahey";
+    githubId = 7294692;
+  };
   danielfullmer = {
     email = "danielrf12@gmail.com";
     github = "danielfullmer";

--- a/pkgs/development/libraries/sentry-native/default.nix
+++ b/pkgs/development/libraries/sentry-native/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "sentry-native";
-  version = "0.6.7";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "getsentry";
     repo = "sentry-native";
     rev = version;
-    hash = "sha256-pEFfs8xjc+6r+60aJF4Sjjy/oSU/+ADWgOBpS3t9rWI=";
+    hash = "sha256-e2VjQ3U72X+bwRAi/6StLDWT8tf/MjatnmC/+jCgzTo=";
   };
 
   nativeBuildInputs = [
@@ -32,6 +32,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DSENTRY_BREAKPAD_SYSTEM=On"
+    "-DSENTRY_BACKEND=breakpad"
   ];
 
   meta = with lib; {
@@ -40,6 +41,6 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/getsentry/sentry-native/blob/${version}/CHANGELOG.md";
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ wheelsandmetal ];
+    maintainers = with maintainers; [ wheelsandmetal daniel-fahey ];
   };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Updating version and hash wasn't enough](https://r.ryantm.com/log/sentry-native/2024-03-04.log) as there was a breaking change in [0.7.0](https://github.com/getsentry/sentry-native/releases/tag/0.7.0) making `crashpad` the default backend for Linux. This version keeps using [`breakpad`](https://github.com/NixOS/nixpkgs/blob/dfd80c8be592f64afcfa5bb47741539c422be223/pkgs/development/misc/breakpad/default.nix). We'd need a derivation for `crashpad` to switch over to using it as the backend. Doing so may break packages that depend on `sentry-native` using `breakpad`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`.
  <details>
  <summary>Click to expand details on package compilation tests</summary>

  ```
  [daniel@laptop:~/Source/nixpkgs]$ nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"
  warning: unknown experimental feature 'configurable-impure-env'
  no oauth token found for github.com
  $ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
  remote: Enumerating objects: 30, done.
  remote: Counting objects: 100% (25/25), done.
  remote: Compressing objects: 100% (7/7), done.
  remote: Total 12 (delta 9), reused 6 (delta 4), pack-reused 0
  Unpacking objects: 100% (12/12), 1.75 KiB | 78.00 KiB/s, done.
  From https://github.com/NixOS/nixpkgs
    46d3bc293531..8cc8bf47c668  master     -> refs/nixpkgs-review/0
  $ git worktree add /home/daniel/.cache/nixpkgs-review/rev-dfb956dbe903d851e5f2f70784f80d5051350de7/nixpkgs 8cc8bf47c668d009ddfe114f57ae013394cb098a
  Preparing worktree (detached HEAD 8cc8bf47c668)
  Updating files: 100% (40372/40372), done.
  HEAD is now at 8cc8bf47c668 Merge pull request #282127 from r-ryantm/auto-update/python311Packages.kubernetes
  $ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f <nixpkgs> --nix-path nixpkgs=/home/daniel/.cache/nixpkgs-review/rev-dfb956dbe903d851e5f2f70784f80d5051350de7/nixpkgs nixpkgs-overlays=/run/user/1000/tmpjuz3n0q8 -qaP --xml --out-path --show-trace --no-allow-import-from-derivation
  warning: unknown experimental feature 'configurable-impure-env'
  $ git merge --no-commit --no-ff dfb956dbe903d851e5f2f70784f80d5051350de7
  Automatic merge went well; stopped before committing as requested
  $ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f <nixpkgs> --nix-path nixpkgs=/home/daniel/.cache/nixpkgs-review/rev-dfb956dbe903d851e5f2f70784f80d5051350de7/nixpkgs nixpkgs-overlays=/run/user/1000/tmpjuz3n0q8 -qaP --xml --out-path --show-trace --no-allow-import-from-derivation --meta
  warning: unknown experimental feature 'configurable-impure-env'
  1 package updated:
  sentry-native (0.6.7 → 0.7.0)

  warning: unknown experimental feature 'configurable-impure-env'
  $ nix build --nix-path nixpkgs=/home/daniel/.cache/nixpkgs-review/rev-dfb956dbe903d851e5f2f70784f80d5051350de7/nixpkgs nixpkgs-overlays=/run/user/1000/tmpjuz3n0q8 --extra-experimental-features nix-command no-url-literals --no-link --keep-going --no-allow-import-from-derivation --option build-use-sandbox relaxed -f /home/daniel/.cache/nixpkgs-review/rev-dfb956dbe903d851e5f2f70784f80d5051350de7/build.nix
  warning: unknown experimental feature 'configurable-impure-env'
  1 package built:
  sentry-native

  warning: unknown experimental feature 'configurable-impure-env'
  $ /nix/store/62fm7r6175k2bgvhc19hn9bdhw90wa3n-nix-2.18.1/bin/nix-shell /home/daniel/.cache/nixpkgs-review/rev-dfb956dbe903d851e5f2f70784f80d5051350de7/shell.nix --nix-path nixpkgs=/home/daniel/.cache/nixpkgs-review/rev-dfb956dbe903d851e5f2f70784f80d5051350de7/nixpkgs nixpkgs-overlays=/run/user/1000/tmpjuz3n0q8
  warning: unknown experimental feature 'configurable-impure-env'
  this path will be fetched (1.08 MiB download, 6.88 MiB unpacked):
    /nix/store/032wiarm65zp3bh9ak3dz2sqcr3n8g70-bash-interactive-5.2p26
  copying path '/nix/store/032wiarm65zp3bh9ak3dz2sqcr3n8g70-bash-interactive-5.2p26' from 'https://cache.nixos.org'...
  ```

  </details>
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
