### PR TITLE
python311Packages.xsdata: 24.2.1 -> 24.3.1

### DIFF
--- a/pkgs/development/python-modules/xsdata/default.nix
+++ b/pkgs/development/python-modules/xsdata/default.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "xsdata";
-  version = "24.2.1";
+  version = "24.3.1";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "tefra";
     repo = "xsdata";
     rev = "refs/tags/v${version}";
-    hash = "sha256-o3G0isXShwNHaOiA4TNml0IhStB3X4jB9CgrVKViBlY=";
+    hash = "sha256-Y9xFj5smGixHX1zuPm860p83NFGGXPG+EW0SeW7PCXg=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/xsdata/paths.patch
+++ b/pkgs/development/python-modules/xsdata/paths.patch
@@ -1,13 +1,22 @@
-diff --git a/xsdata/codegen/writer.py b/xsdata/codegen/writer.py
-index 0301631f..3185c526 100644
---- a/xsdata/codegen/writer.py
-+++ b/xsdata/codegen/writer.py
-@@ -73,7 +73,7 @@ class CodeWriter:
-         """Run ruff format on the src code."""
+diff --git a/xsdata/formats/dataclass/generator.py b/xsdata/formats/dataclass/generator.py
+index eaf23f8d..5ba80a43 100644
+--- a/xsdata/formats/dataclass/generator.py
++++ b/xsdata/formats/dataclass/generator.py
+@@ -221,7 +221,7 @@ class DataclassGenerator(AbstractGenerator):
+         """
          commands = [
              [
 -                "ruff",
 +                "@ruff@",
                  "format",
+                 "--stdin-filename",
+                 str(file_path),
+@@ -229,7 +229,7 @@ class DataclassGenerator(AbstractGenerator):
+                 str(self.config.output.max_line_length),
+             ],
+             [
+-                "ruff",
++                "@ruff@",
+                 "checks",
                  "--stdin-filename",
                  str(file_path),


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/tefra/xsdata/compare/refs/tags/v24.2.1...v24.3.1

Changelog: https://github.com/tefra/xsdata/blob/refs/tags/v24.3.1/CHANGES.md



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
