### PR TITLE
nixos/gatus: init module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16477,6 +16477,12 @@
     githubId = 14542417;
     name = "Sergey Ichtchenko";
   };
+  pizzapim = {
+    email = "pim@kunis.nl";
+    github = "pizzapim";
+    githubId = 23135512;
+    name = "Pim Kunis";
+  };
   pjbarnoy = {
     email = "pjbarnoy@gmail.com";
     github = "waaamb";

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -113,6 +113,8 @@
 
 - [Localsend](https://localsend.org/), an open source cross-platform alternative to AirDrop. Available as [programs.localsend](#opt-programs.localsend.enable).
 
+- [Gatus](https://github.com/TwiN/gatus), an automated developer-oriented status page. Available as [services.gatus](#opt-services.gatus.enable).
+
 - [cryptpad](https://cryptpad.org/), a privacy-oriented collaborative platform (docs/drive/etc), has been added back. Available as [services.cryptpad](#opt-services.cryptpad.enable).
 
 - [realm](https://github.com/zhboner/realm), a simple, high performance relay server written in rust. Available as [services.realm.enable](#opt-services.realm.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -882,6 +882,7 @@
   ./services/monitoring/datadog-agent.nix
   ./services/monitoring/do-agent.nix
   ./services/monitoring/fusion-inventory.nix
+  ./services/monitoring/gatus.nix
   ./services/monitoring/goss.nix
   ./services/monitoring/grafana-agent.nix
   ./services/monitoring/grafana-image-renderer.nix

--- a/nixos/modules/services/monitoring/gatus.nix
+++ b/nixos/modules/services/monitoring/gatus.nix
@@ -1,0 +1,132 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+let
+  cfg = config.services.gatus;
+
+  settingsFormat = pkgs.formats.yaml { };
+
+  inherit (lib)
+    getExe
+    literalExpression
+    maintainers
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    ;
+
+  inherit (lib.types)
+    bool
+    int
+    nullOr
+    path
+    submodule
+    ;
+in
+{
+  options.services.gatus = {
+    enable = mkEnableOption "Gatus";
+
+    package = mkPackageOption pkgs "gatus" { };
+
+    configFile = mkOption {
+      type = path;
+      default = settingsFormat.generate "gatus.yaml" cfg.settings;
+      defaultText = literalExpression ''
+        let settingsFormat = pkgs.formats.yaml { }; in settingsFormat.generate "gatus.yaml" cfg.settings;
+      '';
+      description = ''
+        Path to the Gatus configuration file.
+        Overrides any configuration made using the `settings` option.
+      '';
+    };
+
+    environmentFile = mkOption {
+      type = nullOr path;
+      default = null;
+      description = ''
+        File to load as environment file.
+        Environmental variables from this file can be interpolated in the configuration file using `''${VARIABLE}`.
+        This is useful to avoid putting secrets into the nix store.
+      '';
+    };
+
+    settings = mkOption {
+      type = submodule {
+        freeformType = settingsFormat.type;
+        options = {
+          web.port = mkOption {
+            type = int;
+            default = 8080;
+            description = ''
+              The TCP port to serve the Gatus service at.
+            '';
+          };
+        };
+      };
+
+      default = { };
+
+      example = literalExpression ''
+        {
+          web.port = 8080;
+          endpoints = [{
+            name = "website";
+            url = "https://twin.sh/health";
+            interval = "5m";
+            conditions = [
+              "[STATUS] == 200"
+              "[BODY].status == UP"
+              "[RESPONSE_TIME] < 300"
+            ];
+          }];
+        }
+      '';
+
+      description = ''
+        Configuration for Gatus.
+        Supported options can be found at the [docs](https://gatus.io/docs).
+      '';
+    };
+
+    openFirewall = mkOption {
+      type = bool;
+      default = false;
+      description = ''
+        Whether to open the firewall for the Gatus web interface.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.gatus = {
+      description = "Automated developer-oriented status page";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        DynamicUser = true;
+        User = "gatus";
+        Group = "gatus";
+        Type = "simple";
+        Restart = "on-failure";
+        ExecStart = getExe cfg.package;
+        StateDirectory = "gatus";
+        SyslogIdentifier = "gatus";
+        EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
+      };
+
+      environment = {
+        GATUS_CONFIG_PATH = cfg.configFile;
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall [ cfg.settings.web.port ];
+  };
+
+  meta.maintainers = with maintainers; [ pizzapim ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -365,6 +365,7 @@ in {
   mimir = handleTest ./mimir.nix {};
   gancio = handleTest ./gancio.nix {};
   garage = handleTest ./garage {};
+  gatus = runTest ./gatus.nix;
   gemstash = handleTest ./gemstash.nix {};
   geoserver = runTest ./geoserver.nix;
   gerrit = handleTest ./gerrit.nix {};

--- a/nixos/tests/gatus.nix
+++ b/nixos/tests/gatus.nix
@@ -1,0 +1,34 @@
+{ pkgs, ... }:
+{
+  name = "gatus";
+  meta.maintainers = with pkgs.lib.maintainers; [ pizzapim ];
+
+  nodes.machine =
+    { ... }:
+    {
+      services.gatus = {
+        enable = true;
+
+        settings = {
+          web.port = 8080;
+          metrics = true;
+
+          endpoints = [
+            {
+              name = "metrics";
+              url = "http://localhost:8080/metrics";
+              interval = "1s";
+              conditions = [
+                "[STATUS] == 200"
+              ];
+            }
+          ];
+        };
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("gatus.service")
+    machine.succeed("curl -s http://localhost:8080/metrics | grep go_info")
+  '';
+}

--- a/pkgs/by-name/ga/gatus/package.nix
+++ b/pkgs/by-name/ga/gatus/package.nix
@@ -1,4 +1,9 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nixosTests,
+}:
 
 buildGoModule rec {
   pname = "gatus";
@@ -15,12 +20,15 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
-  meta = with lib;
-    {
-      description = "Automated developer-oriented status page";
-      homepage = "https://gatus.io";
-      license = licenses.asl20;
-      maintainers = with maintainers; [ undefined-moe ];
-      mainProgram = "gatus";
-    };
+  passthru.tests = {
+    inherit (nixosTests) gatus;
+  };
+
+  meta = with lib; {
+    description = "Automated developer-oriented status page";
+    homepage = "https://gatus.io";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ undefined-moe ];
+    mainProgram = "gatus";
+  };
 }


### PR DESCRIPTION
## Description of changes

In https://github.com/NixOS/nixpkgs/pull/269477, the Gatus package was added to nixpkgs. I created a NixOS module to run Gatus as a Systemd service. I have been running this myself for a week with no problems. You can see on my personal Git server how this can be used: [here](https://git.kun.is/home/nixos-servers/src/commit/01d54f8c2e0051cb688cb70fd0a953505fd4cea3/nix/modules/monitoring/gatus-endpoints.nix) I define Gatus endpoints which are services I monitor, and [here](https://git.kun.is/home/nixos-servers/src/commit/01d54f8c2e0051cb688cb70fd0a953505fd4cea3/nix/modules/monitoring/default.nix#L56) I configure the service itself.

This is my first contribution to nixpkgs so any comments are greatly appreciated!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
