### PR TITLE
xdg-user-dirs: fix manpage rendering

### DIFF
--- a/pkgs/by-name/xd/xdg-user-dirs/package.nix
+++ b/pkgs/by-name/xd/xdg-user-dirs/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   libxslt,
   docbook_xsl,
+  docbook_xml_dtd_43,
   gettext,
   libiconv,
   makeWrapper,
@@ -24,6 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
     libxslt
     docbook_xsl
+    docbook_xml_dtd_43
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ gettext ];
 
   preFixup = ''

--- a/pkgs/by-name/xd/xdg-user-dirs/package.nix
+++ b/pkgs/by-name/xd/xdg-user-dirs/package.nix
@@ -38,7 +38,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "http://freedesktop.org/wiki/Software/xdg-user-dirs";
     description = "Tool to help manage well known user directories like the desktop folder and the music folder";
     license = licenses.gpl2;
-    maintainers = with maintainers; [ donovanglover ];
+    maintainers = with maintainers; [
+      donovanglover
+      iFreilicht
+    ];
     platforms = platforms.unix;
     mainProgram = "xdg-user-dirs-update";
   };


### PR DESCRIPTION
## Description of changes

Currently

```
nix shell github:NixOS/nixpkgs/nixos-unstable#xdg-user-dirs --command sh -c "man xdg-user-dirs-update"
```

```
--set NAME PATH
   Sets the XDG user dir with the given name.

   NAME should be one of the following:

       PATH must be an absolute path, e.g.  $HOME/Some/Directory.
```

Now, it's correctly rendered:

```
nix shell github:iFreilicht/nixpkgs/xdg-user-dirs-fix#xdg-user-dirs --command sh -c "man xdg-user-dirs-update"
```

```
--set NAME PATH
   Sets the XDG user dir with the given name.

   NAME should be one of the following:
       DESKTOP
       DOWNLOAD
       TEMPLATES
       PUBLICSHARE
       DOCUMENTS
       MUSIC
       PICTURES
       VIDEOS

   PATH must be an absolute path, e.g.  $HOME/Some/Directory.
```

Also migrated to by-name.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
