### PR TITLE
hpfeeds: init at 3.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15784,6 +15784,11 @@
     githubId = 5636;
     name = "Steve Purcell";
   };
+  purefns = {
+    name = "James Adam";
+    github = "purefns";
+    githubId = 44219367;
+  };
   putchar = {
     email = "slim.cadoux@gmail.com";
     matrix = "@putch4r:matrix.org";

--- a/pkgs/development/python-modules/hpfeeds/default.nix
+++ b/pkgs/development/python-modules/hpfeeds/default.nix
@@ -47,5 +47,6 @@ buildPythonPackage rec {
     description = "Honeynet Project generic authenticated datafeed protocol";
     homepage = "https://github.com/hpfeeds/hpfeeds";
     license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ purefns ];
   };
 }

--- a/pkgs/development/python-modules/hpfeeds/default.nix
+++ b/pkgs/development/python-modules/hpfeeds/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  # deps
+  aiohttp,
+  aiorun,
+  async-timeout,
+  attrs,
+  chardet,
+  idna,
+  idna-ssl,
+  multidict,
+  prometheus-client,
+  yarl,
+  wrapt,
+  ...
+}:
+
+buildPythonPackage rec {
+  pname = "hpfeeds";
+  version = "3.1.0";
+  format = "wheel";
+
+  src = fetchPypi rec {
+    inherit pname version format;
+    hash = "sha256-lI18P8b/8yu3/9t6Jop5usAvc+xlpIaRYwDv5ipDI/o=";
+    dist = python;
+    python = "py2.py3";
+  };
+
+  propagatedBuildInputs = [
+    aiohttp
+    aiorun
+    async-timeout
+    attrs
+    chardet
+    idna
+    idna-ssl
+    multidict
+    prometheus-client
+    yarl
+    wrapt
+  ];
+
+  meta = {
+    description = "Honeynet Project generic authenticated datafeed protocol";
+    homepage = "https://github.com/hpfeeds/hpfeeds";
+    license = lib.licenses.gpl3Only;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5325,6 +5325,8 @@ self: super: with self; {
 
   hpccm = callPackage ../development/python-modules/hpccm { };
 
+  hpfeeds = callPackage ../development/python-modules/hpfeeds { };
+
   hpp-fcl = toPythonModule (pkgs.hpp-fcl.override {
     pythonSupport = true;
     python3Packages = self;


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

I have used this personally with OpenCanary (#294580 ) and have not noticed any issues.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
