### PR TITLE
rtabmap: 0.21.0 -> 0.21.4

### DIFF
--- a/pkgs/applications/video/rtabmap/default.nix
+++ b/pkgs/applications/video/rtabmap/default.nix
@@ -27,27 +27,14 @@
 
 stdenv.mkDerivation rec {
   pname = "rtabmap";
-  version = "0.21.0";
+  version = "0.21.4";
 
   src = fetchFromGitHub {
     owner = "introlab";
     repo = "rtabmap";
     rev = "refs/tags/${version}";
-    hash = "sha256-1xb8O3VrErldid2OgAUMG28mSUO7QBUsPuSz8p03tSI";
+    hash = "sha256-HrIATYRuhFfTlO4oTRZo7CM30LFVyatZJON31Fe4HTQ=";
   };
-
-  patches = [
-    # Fix build with g2o 20230806
-    (fetchpatch {
-      url = "https://github.com/introlab/rtabmap/commit/85cc6fe3c742855ad16c8442895e12dbb10b6e8b.patch";
-      hash = "sha256-P6GkYKCNwe9dgZdgF/oEhgjA3bJnwXFWJCPoyIknQCo=";
-    })
-    # Fix typo in previous patch
-    (fetchpatch {
-      url = "https://github.com/introlab/rtabmap/commit/c4e94bcdc31b859c1049724dbb7671e4597d86de.patch";
-      hash = "sha256-1btkV4/y+bnF3xEVqlUy/9F6BoANeTOEJjZLmRzG3iA=";
-    })
-  ];
 
   nativeBuildInputs = [ cmake pkg-config wrapQtAppsHook wrapGAppsHook ];
   buildInputs = [


### PR DESCRIPTION
## Description of changes

https://github.com/introlab/rtabmap/releases/tag/0.21.4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@ckiee
