### PR TITLE
validator-nu: 22.9.29 -> 23.4.11-unstable-2023-12-18

### DIFF
--- a/pkgs/tools/text/validator-nu/default.nix
+++ b/pkgs/tools/text/validator-nu/default.nix
@@ -10,14 +10,14 @@
 
 let
   pname = "validator-nu";
-  version = "22.9.29";
+  version = "23.4.11-unstable-2023-12-18";
 
   src = fetchFromGitHub {
     owner = "validator";
     repo = "validator";
-    rev = version;
+    rev = "c3a401feb6555affdc891337f5a40af238f9ac2d";
     fetchSubmodules = true;
-    hash = "sha256-NH/OyaKGITAL2yttB1kmuKVuZuYzhVuS0Oohj1N4icI=";
+    hash = "sha256-pcA3HXduzFKzoOHhor12qvzbGSSvo3k3Bpy2MvvQlCI=";
   };
 
   deps = stdenvNoCC.mkDerivation {

--- a/pkgs/tools/text/validator-nu/default.nix
+++ b/pkgs/tools/text/validator-nu/default.nix
@@ -61,7 +61,7 @@ stdenvNoCC.mkDerivation rec {
     description = "Helps you catch problems in your HTML/CSS/SVG";
     homepage = "https://validator.github.io/validator/";
     license = licenses.mit;
-    maintainers = with maintainers; [ andersk ];
+    maintainers = with maintainers; [ andersk ivan ];
     mainProgram = "vnu";
     sourceProvenance = with sourceTypes; [ binaryBytecode fromSource ];
   };


### PR DESCRIPTION
## Description of changes

This bumps the version to an unreleased commit to fix the build: https://hydra.nixos.org/build/252873736/nixlog/1

There is no release yet: https://github.com/validator/validator/issues/1684

I checked the dependency hash; the dependencies didn't seem to be updated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc maintainer @andersk 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
