### PR TITLE
rep-grep: init at 0-unstable-2024-02-06

### DIFF
--- a/pkgs/by-name/re/rep-grep/package.nix
+++ b/pkgs/by-name/re/rep-grep/package.nix
@@ -1,0 +1,26 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "rep-grep";
+  version = "0-unstable-2024-02-06";
+
+  src = fetchFromGitHub {
+    owner = "robenkleene";
+    repo = "rep-grep";
+    rev = "10510d47e392cb9d30a861c69f702fd194b3fa88";
+    hash = "sha256-/dH+mNtNHaYFndVhoqmz4Sc3HeemoQt1HGD98mb9Qhw=";
+  };
+
+  cargoHash = "sha256-ch+RMLc+xogL0gkrnw+n+bmUVIcixdPTaNPHPuJ0/EI=";
+
+  meta = with lib; {
+    description = "A command-line utility that takes grep-formatted lines and performs a find-and-replace on them.";
+    homepage = "https://github.com/robenkleene/rep-grep";
+    license = licenses.mit;
+    maintainers = with maintainers; [ philiptaron ];
+    mainProgram = "rep";
+  };
+}


### PR DESCRIPTION
## Description of changes

From [Introducing `rep` & `ren`: A New Approach to Command-Line Find & Replace, and Renaming](https://blog.robenkleene.com/2023/12/26/introducing-rep-ren/)

> [rep](https://github.com/robenkleene/rep-grep) and [ren](https://github.com/robenkleene/ren-find) are two new tools for performing find and replace in files, and renaming files, respectively.
>
> They share a similar design in two ways:
> 
> *    Standard input determines what should be changed. `rep` takes `grep`-formatted text via standard input to determine which lines to change, and `ren` takes a single file per line to determine which files to rename.
> *    A preview of the resulting diff is printed to standard output by default. By default, `rep` and `ren` both print a diff of the changes that would result by performing the find and replace or rename. In order to actually write the changes to disk, both have a `-w` / `--write` flag.

- https://github.com/NixOS/nixpkgs/pull/294894

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).