### PR TITLE
d-spy: 1.8.0 -> 1.9.0

### DIFF
--- a/pkgs/development/tools/misc/d-spy/default.nix
+++ b/pkgs/development/tools/misc/d-spy/default.nix
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation rec {
   pname = "d-spy";
-  version = "1.8.0";
+  version = "1.9.0";
 
   outputs = [ "out" "lib" "dev" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/d-spy/${lib.versions.majorMinor version}/d-spy-${version}.tar.xz";
-    sha256 = "+J15XQaG2C2h3OsjYUj3zlTVynjwuY4PEzayY6WvzqE=";
+    hash = "sha256-NytrpYzhwQFl3RR+vus5kQSP1tgCOe6ajbYn91yCjzY=";
   };
 
   nativeBuildInputs = [
@@ -54,6 +54,7 @@ stdenv.mkDerivation rec {
       lgpl3Plus # library
       gpl3Plus # app
     ];
+    mainProgram = "d-spy";
     maintainers = teams.gnome.members;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
## Description of changes

Not updating to 1.9.1 because

```
../src/main.c:84:12: error: implicit declaration of function 'adw_about_dialog_new'; did you mean 'gtk_about_dialog_new'? [-Werror=implicit-function-declaration]
   84 |   dialog = adw_about_dialog_new ();
      |            ^~~~~~~~~~~~~~~~~~~~
      |            gtk_about_dialog_new
../src/main.c:84:12: warning: nested extern declaration of 'adw_about_dialog_new' [-Wnested-externs]
../src/main.c:84:10: error: assignment to 'int *' from 'int' makes pointer from integer without a cast [-Werror=int-conversion]
   84 |   dialog = adw_about_dialog_new ();
      |          ^
../src/main.c:85:3: error: implicit declaration of function 'adw_about_dialog_set_application_name'; did you mean 'adw_about_window_set_application_name'? [-Werror=implicit-function-declaration]
   85 |   adw_about_dialog_set_application_name (ADW_ABOUT_DIALOG(dialog), _("D-Spy"));
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |   adw_about_window_set_application_name
../src/main.c:85:3: warning: nested extern declaration of 'adw_about_dialog_set_application_name' [-Wnested-externs]
../src/main.c:85:42: error: implicit declaration of function 'ADW_ABOUT_DIALOG'; did you mean 'GTK_ABOUT_DIALOG'? [-Werror=implicit-function-declaration]
   85 |   adw_about_dialog_set_application_name (ADW_ABOUT_DIALOG(dialog), _("D-Spy"));
      |                                          ^~~~~~~~~~~~~~~~
      |                                          GTK_ABOUT_DIALOG
../src/main.c:85:42: warning: nested extern declaration of 'ADW_ABOUT_DIALOG' [-Wnested-externs]
../src/main.c:86:3: error: implicit declaration of function 'adw_about_dialog_set_application_icon'; did you mean 'adw_about_window_set_application_icon'? [-Werror=implicit-function-declaration]
   86 |   adw_about_dialog_set_application_icon (ADW_ABOUT_DIALOG(dialog), PACKAGE_ICON_NAME);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |   adw_about_window_set_application_icon
../src/main.c:86:3: warning: nested extern declaration of 'adw_about_dialog_set_application_icon' [-Wnested-externs]
../src/main.c:87:3: error: implicit declaration of function 'adw_about_dialog_set_developers'; did you mean 'adw_about_window_set_developers'? [-Werror=implicit-function-declaration]
   87 |   adw_about_dialog_set_developers (ADW_ABOUT_DIALOG(dialog), authors);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |   adw_about_window_set_developers
../src/main.c:87:3: warning: nested extern declaration of 'adw_about_dialog_set_developers' [-Wnested-externs]
../src/main.c:88:3: error: implicit declaration of function 'adw_about_dialog_set_designers'; did you mean 'adw_about_window_set_designers'? [-Werror=implicit-function-declaration]
   88 |   adw_about_dialog_set_designers (ADW_ABOUT_DIALOG(dialog), artists);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |   adw_about_window_set_designers
../src/main.c:88:3: warning: nested extern declaration of 'adw_about_dialog_set_designers' [-Wnested-externs]
../src/main.c:92:3: error: implicit declaration of function 'adw_about_dialog_set_version'; did you mean 'gtk_about_dialog_set_version'? [-Werror=implicit-function-declaration]
   92 |   adw_about_dialog_set_version (ADW_ABOUT_DIALOG(dialog), SYMBOLIC_VERSION);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |   gtk_about_dialog_set_version
../src/main.c:92:3: warning: nested extern declaration of 'adw_about_dialog_set_version' [-Wnested-externs]
../src/main.c:94:3: error: implicit declaration of function 'adw_about_dialog_set_copyright'; did you mean 'gtk_about_dialog_set_copyright'? [-Werror=implicit-function-declaration]
   94 |   adw_about_dialog_set_copyright (ADW_ABOUT_DIALOG(dialog), "© 2019-2021 Christian Hergert");
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |   gtk_about_dialog_set_copyright
../src/main.c:94:3: warning: nested extern declaration of 'adw_about_dialog_set_copyright' [-Wnested-externs]
../src/main.c:95:3: error: implicit declaration of function 'adw_about_dialog_set_license_type'; did you mean 'gtk_about_dialog_set_license_type'? [-Werror=implicit-function-declaration]
   95 |   adw_about_dialog_set_license_type (ADW_ABOUT_DIALOG(dialog), GTK_LICENSE_GPL_3_0);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |   gtk_about_dialog_set_license_type
../src/main.c:95:3: warning: nested extern declaration of 'adw_about_dialog_set_license_type' [-Wnested-externs]
../src/main.c:96:3: error: implicit declaration of function 'adw_about_dialog_set_website'; did you mean 'gtk_about_dialog_set_website'? [-Werror=implicit-function-declaration]
   96 |   adw_about_dialog_set_website (ADW_ABOUT_DIALOG(dialog), PACKAGE_WEBSITE);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |   gtk_about_dialog_set_website
../src/main.c:96:3: error: implicit declaration of function 'adw_about_dialog_set_website'; did you mean 'gtk_about_dialog_set_website'? [-Werror=implicit-function-declaration]
   96 |   adw_about_dialog_set_website (ADW_ABOUT_DIALOG(dialog), PACKAGE_WEBSITE);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |   gtk_about_dialog_set_website
../src/main.c:96:3: warning: nested extern declaration of 'adw_about_dialog_set_website' [-Wnested-externs]
../src/main.c:97:3: error: implicit declaration of function 'adw_about_dialog_set_issue_url'; did you mean 'adw_about_window_set_issue_url'? [-Werror=implicit-function-declaration]
   97 |   adw_about_dialog_set_issue_url (ADW_ABOUT_DIALOG(dialog), "https://gitlab.gnome.org/GNOME/d-spy/-/issues/new");
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |   adw_about_window_set_issue_url
../src/main.c:97:3: warning: nested extern declaration of 'adw_about_dialog_set_issue_url' [-Wnested-externs]
../src/main.c:101:3: error: implicit declaration of function 'adw_dialog_present' [-Werror=implicit-function-declaration]
  101 |   adw_dialog_present (ADW_DIALOG (dialog), GTK_WIDGET(window));
      |   ^~~~~~~~~~~~~~~~~~
../src/main.c:101:3: warning: nested extern declaration of 'adw_dialog_present' [-Wnested-externs]
../src/main.c:101:23: error: implicit declaration of function 'ADW_DIALOG'; did you mean 'GTK_DIALOG'? [-Werror=implicit-function-declaration]
  101 |   adw_dialog_present (ADW_DIALOG (dialog), GTK_WIDGET(window));
      |                       ^~~~~~~~~~
      |                       GTK_DIALOG
../src/main.c:101:23: warning: nested extern declaration of 'ADW_DIALOG' [-Wnested-externs]

```

Seems like it's needing a newer version of gtk4/libadwaita.

This update is tested.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
