### PR TITLE
mythtv: 32.0 -> 34.0

### DIFF
--- a/pkgs/applications/video/mythtv/default.nix
+++ b/pkgs/applications/video/mythtv/default.nix
@@ -8,34 +8,18 @@
 
 mkDerivation rec {
   pname = "mythtv";
-  version = "32.0";
+  version = "34.0";
 
   src = fetchFromGitHub {
     owner = "MythTV";
     repo = "mythtv";
     rev = "v${version}";
-    sha256 = "0i4fs3rbk1jggh62wflpa2l03na9i1ihpz2vsdic9vfahqqjxff1";
+    hash = "sha256-6/TEoyYIRq6pufYzGOmO5DB05JuDo9lqRAYT5N5M/L4=";
   };
 
   patches = [
     # Disable sourcing /etc/os-release
     ./dont-source-os-release.patch
-
-    # Fix QMake variable substitution syntax - MythTV/mythtv#550
-    (fetchpatch {
-      name = "fix-qmake-var-syntax.patch";
-      url = "https://github.com/MythTV/mythtv/commit/a8da7f7e7ec069164adbef65a8104adc9bb52e36.patch";
-      stripLen = 1;
-      hash = "sha256-JfRME00YNNjl6SKs1HBa0wBa/lR/Rt3zbQtWhsC36JM=";
-    })
-
-    # Bachport the build against binutils-2.41
-    (fetchpatch {
-      name = "binutils-2.41.patch";
-      url = "https://github.com/MythTV/mythtv/commit/f9f9bba62ee2743c816cb2b9634b6b4397e5e2e3.patch";
-      stripLen = 1;
-      hash = "sha256-IcXgBtfqPZ42inYFe7l8mWvKUV13S/YEQAHcOFaDivI=";
-    })
   ];
 
   setSourceRoot = "sourceRoot=$(echo */mythtv)";

--- a/pkgs/applications/video/mythtv/dont-source-os-release.patch
+++ b/pkgs/applications/video/mythtv/dont-source-os-release.patch
@@ -1,6 +1,6 @@
 --- a/configure
 +++ b/configure
-@@ -5894,9 +5894,9 @@ else
+@@ -5451,9 +5451,9 @@ else
      die "ERROR: cannot find soundtouch 1.8.0 or later."
  fi
  


### PR DESCRIPTION
## Description of changes
https://www.mythtv.org/wiki/Release_Notes_-_33
https://www.mythtv.org/wiki/Release_Notes_-_34

Closes https://github.com/NixOS/nixpkgs/issues/287809

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
