### PR TITLE
java-service-wrapper: make deterministic, do some cleanup

### DIFF
--- a/pkgs/by-name/ja/java-service-wrapper/package.nix
+++ b/pkgs/by-name/ja/java-service-wrapper/package.nix
@@ -2,18 +2,19 @@
   lib,
   stdenv,
   fetchurl,
-  jdk,
   ant,
+  jdk,
+  stripJavaArchivesHook,
   cunit,
   ncurses,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "java-service-wrapper";
   version = "3.6.0";
 
   src = fetchurl {
-    url = "https://wrapper.tanukisoftware.com/download/${version}/wrapper_${version}_src.tar.gz";
+    url = "https://wrapper.tanukisoftware.com/download/${finalAttrs.version}/wrapper_${finalAttrs.version}_src.tar.gz";
     hash = "sha256-b9H7teM3zIXvuek1UNlxlzjxPNPy82ElATAGT/Fvjgw=";
   };
 
@@ -27,11 +28,12 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     ant
     jdk
+    stripJavaArchivesHook
   ];
 
   postConfigure = ''
     substituteInPlace default.properties \
-      --replace "javac.target.version=1.4" "javac.target.version=8"
+      --replace-fail "javac.target.version=1.4" "javac.target.version=8"
   '';
 
   buildPhase = ''
@@ -60,7 +62,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Enables a Java Application to be run as a Windows Service or Unix Daemon";
     homepage = "https://wrapper.tanukisoftware.com/";
-    changelog = "https://wrapper.tanukisoftware.com/doc/english/release-notes.html#${version}";
+    changelog = "https://wrapper.tanukisoftware.com/doc/english/release-notes.html#${finalAttrs.version}";
     license = licenses.gpl2Only;
     platforms = [
       "x86_64-linux"
@@ -74,4 +76,4 @@ stdenv.mkDerivation rec {
     # Tracking issue: https://github.com/NixOS/nixpkgs/issues/281557
     broken = stdenv.hostPlatform.isMusl;
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Tracking issue: https://github.com/NixOS/nixpkgs/issues/278518

This small PR adds `stripJavaArchivesHook` to the `nativeBuildInputs` of the `java-service-wrapper` package to make it deterministic.

It also does some minor cleanup:
- Use `finalAttrs` instead of `rec`
- change the deprecated `--replace` flag to `--replace-fail`, which can't fail silently.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
