### PR TITLE
terraform-cloud-agent: init at 1.13.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -589,6 +589,7 @@
   ./services/home-automation/matter-server.nix
   ./services/home-automation/zigbee2mqtt.nix
   ./services/home-automation/zwave-js.nix
+  ./services/infrastructure/terraform-cloud-agent/default.nix
   ./services/logging/SystemdJournal2Gelf.nix
   ./services/logging/awstats.nix
   ./services/logging/filebeat.nix

--- a/nixos/modules/services/infrastructure/terraform-cloud-agent/default.nix
+++ b/nixos/modules/services/infrastructure/terraform-cloud-agent/default.nix
@@ -1,0 +1,187 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.terraform-cloud-agent;
+
+  packageWithMain = lib.types.addCheck lib.types.package (x: x ? meta.mainProgram);
+in
+{
+  options.services.terraform-cloud-agent = {
+    enable = lib.mkEnableOption "terraform-cloud-agent";
+
+    tokenPath = lib.mkOption {
+      type = lib.types.str;
+      default = "$CONFIGURATION_DIRECTORY/token";
+      description = lib.mdDoc "Path to the Terraform Cloud token this agent should use.";
+      example = "/etc/terraform-cloud-agent/token";
+    };
+
+    hooks = lib.mkOption {
+      description = lib.mdDoc "Set of hooks the TFC agent should run (if any).";
+      default = {};
+      type = lib.types.submodule {
+        options = {
+          pre-plan = lib.mkOption {
+            type = lib.types.nullOr packageWithMain;
+            default = null;
+            description = lib.mdDoc "Terraform pre-plan hook script.";
+            example = lib.literalExpression ''
+              pkgs.writeShellApplication {
+                name = "pre-plan";
+                text = "echo 'TESTING 123'";
+              };
+            '';
+          };
+
+          post-plan = lib.mkOption {
+            type = lib.types.nullOr packageWithMain;
+            default = null;
+            description = lib.mdDoc "Terraform post-plan hook script.";
+          };
+
+          pre-apply = lib.mkOption {
+            type = lib.types.nullOr packageWithMain;
+            default = null;
+            description = lib.mdDoc "Terraform pre-apply hook script.";
+          };
+
+          post-apply = lib.mkOption {
+            type = lib.types.nullOr packageWithMain;
+            default = null;
+            description = lib.mdDoc "Terraform post-apply hook script.";
+          };
+        };
+      };
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "tfc-agent";
+      description = lib.mdDoc "User account under which terraform-cloud-agent runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "tfc-agent";
+      description = lib.mdDoc "Group account under which terraform-cloud-agent runs.";
+    };
+
+    flags = lib.mkOption {
+      description = lib.mdDoc "Set of NixOS options that are used as flags to the tfc-agent executable.";
+      type = lib.types.submodule {
+        freeformType = lib.types.attrsOf lib.types.str;
+
+        options = {
+          name = lib.mkOption {
+            type = lib.types.str;
+            description = lib.mdDoc "Name of the tfc-agent process.";
+            example = "silly-rhino-balderdash";
+          };
+
+          log-level = lib.mkOption {
+            type = lib.types.nullOr (lib.types.enum [ "trace" "debug" "info" "warn" "error" ]);
+            default = null;
+            description = lib.mdDoc "Level at which log messages should be emitted.";
+            example = "warn";
+          };
+
+          address = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            description = lib.mdDoc "HTTP or HTTPS address of the Terraform Cloud API.";
+            example = "https://app.terraform.io";
+          };
+
+          accept = lib.mkOption {
+            type = lib.types.commas;
+            default = "plan,apply,policy,assessment";
+            description = lib.mdDoc "Optional string of comma-separated job types that this agent may run. Acceptable job types are 'plan', 'apply', 'policy', and 'assessment'. Do not put whitespace in between entries.";
+            example = "plan,apply";
+          };
+
+          auto-update = lib.mkOption {
+            type = lib.types.str;
+            readOnly = true;
+            default = "disabled";
+            description = lib.mdDoc "Controls automatic core updates behavior. Not acceptable in NixOS, so disabled.";
+          };
+        };
+      };
+    };
+  };
+
+  config = {
+    systemd.services.terraform-cloud-agent = lib.mkIf cfg.enable {
+      description = "Agent that executes plans from Terraform Cloud";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+
+      preStart =
+        let
+          linkHook = name: pkg: if (pkg != null) then ''
+            ln -f -s ${lib.getExe pkg} $STATE_DIRECTORY/hooks/terraform-${name}
+          '' else ''
+            rm -f $STATE_DIRECTORY/hooks/terraform-${name}
+          '';
+        in ''
+          mkdir -p $STATE_DIRECTORY/hooks
+
+          ${lib.concatStringsSep "\n" (lib.mapAttrsToList linkHook cfg.hooks)}
+        '';
+
+      script = ''
+        export TFC_AGENT_TOKEN=$(${pkgs.coreutils}/bin/cat ${cfg.tokenPath})
+        export TFC_AGENT_DATA_DIR=$STATE_DIRECTORY
+        export TFC_AGENT_CACHE_DIR=$CACHE_DIRECTORY
+    
+        ${lib.getExe pkgs.terraform-cloud-agent} ${lib.cli.toGNUCommandLineShell { mkOptionName = k: "-${k}"; } cfg.flags}
+      '';
+
+      serviceConfig = {
+        StateDirectory = "terraform-cloud-agent";
+        CacheDirectory = "terraform-cloud-agent";
+
+        ConfigurationDirectory = "terraform-cloud-agent";
+
+        # User and group
+        User = cfg.user;
+        Group = cfg.group;
+
+        # Below shamelessly cribbed from the nginx module: https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/web-servers/nginx/default.nix
+
+        # Security
+        NoNewPrivileges = true;
+
+        # Sandboxing (sorted by occurrence in https://www.freedesktop.org/software/systemd/man/systemd.exec.html)
+        ProtectSystem = "strict";
+        ProtectHome = lib.mkDefault true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectHostname = true;
+        ProtectClock = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" ];
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        RemoveIPC = true;
+        PrivateMounts = true;
+      };
+    };
+
+    users.users = lib.mkIf (cfg.user == "tfc-agent") {
+      "tfc-agent" = {
+        group = cfg.group;
+        isSystemUser = true;
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == "tfc-agent") {
+      "tfc-agent" = { };
+    };
+  };
+}

