### PR TITLE
hareHook: init

### DIFF
--- a/doc/languages-frameworks/hare.section.md
+++ b/doc/languages-frameworks/hare.section.md
@@ -1,0 +1,53 @@
+# Hare {#sec-language-hare}
+
+## Building Hare programs with `hareHook` {#ssec-language-hare}
+
+The `hareHook` package sets up the environment for building Hare programs by
+doing the following:
+
+1. Setting the `HARECACHE`, `HAREPATH` and `NIX_HAREFLAGS` environment variables;
+1. Propagating `harec`, `qbe` and two wrapper scripts  for the hare binary.
+
+It is not a function as is the case for some other languages --- *e. g.*, Go or
+Rust ---, but a package to be added to `nativeBuildInputs`.
+
+## Attributes of `hareHook` {#hareHook-attributes}
+
+The following attributes are accepted by `hareHook`:
+
+1. `hareBuildType`: Either `release` (default) or `debug`. It controls if the
+   `-R` flag is added to `NIX_HAREFLAGS`.
+
+## Example for `hareHook` {#ex-hareHook}
+
+```nix
+{
+  hareHook,
+  lib,
+  stdenv,
+}: stdenv.mkDerivation {
+  pname = "<name>";
+  version = "<version>";
+  src = "<src>";
+
+  nativeBuildInputs = [ hareHook ];
+
+  meta = {
+    description = "<description>";
+    inherit (hareHook) badPlatforms platforms;
+  };
+}
+```
+
+## Cross Compilation {#hareHook-cross-compilation}
+
+`hareHook` should handle cross compilation out of the box. This is the main
+purpose of `NIX_HAREFLAGS`: In it, the `-a` flag is passed with the architecture
+of the `hostPlatform`.
+
+However, manual intervention may be needed when a binary compiled by the build
+process must be run for the build to complete --- *e. g.*, when using Hare's
+`hare` module for code generation.
+
+In those cases, `hareHook` provides the `hare-native` script, which is a wrapper
+around the hare binary for using the native (`buildPlatform`) toolchain.

--- a/doc/languages-frameworks/index.md
+++ b/doc/languages-frameworks/index.md
@@ -19,6 +19,7 @@ dotnet.section.md
 emscripten.section.md
 gnome.section.md
 go.section.md
+hare.section.md
 haskell.section.md
 hy.section.md
 idris.section.md

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -46,6 +46,10 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `hareHook` has been added as the language framework for Hare. From now on, it,
+  not the `hare` package, should be added to `nativeBuildInputs` when building
+  Hare programs.
+
 - To facilitate dependency injection, the `imgui` package now builds a static archive using vcpkg' CMake rules.
   The derivation now installs "impl" headers selectively instead of by a wildcard.
   Use `imgui.src` if you just want to access the unpacked sources.

