### PR TITLE
varia: init at 2024.2.29-2

### DIFF
--- a/pkgs/by-name/va/varia/package.nix
+++ b/pkgs/by-name/va/varia/package.nix
@@ -1,0 +1,68 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+, aria2
+, meson
+, ninja
+, pkg-config
+, gobject-introspection
+, wrapGAppsHook4
+, desktop-file-utils
+, libadwaita
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "varia";
+  version = "2024.2.29-2";
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "giantpinkrobots";
+    repo = "varia";
+    rev = "v${version}";
+    hash = "sha256-PDI+URSop95e0bkSkE/9xV5Ezwj3vRmDA4Qyr1n8mCw=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/varia-py.in \
+      --replace-fail 'aria2cexec = sys.argv[1]' 'aria2cexec = "${lib.getExe aria2}"'
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gobject-introspection
+    wrapGAppsHook4
+    desktop-file-utils
+  ];
+
+  buildInputs = [
+    libadwaita
+  ];
+
+  propagatedBuildInputs = with python3Packages; [
+    pygobject3
+    aria2p
+  ];
+
+  postInstall = ''
+    rm $out/bin/varia
+    mv $out/bin/varia-py.py $out/bin/varia
+  '';
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  meta = with lib; {
+    description = "A simple download manager based on aria2 and libadwaita";
+    homepage = "https://giantpinkrobots.github.io/varia";
+    license = licenses.mpl20;
+    mainProgram = "varia";
+    maintainers = with maintainers; [ aleksana ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Tested. Sometimes it will error out
```
Traceback (most recent call last):
  File "/nix/store/sxr2igfkwhxbagri49b8krmcqz168sim-python3-3.11.8/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
    self.run()
  File "/nix/store/rw5f10xar441rl62ixzl0gywzsaydx4f-varia-2024.2.29-2/share/varia/varia/download/thread.py", line 86, in run
    downloadname = self.download.name
                   ^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'name'
Traceback (most recent call last):                                                                               
  File "/nix/store/rw5f10xar441rl62ixzl0gywzsaydx4f-varia-2024.2.29-2/share/varia/varia/download/actionrow.py", line 112, in on_stop_clicked
    if ((download_thread.download.is_torrent) and (download_thread.download.seeder)):
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'is_torrent'
```
But doesn't happen for the same link again. Seems to be a bug.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
