### PR TITLE
DisnixWebService: make deterministic and clean up

### DIFF
--- a/pkgs/tools/package-management/disnix/DisnixWebService/default.nix
+++ b/pkgs/tools/package-management/disnix/DisnixWebService/default.nix
@@ -1,13 +1,13 @@
-{lib, stdenv, fetchFromGitHub, fetchpatch, apacheAnt, jdk, axis2, dbus_java }:
+{ lib, stdenv, fetchFromGitHub, fetchpatch, ant, jdk, xmlstarlet, axis2, dbus_java }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "DisnixWebService";
   version = "0.10.1";
 
   src = fetchFromGitHub {
     owner = "svanderburg";
     repo = "DisnixWebService";
-    rev = "refs/tags/DisnixWebService-${version}";
+    rev = "DisnixWebService-${finalAttrs.version}";
     hash = "sha256-zcYr2Ytx4pevSthTQLpnQ330wDxN9dWsZA20jbO6PxQ=";
   };
 
@@ -20,26 +20,47 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  buildInputs = [ apacheAnt jdk ];
-  PREFIX = "\${env.out}";
-  AXIS2_LIB = "${axis2}/lib";
-  AXIS2_WEBAPP = "${axis2}/webapps/axis2";
-  DBUS_JAVA_LIB = "${dbus_java}/share/java";
+  nativeBuildInputs = [
+    ant
+    jdk
+    xmlstarlet
+  ];
+
+  env = {
+    PREFIX = "\${env.out}";
+    AXIS2_LIB = "${axis2}/lib";
+    AXIS2_WEBAPP = "${axis2}/webapps/axis2";
+    DBUS_JAVA_LIB = "${dbus_java}/share/java";
+  };
+
   prePatch = ''
+    # add modificationtime="0" to the <jar> and <war> tasks to achieve reproducibility
+    xmlstarlet ed -L -a "//jar|//war" -t attr -n "modificationtime" -v "0" build.xml
+
     sed -i -e "s|#JAVA_HOME=|JAVA_HOME=${jdk}|" \
        -e "s|#AXIS2_LIB=|AXIS2_LIB=${axis2}/lib|" \
         scripts/disnix-soap-client
   '';
-  buildPhase = "ant";
-  installPhase = "ant install";
+
+  buildPhase = ''
+    runHook preBuild
+    ant
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    ant install
+    runHook postIntall
+  '';
 
   meta = {
     description = "A SOAP interface and client for Disnix";
     mainProgram = "disnix-soap-client";
     homepage = "https://github.com/svanderburg/DisnixWebService";
-    changelog = "https://github.com/svanderburg/DisnixWebService/blob/DisnixWebService-${version}/NEWS.txt";
+    changelog = "https://github.com/svanderburg/DisnixWebService/blob/${finalAttrs.src.rev}/NEWS.txt";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.sander ];
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Tracking issue: https://github.com/NixOS/nixpkgs/issues/278518

This PR makes the build of `DisnixWebService` deterministic by stripping the java archives of their timestamps.

I couldn't use `stripJavaArchivesHook` because it uses `strip-nondeterminism` as its backend, and it doesn't auto-detect `.aar` files as a java archive, which seems to be present inside the `.war` app.

Instead I used the more first-party method of patching the `build.xml` to ensure the <jar> and <war> tasks have an explicit `modificationtime` property.

The PR also adds missing `runHook` calls, replaces `rec` with `finalAttrs:` and uses `env.` for environment variables.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
