### PR TITLE
liquidsoap: 2.2.3 → 2.2.4; ocamlPackages.cry: 1.0.1 → 1.0.2

### DIFF
--- a/pkgs/development/ocaml-modules/cry/default.nix
+++ b/pkgs/development/ocaml-modules/cry/default.nix
@@ -2,17 +2,17 @@
 
 buildDunePackage rec {
   pname = "cry";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "ocaml-cry";
     rev = "v${version}";
-    sha256 = "sha256-wn9hLqbydzFTdYsJ1e76dmDLtwcZ7CGjbzFe5o9veYQ=";
+    hash = "sha256-wtilYOUOHElW8ZVxolMNomvT//ho2tACmoubEvU2bpQ=";
   };
 
   postPatch = ''
-    substituteInPlace src/dune --replace bytes ""
+    substituteInPlace src/dune --replace-warn bytes ""
   '';
 
   minimalOCamlVersion = "4.12";

--- a/pkgs/tools/audio/liquidsoap/full.nix
+++ b/pkgs/tools/audio/liquidsoap/full.nix
@@ -7,7 +7,7 @@
 
 let
   pname = "liquidsoap";
-  version = "2.2.3";
+  version = "2.2.4";
 in
 stdenv.mkDerivation {
   inherit pname version;
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
     owner = "savonet";
     repo = "liquidsoap";
     rev = "refs/tags/v${version}";
-    hash = "sha256-oCMSdmdU3oHrq3QFEDQLdb3CLFYcWylxTqKWtGOoQW8=";
+    hash = "sha256-aAW3PeobTRVi5mV321MHZ6RymvOY4DbZITjwcMwGwFo=";
   };
 
   postPatch = ''
@@ -76,6 +76,7 @@ stdenv.mkDerivation {
     ocamlPackages.camomile
     ocamlPackages.uri
     ocamlPackages.fileutils
+    ocamlPackages.magic-mime
     ocamlPackages.menhir # liquidsoap-lang
     ocamlPackages.menhirLib
     ocamlPackages.metadata
@@ -99,7 +100,6 @@ stdenv.mkDerivation {
     ocamlPackages.frei0r
     ocamlPackages.gd4o
     ocamlPackages.graphics
-    ocamlPackages.gstreamer
     ocamlPackages.imagelib
     ocamlPackages.inotify
     ocamlPackages.ladspa
@@ -108,7 +108,6 @@ stdenv.mkDerivation {
     ocamlPackages.lilv
     ocamlPackages.lo
     ocamlPackages.mad
-    ocamlPackages.magic
     ocamlPackages.ogg
     ocamlPackages.opus
     ocamlPackages.portaudio


### PR DESCRIPTION
## Description of changes

Support for gstreamer in liquidsoap has been removed in nixpkgs as:
  - it does not build (see: liquidsoap PR 3769);
  - it is deprecated.

cc/ maintainers @dali99 @ehmry

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