--- a/pkgs/by-name/bo/bonsai/package.nix
+++ b/pkgs/by-name/bo/bonsai/package.nix
@@ -1,9 +1,10 @@
-{ stdenv
-, lib
-, fetchFromSourcehut
-, gitUpdater
-, hare
-, hareThirdParty
+{
+  stdenv,
+  lib,
+  fetchFromSourcehut,
+  gitUpdater,
+  hare,
+  hareThirdParty,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -39,9 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
       --replace 'hare test' 'hare test $(HAREFLAGS)'
   '';
 
-  passthru.updateScript = gitUpdater {
-    rev-prefix = "v";
-  };
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
   meta = with lib; {
     description = "Finite State Machine structured as a tree";

--- a/pkgs/by-name/bo/bonsai/package.nix
+++ b/pkgs/by-name/bo/bonsai/package.nix
@@ -3,7 +3,7 @@
   lib,
   fetchFromSourcehut,
   gitUpdater,
-  hare,
+  hareHook,
   hareThirdParty,
 }:
 
@@ -19,26 +19,16 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    hare
+    hareHook
     hareThirdParty.hare-ev
     hareThirdParty.hare-json
   ];
 
-  makeFlags = [
-    "PREFIX=${builtins.placeholder "out"}"
-    "HARECACHE=.harecache"
-    "HAREFLAGS=-qa${stdenv.hostPlatform.uname.processor}"
-  ];
+  makeFlags = [ "PREFIX=${builtins.placeholder "out"}" ];
 
   enableParallelBuilding = true;
 
   doCheck = true;
-
-  postPatch = ''
-    substituteInPlace Makefile \
-      --replace 'hare build' 'hare build $(HAREFLAGS)' \
-      --replace 'hare test' 'hare test $(HAREFLAGS)'
-  '';
 
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 

--- a/pkgs/by-name/ha/hare/hook.nix
+++ b/pkgs/by-name/ha/hare/hook.nix
@@ -1,0 +1,56 @@
+{
+  hare,
+  lib,
+  makeSetupHook,
+  makeWrapper,
+  runCommand,
+  stdenv,
+  writeShellApplication,
+}:
+let
+  arch = stdenv.targetPlatform.uname.processor;
+  harePropagationInputs = builtins.attrValues { inherit (hare) harec qbe; };
+  hareWrappedScript = writeShellApplication {
+    # `name` MUST be `hare`, since its role is to replace the hare binary.
+    name = "hare";
+    runtimeInputs = [ hare ];
+    excludeShellChecks = [ "SC2086" ];
+    # ''${cmd:+"$cmd"} is used on the default case to keep the same behavior as
+    # the hare binary: If "$cmd" is passed directly and it's empty, the hare
+    # binary will treat it as an unrecognized command.
+    text = ''
+      readonly cmd="$1"
+      shift
+      case "$cmd" in
+        "test"|"run"|"build") exec hare "$cmd" $NIX_HAREFLAGS "$@" ;;
+        *) exec hare ''${cmd:+"$cmd"} "$@"
+      esac
+    '';
+  };
+  hareWrapper = runCommand "hare-wrapper" { nativeBuildInputs = [ makeWrapper ]; } ''
+    mkdir -p $out/bin
+    install ${lib.getExe hareWrappedScript} $out/bin/hare
+    makeWrapper ${lib.getExe hare} $out/bin/hare-native \
+      --inherit-argv0 \
+      --unset AR \
+      --unset LD \
+      --unset CC
+  '';
+in
+makeSetupHook {
+  name = "hare-hook";
+  # The propagation of `qbe` and `harec` (harePropagationInputs) is needed for
+  # build frameworks like `haredo`, which set the HAREC and QBE env vars to
+  # `harec` and `qbe` respectively. We use the derivations from the `hare`
+  # package to assure that there's no different behavior between the `hareHook`
+  # and `hare` packages.
+  propagatedBuildInputs = [ hareWrapper ] ++ harePropagationInputs;
+  substitutions = {
+    hare_unconditional_flags = "-q -a${arch}";
+    hare_stdlib = "${hare}/src/hare/stdlib";
+  };
+  meta = {
+    description = "A setup hook for the Hare compiler";
+    inherit (hare.meta) badPlatforms platforms;
+  };
+} ./setup-hook.sh

