### PR TITLE
ogre: include imgui in overlays

### DIFF
--- a/pkgs/development/libraries/ogre/default.nix
+++ b/pkgs/development/libraries/ogre/default.nix
@@ -34,7 +34,16 @@
 }:
 
 let
-  common = { version, hash }: stdenv.mkDerivation {
+  common = { version, hash, imguiVersion, imguiHash }:
+  let
+    imgui.src = fetchFromGitHub {
+      owner = "ocornut";
+      repo = "imgui";
+      rev = "v${imguiVersion}";
+      hash = imguiHash;
+    };
+  in
+  stdenv.mkDerivation {
     pname = "ogre";
     inherit version;
 
@@ -44,6 +53,12 @@ let
       rev = "v${version}";
       inherit hash;
     };
+
+    postPatch = ''
+      mkdir -p build
+      cp -R ${imgui.src} build/imgui-${imguiVersion}
+      chmod -R u+w build/imgui-${imguiVersion}
+    '';
 
     nativeBuildInputs = [
       cmake
@@ -80,11 +95,10 @@ let
     ];
 
     cmakeFlags = [
-      "-DOGRE_BUILD_COMPONENT_OVERLAY_IMGUI=FALSE"
-      "-DOGRE_BUILD_DEPENDENCIES=OFF"
-      "-DOGRE_BUILD_SAMPLES=${toString withSamples}"
+      (lib.cmakeBool "OGRE_BUILD_DEPENDENCIES" false)
+      (lib.cmakeBool "OGRE_BUILD_SAMPLES" withSamples)
     ] ++ lib.optionals stdenv.isDarwin [
-      "-DOGRE_BUILD_LIBS_AS_FRAMEWORKS=FALSE"
+      (lib.cmakeBool "OGRE_BUILD_LIBS_AS_FRAMEWORKS" false)
     ];
 
     meta = {
@@ -100,10 +114,16 @@ in
   ogre_14 = common {
     version = "14.1.2";
     hash = "sha256-qPoC5VXA9IC1xiFLrvE7cqCZFkuiEM0OMowUXDlmhF4=";
+    # https://github.com/OGRECave/ogre/blob/v14.1.2/Components/Overlay/CMakeLists.txt
+    imguiVersion = "1.89.8";
+    imguiHash = "sha256-pkEm7+ZBYAYgAbMvXhmJyxm6DfyQWkECTXcTHTgfvuo=";
   };
 
   ogre_13 = common {
     version = "13.6.5";
     hash = "sha256-8VQqePrvf/fleHijVIqWWfwOusGjVR40IIJ13o+HwaE=";
+    # https://github.com/OGRECave/ogre/blob/v13.6.5/Components/Overlay/CMakeLists.txt
+    imguiVersion = "1.87";
+    imguiHash = "sha256-H5rqXZFw+2PfVMsYvAK+K+pxxI8HnUC0GlPhooWgEYM=";
   };
 }


### PR DESCRIPTION
## Description of changes

This PR removes the `"-DOGRE_BUILD_COMPONENT_OVERLAY_IMGUI=FALSE"` flag, since building version 14.2.0+ without ImGui requires disabling more components, which seems too bad.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
