### PR TITLE
fix: elan: use relative paths in wrapper script

### DIFF
--- a/pkgs/applications/science/logic/elan/0001-dynamically-patchelf-binaries.patch
+++ b/pkgs/applications/science/logic/elan/0001-dynamically-patchelf-binaries.patch
@@ -2,7 +2,7 @@ diff --git a/src/elan-dist/src/component/package.rs b/src/elan-dist/src/componen
 index c51e76d..ae8159e 100644
 --- a/src/elan-dist/src/component/package.rs
 +++ b/src/elan-dist/src/component/package.rs
-@@ -56,6 +56,35 @@ fn unpack_without_first_dir<R: Read>(archive: &mut tar::Archive<R>, path: &Path)
+@@ -56,6 +56,37 @@ fn unpack_without_first_dir<R: Read>(archive: &mut tar::Archive<R>, path: &Path)
          entry
              .unpack(&full_path)
              .chain_err(|| ErrorKind::ExtractingPackage)?;
@@ -26,9 +26,11 @@ index c51e76d..ae8159e 100644
 +        use std::os::unix::fs::PermissionsExt;
 +        let new_path = dest_path.with_extension("orig");
 +        ::std::fs::rename(dest_path, &new_path)?;
-+        ::std::fs::write(dest_path, format!(r#"#! @shell@
-+LEAN_CC="${{LEAN_CC:-@cc@}}" exec -a "$0" {} "$@" -L {}/lib  # use bundled libraries, but not bundled compiler that doesn't know about NIX_LDFLAGS
-+"#, new_path.to_str().unwrap(), dest_path.parent().unwrap().parent().unwrap().to_str().unwrap()))?;
++        ::std::fs::write(dest_path, r#"#! @shell@
++dir="$(dirname "${BASH_SOURCE[0]}")"
++# use bundled libraries, but not bundled compiler that doesn't know about NIX_LDFLAGS
++LEAN_CC="${LEAN_CC:-@cc@}" exec -a "$0" "$dir/leanc.orig" "$@" -L"$dir/../lib"
++"#)?;
 +        ::std::fs::set_permissions(dest_path, ::std::fs::Permissions::from_mode(0o755))?;
 +    }
 +

--- a/pkgs/applications/science/logic/elan/default.nix
+++ b/pkgs/applications/science/logic/elan/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, runCommand, patchelf, makeWrapper, pkg-config, curl, runtimeShell, fetchpatch
+{ stdenv, lib, runCommand, patchelf, makeWrapper, pkg-config, curl, runtimeShell
 , openssl, zlib, fetchFromGitHub, rustPlatform, libiconv }:
 
 rustPlatform.buildRustPackage rec {
@@ -23,14 +23,6 @@ rustPlatform.buildRustPackage rec {
   buildFeatures = [ "no-self-update" ];
 
   patches = lib.optionals stdenv.isLinux [
-    # revert temporary directory creation, because it break the wrapper
-    # https://github.com/NixOS/nixpkgs/pull/289941#issuecomment-1980778358
-    (fetchpatch {
-      url = "https://github.com/leanprover/elan/commit/bd54acaab75d08b3912ee1f051af8657f3a9cfdf.patch";
-      hash = "sha256-6If/wxWSea8Zjlp3fx9wh3D0TjmWZbvCuY9q5c2qJGA=";
-      revert = true;
-    })
-
     # Run patchelf on the downloaded binaries.
     # This is necessary because Lean 4 is now dynamically linked.
     (runCommand "0001-dynamically-patchelf-binaries.patch" {


### PR DESCRIPTION
since 3.1.1, `elan` extracts to a temporary location and then moves to a final location, this threw the wrapper script off. Updating the patch to use paths relative to the wrapper script, so that it works independent of absolute location.

Tested like this:
```
~/build/lean/mathlib4 $ nix run ~/build/nixpkgs#elan -- run --install $(cat lean-toolchain) lake exec cache
warning: Git tree '/home/jojo/build/nixpkgs' is dirty
info: std: cloning https://github.com/leanprover/std4 to './.lake/packages/std'
info: Qq: cloning https://github.com/leanprover-community/quote4 to './.lake/packages/Qq'
info: aesop: cloning https://github.com/leanprover-community/aesop to './.lake/packages/aesop'
info: proofwidgets: cloning https://github.com/leanprover-community/ProofWidgets4 to './.lake/packages/proofwidgets'
info: Cli: cloning https://github.com/leanprover/lean4-cli to './.lake/packages/Cli'
info: importGraph: cloning https://github.com/leanprover-community/import-graph.git to './.lake/packages/importGraph'
info: [0/9] Downloading proofwidgets cloud release
info: [0/9] Unpacking proofwidgets cloud release
info: [1/9] Building Cache.IO
info: [2/9] Compiling Cache.IO
info: [2/9] Building Cache.Hashing
info: [3/9] Compiling Cache.Hashing
info: [3/9] Building Cache.Requests
info: [4/9] Compiling Cache.Requests
info: [4/9] Building Cache.Main
info: [6/9] Compiling Cache.Main
info: [9/9] Linking cache
Mathlib4 caching CLI
Usage: cache [COMMAND]
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