--- a/pkgs/by-name/ha/hare/package.nix
+++ b/pkgs/by-name/ha/hare/package.nix
@@ -130,13 +130,6 @@ stdenv.mkDerivation (finalAttrs: {
     scdoc
   ];
 
-  # Needed for build frameworks like `haredo`, which set the HAREC and QBE env vars to `harec` and
-  # `qbe` respectively.
-  propagatedBuildInputs = [
-    harec
-    qbe
-  ];
-
   buildInputs = [
     harec
     qbe
@@ -171,8 +164,6 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s configs/${platform}.mk config.mk
   '';
 
-  setupHook = ./setup-hook.sh;
-
   passthru = {
     updateScript = gitUpdater { };
     tests =
@@ -182,6 +173,8 @@ stdenv.mkDerivation (finalAttrs: {
       // lib.optionalAttrs (stdenv.buildPlatform.canExecute stdenv.hostPlatform) {
         mimeModule = callPackage ./mime-module-test.nix { hare = finalAttrs.finalPackage; };
       };
+    # To be propagated by `hareHook`.
+    inherit harec qbe;
   };
 
   meta = {

--- a/pkgs/by-name/ha/hare/package.nix
+++ b/pkgs/by-name/ha/hare/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromSourcehut,
   harec,
-  qbe,
   gitUpdater,
   scdoc,
   tzdata,
@@ -33,6 +32,7 @@ assert
   '';
 
 let
+  inherit (harec) qbe;
   buildArch = stdenv.buildPlatform.uname.processor;
   arch = stdenv.hostPlatform.uname.processor;
   platform = lib.toLower stdenv.hostPlatform.uname.system;

--- a/pkgs/by-name/ha/hare/setup-hook.sh
+++ b/pkgs/by-name/ha/hare/setup-hook.sh
@@ -1,9 +1,36 @@
-addHarepath () {
-    for haredir in third-party stdlib; do
-        if [[ -d "$1/src/hare/$haredir" ]]; then
-            addToSearchPath HAREPATH "$1/src/hare/$haredir"
-        fi
-    done
+# shellcheck disable=SC2154,SC2034,SC2016
+
+addHarepath() {
+    local -r thirdparty="${1-}/src/hare/third-party"
+    if [[ -d "$thirdparty" ]]; then
+        addToSearchPath HAREPATH "$thirdparty"
+    fi
 }
+
+# Hare's stdlib should come after its third party libs, since the latter may
+# expand or shadow the former.
+readonly hareSetStdlibPhase='
+addToSearchPath HAREPATH "@hare_stdlib@"
+'
+readonly hareInfoPhase='
+echoCmd "HARECACHE" "$HARECACHE"
+echoCmd "HAREPATH" "$HAREPATH"
+echoCmd "hare" "$(command -v hare)"
+echoCmd "hare-native" "$(command -v hare-native)"
+'
+prePhases+=("hareSetStdlibPhase" "hareInfoPhase")
+
+readonly hare_unconditional_flags="@hare_unconditional_flags@"
+case "${hareBuildType:-"release"}" in
+"release") export NIX_HAREFLAGS="-R $hare_unconditional_flags" ;;
+"debug") export NIX_HAREFLAGS="$hare_unconditional_flags" ;;
+*)
+    printf -- 'Invalid hareBuildType: "%s"\n' "${hareBuildType-}"
+    exit 1
+    ;;
+esac
+
+HARECACHE="$(mktemp -d)"
+export HARECACHE
 
 addEnvHooks "$hostOffset" addHarepath

--- a/pkgs/by-name/ha/harec/package.nix
+++ b/pkgs/by-name/ha/harec/package.nix
@@ -53,6 +53,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     updateScript = gitUpdater { };
+    # To be kept in sync with the hare package.
+    inherit qbe;
   };
 
   meta = {

--- a/pkgs/by-name/ha/harec/package.nix
+++ b/pkgs/by-name/ha/harec/package.nix
@@ -1,17 +1,20 @@
-{ lib
-, stdenv
-, fetchFromSourcehut
-, qbe
-, gitUpdater
+{
+  fetchFromSourcehut,
+  gitUpdater,
+  lib,
+  qbe,
+  stdenv,
 }:
 let
   platform = lib.toLower stdenv.hostPlatform.uname.system;
   arch = stdenv.hostPlatform.uname.processor;
-  qbePlatform = {
-    x86_64 = "amd64_sysv";
-    aarch64 = "arm64";
-    riscv64 = "rv64";
-  }.${arch};
+  qbePlatform =
+    {
+      x86_64 = "amd64_sysv";
+      aarch64 = "arm64";
+      riscv64 = "rv64";
+    }
+    .${arch};
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "harec";
@@ -24,13 +27,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-NOfoCT/wKZ3CXYzXZq7plXcun+MXQicfzBOmetXN7Qs=";
   };
 
-  nativeBuildInputs = [
-    qbe
-  ];
+  nativeBuildInputs = [ qbe ];
 
-  buildInputs = [
-    qbe
-  ];
+  buildInputs = [ qbe ];
 
   makeFlags = [
     "PREFIX=${builtins.placeholder "out"}"
@@ -65,7 +64,8 @@ stdenv.mkDerivation (finalAttrs: {
     # The upstream developers do not like proprietary operating systems; see
     # https://harelang.org/platforms/
     # UPDATE: https://github.com/hshq/harelang provides a MacOS port
-    platforms = with lib.platforms;
+    platforms =
+      with lib.platforms;
       lib.intersectLists (freebsd ++ openbsd ++ linux) (aarch64 ++ x86_64 ++ riscv64);
     badPlatforms = lib.platforms.darwin;
   };

--- a/pkgs/by-name/ha/haredo/package.nix
+++ b/pkgs/by-name/ha/haredo/package.nix
@@ -2,16 +2,13 @@
   stdenv,
   lib,
   fetchFromSourcehut,
-  hare,
+  hareHook,
   scdoc,
   nix-update-script,
   makeWrapper,
   bash,
   substituteAll,
 }:
-let
-  arch = stdenv.hostPlatform.uname.processor;
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "haredo";
   version = "1.0.5";
@@ -37,27 +34,23 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = [
-    hare
+    hareHook
     makeWrapper
     scdoc
   ];
 
   enableParallelChecking = true;
 
+  env.PREFIX = builtins.placeholder "out";
+
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   dontConfigure = true;
 
-  preBuild = ''
-    HARECACHE="$(mktemp -d)"
-    export HARECACHE
-    export PREFIX=${builtins.placeholder "out"}
-  '';
-
   buildPhase = ''
     runHook preBuild
 
-    hare build -o bin/haredo -qRa${arch} ./src
+    hare build -o bin/haredo ./src
     scdoc <doc/haredo.1.scd >doc/haredo.1
 
     runHook postBuild
@@ -92,6 +85,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.wtfpl;
     maintainers = with lib.maintainers; [ onemoresuza ];
     mainProgram = "haredo";
-    inherit (hare.meta) platforms badPlatforms;
+    inherit (hareHook.meta) platforms badPlatforms;
   };
 })

