### PR TITLE
freetts: clean up and make deterministic

### DIFF
--- a/pkgs/development/libraries/freetts/default.nix
+++ b/pkgs/development/libraries/freetts/default.nix
@@ -1,29 +1,53 @@
-{stdenv, fetchurl, apacheAnt, unzip, sharutils, lib, jdk}:
+{ lib
+, stdenv
+, fetchzip
+, ant
+, jdk8
+, sharutils
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "freetts";
   version = "1.2.2";
-  src = fetchurl {
-    url = "mirror://sourceforge/freetts/${pname}-${version}-src.zip";
-    sha256 = "0mnikqhpf4f4jdr0irmibr8yy0dnffx1i257y22iamxi7a6by2r7";
+
+  src = fetchzip {
+    url = "mirror://sourceforge/freetts/${finalAttrs.pname}-${finalAttrs.version}-src.zip";
+    hash = "sha256-+bhM0ErEZVnmcz5CBqn/AeGaOhKnCjZzGeqgO/89wms=";
+    stripRoot = false;
   };
-  nativeBuildInputs = [ unzip ];
-  buildInputs = [ apacheAnt sharutils jdk ];
-  unpackPhase = ''
-    unzip $src -x META-INF/*
+
+  nativeBuildInputs = [
+    ant
+    jdk8
+    sharutils
+  ];
+
+  sourceRoot = "${finalAttrs.src.name}/freetts-${finalAttrs.version}";
+
+  postPatch = ''
+    # Fix jar timestamps for reproducibility
+    substituteInPlace build.xml demo.xml \
+        --replace-fail '<jar ' '<jar modificationtime="0" '
   '';
 
   buildPhase = ''
-    cd */lib
+    runHook preBuild
+
+    pushd lib
     sed -i -e "s/more/cat/" jsapi.sh
     echo y | sh jsapi.sh
-    cd ..
+    popd
+
     ln -s . src
     ant
+
+    runHook postBuild
   '';
+
   installPhase = ''
-    install -v -m755 -d $out/{lib,docs/{audio,images}}
-    install -v -m644 lib/*.jar $out/lib
+    runHook preInstall
+    install -Dm644 lib/*.jar -t $out/lib
+    runHook postInstall
   '';
 
   meta = {
@@ -32,8 +56,12 @@ stdenv.mkDerivation rec {
       Text to speech system based on Festival written in Java.
       Can be used in combination with KDE accessibility.
     '';
-    license = "GPL";
     homepage = "http://freetts.sourceforge.net";
-    maintainers = [ lib.maintainers.sander ];
+    license = lib.licenses.bsdOriginal;
+    maintainers = with lib.maintainers; [ sander ];
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode # jsapi.jar is bundled in a self-extracting shell-script
+    ];
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -21115,9 +21115,7 @@ with pkgs;
     };
   };
 
-  freetts = callPackage ../development/libraries/freetts {
-    jdk = jdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
-  };
+  freetts = callPackage ../development/libraries/freetts { };
 
   frog = res.languageMachines.frog;
 


### PR DESCRIPTION
## Description of changes

This PR refactors the `freetts` package.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Use `finalAttrs` instead of `rec`
- Use `fetchzip`, use `hash`
- Use `stripRoot = false` and `sourceRoot` instead of custom `unpackPhase`
- Add `postPatch` script to make the build deterministic.
- Use `pushd` and `popd` instead of `cd`
- Don't create empty `docs` directory.
- Use corrected `meta.license`
- Add `meta.sourceProvenence`
- Use `jdk8` explicitly in-file, as higher versions of java are not supported.

---

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
