### PR TITLE
add patchAntBuildfilesHook and use (almost) treewide

### DIFF
--- a/pkgs/applications/graphics/processing/default.nix
+++ b/pkgs/applications/graphics/processing/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchurl, ant, unzip, makeWrapper, jdk, jogl, rsync, ffmpeg, batik, wrapGAppsHook, libGL }:
+{ lib, stdenv, fetchFromGitHub, fetchurl, ant, patchAntBuildfilesHook, unzip, makeWrapper, jdk, jogl, rsync, ffmpeg, batik, wrapGAppsHook, libGL }:
 let
   buildNumber = "1293";
   vaqua = fetchurl {
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-SzQemZ6iZ9o89/doV8YMv7DmyPSDyckJl3oyxJyfrm0=";
   };
 
-  nativeBuildInputs = [ ant unzip makeWrapper wrapGAppsHook ];
+  nativeBuildInputs = [ ant patchAntBuildfilesHook unzip makeWrapper wrapGAppsHook ];
   buildInputs = [ jdk jogl ant rsync ffmpeg batik ];
 
   dontWrapGApps = true;

--- a/pkgs/applications/misc/calcoo/default.nix
+++ b/pkgs/applications/misc/calcoo/default.nix
@@ -2,8 +2,8 @@
 , stdenv
 , fetchzip
 , ant
-, canonicalize-jars-hook
 , jdk
+, patchAntBuildfilesHook
 , makeWrapper
 }:
 
@@ -18,8 +18,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     ant
-    canonicalize-jars-hook
     jdk
+    patchAntBuildfilesHook
     makeWrapper
   ];
 

--- a/pkgs/applications/misc/mkgmap/default.nix
+++ b/pkgs/applications/misc/mkgmap/default.nix
@@ -5,6 +5,7 @@
 , jdk
 , jre
 , ant
+, patchAntBuildfilesHook
 , makeWrapper
 , doCheck ? true
 , withExamples ? false
@@ -30,10 +31,6 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = with deps; ''
-    # Fix the output jar timestamps for reproducibility
-    substituteInPlace build.xml \
-        --replace-fail '<jar ' '<jar modificationtime="0" '
-
     # Manually create version properties file for reproducibility
     mkdir -p build/classes
     cat > build/classes/mkgmap-version.properties << EOF
@@ -61,7 +58,7 @@ stdenv.mkDerivation rec {
     '') testInputs}
   '';
 
-  nativeBuildInputs = [ jdk ant makeWrapper ];
+  nativeBuildInputs = [ jdk ant patchAntBuildfilesHook makeWrapper ];
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/applications/misc/mkgmap/splitter/default.nix
+++ b/pkgs/applications/misc/mkgmap/splitter/default.nix
@@ -5,6 +5,7 @@
 , jdk
 , jre
 , ant
+, patchAntBuildfilesHook
 , makeWrapper
 , doCheck ? true
 }:
@@ -30,10 +31,6 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch = with deps; ''
-    # Fix the output jar timestamps for reproducibility
-    substituteInPlace build.xml \
-        --replace-fail '<jar ' '<jar modificationtime="0" '
-
     # Manually create version properties file for reproducibility
     mkdir -p build/classes
     cat > build/classes/splitter-version.properties << EOF
@@ -58,7 +55,7 @@ stdenv.mkDerivation rec {
     '') testInputs}
   '';
 
-  nativeBuildInputs = [ jdk ant makeWrapper ];
+  nativeBuildInputs = [ jdk ant patchAntBuildfilesHook makeWrapper ];
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/applications/misc/pattypan/default.nix
+++ b/pkgs/applications/misc/pattypan/default.nix
@@ -3,11 +3,11 @@
 , fetchFromGitHub
 , ant
 , jdk
+, patchAntBuildfilesHook
 , makeWrapper
 , wrapGAppsHook
 , makeDesktopItem
 , copyDesktopItems
-, canonicalize-jars-hook
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -24,10 +24,10 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     ant
     jdk
+    patchAntBuildfilesHook
     makeWrapper
     wrapGAppsHook
     copyDesktopItems
-    canonicalize-jars-hook
   ];
 
   dontWrapGApps = true;

--- a/pkgs/applications/networking/remote/dayon/default.nix
+++ b/pkgs/applications/networking/remote/dayon/default.nix
@@ -4,9 +4,9 @@
 , ant
 , jdk
 , jre
