### PR TITLE
marimo: init at 0.3.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4993,6 +4993,12 @@
     githubId = 283316;
     name = "Dane Lipscombe";
   };
+  dmadisetti = {
+    email = "nix@madisetti.me";
+    github = "dmadisetti";
+    githubId = 2689338;
+    name = "Dylan Madisetti";
+  };
   dmalikov = {
     email = "malikov.d.y@gmail.com";
     github = "dmalikov";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -761,6 +761,11 @@
     githubId = 786394;
     name = "Alexander Krupenkin ";
   };
+  akshayka = {
+    github = "akshayka";
+    githubId = 1994308;
+    name = "Akshay Agrawal";
+  };
   akshgpt7 = {
     email = "akshgpt7@gmail.com";
     github = "akshgpt7";

--- a/pkgs/development/python-modules/marimo/default.nix
+++ b/pkgs/development/python-modules/marimo/default.nix
@@ -1,0 +1,65 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+, setuptools
+, click
+, jedi
+, markdown
+, pymdown-extensions
+, pygments
+, tomlkit
+, uvicorn
+, starlette
+, websockets
+, docutils
+, black
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "marimo";
+  version = "0.3.3";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-l5QehU/LqEWb7ybKxace4sm6C9mcNlaHNOp55ExglpQ=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    click
+    jedi
+    markdown
+    pymdown-extensions
+    pygments
+    tomlkit
+    uvicorn
+    starlette
+    websockets
+    docutils
+    black
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "marimo"
+  ];
+
+  meta = with lib; {
+    description = "A reactive Python notebook that's reproducible, git-friendly, and deployable as scripts or apps";
+    homepage = "https://github.com/marimo-team/marimo";
+    license = licenses.asl20;
+    mainProgram = "marimo";
+    maintainers = with maintainers; [ akshayka dmadisetti ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10706,6 +10706,8 @@ with pkgs;
     inherit (python3Packages) mako;
   };
 
+  marimo = with python3Packages; toPythonApplication marimo;
+
   marktext = callPackage ../applications/misc/marktext { };
 
   mars-mips = callPackage ../development/tools/mars-mips { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6961,6 +6961,8 @@ self: super: with self; {
 
   mariadb = callPackage ../development/python-modules/mariadb { };
 
+  marimo = callPackage ../development/python-modules/marimo { };
+
   marisa = callPackage ../development/python-modules/marisa {
     inherit (pkgs) marisa;
   };


### PR DESCRIPTION
## Description of changes

Closing out my packaging request in #279873, by adding [`marimo`](https://docs.marimo.io/index.html) from [pypi packaging](https://pypi.org/project/marimo). Marimo is "A reactive notebook for Python — run reproducible experiments, execute as a script, deploy as an app, and version with git."

Github here: https://github.com/marimo-team/marimo

## Things done

 - Added myself as a maintainer (but happy to cede authority to anyone)
 - Added akshayka as maintainer- for reviewer reference they are the marimo lead
 - Added marimo package
Made sure it works!

![image](https://github.com/NixOS/nixpkgs/assets/2689338/ae051f8d-2023-42ab-a39c-26b00bd3ab6b)

I am also cross-posting this PR into their discord channel for upstream feedback.

---

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
