### PR TITLE
domination: make deterministic and clean up

### DIFF
--- a/pkgs/games/domination/default.nix
+++ b/pkgs/games/domination/default.nix
@@ -4,6 +4,7 @@
 , jdk8
 , jre
 , ant
+, stripJavaArchivesHook
 , makeWrapper
 , makeDesktopItem
 , copyDesktopItems
@@ -41,6 +42,7 @@ in stdenv.mkDerivation {
   nativeBuildInputs = [
     jdk8
     ant
+    stripJavaArchivesHook
     makeWrapper
     copyDesktopItems
   ];
@@ -71,7 +73,6 @@ in stdenv.mkDerivation {
     cp -r build/game/* $out/share/domination/
 
     # Reimplement the two launchers mentioned in Unix_shortcutSpec.xml with makeWrapper
-    mkdir -p $out/bin
     makeWrapper ${jre}/bin/java $out/bin/domination \
       --chdir "$out/share/domination" \
       --add-flags "-jar $out/share/domination/Domination.jar"
@@ -81,6 +82,11 @@ in stdenv.mkDerivation {
 
     install -Dm644 build/game/resources/icon.png $out/share/pixmaps/domination.png
     runHook postInstall
+  '';
+
+  preFixup = ''
+    # remove extra metadata files for jar files which break stripJavaArchivesHook
+    find $out/share/domination/lib -type f -name '._*.jar' -delete
   '';
 
   passthru.tests = {
@@ -101,7 +107,8 @@ in stdenv.mkDerivation {
       fromSource
       binaryBytecode  # source bundles dependencies as jars
     ];
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
+    mainProgram = "domination";
     maintainers = with maintainers; [ fgaz ];
     platforms = platforms.all;
   };


### PR DESCRIPTION
## Description of changes

Tracking issue: https://github.com/NixOS/nixpkgs/issues/278518

This PR makes the build of the `domination` package deterministic by adding `stripJavaArchivesHook` to `nativeBuildInputs`, which resets the internal timestamps of the generated `jar` files.
It also does some minor cleanup in the `installPhase`

Other changes include adding `meta.mainProgram` and setting `meta.license` to a more specific license.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
