### PR TITLE
Upsnap: init at 4.2.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5075,6 +5075,11 @@
       fingerprint = "EE7D 158E F9E7 660E 0C33  86B2 8FC5 F7D9 0A5D 8F4D";
     }];
   };
+  doosty = {
+    name = "Doosty";
+    github = "Doosty";
+    githubId = 747588;
+  };
   donteatoreo = {
     name = "DontEatOreo";
     github = "DontEatOreo";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5075,11 +5075,6 @@
       fingerprint = "EE7D 158E F9E7 660E 0C33  86B2 8FC5 F7D9 0A5D 8F4D";
     }];
   };
-  doosty = {
-    name = "Doosty";
-    github = "Doosty";
-    githubId = 747588;
-  };
   donteatoreo = {
     name = "DontEatOreo";
     github = "DontEatOreo";
@@ -5087,6 +5082,11 @@
     keys = [{
       fingerprint = "33CD 5C0A 673C C54D 661E  5E4C 0DB5 361B EEE5 30AB";
     }];
+  };
+  doosty = {
+    name = "Doosty";
+    github = "Doosty";
+    githubId = 747588;
   };
   doriath = {
     email = "tomasz.zurkowski@gmail.com";

--- a/nixos/modules/services/web-apps/upsnap.nix
+++ b/nixos/modules/services/web-apps/upsnap.nix
@@ -1,0 +1,210 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.services.upsnap;
+in {
+  options.services.upsnap = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = mdDoc ''
+        Upsnap, a simple wake on lan web app.
+
+        TIP: To configure target machines which you want to wakeup:
+        - enable `Wake on LAN/PCIE` in your BIOS/UEFI firmware
+        - enable WoL on your network interface, with whichever OS & app you use for networking
+          for NixOS with NM use `networking.networkmanager.ensureProfiles.profiles.<name>.802-3-ethernet.wake-on-lan = 64;`
+          then reboot and make sure it persisted <https://wiki.debian.org/WakeOnLan#Checking_WOL>
+      '';
+    };
+
+    package = mkOption {
+      default = pkgs.upsnap;
+      type = types.package;
+      description = mdDoc "Upsnap package to use.";
+    };
+
+    address = mkOption {
+      type = types.str;
+      default = "0.0.0.0";
+      example = "127.0.0.1";
+      description = mdDoc "Web interface address.";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 8090;
+      description = mdDoc "Web interface port.";
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = true;
+      description = mdDoc "Allow traffic to TCP port that Upsnap's webui is running on.";
+    };
+
+    dataDir = mkOption {
+      default = "/var/lib/upsnap";
+      type = types.path;
+      description = mdDoc "Location for persistent data.";
+    };
+
+    accessiblePackages = mkOption {
+      default = [pkgs.nmap];
+      example = [pkgs.nmap pkgs.sleep-on-lan pkgs.samba pkgs.sshpass];
+      type = types.listOf types.package;
+      description = mdDoc ''
+        Packages that will be available to Upsnap's environment.
+        The app makes use of some 3rd party tools & provides samples of optional commands.
+        You have to include those desired apps in this set. For example:
+        - network scanning requires `pkgs.nmap`
+        - putting machines to sleep requires `pkgs.sleep-on-lan` (and a daemon of sleep-on-lan running on that machine)
+        - shutting down Windows machines with the webui-suggested command (net rpc) requires `pkgs.samba`
+        - shutting down Linux machines with the webui-suggested command requires `pkgs.sshpass`
+        - ...
+      '';
+    };
+
+    extraServeArgs = mkOption {
+      type = types.str;
+      default = "";
+      example = "--dev --origins <...> --https <...>";
+      description = mdDoc "Text that will be appended to the end of `upsnap serve` command. Use `upsnap serve --help` to discover available cli options.";
+    };
+
+    extraConfig = mkOption {
+      default = {
+        UPSNAP_INTERVAL = "@every 10s";
+        UPSNAP_SCAN_RANGE = "192.168.1.0/24";
+        UPSNAP_SCAN_TIMEOUT = "500ms";
+        UPSNAP_PING_PRIVILEGED = "true";
+        UPSNAP_WEBSITE_TITLE = "Upsnap";
+      };
+      type = types.submodule {
+        freeformType = types.str;
+        options = {
+          UPSNAP_INTERVAL = mkOption {
+            default = "@every 10s";
+            type = types.str;
+            description = mdDoc "Sets the interval in which the devices are pinged";
+          };
+          UPSNAP_SCAN_RANGE = mkOption {
+            default = "192.168.1.0/24";
+            type = types.str;
+            description = mdDoc "Scan range is used for device discovery on local network";
+          };
+          UPSNAP_SCAN_TIMEOUT = mkOption {
+            default = "500ms";
+            type = types.str;
+            description = mdDoc "Scan timeout is nmap's --host-timeout value to wait for devices (https://nmap.org/book/man-performance.html)";
+          };
+          UPSNAP_PING_PRIVILEGED = mkOption {
+            default = "true";
+            type = types.str;
+            description = mdDoc "Set to false if you don't have root user permissions";
+          };
+          UPSNAP_WEBSITE_TITLE = mkOption {
+            default = "Upsnap";
+            type = types.str;
+            description = mdDoc "Custom website title";
+          };
+        };
+      };
+      description = mdDoc "Extra environment variable settings. Preloaded with defaults you can choose to override.";
+    };
+
+    adminUsersFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/run/secrets/upsnap-admins.env";
+      description = lib.mdDoc ''
+        Environment variables from which Upsnap admin users will be created.
+        Supports passwords being changed, however to delete a user you have to manually run `sudo upsnap admin delete <user> --dir <dataDir>`.
+        The format of the environment variables must be:
+        ```
+          UPSNAP_ADMIN_1_EMAIL=alice@email.com
+          UPSNAP_ADMIN_1_PASSWORD=alicepassword
+          UPSNAP_ADMIN_2_EMAIL=bob@email.com
+          UPSNAP_ADMIN_2_PASSWORD=bobpassword
+        ```
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [cfg.package];
+
+    systemd.services.upsnap = {
+      description = "Upsnap, a simple wake on lan web app";
+      after = [
+        "network.target"
+        "network-online.target"
+        "systemd-resolved.service"
+      ];
+      wants = [
+        "network.target"
+        "network-online.target"
+        "systemd-resolved.service"
+      ];
+      wantedBy = ["multi-user.target"];
+      environment =
+        {
+          # upsnap creates an empty `$HOME/.config/upsnap` even when `--dir` arg is set
+          XDG_CONFIG_HOME = cfg.dataDir;
+          HOME = cfg.dataDir;
+        }
+        // lib.mapAttrs (_: toString) cfg.extraConfig;
+      path = cfg.accessiblePackages;
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/upsnap serve --http ${cfg.address}:${builtins.toString cfg.port} --dir ${cfg.dataDir} ${cfg.extraServeArgs}";
+        EnvironmentFile = mkIf (cfg.adminUsersFile != null) (builtins.toString cfg.adminUsersFile);
+        Type = "simple";
+        Restart = "on-failure";
+        # i think we would only need this for non-root user
+        AmbientCapabilities = "CAP_NET_RAW";
+        CapabilityBoundingSet = "CAP_NET_RAW";
+      };
+      preStart = let
+        upsnap = "${cfg.package}/bin/upsnap";
+      in ''
+        ${upsnap} migrate up --dir ${cfg.dataDir}
+        declare -A names
+        declare -A passwords
+        for var in $(env | grep '^UPSNAP_ADMIN_'); do
+            name=$(echo $var | cut -d '=' -f 1)
+            value=$(echo $var | cut -d '=' -f 2-)
+            number=$(echo $name | grep -o '[0-9]\+')
+            if [[ $name == *_EMAIL ]]; then
+                names[$number]=$value
+            elif [[ $name == *_PASSWORD ]]; then
+                passwords[$number]=$value
+            fi
+        done
+        for number in "''${!names[@]}"; do
+            if [ -n "''${names[$number]}" ] && [ -n "''${passwords[$number]}" ]; then
+                output=$(${upsnap} admin create ''${names[$number]} ''${passwords[$number]} --dir ${cfg.dataDir})
+                if echo "$output" | grep -q "UNIQUE constraint failed"; then
+                    output=$(${upsnap} admin update ''${names[$number]} ''${passwords[$number]} --dir ${cfg.dataDir})
+                fi
+                if echo "$output" | grep -q "Success"; then
+                    echo "Successfully initialized user $number"
+                else
+                    echo "Failed to initialize user $number"
+                fi
+            fi
+        done
+      '';
+    };
+
+    systemd.tmpfiles.rules = ["d '${cfg.dataDir}' 0700 root root - -"];
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [cfg.port];
+    };
+  };
+}
+

