### PR TITLE
fop: clean up, make deterministic

### DIFF
--- a/pkgs/tools/typesetting/fop/default.nix
+++ b/pkgs/tools/typesetting/fop/default.nix
@@ -1,38 +1,64 @@
-{ fetchurl, lib, stdenv, ant, jdk, runtimeShell }:
+{ lib
+, stdenv
+, fetchurl
+, ant
+, jdk
+, jre
+, makeWrapper
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "fop";
   version = "2.8";
 
   src = fetchurl {
-    url = "mirror://apache/xmlgraphics/fop/source/${pname}-${version}-src.tar.gz";
-    sha256 = "sha256-b7Av17wu6Ar/npKOiwYqzlvBFSIuXTpqTacM1sxtBvc=";
+    url = "mirror://apache/xmlgraphics/fop/fop-${finalAttrs.version}-src.tar.gz";
+    hash = "sha256-b7Av17wu6Ar/npKOiwYqzlvBFSIuXTpqTacM1sxtBvc=";
   };
 
-  buildInputs = [ ant jdk ];
+  postPatch = ''
+    # Fix jar timestamps for reproducibility
+    substituteInPlace fop/build.xml \
+        --replace-fail '<jar ' '<jar modificationtime="0" '
+  '';
 
-  # build only the "package" target, which generates the fop command.
+  nativeBuildInputs = [
+    ant
+    jdk
+    makeWrapper
+  ];
+
+  # Note: not sure if this is needed anymore
+  env.JAVA_TOOL_OPTIONS = "-Dfile.encoding=UTF8";
+
   buildPhase = ''
-     export JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF8"
-     ant -f fop/build.xml package
+    runHook preBuild
+
+    # build only the "package" target, which generates the fop command.
+    ant -f fop/build.xml package
+
+    runHook postBuild
   '';
 
   installPhase = ''
-    mkdir -p $out/bin $out/lib $out/share/doc/fop
+    runHook preInstall
+
+    mkdir -p $out/lib $out/share/doc/fop
     cp fop/build/*.jar fop/lib/*.jar $out/lib/
     cp -r README fop/examples/ $out/share/doc/fop/
 
     # There is a fop script in the source archive, but it has many impurities.
     # Instead of patching out 90 % of the script, we write our own.
-    cat > "$out/bin/fop" <<EOF
-    #!${runtimeShell}
-    java_exec_args="-Djava.awt.headless=true"
-    exec ${jdk.jre}/bin/java \$java_exec_args -classpath "$out/lib/*" org.apache.fop.cli.Main "\$@"
-    EOF
-    chmod a+x $out/bin/fop
+    makeWrapper ${jre}/bin/java $out/bin/fop \
+        --add-flags "-Djava.awt.headless=true" \
+        --add-flags "-classpath $out/lib/\*" \
+        --add-flags "org.apache.fop.cli.Main"
+
+    runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
+    changelog = "https://xmlgraphics.apache.org/fop/changes.html";
     description = "XML formatter driven by XSL Formatting Objects (XSL-FO)";
     longDescription = ''
       FOP is a Java application that reads a formatting object tree and then
@@ -47,13 +73,13 @@ stdenv.mkDerivation rec {
       This package contains the fop command line tool.
     '';
     homepage = "https://xmlgraphics.apache.org/fop/";
-    license = licenses.asl20;
-    sourceProvenance = with sourceTypes; [
-      fromSource
-      binaryBytecode  # source bundles dependencies as jars
-    ];
-    platforms = platforms.all;
-    maintainers = with maintainers; [ bjornfor ];
+    license = lib.licenses.asl20;
     mainProgram = "fop";
+    maintainers = with lib.maintainers; [ bjornfor tomasajt ];
+    platforms = jre.meta.platforms;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode # source bundles dependencies as jars
+    ];
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5406,9 +5406,7 @@ with pkgs;
   texlive = callPackage ../tools/typesetting/tex/texlive { };
   inherit (texlive.schemes) texliveBasic texliveBookPub texliveConTeXt texliveFull texliveGUST texliveInfraOnly texliveMedium texliveMinimal texliveSmall texliveTeTeX;
 
-  fop = callPackage ../tools/typesetting/fop {
-    jdk = openjdk8;
-  };
+  fop = callPackage ../tools/typesetting/fop { };
 
   fondu = callPackage ../tools/misc/fondu {
     inherit (darwin.apple_sdk.frameworks) CoreServices;


### PR DESCRIPTION
## Description of changes

This PR refactors the `fop` package.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done


Drop the explicit version of jdk: it will now use the latest `jdk` instead of `jdk8` only.

Use `finalAttrs` instead of `rec`

Use `hash` instead of `sha256` in fetcher

Add a patch, which makes the build deterministic.

Add the missing `runHook` calls.

Use `makeWrapper` instead of manually writing the script.



Changes made to `meta`
- remove `with lib;`
- add `changelog`
- add myself to `maintainers`
- use `platforms` from `jre`
- (mostly) sort attributes alphabetically

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
