### PR TITLE
coqPackages.{Vpl,VplTactic}: init at 0.5

### DIFF
--- a/pkgs/development/coq-modules/Vpl/default.nix
+++ b/pkgs/development/coq-modules/Vpl/default.nix
@@ -1,0 +1,17 @@
+{ lib, mkCoqDerivation, coq, version ? null }:
+
+mkCoqDerivation {
+  pname = "Vpl";
+  owner = "VERIMAG-Polyhedra";
+  inherit version;
+
+  defaultVersion = if lib.versions.range "8.8" "8.9" coq.coq-version then "0.5" else null;
+
+  release."0.5".sha256 = "sha256-mSD/xSweeK9WMxWDdX/vzN96iXo74RkufjuNvtzsP9o=";
+
+  sourceRoot = "source/coq";
+
+  meta = coq.ocamlPackages.vpl-core.meta // {
+    description = "Coq interface to VPL abstract domain of convex polyhedra";
+  };
+}

--- a/pkgs/development/coq-modules/VplTactic/default.nix
+++ b/pkgs/development/coq-modules/VplTactic/default.nix
@@ -1,0 +1,18 @@
+{ lib, mkCoqDerivation, coq, Vpl, version ? null }:
+
+mkCoqDerivation {
+  pname = "VplTactic";
+  owner = "VERIMAG-Polyhedra";
+  defaultVersion = if lib.versions.isEq "8.9" coq.version then "0.5" else null;
+
+  release."0.5".rev = "487e3aff8446bed2c5116cefc7d71d98a06e85de";
+  release."0.5".sha256 = "sha256-4h0hyvj9R+GOgnGWQFDi0oENLZPiJoimyK1q327qvIY=";
+
+  buildInputs = [ coq.ocamlPackages.vpl-core ];
+  propagatedBuildInputs = [ Vpl ];
+  mlPlugin = true;
+
+  meta = Vpl.meta // {
+    description = "A Coq Tactic for Arithmetic (based on VPL)";
+  };
+}

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -126,6 +126,7 @@ let
       Velisarios = callPackage ../development/coq-modules/Velisarios {};
       Verdi = callPackage ../development/coq-modules/Verdi {};
       Vpl = callPackage ../development/coq-modules/Vpl {};
+      VplTactic = callPackage ../development/coq-modules/VplTactic {};
       vscoq-language-server = callPackage ../development/coq-modules/vscoq-language-server {};
       VST = callPackage ../development/coq-modules/VST ((lib.optionalAttrs
         (lib.versionAtLeast self.coq.version "8.14") {

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -125,6 +125,7 @@ let
       vcfloat = callPackage ../development/coq-modules/vcfloat {};
       Velisarios = callPackage ../development/coq-modules/Velisarios {};
       Verdi = callPackage ../development/coq-modules/Verdi {};
+      Vpl = callPackage ../development/coq-modules/Vpl {};
       vscoq-language-server = callPackage ../development/coq-modules/vscoq-language-server {};
       VST = callPackage ../development/coq-modules/VST ((lib.optionalAttrs
         (lib.versionAtLeast self.coq.version "8.14") {


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
