### PR TITLE
[Backport release-23.11] buildbot: tie the knot through a scope to make it overridable

### DIFF
--- a/pkgs/development/tools/continuous-integration/buildbot/master.nix
+++ b/pkgs/development/tools/continuous-integration/buildbot/master.nix
@@ -1,9 +1,11 @@
 { lib
 , stdenv
-, buildPythonPackage
 , buildPythonApplication
 , fetchPypi
 , makeWrapper
+# Tie withPlugins through the fixed point here, so it will receive an
+# overridden version properly
+, buildbot
 , pythonOlder
 , python
 , twisted
@@ -35,13 +37,12 @@
 , pythonRelaxDepsHook
 , glibcLocales
 , nixosTests
-, callPackage
 }:
 
 let
   withPlugins = plugins: buildPythonApplication {
-    pname = "${package.pname}-with-plugins";
-    inherit (package) version;
+    pname = "${buildbot.pname}-with-plugins";
+    inherit (buildbot) version;
     format = "other";
 
     dontUnpack = true;
@@ -52,109 +53,108 @@ let
       makeWrapper
     ];
 
-    propagatedBuildInputs = plugins ++ package.propagatedBuildInputs;
+    propagatedBuildInputs = plugins ++ buildbot.propagatedBuildInputs;
 
     installPhase = ''
-      makeWrapper ${package}/bin/buildbot $out/bin/buildbot \
-        --prefix PYTHONPATH : "${package}/${python.sitePackages}:$PYTHONPATH"
-      ln -sfv ${package}/lib $out/lib
+      makeWrapper ${buildbot}/bin/buildbot $out/bin/buildbot \
+        --prefix PYTHONPATH : "${buildbot}/${python.sitePackages}:$PYTHONPATH"
+      ln -sfv ${buildbot}/lib $out/lib
     '';
 
-    passthru = package.passthru // {
+    passthru = buildbot.passthru // {
       withPlugins = morePlugins: withPlugins (morePlugins ++ plugins);
     };
   };