--- a/pkgs/by-name/ha/haredoc/package.nix
+++ b/pkgs/by-name/ha/haredoc/package.nix
@@ -3,10 +3,8 @@
   stdenv,
   scdoc,
   hare,
+  hareHook,
 }:
-let
-  arch = stdenv.hostPlatform.uname.processor;
-in
 stdenv.mkDerivation {
   pname = "haredoc";
   outputs = [
@@ -17,22 +15,17 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     scdoc
-    hare
+    hareHook
   ];
 
   strictDeps = true;
 
   enableParallelBuilding = true;
 
-  preBuild = ''
-    HARECACHE="$(mktemp -d)"
-    export HARECACHE
-  '';
-
   buildPhase = ''
     runHook preBuild
 
-    hare build -qR -a ${arch} -o haredoc ./cmd/haredoc
+    hare build -o haredoc ./cmd/haredoc
     scdoc <docs/haredoc.1.scd >haredoc.1
     scdoc <docs/haredoc.5.scd >haredoc.5
 
@@ -55,6 +48,6 @@ stdenv.mkDerivation {
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ onemoresuza ];
     mainProgram = "haredoc";
-    inherit (hare.meta) platforms badPlatforms;
+    inherit (hareHook.meta) platforms badPlatforms;
   };
 }

