### PR TITLE
soci-snapshotter: init at 0.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17175,6 +17175,11 @@
     githubId = 11613056;
     name = "Scott Dier";
   };
+  seanrmurphy = {
+      github = "seanrmurphy";
+      githubId = 540360;
+      name = "Sean Murphy";
+    };
   SeanZicari = {
     email = "sean.zicari@gmail.com";
     github = "SeanZicari";

--- a/pkgs/by-name/so/soci-snapshotter/package.nix
+++ b/pkgs/by-name/so/soci-snapshotter/package.nix
@@ -1,0 +1,97 @@
+{ lib, buildGoModule, fetchFromGitHub, musl, flatbuffers, pkg-config, zlib }:
+
+buildGoModule rec {
+  # note: there is another package called soci - https://soci.sourceforge.net/
+  #
+  # soci comprises of two binaries: the soci image indexer which is a cli tool
+  # and a grpc service for running soci images in a lazy loading manner.
+
+  # this package has a makefile but I found it difficult to use that here
+  # so I'm using the more or less standard gomodules build approach - there
+  # are a couple of issues:
+  # - the go.mod file in the cmd dir imports the module using a relative path
+  # - the instructions for cgo to import the zlib library are currently not compatible with pkg-config
+  pname = "soci-snapshotter";
+  version = "0.5.0";
+  # I don't know a nice way to obtain the commit hash when specifying the version and using the fetchFromGithub fetcher
+  # this should be updated with the version and is given to the build process as an input so soci --version shows the commit hash
+  commitHash = "77f218d";
+
+  src = fetchFromGitHub {
+    owner = "awslabs";
+    repo = "soci-snapshotter";
+    rev = "v${version}";
+    sha256 = "sha256-xcEAe0gzhuvquzqXwPl+ESh1qSP+vLraFV21bfHwDH0=";
+  };
+
+  vendorHash = "sha256-wU3nCaQ1/ZrvJt3P9j2IeifD9WV+0YmHrYhwAnn/s0M=";
+
+  # zlib is required for some compression stuff that is used within soci
+  buildInputs = [zlib];
+
+  # according to the documentation flatbuffers can be required in the build
+  # but usually it is not
+  nativeBuildInputs = [musl flatbuffers pkg-config];
+
+  # zlib is a C dependency
+  CGO_ENABLED = 1;
+
+  ldflags = [
+    "-linkmode external"
+    "-extldflags '-static -L${musl}/lib'"
+  ];
+
+  modBuildPhase = ''
+    runHook preBuild
+
+    cd cmd
+    sed -i 's/github.com\/awslabs\/soci-snapshotter v0.0.0 => ..\//github.com\/awslabs\/soci-snapshotter v0.0.0 => github.com\/awslabs\/soci-snapshotter v0.5.0/' go.mod
+    sed -i 's/github.com\/awslabs\/soci-snapshotter v0.0.0-local => ..\//github.com\/awslabs\/soci-snapshotter v0.0.0-local => github.com\/awslabs\/soci-snapshotter v0.5.0/' go.mod
+
+    go mod tidy
+    go mod vendor
+
+    runHook postBuild
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    export GOCACHE=$TMPDIR/go-cache
+    export GOPATH=$TMPDIR/go
+    mkdir -p $GOPATH/bin
+
+    export REVISION=$(git rev-parse HEAD)$(if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
+
+    # the go-modules derivation is mounted above where it needs to be mounted for this build
+    cp -r vendor cmd/vendor
+    cd cmd
+    sed -i 's/github.com\/awslabs\/soci-snapshotter v0.0.0 => ..\//github.com\/awslabs\/soci-snapshotter v0.0.0 => github.com\/awslabs\/soci-snapshotter v0.5.0/' go.mod
+    sed -i 's/github.com\/awslabs\/soci-snapshotter v0.0.0-local => ..\//github.com\/awslabs\/soci-snapshotter v0.0.0-local => github.com\/awslabs\/soci-snapshotter v0.5.0/' go.mod
+
+    cat go.mod
+
+    ls -al vendor/github.com/awslabs/soci-snapshotter
+
+    chmod 0777 vendor/github.com/awslabs/soci-snapshotter/ztoc/compression/gzip_zinfo.go
+    #echo "testing..." > vendor/github.com/awslabs/soci-snapshotter/ztoc/compression/gzip_zinfo.go
+    sed 's/#cgo LDFLAGS: -L\''${SRCDIR}\/..\/out -l:libz.a/#cgo pkg-config: zlib/' vendor/github.com/awslabs/soci-snapshotter/ztoc/compression/gzip_zinfo.go > $TMPDIR/gzip_zinfo.go
+    cat $TMPDIR/gzip_zinfo.go > vendor/github.com/awslabs/soci-snapshotter/ztoc/compression/gzip_zinfo.go
+
+    echo
+    echo "*** Starting soci build..."
+    echo
+    go build -v -ldflags "-s -w -X github.com/awslabs/soci-snapshotter/version.Version=${version} -X github.com/awslabs/soci-snapshotter/version.Revision=${commitHash}" -o "''${GOPATH}/bin/soci" ./soci
+    go build -v -ldflags "-s -w -X github.com/awslabs/soci-snapshotter/version.Version=${version} -X github.com/awslabs/soci-snapshotter/version.Revision=${commitHash}" -o "''${GOPATH}/bin/soci-snapshotter-grpc" ./soci-snapshotter-grpc
+
+    runHook postBuild
+  '';
+
+  meta = with lib; {
+    description = "A tool to index OCI images to support lazy loading mechanisms.";
+    homepage = "https://github.com/awslabs/soci-snapshotter";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ seanrmurphy ];
+    platforms = ["x86_64-linux"];
+  };
+}


### PR DESCRIPTION
## Description of changes

(This is my first package for nixpkgs - please be gentle!)

Add [soci-snapshotter](https://github.com/awslabs/soci-snapshotter) - a container subsystem which supports adding an index to container images and lazy loading of container images.

I found the build process within the repo to be a little brittle, specifically having a reference to relative paths - hence I did not use the `Makefile` provided and added some not so elegant `sed` stuff. I have [opened a discussion](https://github.com/awslabs/soci-snapshotter/discussions/1085) on the project to try to change this.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
