### PR TITLE
nixos/stargazer: module bug fix and hardening

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -235,6 +235,12 @@
   for `stateVersion` ≥ 24.11. (It was previously using SQLite for structured
   data and the filesystem for blobs).
 
+- The `stargazer` service has been hardened to improve security, but these
+  changes make break certain setups, particularly around traditional CGI.
+
+  - The `stargazer.allowCgiUser` option has been added, enabling
+    Stargazer's `cgi-user` option to work, which was previously broken.
+
 - The `shiori` service now requires an HTTP secret value `SHIORI_HTTP_SECRET_KEY` to be provided via environment variable. The nixos module therefore, now provides an environmentFile option:
 
   ```

--- a/nixos/modules/services/web-servers/stargazer.nix
+++ b/nixos/modules/services/web-servers/stargazer.nix
@@ -83,6 +83,21 @@ in
       '';
     };
 
+    allowCgiUser = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        When enabled, the stargazer process will be given `CAP_SETGID`
+        and `CAP_SETUID` so that it can run cgi processes as a different
+        user. This is required if the `cgi-user` option is used for a route.
+        Note that these capabilities could allow privilege escalation so be
+        careful. For that reason, this is disabled by default.
+
+        You will need to create the user mentioned `cgi-user` if it does not
+        already exist.
+      '';
+    };
+
     store = lib.mkOption {
       type = lib.types.path;
       default = /var/lib/gemini/certs;
@@ -206,6 +221,10 @@ in
         # User and group
         User = cfg.user;
         Group = cfg.group;
+        AmbientCapabilities = lib.mkIf cfg.allowCgiUser [
+          "CAP_SETGID"
+          "CAP_SETUID"
+        ];
       };
     };
 

--- a/nixos/modules/services/web-servers/stargazer.nix
+++ b/nixos/modules/services/web-servers/stargazer.nix
@@ -225,6 +225,44 @@ in
           "CAP_SETGID"
           "CAP_SETUID"
         ];
+
+        # Hardening
+        UMask = "0077";
+        PrivateTmp = true;
+        ProtectHome = true;
+        ProtectSystem = "full";
+        ProtectClock = true;
+        ProtectHostname = true;
+        ProtectControlGroups = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        PrivateDevices = true;
+        NoNewPrivileges = true;
+        RestrictSUIDSGID = true;
+        PrivateMounts = true;
+        MemoryDenyWriteExecute = true;
+        LockPersonality = true;
+        RestrictRealtime = true;
+        RemoveIPC = true;
+        CapabilityBoundingSet = [
+          "~CAP_SYS_PTRACE"
+          "~CAP_SYS_ADMIN"
+          "~CAP_SETPCAP"
+          "~CAP_SYS_TIME"
+          "~CAP_SYS_PACCT"
+          "~CAP_SYS_TTY_CONFIG "
+          "~CAP_SYS_CHROOT"
+          "~CAP_SYS_BOOT"
+          "~CAP_NET_ADMIN"
+        ] ++ lib.lists.optional (!cfg.allowCgiUser) [
+          "~CAP_SETGID"
+          "~CAP_SETUID"
+        ];
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [ "~@cpu-emulation @debug @keyring @mount @obsolete" ]
+          ++ lib.lists.optional (!cfg.allowCgiUser) [ "@privileged @setuid" ];
       };
     };
 

--- a/nixos/tests/web-servers/stargazer.nix
+++ b/nixos/tests/web-servers/stargazer.nix
@@ -117,16 +117,43 @@ in
         };
       };
     };
+    cgiTestServer = { ... }: {
+      users.users.cgi = {
+        isSystemUser = true;
+        group = "cgi";
+      };
+      users.groups.cgi = { };
+      services.stargazer = {
+        enable = true;
+        connectionLogging = false;
+        requestTimeout = 1;
+        allowCgiUser = true;
+        routes = [
+          {
+            route = "localhost:/cgi-bin";
+            root = "${test_env}/test_data";
+            cgi = true;
+            cgi-timeout = 5;
+            cgi-user = "cgi";
+          }
+        ];
+      };
+    };
   };
 
   testScript = { nodes, ... }: ''
     geminiserver.wait_for_unit("scgi_server")
     geminiserver.wait_for_open_port(1099)
     geminiserver.wait_for_unit("stargazer")
-    geminiserver.wait_for_open_port(1965)
+    geminiserver.wait_for_unit("stargazer")
+    cgiTestServer.wait_for_open_port(1965)
+    cgiTestServer.wait_for_open_port(1965)
 
     with subtest("stargazer test suite"):
       response = geminiserver.succeed("sh -c 'cd ${test_env}; ${test_script}/bin/test'")
+      print(response)
+    with subtest("stargazer cgi-user test"):
+      response = cgiTestServer.succeed("sh -c 'cd ${test_env}; ${test_script}/bin/test --checks CGIVars'")
       print(response)
   '';
 }

--- a/nixos/tests/web-servers/stargazer.nix
+++ b/nixos/tests/web-servers/stargazer.nix
@@ -145,8 +145,6 @@ in
     geminiserver.wait_for_unit("scgi_server")
     geminiserver.wait_for_open_port(1099)
     geminiserver.wait_for_unit("stargazer")
-    geminiserver.wait_for_unit("stargazer")
-    cgiTestServer.wait_for_open_port(1965)
     cgiTestServer.wait_for_open_port(1965)
 
     with subtest("stargazer test suite"):


### PR DESCRIPTION
## Description of changes

I've made some improvements to the stargazer nixos module. This PR contains two changes that are not inherently related but effect each other's implementation. If I should break this into 2 PR please let me know.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
