### PR TITLE
nixos/sunshine: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -140,6 +140,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - [Mealie](https://nightly.mealie.io/), a self-hosted recipe manager and meal planner with a RestAPI backend and a reactive frontend application built in NuxtJS for a pleasant user experience for the whole family. Available as [services.mealie](#opt-services.mealie.enable)
 
+- [Sunshine](https://app.lizardbyte.dev/Sunshine), a self-hosted game stream host for Moonlight. Available as [services.sunshine](#opt-services.sunshine.enable).
+
 - [Uni-Sync](https://github.com/EightB1ts/uni-sync), a synchronization tool for Lian Li Uni Controllers. Available as [hardware.uni-sync](#opt-hardware.uni-sync.enable)
 
 ## Backward Incompatibilities {#sec-release-24.05-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1145,6 +1145,7 @@
   ./services/networking/strongswan.nix
   ./services/networking/stubby.nix
   ./services/networking/stunnel.nix
+  ./services/networking/sunshine.nix
   ./services/networking/supplicant.nix
   ./services/networking/supybot.nix
   ./services/networking/syncplay.nix

--- a/nixos/modules/services/networking/sunshine.nix
+++ b/nixos/modules/services/networking/sunshine.nix
@@ -1,0 +1,156 @@
+{ config, lib, pkgs, utils, ... }:
+let
+  inherit (lib) mkEnableOption mkPackageOption mkOption mkIf mkDefault types optionals getExe;
+  inherit (utils) escapeSystemdExecArgs;
+  cfg = config.services.sunshine;
+
+  # ports used are offset from a single base port, see https://docs.lizardbyte.dev/projects/sunshine/en/latest/about/advanced_usage.html#port
+  generatePorts = port: offsets: map (offset: port + offset) offsets;
+  defaultPort = 47989;
+
+  appsFormat = pkgs.formats.json { };
+  settingsFormat = pkgs.formats.keyValue { };
+
+  appsFile = appsFormat.generate "apps.json" cfg.applications;
+  configFile = settingsFormat.generate "sunshine.conf" cfg.settings;
+in
+{
+  options.services.sunshine = with types; {
+    enable = mkEnableOption "Sunshine, a self-hosted game stream host for Moonlight";
+    package = mkPackageOption pkgs "sunshine" { };
+    openFirewall = mkOption {
+      type = bool;
+      default = false;
+      description = ''
+        Whether to automatically open ports in the firewall.
+      '';
+    };
+    capSysAdmin = mkOption {
+      type = bool;
+      default = false;
+      description = ''
+        Whether to give the Sunshine binary CAP_SYS_ADMIN, required for DRM/KMS screen capture.
+      '';
+    };
+    settings = mkOption {
+      default = { };
+      description = ''
+        Settings to be rendered into the configuration file. If this is set, no configuration is possible from the web UI.
+
+        See https://docs.lizardbyte.dev/projects/sunshine/en/latest/about/advanced_usage.html#configuration for syntax.
+      '';
+      example = ''
+        {
+          sunshine_name = "nixos";
+        }
+      '';
+      type = submodule (settings: {
+        freeformType = settingsFormat.type;
+        options.port = mkOption {
+          type = port;
+          default = defaultPort;
+          description = ''
+            Base port -- others used are offset from this one, see https://docs.lizardbyte.dev/projects/sunshine/en/latest/about/advanced_usage.html#port for details.
+          '';
+        };
+      });
+    };
+    applications = mkOption {
+      default = { };
+      description = ''
+        Configuration for applications to be exposed to Moonlight. If this is set, no configuration is possible from the web UI, and must be by the `settings` option.
+      '';
+      example = ''
+        {
+          env = {
+            PATH = "$(PATH):$(HOME)/.local/bin";
+          };
+          apps = [
+            {
+              name = "1440p Desktop";
+              prep-cmd = [
+                {
+                  do = "''${pkgs.kdePackages.libkscreen}/bin/kscreen-doctor output.DP-4.mode.2560x1440@144";
+                  undo = "''${pkgs.kdePackages.libkscreen}/bin/kscreen-doctor output.DP-4.mode.3440x1440@144";
+                }
+              ];
+              exclude-global-prep-cmd = "false";
+              auto-detach = "true";
+            }
+          ];
+        }
+      '';
+      type = submodule {
+        options = {
+          env = mkOption {
+            default = { };
+            description = ''
+              Environment variables to be set for the applications.
+            '';
+            type = attrsOf str;
+          };
+          apps = mkOption {
+            default = [ ];
+            description = ''
+              Applications to be exposed to Moonlight.
+            '';
+            type = listOf attrs;
+          };
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.sunshine.settings.file_apps = mkIf (cfg.applications.apps != [ ]) "${appsFile}";
+
+    environment.systemPackages = [
+      cfg.package
+    ];
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = generatePorts cfg.settings.port [ (-5) 0 1 21 ];
+      allowedUDPPorts = generatePorts cfg.settings.port [ 9 10 11 13 21 ];
+    };
+
+    boot.kernelModules = [ "uinput" ];
+
+    services.udev.packages = [ cfg.package ];
+
+    services.avahi = {
+      enable = mkDefault true;
+      publish = {
+        enable = mkDefault true;
+        userServices = mkDefault true;
+      };
+    };
+
+    security.wrappers.sunshine = mkIf cfg.capSysAdmin {
+      owner = "root";
+      group = "root";
+      capabilities = "cap_sys_admin+p";
+      source = getExe cfg.package;
+    };
+
+    systemd.user.services.sunshine = {
+      description = "Self-hosted game stream host for Moonlight";
+
+      wantedBy = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
+      wants = [ "graphical-session.target" ];
+      after = [ "graphical-session.target" ];
+
+      startLimitIntervalSec = 500;
+      startLimitBurst = 5;
+
+      serviceConfig = {
+        # only add configFile if an application or a setting other than the default port is set to allow configuration from web UI
+        ExecStart = escapeSystemdExecArgs ([
+          (if cfg.capSysAdmin then "${config.security.wrapperDir}/sunshine" else "${getExe cfg.package}")
+        ] ++ optionals (cfg.applications.apps != [ ] || (builtins.length (builtins.attrNames cfg.settings) > 1 || cfg.settings.port != defaultPort)) [ "${configFile}" ]);
+        Restart = "on-failure";
+        RestartSec = "5s";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -842,6 +842,7 @@ in {
   stunnel = handleTest ./stunnel.nix {};
   sudo = handleTest ./sudo.nix {};
   sudo-rs = handleTest ./sudo-rs.nix {};
+  sunshine = handleTest ./sunshine.nix {};
   suwayomi-server = handleTest ./suwayomi-server.nix {};
   swap-file-btrfs = handleTest ./swap-file-btrfs.nix {};
   swap-partition = handleTest ./swap-partition.nix {};

--- a/nixos/tests/sunshine.nix
+++ b/nixos/tests/sunshine.nix
@@ -1,0 +1,70 @@
+import ./make-test-python.nix ({ pkgs, lib, ... }: {
+  name = "sunshine";
+  meta = {
+    # test is flaky on aarch64
+    broken = pkgs.stdenv.isAarch64;
+    maintainers = [ lib.maintainers.devusb ];
+  };
+
+  nodes.sunshine = { config, pkgs, ... }: {
+    imports = [
+      ./common/x11.nix
+    ];
+
+    services.sunshine = {
+      enable = true;
+      openFirewall = true;
+      settings = {
+        capture = "x11";
+        encoder = "software";
+        output_name = 0;
+      };
+    };
+
+    environment.systemPackages = with pkgs; [
+      gxmessage
+    ];
+
+  };
+
+  nodes.moonlight = { config, pkgs, ... }: {
+    imports = [
+      ./common/x11.nix
+    ];
+
+    environment.systemPackages = with pkgs; [
+      moonlight-qt
+    ];
+
+  };
+
+  enableOCR = true;
+
+  testScript = ''
+    # start the tests, wait for sunshine to be up
+    start_all()
+    sunshine.wait_for_open_port(48010,"localhost")
+
+    # set the admin username/password, restart sunshine
+    sunshine.execute("sunshine --creds sunshine sunshine")
+    sunshine.systemctl("restart sunshine","root")
+    sunshine.wait_for_open_port(48010,"localhost")
+
+    # initiate pairing from moonlight
+    moonlight.execute("moonlight pair sunshine --pin 1234 >&2 & disown")
+    moonlight.wait_for_console_text("Executing request")
+
+    # respond to pairing request from sunshine
+    sunshine.succeed("curl --insecure -u sunshine:sunshine -d '{\"pin\": \"1234\"}' https://localhost:47990/api/pin")
+
+    # close moonlight once pairing complete
+    moonlight.send_key("kp_enter")
+
+    # put words on the sunshine screen for moonlight to see
+    sunshine.execute("gxmessage 'hello world' -center -font 'sans 75' >&2 & disown")
+
+    # connect to sunshine from moonlight and look for the words
+    moonlight.execute("moonlight --video-decoder software stream sunshine 'Desktop' >&2 & disown")
+    moonlight.wait_for_text("hello world")
+  '';
+})

--- a/pkgs/servers/sunshine/default.nix
+++ b/pkgs/servers/sunshine/default.nix
@@ -4,6 +4,7 @@
 , autoPatchelfHook
 , makeWrapper
 , buildNpmPackage
+, nixosTests
 , cmake
 , avahi
 , libevdev
@@ -181,7 +182,10 @@ stdenv'.mkDerivation rec {
     install -Dm644 ../packaging/linux/${pname}.desktop $out/share/applications/${pname}.desktop
   '';
 
-  passthru.updateScript = ./updater.sh;
+  passthru = {
+    tests.sunshine = nixosTests.sunshine;
+    updateScript = ./updater.sh;
+  };
 
   meta = with lib; {
     description = "Sunshine is a Game stream host for Moonlight";


### PR DESCRIPTION
## Description of changes

Adds a NixOS module for [Sunshine](https://app.lizardbyte.dev/Sunshine/), a self-hosted game stream host for Moonlight. 

Closes #293298 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
