### PR TITLE
glsl_analyzer: init at 1.4.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21765,6 +21765,12 @@
     github = "wr0belj";
     githubId = 40501814;
   };
+  wr7 = {
+    name = "wr7";
+    email = "d-wr7@outlook.com";
+    github = "wr7";
+    githubId = 53203261;
+  };
   wraithm = {
     name = "Matthew Wraith";
     email = "wraithm@gmail.com";

--- a/pkgs/by-name/gl/glsl_analyzer/package.nix
+++ b/pkgs/by-name/gl/glsl_analyzer/package.nix
@@ -1,0 +1,39 @@
+{ lib
+, pkgs
+, fetchFromGitHub
+, zig_0_12
+, darwin
+}:
+
+let stdenv = if pkgs.stdenv.isDarwin then darwin.apple_sdk_11_0.stdenv else pkgs.stdenv; in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "glsl_analyzer";
+  version = "1.4.5";
+
+  src = fetchFromGitHub {
+    owner = "nolanderc";
+    repo = "glsl_analyzer";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-+eYBw/F1RzI5waAkLgbV0J/Td91hbNcAtHcisQaL82k=";
+  };
+
+  nativeBuildInputs = [
+    zig_0_12.hook
+  ];
+
+  postPatch = ''
+    substituteInPlace build.zig \
+      --replace-fail 'b.run(&.{ "git", "describe", "--tags", "--always" })' '"${finalAttrs.src.rev}"'
+  '';
+
+  meta = {
+    description = "Language server for GLSL (OpenGL Shading Language)";
+    changelog = "https://github.com/nolanderc/glsl_analyzer/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/nolanderc/glsl_analyzer";
+    mainProgram = "glsl_analyzer";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ wr7 ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description of changes
Created a package for [glsl_analyzer](https://github.com/nolanderc/glsl_analyzer). This is a language server for the OpenGL Shading Language. Currently the only other GLSL language server on Nix is [glslls](https://search.nixos.org/packages?channel=23.11&show=glslls), but it's slightly buggy and has worse descriptions compared to [glsl_analyzer](https://github.com/nolanderc/glsl_analyzer).


I've been using this package for a while, it seems to fully work.

![Package screenshot ](https://github.com/NixOS/nixpkgs/assets/53203261/051d3ae1-663c-4487-bb0c-aa2c81c5c30d)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
