### PR TITLE
treewide: fix hard-coded `sourceRoot` prefix for `fetchgit`-based `src`

### DIFF
--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -996,7 +996,7 @@
       spectre_oxi = rustPlatform.buildRustPackage {
         pname = "spectre_oxi";
         inherit (old) version src;
-        sourceRoot = "source/spectre_oxi";
+        sourceRoot = "${old.src.name}/spectre_oxi";
 
         cargoHash = "sha256-gCGuD5kipgfR0Le8npNmyBxNsUq0PavXvKkxkiPx13E=";
 

--- a/pkgs/applications/graphics/awesomebump/default.nix
+++ b/pkgs/applications/graphics/awesomebump/default.nix
@@ -14,7 +14,7 @@ let
   qtnproperty = mkDerivation {
     name = "qtnproperty";
     inherit src;
-    sourceRoot = "AwesomeBump/Sources/utils/QtnProperty";
+    sourceRoot = "${src.name}/Sources/utils/QtnProperty";
     patches = [ ./qtnproperty-parallel-building.patch ];
     buildInputs = [ qtscript qtbase qtdeclarative ];
     nativeBuildInputs = [ qmake flex bison ];

--- a/pkgs/applications/networking/geph/default.nix
+++ b/pkgs/applications/networking/geph/default.nix
@@ -64,7 +64,7 @@ in
       pname = "${pname}-pnpm-deps";
       inherit src version;
 
-      sourceRoot = "source/gephgui-wry/gephgui";
+      sourceRoot = "${src.name}/gephgui-wry/gephgui";
 
       nativeBuildInputs = [
         jq
@@ -95,7 +95,7 @@ in
       pname = "gephgui-wry";
       inherit version src;
 
-      sourceRoot = "source/gephgui-wry";
+      sourceRoot = "${src.name}/gephgui-wry";
 
       cargoLock = {
         lockFile = ./Cargo.lock;

--- a/pkgs/applications/networking/localsend/default.nix
+++ b/pkgs/applications/networking/localsend/default.nix
@@ -13,7 +13,7 @@ let
   pname = "localsend";
   version = "1.14.0";
 
-  linux = flutter313.buildFlutterApplication {
+  linux = flutter313.buildFlutterApplication rec {
     inherit pname version;
 
     src = fetchFromGitHub {
@@ -23,7 +23,7 @@ let
       hash = "sha256-CO0uFcZnOfE31EZxRUpgtod3+1lyXPpbytHB45DEM98=";
     };
 
-    sourceRoot = "source/app";
+    sourceRoot = "${src.name}/app";
 
     pubspecLock = lib.importJSON ./pubspec.lock.json;
 
@@ -59,7 +59,7 @@ let
 
     passthru.updateScript = ./update.sh;
 
-    meta = meta // {
+    meta = metaCommon // {
       mainProgram = "localsend_app";
     };
   };
@@ -81,13 +81,13 @@ let
       cp -r *.app $out/Applications
     '';
 
-    meta = meta // {
+    meta = metaCommon // {
       sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
       platforms = [ "x86_64-darwin" "aarch64-darwin" ];
     };
   };
 
-  meta = with lib; {
+  metaCommon = with lib; {
     description = "An open source cross-platform alternative to AirDrop";
     homepage = "https://localsend.org/";
     license = licenses.mit;

--- a/pkgs/applications/science/chemistry/autodock-vina/default.nix
+++ b/pkgs/applications/science/chemistry/autodock-vina/default.nix
@@ -20,10 +20,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-yguUMEX0tn75wKrPKyqlCYbBFaEwC5b1s3k9xept1Fw=";
   };
 
-  sourceRoot =
-    if stdenv.isDarwin
-    then "source/build/mac/release"
-    else "source/build/linux/release";
+  sourceRoot = "${finalAttrs.src.name}/build/${
+    if stdenv.hostPlatform.isDarwin then "mac"
+    else "linux"
+  }/release";
 
   buildInputs = [
     boost'

--- a/pkgs/applications/science/misc/openrefine/default.nix
+++ b/pkgs/applications/science/misc/openrefine/default.nix
@@ -27,7 +27,7 @@ let
     inherit src version;
 
     pname = "openrefine-npm";
-    sourceRoot = "source/main/webapp";
+    sourceRoot = "${src.name}/main/webapp";
 
     npmDepsHash = "sha256-8GhcL4tohQ5u2HeYN6JyTMMobUOqAL8ETCLiP1SoDSk=";
 

--- a/pkgs/applications/video/anilibria-winmaclinux/default.nix
+++ b/pkgs/applications/video/anilibria-winmaclinux/default.nix
@@ -25,7 +25,7 @@ mkDerivation rec {
     sha256 = "sha256-G4KlYAjOT1UV29vcX7Q8dMTj0BX0rsJcLtK2MQag5nU=";
   };
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   qmakeFlags = [ "PREFIX=${placeholder "out"}" "CONFIG+=unixvlc" ];
 

--- a/pkgs/by-name/c2/c2fmzq/package.nix
+++ b/pkgs/by-name/c2/c2fmzq/package.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
 
   ldflags = [ "-s" "-w" ];
 
-  sourceRoot = "source/c2FmZQ";
+  sourceRoot = "${src.name}/c2FmZQ";
 
   vendorHash = "sha256-cTXSFwWGHV2QJM4mX/Z+ZxCXKwr+59lEPvJa/PTA1wU=";
 

--- a/pkgs/by-name/fr/frankenphp/package.nix
+++ b/pkgs/by-name/fr/frankenphp/package.nix
@@ -35,7 +35,7 @@ in buildGoModule rec {
     hash = "sha256-tQ35GZuw7Ag1YfmOUarVY45yk4yugNLJetEV4m2w3GE=";
   };
 
-  sourceRoot = "source/caddy";
+  sourceRoot = "${src.name}/caddy";
 
   # frankenphp requires C code that would be removed with `go mod tidy`
   # https://github.com/golang/go/issues/26366

--- a/pkgs/by-name/in/intiface-central/package.nix
+++ b/pkgs/by-name/in/intiface-central/package.nix
@@ -27,7 +27,7 @@ flutter.buildFlutterApplication rec {
   cargoDeps = rustPlatform.fetchCargoTarball {
     name = "${pname}-${version}-cargo-deps";
     inherit src;
-    sourceRoot = "source/intiface-engine-flutter-bridge";
+    sourceRoot = "${src.name}/intiface-engine-flutter-bridge";
     hash = "sha256-0sCHa3rMaLYaUG3E3fmsLi0dSdb9vGyv7qNR3JQkXuU=";
   };
   cargoRoot = "intiface-engine-flutter-bridge";

--- a/pkgs/by-name/la/lanzaboote-tool/package.nix
+++ b/pkgs/by-name/la/lanzaboote-tool/package.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-Fb5TeRTdvUlo/5Yi2d+FC8a6KoRLk2h1VE0/peMhWPs=";
   };
 
-  sourceRoot = "source/rust/tool";
+  sourceRoot = "${src.name}/rust/tool";
   cargoHash = "sha256-g4WzqfH6DZVUuNb0jV3MFdm3h7zy2bQ6d3agrXesWgc=";
 
   env.TEST_SYSTEMD = systemd;

--- a/pkgs/by-name/li/liana/package.nix
+++ b/pkgs/by-name/li/liana/package.nix
@@ -61,7 +61,7 @@ rustPlatform.buildRustPackage rec {
     systemd
   ];
 
-  sourceRoot = "source/gui";
+  sourceRoot = "${src.name}/gui";
 
   postInstall = ''
     install -Dm0644 ./ui/static/logos/liana-app-icon.svg $out/share/icons/hicolor/scalable/apps/liana.svg

--- a/pkgs/by-name/li/linien-gui/package.nix
+++ b/pkgs/by-name/li/linien-gui/package.nix
@@ -9,7 +9,7 @@ python3.pkgs.buildPythonApplication rec {
 
   inherit (python3.pkgs.linien-common) src version;
 
-  sourceRoot = "source/linien-gui";
+  sourceRoot = "${src.name}/linien-gui";
 
   nativeBuildInputs = with python3.pkgs; [
     setuptools

--- a/pkgs/by-name/me/mercure/package.nix
+++ b/pkgs/by-name/me/mercure/package.nix
@@ -17,7 +17,7 @@ buildGoModule rec {
     hash = "sha256-4Y+yZSZrBDLPbQXaOCSKk/EY20Ka8CS4ivUg1TEaqXo=";
   };
 
-  sourceRoot = "source/caddy";
+  sourceRoot = "${src.name}/caddy";
 
   vendorHash = "sha256-N0RmvhBlTiWmBb4TzLmaThD9jVkKgcIO9vPWxJAvLRQ=";
 

--- a/pkgs/by-name/mo/monophony/package.nix
+++ b/pkgs/by-name/mo/monophony/package.nix
@@ -15,7 +15,7 @@ python3Packages.buildPythonApplication rec {
   version = "2.7.0";
   format = "other";
 
-  sourceRoot = "source/source";
+  sourceRoot = "${src.name}/source";
   src = fetchFromGitLab {
     owner = "zehkira";
     repo = "monophony";

--- a/pkgs/by-name/ru/rustdesk-flutter/package.nix
+++ b/pkgs/by-name/ru/rustdesk-flutter/package.nix
@@ -39,7 +39,7 @@
 
   sharedLibraryExt = rustc.stdenv.hostPlatform.extensions.sharedLibrary;
 
-in flutter316.buildFlutterApplication {
+in flutter316.buildFlutterApplication rec {
   pname = "rustdesk";
   version = "1.2.3-unstable-2024-02-11";
   src = fetchFromGitHub {
@@ -52,7 +52,7 @@ in flutter316.buildFlutterApplication {
   strictDeps = true;
 
   # Configure the Flutter/Dart build
-  sourceRoot = "source/flutter";
+  sourceRoot = "${src.name}/flutter";
   # curl https://raw.githubusercontent.com/rustdesk/rustdesk/16db977fd81e14af62ec5ac7760a7661a5c24be8/flutter/pubspec.lock | yq
   pubspecLock = lib.importJSON ./pubspec.lock.json;
   gitHashes = {

--- a/pkgs/by-name/sn/snippetexpanderx/package.nix
+++ b/pkgs/by-name/sn/snippetexpanderx/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   pname = "snippetexpanderx";
 
-  sourceRoot = "source/cmd/snippetexpanderx";
+  sourceRoot = "${src.name}/cmd/snippetexpanderx";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/sv/svix-server/package.nix
+++ b/pkgs/by-name/sv/svix-server/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-6758ej7bTvwZPWifl239rQMazM8uw+Y4+3EbjE8XsTg=";
   };
 
-  sourceRoot = "source/server";
+  sourceRoot = "${src.name}/server";
 
   cargoLock = {
     lockFile = ./Cargo.lock;

--- a/pkgs/by-name/sy/syn2mas/package.nix
+++ b/pkgs/by-name/sy/syn2mas/package.nix
@@ -14,7 +14,7 @@ buildNpmPackage rec {
     hash = "sha256-DPGigs6DifTRa7VQVHgizZ3BUy3FPX3YhZi++yoBFBA=";
   };
 
-  sourceRoot = "source/tools/syn2mas";
+  sourceRoot = "${src.name}/tools/syn2mas";
 
   npmDepsHash = "sha256-HvBFuRyP1APg5V+yhvlODAJ02MEkdpuLfNjWB/UT2vg=";
 

--- a/pkgs/by-name/to/torrentstream/package.nix
+++ b/pkgs/by-name/to/torrentstream/package.nix
@@ -16,7 +16,7 @@ buildDotnetModule rec {
     hash = "sha256-41zlzrQ+YGY2wEvq4Su/lp6lOmGW4u0F37ub2a3z+7o=";
   };
 
-  sourceRoot = "source/src";
+  sourceRoot = "${src.name}/src";
 
   projectFile = "TorrentStream.sln";
   nugetDeps = ./deps.nix;

--- a/pkgs/development/compilers/flutter/flutter-tools.nix
+++ b/pkgs/development/compilers/flutter/flutter-tools.nix
@@ -18,7 +18,7 @@ buildDartApplication.override { inherit dart; } rec {
   dartOutputType = "jit-snapshot";
 
   src = flutterSrc;
-  sourceRoot = "source/packages/flutter_tools";
+  sourceRoot = "${src.name}/packages/flutter_tools";
   postUnpack = ''chmod -R u+w "$NIX_BUILD_TOP/source"'';
 
   inherit patches;

--- a/pkgs/development/coq-modules/vcfloat/default.nix
+++ b/pkgs/development/coq-modules/vcfloat/default.nix
@@ -1,10 +1,10 @@
 { lib, mkCoqDerivation, coq, interval, compcert, flocq, bignums, version ? null }:
 
-with lib; mkCoqDerivation {
+let self = with lib; mkCoqDerivation {
   pname = "vcfloat";
   owner = "VeriNum";
   inherit version;
-  sourceRoot = "source/vcfloat";
+  sourceRoot = "${self.src.name}/vcfloat";
   postPatch = ''
     coq_makefile -o Makefile -f _CoqProject *.v
   '';
@@ -21,4 +21,5 @@ with lib; mkCoqDerivation {
     maintainers = with maintainers; [ quinn-dougherty ];
     license = licenses.lgpl3Plus;
   };
-}
+};
+in self

--- a/pkgs/development/libraries/mpfi/default.nix
+++ b/pkgs/development/libraries/mpfi/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-aj/QmJ38ifsW36JFQcbp55aIQRvOpiqLHwEh/aFXsgo=";
   };
 
-  sourceRoot = "source/mpfi";
+  sourceRoot = "${src.name}/mpfi";
 
   nativeBuildInputs = [ autoreconfHook texinfo ];
   buildInputs = [ mpfr ];

--- a/pkgs/development/php-packages/opentelemetry/default.nix
+++ b/pkgs/development/php-packages/opentelemetry/default.nix
@@ -2,7 +2,7 @@
 
 let
   version = "1.0.1";
-in buildPecl {
+in buildPecl rec {
   inherit version;
   pname = "opentelemetry";
 
@@ -13,7 +13,7 @@ in buildPecl {
     hash = "sha256-VHUzRhTtHygHoW+poItaphV+mxe4rmmSfGgesUgPz8Q=";
   };
 
-  sourceRoot = "source/ext";
+  sourceRoot = "${src.name}/ext";
 
   doCheck = true;
 

--- a/pkgs/development/python-modules/bootstrap/flit-core/default.nix
+++ b/pkgs/development/python-modules/bootstrap/flit-core/default.nix
@@ -4,11 +4,11 @@
 , flit-core
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "${python.libPrefix}-bootstrap-${flit-core.pname}";
   inherit (flit-core) version src patches meta;
 
-  sourceRoot = "source/flit_core";
+  sourceRoot = "${src.name}/flit_core";
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/development/python-modules/catboost/default.nix
+++ b/pkgs/development/python-modules/catboost/default.nix
@@ -13,11 +13,11 @@
 , wheel
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   inherit (catboost) pname version src meta;
   format = "pyproject";
 
-  sourceRoot = "source/catboost/python-package";
+  sourceRoot = "${src.name}/catboost/python-package";
 
   nativeBuildInputs = [
     setuptools

--- a/pkgs/development/python-modules/daqp/default.nix
+++ b/pkgs/development/python-modules/daqp/default.nix
@@ -8,7 +8,7 @@
 , wheel
 , numpy
 }:
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "daqp";
   version = "0.5.1";
   format = "pyproject";
@@ -20,7 +20,7 @@ buildPythonPackage {
     hash = "sha256-in7Ci/wM7i0csJ4XVfo1lboWOyfuuU+8E+TzGmMV3x0=";
   };
 
-  sourceRoot = "source/interfaces/daqp-python";
+  sourceRoot = "${src.name}/interfaces/daqp-python";
 
   postPatch = ''
     sed -i 's|../../../daqp|../..|' setup.py

--- a/pkgs/development/python-modules/flit-core/default.nix
+++ b/pkgs/development/python-modules/flit-core/default.nix
@@ -10,7 +10,7 @@ buildPythonPackage rec {
 
   inherit (flit) src patches;
 
-  sourceRoot = "source/flit_core";
+  sourceRoot = "${src.name}/flit_core";
 
   # Tests are run in the "flit" package.
   doCheck = false;

--- a/pkgs/development/python-modules/kanidm/default.nix
+++ b/pkgs/development/python-modules/kanidm/default.nix
@@ -22,7 +22,7 @@ let
   pname = "kanidm";
   version = "0.0.3-unstable-2023-08-23";
 in
-buildPythonPackage {
+buildPythonPackage rec {
   inherit pname version;
   pyproject = true;
 
@@ -35,7 +35,7 @@ buildPythonPackage {
     hash = "sha256-5qQb+Itguw2v1Wdvc2vp00zglfvNd3LFEDvaweRJcOc=";
   };
 
-  sourceRoot = "source/pykanidm";
+  sourceRoot = "${src.name}/pykanidm";
 
   nativeBuildInputs = [
     poetry-core

--- a/pkgs/development/python-modules/linien-client/default.nix
+++ b/pkgs/development/python-modules/linien-client/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   inherit (linien-common) src version;
 
-  sourceRoot = "source/linien-client";
+  sourceRoot = "${src.name}/linien-client";
 
   preBuild = ''
     export HOME=$(mktemp -d)

--- a/pkgs/development/python-modules/linien-common/default.nix
+++ b/pkgs/development/python-modules/linien-common/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     hash = "sha256-ZgAp1SEiHijyjK74VZyRLYY3Hzfc3BQ6cnoO3hZzvbE=";
   };
 
-  sourceRoot = "source/linien-common";
+  sourceRoot = "${src.name}/linien-common";
 
   preBuild = ''
     export HOME=$(mktemp -d)

--- a/pkgs/development/python-modules/openllm-client/default.nix
+++ b/pkgs/development/python-modules/openllm-client/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.8";
 
-  sourceRoot = "source/openllm-client";
+  sourceRoot = "${src.name}/openllm-client";
 
   postPatch = ''
     substituteInPlace pyproject.toml \

--- a/pkgs/development/python-modules/openllm-core/default.nix
+++ b/pkgs/development/python-modules/openllm-core/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     hash = "sha256-kRR715Vnt9ZAmxuWvtH0z093crH0JFrEKPtbjO3QMRc=";
   };
 
-  sourceRoot = "source/openllm-core";
+  sourceRoot = "${src.name}/openllm-core";
 
   nativeBuildInputs = [
     pythonRelaxDepsHook

--- a/pkgs/development/python-modules/openllm/default.nix
+++ b/pkgs/development/python-modules/openllm/default.nix
@@ -51,7 +51,7 @@ buildPythonPackage rec {
 
   disabled = pythonOlder "3.8";
 
-  sourceRoot = "source/openllm-python";
+  sourceRoot = "${src.name}/openllm-python";
 
   nativeBuildInputs = [
     pythonRelaxDepsHook

--- a/pkgs/development/python-modules/pendulum/3.nix
+++ b/pkgs/development/python-modules/pendulum/3.nix
@@ -44,7 +44,7 @@ buildPythonPackage rec {
   cargoRoot = "rust";
   cargoDeps = rustPlatform.fetchCargoTarball {
     inherit src;
-    sourceRoot = "source/rust";
+    sourceRoot = "${src.name}/rust";
     name = "${pname}-${version}";
     hash = "sha256-6fw0KgnPIMfdseWcunsGjvjVB+lJNoG3pLDqkORPJ0I=";
     postPatch = ''

--- a/pkgs/development/python-modules/prophet/default.nix
+++ b/pkgs/development/python-modules/prophet/default.nix
@@ -32,7 +32,7 @@ buildPythonPackage rec {
     hash = "sha256-liTg5Hm+FPpRQajBnnJKBh3JPGyu0Hflntf0isj1FiQ=";
   };
 
-  sourceRoot = "source/python";
+  sourceRoot = "${src.name}/python";
 
   env.PROPHET_REPACKAGE_CMDSTAN = "false";
 

--- a/pkgs/development/python-modules/sudachidict/default.nix
+++ b/pkgs/development/python-modules/sudachidict/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
     hash = "sha256-xJ/iPywOZA2kzHaVU43Bc8TUboj3OpDg1kLFMIc/T90=";
   };
 
-  sourceRoot = "source/python";
+  sourceRoot = "${src.name}/python";
 
   # setup script tries to get data from the network but we use the nixpkgs' one
   postPatch = ''

--- a/pkgs/development/tools/electron/common.nix
+++ b/pkgs/development/tools/electron/common.nix
@@ -34,9 +34,11 @@ in (chromium.override { upstream-info = info.chromium; }).mkDerivation (base: {
     yarnLock = (fetchdep info.deps."src/electron") + "/yarn.lock";
     sha256 = info.electron_yarn_hash;
   };
-  npmDeps = fetchNpmDeps {
+  npmDeps = fetchNpmDeps rec {
     src = fetchdep info.deps."src";
-    sourceRoot = "source/third_party/node";
+    # Assume that the fetcher always unpack the source,
+    # based on update.py
+    sourceRoot = "${src.name}/third_party/node";
     hash = info.chromium_npm_hash;
   };
 

--- a/pkgs/development/tools/gendef/default.nix
+++ b/pkgs/development/tools/gendef/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-0vbAHSN+uwxoXXZtbuycP67PxjcB8Ftxd/Oij1gqE3Y=";
   };
 
-  sourceRoot = "mingw-w64/mingw-w64-tools/gendef";
+  sourceRoot = "${finalAttrs.src.name}/mingw-w64-tools/gendef";
 
   meta = {
     description = "A tool which generate def files from DLLs";

--- a/pkgs/os-specific/linux/opensnitch-ebpf/default.nix
+++ b/pkgs/os-specific/linux/opensnitch-ebpf/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   inherit (opensnitch) src;
 
-  sourceRoot = "source/ebpf_prog";
+  sourceRoot = "${src.name}/ebpf_prog";
 
   nativeBuildInputs = with llvmPackages; [
     bc

--- a/pkgs/os-specific/linux/tailor-gui/default.nix
+++ b/pkgs/os-specific/linux/tailor-gui/default.nix
@@ -15,7 +15,7 @@
 }:
 let
   src = tuxedo-rs.src;
-  sourceRoot = "source/tailor_gui";
+  sourceRoot = "${src.name}/tailor_gui";
   pname = "tailor_gui";
   version = "0.2.3";
 in

--- a/pkgs/servers/monitoring/openobserve/default.nix
+++ b/pkgs/servers/monitoring/openobserve/default.nix
@@ -27,7 +27,7 @@ let
     inherit src version;
     pname = "openobserve-ui";
 
-    sourceRoot = "source/web";
+    sourceRoot = "${src.name}/web";
 
     npmDepsHash = "sha256-RNUCR80ewFt9F/VHv7kXLa87h0fz0YBp+9gSOUhtrdU=";
 

--- a/pkgs/tools/misc/SP800-90B_EntropyAssessment/default.nix
+++ b/pkgs/tools/misc/SP800-90B_EntropyAssessment/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
       --replace "-march=native" ""
   '';
 
-  sourceRoot = "source/cpp";
+  sourceRoot = "${src.name}/cpp";
 
   makeFlags = [
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"

--- a/pkgs/tools/misc/mpremote/default.nix
+++ b/pkgs/tools/misc/mpremote/default.nix
@@ -17,7 +17,7 @@ buildPythonApplication rec {
     rev = "refs/tags/v${version}";
     hash = "sha256-67CAR34VrMOzvNkukDeGRnUfoOLO66R37wsrRHjpp5E=";
   };
-  sourceRoot = "source/tools/mpremote";
+  sourceRoot = "${src.name}/tools/mpremote";
   format = "pyproject";
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

According to [Nixpkgs manual](https://nixos.org/manual/nixpkgs/unstable/#var-stdenv-sourceRoot) and [NixOS 23.11 Release Note](https://nixos.org/manual/nixos/stable/release-notes#sec-release-23.11), the `sourceRoot` attribute passed to `stdenv.mkDerivation` should be specified as `"${src.name}"` or `"${src.name}/subdir"` when `src` is produced using `fetchgit`-based fetchers.

`sourceRoot = "source"` or `sourceRoot = "source/subdir"` is based on the assumption that the `name` attribute of these pre-unpacked fetchers are always `"source"`, which is not the case. Expecting constant `name` also makes the source FODs prone to irrelevent hashes during version bumps.

This PR should cause no rebuild. As the issue occurs also on the stable branch, we could also backport this fix to the stable branch.

This is a continuation of #245388 and an initial effort for #294068.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux (no rebuild)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