--- a/pkgs/by-name/ha/haredoc/package.nix
+++ b/pkgs/by-name/ha/haredoc/package.nix
@@ -1,23 +1,28 @@
-{ lib
-, stdenv
-, scdoc
-, hare
+{
+  lib,
+  stdenv,
+  scdoc,
+  hare,
 }:
 let
   arch = stdenv.hostPlatform.uname.processor;
 in
 stdenv.mkDerivation {
   pname = "haredoc";
-  outputs = [ "out" "man" ];
+  outputs = [
+    "out"
+    "man"
+  ];
   inherit (hare) version src;
-
-  strictDeps = true;
-  enableParallelBuilding = true;
 
   nativeBuildInputs = [
     scdoc
     hare
   ];
+
+  strictDeps = true;
+
+  enableParallelBuilding = true;
 
   preBuild = ''
     HARECACHE="$(mktemp -d)"

--- a/pkgs/by-name/tr/treecat/package.nix
+++ b/pkgs/by-name/tr/treecat/package.nix
@@ -1,15 +1,19 @@
-{ stdenv
-, fetchFromSourcehut
-, hare
-, haredo
-, lib
-, scdoc
+{
+  stdenv,
+  fetchFromSourcehut,
+  hare,
+  haredo,
+  lib,
+  scdoc,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "treecat";
   version = "1.0.2-unstable-2023-11-28";
 
-  outputs = [ "out" "man" ];
+  outputs = [
+    "out"
+    "man"
+  ];
 
   src = fetchFromSourcehut {
     owner = "~autumnull";

--- a/pkgs/by-name/tr/treecat/package.nix
+++ b/pkgs/by-name/tr/treecat/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   fetchFromSourcehut,
-  hare,
+  hareHook,
   haredo,
   lib,
   scdoc,
@@ -23,18 +23,14 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    hare
+    hareHook
     haredo
     scdoc
   ];
 
-  dontConfigure = true;
+  env.PREFIX = builtins.placeholder "out";
 
-  preBuild = ''
-    HARECACHE="$(mktemp -d)"
-    export HARECACHE
-    export PREFIX="${builtins.placeholder "out"}"
-  '';
+  dontConfigure = true;
 
   meta = {
     description = "Serialize a directory to a tree diagram, and vice versa";
@@ -46,6 +42,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.wtfpl;
     maintainers = with lib.maintainers; [ onemoresuza ];
     mainProgram = "treecat";
-    inherit (hare.meta) platforms badPlatforms;
+    inherit (hareHook.meta) platforms badPlatforms;
   };
 })

--- a/pkgs/development/hare-third-party/hare-compress/default.nix
+++ b/pkgs/development/hare-third-party/hare-compress/default.nix
@@ -1,8 +1,14 @@
-{ lib, stdenv, hare, harec, fetchFromSourcehut }:
+{
+  lib,
+  stdenv,
+  hare,
+  harec,
+  fetchFromSourcehut,
+}:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hare-compress";
-  version = "unstable-2023-11-01";
+  version = "0-unstable-2023-11-01";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
@@ -25,7 +31,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Compression algorithms for Hare";
     license = with licenses; [ mpl20 ];
     maintainers = with maintainers; [ starzation ];
-
     inherit (harec.meta) platforms badPlatforms;
   };
 })

--- a/pkgs/development/hare-third-party/hare-compress/default.nix
+++ b/pkgs/development/hare-third-party/hare-compress/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  hare,
+  hareHook,
   harec,
   fetchFromSourcehut,
 }:
@@ -17,12 +17,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-sz8xPBZaUFye3HH4lkRnH52ye451e6seZXN/qvg87jE=";
   };
 
-  nativeBuildInputs = [ hare ];
+  nativeBuildInputs = [ hareHook ];
 
-  makeFlags = [
-    "HARECACHE=.harecache"
-    "PREFIX=${builtins.placeholder "out"}"
-  ];
+  makeFlags = [ "PREFIX=${builtins.placeholder "out"}" ];
 
   doCheck = true;
 