+, patchAntBuildfilesHook
 , makeWrapper
 , copyDesktopItems
-, canonicalize-jars-hook
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -23,9 +23,9 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     ant
     jdk
+    patchAntBuildfilesHook
     makeWrapper
     copyDesktopItems
-    canonicalize-jars-hook
   ];
 
   buildPhase = ''

--- a/pkgs/applications/office/jameica/default.nix
+++ b/pkgs/applications/office/jameica/default.nix
@@ -7,6 +7,7 @@
 , ant
 , jdk
 , jre
+, patchAntBuildfilesHook
 , gtk2
 , glib
 , libXtst
@@ -46,13 +47,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-MSVSd5DyVL+dcfTDv1M99hxickPwT2Pt6QGNsu6DGZI=";
   };
 
-  postPatch = ''
-    # Fix jar timestamps for reproducibility
-    substituteInPlace build/build.xml \
-        --replace-fail '<jar ' '<jar modificationtime="0" '
-  '';
-
-  nativeBuildInputs = [ ant jdk wrapGAppsHook makeWrapper ];
+  nativeBuildInputs = [ ant jdk patchAntBuildfilesHook wrapGAppsHook makeWrapper ];
   buildInputs = lib.optionals stdenv.isLinux [ gtk2 glib libXtst ]
     ++ lib.optional stdenv.isDarwin Cocoa;
 

--- a/pkgs/applications/science/biology/trimmomatic/default.nix
+++ b/pkgs/applications/science/biology/trimmomatic/default.nix
@@ -4,8 +4,8 @@
 , ant
 , jdk
 , jre
+, patchAntBuildfilesHook
 , makeWrapper
-, canonicalize-jars-hook
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -21,15 +21,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Remove jdk version requirement
   postPatch = ''
-    substituteInPlace ./build.xml \
-      --replace 'source="1.5" target="1.5"' ""
+    substituteInPlace build.xml \
+        --replace-fail 'source="1.5" target="1.5"' ""
   '';
 
   nativeBuildInputs = [
     ant
     jdk
+    patchAntBuildfilesHook
     makeWrapper
-    canonicalize-jars-hook
   ];
 
   buildPhase = ''

--- a/pkgs/build-support/setup-hooks/patch-ant-buildfiles.sh
+++ b/pkgs/build-support/setup-hooks/patch-ant-buildfiles.sh
@@ -1,0 +1,29 @@
+# Sets the `modificationtime` attribute on the <jar> and <war> ant tasks
+# This is done to make the final archives deterministic
+patchAntBuildfile() {
+    local buildfile="$1"
+    # using `local-name()` ignores the `xmlns` attribute in a parent node
+    @xmlstarlet@ ed --inplace \
+        --var T '//*[local-name()="jar" or local-name()="war"]' \
+        --update '$T/@modificationtime' -v '0' \
+        --insert '$T[not(@modificationtime)]' -t attr -n 'modificationtime' -v '0' \
+        "$buildfile"
+}
+
+patchAntBuildfilesHook() {
+    find -name '*.xml' -type f -print0 |
+        while IFS= read -r -d '' file; do
+            file=$(realpath "$file")
+            # check if the xml file has any <target> nodes inside a top-level <project> node
+            # this is done to only patch ant buildfiles, not just any xml file
+            # using `local-name()` ignores the `xmlns` attribute in the <project> node
+            if @xmlstarlet@ sel -Q -t -c '/*[local-name()="project"]/*[local-name()="target"]' "$file"; then
+                echo "patching ant buildfile $file"
+                patchAntBuildfile "$file"
+            fi
+        done
+}
+
+if [ -z "${dontPatchAntBuildfiles-}" ]; then
+    postPatchHooks+=(patchAntBuildfilesHook)
+fi

--- a/pkgs/by-name/jo/jogl/package.nix
+++ b/pkgs/by-name/jo/jogl/package.nix
@@ -3,6 +3,7 @@
 , fetchgit
 , ant
 , jdk11
+, patchAntBuildfilesHook
 , git
 , xmlstarlet
 , xcbuild
