### PR TITLE
nixos/guix: add declarative substituters option

### DIFF
--- a/nixos/modules/services/misc/guix/default.nix
+++ b/nixos/modules/services/misc/guix/default.nix
@@ -259,11 +259,6 @@ in
 
   config = lib.mkIf cfg.enable (lib.mkMerge [
     {
-      services.guix.extraArgs =
-        lib.optionals (cfg.substituters.urls != [ ]) [
-          "--substitute-urls='${lib.concatStringsSep " " cfg.substituters.urls}'"
-        ];
-
       environment.systemPackages = [ package ];
 
       users.users = guixBuildUsers cfg.nrBuildUsers;
@@ -282,6 +277,8 @@ in
         script = ''
           ${lib.getExe' package "guix-daemon"} \
             --build-users-group=${cfg.group} \
+            ${lib.optionalString (cfg.substituters.urls != [ ])
+              "--substitute-urls='${lib.concatStringsSep " " cfg.substituters.urls}'"} \
             ${lib.escapeShellArgs cfg.extraArgs}
         '';
         serviceConfig = {

--- a/nixos/modules/services/misc/guix/default.nix
+++ b/nixos/modules/services/misc/guix/default.nix
@@ -46,6 +46,17 @@ let
     GUIX_LOCPATH = "${cfg.stateDir}/guix/profiles/per-user/root/guix-profile/lib/locale";
     LC_ALL = "C.UTF-8";
   };
+
+  # Currently, this is just done the lazy way with the official Guix script. A
+  # more "formal" way would be creating our own Guix script to handle and
+  # generate the ACL file ourselves.
+  aclFile = pkgs.runCommandLocal "guix-acl" { } ''
+    export GUIX_CONFIGURATION_DIRECTORY=./
+    for official_server_keys in ${lib.concatStringsSep " " cfg.substituters.authorizedKeys}; do
+      ${lib.getExe' cfg.package "guix"} archive --authorize < "$official_server_keys"
+    done
+    install -Dm0600 ./acl "$out"
+  '';
 in
 {
   meta.maintainers = with lib.maintainers; [ foo-dogsquared ];
@@ -116,6 +127,57 @@ in
         :::
       '';
       example = "/gnu/var";
+    };
+
+    substituters = {
+      urls = lib.mkOption {
+        type = with lib.types; listOf str;
+        default = [
+          "https://ci.guix.gnu.org"
+          "https://bordeaux.guix.gnu.org"
+          "https://berlin.guix.gnu.org"
+        ];
+        example = lib.literalExpression ''
+          options.services.guix.substituters.urls.default ++ [
+            "https://guix.example.com"
+            "https://guix.example.org"
+          ]
+        '';
+        description = ''
+          A list of substitute servers' URLs for the Guix daemon to download
+          substitutes from.
+        '';
+      };
+
+      authorizedKeys = lib.mkOption {
+        type = with lib.types; listOf path;
+        default = [
+          "${cfg.package}/share/guix/ci.guix.gnu.org.pub"
+          "${cfg.package}/share/guix/bordeaux.guix.gnu.org.pub"
+          "${cfg.package}/share/guix/berlin.guix.gnu.org.pub"
+        ];
+        defaultText = ''
+          The packaged signing keys from {option}`services.guix.package`.
+        '';
+        example = lib.literalExpression ''
+          options.services.guix.substituters.authorizedKeys.default ++ [
+            (builtins.fetchurl {
+              url = "https://guix.example.com/signing-key.pub";
+            })
+
+            (builtins.fetchurl {
+              url = "https://guix.example.org/static/signing-key.pub";
+            })
+          ]
+        '';
+        description = ''
+          A list of signing keys for each substitute server to be authorized as
+          a source of substitutes. Without this, the listed substitute servers
+          from {option}`services.guix.substituters.urls` would be ignored [with
+          some
+          exceptions](https://guix.gnu.org/manual/en/html_node/Substitute-Authentication.html).
+        '';
+      };
     };
 
     publish = {
@@ -197,6 +259,11 @@ in
 
   config = lib.mkIf cfg.enable (lib.mkMerge [
     {
+      services.guix.extraArgs =
+        lib.optionals (cfg.substituters.urls != [ ]) [
+          "--substitute-urls='${lib.concatStringsSep " " cfg.substituters.urls}'"
+        ];
+
       environment.systemPackages = [ package ];
 
       users.users = guixBuildUsers cfg.nrBuildUsers;
@@ -254,11 +321,7 @@ in
 
       # Make transferring files from one store to another easier with the usual
       # case being of most substitutes from the official Guix CI instance.
-      system.activationScripts.guix-authorize-keys = ''
-        for official_server_keys in ${package}/share/guix/*.pub; do
-          ${lib.getExe' package "guix"} archive --authorize < $official_server_keys
-        done
-      '';
+      environment.etc."guix/acl".source = aclFile;
 
       # Link the usual Guix profiles to the home directory. This is useful in
       # ephemeral setups where only certain part of the filesystem is
@@ -270,8 +333,8 @@ in
         in ''
           [ -d "${userProfile}" ] && ln -sfn "${userProfile}" "${location}"
         '';
-        linkProfileToPath = acc: profile: location: let
-          in acc + (linkProfile profile location);
+        linkProfileToPath = acc: profile: location:
+          acc + (linkProfile profile location);
 
         # This should contain export-only Guix user profiles. The rest of it is
         # handled manually in the activation script.
@@ -387,7 +450,7 @@ in
           Type = "oneshot";
 
           PrivateDevices = true;
-          PrivateNetworks = true;
+          PrivateNetwork = true;
           ProtectControlGroups = true;
           ProtectHostname = true;
           ProtectKernelTunables = true;

--- a/nixos/tests/guix/publish.nix
+++ b/nixos/tests/guix/publish.nix
@@ -47,12 +47,12 @@ in {
       services.guix = {
         enable = true;
 
-        extraArgs = [
-          # Force to only get all substitutes from the local server. We don't
-          # have anything in the Guix store directory and we cannot get
-          # anything from the official substitute servers anyways.
-          "--substitute-urls='http://server.local:${toString publishPort}'"
+        # Force to only get all substitutes from the local server. We don't
+        # have anything in the Guix store directory and we cannot get
+        # anything from the official substitute servers anyways.
+        substituters.urls = [ "http://server.local:${toString publishPort}" ];
 
+        extraArgs = [
           # Enable autodiscovery of the substitute servers in the local
           # network. This machine shouldn't need to import the signing key from
           # the substitute server since it is automatically done anyways.


### PR DESCRIPTION
## Description of changes

Resolves #293742 and #294672 as it would correctly set the ACL every boot now.

I don't know if this is considered a significant change but it shouldn't change the way it's used (still only requires `services.guix.enable = true` for it to work).

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
