### PR TITLE
fetchFromGitHub: takes `passthru` and enhance overriding

### DIFF
--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -33,6 +33,7 @@ lib.makeOverridable (lib.fetchers.withNormalizedHash { } (
 , # Impure env vars (https://nixos.org/nix/manual/#sec-advanced-attributes)
   # needed for netrcPhase
   netrcImpureEnvVars ? []
+, passthru ? {}
 , meta ? {}
 , allowedRequisites ? null
 }:
@@ -121,6 +122,6 @@ stdenvNoCC.mkDerivation {
   passthru = {
     gitRepoUrl = url;
     inherit tag;
-  };
+  } // passthru;
 }
 ))

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -10,6 +10,7 @@ lib.makeOverridable (
 , fetchLFS ? false
 , sparseCheckout ? []
 , githubBase ? "github.com", varPrefix ? null
+, passthru ? { }
 , meta ? { }
 , ... # For hash agility
 }@args:
@@ -26,6 +27,9 @@ let
       builtins.unsafeGetAttrPos "rev" args
   );
   baseUrl = "https://${githubBase}/${owner}/${repo}";
+  newPassthru = {
+    inherit owner repo;
+  } // passthru;
   newMeta = meta // {
     homepage = meta.homepage or baseUrl;
   } // lib.optionalAttrs (position != null) {
@@ -63,17 +67,25 @@ let
 
   fetcherArgs = (if useFetchGit
     then {
-      inherit tag rev deepClone fetchSubmodules sparseCheckout fetchLFS; url = gitRepoUrl;
+      inherit tag rev deepClone fetchSubmodules sparseCheckout fetchLFS;
+      url = gitRepoUrl;
+      passthru = newPassthru;
     } // lib.optionalAttrs (leaveDotGit != null) { inherit leaveDotGit; }
     else {
       url = "${baseUrl}/archive/${revWithTag}.tar.gz";
 
       passthru = {
-        inherit gitRepoUrl;
-      };
+        inherit
+          gitRepoUrl
+          tag
+          ;
+        rev = revWithTag;
+      } // newPassthru;
     }
-  ) // privateAttrs // passthruAttrs // { inherit name; };
+  ) // privateAttrs // passthruAttrs // {
+    inherit name;
+    meta = newMeta;
+  };
 in
 
-fetcher fetcherArgs // { meta = newMeta; inherit owner repo tag; rev = revWithTag; }
-)
+fetcher fetcherArgs)


### PR DESCRIPTION
## Description of changes

This PR
* Make fetchers `fetchgit` `fetchFromGitHub` support `passthru` as an optional argument. This enables user to specify `passthru` arguments the idiomatic, non-hacky way. This also make their interface more aligned to that of `fetchurl`.
* Enhance overriding for result FOD of `fetchFromGitHub` with `<pkg>.overrideAttrs` and `passthru`.
    * Update the `meta` attribute of the result package by `<pkgs>.overrideAttrs` the one returned by the base fetcher.
    * Attach `owner`, `repo` and `rev` attributes via `passthru` instead of directly updating the attribute set via `//`, preserving these attributes across `<pkg>.overrideAttrs`.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux (no rebuild)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
