### PR TITLE
i3: fix and reenable the testsuite

### DIFF
--- a/pkgs/applications/window-managers/i3/default.nix
+++ b/pkgs/applications/window-managers/i3/default.nix
@@ -39,8 +39,10 @@ stdenv.mkDerivation rec {
 
     # This testcase generates a Perl executable file with a shebang, and
     # patchShebangs can't replace a shebang in the middle of a file.
-    substituteInPlace testcases/t/318-i3-dmenu-desktop.t \
-      --replace-fail "#!/usr/bin/env perl" "#!${perl}/bin/perl"
+    if [ -f testcases/t/318-i3-dmenu-desktop.t ]; then
+      substituteInPlace testcases/t/318-i3-dmenu-desktop.t \
+        --replace-fail "#!/usr/bin/env perl" "#!${perl}/bin/perl"
+    fi
   '';
 
   doCheck = stdenv.hostPlatform.system == "x86_64-linux";

--- a/pkgs/applications/window-managers/i3/default.nix
+++ b/pkgs/applications/window-managers/i3/default.nix
@@ -1,7 +1,7 @@
 { fetchurl, lib, stdenv, pkg-config, makeWrapper, meson, ninja, installShellFiles, libxcb, xcbutilkeysyms
 , xcbutil, xcbutilwm, xcbutilxrm, libstartup_notification, libX11, pcre2, libev
 , yajl, xcb-util-cursor, perl, pango, perlPackages, libxkbcommon
-, xvfb-run
+, xorgserver, xvfb-run, xdotool, xorg, which
 , asciidoc, xmlto, docbook_xml_dtd_45, docbook_xsl, findXMLCatalogs
 }:
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     libstartup_notification libX11 pcre2 libev yajl xcb-util-cursor perl pango
     perlPackages.AnyEventI3 perlPackages.X11XCB perlPackages.IPCRun
     perlPackages.ExtUtilsPkgConfig perlPackages.InlineC
-    xvfb-run
+    xorgserver xvfb-run xdotool xorg.setxkbmap xorg.xrandr which
   ];
 
   configureFlags = [ "--disable-builddir" ];

--- a/pkgs/applications/window-managers/i3/default.nix
+++ b/pkgs/applications/window-managers/i3/default.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
     libstartup_notification libX11 pcre2 libev yajl xcb-util-cursor perl pango
     perlPackages.AnyEventI3 perlPackages.X11XCB perlPackages.IPCRun
     perlPackages.ExtUtilsPkgConfig perlPackages.InlineC
+  ] ++ lib.optionals doCheck [
     xorgserver xvfb-run xdotool xorg.setxkbmap xorg.xrandr which
   ];
 

--- a/pkgs/applications/window-managers/i3/default.nix
+++ b/pkgs/applications/window-managers/i3/default.nix
@@ -45,10 +45,10 @@ stdenv.mkDerivation rec {
     fi
   '';
 
-  doCheck = stdenv.hostPlatform.system == "x86_64-linux";
+  # xvfb-run is available only on Linux
+  doCheck = stdenv.isLinux;
 
-  checkPhase = lib.optionalString (stdenv.hostPlatform.system == "x86_64-linux")
-  ''
+  checkPhase = ''
     test_failed=
     # "| cat" disables fancy progress reporting which makes the log unreadable.
     ./complete-run.pl -p 1 --keep-xserver-output | cat || test_failed="complete-run.pl returned $?"

--- a/pkgs/applications/window-managers/i3/rounded.nix
+++ b/pkgs/applications/window-managers/i3/rounded.nix
@@ -13,6 +13,9 @@ i3.overrideAttrs (oldAttrs: rec {
 
   buildInputs = oldAttrs.buildInputs ++ [ pcre ];
 
+  # Some tests are failing.
+  doCheck = false;
+
   meta = with lib; {
     description = "Fork of i3-gaps that adds rounding to window corners";
     homepage = "https://github.com/LinoBigatti/i3-rounded";


### PR DESCRIPTION
## Description of changes

Although the `i3` package has an extensive testsuite, the execution of that testsuite was disabled since #8399 (the bug report about failing tests was #7957).  The major problem which prevented the execution of the testsuite was that `perlPackages.X11XCB` was broken; that was fixed in #294728, and this PR fixes the rest of problems in the `i3` package and enables the testsuite again.

Changes done:
1. The `checkPhase` script was stale and needed to be rewritten for the new version of i3 (paths are different now, and `complete-run.pl` now invokes `xvfb-run` internally).  The code to check the log file for errors might be unneeded for the new version (`complete-run.pl` seems to return a non-zero exit code correctly on errors), but is left to catch any possible regressions in the test runner behavior.
2. The `318-i3-dmenu-desktop.t` testcase was failing, because that testcase was creating a temporary Perl script intended to shadow the real `i3-msg` executable, but the `#!/usr/bin/env perl` shebang in that script did not work in the build environment; this problem was not really obvious, because `system('i3-msg', $cmd)` silently continued to search for the `i3-msg` executable further in `$PATH` and launched the real binary instead of the replacement script.  The problematic shebang needed to be replaced manually (using `substituteInPlace` in `postPatch`), because `patchShebangs` handles only real shebangs on the first line of each executable file.
3. Some tests required more dependencies, which needed to be added to `buildInputs`:
   - `xdotool`
   - `xorg.setxkbmap`
   - `xorg.xrandr`
   - `which`
  
   Unfortunately, not having these packages in `buildInputs` does not actually cause test failures, because the corresponding testcases check for the availability of those tools and skip the actual tests if the tools are not found; so if any future updates of `i3` would add more tests with such optional dependencies, this may be missed.  But detecting this problem automatically is hard, because the testsuite also has other tests which get skipped (e.g., there are some tests which were written before the corresponding behavior had actually been implemented in `i3`), so just the presence of `skip` marks in the test log does not mean that there is a problem.
4. The `i3-rounded` package uses `i3.overrideAttrs` to build some old fork of `i3`, and apparently the testsuite in that fork is not properly maintained, and some tests are failing.  I don't intend to use that fork, but apparently the packaged commit points to the 4.20.1 release of that fork (dated 2021-11-03), while there is also the 4.21.1 release there (dated 2022-11-06), so the `i3-rounded` package does not look really maintained; anyway, I disabled tests in that package to keep it building as before.
5. The old condition to enable the testsuite (`doCheck = stdenv.hostPlatform.system == "x86_64-linux"`) was replaced with `doCheck = stdenv.isLinux`, because the tests are not `x86_64`-specific, but can be run only on Linux at the moment (the problem is that the `xvfb-run` package did not work properly on Darwin, but in #123097 it was made Linux-only to reflect that without fixing the underlying problem).
6. The condition on `checkPhase` was removed (it was introduced in #6135 to fix the evaluation failure on Darwin, because at that time the `checkPhase` script contained `${xdummy}`, and the `xdummy` package was not available on Darwin; however, the current version of the `checkPhase` script does not have any references to package paths and therefore does not need a conditional guard).
7. The packages which are required only for running the testsuite are added to `buildInputs` only if the platform actually supports running the testsuite (reusing the `doCheck` condition).  This change makes the `i3` package buildable on Darwin (apparently someone actually wanted that and fixed the build in #6135, but nobody stepped up to fix the Darwin build after #123097 broke it).  However, I can't actually test the Darwin build apart from looking at the ofborg logs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
