### PR TITLE
jetbrains-resharper: init at 2023.3.3

### DIFF
--- a/pkgs/by-name/je/jetbrains-resharper/package.nix
+++ b/pkgs/by-name/je/jetbrains-resharper/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  pkgs,
+  buildDotnetModule,
+  emptyDirectory,
+  stdenv,
+  mkNugetDeps,
+}: let
+  nugetName = "JetBrains.ReSharper.GlobalTools";
+  version = "2023.3.3";
+  nugetSha256 = "sha256-Nn3imJvnqLe02gR1GyUHYH4+XkrNnhLy9dyCjJCkB7M=";
+  pname = "jb";
+in
+  buildDotnetModule {
+    inherit nugetName version nugetSha256 pname;
+
+    src = emptyDirectory;
+
+    executables = "jb";
+
+    dotnet-runtime = pkgs.dotnet-sdk;
+
+    nugetDeps = mkNugetDeps {
+      name = pname;
+      nugetDeps = {fetchNuGet}: [
+        (fetchNuGet {
+          pname = nugetName;
+          inherit version;
+          sha256 = nugetSha256;
+        })
+      ];
+    };
+
+    projectFile = "";
+
+    useDotnetFromEnv = true;
+
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      dotnet tool install --tool-path $out/lib/${pname} ${nugetName} ${
+        if stdenv.isAarch64
+        then "--arch arm64"
+        else ""
+      }
+
+      # remove files that contain nix store paths to temp nuget sources we made
+      find $out -name 'project.assets.json' -delete
+      find $out -name '.nupkg.metadata' -delete
+
+      runHook postInstall
+    '';
+
+    meta = with lib; {
+      homepage = "https://www.jetbrains.com/help/resharper/ReSharper_Command_Line_Tools.html";
+      changelog = "https://www.jetbrains.com/resharper/whatsnew/";
+      license = licenses.unfree;
+      platforms = platforms.unix;
+      maintainers = with maintainers; [tarantoj];
+      mainProgram = "jb";
+    };
+  }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds Jetbrain's ReSharper command line tools.

> ReSharper Command Line Tools is a set of free cross-platform standalone tools that help you integrate automatic code quality procedures into your CI, version control, or any other server.

https://www.jetbrains.com/help/resharper/ReSharper_Command_Line_Tools.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
