### PR TITLE
dwarffs: init at 2.0.0, nixos/dwarffs: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -966,6 +966,16 @@
     githubId = 60479013;
     name = "Alma Cemerlic";
   };
+  alois31 = {
+    name = "Alois Wohlschlager";
+    email = "alois1@gmx-topmail.de";
+    matrix = "@aloisw:kde.org";
+    github = "alois31";
+    githubId = 36605164;
+    keys = [{
+      fingerprint = "CA97 A822 FF24 25D4 74AF  3E4B E0F5 9EA5 E521 6914";
+    }];
+  };
   Alper-Celik = {
     email = "alper@alper-celik.dev";
     name = "Alper Çelik";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -498,6 +498,7 @@
   ./services/development/blackfire.nix
   ./services/development/bloop.nix
   ./services/development/distccd.nix
+  ./services/development/dwarffs.nix
   ./services/development/gemstash.nix
   ./services/development/hoogle.nix
   ./services/development/jupyter/default.nix

--- a/nixos/modules/services/development/dwarffs.nix
+++ b/nixos/modules/services/development/dwarffs.nix
@@ -1,0 +1,48 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.dwarffs;
+in
+{
+  options.services.dwarffs = {
+    enable = lib.mkEnableOption "a filesystem for fetching debug info on demand";
+    package = lib.mkPackageOption pkgs "dwarffs" { };
+    maxAge = lib.mkOption {
+      type = lib.types.str;
+      default = "7d";
+      example = "12h";
+      description = ''
+        Time after which the cached debug info should be cleaned up.
+        See {manpage}`tmpfiles.d(5)` for the format.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment = {
+      systemPackages = [ cfg.package ];
+      variables.NIX_DEBUG_INFO_DIRS = [ "/run/dwarffs" ];
+    };
+    users = {
+      groups.dwarffs = { };
+      users.dwarffs = {
+        isSystemUser = true;
+        group = "dwarffs";
+      };
+    };
+    systemd = {
+      automounts = [
+        {
+          wantedBy = [ "multi-user.target" ];
+          where = "/run/dwarffs";
+        }
+      ];
+      packages = [ cfg.package ];
+      tmpfiles.rules = [ "d /var/cache/dwarffs 0755 dwarffs dwarffs ${cfg.maxAge}" ];
+    };
+  };
+}

--- a/pkgs/by-name/dw/dwarffs/package.nix
+++ b/pkgs/by-name/dw/dwarffs/package.nix
@@ -1,0 +1,48 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  boost,
+  fuse,
+  nix,
+  lib,
+}:
+stdenv.mkDerivation (final: {
+  pname = "dwarffs";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "edolstra";
+    repo = "dwarffs";
+    rev = "v${final.version}";
+    hash = "sha256-n3go513OO7HqfPsolxPga7pbRcv38KjuyTvVTNLkthA=";
+  };
+
+  strictDeps = true;
+
+  buildInputs = [
+    boost
+    fuse
+    nix
+  ];
+  env.NIX_CFLAGS_COMPILE = "-I${nix.dev}/include/nix -D_FILE_OFFSET_BITS=64 -DVERSION=\"${final.version}\"";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 dwarffs "$out/bin/dwarffs"
+    ln -s dwarffs "$out/bin/mount.fuse.dwarffs"
+
+    install -Dm644 run-dwarffs.mount "$out/lib/systemd/system/run-dwarffs.mount"
+    install -Dm644 run-dwarffs.automount "$out/lib/systemd/system/run-dwarffs.automount"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A filesystem that fetches DWARF debug info from the Internet on demand";
+    homepage = "https://github.com/edolstra/dwarffs";
+    license = [ lib.licenses.gpl3Only ];
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.alois31 ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -39905,6 +39905,10 @@ with pkgs;
 
   dump = callPackage ../tools/backup/dump { };
 
+  dwarffs = callPackage ../by-name/dw/dwarffs/package.nix {
+    nix = nixVersions.nix_2_19;
+  };
+
   ec2stepshell = callPackage ../tools/security/ec2stepshell { };
 
   ecdsatool = callPackage ../tools/security/ecdsatool { };


### PR DESCRIPTION
## Description of changes

The packaging follows the upstream flake quite closely.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
