### PR TITLE
jetbrains: allow using a different vmopts file in remote-dev-server

### DIFF
--- a/pkgs/applications/editors/jetbrains/bin/linux.nix
+++ b/pkgs/applications/editors/jetbrains/bin/linux.nix
@@ -70,6 +70,9 @@ with stdenv; lib.makeOverridable mkDerivation (rec {
 
     if [ -d "plugins/remote-dev-server" ]; then
       patch -F3 -p1 < ${../patches/jetbrains-remote-dev.patch}
+
+      patch -F3 -p1 < ${../patches/jetbrains-remote-vmopts.patch}
+      substituteInPlace plugins/remote-dev-server/bin/launcher.sh --replace 'HINAME' '${hiName}'
     fi
 
     vmopts_file=bin/linux/${vmoptsName}

--- a/pkgs/applications/editors/jetbrains/patches/jetbrains-remote-vmopts.patch
+++ b/pkgs/applications/editors/jetbrains/patches/jetbrains-remote-vmopts.patch
@@ -1,0 +1,22 @@
+--- a/plugins/remote-dev-server/bin/launcher.sh
++++ b/plugins/remote-dev-server/bin/launcher.sh
+@@ -468,12 +468,16 @@ printf '\nide.ui.font.force.use.inter.font=true' >> "$TEMP_REMOTE_DEV_PROPERTIES
+ # --------------------------------
+
+ TEMP_REMOTE_DEV_VM_OPTIONS="$TEMP_SYSTEM_LIKE_DIR/pid.$$.temp.vmoptions"
+-if [ $IS_DARWIN -eq 1 ]; then
+-  cp "$IDE_BIN_DIR/${IDE_PRODUCT_VM_OPTIONS}.vmoptions" "$TEMP_REMOTE_DEV_VM_OPTIONS"
++if [[ -n "${HINAME_VM_OPTIONS+1}" ]]; then
++  BASE_VM_OPTIONS="${HINAME_VM_OPTIONS}"
++elif [ $IS_DARWIN -eq 1 ]; then
++  BASE_VM_OPTIONS="$IDE_BIN_DIR/${IDE_PRODUCT_VM_OPTIONS}.vmoptions"
+ else
+-  cp "$IDE_BIN_DIR/${IDE_PRODUCT_VM_OPTIONS}64.vmoptions" "$TEMP_REMOTE_DEV_VM_OPTIONS"
++  BASE_VM_OPTIONS="$IDE_BIN_DIR/${IDE_PRODUCT_VM_OPTIONS}64.vmoptions"
+ fi
+
++cp "$BASE_VM_OPTIONS" "$TEMP_REMOTE_DEV_VM_OPTIONS"
++
+ # [+ <IDE_HOME>.vmoptions (Toolbox style)
+ if [ -r "${IDE_HOME}.vmoptions" ]; then
+   cat "${IDE_HOME}.vmoptions" >>"$TEMP_REMOTE_DEV_VM_OPTIONS"


### PR DESCRIPTION
## Description of changes

This allow using `${IDE_NAME}_VM_OPTIONS` to change the `.vmoptions` file used by the remote dev server in the same way you can do with the non-remote ides.

This is useful because the built-in option to change the java heap limit tries to write to the `.vmoptions` in the nix store

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