@@ -42,13 +43,6 @@ stdenv.mkDerivation {
     substituteInPlace gluegen/src/java/com/jogamp/common/util/IOUtil.java \
       --replace-fail '#!/bin/true' '#!${coreutils}/bin/true'
   ''
-  # set timestamp of files in jar to a fixed point in time
-  + ''
-    xmlstarlet ed --inplace \
-      --append //jar --type attr -n modificationtime --value 1980-01-01T00:00Z \
-      gluegen/make/{build.xml,gluegen-cpptasks-base.xml} \
-      jogl/make/{build.xml,build-nativewindow.xml,build-jogl.xml}
-  ''
   # prevent looking for native libraries in /usr/lib
   + ''
     substituteInPlace jogl/make/build-*.xml \
@@ -70,6 +64,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     ant
     jdk11
+    patchAntBuildfilesHook
     git
     xmlstarlet
   ] ++ lib.optionals stdenv.isDarwin [

--- a/pkgs/by-name/op/openrocket/package.nix
+++ b/pkgs/by-name/op/openrocket/package.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , ant
 , jdk17
+, patchAntBuildfilesHook
 , makeWrapper
 }:
 
@@ -24,6 +25,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     ant
     jdk
+    patchAntBuildfilesHook
     makeWrapper
   ];
 

--- a/pkgs/development/compilers/abcl/default.nix
+++ b/pkgs/development/compilers/abcl/default.nix
@@ -5,8 +5,8 @@
 , ant
 , jdk
 , jre
+, patchAntBuildfilesHook
 , makeWrapper
-, canonicalize-jars-hook
 }:
 
 let
@@ -28,9 +28,9 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     ant
     jdk
+    patchAntBuildfilesHook
     fakeHostname
     makeWrapper
-    canonicalize-jars-hook
   ];
 
   buildPhase = ''

--- a/pkgs/development/compilers/jasmin/default.nix
+++ b/pkgs/development/compilers/jasmin/default.nix
@@ -4,8 +4,8 @@
 , unzip
 , ant
 , jdk8
+, patchAntBuildfilesHook
 , makeWrapper
-, canonicalize-jars-hook
 , callPackage
 }:
 
@@ -26,8 +26,8 @@ in stdenv.mkDerivation (finalAttrs: {
     unzip
     ant
     jdk
+    patchAntBuildfilesHook
     makeWrapper
-    canonicalize-jars-hook
   ];
 
   buildPhase = ''

--- a/pkgs/development/libraries/freetts/default.nix
+++ b/pkgs/development/libraries/freetts/default.nix
@@ -3,6 +3,7 @@
 , fetchzip
 , ant
 , jdk8
+, patchAntBuildfilesHook
 , sharutils
 }:
 
@@ -19,16 +20,11 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     ant
     jdk8
+    patchAntBuildfilesHook
     sharutils
   ];
 
   sourceRoot = "${finalAttrs.src.name}/freetts-${finalAttrs.version}";
-
-  postPatch = ''
-    # Fix jar timestamps for reproducibility
-    substituteInPlace build.xml demo.xml \
-        --replace-fail '<jar ' '<jar modificationtime="0" '
-  '';
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/development/libraries/java/cup/default.nix
+++ b/pkgs/development/libraries/java/cup/default.nix
@@ -3,8 +3,8 @@
 , fetchurl
 , ant
 , jdk
+, patchAntBuildfilesHook
 , makeWrapper
-, canonicalize-jars-hook
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -23,8 +23,8 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     ant
     jdk
+    patchAntBuildfilesHook
     makeWrapper
-    canonicalize-jars-hook
   ];
 
   buildPhase = ''

--- a/pkgs/development/libraries/java/hydra-ant-logger/default.nix
+++ b/pkgs/development/libraries/java/hydra-ant-logger/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , ant
 , jdk
-, canonicalize-jars-hook
+, patchAntBuildfilesHook
 }:
 
 stdenv.mkDerivation {
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     ant
     jdk
-    canonicalize-jars-hook
+    patchAntBuildfilesHook
   ];
 
   buildPhase = ''

--- a/pkgs/development/tools/analysis/jdepend/default.nix
+++ b/pkgs/development/tools/analysis/jdepend/default.nix
@@ -4,7 +4,7 @@
 , ant
 , jdk
 , makeWrapper
-, canonicalize-jars-hook
+, patchAntBuildfilesHook
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -21,8 +21,8 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     ant
     jdk
+    patchAntBuildfilesHook
     makeWrapper
-    canonicalize-jars-hook
   ];
 
   buildPhase = ''

