### PR TITLE
borgmatic: add enableApprise attr and package option

### DIFF
--- a/nixos/modules/services/backup/borgmatic.nix
+++ b/nixos/modules/services/backup/borgmatic.nix
@@ -61,6 +61,8 @@ in
   options.services.borgmatic = {
     enable = mkEnableOption "borgmatic";
 
+    package = mkPackageOption pkgs "borgmatic" { };
+
     settings = mkOption {
       description = ''
         See https://torsion.org/borgmatic/docs/reference/configuration/
@@ -103,11 +105,11 @@ in
             "`services.borgmatic.configurations.<name>.location` is deprecated, please move your options out of sections to the global scope"
         ;
 
-        environment.systemPackages = [ pkgs.borgmatic ];
+        environment.systemPackages = [ cfg.package ];
 
         environment.etc = configFiles;
 
-        systemd.packages = [ pkgs.borgmatic ];
+        systemd.packages = [ cfg.package ];
 
         # Workaround: https://github.com/NixOS/nixpkgs/issues/81138
         systemd.timers.borgmatic.wantedBy = [ "timers.target" ];

--- a/pkgs/tools/backup/borgmatic/default.nix
+++ b/pkgs/tools/backup/borgmatic/default.nix
@@ -2,6 +2,7 @@
   borgbackup,
   borgmatic,
   coreutils,
+  enableApprise ? false,
   enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
   fetchPypi,
   installShellFiles,
@@ -21,7 +22,7 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-WYs7wiwZ1TvTdeUpWv7FbREXWfdGcYRarP4FXFOfp0Y=";
   };
 
-  nativeCheckInputs = with python3Packages; [ flexmock pytestCheckHook pytest-cov ] ++ optional-dependencies.apprise;
+  nativeCheckInputs = with python3Packages; [ flexmock pytestCheckHook pytest-cov apprise ];
 
   # - test_borgmatic_version_matches_news_version
   # The file NEWS not available on the pypi source, and this test is useless
@@ -39,11 +40,7 @@ python3Packages.buildPythonApplication rec {
     requests
     ruamel-yaml
     setuptools
-  ];
-
-  optional-dependencies = {
-    apprise = [ python3Packages.apprise ];
-  };
+  ] ++ lib.optional enableApprise apprise;
 
   postInstall = ''
     installShellCompletion --cmd borgmatic \


### PR DESCRIPTION
## Description of changes

In the last PR #264104, I introduced the `optional-dependencies.apprise` attrs to support Apprise as an optional dependency.

Later I realized `optional-dependencies` are more complicated than to use a simple bool parameter.

For example, if I want to use borgmatic with apprise support, I have to use following overlay code.

```
  borgmatic = (with prev.python3Packages;
    toPythonApplication (channels.latest.borgmatic.overridePythonAttrs
      (oldAttrs: {
        propagatedBuildInputs = oldAttrs.propagatedBuildInputs
          ++ channels.latest.borgmatic.optional-dependencies.apprise;
      })));
```

But if we're using `enableApprise` flag, it's more simple and easy to read.

```
  borgmatic = pkgs.borgmatic.override { enableApprise = true; };
```

I asked some friends, and they told me `optional-dependencies` are designed for Python library, so as a Python application, I think it should be fine not to use the `optional-dependencies`

The next change I made is adding a `package` option to the systemd services, so that the user doesn't need to use overlay to override the package.

cc @Pizmovc @tomodachi94

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
