### PR TITLE
python311Packages.aiohttp-client-cache: Use standard packaging

### DIFF
--- a/pkgs/development/python-modules/aiohttp-client-cache/default.nix
+++ b/pkgs/development/python-modules/aiohttp-client-cache/default.nix
@@ -1,6 +1,14 @@
-{ lib, fetchPypi, python3, ...}:
+{ lib
+, fetchPypi
+, buildPythonPackage
+, poetry-core
+, aiohttp
+, attrs
+, itsdangerous
+, url-normalize
+}:
 
-python3.pkgs.buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "aiohttp_client_cache";
   version = "0.11.0";
   pyproject = true;
@@ -8,10 +16,10 @@ python3.pkgs.buildPythonPackage rec {
     inherit pname version;
     sha256 = "sha256-B2b/9O2gVJjHUlN0pYeBDcwsy3slaAnd5SroeQqEU+s=";
   };
-  nativeBuildInputs = with python3.pkgs; [
+  nativeBuildInputs = [
     poetry-core
   ];
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = [
     aiohttp
     attrs
     itsdangerous


### PR DESCRIPTION
## Description of changes

The current packaging makes it impossible to deal with python overrides. More precisely, I got a problem when trying to package a new package with a modified version of python :

```
Found duplicated packages in closure for dependency 'aiohttp':
  aiohttp 3.9.3 (/nix/store/idh9g9m80jdjlg6jmyh5z89p03pdrr2n-python3.11-aiohttp-3.9.3)
    dependency chain:
      this derivation: /nix/store/yw1j61319zdlib27z17d4dgf6qq1zj60-python3.11-homeassistant-api-4.2.1
      ...depending on: /nix/store/idh9g9m80jdjlg6jmyh5z89p03pdrr2n-python3.11-aiohttp-3.9.3
  aiohttp 3.9.3 (/nix/store/z8gd5li9y5ycbjvskraq8q78gnvallfg-python3.11-aiohttp-3.9.3)
    dependency chain:
      this derivation: /nix/store/yw1j61319zdlib27z17d4dgf6qq1zj60-python3.11-homeassistant-api-4.2.1
      ...depending on: /nix/store/5jnv202px2znrw741ydmi1razzwhrk6q-python3.11-aiohttp_client_cache-0.11.0
      ...depending on: /nix/store/z8gd5li9y5ycbjvskraq8q78gnvallfg-python3.11-aiohttp-3.9.3
```

In the first case it is pointing to aiohttp built with my modified version of python. The second case aiohttp is built against python3 (due to defective packaging). I believe this problem may also arise if the "modified python" is just python 3.12.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
