### PR TITLE
nixos/duckdns: init module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15633,6 +15633,12 @@
     githubId = 30374463;
     name = "Michal S.";
   };
+  notthebee = {
+    email = "moe@notthebe.ee";
+    github = "notthebee";
+    githubId = 30384331;
+    name = "Wolfgang";
+  };
   notthemessiah = {
     email = "brian.cohen.88@gmail.com";
     github = "NOTtheMessiah";

--- a/nixos/modules/services/misc/duckdns.nix
+++ b/nixos/modules/services/misc/duckdns.nix
@@ -1,0 +1,125 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.services.duckdns;
+  duckdns = pkgs.writeShellScriptBin "duckdns" ''
+    DRESPONSE=$(curl -sS --max-time 60 --no-progress-meter -k -K- <<< "url = \"https://www.duckdns.org/update?verbose=true&domains=$DUCKDNS_DOMAINS&token=$DUCKDNS_TOKEN&ip=\"")
+    IPV4=$(echo "$DRESPONSE" | awk 'NR==2')
+    IPV6=$(echo "$DRESPONSE" | awk 'NR==3')
+    RESPONSE=$(echo "$DRESPONSE" | awk 'NR==1')
+    IPCHANGE=$(echo "$DRESPONSE" | awk 'NR==4')
+
+    if [[ "$RESPONSE" = "OK" ]] && [[ "$IPCHANGE" = "UPDATED" ]]; then
+        if [[ "$IPV4" != "" ]] && [[ "$IPV6" == "" ]]; then
+            echo "Your IP was updated at $(date) to IPv4: $IPV4"
+        elif [[ "$IPV4" == "" ]] && [[ "$IPV6" != "" ]]; then
+            echo "Your IP was updated at $(date) to IPv6: $IPV6"
+        else
+            echo "Your IP was updated at $(date) to IPv4: $IPV4 & IPv6 to: $IPV6"
+        fi
+    elif [[ "$RESPONSE" = "OK" ]] && [[ "$IPCHANGE" = "NOCHANGE" ]]; then
+        echo "DuckDNS request at $(date) successful. IP(s) unchanged."
+    else
+        echo -e "Something went wrong, please check your settings\nThe response returned was:\n$DRESPONSE\n"
+        exit 1
+    fi
+  '';
+in
+{
+  options.services.duckdns = {
+    enable = lib.mkEnableOption "DuckDNS Dynamic DNS Client";
+    tokenFile = lib.mkOption {
+      default = null;
+      type = lib.types.path;
+      description = ''
+        The path to a file containing the token
+        used to authenticate with DuckDNS.
+      '';
+    };
+
+    domains = lib.mkOption {
+      default = null;
+      type = lib.types.nullOr (lib.types.listOf lib.types.str);
+      example = [ "examplehost" ];
+      description = ''
+        The domain(s) to update in DuckDNS
+        (without the .duckdns.org suffix)
+      '';
+    };
+
+    domainsFile = lib.mkOption {
+      default = null;
+      type = lib.types.nullOr lib.types.path;
+      example = lib.literalExpression ''
+        pkgs.writeText "duckdns-domains.txt" '''
+          examplehost
+          examplehost2
+          examplehost3
+        '''
+      '';
+      description = ''
+        The path to a file containing a
+        newline-separated list of DuckDNS
+        domain(s) to be updated
+        (without the .duckdns.org suffix)
+      '';
+    };
+
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.domains != null || cfg.domainsFile != null;
+        message = "Either services.duckdns.domains or services.duckdns.domainsFile has to be defined";
+      }
+      {
+        assertion = !(cfg.domains != null && cfg.domainsFile != null);
+        message = "services.duckdns.domains and services.duckdns.domainsFile can't both be defined at the same time";
+      }
+      {
+        assertion = (cfg.tokenFile != null);
+        message = "services.duckdns.tokenFile has to be defined";
+      }
+    ];
+
+    environment.systemPackages = [ duckdns ];
+
+    systemd.services.duckdns = {
+      description = "DuckDNS Dynamic DNS Client";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      startAt = "*:0/5";
+      path = [
+        pkgs.gnused
+        pkgs.systemd
+        pkgs.curl
+        pkgs.gawk
+        duckdns
+      ];
+      serviceConfig = {
+        Type = "simple";
+        LoadCredential = [
+          "DUCKDNS_TOKEN_FILE:${cfg.tokenFile}"
+        ] ++ lib.optionals (cfg.domainsFile != null) [ "DUCKDNS_DOMAINS_FILE:${cfg.domainsFile}" ];
+        DynamicUser = true;
+      };
+      script = ''
+        export DUCKDNS_TOKEN=$(systemd-creds cat DUCKDNS_TOKEN_FILE)
+        ${lib.optionalString (cfg.domains != null) ''
+          export DUCKDNS_DOMAINS='${lib.strings.concatStringsSep "," cfg.domains}'
+        ''}
+        ${lib.optionalString (cfg.domainsFile != null) ''
+          export DUCKDNS_DOMAINS=$(systemd-creds cat DUCKDNS_DOMAINS_FILE | sed -z 's/\n/,/g')
+        ''}
+        exec ${lib.getExe duckdns}
+      '';
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ notthebee ];
+}


### PR DESCRIPTION
## Description of changes

Added a Systemd service for updating DuckDNS domains

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
