### PR TITLE
tpnote: init at 1.23.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7048,6 +7048,12 @@
     github = "getpsyched";
     githubId = 43472218;
   };
+  getreu = {
+    email = "getreu@web.de";
+    github = "getreu";
+    githubId = 579082;
+    name = "Jens Getreu";
+  };
   gfrascadorio = {
     email = "gfrascadorio@tutanota.com";
     github = "gfrascadorio";

--- a/pkgs/by-name/tp/tpnote/package.nix
+++ b/pkgs/by-name/tp/tpnote/package.nix
@@ -1,0 +1,59 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchpatch
+, rustPlatform
+, cmake
+, pkg-config
+, oniguruma
+, darwin
+, installShellFiles
+, tpnote
+, testers
+}:
+
+
+rustPlatform.buildRustPackage rec {
+  pname = "tpnote";
+  version = "1.23.9";
+
+  src = fetchFromGitHub {
+    owner = "getreu";
+    repo = "tp-note";
+    rev = "v${version}";
+    hash = "sha256-HOCd5N8oS8N+9alR3cG7IEghvhvcc8A+O24L6FD1F38=";
+  };
+
+  cargoHash = "sha256-T1AYiwGPolYUhJQzTyR7v5dqqNFUCSfSBzU3CithZPw=";
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    installShellFiles
+  ];
+  buildInputs = [
+    oniguruma
+  ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+     AppKit
+     CoreServices
+     SystemConfiguration
+  ]);
+
+  RUSTONIG_SYSTEM_LIBONIG = true;
+
+  passthru.tests.version = testers.testVersion { package = tpnote; };
+
+  # The `tpnote` crate has no unit tests. All tests are in `tpnote-lib`.
+  checkType = "debug";
+  cargoTestFlags = "--package tpnote-lib";
+  doCheck = true;
+
+  meta = {
+    changelog = "https://github.com/getreu/tp-note/releases/tag/v${version}";
+    description = "Markup enhanced granular note-taking";
+    homepage = "https://blog.getreu.net/projects/tp-note/";
+    license = lib.licenses.mit;
+    mainProgram = "tpnote";
+    maintainers = with lib.maintainers; [ getreu ];
+  };
+}


### PR DESCRIPTION
## Add new package: Tp-Note

**Tp-Note: Markup enhanced granular note-taking**

*Save and edit your clipboard content as a note file*


[![Cargo](https://img.shields.io/crates/v/tp-note.svg)](
https://crates.io/crates/tp-note)
[![Documentation](https://docs.rs/tpnote-lib/badge.svg)](
https://docs.rs/tpnote-lib)
[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](
https://gitlab.com/getreu/tp-note)

_Tp-Note_ is a note-taking-tool and a template system - freely available for
Windows, MacOS and Linux - that consistently synchronizes the note’s meta-data
with its filename. _Tp-Note_'s main design goal is to convert some input text -
usually provided by the system's clipboard - into a Markdown note file with
a descriptive YAML header and a meaningful filename.
_Tp-Note_ collects various information about its environment
and the clipboard and stores them in variables. New notes are created by
filling these variables in predefined and customizable _Tera_-templates.
_TP-Note's_ default templates are written in Markdown and can be easily adapted
to any other markup language if needed. After creating a new note, _TP-Note_
launches the system's text editor and connects the default web browser to _Tp-
Note_'s internal Markdown/RestructuredText renderer and web server. The viewer
detects note file changes and updates the rendition accordingly.

_On Tue, 2023-12-19 at 12:58 +1100, Dev Rain wrote:_

> _Found Tp-Note awhile back and it has become part of my daily workflow,
> and indeed part of my daily note-taking life. I wanted to extend my
> thanks; so thank you. 
> dev.rain_

Read more in [Tp-Note’s user manual], [Download Tp-Note] or visit the project 
page: [Tp-Note - Minimalistic note-taking].

[Tp-Note’s user manual]: https://blog.getreu.net/projects/tp-note/tpnote--manual.html
[Download Tp-Note]: https://blog.getreu.net/projects/tp-note/index.html#distribution
[Tp-Note - Minimalistic note-taking]: https://blog.getreu.net/projects/tp-note/

## Things done


- Builts on platform(s) (tested with `cargo test` and `cargo build`) 
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin


- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [-] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) [does not apply]
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
