### PR TITLE
Proof of concept, refactor/extract `makeDerivationArgument`

### DIFF
--- a/pkgs/build-support/lib/cmake.nix
+++ b/pkgs/build-support/lib/cmake.nix
@@ -1,0 +1,30 @@
+{ stdenv, lib }:
+
+let
+  inherit (lib) findFirst isString optional optionals;
+
+  makeCMakeFlags = { cmakeFlags ? [], ... }:
+    cmakeFlags
+    ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) ([
+      "-DCMAKE_SYSTEM_NAME=${findFirst isString "Generic" (optional (!stdenv.hostPlatform.isRedox) stdenv.hostPlatform.uname.system)}"
+    ] ++ optionals (stdenv.hostPlatform.uname.processor != null) [
+      "-DCMAKE_SYSTEM_PROCESSOR=${stdenv.hostPlatform.uname.processor}"
+    ] ++ optionals (stdenv.hostPlatform.uname.release != null) [
+      "-DCMAKE_SYSTEM_VERSION=${stdenv.hostPlatform.uname.release}"
+    ] ++ optionals (stdenv.hostPlatform.isDarwin) [
+      "-DCMAKE_OSX_ARCHITECTURES=${stdenv.hostPlatform.darwinArch}"
+    ] ++ optionals (stdenv.buildPlatform.uname.system != null) [
+      "-DCMAKE_HOST_SYSTEM_NAME=${stdenv.buildPlatform.uname.system}"
+    ] ++ optionals (stdenv.buildPlatform.uname.processor != null) [
+      "-DCMAKE_HOST_SYSTEM_PROCESSOR=${stdenv.buildPlatform.uname.processor}"
+    ] ++ optionals (stdenv.buildPlatform.uname.release != null) [
+      "-DCMAKE_HOST_SYSTEM_VERSION=${stdenv.buildPlatform.uname.release}"
+    ] ++ optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+      "-DCMAKE_CROSSCOMPILING_EMULATOR=env"
+    ] ++ optionals stdenv.hostPlatform.isStatic [
+      "-DCMAKE_LINK_SEARCH_START_STATIC=ON"
+    ]);
+in
+{
+  inherit makeCMakeFlags;
+}

--- a/pkgs/build-support/lib/meson.nix
+++ b/pkgs/build-support/lib/meson.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib }:
+
+let
+  inherit (lib) boolToString optionals;
+
+  # See https://mesonbuild.com/Reference-tables.html#cpu-families
+  cpuFamily = platform: with platform;
+    /**/ if isAarch32 then "arm"
+    else if isx86_32  then "x86"
+    else platform.uname.processor;
+
+  makeMesonFlags = { mesonFlags ? [], ... }:
+    let
+      crossFile = builtins.toFile "cross-file.conf" ''
+        [properties]
+        bindgen_clang_arguments = ['-target', '${stdenv.targetPlatform.config}']
+        needs_exe_wrapper = ${boolToString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform)}
+
+        [host_machine]
+        system = '${stdenv.targetPlatform.parsed.kernel.name}'
+        cpu_family = '${cpuFamily stdenv.targetPlatform}'
+        cpu = '${stdenv.targetPlatform.parsed.cpu.name}'
+        endian = ${if stdenv.targetPlatform.isLittleEndian then "'little'" else "'big'"}
+
+        [binaries]
+        llvm-config = 'llvm-config-native'
+        rust = ['rustc', '--target', '${stdenv.targetPlatform.rust.rustcTargetSpec}']
+      '';
+      crossFlags = optionals (stdenv.hostPlatform != stdenv.buildPlatform) [ "--cross-file=${crossFile}" ];
+    in crossFlags ++ mesonFlags;
+
+in
+{
+  inherit makeMesonFlags;
+}

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -6,7 +6,7 @@
 
 let
   # N.B. Keep in sync with default arg for stdenv/generic.
-  defaultMkDerivationFromStdenv = import ./generic/make-derivation.nix { inherit lib config; };
+  defaultMkDerivationFromStdenv = stdenv: (import ./generic/make-derivation.nix { inherit lib config; } stdenv).mkDerivation;
 
   # Low level function to help with overriding `mkDerivationFromStdenv`. One
   # gives it the old stdenv arguments and a "continuation" function, and

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -52,7 +52,7 @@ argsStdenv@{ name ? "stdenv", preHook ? "", initialPath
 
 , # The implementation of `mkDerivation`, parameterized with the final stdenv so we can tie the knot.
   # This is convient to have as a parameter so the stdenv "adapters" work better
-  mkDerivationFromStdenv ? import ./make-derivation.nix { inherit lib config; }
+  mkDerivationFromStdenv ? stdenv: (import ./make-derivation.nix { inherit lib config; } stdenv).mkDerivation
 }:
 
 let

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -158,6 +158,9 @@ let
 
       mkDerivation = mkDerivationFromStdenv stdenv;
 