--- a/pkgs/by-name/up/upsnap/mk-pnpm-package/derivation.nix
+++ b/pkgs/by-name/up/upsnap/mk-pnpm-package/derivation.nix
@@ -1,0 +1,167 @@
+# source is <https://github.com/nzbr/pnpm2nix-nzbr/blob/main/derivation.nix>
+
+{ lib
+, stdenv
+, nodejs
+, pkg-config
+, callPackage
+, writeText
+, runCommand
+, ...
+}:
+
+with builtins; with lib; with callPackage ./lockfile.nix { };
+let
+  nodePkg = nodejs;
+  pkgConfigPkg = pkg-config;
+in
+{
+  mkPnpmPackage =
+    { src
+    , packageJSON ? src + "/package.json"
+    , pnpmLockYaml ? src + "/pnpm-lock.yaml"
+    , pname ? (fromJSON (readFile packageJSON)).name
+    , version ? (fromJSON (readFile packageJSON)).version or null
+    , name ? if version != null then "${pname}-${version}" else pname
+    , registry ? "https://registry.npmjs.org"
+    , script ? "build"
+    , distDir ? "dist"
+    , installInPlace ? false
+    , installEnv ? { }
+    , noDevDependencies ? false
+    , extraNodeModuleSources ? [ ]
+    , copyPnpmStore ? true
+    , copyNodeModules ? false
+    , extraBuildInputs ? [ ]
+    , nodejs ? nodePkg
+    , pnpm ? nodejs.pkgs.pnpm
+    , pkg-config ? pkgConfigPkg
+    , ...
+    }@attrs:
+    let
+      nativeBuildInputs = [
+        nodejs
+        pnpm
+        pkg-config
+      ] ++ extraBuildInputs;
+    in
+    stdenv.mkDerivation (
+      recursiveUpdate
+        (rec {
+          inherit src name nativeBuildInputs;
+
+          configurePhase = ''
+            export HOME=$NIX_BUILD_TOP # Some packages need a writable HOME
+            export npm_config_nodedir=${nodejs}
+
+            runHook preConfigure
+
+            ${if installInPlace
+              then passthru.nodeModules.buildPhase
+              else ''
+                ${if !copyNodeModules
+                  then "ln -s"
+                  else "cp -r"
+                } ${passthru.nodeModules}/node_modules node_modules
+              ''
+            }
+
+            runHook postConfigure
+          '';
+
+          buildPhase = ''
+            runHook preBuild
+
+            pnpm run ${script}
+
+            runHook postBuild
+          '';
+
+          installPhase = ''
+            runHook preInstall
+
+            ${if distDir == "." then "cp -r" else "mv"} ${distDir} $out
+
+            runHook postInstall
+          '';
+
+          passthru =
+            let
+              processResult = processLockfile { inherit registry noDevDependencies; lockfile = pnpmLockYaml; };
+            in
+            {
+              inherit attrs;
+
+              patchedLockfile = processResult.patchedLockfile;
+              patchedLockfileYaml = writeText "pnpm-lock.yaml" (toJSON passthru.patchedLockfile);
+
+              pnpmStore = runCommand "${name}-pnpm-store"
+                {
+                  nativeBuildInputs = [ nodejs pnpm ];
+                } ''
+                mkdir -p $out
+
+                store=$(pnpm store path)
+                mkdir -p $(dirname $store)
+                ln -s $out $(pnpm store path)
+
+                pnpm store add ${concatStringsSep " " (unique processResult.dependencyTarballs)}
+              '';
+
+              nodeModules = stdenv.mkDerivation {
+                name = "${name}-node-modules";
+
+                inherit nativeBuildInputs;
+
+                unpackPhase = concatStringsSep "\n"
+                  (
+                    map
+                      (v:
+                        let
+                          nv = if isAttrs v then v else { name = "."; value = v; };
+                        in
+                        "cp -vr ${nv.value} ${nv.name}"
+                      )
+                      ([
+                        { name = "package.json"; value = packageJSON; }
+                        { name = "pnpm-lock.yaml"; value = passthru.patchedLockfileYaml; }
+                      ] ++ extraNodeModuleSources)
+                  );
+
+                buildPhase = ''
+                  export HOME=$NIX_BUILD_TOP # Some packages need a writable HOME
+
+                  store=$(pnpm store path)
+                  mkdir -p $(dirname $store)
+
+                  cp -f ${passthru.patchedLockfileYaml} pnpm-lock.yaml
+
+                  # solve pnpm: EACCES: permission denied, copyfile '/build/.pnpm-store
+                  ${if !copyPnpmStore
+                    then "ln -s"
+                    else "cp -RL"
+                  } ${passthru.pnpmStore} $(pnpm store path)
+
+                  ${lib.optionalString copyPnpmStore "chmod -R +w $(pnpm store path)"}
+
+                  ${concatStringsSep "\n" (
+                    mapAttrsToList
+                      (n: v: ''export ${n}="${v}"'')
+                      installEnv
+                  )}
+
+                  pnpm install ${optionalString noDevDependencies "--prod "}--frozen-lockfile --offline
+                '';
+
+                installPhase = ''
+                  mkdir -p $out
+                  cp -r node_modules/. $out/node_modules
+                '';
+              };
+            };
+
+        })
+        (attrs // { extraNodeModuleSources = null; installEnv = null; })
+    );
+}
+

--- a/pkgs/by-name/up/upsnap/mk-pnpm-package/lockfile.nix
+++ b/pkgs/by-name/up/upsnap/mk-pnpm-package/lockfile.nix
@@ -1,0 +1,126 @@
+# source is <https://github.com/nzbr/pnpm2nix-nzbr/blob/main/lockfile.nix>
+
+{ lib
+, runCommand
+, remarshal
+, fetchurl
+, ...
+}:
+
+with lib;
+rec {
+
+  parseLockfile = lockfile: builtins.fromJSON (readFile (runCommand "toJSON" { } "${remarshal}/bin/yaml2json ${lockfile} $out"));
+
+  processLockfile = { registry, lockfile, noDevDependencies }:
+    let
+      splitVersion = name: splitString "@" (head (splitString "(" name));
+      getVersion = name: last (splitVersion name);
+      withoutVersion = name: concatStringsSep "@" (init (splitVersion name));
+      switch = options:
+        if ((length options) == 0)
+        then throw "No matching case found!"
+        else
+          if ((head options).case or true)
+          then (head options).result
+          else switch (tail options);
+      mkTarball = pkg: contents:
+        runCommand "${last (init (splitString "/" (head (splitString "(" pkg))))}.tgz" { } ''
+          tar -czf $out -C ${contents} .
+        '';
+      findTarball = n: v:
+        switch [
+          {
+            case = (v.resolution.type or "") == "git";
+            result =
+              mkTarball n (
+                fetchGit {
+                  url = v.resolution.repo;
+                  rev = v.resolution.commit;
+                  shallow = true;
+                }
+              );
+          }
+          {
+            case = hasAttrByPath [ "resolution" "tarball" ] v && hasAttrByPath [ "resolution" "integrity" ] v;
+            result = fetchurl {
+              url = v.resolution.tarball;
+              ${head (splitString "-" v.resolution.integrity)} = v.resolution.integrity;
+            };
+          }
+          {
+            case = hasPrefix "https://codeload.github.com" (v.resolution.tarball or "");
+            result =
+              let
+                m = strings.match "https://codeload.github.com/([^/]+)/([^/]+)/tar\\.gz/([a-f0-9]+)" v.resolution.tarball;
+              in
+              mkTarball n (
+                fetchGit {
+                  url = "https://github.com/${elemAt m 0}/${elemAt m 1}";
+                  rev = (elemAt m 2);
+                  shallow = true;
+                }
+              );
+          }
+          {
+            case = (v ? id);
+            result =
+              let
+                split = splitString "/" v.id;
+              in
+              mkTarball n (
+                fetchGit {
+                  url = "https://${concatStringsSep "/" (init split)}.git";
+                  rev = (last split);
+                  shallow = true;
+                }
+              );
+          }
+          {
+            case = hasPrefix "/" n;
+            result =
+              let
+                name = withoutVersion n;
+                baseName = last (splitString "/" (withoutVersion n));
+                version = getVersion n;
+              in
+              fetchurl {
+                url = "${registry}/${name}/-/${baseName}-${version}.tgz";
+                ${head (splitString "-" v.resolution.integrity)} = v.resolution.integrity;
+              };
+          }
+        ];
+    in
+    {
+      dependencyTarballs =
+        unique (
+          mapAttrsToList
+            findTarball
+            (filterAttrs
+              (n: v: !noDevDependencies || !(v.dev or false))
+              (parseLockfile lockfile).packages
+            )
+        );
+
+      patchedLockfile =
+        let
+          orig = parseLockfile lockfile;
+        in
+        orig // {
+          packages = mapAttrs
+            (n: v:
+              v // (
+                if noDevDependencies && (v.dev or false)
+                then { resolution = { }; }
+                else {
+                  resolution.tarball = "file:${findTarball n v}";
+                }
+              )
+            )
+            orig.packages;
+
+        };
+    };
+
+}
+

