### PR TITLE
libbluray: fix build using withJava, make java build deterministic

### DIFF
--- a/pkgs/development/libraries/libbluray/default.nix
+++ b/pkgs/development/libraries/libbluray/default.nix
@@ -1,5 +1,5 @@
 { lib, stdenv, fetchurl, fetchpatch, pkg-config, fontconfig, autoreconfHook, DiskArbitration
-, withJava ? false, jdk, ant
+, withJava ? false, jdk17, ant, stripJavaArchivesHook
 , withAACS ? false, libaacs
 , withBDplus ? false, libbdplus
 , withMetadata ? true, libxml2
@@ -19,22 +19,17 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config autoreconfHook ]
-    ++ lib.optionals withJava [ ant ];
+    ++ lib.optionals withJava [ jdk17 ant stripJavaArchivesHook ];
 
   buildInputs = [ fontconfig ]
-    ++ lib.optional withJava jdk
     ++ lib.optional withMetadata libxml2
     ++ lib.optional withFonts freetype
     ++ lib.optional stdenv.isDarwin DiskArbitration;
 
   propagatedBuildInputs = lib.optional withAACS libaacs;
 
-  NIX_LDFLAGS = lib.optionalString withAACS "-L${libaacs}/lib -laacs"
+  env.NIX_LDFLAGS = lib.optionalString withAACS "-L${libaacs}/lib -laacs"
     + lib.optionalString withBDplus " -L${libbdplus}/lib -lbdplus";
-
-  preConfigure = lib.optionalString withJava ''
-    export JDK_HOME="${jdk.home}"
-  '';
 
   configureFlags = lib.optional (!withJava) "--disable-bdjava-jar"
     ++ lib.optional (!withMetadata) "--without-libxml2"


### PR DESCRIPTION
## Description of changes

Tracking issue: https://github.com/NixOS/nixpkgs/issues/278518

This PR adds a fix to `libbluray` when building with `withJava = true`.
The issue was that it can't build the `.jar` files using `jdk21`, which is now the default value for `jdk`. I locked the `jdk` version to `jdk17` (that's the previous LTS version).
I moved the JDK from `buildInputs` to `nativeBuildInputs`

The other change made was the addition of `stripJavaArchivesHook` to `nativeBuildInputs`, which strips the final jar file from its timestamps, which makes it deterministic.

There's also a small change to the environment variables. (Add `env.` prefix, remove unnecessary `JDK_HOME` env-var)

Note: I am not sure if this should go into master or staging (rebuilds 101-500)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
