### PR TITLE
lib: avoid top-level `with ...;` in lib/kernel.nix

### DIFF
--- a/lib/kernel.nix
+++ b/lib/kernel.nix
@@ -1,6 +1,8 @@
 { lib }:
 
-with lib;
+let
+  inherit (lib) mkIf versionAtLeast versionOlder;
+in
 {
 
 


### PR DESCRIPTION
## Description of changes

What it says on the tin. Uses the refactor strategy that looks for the uses of names [coming from `lib`.](https://gist.github.com/philiptaron/04326000d5ff20cb72c2805efd09701c)

## Things done

- [x] Tested, as applicable:
  - [x] `nix-instantiate --strict --eval lib/tests/misc.nix`
  - [x] `nix-instantiate --json --eval --expr "let lib = import ./lib; in builtins.attrNames (import ./lib/kernel.nix { inherit lib; })"`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).