### PR TITLE
appium-inspector: init at 2024.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2753,6 +2753,12 @@
     githubId = 115711;
     name = "bpaulin";
   };
+  bprevor = {
+    email = "benprevor@gmail.com";
+    github = "charles37";
+    githubId = 29279583;
+    name = "Benjamin Prevor";
+  };
   Br1ght0ne = {
     email = "brightone@protonmail.com";
     github = "Br1ght0ne";

--- a/pkgs/by-name/ap/appium-inspector/package.nix
+++ b/pkgs/by-name/ap/appium-inspector/package.nix
@@ -1,0 +1,35 @@
+{ appimageTools, fetchurl, lib }:
+
+let
+  pname = "appium-inspector";
+  version = "2024.3.1";
+
+  src = fetchurl {
+    url = "https://github.com/appium/appium-inspector/releases/download/v${version}/Appium-Inspector-linux-${version}.AppImage";
+    hash = "sha256-ua0Tnjp+evG5dwVIzHyG4eG3WQEMQLedZHLX7hxlWSo=";
+  };
+
+  appimageContents = appimageTools.extract {
+    inherit pname version src;
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraInstallCommands = ''
+    mv $out/bin/${pname}-${version} $out/bin/${pname}
+    install -m 444 -D ${appimageContents}/appium-inspector.desktop -t $out/share/applications/
+    install -m 444 -D ${appimageContents}/appium-inspector.png -t $out/share/icons/hicolor/512x512/apps/
+    substituteInPlace $out/share/applications/appium-inspector.desktop \
+      --replace 'Exec=AppRun' 'Exec=${pname}'
+  '';
+
+  meta = with lib; {
+    description = "A GUI inspector for mobile apps and more, powered by a (separately installed) Appium server";
+    homepage = "https://github.com/appium/appium-inspector";
+    changelog = "https://github.com/appium/appium-inspector/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ bprevor ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This pull request adds a new package for Appium Inspector, a GUI tool for inspecting and debugging mobile applications using the Appium automation framework.

Appium Inspector is a powerful tool that allows developers and testers to easily inspect the hierarchy of mobile app elements, view and edit app source code, and perform various debugging tasks. It integrates seamlessly with the Appium server and provides a user-friendly interface for interacting with mobile apps.

Homepage: https://github.com/appium/appium-inspector

## Things done

- Built on platform(s)
 - [x] x86_64-linux
 - [ ] aarch64-linux
 - [ ] x86_64-darwin
 - [ ] aarch64-darwin
- [x] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
 - [x] NixOS
 - [ ] macOS
 - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---