### PR TITLE
advantagescope: init at 3.2.0

### DIFF
--- a/pkgs/by-name/ad/advantagescope/package.nix
+++ b/pkgs/by-name/ad/advantagescope/package.nix
@@ -1,0 +1,50 @@
+{ lib, stdenv, fetchurl, appimageTools, makeDesktopItem }:
+
+let
+  pname = "advantagescope";
+  version = "3.2.0";
+
+  desktopItem = makeDesktopItem {
+    type = "Application";
+    name = "AdvantageScope";
+    desktopName = "AdvantageScope";
+    comment = "Robot telemetry viewer for FIRST Robotics Competition teams";
+    icon = "advantagescope";
+    exec = "advantagescope %u";
+  };
+
+  icon = fetchurl {
+    url = "https://raw.githubusercontent.com/Mechanical-Advantage/AdvantageScope/v${version}/icons/window-icon.png";
+    hash = "sha256-gqcCqthqM2g4sylg9zictKwRggbaALQk9ln/NaFHxdY=";
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname version;
+
+  src = {
+    x86_64-linux = fetchurl {
+      url = "https://github.com/Mechanical-Advantage/AdvantageScope/releases/download/v${version}/advantagescope-linux-x64-v${version}.AppImage";
+      hash = "sha256-VLHcJVRYdAf1TEGmKvSJKauJwnUvHNG67WhX1rj8rKk=";
+    };
+
+    aarch64-linux = fetchurl {
+      url = "https://github.com/Mechanical-Advantage/AdvantageScope/releases/download/v${version}/advantagescope-linux-arm64-v${version}.AppImage";
+      hash = "sha256-FAhJr8PFDhkR03WWT/FvIAJhrnR2tcBWCv8NqrPL7oM=";
+    };
+  }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  extraInstallCommands = ''
+    mv $out/bin/${pname}-${version} $out/bin/${pname}
+    install -D "${desktopItem}/share/applications/"* -t $out/share/applications/
+    install -D ${icon} $out/share/pixmaps/advantagescope.png
+  '';
+
+  meta = with lib; {
+    description = "Robot telemetry viewer for FIRST Robotics Competition teams";
+    homepage = "https://github.com/Mechanical-Advantage/AdvantageScope";
+    license = licenses.mit;
+    mainProgram = "advantagescope";
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    maintainers = with maintainers; [ max-niederman ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds [AdvantageScope](https://github.com/Mechanical-Advantage/AdvantageScope), a log viewer, diagnostics, and data visualization tool used by [FIRST Robotics Competition](https://www.firstinspires.org/robotics/frc) teams. This is part of a wider effort of mine to make NixOS more usable for FRC development.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
