### PR TITLE
lib: move the list of supportedSystems from `pkgs/top-level/release.nix` to `lib/systems/doubles.nix`

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -5,6 +5,10 @@ let
   inherit (lib.systems.inspect) predicates;
   inherit (lib.attrsets) matchAttrs;
 
+  # The platform doubles for which we build Nixpkgs.
+  # See `pkgs/top-level/release.nix` for where this value is consumed.
+  builtOnNixosHydra = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+
   all = [
     # Cygwin
     "i686-cygwin" "x86_64-cygwin"
@@ -63,7 +67,7 @@ let
   filterDoubles = f: map parse.doubleFromSystem (lists.filter f allParsed);
 
 in {
-  inherit all;
+  inherit all builtOnNixosHydra;
 
   none = [];
 

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -4,11 +4,11 @@
 , scrubJobs ? true
 , # Attributes passed to nixpkgs. Don't build packages marked as unfree.
   nixpkgsArgs ? { config = { allowUnfree = false; inHydra = true; }; }
+# Just the Nixpkgs library functions and data.
+, lib ? (import ../../lib)
 }:
 
 let
-  lib = import ../../lib;
-
   inherit (lib)
     addMetaAttrs
     any

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -8,11 +8,11 @@
 
    $ nix-build pkgs/top-level/release.nix -A coreutils.x86_64-linux
 */
-{ nixpkgs ? { outPath = (import ../../lib).cleanSource ../..; revCount = 1234; shortRev = "abcdef"; revision = "0000000000000000000000000000000000000000"; }
+{ nixpkgs ? { outPath = lib.cleanSource ../..; revCount = 1234; shortRev = "abcdef"; revision = "0000000000000000000000000000000000000000"; }
 , system ? builtins.currentSystem
 , officialRelease ? false
   # The platform doubles for which we build Nixpkgs.
-, supportedSystems ? [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ]
+, supportedSystems ? lib.systems.doubles.builtOnNixosHydra
   # The platform triples for which we build bootstrap tools.
 , bootstrapConfigs ? [
     "aarch64-apple-darwin"
@@ -45,11 +45,14 @@
   # pkgs/top-level/.
   #
 , attrNamesOnly ? false
+
+# Just the Nixpkgs library functions and data.
+, lib ? (import ../../lib)
 }:
 
 let
   release-lib = import ./release-lib.nix {
-    inherit supportedSystems scrubJobs nixpkgsArgs system;
+    inherit supportedSystems scrubJobs nixpkgsArgs system lib;
   };
 
   inherit (release-lib) mapTestOn pkgs;


### PR DESCRIPTION
## Description of changes

This allows flakes which depend on `nixpkgs` to reference this list from `nixpkgs.lib.systems.doubles.builtOnNixosHydra`, which is a long name but very true. These are the doubles that are built on [Hydra](https://hydra.nixos.org/)!

See also:
- https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md
- https://github.com/NixOS/rfcs/pull/112 (closed)
- https://github.com/NixOS/nixpkgs/pull/143732 (stalled)
- https://github.com/nix-systems/default

## Things done

- [x] Ran `nix-build pkgs/top-level/release.nix -A coreutils.x86_64-linux` to see that `release.nix` worked
- [x] Ran `nix-instantiate --strict --eval -A lib.systems.doubles.builtOnNixosHydra` to see the list.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
