### PR TITLE
sleuthkit: clean up and make deterministic

### DIFF
--- a/pkgs/tools/system/sleuthkit/default.nix
+++ b/pkgs/tools/system/sleuthkit/default.nix
@@ -2,37 +2,33 @@
 , stdenv
 , fetchFromGitHub
 , autoreconfHook
-, libewf
+, ant
+, jdk
+, perl
+, stripJavaArchivesHook
 , afflib
+, libewf
 , openssl
 , zlib
-, openjdk
-, perl
-, ant
 }:
 
-stdenv.mkDerivation rec {
-  version = "4.12.1";
+stdenv.mkDerivation (finalAttrs: {
   pname = "sleuthkit";
+  version = "4.12.1"; # Note: when updating don't forget to also update the rdeps outputHash
 
-  sleuthsrc = fetchFromGitHub {
+  src = fetchFromGitHub {
     owner = "sleuthkit";
     repo = "sleuthkit";
-    rev = "${pname}-${version}";
+    rev = "sleuthkit-${finalAttrs.version}";
     hash = "sha256-q51UY2lIcLijycNaq9oQIwUXpp/1mfc3oPN4syOPF44=";
   };
 
   # Fetch libraries using a fixed output derivation
-  rdeps = stdenv.mkDerivation rec {
+  rdeps = stdenv.mkDerivation {
+    name = "sleuthkit-${finalAttrs.version}-deps";
+    inherit (finalAttrs) src;
 
-    version = "1.0";
-    pname = "sleuthkit-deps";
-    nativeBuildInputs = [
-      openjdk
-      ant
-    ];
-
-    src = sleuthsrc;
+    nativeBuildInputs = [ ant jdk ];
 
     # unpack, build, install
     dontConfigure = true;
@@ -48,7 +44,6 @@ stdenv.mkDerivation rec {
     '';
 
     installPhase = ''
-      export IVY_HOME=$NIX_BUILD_TOP/.ant
       mkdir -m 755 -p $out/bindings/java
       cp -r bindings/java/lib $out/bindings/java
       mkdir -m 755 -p $out/case-uco/java
@@ -58,11 +53,23 @@ stdenv.mkDerivation rec {
     '';
 
     outputHashMode = "recursive";
-    outputHash = "0fq7v6zlgybg4v6k9wqjlk4gaqgjrpihbnr182vaqriihflav2s8";
     outputHashAlgo = "sha256";
+    outputHash = "sha256-mc/KQrwn3xpPI0ngOLcpoQDaJJm/rM8XgaX//5PiRZk=";
   };
 
-  src = sleuthsrc;
+  postUnpack = ''
+    export IVY_HOME="$NIX_BUILD_TOP/.ant"
+    export ANT_ARGS="-Doffline=true -Ddefault-jar-location=$IVY_HOME/lib"
+
+    # pre-positioning these jar files allows -Doffline=true to work
+    mkdir -p source/{bindings,case-uco}/java $IVY_HOME
+    cp -r ${finalAttrs.rdeps}/bindings/java/lib source/bindings/java
+    chmod -R 755 source/bindings/java
+    cp -r ${finalAttrs.rdeps}/case-uco/java/lib source/case-uco/java
+    chmod -R 755 source/case-uco/java
+    cp -r ${finalAttrs.rdeps}/lib $IVY_HOME
+    chmod -R 755 $IVY_HOME
+  '';
 
   postPatch = ''
     substituteInPlace tsk/img/ewf.cpp --replace libewf_handle_read_random libewf_handle_read_buffer_at_offset
@@ -72,15 +79,15 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     autoreconfHook
-    openjdk
-    perl
     ant
-    rdeps
+    jdk
+    perl
+    stripJavaArchivesHook
   ];
 
   buildInputs = [
-    libewf
     afflib
+    libewf
     openssl
     zlib
   ];
@@ -90,31 +97,16 @@ stdenv.mkDerivation rec {
     rm -rf */.libs
   '';
 
-  postUnpack = ''
-    export IVY_HOME="$NIX_BUILD_TOP/.ant"
-    export JAVA_HOME="${openjdk}"
-    export ant_args="-Doffline=true -Ddefault-jar-location=$IVY_HOME/lib"
-
-    # pre-positioning these jar files allows -Doffline=true to work
-    mkdir -p source/{bindings,case-uco}/java $IVY_HOME
-    cp -r ${rdeps}/bindings/java/lib source/bindings/java
-    chmod -R 755 source/bindings/java
-    cp -r ${rdeps}/case-uco/java/lib source/case-uco/java
-    chmod -R 755 source/case-uco/java
-    cp -r ${rdeps}/lib $IVY_HOME
-    chmod -R 755 $IVY_HOME
-  '';
-
   meta = with lib; {
     description = "A forensic/data recovery tool";
     homepage = "https://www.sleuthkit.org/";
-    changelog = "https://github.com/sleuthkit/sleuthkit/releases/tag/sleuthkit-${version}";
+    changelog = "https://github.com/sleuthkit/sleuthkit/blob/${finalAttrs.src.rev}/NEWS.txt";
     maintainers = with maintainers; [ raskin gfrascadorio ];
     platforms = platforms.linux;
     sourceProvenance = with sourceTypes; [
       fromSource
-      binaryBytecode  # dependencies
+      binaryBytecode # dependencies
     ];
     license = licenses.ipl10;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

This PR does cleans up the `sleuthkit` derivation and adds `stripJavaArchivesHook` to `nativeBuildInputs` which makes the build deterministic (it removes timestamps from `.jar` files)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->



## Things done

- Reorder attributes
- use `finalAttrs` instead of `rec`
- use only `src`
- update `outputHash` of `rdeps`
  - add reminder for people to not forget to also update the `outputHash`
  - it would be great to have an `passthru.updateScript`
- move `postUnpack` higher
- change `meta.changelog` to a different one, which contains all previous versions as well
---

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