--- a/pkgs/by-name/up/upsnap/package.nix
+++ b/pkgs/by-name/up/upsnap/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildGoModule,
+  callPackage,
+  fetchFromGitHub,
+  mkPnpmPackage ? ((callPackage ./mk-pnpm-package/derivation.nix {}).mkPnpmPackage),
+}: let
+  src = fetchFromGitHub {
+    owner = "seriousm4x";
+    repo = "UpSnap";
+    rev = "b05cf7a4852e818703135871c17d97635ab65c28";
+    hash = "sha256-mZdW6yljYOBaWeN3d3qhV9YDyJeIohybg6j81wJ5SCo=";
+  };
+  version = "4.2.7";
+in
+  buildGoModule {
+    vendorHash = "sha256-K+RMedWT0rR3v/f2e5gP61WffBA2Cy3TDpUhwIiF3gY=";
+    pname = "upsnap";
+    version = version;
+
+    src = builtins.path {path = "${src}/backend";};
+
+    preBuild = let
+      frontend = mkPnpmPackage {
+        src = builtins.path {path = "${src}/frontend";};
+        distDir = ".";
+      };
+    in ''
+      cp -r ${frontend}/build/* ./pb_public
+    '';
+
+    checkPhase = ''
+      runHook preCheck
+      runHook postCheck
+    '';
+
+    CGO_ENABLED = "0";
+
+    meta = with lib; {
+      description = "A simple wake on lan web app";
+      homepage = "https://github.com/seriousm4x/UpSnap";
+      license = licenses.mit;
+      maintainers = with maintainers; ["doosty"];
+      mainProgram = "upsnap";
+      platforms = platforms.all;
+    };
+  }

--- a/pkgs/by-name/up/upsnap/package.nix
+++ b/pkgs/by-name/up/upsnap/package.nix
@@ -20,6 +20,8 @@ in
 
     src = builtins.path {path = "${src}/backend";};
 
+    outputs = ["out"];
+
     preBuild = let
       frontend = mkPnpmPackage {
         src = builtins.path {path = "${src}/frontend";};

--- a/pkgs/by-name/up/upsnap/package.nix
+++ b/pkgs/by-name/up/upsnap/package.nix
@@ -18,13 +18,15 @@ in
     pname = "upsnap";
     version = version;
 
-    src = builtins.path {path = "${src}/backend";};
-
-    outputs = ["out"];
+    inherit src;
+    sourceRoot = "${src.name}/backend";
 
     preBuild = let
       frontend = mkPnpmPackage {
-        src = builtins.path {path = "${src}/frontend";};
+        inherit src;
+        sourceRoot = "${src.name}/frontend";
+        packageJSON = "${src}/frontend/package.json";
+        pnpmLockYaml = "${src}/frontend/pnpm-lock.yaml";
         distDir = ".";
       };
     in ''

--- a/pkgs/by-name/up/upsnap/package.nix
+++ b/pkgs/by-name/up/upsnap/package.nix
@@ -21,6 +21,8 @@ in
     inherit src;
     sourceRoot = "${src.name}/backend";
 
+    # outputs = ["out"];
+
     preBuild = let
       frontend = mkPnpmPackage {
         inherit src;


### PR DESCRIPTION
## Description of changes

- Added package of [Upsnap WoL web app](https://github.com/seriousm4x/UpSnap) & its service module.
- The build helper for frontend subpackage is ripped from [pnpm2nix-nzbr](https://github.com/nzbr/pnpm2nix-nzbr/), i am unsure if including it is frowned upon, but havent found anything in nixpkgs that could do the job.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
