### PR TITLE
gmic-qt: refactor

### DIFF
--- a/pkgs/by-name/gm/gmic-qt/package.nix
+++ b/pkgs/by-name/gm/gmic-qt/package.nix
@@ -1,10 +1,9 @@
 { lib
-, stdenv
-, fetchzip
 , cimg
 , cmake
 , coreutils
 , curl
+, fetchzip
 , fftw
 , gimp
 , gimpPlugins
@@ -14,14 +13,13 @@
 , graphicsmagick
 , libjpeg
 , libpng
+, libsForQt5
 , libtiff
 , ninja
 , nix-update
 , openexr
 , pkg-config
-, qtbase
-, qttools
-, wrapQtAppsHook
+, stdenv
 , writeShellScript
 , zlib
 , variant ? "standalone"
@@ -38,6 +36,7 @@ let
     };
 
     standalone = {
+      extraDeps = []; # Just to keep uniformity and avoid test-for-null
       description = "Versatile front-end to the image processing framework G'MIC";
     };
   };
@@ -49,7 +48,7 @@ assert lib.assertMsg
   "gmic-qt variant \"${variant}\" is not supported. Please use one of ${lib.concatStringsSep ", " (builtins.attrNames variants)}.";
 
 assert lib.assertMsg
-  (builtins.all (d: d != null) variants.${variant}.extraDeps or [])
+  (builtins.all (d: d != null) variants.${variant}.extraDeps)
   "gmic-qt variant \"${variant}\" is missing one of its dependencies.";
 
 stdenv.mkDerivation (finalAttrs: {
@@ -61,30 +60,29 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-/Hh5yzH//i01kyeoqETokvsKUOcY2iZsiYJBEmgw1rU=";
   };
 
+  sourceRoot = "${finalAttrs.src.name}/gmic-qt";
+
   nativeBuildInputs = [
     cmake
-    pkg-config
+    libsForQt5.wrapQtAppsHook
     ninja
-    wrapQtAppsHook
+    pkg-config
   ];
 
   buildInputs = [
+    curl
+    fftw
     gmic
+    graphicsmagick
+    libjpeg
+    libpng
+    libtiff
+    openexr
+    zlib
+  ] ++ (with libsForQt5; [
     qtbase
     qttools
-    fftw
-    zlib
-    libjpeg
-    libtiff
-    libpng
-    openexr
-    graphicsmagick
-    curl
-  ] ++ variants.${variant}.extraDeps or [];
-
-  preConfigure = ''
-    cd gmic-qt
-  '';
+  ]) ++ variants.${variant}.extraDeps;
 
   postPatch = ''
     patchShebangs \
@@ -93,9 +91,9 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   cmakeFlags = [
-    (lib.cmakeFeature "GMIC_QT_HOST" (if variant == "standalone" then "none" else variant))
-    (lib.cmakeBool "ENABLE_SYSTEM_GMIC" true)
     (lib.cmakeBool "ENABLE_DYNAMIC_LINKING" true)
+    (lib.cmakeBool "ENABLE_SYSTEM_GMIC" true)
+    (lib.cmakeFeature "GMIC_QT_HOST" (if variant == "standalone" then "none" else variant))
   ];
 
   postFixup = lib.optionalString (variant == "gimp") ''
@@ -105,8 +103,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests = {
+      # They need to be update in lockstep.
       gimp-plugin = gimpPlugins.gmic;
-      # Needs to update them all in lockstep.
       inherit cimg gmic;
     };
 
@@ -134,10 +132,7 @@ stdenv.mkDerivation (finalAttrs: {
     inherit (variants.${variant}) description;
     license = lib.licenses.gpl3Plus;
     mainProgram = "gmic_qt";
-    maintainers = [
-      lib.maintainers.AndersonTorres
-      lib.maintainers.lilyinstarlight
-    ];
+    maintainers = with lib.maintainers; [ AndersonTorres lilyinstarlight ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5528,8 +5528,6 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Cocoa;
   };
 
-  gmic-qt = libsForQt5.callPackage ../tools/graphics/gmic-qt { };
-
   gpg-tui = callPackage ../tools/security/gpg-tui {
     inherit (darwin.apple_sdk.frameworks) AppKit Foundation;
     inherit (darwin) libobjc libresolv;


### PR DESCRIPTION
- bring uniformity to variants set
- set sourceRoot
- intern libsForQt5
- migrate to by-name

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
