### PR TITLE
mediasynclite: init at 0.4.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18299,6 +18299,12 @@
     githubId = 858790;
     name = "Tobias Mayer";
   };
+  tobz619 = {
+    email = "toloke@yahoo.co.uk";
+    github = "tobz619";
+    githubId = 93312805;
+    name = "Tobi Oloke";
+  };
   tochiaha = {
     email = "tochiahan@proton.me";
     github = "Tochiaha";

--- a/pkgs/by-name/me/mediasynclite/package.nix
+++ b/pkgs/by-name/me/mediasynclite/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
     owner = "iBroadcastMediaServices";
     repo = "MediaSyncLiteLinux";
     rev = version;
-    hash = "sha256-mS2e6zZutSEAr5gCS58t0Nzg8dCJgn/yoFMmbgnIM2I=";
+    hash = "sha256-ToSkR6tPJMBCcj1NUBAywKjCAPlpmh+ngIopFrT2PIA=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/me/mediasynclite/package.nix
+++ b/pkgs/by-name/me/mediasynclite/package.nix
@@ -24,15 +24,15 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
    curl
-   openssl.dev
+   glib
+   gtk3
+   openssl
    jansson
   ];
 
   strictDeps = true;
 
   nativeBuildInputs = [
-   gtk3
-   glib
    gsettings-desktop-schemas
    pkg-config
    wrapGAppsHook3

--- a/pkgs/by-name/me/mediasynclite/package.nix
+++ b/pkgs/by-name/me/mediasynclite/package.nix
@@ -20,22 +20,22 @@ stdenv.mkDerivation rec {
     repo = "MediaSyncLiteLinux";
     rev = version;
     hash = "sha256-mS2e6zZutSEAr5gCS58t0Nzg8dCJgn/yoFMmbgnIM2I=";
-    };
+  };
 
   buildInputs = [
-   curl
-   glib
-   gtk3
-   openssl
-   jansson
+    curl
+    glib
+    gtk3
+    openssl
+    jansson
   ];
 
   strictDeps = true;
 
   nativeBuildInputs = [
-   gsettings-desktop-schemas
-   pkg-config
-   wrapGAppsHook3
+    gsettings-desktop-schemas
+    pkg-config
+    wrapGAppsHook3
   ];
 
   makeFlags = [ "PREFIX=$(out)" ];

--- a/pkgs/by-name/me/mediasynclite/package.nix
+++ b/pkgs/by-name/me/mediasynclite/package.nix
@@ -1,0 +1,54 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, gtk3
+, glib
+, gsettings-desktop-schemas
+, pkg-config
+, curl
+, openssl
+, jansson
+, wrapGAppsHook3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mediasynclite";
+  version = "0.4.2";
+
+  src = fetchFromGitHub {
+    owner = "iBroadcastMediaServices";
+    repo = "MediaSyncLiteLinux";
+    rev = version;
+    hash = "sha256-mS2e6zZutSEAr5gCS58t0Nzg8dCJgn/yoFMmbgnIM2I=";
+    };
+
+  buildInputs = [
+   curl
+   openssl.dev
+   jansson
+  ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+   gtk3
+   glib
+   gsettings-desktop-schemas
+   pkg-config
+   wrapGAppsHook3
+  ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  postPatch = ''
+    substitute ./src/ibmsl.c ./src/ibmsl.c --subst-var out
+  '';
+
+  meta = with lib; {
+    description = "A Linux-native graphical uploader for iBroadcast";
+    downloadPage = "https://github.com/tobz619/MediaSyncLiteLinuxNix";
+    homepage = "https://github.com/iBroadcastMediaServices/MediaSyncLiteLinux";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ tobz619 ];
+  };
+}


### PR DESCRIPTION
## Description of changes
Packaged iBroadcast Mediasynclite. Homepage is found [here](https://github.com/iBroadcastMediaServices/MediaSyncLiteLinux). I have learned how to fetch from upstream and use my edits.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
