### PR TITLE
projectlibre: make deterministic and clean up

### DIFF
--- a/pkgs/applications/misc/projectlibre/default.nix
+++ b/pkgs/applications/misc/projectlibre/default.nix
@@ -1,46 +1,66 @@
-{ lib, stdenv, fetchgit, ant, jdk, makeWrapper, jre, coreutils, which }:
+{ lib
+, stdenv
+, fetchgit
+, ant
+, jdk
+, makeWrapper
+, jre
+, coreutils
+, which
+}:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "projectlibre";
   version = "1.7.0";
 
   src = fetchgit {
     url = "https://git.code.sf.net/p/projectlibre/code";
     rev = "0c939507cc63e9eaeb855437189cdec79e9386c2"; # version 1.7.0 was not tagged
-    sha256 = "0vy5vgbp45ai957gaby2dj1hvmbxfdlfnwcanwqm9f8q16qipdbq";
+    hash = "sha256-eLUbsQkYuVQxt4px62hzfdUNg2zCL/VOSVEVctfbxW8=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [ ant jdk ];
-  buildPhase = ''
-    export ANT_OPTS=-Dbuild.sysclasspath=ignore
-    ${ant}/bin/ant -f openproj_build/build.xml
-  '';
+  nativeBuildInputs = [
+    ant
+    jdk
+    makeWrapper
+  ];
 
-  resourcesPath = "openproj_build/resources";
-  desktopItem = "${resourcesPath}/projectlibre.desktop";
+  buildPhase = ''
+    runHook preBuild
+    ant -f openproj_build/build.xml
+    runHook postBuild
+  '';
 
   installPhase = ''
-    mkdir -p $out/share/{applications,projectlibre/samples,pixmaps,doc/projectlibre} $out/bin
+    runHook preInstall
 
-    substitute $resourcesPath/projectlibre $out/bin/projectlibre \
-      --replace "\"/usr/share/projectlibre\"" "\"$out/share/projectlibre\""
-    chmod +x $out/bin/projectlibre
+    mkdir -p $out/share/{projectlibre/samples,doc/projectlibre}
+
+    pushd openproj_build
+    cp -R dist/* $out/share/projectlibre
+    cp -R license $out/share/doc/projectlibre
+    cp -R resources/samples/* $out/share/projectlibre/samples
+    install -Dm644 resources/projectlibre.desktop -t $out/share/applications
+    install -Dm644 resources/projectlibre.png -t $out/share/pixmaps
+    install -Dm755 resources/projectlibre -t $out/bin
+    popd
+
+    substituteInPlace $out/bin/projectlibre \
+        --replace-fail "/usr/share/projectlibre" "$out/share/projectlibre"
+
     wrapProgram $out/bin/projectlibre \
-     --prefix PATH : "${jre}/bin:${coreutils}/bin:${which}/bin"
+        --prefix PATH : ${lib.makeBinPath [ jre coreutils which ]}
 
-    cp -R openproj_build/dist/* $out/share/projectlibre
-    cp -R openproj_build/license $out/share/doc/projectlibre
-    cp $desktopItem $out/share/applications
-    cp $resourcesPath/projectlibre.png $out/share/pixmaps
-    cp -R $resourcesPath/samples/* $out/share/projectlibre/samples
+    runHook postInstall
   '';
 
-  meta = with lib; {
-    homepage = "https://www.projectlibre.com/";
+  meta = {
     description = "Project-Management Software similar to MS-Project";
+    homepage = "https://www.projectlibre.com/";
+    license = lib.licenses.cpal10;
     mainProgram = "projectlibre";
-    maintainers = [ maintainers.Mogria ];
-    license = licenses.cpal10;
+    maintainers = with lib.maintainers; [ Mogria tomasajt ];
+    platforms = jre.meta.platforms;
   };
 }
+

--- a/pkgs/applications/misc/projectlibre/default.nix
+++ b/pkgs/applications/misc/projectlibre/default.nix
@@ -3,6 +3,7 @@
 , fetchgit
 , ant
 , jdk
+, stripJavaArchivesHook
 , makeWrapper
 , jre
 , coreutils
@@ -22,6 +23,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     ant
     jdk
+    stripJavaArchivesHook
     makeWrapper
   ];
 


### PR DESCRIPTION
## Description of changes

Tracking issue: https://github.com/NixOS/nixpkgs/issues/278518

This PR does a rewrite of the `projectlibre` package and adds a patch, which makes the build reproducible.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Add `postPatch` phase for determinism
- Combine `buildInputs` and `nativeBuildInputs`
- Add `runHook` calls
- Use more `install` calls instead of `mkdir` and `cp`
- Add more `meta` attributes
- Add myself to `meta.maintainers`

---

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
