### PR TITLE
polkit: 123 -> 124

### DIFF
--- a/pkgs/development/libraries/polkit/0001-build-Use-datarootdir-in-Meson-generated-pkg-config-.patch
+++ b/pkgs/development/libraries/polkit/0001-build-Use-datarootdir-in-Meson-generated-pkg-config-.patch
@@ -1,0 +1,53 @@
+From 7ba07551dfcd4ef9a87b8f0d9eb8b91fabcb41b3 Mon Sep 17 00:00:00 2001
+From: Jan Tojnar <jtojnar@gmail.com>
+Date: Mon, 1 Nov 2021 14:17:17 +0100
+Subject: [PATCH] build: Use datarootdir in Meson-generated pkg-config files
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+With datadir outside of prefix (currently unsupported by Meson[1]
+but a frequent occurrence in Nixpkgs), the `datadir` entry,
+in the `polkit-gobject-1` pkg-config file will be an absolute path.
+This will prevent changing the base directory of `policydir`
+with `--define-variable=prefix=…`, which many projects use
+to install policy files to their own prefix.
+
+Previously, this worked without changes on Nixpkgs’s part because
+the pkg-config template used by Autotools contained `@datarootdir@`,
+which resolves to `$(prefix)/share`[2], taking no heed of the changed datadir.
+
+Similar issue can happen when a distribution package redefines datadir
+like Debian does/did.[3]
+
+This patch changes Meson-based build system to use `$(prefix)/share`
+in the generated pkg-config files, mirroring Autotools.
+
+---
+
+1. Likely to change in the future: https://github.com/mesonbuild/meson/issues/2561#issuecomment-939253717
+2. https://www.gnu.org/prep/standards/html_node/Directory-Variables.html
+3. https://blogs.gnome.org/hughsie/2014/06/16/datarootdir-v-s-datadir/
+---
+ src/polkit/meson.build | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/src/polkit/meson.build b/src/polkit/meson.build
+index 63dc1e85..c92cb70f 100644
+--- a/src/polkit/meson.build
++++ b/src/polkit/meson.build
+@@ -113,9 +113,8 @@ pkg.generate(
+   requires: common_deps,
+   variables: [
+     'exec_prefix=${prefix}',
+-    'datadir=' + ('${prefix}' / pk_datadir),
+-    'policydir=' + ('${datadir}' / pk_actiondir),
+-    'actiondir=' + ('${datadir}' / pk_actiondir),
++    'policydir=' + ('${prefix}' / 'share' / pk_actiondir),
++    'actiondir=' + ('${prefix}' / 'share' / pk_actiondir),
+     'pkcheck_supports_uid=true',
+   ],
+ )
+-- 
+GitLab
+

--- a/pkgs/development/libraries/polkit/default.nix
+++ b/pkgs/development/libraries/polkit/default.nix
@@ -38,7 +38,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "polkit";
-  version = "123";
+  version = "124";
 
   outputs = [ "bin" "dev" "out" ]; # small man pages in $bin
 
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     owner = "polkit-org";
     repo = "polkit";
     rev = version;
-    hash = "sha256-/kjWkh6w2FYgtYWzw3g3GlWJKKpkJ3cqwfE0iDqJctw=";
+    hash = "sha256-Vc9G2xK6U1cX+xW2BnKp3oS/ACbSXS/lztbFP5oJOlM=";
   };
 
   patches = [
@@ -107,10 +107,14 @@ stdenv.mkDerivation rec {
     ]))
   ];
 
+  env = {
+    PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
+    PKG_CONFIG_SYSTEMD_SYSUSERS_DIR = "${placeholder "out"}/lib/sysusers.d";
+  };
+
   mesonFlags = [
     "--datadir=${system}/share"
     "--sysconfdir=/etc"
-    "-Dsystemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
     "-Dpolkitd_user=polkituser" #TODO? <nixos> config.ids.uids.polkituser
     "-Dos_type=redhat" # only affects PAM includes
     "-Dintrospection=${lib.boolToString withIntrospection}"

--- a/pkgs/development/libraries/polkit/default.nix
+++ b/pkgs/development/libraries/polkit/default.nix
@@ -10,7 +10,6 @@
 , ninja
 , perl
 , python3
-, fetchpatch
 , gettext
 , duktape
 , gobject-introspection
@@ -53,10 +52,7 @@ stdenv.mkDerivation rec {
   patches = [
     # Allow changing base for paths in pkg-config file as before.
     # https://gitlab.freedesktop.org/polkit/polkit/-/merge_requests/100
-    (fetchpatch {
-      url = "https://gitlab.freedesktop.org/polkit/polkit/-/commit/7ba07551dfcd4ef9a87b8f0d9eb8b91fabcb41b3.patch";
-      sha256 = "ebbLILncq1hAZTBMsLm+vDGw6j0iQ0crGyhzyLZQgKA=";
-    })
+    ./0001-build-Use-datarootdir-in-Meson-generated-pkg-config-.patch
   ];
 
   depsBuildBuild = [

--- a/pkgs/development/libraries/polkit/default.nix
+++ b/pkgs/development/libraries/polkit/default.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, fetchFromGitLab
+, fetchFromGitHub
 , pkg-config
 , glib
 , expat
@@ -43,9 +43,8 @@ stdenv.mkDerivation rec {
   outputs = [ "bin" "dev" "out" ]; # small man pages in $bin
 
   # Tarballs do not contain subprojects.
-  src = fetchFromGitLab {
-    domain = "gitlab.freedesktop.org";
-    owner = "polkit";
+  src = fetchFromGitHub {
+    owner = "polkit-org";
     repo = "polkit";
     rev = version;
     hash = "sha256-/kjWkh6w2FYgtYWzw3g3GlWJKKpkJ3cqwfE0iDqJctw=";
@@ -175,7 +174,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "https://gitlab.freedesktop.org/polkit/polkit/";
+    homepage = "https://github.com/polkit-org/polkit";
     description = "A toolkit for defining and handling the policy that allows unprivileged processes to speak to privileged processes";
     license = licenses.lgpl2Plus;
     platforms = platforms.linux;


### PR DESCRIPTION
upstream archived the project on the freedesktop gitlab and migrated to github.

also the new release won't build with Nix anymore, so another patch is necessary.

Changes: https://github.com/polkit-org/polkit/compare/123...124

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
