### PR TITLE
buildHarePackage: init

### DIFF
--- a/pkgs/build-support/hare/build-hare-package/default.nix
+++ b/pkgs/build-support/hare/build-hare-package/default.nix
@@ -1,0 +1,65 @@
+{ hare, stdenv, lib }:
+# Based on php's buildComposerProject:
+# <https://github.com/NixOS/nixpkgs/blob/4e0a85752775cb57f81af602fe19cd1d39c8179f/pkgs/build-support/php/build-composer-project.nix>
+let
+  hareBuildPackageOverride = finalAttrs: previousAttrs:
+    let
+      arch = stdenv.hostPlatform.uname.processor;
+      drvHareFlags =
+        if !previousAttrs?hareFlags then [ ]
+        else
+          builtins.filter (x: !(lib.hasPrefix "-a" x))
+            previousAttrs.hareFlags;
+      hareFlags = lib.concatStringsSep " "
+        ([
+          "-q"
+          "-R"
+          "-a${arch}"
+        ] ++ drvHareFlags);
+      hareSetupPhase = ''
+        export PREFIX="$out"
+        echoCmd "PREFIX" "$PREFIX"
+        HARECACHE="$(mktemp -d)"
+        export HARECACHE
+        echoCmd "HARECACHE" "$HARECACHE"
+        export HAREFLAGS="${hareFlags}"
+        echoCmd "HAREFLAGS" "$HAREFLAGS"
+        makeFlagsArray+=(
+          PREFIX="$PREFIX"
+          HARECACHE="$HARECACHE"
+          HAREFLAGS="${hareFlags}"
+        )
+      '';
+      prePhases = [ "hareSetupPhase" ];
+      nativeBuildInputs' = previousAttrs.nativeBuildInputs or [ ];
+      meta' = previousAttrs.meta or { };
+      # Warnings.
+      isArchSetByDrv = lib.any (x: (lib.hasPrefix "-a" x)) previousAttrs.hareFlags or [ ];
+      archSetByDrvMsg = "`-a` hare flag ignored; using `${arch}` (`stdenv.hostPlatform.uname.processor`) instead";
+      isHareOnNativeBuildInputs = lib.any (x: x.pname or "" == "hare") nativeBuildInputs';
+      hareOnNativeBuildInputsMsg = "`hare` is already added to `nativeBuildInputs`";
+      isMetaPlatformsSet = meta'?platforms;
+      metaPlatformsSetMsg = "`platforms` ignored; using `{ inherit (hare.meta) platforms; }`";
+      isMetaBadPlatformsSet = meta'?badPlatforms;
+      metaBadPlatformsSetMsg = "`badPlatforms` ignored; using `{ inherit (hare.meta) badPlatforms; }`";
+    in
+    lib.warnIf
+      isArchSetByDrv
+      archSetByDrvMsg
+      lib.warnIf
+      isHareOnNativeBuildInputs
+      hareOnNativeBuildInputsMsg
+      lib.warnIf
+      isMetaPlatformsSet
+      metaPlatformsSetMsg
+      lib.warnIf
+      isMetaBadPlatformsSet
+      metaBadPlatformsSetMsg
+
+      previousAttrs // {
+      inherit hareSetupPhase prePhases;
+      nativeBuildInputs = nativeBuildInputs' ++ [ hare ];
+      meta = meta' // { inherit (hare.meta) platforms badPlatforms; };
+    };
+in
+args: (stdenv.mkDerivation args).overrideAttrs hareBuildPackageOverride

--- a/pkgs/development/hare-third-party/hare-toml/default.nix
+++ b/pkgs/development/hare-third-party/hare-toml/default.nix
@@ -1,11 +1,10 @@
-{ stdenv
-, hare
+{ buildHarePackage
 , scdoc
 , lib
 , fetchFromGitea
 , nix-update-script
 }:
-stdenv.mkDerivation (finalAttrs: {
+buildHarePackage (finalAttrs: {
   pname = "hare-toml";
   version = "0.1.1";
 
@@ -19,12 +18,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     scdoc
-    hare
-  ];
-
-  makeFlags = [
-    "HARECACHE=.harecache"
-    "PREFIX=${builtins.placeholder "out"}"
   ];
 
   checkTarget = "check_local";
@@ -33,6 +26,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   dontConfigure = true;
 
+  postPatch = ''
+    substituteInPlace ./Makefile \
+      --replace-fail '$(HARE) test' '$(HARE) test $(HAREFLAGS)'
+  '';
+
   passthru.updateScript = nix-update-script { };
 
   meta = {
@@ -40,6 +38,5 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://codeberg.org/lunacb/hare-toml";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ onemoresuza ];
-    inherit (hare.meta) platforms badPlatforms;
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25622,6 +25622,10 @@ with pkgs;
 
   leaps = callPackage ../development/tools/leaps { };
 
+  ### DEVELOPMENT / HARE
+
+  buildHarePackage = callPackage ../build-support/hare/build-hare-package { };
+
   ### DEVELOPMENT / JAVA MODULES
 
   javaPackages = recurseIntoAttrs (callPackage ./java-packages.nix { });


### PR DESCRIPTION
## Description of changes

- **buildHarePackage: init function**
- **haredo: make use of buildHarePackage**
- **hareThirdParty.hare-toml: make use of buildHarePackage**

The `buildHarePackage` gets rid of boilerplate code for Hare packages:

1. No need to set `HARECACHE`;
2. No need to set `PREFIX`;
3. No need to set `-qRa<arch>` hare flags.
4. By setting `-a${stdenv.hostPlatform.uname.processor}`, the derivation needs
   to do nothing else for the package to cross-compile.

It, however, relies on the existence of the `HAREFLAGS` make or environment
variable. Thus, if not yet present on the project, the derivation must patch it.
This is behavior goes hand in hand with [`Hare`'s project structure](https://harelang.org/documentation/usage/project-structure.html#example-makefile-with-executables) described in its documentation.

Do note that `HARECACHE`, `PREFIX` and `HAREFLAGS` are set both as make flags and
as environment variables, so that it may be accessed by other build systems, *e. g.*, `haredo`.

I've only changed `haredo` and `hareThirdParty.hare-toml` to make use of
`buildHarePackage` because I am their maintainer and we have with them both
examples of a Hare package: a program, the former, and a library, the latter.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