--- a/pkgs/development/hare-third-party/hare-ev/default.nix
+++ b/pkgs/development/hare-third-party/hare-ev/default.nix
@@ -1,8 +1,9 @@
-{ stdenv
-, lib
-, fetchFromSourcehut
-, hare
-, unstableGitUpdater
+{
+  fetchFromSourcehut,
+  hare,
+  lib,
+  stdenv,
+  unstableGitUpdater,
 }:
 
 stdenv.mkDerivation {
@@ -16,9 +17,7 @@ stdenv.mkDerivation {
     hash = "sha256-SXExwDZKlW/2XYzmJUhkLWj6NF/znrv3vY9V0mD5iFQ=";
   };
 
-  nativeCheckInputs = [
-    hare
-  ];
+  nativeCheckInputs = [ hare ];
 
   makeFlags = [
     "HARECACHE=.harecache"

--- a/pkgs/development/hare-third-party/hare-ev/default.nix
+++ b/pkgs/development/hare-third-party/hare-ev/default.nix
@@ -1,6 +1,6 @@
 {
   fetchFromSourcehut,
-  hare,
+  hareHook,
   lib,
   stdenv,
   unstableGitUpdater,
@@ -17,12 +17,9 @@ stdenv.mkDerivation {
     hash = "sha256-SXExwDZKlW/2XYzmJUhkLWj6NF/znrv3vY9V0mD5iFQ=";
   };
 
-  nativeCheckInputs = [ hare ];
+  nativeCheckInputs = [ hareHook ];
 
-  makeFlags = [
-    "HARECACHE=.harecache"
-    "PREFIX=${builtins.placeholder "out"}"
-  ];
+  makeFlags = [ "PREFIX=${builtins.placeholder "out"}" ];
 
   doCheck = true;
 
@@ -33,6 +30,6 @@ stdenv.mkDerivation {
     homepage = "https://sr.ht/~sircmpwn/hare-ev";
     license = licenses.mpl20;
     maintainers = with maintainers; [ colinsane ];
-    inherit (hare.meta) platforms badPlatforms;
+    inherit (hareHook.meta) platforms badPlatforms;
   };
 }

--- a/pkgs/development/hare-third-party/hare-json/default.nix
+++ b/pkgs/development/hare-third-party/hare-json/default.nix
@@ -1,6 +1,6 @@
 {
   fetchFromSourcehut,
-  hare,
+  hareHook,
   harec,
   lib,
   stdenv,
@@ -17,12 +17,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Sx+RBiLhR3ftP89AwinVlBg0u0HX4GVP7TLmuofgC9s=";
   };
 
-  nativeBuildInputs = [ hare ];
+  nativeBuildInputs = [ hareHook ];
 
-  makeFlags = [
-    "HARECACHE=.harecache"
-    "PREFIX=${builtins.placeholder "out"}"
-  ];
+  makeFlags = [ "PREFIX=${builtins.placeholder "out"}" ];
 
   doCheck = true;
 

--- a/pkgs/development/hare-third-party/hare-json/default.nix
+++ b/pkgs/development/hare-third-party/hare-json/default.nix
@@ -1,8 +1,14 @@
-{ lib, stdenv, hare, harec, fetchFromSourcehut }:
+{
+  fetchFromSourcehut,
+  hare,
+  harec,
+  lib,
+  stdenv,
+}:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hare-json";
-  version = "unstable-2023-03-13";
+  version = "0-unstable-2023-03-13";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
@@ -25,7 +31,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "This package provides JSON support for Hare";
     license = with licenses; [ mpl20 ];
     maintainers = with maintainers; [ starzation ];
-
     inherit (harec.meta) platforms badPlatforms;
   };
 })

--- a/pkgs/development/hare-third-party/hare-png/default.nix
+++ b/pkgs/development/hare-third-party/hare-png/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  hare,
+  hareHook,
   hareThirdParty,
   fetchFromSourcehut,
 }:
@@ -17,13 +17,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Q7xylsLVd/sp57kv6WzC7QHGN1xOsm7YEsYCbY/zi1Q=";
   };
 
