### PR TITLE
got: 0.96 -> 0.97

### DIFF
--- a/pkgs/applications/version-management/got/default.nix
+++ b/pkgs/applications/version-management/got/default.nix
@@ -16,11 +16,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "got";
-  version = "0.96";
+  version = "0.97";
 
   src = fetchurl {
     url = "https://gameoftrees.org/releases/portable/got-portable-${finalAttrs.version}.tar.gz";
-    hash = "sha256-/R7r6IJtgkuNQwoLxys/1HcXW+l3PVkjnPXphFpAFTs=";
+    hash = "sha256-4HpIlKRYUDoymCBH8GS8DDXaY0nYiVvotpBkwglOO3I=";
   };
 
   nativeBuildInputs = [ pkg-config bison ]
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
     # The configure script assumes dependencies on Darwin are installed via
     # Homebrew or MacPorts and hardcodes assumptions about the paths of
     # dependencies which fails the nixpkgs configurePhase.
-    substituteInPlace configure --replace 'xdarwin' 'xhomebrew'
+    substituteInPlace configure --replace-fail 'xdarwin' 'xhomebrew'
   '';
 
   env.NIX_CFLAGS_COMPILE = toString (lib.optionals stdenv.isDarwin [
@@ -49,11 +49,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   installCheckPhase = ''
     runHook preInstallCheck
-    test "$($out/bin/got --version)" = "${finalAttrs.pname} ${finalAttrs.version}"
+    test "$($out/bin/got --version)" = "got ${finalAttrs.version}"
     runHook postInstallCheck
   '';
 
-  meta = with lib; {
+  meta = {
+    changelog = "https://gameoftrees.org/releases/CHANGES";
     description = "A version control system which prioritizes ease of use and simplicity over flexibility";
     longDescription = ''
       Game of Trees (Got) is a version control system which prioritizes
@@ -65,9 +66,9 @@ stdenv.mkDerivation (finalAttrs: {
       on the same repository.
     '';
     homepage = "https://gameoftrees.org";
-    changelog = "https://gameoftrees.org/releases/CHANGES";
-    license = licenses.isc;
-    platforms = platforms.linux ++ platforms.darwin;
-    maintainers = with maintainers; [ abbe afh ];
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ abbe afh ];
+    mainProgram = "got";
+    platforms = with lib.platforms; darwin ++ linux;
   };
 })


### PR DESCRIPTION
## Description of changes

From the upstream [ChangeLog](https://gameoftrees.org/releases/CHANGES):
```
* got 0.97; 2024-03-11
  see git repository history for per-change authorship information
- improve error messages shown upon execv failure 
- fix 'gotadmin pack' crash upon Ctrl-C due to invalid imsg_free()
- significantly speed up deltification of large files
- improve error handling in got_privsep_recv_imsg()
```

Additional things done to "modernize" the package:

* remove `with lib;` from meta
* sort meta keys alphabeticall
* add `meta.mainProgram'
* Remove deprecated use of `${finalAttrs.pname}` within the package
* Remove `substituteInPlace` warning when using `--replace`

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