+      # FIXME: figure out why mkDerivationFromStdenv is overridable and adapt this
+      makeDerivationArgument = (import ./make-derivation.nix { inherit lib config; } stdenv).makeDerivationArgument;
+
       inherit fetchurlBoot;
 
       inherit overrides;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -160,6 +160,8 @@ let
 
     patches ? [],
 
+    configureFlags ? [],
+
     # TODO(@Ericson2314): Make unconditional / resolve #33599
     # Check phase
     doCheck ? config.doCheckByDefault or false,
@@ -464,8 +466,7 @@ let
 {
 
 # Configure Phase
-  configureFlags ? []
-, cmakeFlags ? []
+  cmakeFlags ? []
 , mesonFlags ? []
 , # Target is not included by default because most programs don't care.
   # Including it then would cause needless mass rebuilds.
@@ -551,7 +552,7 @@ else let
   envIsExportable = isAttrs env && !isDerivation env;
 
   derivationArg = makeDerivationArgument
-    { inherit configureFlags configurePlatforms cmakeFlags mesonFlags __contentAddressed enableParallelBuilding hardeningDisable hardeningEnable enabledHardeningOptions __darwinAllowLocalNetworking; }
+    { inherit configurePlatforms cmakeFlags mesonFlags __contentAddressed enableParallelBuilding hardeningDisable hardeningEnable enabledHardeningOptions __darwinAllowLocalNetworking; }
     (removeAttrs
       attrs
         (["meta" "passthru" "pos"]

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -609,4 +609,6 @@ extendDerivation
   (derivation (derivationArg // optionalAttrs envIsExportable checkedEnv));
 
 in
-  mkDerivation
+{
+  inherit mkDerivation;
+}

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -108,8 +108,15 @@ let
           makeDerivationExtensible (self: attrs // (if builtins.isFunction f0 || f0?__functor then f self attrs else f0)))
       attrs;
 
+  # Turn a derivation into its outPath without a string context attached.
+  # See the comment at the usage site.
+  unsafeDerivationToUntrackedOutpath = drv:
+    if isDerivation drv
+    then builtins.unsafeDiscardStringContext drv.outPath
+    else drv;
+
   # Subset of argument, matching mkDerivation below
-  makeDerivationArgument = { configureFlags, configurePlatforms, cmakeFlags, mesonFlags, patches, __contentAddressed, enableParallelBuilding, hardeningDisable, hardeningEnable, enabledHardeningOptions, __darwinAllowLocalNetworking, unsafeDerivationToUntrackedOutpath }:
+  makeDerivationArgument = { configureFlags, configurePlatforms, cmakeFlags, mesonFlags, patches, __contentAddressed, enableParallelBuilding, hardeningDisable, hardeningEnable, enabledHardeningOptions, __darwinAllowLocalNetworking }:
   attrs@{
     separateDebugInfo ? false,
     outputs ? [ "out" ],
@@ -507,13 +514,6 @@ assert attrs ? outputHash -> (
 );
 
 let
-  # Turn a derivation into its outPath without a string context attached.
-  # See the comment at the usage site.
-  unsafeDerivationToUntrackedOutpath = drv:
-    if isDerivation drv
-    then builtins.unsafeDiscardStringContext drv.outPath
-    else drv;
-
   hardeningDisable' = if any (x: x == "fortify") hardeningDisable
     # disabling fortify implies fortify3 should also be disabled
     then unique (hardeningDisable ++ [ "fortify3" ])
@@ -551,7 +551,7 @@ else let
   envIsExportable = isAttrs env && !isDerivation env;
 
   derivationArg = makeDerivationArgument
-    { inherit configureFlags configurePlatforms cmakeFlags mesonFlags patches __contentAddressed enableParallelBuilding hardeningDisable hardeningEnable enabledHardeningOptions __darwinAllowLocalNetworking unsafeDerivationToUntrackedOutpath; }
+    { inherit configureFlags configurePlatforms cmakeFlags mesonFlags patches __contentAddressed enableParallelBuilding hardeningDisable hardeningEnable enabledHardeningOptions __darwinAllowLocalNetworking; }
     (removeAttrs
       attrs
         (["meta" "passthru" "pos"]

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -40,6 +40,12 @@ let
     unique
   ;
 
+  mkDerivation =
+    fnOrAttrs:
+      if builtins.isFunction fnOrAttrs
+      then makeDerivationExtensible fnOrAttrs
+      else makeDerivationExtensibleConst fnOrAttrs;
+
   checkMeta = import ./check-meta.nix {
     inherit lib config;
     # Nix itself uses the `system` field of a derivation to decide where
@@ -603,7 +609,4 @@ extendDerivation
   (derivation (derivationArg // optionalAttrs envIsExportable checkedEnv));
 
 in
-  fnOrAttrs:
-    if builtins.isFunction fnOrAttrs
-    then makeDerivationExtensible fnOrAttrs
-    else makeDerivationExtensibleConst fnOrAttrs
+  mkDerivation

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -116,7 +116,7 @@ let
     else drv;
 
   # Subset of argument, matching mkDerivation below
-  makeDerivationArgument = { cmakeFlags, mesonFlags, __darwinAllowLocalNetworking }:
+  makeDerivationArgument = { cmakeFlags, mesonFlags }:
   attrs@{
     separateDebugInfo ? false,
     outputs ? [ "out" ],
@@ -157,6 +157,7 @@ let
 
     __impureHostDeps ? [],
     __propagatedImpureHostDeps ? [],
+    __darwinAllowLocalNetworking ? false,
 
     sandboxProfile ? "",
     propagatedSandboxProfile ? "",
@@ -524,7 +525,6 @@ let
       else if attrs.version or null != null
       then builtins.unsafeGetAttrPos "version" attrs
       else builtins.unsafeGetAttrPos "name" attrs)
-, __darwinAllowLocalNetworking ? false
 
 # Experimental.  For simple packages mostly just works,
 # but for anything complex, be prepared to debug if enabling.
@@ -549,7 +549,7 @@ let
   envIsExportable = isAttrs env && !isDerivation env;
 
   derivationArg = makeDerivationArgument
-    { inherit cmakeFlags mesonFlags __darwinAllowLocalNetworking; }
+    { inherit cmakeFlags mesonFlags; }
     (removeAttrs
       attrs
         (["meta" "passthru" "pos"]

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -116,6 +116,20 @@ let
     then builtins.unsafeDiscardStringContext drv.outPath
     else drv;
 
+  knownHardeningFlags = [
+    "bindnow"
+    "format"
+    "fortify"
+    "fortify3"
+    "pic"
+    "pie"
+    "relro"
+    "stackprotector"
+    "strictoverflow"
+    "trivialautovarinit"
+    "zerocallusedregs"
+  ];
+
   # Subset of argument, matching mkDerivation below
   makeDerivationArgument = attrs@{
     separateDebugInfo ? false,
@@ -203,19 +217,6 @@ let
         # disabling fortify implies fortify3 should also be disabled
         then unique (hardeningDisable ++ [ "fortify3" ])
         else hardeningDisable;
-      knownHardeningFlags = [
-        "bindnow"
-        "format"
-        "fortify"
-        "fortify3"
-        "pic"
-        "pie"
-        "relro"
-        "stackprotector"
-        "strictoverflow"
-        "trivialautovarinit"
-        "zerocallusedregs"
-      ];
       defaultHardeningFlags =
         (if stdenv.hasCC then stdenv.cc else {}).defaultHardeningFlags or
           # fallback safe-ish set of flags

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -116,7 +116,7 @@ let
     ...
   }:
     (removeAttrs attrs
-      (["meta" "passthru" "pos"
+      ([
        "checkInputs" "installCheckInputs"
        "nativeCheckInputs" "nativeInstallCheckInputs"
        "__contentAddressed"
@@ -547,7 +547,7 @@ else let
 
   derivationArg = makeDerivationArgument
     { inherit envIsExportable dontAddHostSuffix checkedEnv outputs strictDeps configureFlags configurePlatforms doCheck cmakeFlags mesonFlags dependencies propagatedDependencies patches doInstallCheck __contentAddressed enableParallelBuilding hardeningDisable hardeningEnable enabledHardeningOptions computedSandboxProfile computedPropagatedSandboxProfile propagatedSandboxProfile sandboxProfile computedImpureHostDeps computedPropagatedImpureHostDeps __propagatedImpureHostDeps __impureHostDeps __darwinAllowLocalNetworking unsafeDerivationToUntrackedOutpath; }
-    attrs;
+    (removeAttrs attrs ["meta" "passthru" "pos"]);
 
   meta = checkMeta.commonMeta { inherit validity attrs pos references; };
   validity = checkMeta.assertValidity { inherit meta attrs; };

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -9,7 +9,6 @@ let
     assertMsg
     attrNames
     boolToString
-    chooseDevOutputs
     concatLists
     concatMap
     concatMapStrings
@@ -19,7 +18,7 @@ let
     extendDerivation
     filter
     findFirst
-    flip
+    getDev
     head
     imap1
     isAttrs
@@ -244,37 +243,40 @@ let
         ++ optionals doInstallCheck installCheckInputs;
 
       checkDependencyList = checkDependencyList' [];
-      checkDependencyList' = positions: name: deps: flip imap1 deps (index: dep:
-        if isDerivation dep || dep == null || builtins.isString dep || builtins.isPath dep then dep
-        else if isList dep then checkDependencyList' ([index] ++ positions) name dep
-        else throw "Dependency is not of a valid type: ${concatMapStrings (ix: "element ${toString ix} of ") ([index] ++ positions)}${name} for ${attrs.name or attrs.pname}");
+      checkDependencyList' = positions: name: deps:
+        imap1
+          (index: dep:
+            if isDerivation dep || dep == null || builtins.isString dep || builtins.isPath dep then dep
+            else if isList dep then checkDependencyList' ([index] ++ positions) name dep
+            else throw "Dependency is not of a valid type: ${concatMapStrings (ix: "element ${toString ix} of ") ([index] ++ positions)}${name} for ${attrs.name or attrs.pname}")
+          deps;
 
-      dependencies = map (map chooseDevOutputs) [
+      dependencies = [
         [
-          (map (drv: drv.__spliced.buildBuild or drv) (checkDependencyList "depsBuildBuild" depsBuildBuild))
-          (map (drv: drv.__spliced.buildHost or drv) (checkDependencyList "nativeBuildInputs" nativeBuildInputs'))
-          (map (drv: drv.__spliced.buildTarget or drv) (checkDependencyList "depsBuildTarget" depsBuildTarget))
+          (map (drv: getDev drv.__spliced.buildBuild or drv) (checkDependencyList "depsBuildBuild" depsBuildBuild))
+          (map (drv: getDev drv.__spliced.buildHost or drv) (checkDependencyList "nativeBuildInputs" nativeBuildInputs'))
+          (map (drv: getDev drv.__spliced.buildTarget or drv) (checkDependencyList "depsBuildTarget" depsBuildTarget))
         ]
         [
-          (map (drv: drv.__spliced.hostHost or drv) (checkDependencyList "depsHostHost" depsHostHost))
-          (map (drv: drv.__spliced.hostTarget or drv) (checkDependencyList "buildInputs" buildInputs'))
+          (map (drv: getDev drv.__spliced.hostHost or drv) (checkDependencyList "depsHostHost" depsHostHost))
+          (map (drv: getDev drv.__spliced.hostTarget or drv) (checkDependencyList "buildInputs" buildInputs'))
         ]
         [
-          (map (drv: drv.__spliced.targetTarget or drv) (checkDependencyList "depsTargetTarget" depsTargetTarget))
+          (map (drv: getDev drv.__spliced.targetTarget or drv) (checkDependencyList "depsTargetTarget" depsTargetTarget))
         ]
       ];
-      propagatedDependencies = map (map chooseDevOutputs) [
+      propagatedDependencies = [
         [
-          (map (drv: drv.__spliced.buildBuild or drv) (checkDependencyList "depsBuildBuildPropagated" depsBuildBuildPropagated))
-          (map (drv: drv.__spliced.buildHost or drv) (checkDependencyList "propagatedNativeBuildInputs" propagatedNativeBuildInputs))
-          (map (drv: drv.__spliced.buildTarget or drv) (checkDependencyList "depsBuildTargetPropagated" depsBuildTargetPropagated))
+          (map (drv: getDev drv.__spliced.buildBuild or drv) (checkDependencyList "depsBuildBuildPropagated" depsBuildBuildPropagated))
+          (map (drv: getDev drv.__spliced.buildHost or drv) (checkDependencyList "propagatedNativeBuildInputs" propagatedNativeBuildInputs))
+          (map (drv: getDev drv.__spliced.buildTarget or drv) (checkDependencyList "depsBuildTargetPropagated" depsBuildTargetPropagated))
         ]
         [
-          (map (drv: drv.__spliced.hostHost or drv) (checkDependencyList "depsHostHostPropagated" depsHostHostPropagated))
-          (map (drv: drv.__spliced.hostTarget or drv) (checkDependencyList "propagatedBuildInputs" propagatedBuildInputs))
+          (map (drv: getDev drv.__spliced.hostHost or drv) (checkDependencyList "depsHostHostPropagated" depsHostHostPropagated))
+          (map (drv: getDev drv.__spliced.hostTarget or drv) (checkDependencyList "propagatedBuildInputs" propagatedBuildInputs))
         ]
         [
-          (map (drv: drv.__spliced.targetTarget or drv) (checkDependencyList "depsTargetTargetPropagated" depsTargetTargetPropagated))
+          (map (drv: getDev drv.__spliced.targetTarget or drv) (checkDependencyList "depsTargetTargetPropagated" depsTargetTargetPropagated))
         ]
       ];
 

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -588,5 +588,5 @@ extendDerivation
 
 in
 {
-  inherit mkDerivation;
+  inherit mkDerivation makeDerivationArgument;
 }

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -116,7 +116,7 @@ let
     else drv;
 
   # Subset of argument, matching mkDerivation below
-  makeDerivationArgument = { configureFlags, configurePlatforms, cmakeFlags, mesonFlags, patches, __contentAddressed, enableParallelBuilding, hardeningDisable, hardeningEnable, enabledHardeningOptions, __darwinAllowLocalNetworking }:
+  makeDerivationArgument = { configureFlags, configurePlatforms, cmakeFlags, mesonFlags, __contentAddressed, enableParallelBuilding, hardeningDisable, hardeningEnable, enabledHardeningOptions, __darwinAllowLocalNetworking }:
   attrs@{
     separateDebugInfo ? false,
     outputs ? [ "out" ],
@@ -157,6 +157,8 @@ let
 
     sandboxProfile ? "",
     propagatedSandboxProfile ? "",
+
+    patches ? [],
 
     # TODO(@Ericson2314): Make unconditional / resolve #33599
     # Check phase
@@ -488,8 +490,6 @@ let
 , hardeningEnable ? []
 , hardeningDisable ? []
 
-, patches ? []
-
 , __contentAddressed ?
   (! attrs ? outputHash) # Fixed-output drvs can't be content addressed too
   && config.contentAddressedByDefault
@@ -551,7 +551,7 @@ else let
   envIsExportable = isAttrs env && !isDerivation env;
 
   derivationArg = makeDerivationArgument
-    { inherit configureFlags configurePlatforms cmakeFlags mesonFlags patches __contentAddressed enableParallelBuilding hardeningDisable hardeningEnable enabledHardeningOptions __darwinAllowLocalNetworking; }
+    { inherit configureFlags configurePlatforms cmakeFlags mesonFlags __contentAddressed enableParallelBuilding hardeningDisable hardeningEnable enabledHardeningOptions __darwinAllowLocalNetworking; }
     (removeAttrs
       attrs
         (["meta" "passthru" "pos"]

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -109,21 +109,19 @@ let
       attrs;
 
   # Subset of argument, matching mkDerivation below
-  makeDerivationArgument = { envIsExportable, dontAddHostSuffix, checkedEnv, outputs, strictDeps, configureFlags, configurePlatforms, doCheck, cmakeFlags, mesonFlags, dependencies, propagatedDependencies, patches, doInstallCheck, __contentAddressed, enableParallelBuilding, hardeningDisable, hardeningEnable, enabledHardeningOptions, computedSandboxProfile, computedPropagatedSandboxProfile, propagatedSandboxProfile, sandboxProfile, computedImpureHostDeps, computedPropagatedImpureHostDeps, __propagatedImpureHostDeps, __impureHostDeps, __darwinAllowLocalNetworking, unsafeDerivationToUntrackedOutpath }:
+  makeDerivationArgument = { dontAddHostSuffix, outputs, strictDeps, configureFlags, configurePlatforms, doCheck, cmakeFlags, mesonFlags, dependencies, propagatedDependencies, patches, doInstallCheck, __contentAddressed, enableParallelBuilding, hardeningDisable, hardeningEnable, enabledHardeningOptions, computedSandboxProfile, computedPropagatedSandboxProfile, propagatedSandboxProfile, sandboxProfile, computedImpureHostDeps, computedPropagatedImpureHostDeps, __propagatedImpureHostDeps, __impureHostDeps, __darwinAllowLocalNetworking, unsafeDerivationToUntrackedOutpath }:
   attrs@{
     __structuredAttrs ? config.structuredAttrsByDefault or false,
-    env ? { },
     ...
   }:
     (removeAttrs attrs
-      ([
+      [
        "checkInputs" "installCheckInputs"
        "nativeCheckInputs" "nativeInstallCheckInputs"
        "__contentAddressed"
        "__darwinAllowLocalNetworking"
        "__impureHostDeps" "__propagatedImpureHostDeps"
-       "sandboxProfile" "propagatedSandboxProfile"]
-       ++ optional (__structuredAttrs || envIsExportable) "env"))
+       "sandboxProfile" "propagatedSandboxProfile"])
     // (optionalAttrs (attrs ? name || (attrs ? pname && attrs ? version)) {
       name =
         let
@@ -151,7 +149,7 @@ let
             assert assertMsg (attrs ? version && attrs.version != null) "The ‘version’ attribute cannot be null.";
             "${attrs.pname}${staticMarker}${hostSuffix}-${attrs.version}"
         );
-    }) // optionalAttrs __structuredAttrs { env = checkedEnv; } // {
+    }) // {
       builder = attrs.realBuilder or stdenv.shell;
       args = attrs.args or ["-e" (attrs.builder or ./default-builder.sh)];
       inherit stdenv;
@@ -546,8 +544,13 @@ else let
   envIsExportable = isAttrs env && !isDerivation env;
 
   derivationArg = makeDerivationArgument
-    { inherit envIsExportable dontAddHostSuffix checkedEnv outputs strictDeps configureFlags configurePlatforms doCheck cmakeFlags mesonFlags dependencies propagatedDependencies patches doInstallCheck __contentAddressed enableParallelBuilding hardeningDisable hardeningEnable enabledHardeningOptions computedSandboxProfile computedPropagatedSandboxProfile propagatedSandboxProfile sandboxProfile computedImpureHostDeps computedPropagatedImpureHostDeps __propagatedImpureHostDeps __impureHostDeps __darwinAllowLocalNetworking unsafeDerivationToUntrackedOutpath; }
-    (removeAttrs attrs ["meta" "passthru" "pos"]);
+    { inherit dontAddHostSuffix outputs strictDeps configureFlags configurePlatforms doCheck cmakeFlags mesonFlags dependencies propagatedDependencies patches doInstallCheck __contentAddressed enableParallelBuilding hardeningDisable hardeningEnable enabledHardeningOptions computedSandboxProfile computedPropagatedSandboxProfile propagatedSandboxProfile sandboxProfile computedImpureHostDeps computedPropagatedImpureHostDeps __propagatedImpureHostDeps __impureHostDeps __darwinAllowLocalNetworking unsafeDerivationToUntrackedOutpath; }
+    (removeAttrs
+      attrs
+        (["meta" "passthru" "pos"]
+        ++ optional (__structuredAttrs || envIsExportable) "env"
+        )
+    // optionalAttrs __structuredAttrs { env = checkedEnv; });
 
   meta = checkMeta.commonMeta { inherit validity attrs pos references; };
   validity = checkMeta.assertValidity { inherit meta attrs; };

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -116,11 +116,14 @@ let
     else drv;
 
   # Subset of argument, matching mkDerivation below
-  makeDerivationArgument = { cmakeFlags, mesonFlags, __contentAddressed, enableParallelBuilding, hardeningDisable, hardeningEnable, enabledHardeningOptions, __darwinAllowLocalNetworking }:
+  makeDerivationArgument = { cmakeFlags, mesonFlags, enableParallelBuilding, hardeningDisable, hardeningEnable, enabledHardeningOptions, __darwinAllowLocalNetworking }:
   attrs@{
     separateDebugInfo ? false,
     outputs ? [ "out" ],
     __structuredAttrs ? config.structuredAttrsByDefault or false,
+    __contentAddressed ?
+      (! attrs ? outputHash) # Fixed-output drvs can't be content addressed too
+      && config.contentAddressedByDefault,
 
     # TODO(@Ericson2314): Make always true and remove / resolve #178468
     strictDeps ? if config.strictDepsByDefault then true else stdenv.hostPlatform != stdenv.buildPlatform,
@@ -491,10 +494,6 @@ let
 , hardeningEnable ? []
 , hardeningDisable ? []
 
-, __contentAddressed ?
-  (! attrs ? outputHash) # Fixed-output drvs can't be content addressed too
-  && config.contentAddressedByDefault
-
 # Experimental.  For simple packages mostly just works,
 # but for anything complex, be prepared to debug if enabling.
 , __structuredAttrs ? config.structuredAttrsByDefault or false
@@ -552,7 +551,7 @@ else let
   envIsExportable = isAttrs env && !isDerivation env;
 
   derivationArg = makeDerivationArgument
-    { inherit cmakeFlags mesonFlags __contentAddressed enableParallelBuilding hardeningDisable hardeningEnable enabledHardeningOptions __darwinAllowLocalNetworking; }
+    { inherit cmakeFlags mesonFlags enableParallelBuilding hardeningDisable hardeningEnable enabledHardeningOptions __darwinAllowLocalNetworking; }
     (removeAttrs
       attrs
         (["meta" "passthru" "pos"]

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -280,26 +280,6 @@ let
         ]
       ];
 
-      computedSandboxProfile =
-        concatMap (input: input.__propagatedSandboxProfile or [])
-          (stdenv.extraNativeBuildInputs
-          ++ stdenv.extraBuildInputs
-          ++ concatLists dependencies);
-
-      computedPropagatedSandboxProfile =
-        concatMap (input: input.__propagatedSandboxProfile or [])
-          (concatLists propagatedDependencies);
-
-      computedImpureHostDeps =
-        unique (concatMap (input: input.__propagatedImpureHostDeps or [])
-          (stdenv.extraNativeBuildInputs
-          ++ stdenv.extraBuildInputs
-          ++ concatLists dependencies));
-
-      computedPropagatedImpureHostDeps =
-        unique (concatMap (input: input.__propagatedImpureHostDeps or [])
-          (concatLists propagatedDependencies));
-
       noNonNativeDeps =
         0 ==
           builtins.length
@@ -402,7 +382,29 @@ let
       NIX_HARDENING_ENABLE = enabledHardeningOptions;
     } // optionalAttrs (stdenv.hostPlatform.isx86_64 && stdenv.hostPlatform ? gcc.arch) {
       requiredSystemFeatures = attrs.requiredSystemFeatures or [] ++ [ "gccarch-${stdenv.hostPlatform.gcc.arch}" ];
-    } // optionalAttrs (stdenv.buildPlatform.isDarwin) {
+    } // optionalAttrs (stdenv.buildPlatform.isDarwin) (
+      let
+        computedSandboxProfile =
+          concatMap (input: input.__propagatedSandboxProfile or [])
+            (stdenv.extraNativeBuildInputs
+            ++ stdenv.extraBuildInputs
+            ++ concatLists dependencies);
+
+        computedPropagatedSandboxProfile =
+          concatMap (input: input.__propagatedSandboxProfile or [])
+            (concatLists propagatedDependencies);
+
+        computedImpureHostDeps =
+          unique (concatMap (input: input.__propagatedImpureHostDeps or [])
+            (stdenv.extraNativeBuildInputs
+            ++ stdenv.extraBuildInputs
+            ++ concatLists dependencies));
+
+        computedPropagatedImpureHostDeps =
+          unique (concatMap (input: input.__propagatedImpureHostDeps or [])
+            (concatLists propagatedDependencies));
+      in
+      {
       inherit __darwinAllowLocalNetworking;
       # TODO: remove `unique` once nix has a list canonicalization primitive
       __sandboxProfile =
@@ -417,7 +419,7 @@ let
         "/bin/sh"
       ];
       __propagatedImpureHostDeps = computedPropagatedImpureHostDeps ++ __propagatedImpureHostDeps;
-    } //
+    }) //
     # If we use derivations directly here, they end up as build-time dependencies.
     # This is especially problematic in the case of disallowed*, since the disallowed
     # derivations will be built by nix as build-time dependencies, while those

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -130,6 +130,15 @@ let
     "zerocallusedregs"
   ];
 
+  removedOrReplacedAttrs = [
+    "checkInputs" "installCheckInputs"
+    "nativeCheckInputs" "nativeInstallCheckInputs"
+    "__contentAddressed"
+    "__darwinAllowLocalNetworking"
+    "__impureHostDeps" "__propagatedImpureHostDeps"
+    "sandboxProfile" "propagatedSandboxProfile"
+  ];
+
   # Subset of argument, matching mkDerivation below
   makeDerivationArgument = attrs@{
     separateDebugInfo ? false,
@@ -291,14 +300,7 @@ let
 
       dontAddHostSuffix = attrs ? outputHash && !noNonNativeDeps || !stdenv.hasCC;
     in
-    (removeAttrs attrs
-      [
-       "checkInputs" "installCheckInputs"
-       "nativeCheckInputs" "nativeInstallCheckInputs"
-       "__contentAddressed"
-       "__darwinAllowLocalNetworking"
-       "__impureHostDeps" "__propagatedImpureHostDeps"
-       "sandboxProfile" "propagatedSandboxProfile"])
+    (removeAttrs attrs removedOrReplacedAttrs)
     // (optionalAttrs (attrs ? name || (attrs ? pname && attrs ? version)) {
       name =
         let

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -116,7 +116,7 @@ let
     else drv;
 
   # Subset of argument, matching mkDerivation below
-  makeDerivationArgument = { cmakeFlags, mesonFlags, enableParallelBuilding, hardeningDisable, hardeningEnable, enabledHardeningOptions, __darwinAllowLocalNetworking }:
+  makeDerivationArgument = { cmakeFlags, mesonFlags, hardeningDisable, hardeningEnable, enabledHardeningOptions, __darwinAllowLocalNetworking }:
   attrs@{
     separateDebugInfo ? false,
     outputs ? [ "out" ],
@@ -171,6 +171,8 @@ let
     configurePlatforms ? optionals
       (stdenv.hostPlatform != stdenv.buildPlatform || config.configurePlatformsByDefault)
       [ "build" "host" ],
+
+    enableParallelBuilding ? config.enableParallelBuildingByDefault,
 
     # TODO(@Ericson2314): Make unconditional / resolve #33599
     # Check phase
@@ -479,8 +481,6 @@ let
   cmakeFlags ? []
 , mesonFlags ? []
 
-, enableParallelBuilding ? config.enableParallelBuildingByDefault
-
 , meta ? {}
 , passthru ? {}
 , pos ? # position used in error messages and for meta.position
@@ -551,7 +551,7 @@ else let
   envIsExportable = isAttrs env && !isDerivation env;
 
   derivationArg = makeDerivationArgument
-    { inherit cmakeFlags mesonFlags enableParallelBuilding hardeningDisable hardeningEnable enabledHardeningOptions __darwinAllowLocalNetworking; }
+    { inherit cmakeFlags mesonFlags hardeningDisable hardeningEnable enabledHardeningOptions __darwinAllowLocalNetworking; }
     (removeAttrs
       attrs
         (["meta" "passthru" "pos"]


### PR DESCRIPTION
## Description of changes

A clean refactor of `make-derivation.nix` to extract a function that only generates the `derivation` argument.

See commit messages for some more details.

- This is research for https://github.com/NixOS/nixpkgs/issues/273815
  - Goal for this PR is to test a solution to cleanly and efficiently provide an improved `mkDerivation` that's compatible and does not duplicate any code unnecessarily.

Questions:

- Does ofborg agree? 
   - It's a fairly clean refactor, so I expect it to, but I'm only human
   - **It agrees**

- What's the possible performance impact? 
   - I've "doubled" the `removeAttrs` call and I've added at least three function calls.
   - Performance can be regained later by using a derivation making function that omits meson and cmake attributes (unless requested by user in a modular way), although this is hard to measure ahead of time.
   - **Not significant**
   - **Optimizations possible**

- Would it be cleaner to refactor the other way around?
   - I might call what I've done "inside out", pulling out a variable into a function of its scope, and then going from there.
     This is the most mechanical and therefore more reliable method.
     However, now that we know the end state of the small `mkDerivation` function, we could
       - Start over
       - Rename `mkDerivation` to `makeDerivationArgument`
       - Strip all the undesired bits and bobs
       - Copy `mkDerivation` from this PR
       - End up with a diff that's
          - smaller
          - a very good git blame for the most relevant parts that go into the actual derivation
          - *maybe* not a great git blame for the other things like `passthru`, or maybe it's fine, being near the end, and already nicely indented
  - **Will follow up**
  
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
