### PR TITLE
python312Packages.iocsearcher: init at 2.3-unstable-2024-03-04

### DIFF
--- a/pkgs/development/python-modules/cashaddress/default.nix
+++ b/pkgs/development/python-modules/cashaddress/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, pythonOlder
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "cashaddress";
+  version = "1.0.6-unstable-2015-05-19";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "oskyk";
+    repo = "cashaddress";
+    rev = "0ca44cff6bd3e63a67b494296c0d1eeaf6cc120d";
+    hash = "sha256-4izWD2KZqy1F7CAgdbe1fpjMlMZC0clrkHKS9IIQuoc=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "cashaddress"
+  ];
+
+  meta = with lib; {
+    description = "Python tool for convert bitcoin cash legacy addresses";
+    homepage = "https://github.com/oskyk/cashaddress";
+    changelog = "https://github.com/oskyk/cashaddress/releases/tag/${version}";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/iocsearcher/default.nix
+++ b/pkgs/development/python-modules/iocsearcher/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, beautifulsoup4
+, buildPythonPackage
+, fetchFromGitHub
+, base58
+, bech32
+, cashaddress
+, cbor
+, eth-hash
+, intervaltree
+, langdetect
+, lxml
+, pdfminer-six
+, phonenumbers
+, python-magic
+, readabilipy
+, pytestCheckHook
+, pythonOlder
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "iocsearcher";
+  version = "2.3-unstable-2024-03-04";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "malicialab";
+    repo = "iocsearcher";
+    rev = "5f7b87761f2195eb358006f3492f0beac7ecc4b0";
+    hash = "sha256-SYh0+JEZa95iBznNzXut/9Vwof6VFeSlt0/g+XmMPC0=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    base58
+    beautifulsoup4
+    bech32
+    cashaddress
+    cbor
+    eth-hash
+    intervaltree
+    langdetect
+    lxml
+    pdfminer-six
+    phonenumbers
+    python-magic
+    readabilipy
+  ] ++ eth-hash.optional-dependencies.pycryptodome;
+
+  # Module has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "iocsearcher"
+  ];
+
+  meta = with lib; {
+    description = "Library and command line tool for extracting indicators of compromise (IOCs)";
+    homepage = "https://github.com/malicialab/iocsearcher";
+    changelog = "https://github.com/malicialab/iocsearcher/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/readabilipy/default.nix
+++ b/pkgs/development/python-modules/readabilipy/default.nix
@@ -1,0 +1,66 @@
+{ lib
+, beautifulsoup4
+, buildPythonPackage
+, fetchFromGitHub
+, html5lib
+, lxml
+, pytestCheckHook
+, pythonOlder
+, regex
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "readabilipy";
+  version = "0.2.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "alan-turing-institute";
+    repo = "ReadabiliPy";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-XrmdQjLFYdadWeO5DoKAQeEdta+6T6BqfvGlDkzLMyM=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    beautifulsoup4
+    html5lib
+    lxml
+    regex
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "readabilipy"
+  ];
+
+  disabledTests = [
+    # AssertionError
+    "test_extract_simple_article_with_readability_js"
+    "test_extract_article_from_page_with_readability_js"
+    "test_plain_element_with_comments"
+    "test_content_digest_on_filled_and_empty_elements"
+  ];
+
+  disabledTestPaths = [
+    # Exclude benchmarks
+    "tests/test_benchmarking.py"
+  ];
+
+  meta = with lib; {
+    description = "HTML content extractor";
+    homepage = "https://github.com/alan-turing-institute/ReadabiliPy";
+    changelog = "https://github.com/alan-turing-institute/ReadabiliPy/blob/${version}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9382,6 +9382,8 @@ with pkgs;
 
   iocextract = with python3Packages; toPythonApplication iocextract;
 
+  iocsearcher = with python3Packages; toPythonApplication iocsearcher;
+
   ioping = callPackage ../tools/system/ioping { };
 
   ior = callPackage ../tools/system/ior { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12716,6 +12716,8 @@ self: super: with self; {
 
   readability-lxml = callPackage ../development/python-modules/readability-lxml { };
 
+  readabilipy = callPackage ../development/python-modules/readabilipy { };
+
   readchar = callPackage ../development/python-modules/readchar { };
 
   readlike = callPackage ../development/python-modules/readlike { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1884,6 +1884,8 @@ self: super: with self; {
 
   case = callPackage ../development/python-modules/case { };
 
+  cashaddress = callPackage ../development/python-modules/cashaddress { };
+
   cassandra-driver = callPackage ../development/python-modules/cassandra-driver { };
 
   castepxbin = callPackage ../development/python-modules/castepxbin { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5700,6 +5700,8 @@ self: super: with self; {
 
   invoke = callPackage ../development/python-modules/invoke { };
 
+  iocsearcher = callPackage ../development/python-modules/iocsearcher { };
+
   iodata = callPackage ../development/python-modules/iodata { };
 
   iocapture = callPackage ../development/python-modules/iocapture { };


### PR DESCRIPTION
## Description of changes
Library and command line tool for extracting indicators of compromise (IOCs)

https://github.com/malicialab/iocsearcher

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
