### PR TITLE
doc: Fix test in writing-nixos-tests.section.md

### DIFF
--- a/nixos/doc/manual/development/writing-nixos-tests.section.md
+++ b/nixos/doc/manual/development/writing-nixos-tests.section.md
@@ -261,7 +261,7 @@ added using the parameter `extraPythonPackages`. For example, you could add
 
   testScript = ''
     import numpy as np
-    assert str(np.zeros(4) == "array([0., 0., 0., 0.])")
+    assert str(np.zeros(4)) == "array([0., 0., 0., 0.])"
   '';
 }
 ```

--- a/nixos/doc/manual/development/writing-nixos-tests.section.md
+++ b/nixos/doc/manual/development/writing-nixos-tests.section.md
@@ -261,7 +261,7 @@ added using the parameter `extraPythonPackages`. For example, you could add
 
   testScript = ''
     import numpy as np
-    assert str(np.zeros(4)) == "array([0., 0., 0., 0.])"
+    assert str(np.zeros(4)) == "[0. 0. 0. 0.]"
   '';
 }
 ```


### PR DESCRIPTION
That paren couldn't possibly have been in the right place. CC @tljuniper who authored this section

## Description of changes

Replaced `assert str(a == "b")` with `assert str(a) == "b"`

````diff
diff --git a/nixos/doc/manual/development/writing-nixos-tests.section.md b/nixos/doc/manual/development/writing-nixos-tests.section.md
index 84b247fd2042fe..48973fcc0e1edd 100644
--- a/nixos/doc/manual/development/writing-nixos-tests.section.md
+++ b/nixos/doc/manual/development/writing-nixos-tests.section.md
@@ -261,7 +261,7 @@ added using the parameter `extraPythonPackages`. For example, you could add
 
   testScript = ''
     import numpy as np
-    assert str(np.zeros(4) == "array([0., 0., 0., 0.])")
+    assert str(np.zeros(4)) == "array([0., 0., 0., 0.])"
   '';
 }
 ```
 ````

## Things done

I do not have nix set up to generate `writing-nixos-tests.section.xml` or verify the test or anything.
Please do whatever is appropriate with this trivial change

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
