### PR TITLE
kcolorpicker: 0.3.0 -> 0.3.1 & kimageannotator: 0.7.0 -> 0.7.1

### DIFF
--- a/pkgs/development/libraries/kcolorpicker/default.nix
+++ b/pkgs/development/libraries/kcolorpicker/default.nix
@@ -4,13 +4,13 @@ let
   isQt6 = lib.versions.major qtbase.version == "6";
 in stdenv.mkDerivation rec {
   pname = "kcolorpicker";
-  version = "0.3.0";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "ksnip";
     repo = "kColorPicker";
     rev = "v${version}";
-    hash = "sha256-gkjlIiLB3/074EEFrQUa0djvVt/C44O3afqqNis64P0=";
+    hash = "sha256-FG/A4pDNuhGPOeJNZlsnX3paEy4ibJVWKxn8rVUGpN8=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/kimageannotator/default.nix
+++ b/pkgs/development/libraries/kimageannotator/default.nix
@@ -4,13 +4,13 @@ let
   isQt6 = lib.versions.major qtbase.version == "6";
 in stdenv.mkDerivation rec {
   pname = "kimageannotator";
-  version = "0.7.0";
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "ksnip";
     repo = "kImageAnnotator";
     rev = "v${version}";
-    hash = "sha256-Dq9CM/D3nA7MaY9rfwqF/UAw/+1ptKLf3P8jhFdngKk=";
+    hash = "sha256-LFou8gTF/XDBLNQbA4uurYJHQl7yOTKe2OGklUsmPrg=";
   };
 
   nativeBuildInputs = [ cmake qttools ];

--- a/pkgs/tools/misc/ksnip/default.nix
+++ b/pkgs/tools/misc/ksnip/default.nix
@@ -31,10 +31,6 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  postPatch = ''
-    substituteInPlace src/CMakeLists.txt --replace-fail "kColorPicker::kColorPicker" "kColorPicker::kColorPicker-Qt5"
-  '';
-
   nativeBuildInputs = [
     cmake
     extra-cmake-modules


### PR DESCRIPTION
## Description of changes

Simple package updates. It is necessary to update both packages at the same time, otherwise kimageannotator and therefore gwenview don't build.

https://github.com/ksnip/kImageAnnotator/compare/v0.7.0...v0.7.1
https://github.com/ksnip/kColorPicker/compare/v0.3.0...v0.3.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
