### PR TITLE
git-cola: 4.5.0 -> 4.6.1

### DIFF
--- a/pkgs/applications/version-management/git-cola/default.nix
+++ b/pkgs/applications/version-management/git-cola/default.nix
@@ -10,13 +10,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "git-cola";
-  version = "4.5.0";
+  version = "4.6.1";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "git-cola";
     repo = "git-cola";
     rev = "v${version}";
-    hash = "sha256-HORGtpiZGWpeRDhr4E9KW5LSAD6r74l7rl6RhhVtiJo=";
+    hash = "sha256-qAvoBVZt2IwrWFNzGWpCZqj8gbjysGlB/VXaa1CMH4o=";
   };
 
   buildInputs = lib.optionals stdenv.isLinux [
@@ -24,10 +25,12 @@ python3Packages.buildPythonApplication rec {
   ];
 
   propagatedBuildInputs = with python3Packages; [
+    setuptools
     git
     pyqt5
     qtpy
     send2trash
+    polib
   ];
 
   nativeBuildInputs = with python3Packages; [

--- a/pkgs/applications/version-management/git-cola/default.nix
+++ b/pkgs/applications/version-management/git-cola/default.nix
@@ -1,4 +1,12 @@
-{ stdenv, lib, fetchFromGitHub, python3Packages, gettext, git, qt5, gitUpdater }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, python3Packages
+, gettext
+, git
+, qt5
+, gitUpdater
+}:
 
 python3Packages.buildPythonApplication rec {
   pname = "git-cola";
@@ -11,10 +19,27 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-HORGtpiZGWpeRDhr4E9KW5LSAD6r74l7rl6RhhVtiJo=";
   };
 
-  buildInputs = lib.optionals stdenv.isLinux [ qt5.qtwayland ];
-  propagatedBuildInputs = with python3Packages; [ git pyqt5 qtpy send2trash ];
-  nativeBuildInputs = with python3Packages; [ setuptools-scm gettext qt5.wrapQtAppsHook ];
-  nativeCheckInputs = with python3Packages; [ git pytestCheckHook ];
+  buildInputs = lib.optionals stdenv.isLinux [
+    qt5.qtwayland
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    git
+    pyqt5
+    qtpy
+    send2trash
+  ];
+
+  nativeBuildInputs = with python3Packages; [
+    setuptools-scm
+    gettext
+    qt5.wrapQtAppsHook
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    git
+    pytestCheckHook
+  ];
 
   disabledTestPaths = [
     "qtpy/"


### PR DESCRIPTION
## Description of changes

Upgrade of git-cola.

`pyproject = true;` is needed because `setup.py` was removed from the project. See https://github.com/git-cola/git-cola/commit/24c343c88b556af3dc125385218c068894d0b9fd

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
