### PR TITLE
reactphysics3d: 0.9.0 -> 0.10.0

### DIFF
--- a/pkgs/by-name/re/reactphysics3d/package.nix
+++ b/pkgs/by-name/re/reactphysics3d/package.nix
@@ -2,24 +2,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "reactphysics3d";
-  version = "0.9.0";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "DanielChappuis";
     repo = "reactphysics3d";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-AUdsUXsygsGfS8H+AHEV1fSrrX7zGmfsaTONYUG3zqk=";
+    hash = "sha256-LWBnrqDFhpzN/XUEGniZeViDq3R1MtmuU5CMCQ59VOY=";
   };
-
-  patches = [
-    # Fix gcc-13 build failure:
-    #   https://github.com/DanielChappuis/reactphysics3d/pull/371
-    (fetchpatch {
-      name ="gcc-13.patch";
-      url = "https://github.com/DanielChappuis/reactphysics3d/commit/9335856664fdc3bd1073209f0b4f6eae24c35848.patch";
-      hash = "sha256-pCiAHfv66tbE8+hpVvjS22jLi7I+pPofSy8w7eWEp9o=";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
 


### PR DESCRIPTION
## Description of changes

Updated Reactphysics3d from 0.9.0 to 0.10.0

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

