### PR TITLE
Add lprint, update pappl

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3446,6 +3446,12 @@
     githubId = 1118859;
     name = "Scott Worley";
   };
+  ChlorideCull = {
+    email = "nixrelated@chcl.se";
+    github = "ChlorideCull";
+    githubId = 4977063;
+    name = "Sebastian Johansson";
+  };
   choochootrain = {
     email = "hurshal@imap.cc";
     github = "choochootrain";

--- a/pkgs/applications/printing/pappl/default.nix
+++ b/pkgs/applications/printing/pappl/default.nix
@@ -13,22 +13,14 @@
 
 stdenv.mkDerivation rec {
   pname = "pappl";
-  version = "1.1.0";
+  version = "1.4.6";
 
   src = fetchFromGitHub {
     owner = "michaelrsweet";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-FsmR0fFb9bU9G3oUyJU1eDLcoZ6OQ2//TINlPrW6lU0=";
+    sha256 = "sha256-d7QD6Kz4tBVHGFPBYcvRSzW+EtsNgpfweFvCx3ovfWE=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "file-offset-bits-64-linux.patch";
-      url = "https://github.com/michaelrsweet/pappl/commit/7ec4ce4331b6637c54a37943269e05d15ff6dd47.patch";
-      sha256 = "sha256-x5lriopWw6Mn2qjv19flsleEzPMHU4jYWRy0y6hTL5k=";
-    })
-  ];
 
   outputs = [ "out" "dev" ];
 
@@ -66,6 +58,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/michaelrsweet/pappl";
     license = licenses.asl20;
     platforms = platforms.linux; # should also work for darwin, but requires additional work
-    maintainers = with maintainers; [ jonringer ];
+    maintainers = with maintainers; [ jonringer ChlorideCull ];
   };
 }

--- a/pkgs/by-name/lp/lprint/package.nix
+++ b/pkgs/by-name/lp/lprint/package.nix
@@ -1,0 +1,43 @@
+{ lib, stdenv, fetchFromGitHub
+, pappl
+, cups
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "lprint";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "michaelrsweet";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-1OOLGQ8S4oRNSJanX/AzJ+g5F+jYnE/+o+ie5ucY22U=";
+  };
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    pappl
+    cups
+  ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    $out/bin/lprint --help
+  '';
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    description = "LPrint implements printing for a variety of common label and receipt printers connected via network or USB.";
+    homepage = "https://github.com/michaelrsweet/lprint";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ChlorideCull ];
+  };
+}


### PR DESCRIPTION
## Description of changes

I need lprint for a print server I'm setting up, and #211615 seems to have stalled.

lprint implements LPP Everywhere for a lot of label printers. [The github repo for lprint is here.](https://github.com/michaelrsweet/lprint)

pappl had no users in nixpkgs until now, so the version bump is from 2011 to the latest version, released this February. [The changelog is in the github releases.](https://github.com/michaelrsweet/pappl/releases)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
