### PR TITLE
lib/tests: remove top-level `with` in `lib/tests`

### DIFF
--- a/lib/tests/modules/alias-with-priority-can-override.nix
+++ b/lib/tests/modules/alias-with-priority-can-override.nix
@@ -6,12 +6,19 @@
 
 { config, lib, ... }:
 
-with lib;
+let
+  inherit (lib)
+    mkAliasOptionModule
+    mkForce
+    mkOption
+    types
+    ;
+in
 
 {
   options = {
     # A simple boolean option that can be enabled or disabled.
-    enable = lib.mkOption {
+    enable = mkOption {
       type = types.nullOr types.bool;
       default = null;
       example = true;
@@ -41,7 +48,7 @@ with lib;
     # should override the next import.
     ( { config, lib, ... }:
       {
-        enableAlias = lib.mkForce false;
+        enableAlias = mkForce false;
       }
     )
 

--- a/lib/tests/modules/alias-with-priority.nix
+++ b/lib/tests/modules/alias-with-priority.nix
@@ -6,12 +6,19 @@
 
 { config, lib, ... }:
 
-with lib;
+let
+  inherit (lib)
+    mkAliasOptionModule
+    mkDefault
+    mkOption
+    types
+    ;
+in
 
 {
   options = {
     # A simple boolean option that can be enabled or disabled.
-    enable = lib.mkOption {
+    enable = mkOption {
       type = types.nullOr types.bool;
       default = null;
       example = true;
@@ -41,7 +48,7 @@ with lib;
     # should be able to be overridden by the next import.
     ( { config, lib, ... }:
       {
-        enableAlias = lib.mkDefault false;
+        enableAlias = mkDefault false;
       }
     )
 

--- a/lib/tests/modules/extendModules-168767-imports.nix
+++ b/lib/tests/modules/extendModules-168767-imports.nix
@@ -2,7 +2,14 @@
 , extendModules
 , ...
 }:
-with lib;
+
+let
+  inherit (lib)
+    mkOption
+    mkOverride
+    types
+    ;
+in
 {
   imports = [
 


### PR DESCRIPTION
## Description of changes

Using `with` at a top-level scope is [an anti-pattern](https://nix.dev/guides/best-practices#with-scopes). The tracking issue is #208242. This is a pure refactor: there is no functional change contained in this PR.

I used the refactor strategy that looks for the uses of names [coming from `lib`.](https://gist.github.com/philiptaron/04326000d5ff20cb72c2805efd09701c)

This PR changes the files that used top-level `with lib;` and `with import ...;` in the `lib/tests/` directory.

## Things done

- [x] Tested, as applicable:
  - [x] `nix-instantiate --strict --eval lib/tests/misc.nix`
  - [x] `lib/tests/modules.sh`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).