--- a/pkgs/development/tools/parsing/javacc/default.nix
+++ b/pkgs/development/tools/parsing/javacc/default.nix
@@ -4,8 +4,8 @@
 , ant
 , jdk
 , jre
+, patchAntBuildfilesHook
 , makeWrapper
-, canonicalize-jars-hook
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -22,8 +22,8 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     ant
     jdk
+    patchAntBuildfilesHook
     makeWrapper
-    canonicalize-jars-hook
   ];
 
   buildPhase = ''

--- a/pkgs/tools/games/jpsxdec/default.nix
+++ b/pkgs/tools/games/jpsxdec/default.nix
@@ -4,10 +4,10 @@
 , ant
 , jdk8 # the build script wants JAVA 8 for compilation
 , jre # version can be >= 8 (latest version by default)
+, patchAntBuildfilesHook
 , makeWrapper
 , makeDesktopItem
 , copyDesktopItems
-, canonicalize-jars-hook
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -26,9 +26,9 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     ant
     jdk8
+    patchAntBuildfilesHook
     makeWrapper
     copyDesktopItems
-    canonicalize-jars-hook
   ];
 
   buildPhase = ''

--- a/pkgs/tools/misc/ili2c/default.nix
+++ b/pkgs/tools/misc/ili2c/default.nix
@@ -4,8 +4,8 @@
 , ant
 , jdk8
 , jre8
+, patchAntBuildfilesHook
 , makeWrapper
-, canonicalize-jars-hook
 }:
 
 let
@@ -19,8 +19,8 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     ant
     jdk
+    patchAntBuildfilesHook
     makeWrapper
-    canonicalize-jars-hook
   ];
 
   src = fetchFromGitHub {

--- a/pkgs/tools/typesetting/fop/default.nix
+++ b/pkgs/tools/typesetting/fop/default.nix
@@ -4,6 +4,7 @@
 , ant
 , jdk
 , jre
+, patchAntBuildfilesHook
 , makeWrapper
 }:
 
@@ -16,15 +17,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-b7Av17wu6Ar/npKOiwYqzlvBFSIuXTpqTacM1sxtBvc=";
   };
 
-  postPatch = ''
-    # Fix jar timestamps for reproducibility
-    substituteInPlace fop/build.xml \
-        --replace-fail '<jar ' '<jar modificationtime="0" '
-  '';
-
   nativeBuildInputs = [
     ant
     jdk
+    patchAntBuildfilesHook
     makeWrapper
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18230,6 +18230,13 @@ with pkgs;
   apacheAnt = callPackage ../development/tools/build-managers/apache-ant { };
   ant = apacheAnt;
 
+  patchAntBuildfilesHook = makeSetupHook {
+    name = "patchAntBuildfilesHook";
+    substitutions = {
+      xmlstarlet = lib.escapeShellArg (lib.getExe xmlstarlet);
+    };
+  } ../build-support/setup-hooks/patch-ant-buildfiles.sh;
+
   apacheKafka = apacheKafka_3_5;
   apacheKafka_2_8 = callPackage ../servers/apache-kafka { majorVersion = "2.8"; };
   apacheKafka_3_0 = callPackage ../servers/apache-kafka { majorVersion = "3.0"; };


### PR DESCRIPTION
## Description of changes

This is a followup cleanup to the changes listed in https://github.com/NixOS/nixpkgs/issues/278518
After realizing, that `canonicalize-jars-hook` was a bit broken and realizing that [almost every major way of packaging java apps has a builtin solution for determinism](https://github.com/NixOS/nixpkgs/issues/278518#issuecomment-1934535129) I decided that it was better to move away from `canonicalize-jars-hook`.

This PR modifies every `ant` package using `canonicalize-jars-hook` and some others which might have a similar fix in place to use the newly added `patchAntBuildfilesHook`.

I haven't added this to all `ant`-based packages, because I want to create separate PRs for them.

Note that there are two remaining packages using `canonicalize-jars-hook`: `prismlauncher` and `swt`. These cannot be migrated over, because they use the `jar` command directly.

```sh
# Shorter builds
nix build .#{calcoo,mkgmap,mkgmap-splitter,pattypan,dayon,jameica,trimmomatic,jasmin,freetts,javaCup,hydraAntLogger,jdepend,javacc,jpsxdec,ili2c,fop}
# Longer builds
nix build .#{openrocket,jogl,processing,abcl}

# Run the commands again with the `--rebuild` flag to check for determinism
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