--- a/pkgs/by-name/te/terraform-cloud-agent/default.nix
+++ b/pkgs/by-name/te/terraform-cloud-agent/default.nix
@@ -1,0 +1,31 @@
+{ lib, stdenv, fetchzip }:
+
+stdenv.mkDerivation rec {
+  pname = "tfc-agent";
+  version = "1.13.0";
+  src = fetchzip {
+    url = "https://releases.hashicorp.com/tfc-agent/${version}/tfc-agent_${version}_linux_amd64.zip";
+    sha256 = "sha256-juhTmxf5+6pGare598HKu8ha5Mxs5RaGWQima/jpf2o=";
+    stripRoot = false;
+  };
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install tfc-agent* $out/bin/
+  '';
+
+  meta = {
+    description = "Polling Terraform Cloud Agent";
+    license = lib.licenses.unfree;
+    homepage = "https://developer.hashicorp.com/terraform/cloud-docs/agents";
+    sourceProvenance = [
+      lib.sourceTypes.binaryNativeCode
+    ];
+
+    platforms = [
+      "x86_64-linux"
+    ];
+
+    mainProgram = "tfc-agent";
+  };
+}


### PR DESCRIPTION
This change adds a derivation for the [`terraform-cloud-agent`][1] proprietary executable from Hashicorp and a NixOS module that defines a systemd service for running that agent.

[1]: https://developer.hashicorp.com/terraform/cloud-docs/agents.

## Description of changes

This change adds:

- a new package derivation for the `terraform-cloud-agent` Go executable; and,
- a new NixOS module for running that executable as a systemd service.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).