### PR TITLE
basalt-monado: init at 0-unstable-2024-06-21

### DIFF
--- a/pkgs/by-name/ba/basalt-monado/package.nix
+++ b/pkgs/by-name/ba/basalt-monado/package.nix
@@ -1,0 +1,78 @@
+{
+  autoPatchelfHook,
+  boost,
+  bzip2,
+  cereal,
+  cmake,
+  eigen,
+  extra-cmake-modules,
+  fetchFromGitLab,
+  fmt,
+  freeglut,
+  glew,
+  lib,
+  libepoxy,
+  libGL,
+  lz4,
+  magic-enum,
+  nix-update-script,
+  opencv,
+  pkg-config,
+  stdenv,
+  tbb,
+  xorg,
+}:
+stdenv.mkDerivation {
+  pname = "basalt-monado";
+  version = "0-unstable-2024-06-21";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "mateosss";
+    repo = "basalt";
+    rev = "385c161f35720df3a6c606054565f9d49a1c5787";
+    hash = "sha256-+2/pc2OWDwE04xPcfHL5GGyhQ1ZTN6o7cCNAilDgd2Y=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    cmake
+    extra-cmake-modules
+    pkg-config
+  ];
+
+  buildInputs = [
+    boost
+    bzip2
+    cereal
+    eigen
+    fmt
+    freeglut
+    glew
+    libepoxy
+    libGL
+    lz4
+    magic-enum
+    opencv
+    tbb
+    xorg.libX11
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BASALT_INSTANTIATIONS_DOUBLE" false)
+    (lib.cmakeBool "BUILD_TESTS" false)
+    (lib.cmakeFeature "EIGEN_ROOT" "${eigen}/include/eigen3")
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A fork of Basalt improved for tracking XR devices with Monado";
+    homepage = "https://gitlab.freedesktop.org/mateosss/basalt";
+    license = lib.licenses.bsd3;
+    mainProgram = "basalt_vio";
+    maintainers = [ lib.maintainers.locochoco ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -326,6 +326,12 @@ with pkgs;
 
   banana-accounting = callPackage ../applications/office/banana-accounting { };
 
+  basalt-monado = callPackage ../by-name/ba/basalt-monado/package.nix {
+    tbb = tbb_2021_11;
+    cereal = cereal_1_3_2;
+    opencv = opencv.override { enableGtk3 = true; };
+  };
+
   beebeep = libsForQt5.callPackage ../applications/office/beebeep { };
 
   beeper = callPackage ../applications/networking/instant-messengers/beeper { };


### PR DESCRIPTION
## Description of changes
[Basalt for Monado](https://gitlab.freedesktop.org/mateosss/basalt) "is a fork of [Basalt](https://gitlab.com/VladyslavUsenko/basalt) improved for tracking XR devices with [Monado](https://gitlab.freedesktop.org/monado/monado)."
Adds the package in https://github.com/NixOS/nixpkgs/issues/294764 for https://github.com/NixOS/nixpkgs/pull/245005#issuecomment-1962320314.

Closes NixOS/nixpkgs#294764

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
