### PR TITLE
firefox*: fix collisions due to identical `binaryName`

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -399,6 +399,7 @@ buildStdenv.mkDerivation {
     "--enable-application=${application}"
     "--enable-default-toolkit=cairo-gtk3${lib.optionalString waylandSupport "-wayland"}"
     "--enable-system-pixman"
+    "--with-app-name=${binaryName}"
     "--with-distribution-id=org.nixos"
     "--with-libclang-path=${llvmPackagesBuildBuild.libclang.lib}/lib"
     "--with-system-ffi"

--- a/pkgs/applications/networking/browsers/firefox/packages.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages.nix
@@ -33,6 +33,7 @@
 
   firefox-beta = buildMozillaMach rec {
     pname = "firefox-beta";
+    binaryName = "firefox-beta";
     version = "128.0b3";
     applicationName = "Mozilla Firefox Beta";
     src = fetchurl {
@@ -51,7 +52,7 @@
                                              # not in `badPlatforms` because cross-compilation on 64-bit machine might work.
       maxSilent = 14400; # 4h, double the default of 7200s (c.f. #129212, #129115)
       license = lib.licenses.mpl20;
-      mainProgram = "firefox";
+      mainProgram = binaryName;
     };
     tests = [ nixosTests.firefox-beta ];
     updateScript = callPackage ./update.nix {
@@ -62,6 +63,7 @@
 
   firefox-devedition = buildMozillaMach rec {
     pname = "firefox-devedition";
+    binaryName = "firefox-developer-edition";
     version = "128.0b3";
     applicationName = "Mozilla Firefox Developer Edition";
     requireSigning = false;
@@ -82,7 +84,7 @@
                                              # not in `badPlatforms` because cross-compilation on 64-bit machine might work.
       maxSilent = 14400; # 4h, double the default of 7200s (c.f. #129212, #129115)
       license = lib.licenses.mpl20;
-      mainProgram = "firefox";
+      mainProgram = binaryName;
     };
     tests = [ nixosTests.firefox-devedition ];
     updateScript = callPackage ./update.nix {
@@ -94,6 +96,7 @@
 
   firefox-esr-115 = buildMozillaMach rec {
     pname = "firefox-esr-115";
+    binaryName = "firefox-esr";
     version = "115.12.0esr";
     applicationName = "Mozilla Firefox ESR";
     src = fetchurl {
@@ -111,7 +114,7 @@
       broken = stdenv.buildPlatform.is32bit; # since Firefox 60, build on 32-bit platforms fails with "out of memory".
                                              # not in `badPlatforms` because cross-compilation on 64-bit machine might work.
       license = lib.licenses.mpl20;
-      mainProgram = "firefox";
+      mainProgram = binaryName;
     };
     tests = [ nixosTests.firefox-esr-115 ];
     updateScript = callPackage ./update.nix {

--- a/pkgs/applications/networking/browsers/floorp/default.nix
+++ b/pkgs/applications/networking/browsers/floorp/default.nix
@@ -26,7 +26,6 @@
   };
 
   extraConfigureFlags = [
-    "--with-app-name=${pname}"
     "--with-app-basename=${applicationName}"
     "--with-unsigned-addon-scopes=app,system"
   ];

--- a/pkgs/applications/networking/browsers/librewolf/librewolf.nix
+++ b/pkgs/applications/networking/browsers/librewolf/librewolf.nix
@@ -9,7 +9,6 @@ rec {
   extraPatches = [ ];
 
   extraConfigureFlags = [
-    "--with-app-name=librewolf"
     "--with-app-basename=LibreWolf"
     "--with-unsigned-addon-scopes=app,system"
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -30965,13 +30965,11 @@ with pkgs;
 
   firefox = wrapFirefox firefox-unwrapped { };
   firefox-beta = wrapFirefox firefox-beta-unwrapped {
-    nameSuffix = "-beta";
     desktopName = "Firefox Beta";
     wmClass = "firefox-beta";
     icon = "firefox-beta";
   };
   firefox-devedition = wrapFirefox firefox-devedition-unwrapped {
-    nameSuffix = "-devedition";
     desktopName = "Firefox Developer Edition";
     wmClass = "firefox-devedition";
     icon = "firefox-devedition";
@@ -30981,7 +30979,6 @@ with pkgs;
 
   firefox-esr = firefox-esr-115;
   firefox-esr-115 = wrapFirefox firefox-esr-115-unwrapped {
-    nameSuffix = "-esr";
     desktopName = "Firefox ESR";
     wmClass = "firefox-esr";
     icon = "firefox-esr";


### PR DESCRIPTION
All `nixpkgs` Firefox builds are built with the same `binaryName`, and as a result these packages collide when installing the unwrapped packages, or even in the case of the wrapped packages, although the `nameSuffix` is set differently for `firefox-beta`, `firefox-devedition`, and `firefox-esr-115`, inside of the wrapper a `".${binaryName}-wrapper"` file is created, and _these_ still collide with one another.

In NixOS, this is not an issue because its call to `buildEnv` allows collisions, but in the case of Home Manager, its call to `buildEnv` does not, and so one cannot install multiple versions of these packages at the same time:

```
error: builder for '/nix/store/anwr04997ywn8qm1f2mcwav0d1qip8f5-home-manager-path.drv' failed with exit code 25;
       last 1 log lines:
       > error: collision between `/nix/store/in499wgsizvkzdvvrkykycvx7f0cq5dw-firefox-124.0b5/bin/.firefox-wrapped' and `/nix/store/zc4zrgmr1r2csm8xcwnlbvmmyrf6220z-firefox-123.0/bin/.firefox-wrapped'
       For full logs, run 'nix log /nix/store/anwr04997ywn8qm1f2mcwav0d1qip8f5-home-manager-path.drv'.
error: 1 dependencies of derivation '/nix/store/f06n5k5xr69bl54cfm4v98pxacciifn3-home-manager-generation.drv' failed to build
error: 1 dependencies of derivation '/nix/store/i1mfkn07ryf4j1cpkh6flj3sak2iwdwi-user-environment.drv' failed to build
error: 1 dependencies of derivation '/nix/store/aws7kf1a5jd129j4alj71mc8x7vlbs5x-etc.drv' failed to build
error: 1 dependencies of derivation '/nix/store/x8yvvb6kxp32pplclxk6wkiam7gcbz65-nixos-system-guru-23.11.20240301.79baff8.drv' failed to build
```

The `-bin` variants already have different binary names, as Mozilla builds them with different binary names, and thus for them these collisions don't occur.

Should the release notes include a note about the changed binary names?

## Description of changes

I have adjusted the `nixpkgs` builds of Firefox to use different binary names.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
