### PR TITLE
texlive.bin.dvisvgm: 3.0.3 -> 3.1.2

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -322,43 +322,24 @@ context = stdenv.mkDerivation rec {
   };
 };
 
-dvisvgm = stdenv.mkDerivation {
+dvisvgm = stdenv.mkDerivation rec {
   pname = "dvisvgm";
-  inherit (texlive.pkgs.dvisvgm) version;
+  version = "3.1.2";
 
-  inherit (common) src;
+  src = assert lib.assertMsg (version == texlive.pkgs.dvisvgm.version) "dvisvgm: TeX Live version (${texlive.pkgs.dvisvgm.version}) different from source (${version}), please update dvisvgm"; fetchurl {
+    url = "https://github.com/mgieseki/dvisvgm/releases/download/${version}/dvisvgm-${version}.tar.gz";
+    hash = "sha256-vqeDrf6TG3eUoMMNeQK4Kw1NmtaBbc2KCVqTHNM+rPY=";
+  };
 
-  patches = [
-    # do not use deprecated NEWPDF option with Ghostscript >= 10.02.0
-    # https://github.com/mgieseki/dvisvgm/issues/245
-    (fetchpatch {
-      name = "dont-use-NEWPDF-with-GS-10.02.0.patch";
-      url = "https://github.com/mgieseki/dvisvgm/commit/f31cdf14d73f586e2b92b4b0891d097a90274a0b.patch";
-      hash = "sha256-Yf/GhmJYM87M0ITZ/+7q2ZvSYnac4N2/NkTkFlJ2VII=";
-      stripLen = 1;
-      extraPrefix = "texk/dvisvgm/dvisvgm-src/";
-    })
+  configureFlags = [
+    "--disable-manpage" # man pages are provided by the doc container
   ];
 
-  # since we are running configure directly in texk/dvisvgm,
-  # the option --with-system-potrace is not picked up properly
-  # and dvisvgm tries to build a vendored copy of potrace
+  # PDF handling requires mutool (from mupdf) since Ghostscript 10.01
   postPatch = ''
-    cat > texk/dvisvgm/dvisvgm-src/libs/potrace/Makefile <<EOF
-    all:
-    install:
-    EOF
-  '' +
-    # PDF handling requires mutool (from mupdf) since Ghostscript 10.01
-  ''
-    substituteInPlace texk/dvisvgm/dvisvgm-src/src/PDFHandler.cpp \
-      --replace 'Process("mutool"' "Process(\"$(PATH="$HOST_PATH" command -v mutool)\""
+    substituteInPlace src/PDFHandler.cpp \
+      --replace-fail 'Process("mutool"' "Process(\"$(PATH="$HOST_PATH" command -v mutool)\""
   '';
-
-  preConfigure = "cd texk/dvisvgm";
-
-  configureFlags = common.configureFlags
-    ++ [ "--with-system-kpathsea" ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ core brotli ghostscript zlib freetype woff2 potrace xxHash mupdf-headless ];


### PR DESCRIPTION
## Description of changes
Build dvisvgm from upstream sources to align with binaries distributed by TeX Live.

This will need backporting to 23.11 (with appropriate changes to version number, hash, and mutool) to fix https://github.com/NixOS/nixpkgs/pull/293894#issuecomment-1984213870. How do I backport this by the way? Amended cherry-pick, or cherry-pick + downgrade commit? Not to mention, mupdf-headless does not exists in 23.11...

PS: so it turns out that the TeX Live source tarball is not good for all binaries – some get updated during the year. Presumably dvisvgm was inevitable, due to the dependency on Ghostscript.

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