-  nativeBuildInputs = [ hare ];
+  nativeBuildInputs = [ hareHook ];
   propagatedBuildInputs = [ hareThirdParty.hare-compress ];
 
-  makeFlags = [
-    "PREFIX=${builtins.placeholder "out"}"
-    "HARECACHE=.harecache"
-  ];
+  makeFlags = [ "PREFIX=${builtins.placeholder "out"}" ];
 
   doCheck = true;
 
@@ -32,6 +29,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "PNG implementation for Hare";
     license = with licenses; [ mpl20 ];
     maintainers = with maintainers; [ starzation ];
-    inherit (hare.meta) platforms badPlatforms;
+    inherit (hareHook.meta) platforms badPlatforms;
   };
 })

--- a/pkgs/development/hare-third-party/hare-png/default.nix
+++ b/pkgs/development/hare-third-party/hare-png/default.nix
@@ -1,8 +1,14 @@
-{ lib, stdenv, hare, hareThirdParty, fetchFromSourcehut }:
+{
+  lib,
+  stdenv,
+  hare,
+  hareThirdParty,
+  fetchFromSourcehut,
+}:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hare-png";
-  version = "unstable-2023-09-09";
+  version = "0-unstable-2023-09-09";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
@@ -26,7 +32,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "PNG implementation for Hare";
     license = with licenses; [ mpl20 ];
     maintainers = with maintainers; [ starzation ];
-
     inherit (hare.meta) platforms badPlatforms;
   };
 })

--- a/pkgs/development/hare-third-party/hare-ssh/default.nix
+++ b/pkgs/development/hare-third-party/hare-ssh/default.nix
@@ -1,6 +1,6 @@
 {
   fetchFromSourcehut,
-  hare,
+  hareHook,
   lib,
   stdenv,
 }:
@@ -16,12 +16,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-I43TLPoImBsvkgV3hDy9dw0pXVt4ezINnxFtEV9P2/M=";
   };
 
-  nativeBuildInputs = [ hare ];
+  nativeBuildInputs = [ hareHook ];
 
-  makeFlags = [
-    "PREFIX=${builtins.placeholder "out"}"
-    "HARECACHE=.harecache"
-  ];
+  makeFlags = [ "PREFIX=${builtins.placeholder "out"}" ];
 
   doCheck = true;
 
@@ -31,6 +28,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = with licenses; [ mpl20 ];
     maintainers = with maintainers; [ patwid ];
 
-    inherit (hare.meta) platforms badPlatforms;
+    inherit (hareHook.meta) platforms badPlatforms;
   };
 })

--- a/pkgs/development/hare-third-party/hare-ssh/default.nix
+++ b/pkgs/development/hare-third-party/hare-ssh/default.nix
@@ -1,8 +1,13 @@
-{ lib, stdenv, hare, hareThirdParty, fetchFromSourcehut }:
+{
+  fetchFromSourcehut,
+  hare,
+  lib,
+  stdenv,
+}:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hare-ssh";
-  version = "unstable-2023-11-16";
+  version = "0-unstable-2023-11-16";
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";

--- a/pkgs/development/hare-third-party/hare-toml/default.nix
+++ b/pkgs/development/hare-third-party/hare-toml/default.nix
@@ -1,6 +1,6 @@
 {
   fetchFromGitea,
-  hare,
+  hareHook,
   lib,
   nix-update-script,
   scdoc,
@@ -20,13 +20,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     scdoc
-    hare
+    hareHook
   ];
 
-  makeFlags = [
-    "HARECACHE=.harecache"
-    "PREFIX=${builtins.placeholder "out"}"
-  ];
+  makeFlags = [ "PREFIX=${builtins.placeholder "out"}" ];
 
   checkTarget = "check_local";
 
@@ -41,6 +38,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://codeberg.org/lunacb/hare-toml";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ onemoresuza ];
-    inherit (hare.meta) platforms badPlatforms;
+    inherit (hareHook.meta) platforms badPlatforms;
   };
 })

