### PR TITLE
jameica: make deterministic and clean up

### DIFF
--- a/pkgs/applications/office/jameica/default.nix
+++ b/pkgs/applications/office/jameica/default.nix
@@ -1,4 +1,17 @@
-{ lib, stdenv, fetchFromGitHub, makeDesktopItem, makeWrapper, wrapGAppsHook, ant, jdk, jre, gtk2, glib, xorg, Cocoa }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, makeDesktopItem
+, makeWrapper
+, wrapGAppsHook
+, ant
+, jdk
+, jre
+, gtk2
+, glib
+, libXtst
+, Cocoa
+}:
 
 let
   _version = "2.10.4";
@@ -26,10 +39,6 @@ stdenv.mkDerivation rec {
   pname = "jameica";
   inherit version;
 
-  nativeBuildInputs = [ ant jdk wrapGAppsHook makeWrapper ];
-  buildInputs = lib.optionals stdenv.isLinux [ gtk2 glib xorg.libXtst ]
-    ++ lib.optional stdenv.isDarwin Cocoa;
-
   src = fetchFromGitHub {
     owner = "willuhn";
     repo = "jameica";
@@ -37,15 +46,29 @@ stdenv.mkDerivation rec {
     hash = "sha256-MSVSd5DyVL+dcfTDv1M99hxickPwT2Pt6QGNsu6DGZI=";
   };
 
+  postPatch = ''
+    # Fix jar timestamps for reproducibility
+    substituteInPlace build/build.xml \
+        --replace-fail '<jar ' '<jar modificationtime="0" '
+  '';
+
+  nativeBuildInputs = [ ant jdk wrapGAppsHook makeWrapper ];
+  buildInputs = lib.optionals stdenv.isLinux [ gtk2 glib libXtst ]
+    ++ lib.optional stdenv.isDarwin Cocoa;
+
   dontWrapGApps = true;
 
   # there is also a build.gradle, but it only seems to be used to vendor 3rd party libraries
   # and is not able to build the application itself
   buildPhase = ''
-    (cd build; ant -Dsystem.version=${version} init compile jar)
+    runHook preBuild
+    ant -f build -Dsystem.version=${version} init compile jar
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/libexec $out/lib $out/bin $out/share/{applications,jameica-${version},java}/
 
     # copy libraries except SWT
@@ -57,6 +80,8 @@ stdenv.mkDerivation rec {
     install -Dm644 plugin.xml $out/share/java/
     install -Dm644 build/jameica-icon.png $out/share/pixmaps/jameica.png
     cp ${desktopItem}/share/applications/* $out/share/applications/
+
+    runHook postInstall
   '';
 
   postFixup = ''


### PR DESCRIPTION
## Description of changes

This PR makes some minor changes to the build script of `jameica` and adds a `postPatch` script, which makes the build actually deterministic.

If you have any issues with my other changes, I can revert them.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
