### PR TITLE
ytdownloader: add patch to set correct config dir

### DIFF
--- a/pkgs/by-name/yt/ytdownloader/config-dir.patch
+++ b/pkgs/by-name/yt/ytdownloader/config-dir.patch
@@ -1,0 +1,18 @@
+--- a/main.js
++++ b/main.js
+@@ -13,6 +13,15 @@
+ const fs = require("fs");
+ const path = require("path");
+ autoUpdater.autoDownload = false;
++
++// Set the config directory to XDG_CONFIG_HOME/ytdownloader
++const xdgConfigHome = process.env.XDG_CONFIG_HOME;
++let configDir = app.getPath('home') + "/.config/ytdownloader";
++if (xdgConfigHome) {
++	configDir = xdgConfigHome + "/ytdownloader";
++}
++app.setPath ('userData', configDir);
++
+ /**@type {BrowserWindow} */
+ let win = null;
+ let secondaryWindow = null;

--- a/pkgs/by-name/yt/ytdownloader/package.nix
+++ b/pkgs/by-name/yt/ytdownloader/package.nix
@@ -25,18 +25,22 @@ buildNpmPackage rec {
   buildInputs = [ ffmpeg yt-dlp ];
 
   desktopItem = makeDesktopItem {
-    name = "YTDownloader";
+    name = "ytDownloader";
     exec = "ytdownloader %U";
     icon = "ytdownloader";
-    desktopName = "YT Downloader";
+    desktopName = "ytDownloader";
     comment = "A modern GUI video and audio downloader";
     categories = [ "Utility" ];
-    startupWMClass = "YTDownloader";
+    startupWMClass = "ytDownloader";
   };
 
   ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
   dontNpmBuild = true;
+
+  # Patch config dir to ~/.config/ytdownloader
+  # Otherwise it stores config in ~/.config/Electron
+  patches = [ ./config-dir.patch ];
 
   # Replace hardcoded ffmpeg and ytdlp paths
   # Also stop it from downloading ytdlp


### PR DESCRIPTION
## Description of changes
ytdownloader currently stores it's configuration data in `~/.config/Electron` which is obviously far from ideal. I've added a patch file to change this to `$XDG_CONFIG_DIR/ytdownloader` or `~/.config/ytdownloader` if XDG_CONFIG_DIR isn't set.

To test these changes:
1. build & run old `ytdownloader` from master. Check `~/.config` directory and run e.g. `ls -lrth` to show recently changed files. `Electron` should appear as the most recently changed, with no sign of any `ytdownloader` folder
2. Delete / rename the Electron folder.
3. Build & run `ydownloader` from this PR. This time there should be no `Electron` folder created in `~/.config` and instead a `ytdownloader` folder is created as desired.
4. Finally to test that the patch respects XDG_CONFIG_HOME settings, create a folder in your home directory called `tempxdg`. Then run:
```
XDG_CONFIG_HOME="$HOME/tempxdg"; ./result/bin/ytdownloader; XDG_CONFIG_HOME=""
```
This time a `ytdownloader` folder should be created in `~/tempxdg/`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
