### PR TITLE
systemd: fix build on riscv64 and ppc64

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -5,6 +5,7 @@
 , nixosTests
 , pkgsCross
 , fetchFromGitHub
+, fetchpatch
 , fetchzip
 , buildPackages
 , makeBinaryWrapper
@@ -224,6 +225,15 @@ stdenv.mkDerivation (finalAttrs: {
     ./0017-meson.build-do-not-create-systemdstatedir.patch
   ] ++ lib.optional (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isGnu) [
     ./0018-timesyncd-disable-NSCD-when-DNSSEC-validation-is-dis.patch
+  ] ++ lib.optional (stdenv.hostPlatform.isPower || stdenv.hostPlatform.isRiscV) [
+    # Fixed upstream and included in the main and stable branches. Can be dropped
+    # when bumping to >= v255.5.
+    # https://github.com/systemd/systemd/issues/30448
+    # https://github.com/NixOS/nixpkgs/pull/282607
+    (fetchpatch {
+      url = "https://github.com/systemd/systemd/commit/8040fa55a1cbc34dede3205a902095ecd26c21e3.patch";
+      sha256 = "0l8jk0w0wavagzck0vy5m0s6fhxab0hpdr4ib111bacqrvvda3kd";
+    })
   ] ++ lib.optional stdenv.hostPlatform.isMusl (
     let
       oe-core = fetchzip {


### PR DESCRIPTION
## Description of changes

This fixes build failures by pulling in the upstream fix for https://github.com/systemd/systemd/issues/30448. This PR replaces a previous unmerged PR https://github.com/NixOS/nixpkgs/pull/282607.

### Steps to reproduce the failure

By cross-compilation
```
nix build github:NixOS/nixpkgs/9289a0678efadcd95fae82ea8c82318d3a86694a#pkgsCross.riscv64.systemd
```
or natively
```
nix build github:NixOS/nixpkgs/9289a0678efadcd95fae82ea8c82318d3a86694a#systemd
```

<details><summary>Build log</summary>
<p>

```
FAILED: src/shared/libsystemd-shared-255.a.p/install.c.o 
gcc -Isrc/shared/libsystemd-shared-255.a.p -Isrc/shared -I../src/shared -Isrc/basic -I../src/basic -Isrc/fundamental -I>
In file included from ../src/basic/macro.h:392,
                 from ../src/basic/alloc-util.h:10,
                 from ../src/shared/install.c:12:
../src/shared/install.c: In function ‘install_changes_dump’:
../src/shared/install.c:432:64: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
  432 |                         err = log_error_errno(changes[i].type, "Failed to %s unit, unit %s does not exist.",
      |                                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/basic/log.h:214:86: note: in definition of macro ‘log_full_errno_zerook’
  214 |                         ? log_internal(_level, _e, PROJECT_FILE, __LINE__, __func__, __VA_ARGS__) \
      |                                                                                      ^~~~~~~~~~~
../src/basic/log.h:254:41: note: in expansion of macro ‘log_full_errno’
  254 | #define log_error_errno(error, ...)     log_full_errno(LOG_ERR,     error, __VA_ARGS__)
      |                                         ^~~~~~~~~~~~~~
../src/shared/install.c:432:31: note: in expansion of macro ‘log_error_errno’
  432 |                         err = log_error_errno(changes[i].type, "Failed to %s unit, unit %s does not exist.",
      |                               ^~~~~~~~~~~~~~~
../src/shared/install.c:432:75: note: format string is defined here
  432 |                         err = log_error_errno(changes[i].type, "Failed to %s unit, unit %s does not exist.",
      |                                                                           ^~
```

</p>
</details> 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] riscv64-linux (native)
  - [X] riscv64-linux (cross)
  - [X] ppc64-linux (cross)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
