### PR TITLE
bcache-tools: 1.0.7 -> 1.0.8

### DIFF
--- a/pkgs/tools/filesystems/bcache-tools/bcache-udev-modern.patch
+++ b/pkgs/tools/filesystems/bcache-tools/bcache-udev-modern.patch
@@ -1,15 +1,15 @@
 This patch does two things:
-1) Drops probe-bcache, so now new util-linux detecting functionality is used.
-2) Drops bcache-register, using kmod (built in udev) and moving registering device
-   into rule using 'sh'.
-This reduces things that need to be present in initrd, replacing them with already
-existing functionality and reducing overall initrd size.
+1) Drops probe-bcache, so now util-linux detecting functionality is used.
+2) Drops bcache-register, moving registering device functionality into rule
+   using 'sh'.
+This reduces things that need to be present in initrd, replacing them with
+already existing functionality and reducing overall initrd size.
 
 diff --git a/69-bcache.rules b/69-bcache.rules
-index 5d28e70..6a52893 100644
+index 9cc7f0d..6a52893 100644
 --- a/69-bcache.rules
 +++ b/69-bcache.rules
-@@ -10,15 +10,11 @@ KERNEL=="fd*|sr*", GOTO="bcache_end"
+@@ -10,16 +10,11 @@ KERNEL=="fd*|sr*", GOTO="bcache_end"
  # It recognised bcache (util-linux 2.24+)
  ENV{ID_FS_TYPE}=="bcache", GOTO="bcache_backing_found"
  # It recognised something else; bail
@@ -22,31 +22,21 @@ index 5d28e70..6a52893 100644
 +GOTO="bcache_backing_end"
  
  LABEL="bcache_backing_found"
+ RUN{builtin}+="kmod load bcache"
 -RUN+="bcache-register $tempnode"
-+RUN{builtin}+="kmod load bcache"
 +RUN+="/bin/sh -c 'echo $tempnode > /sys/fs/bcache/register_quiet'"
  LABEL="bcache_backing_end"
  
  # Cached devices: symlink
 diff --git a/Makefile b/Makefile
-index 3f8d87b..15638a7 100644
+index c824ae3..c5f7309 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -9,7 +9,7 @@ all: make-bcache probe-bcache bcache-super-show
+@@ -9,7 +9,6 @@ all: make-bcache probe-bcache bcache-super-show bcache-register
  
  install: make-bcache probe-bcache bcache-super-show
  	$(INSTALL) -m0755 make-bcache bcache-super-show	$(DESTDIR)${PREFIX}/sbin/
 -	$(INSTALL) -m0755 probe-bcache bcache-register		$(DESTDIR)$(UDEVLIBDIR)/
-+#	$(INSTALL) -m0755 probe-bcache bcache-register		$(DESTDIR)$(UDEVLIBDIR)/
  	$(INSTALL) -m0644 69-bcache.rules	$(DESTDIR)$(UDEVLIBDIR)/rules.d/
  	$(INSTALL) -m0644 -- *.8 $(DESTDIR)${PREFIX}/share/man/man8/
  	$(INSTALL) -D -m0755 initramfs/hook	$(DESTDIR)/usr/share/initramfs-tools/hooks/bcache
-diff --git a/bcache-register b/bcache-register
-index 9b592bc..75b4faf 100755
---- a/bcache-register
-+++ b/bcache-register
-@@ -1,4 +1,3 @@
- #!/bin/sh
--/sbin/modprobe -qba bcache
- test -f /sys/fs/bcache/register_quiet && echo "$1" > /sys/fs/bcache/register_quiet
- 

--- a/pkgs/tools/filesystems/bcache-tools/default.nix
+++ b/pkgs/tools/filesystems/bcache-tools/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "bcache-tools";
-  version = "1.0.7";
+  version = "1.0.8";
 
   src = fetchFromGitHub {
     owner = "g2p";
     repo = "bcache-tools";
     rev = "v${version}";
-    hash = "sha256-Ors2xXRrVTf8Cq3BYnSVSfJy/nyGjT5BGLSNpxOcHR4=";
+    hash = "sha256-6gy0ymecMgEHXbwp/nXHlrUEeDFnmFXWZZPlzP292g4=";
   };
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
## Description of changes

Practically none.  Between 1.0.7 and 1.0.8:
 - The code was changed to use builtin kmod, which our patch already did (so this lets us remove it from the patch)
 -  The bcache-register script was replaced with a small executable, but we don't use it - we already delete it entirely and use a line of shell in the rule - so it doesn't matter at all.

https://github.com/g2p/bcache-tools/compare/v1.0.7...v1.0.8

In all honesty, the only reason why I am providing this PR *at all* is because I found it **very** entertaining that technically this package is nine-and-a-quarter years out of date.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
