### PR TITLE
tuya-device-sharing-sdk: init at 0.2.0, home-assistant: update component-packages

### DIFF
--- a/pkgs/development/python-modules/tuya-device-sharing-sdk/default.nix
+++ b/pkgs/development/python-modules/tuya-device-sharing-sdk/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools
+, requests
+, paho-mqtt
+, cryptography
+}:
+let
+  pname = "tuya-device-sharing-sdk";
+  version = "0.2.0";
+in
+buildPythonPackage {
+  inherit pname version;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-fu8zh59wlnxtstNbNL8mIm10tiXy22oPbi6oUy5x8c8=";
+  };
+
+  # workaround needed, upstream issue: https://github.com/tuya/tuya-device-sharing-sdk/issues/10
+  postPatch = ''
+    touch requirements.txt
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    requests
+    paho-mqtt
+    cryptography
+  ];
+
+  doCheck = false; # no tests
+
+  meta = with lib; {
+    description = "Tuya Device Sharing SDK";
+    homepage = "https://github.com/tuya/tuya-device-sharing-sdk";
+    license = licenses.mit;
+    maintainers = with maintainers; [ aciceri ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -5265,7 +5265,8 @@
     ];
     "tuya" = ps: with ps; [
       ha-ffmpeg
-    ]; # missing inputs: tuya-device-sharing-sdk
+      tuya-device-sharing-sdk
+    ];
     "twentemilieu" = ps: with ps; [
       twentemilieu
     ];
@@ -6574,6 +6575,7 @@
     "transport_nsw"
     "trend"
     "tts"
+    "tuya"
     "twentemilieu"
     "twilio"
     "twinkly"

--- a/pkgs/servers/home-assistant/parse-requirements.py
+++ b/pkgs/servers/home-assistant/parse-requirements.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i python3 -p "python3.withPackages (ps: with ps; [ packaging rich ])" -p nodePackages.pyright ruff isort"
+#! nix-shell -i python3 -p "python3.withPackages (ps: with ps; [ packaging rich ])" -p nodePackages.pyright ruff isort
 #
 # This script downloads Home Assistant's source tarball.
 # Inside the homeassistant/components directory, each integration has an associated manifest.json,

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15030,6 +15030,8 @@ self: super: with self; {
 
   turnt = callPackage ../development/python-modules/turnt { };
 
+  tuya-device-sharing-sdk = callPackage ../development/python-modules/tuya-device-sharing-sdk { };
+
   tuya-iot-py-sdk = callPackage ../development/python-modules/tuya-iot-py-sdk { };
 
   tuyaha = callPackage ../development/python-modules/tuyaha { };


### PR DESCRIPTION
## Description of changes

The new `tuya` integration requires the python package `tuya-device-sharing-sdk` which is added by this PR.
Also I re-generated the `component-packages.nix` adding the previously missing propagated inputs for `tuya` and re-enabling tests for it. Also fixed minor typo in the script shebang (or I'm missing something? Without my change I couldn't run it but actually I find weird that nobody noticed in 1 year i.e. since when the supposed typo was introduced).

I tried building the new python package on my `x86_64-linux` workstation and then I also re-deployed my home-assistant (on an `aarch64-linux` host) using this branch and `tuya` seems to work now.


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
