### PR TITLE
citrix_workspace: 23.11.0.82 -> 24.2.0.65; remove EOL versions

### DIFF
--- a/pkgs/applications/networking/remote/citrix-workspace/default.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/default.nix
@@ -1,7 +1,7 @@
 { lib, callPackage }:
 
 # For detailed information about the Citrix source-tarball, please refer to the OEM
-# reference guide: https://developer-docs.citrix.com/projects/workspace-app-for-linux-oem-guide/en/latest/
+# reference guide: https://developer-docs.citrix.com/en-us/citrix-workspace-app-for-linux/citrix-workspace-app-for-linux-oem-reference-guide
 
 let
   inherit (callPackage ./sources.nix { }) supportedVersions unsupportedVersions;
@@ -13,7 +13,7 @@ let
       Citrix Workspace at version ${x} is not supported anymore!
 
       Actively supported releases are listed here:
-      https://www.citrix.com/support/product-lifecycle/milestones/receiver.html
+      https://www.citrix.com/support/product-lifecycle/workspace-app.html
     '')) unsupportedVersions
   );
 

--- a/pkgs/applications/networking/remote/citrix-workspace/generic.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/generic.nix
@@ -196,7 +196,7 @@ stdenv.mkDerivation rec {
 
     ${mkWrappers copyCert extraCerts}
 
-    # See https://developer-docs.citrix.com/projects/workspace-app-for-linux-oem-guide/en/latest/reference-information/#library-files
+    # See https://developer-docs.citrix.com/en-us/citrix-workspace-app-for-linux/citrix-workspace-app-for-linux-oem-reference-guide/reference-information/#library-files
     # Those files are fallbacks to support older libwekit.so and libjpeg.so
     rm $out/opt/citrix-icaclient/lib/ctxjpeg_fb_8.so || true
     rm $out/opt/citrix-icaclient/lib/UIDialogLibWebKit.so || true

--- a/pkgs/applications/networking/remote/citrix-workspace/generic.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/generic.nix
@@ -238,7 +238,7 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     description = "Citrix Workspace";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    platforms = platforms.linux;
+    platforms = [ "x86_64-linux" ] ++ optional (versionOlder version "24") "i686-linux";
     maintainers = with maintainers; [ michaeladler ];
     inherit homepage;
   };

--- a/pkgs/applications/networking/remote/citrix-workspace/sources.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/sources.nix
@@ -52,7 +52,7 @@ let
   # provide a meaningful error-message if it's attempted to use such an old one.
   #
   # The lifespans of Citrix products can be found here:
-  # https://www.citrix.com/support/product-lifecycle/milestones/receiver.html
+  # https://www.citrix.com/support/product-lifecycle/workspace-app.html
   unsupportedVersions = [ "23.02.0" "23.07.0" ];
 in {
   inherit supportedVersions unsupportedVersions;

--- a/pkgs/applications/networking/remote/citrix-workspace/sources.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/sources.nix
@@ -13,29 +13,6 @@ let
   #
   # The latest versions can be found at https://www.citrix.com/downloads/workspace-app/linux/
   supportedVersions = lib.mapAttrs mkVersionInfo {
-
-    "23.02.0" = {
-      major     = "23";
-      minor     = "2";
-      patch     = "0";
-      x64hash   = "d0030a4782ba4b2628139635a12a7de044a4eb36906ef1eadb05b6ea77c1a7bc";
-      x86hash   = "39228fc8dd69adca4e56991c1ebc0832fec183c3ab5abd2d65c66b39b634391b";
-      x64suffix = "10";
-      x86suffix = "10";
-      homepage  = "https://www.citrix.com/downloads/workspace-app/legacy-workspace-app-for-linux/workspace-app-for-linux-latest6.html";
-    };
-
-    "23.07.0" = {
-      major     = "23";
-      minor     = "7";
-      patch     = "0";
-      x64hash   = "d4001226e79b5353fc74da4c8ed4f6295c1859fe18142cb5de345a3c7ae48168";
-      x86hash   = "4a7da238286ae28d7baf0fefa1e7e09d077c8bc56c2bf7bec00da42c331bee59";
-      x64suffix = "17";
-      x86suffix = "17";
-      homepage  = "https://www.citrix.com/downloads/workspace-app/legacy-workspace-app-for-linux/workspace-app-for-linux-latest21.html";
-    };
-
     "23.09.0" = {
       major     = "23";
       minor     = "9";
@@ -65,7 +42,7 @@ let
   #
   # The lifespans of Citrix products can be found here:
   # https://www.citrix.com/support/product-lifecycle/milestones/receiver.html
-  unsupportedVersions = [ ];
+  unsupportedVersions = [ "23.02.0" "23.07.0" ];
 in {
   inherit supportedVersions unsupportedVersions;
 }

--- a/pkgs/applications/networking/remote/citrix-workspace/sources.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/sources.nix
@@ -12,6 +12,7 @@ let
   # for Linux.
   #
   # The latest versions can be found at https://www.citrix.com/downloads/workspace-app/linux/
+  # x86 is unsupported past 23.11, see https://docs.citrix.com/en-us/citrix-workspace-app-for-linux/deprecation
   supportedVersions = lib.mapAttrs mkVersionInfo {
     "23.09.0" = {
       major     = "23";
@@ -32,9 +33,19 @@ let
       x86hash   = "65b8c144e51b5bd78b98ae69e0fa76d6c020a857d74fd5254be49492527072b6";
       x64suffix = "82";
       x86suffix = "82";
-      homepage  = "https://www.citrix.com/downloads/workspace-app/linux/workspace-app-for-linux-latest.html";
+      homepage  = "https://www.citrix.com/downloads/workspace-app/legacy-workspace-app-for-linux/workspace-app-for-linux-latest10.html";
     };
 
+    "24.02.0" = {
+      major     = "24";
+      minor     = "2";
+      patch     = "0";
+      x64hash   = "eaeb5d3bd079d4e5c9707da67f5f7a25cb765e19c36d01861290655dbf2aaee4";
+      x86hash   = "";
+      x64suffix = "65";
+      x86suffix = "";
+      homepage  = "https://www.citrix.com/downloads/workspace-app/linux/workspace-app-for-linux-latest.html";
+    };
   };
 
   # Retain attribute-names for abandoned versions of Citrix workspace to

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6810,8 +6810,6 @@ with pkgs;
   cirrusgo = callPackage ../tools/security/cirrusgo { };
 
   inherit (callPackage ../applications/networking/remote/citrix-workspace { })
-    citrix_workspace_23_02_0
-    citrix_workspace_23_07_0
     citrix_workspace_23_09_0
     citrix_workspace_23_11_0
   ;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6812,8 +6812,9 @@ with pkgs;
   inherit (callPackage ../applications/networking/remote/citrix-workspace { })
     citrix_workspace_23_09_0
     citrix_workspace_23_11_0
+    citrix_workspace_24_02_0
   ;
-  citrix_workspace = citrix_workspace_23_11_0;
+  citrix_workspace = citrix_workspace_24_02_0;
 
   clima = callPackage ../tools/text/clima { };
 


### PR DESCRIPTION
## Description of changes

remove versions < 23.09, bump existing version.

**This release appears to drop support for i686-linux** (though I don't see it listed under https://docs.citrix.com/en-us/citrix-workspace-app-for-linux/deprecation)

Changelog: https://docs.citrix.com/en-us/citrix-workspace-app-for-linux/whats-new.html#whats-new-in-2402

Building this successfully requires #293126 to be merged first.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
