### PR TITLE
python3Packages.asyncpg: fix build and bump minimum Python version

### DIFF
--- a/pkgs/development/python-modules/asyncpg/default.nix
+++ b/pkgs/development/python-modules/asyncpg/default.nix
@@ -1,6 +1,7 @@
 { lib
 , fetchPypi
 , buildPythonPackage
+, async-timeout
 , uvloop
 , postgresql
 , pythonOlder
@@ -13,7 +14,7 @@ buildPythonPackage rec {
   version = "0.29.0";
   format = "setuptools";
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
@@ -22,6 +23,12 @@ buildPythonPackage rec {
 
   # sandboxing issues on aarch64-darwin, see https://github.com/NixOS/nixpkgs/issues/198495
   doCheck = postgresql.doCheck;
+
+  # required for compatibility with Python versions older than 3.11
+  # see https://github.com/MagicStack/asyncpg/blob/v0.29.0/asyncpg/_asyncio_compat.py#L13
+  propagatedBuildInputs = lib.optionals (pythonOlder "3.11") [
+    async-timeout
+  ];
 
   nativeCheckInputs = [
     uvloop


### PR DESCRIPTION
## Description of changes

I added the package's dependency on `async-timeout`. Because it was missing, attempting to build it with Python <=3.10 resulted in this error.

```
Running phase: pythonImportsCheckPhase
Executing pythonImportsCheckPhase
Check whether the following modules can be imported: asyncpg
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<string>", line 1, in <lambda>
  File "/nix/store/9d1gknfymymdfm8fwry11vxvh80q7sj6-python3-3.10.13/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/nix/store/3x47wzy9rk0gdf9lc4ryy6kmr3xq5cl4-python3.10-asyncpg-0.29.0/lib/python3.10/site-packages/asyncpg/__init__.py", line 8, in <module>
    from .connection import connect, Connection  # NOQA
  File "/nix/store/3x47wzy9rk0gdf9lc4ryy6kmr3xq5cl4-python3.10-asyncpg-0.29.0/lib/python3.10/site-packages/asyncpg/connection.py", line 24, in <module>
    from . import compat
  File "/nix/store/3x47wzy9rk0gdf9lc4ryy6kmr3xq5cl4-python3.10-asyncpg-0.29.0/lib/python3.10/site-packages/asyncpg/compat.py", line 53, in <module>
    from ._asyncio_compat import wait_for as wait_for  # noqa: F401
  File "/nix/store/3x47wzy9rk0gdf9lc4ryy6kmr3xq5cl4-python3.10-asyncpg-0.29.0/lib/python3.10/site-packages/asyncpg/_asyncio_compat.py", line 13, in <module>
    from async_timeout import timeout as timeout_ctx
ModuleNotFoundError: No module named 'async_timeout'
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