--- a/pkgs/development/hare-third-party/hare-toml/default.nix
+++ b/pkgs/development/hare-third-party/hare-toml/default.nix
@@ -1,9 +1,10 @@
-{ stdenv
-, hare
-, scdoc
-, lib
-, fetchFromGitea
-, nix-update-script
+{
+  fetchFromGitea,
+  hare,
+  lib,
+  nix-update-script,
+  scdoc,
+  stdenv,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "hare-toml";

--- a/pkgs/tools/security/himitsu/default.nix
+++ b/pkgs/tools/security/himitsu/default.nix
@@ -1,6 +1,6 @@
 {
   fetchFromSourcehut,
-  hare,
+  hareHook,
   lib,
   scdoc,
   stdenv,
@@ -18,13 +18,9 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    hare
+    hareHook
     scdoc
   ];
-
-  preConfigure = ''
-    export HARECACHE=$(mktemp -d)
-  '';
 
   installFlags = [ "PREFIX=${builtins.placeholder "out"}" ];
 
@@ -33,6 +29,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "A secret storage manager";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ auchter ];
-    inherit (hare.meta) platforms badPlatforms;
+    inherit (hareHook.meta) platforms badPlatforms;
   };
 })

--- a/pkgs/tools/security/himitsu/default.nix
+++ b/pkgs/tools/security/himitsu/default.nix
@@ -1,19 +1,19 @@
-{ lib
-, stdenv
-, fetchFromSourcehut
-, hare
-, scdoc
+{
+  fetchFromSourcehut,
+  hare,
+  lib,
+  scdoc,
+  stdenv,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "himitsu";
   version = "0.7";
 
   src = fetchFromSourcehut {
-    name = pname + "-src";
     owner = "~sircmpwn";
-    repo = pname;
-    rev = version;
+    repo = "himitsu";
+    rev = finalAttrs.version;
     hash = "sha256-jDxQajc8Kyfihm8q3wCpA+WsbAkQEZerLckLQXNhTa8=";
   };
 
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     export HARECACHE=$(mktemp -d)
   '';
 
-  installFlags = [ "PREFIX=" "DESTDIR=$(out)" ];
+  installFlags = [ "PREFIX=${builtins.placeholder "out"}" ];
 
   meta = with lib; {
     homepage = "https://himitsustore.org/";
@@ -35,4 +35,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ auchter ];
     inherit (hare.meta) platforms badPlatforms;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -25196,6 +25196,10 @@ with pkgs;
 
   leaps = callPackage ../development/tools/leaps { };
 
+  ### DEVELOPMENT / HARE
+
+  hareHook = callPackage ../by-name/ha/hare/hook.nix { };
+
   ### DEVELOPMENT / JAVA MODULES
 
   javaPackages = recurseIntoAttrs (callPackage ./java-packages.nix { });


### PR DESCRIPTION
## Description of changes

The `hareHook` package does the following:

1. Sets `HARECACHE` to `$(mktemp -d)`;
2. Allows for cross-compilation out of the box, by wrapping the hare binary in a script that passes the `-a` flag for it;
3. Provides the `hareBuildType` attribute, which accepts either `release` (default) or `debug` for passing the `-R` for the wrapper script;
4. Removes the pollution of logs by passing the `-q` flag to the wrapper script;
5. Provides the `hare-native` script for when there's a need to run compiled binaries on the build process; and
6. Appends Hare's stdlib to `HAREPATH` only after all third party libraries are added, so that it may be extended or shadowed by them.

### TODO

- [x] Fix cross-compilation (Fixed, thanks to @uninsane in https://github.com/onemoresuza/nixpkgs/pull/1#issue-2182138217.)
	The hook does not seem to pass the `buildPlatform` `hare` binary when
	cross-compiling, but the one from `hostPlatform`.
- [x] Add an entry to the nixpkgs manual.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