+in
+buildPythonApplication rec {
+  pname = "buildbot";
+  version = "3.9.2";
+  format = "pyproject";
 
-  package = buildPythonApplication rec {
-    pname = "buildbot";
-    version = "3.9.2";
-    format = "pyproject";
+  disabled = pythonOlder "3.7";
 
-    disabled = pythonOlder "3.7";
-
-    src = fetchPypi {
-      inherit pname version;
-      hash = "sha256-7QhIMUpzmxbh8qjz0hgqzibLkWADhTV523neo1wpGSA=";
-    };
-
-    propagatedBuildInputs = [
-      # core
-      twisted
-      jinja2
-      msgpack
-      zope_interface
-      sqlalchemy
-      alembic
-      python-dateutil
-      txaio
-      autobahn
-      pyjwt
-      pyyaml
-      setuptools
-    ]
-      # tls
-      ++ twisted.optional-dependencies.tls;
-
-    nativeCheckInputs = [
-      treq
-      txrequests
-      pypugjs
-      boto3
-      moto
-      markdown
-      lz4
-      setuptools-trial
-      buildbot-worker
-      buildbot-pkg
-      buildbot-plugins.www
-      parameterized
-      git
-      openssh
-      glibcLocales
-      pythonRelaxDepsHook
-    ];
-
-    pythonRelaxDeps = [ "Twisted" ];
-
-    patches = [
-      # This patch disables the test that tries to read /etc/os-release which
-      # is not accessible in sandboxed builds.
-      ./skip_test_linux_distro.patch
-    ];
-
-    postPatch = ''
-      substituteInPlace buildbot/scripts/logwatcher.py --replace '/usr/bin/tail' "$(type -P tail)"
-    '';
-
-    # Silence the depreciation warning from SqlAlchemy
-    SQLALCHEMY_SILENCE_UBER_WARNING = 1;
-
-    # TimeoutErrors on slow machines -> aarch64
-    doCheck = !stdenv.isAarch64;
-
-    preCheck = ''
-      export LC_ALL="en_US.UTF-8"
-      export PATH="$out/bin:$PATH"
-
-      # remove testfile which is missing configuration file from sdist
-      rm buildbot/test/integration/test_graphql.py
-      # tests in this file are flaky, see https://github.com/buildbot/buildbot/issues/6776
-      rm buildbot/test/integration/test_try_client.py
-    '';
-
-    passthru = {
-      inherit withPlugins;
-      tests.buildbot = nixosTests.buildbot;
-      updateScript = ./update.sh;
-    };
-
-    meta = with lib; {
-      description = "An open-source continuous integration framework for automating software build, test, and release processes";
-      homepage = "https://buildbot.net/";
-      changelog = "https://github.com/buildbot/buildbot/releases/tag/v${version}";
-      maintainers = with maintainers; [ ryansydnor lopsided98 ];
-      license = licenses.gpl2Only;
-      broken = stdenv.isDarwin;
-    };
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-7QhIMUpzmxbh8qjz0hgqzibLkWADhTV523neo1wpGSA=";
   };
-in package
+
+  propagatedBuildInputs = [
+    # core
+    twisted
+    jinja2
+    msgpack
+    zope_interface
+    sqlalchemy
+    alembic
+    python-dateutil
+    txaio
+    autobahn
+    pyjwt
+    pyyaml
+    setuptools
+  ]
+    # tls
+    ++ twisted.optional-dependencies.tls;
+
+  nativeCheckInputs = [
+    treq
+    txrequests
+    pypugjs
+    boto3
+    moto
+    markdown
+    lz4
+    setuptools-trial
+    buildbot-worker
+    buildbot-pkg
+    buildbot-plugins.www
+    parameterized
+    git
+    openssh
+    glibcLocales
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [ "Twisted" ];
+
+  patches = [
+    # This patch disables the test that tries to read /etc/os-release which
+    # is not accessible in sandboxed builds.
+    ./skip_test_linux_distro.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace buildbot/scripts/logwatcher.py --replace '/usr/bin/tail' "$(type -P tail)"
+  '';
+
+  # Silence the depreciation warning from SqlAlchemy
+  SQLALCHEMY_SILENCE_UBER_WARNING = 1;
+
+  # TimeoutErrors on slow machines -> aarch64
+  doCheck = !stdenv.isAarch64;
+
+  preCheck = ''
+    export LC_ALL="en_US.UTF-8"
+    export PATH="$out/bin:$PATH"
+
+    # remove testfile which is missing configuration file from sdist
+    rm buildbot/test/integration/test_graphql.py
+    # tests in this file are flaky, see https://github.com/buildbot/buildbot/issues/6776
+    rm buildbot/test/integration/test_try_client.py
+  '';
+
+  passthru = {
+    inherit withPlugins;
+    tests.buildbot = nixosTests.buildbot;
+    updateScript = ./update.sh;
+  };
+
+  meta = with lib; {
+    description = "An open-source continuous integration framework for automating software build, test, and release processes";
+    homepage = "https://buildbot.net/";
+    changelog = "https://github.com/buildbot/buildbot/releases/tag/v${version}";
+    maintainers = with maintainers; [ ryansydnor lopsided98 ];
+    license = licenses.gpl2Only;
+    broken = stdenv.isDarwin;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3598,8 +3598,8 @@ with pkgs;
   bucklespring-libinput = callPackage ../applications/audio/bucklespring { };
   bucklespring-x11 = callPackage ../applications/audio/bucklespring { legacy = true; };
 
-  inherit (python3.pkgs.callPackage ../development/tools/continuous-integration/buildbot {})
-    buildbot buildbot-ui buildbot-full buildbot-plugins buildbot-worker;
+  buildbotPackages = recurseIntoAttrs (python3.pkgs.callPackage ../development/tools/continuous-integration/buildbot { });
+  inherit (buildbotPackages) buildbot buildbot-ui buildbot-full buildbot-plugins buildbot-worker;
 
   bunyan-rs = callPackage ../development/tools/bunyan-rs { };
 


### PR DESCRIPTION
Currently it is impossible to overlay buildbot since all the references between components are directly bound to the values in scope. Let's fix this by introducing a scope so you can overrideScope parts of buildbot.

I also changed buildbot-worker to use our overridden python, which is no functional change, but makes things more consistent.

(cherry picked from commit ebf346ff0416630c21166bb8568812075ae853bf)

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
