### PR TITLE
dpdk: use `elfutils` instead of abandoned `libelf`

### DIFF
--- a/pkgs/os-specific/linux/dpdk/default.nix
+++ b/pkgs/os-specific/linux/dpdk/default.nix
@@ -2,7 +2,7 @@
 , kernel
 , fetchurl
 , pkg-config, meson, ninja, makeWrapper
-, libbsd, numactl, libbpf, zlib, libelf, jansson, openssl, libpcap, rdma-core
+, libbsd, numactl, libbpf, zlib, elfutils, jansson, openssl, libpcap, rdma-core
 , doxygen, python3, pciutils
 , withExamples ? []
 , shared ? false
@@ -38,7 +38,7 @@ in stdenv.mkDerivation {
   buildInputs = [
     jansson
     libbpf
-    libelf
+    elfutils
     libpcap
     numactl
     openssl.dev

--- a/pkgs/os-specific/linux/odp-dpdk/default.nix
+++ b/pkgs/os-specific/linux/odp-dpdk/default.nix
@@ -10,8 +10,9 @@
 , numactl
 , openssl
 , zlib
+, zstd
 , libbsd
-, libelf
+, elfutils
 , jansson
 , libnl
 }:
@@ -37,8 +38,9 @@ stdenv.mkDerivation rec {
     numactl
     openssl
     zlib
+    zstd
     libbsd
-    libelf
+    elfutils
     jansson
     libbpf
     libnl


### PR DESCRIPTION
## Description of changes

Switch from using unmaintained `libelf` to `elfutils` (https://github.com/NixOS/nixpkgs/issues/271473).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>25 packages marked as broken and skipped:</summary>
  <ul>
    <li>linuxKernel.packages.linux_4_19_hardened.dpdk</li>
    <li>linuxKernel.packages.linux_4_19_hardened.dpdk.doc</li>
    <li>linuxKernel.packages.linux_4_19_hardened.dpdk.kmod</li>
    <li>linuxKernel.packages.linux_5_10_hardened.dpdk</li>
    <li>linuxKernel.packages.linux_5_10_hardened.dpdk.doc</li>
    <li>linuxKernel.packages.linux_5_10_hardened.dpdk.kmod</li>
    <li>linuxKernel.packages.linux_5_15_hardened.dpdk</li>
    <li>linuxKernel.packages.linux_5_15_hardened.dpdk.doc</li>
    <li>linuxKernel.packages.linux_5_15_hardened.dpdk.kmod</li>
    <li>linuxKernel.packages.linux_5_4_hardened.dpdk</li>
    <li>linuxKernel.packages.linux_5_4_hardened.dpdk.doc</li>
    <li>linuxKernel.packages.linux_5_4_hardened.dpdk.kmod</li>
    <li>linuxKernel.packages.linux_6_1_hardened.dpdk</li>
    <li>linuxKernel.packages.linux_6_1_hardened.dpdk.doc</li>
    <li>linuxKernel.packages.linux_6_1_hardened.dpdk.kmod</li>
    <li>linuxKernel.packages.linux_6_6_hardened.dpdk</li>
    <li>linuxKernel.packages.linux_6_6_hardened.dpdk.doc</li>
    <li>linuxKernel.packages.linux_6_6_hardened.dpdk.kmod</li>
    <li>linuxKernel.packages.linux_6_7_hardened.dpdk</li>
    <li>linuxKernel.packages.linux_6_7_hardened.dpdk.doc</li>
    <li>linuxKernel.packages.linux_6_7_hardened.dpdk.kmod</li>
    <li>linuxKernel.packages.linux_hardened.dpdk</li>
    <li>linuxKernel.packages.linux_hardened.dpdk.doc</li>
    <li>linuxKernel.packages.linux_hardened.dpdk.kmod</li>
    <li>redpanda-server</li>
  </ul>
</details>
<details>
  <summary>10 packages failed to build: <b>(I think these are OK.)</b></summary>
  <ul>
    <li>linuxKernel.packages.linux_4_19.pktgen</li>
    <li>linuxKernel.packages.linux_6_8.dpdk</li>
    <li>linuxKernel.packages.linux_6_8.dpdk.doc</li>
    <li>linuxKernel.packages.linux_6_8.dpdk.kmod</li>
    <li>linuxKernel.packages.linux_latest_libre.dpdk</li>
    <li>linuxKernel.packages.linux_latest_libre.dpdk.doc</li>
    <li>linuxKernel.packages.linux_latest_libre.dpdk.kmod</li>
    <li>linuxKernel.packages.linux_zen.dpdk</li>
    <li>linuxKernel.packages.linux_zen.dpdk.doc</li>
    <li>linuxKernel.packages.linux_zen.dpdk.kmod</li>
  </ul>
</details>
<details>
  <summary>36 packages built:</summary>
  <ul>
    <li>dpdk</li>
    <li>dpdk.doc</li>
    <li>linuxKernel.packages.linux_4_19.dpdk</li>
    <li>linuxKernel.packages.linux_4_19.dpdk.doc</li>
    <li>linuxKernel.packages.linux_4_19.dpdk.kmod</li>
    <li>linuxKernel.packages.linux_5_10.dpdk</li>
    <li>linuxKernel.packages.linux_5_10.dpdk.doc</li>
    <li>linuxKernel.packages.linux_5_10.dpdk.kmod</li>
    <li>linuxKernel.packages.linux_5_15.dpdk</li>
    <li>linuxKernel.packages.linux_5_15.dpdk.doc</li>
    <li>linuxKernel.packages.linux_5_15.dpdk.kmod</li>
    <li>linuxKernel.packages.linux_5_4.dpdk</li>
    <li>linuxKernel.packages.linux_5_4.dpdk.doc</li>
    <li>linuxKernel.packages.linux_5_4.dpdk.kmod</li>
    <li>linuxKernel.packages.linux_6_1.dpdk</li>
    <li>linuxKernel.packages.linux_6_1.dpdk.doc</li>
    <li>linuxKernel.packages.linux_6_1.dpdk.kmod</li>
    <li>linuxKernel.packages.linux_6_6.dpdk</li>
    <li>linuxKernel.packages.linux_6_6.dpdk.doc</li>
    <li>linuxKernel.packages.linux_6_6.dpdk.kmod</li>
    <li>linuxKernel.packages.linux_6_7.dpdk</li>
    <li>linuxKernel.packages.linux_6_7.dpdk.doc</li>
    <li>linuxKernel.packages.linux_6_7.dpdk.kmod</li>
    <li>linuxKernel.packages.linux_libre.dpdk</li>
    <li>linuxKernel.packages.linux_libre.dpdk.doc</li>
    <li>linuxKernel.packages.linux_libre.dpdk.kmod</li>
    <li>linuxKernel.packages.linux_lqx.dpdk</li>
    <li>linuxKernel.packages.linux_lqx.dpdk.doc</li>
    <li>linuxKernel.packages.linux_lqx.dpdk.kmod</li>
    <li>linuxKernel.packages.linux_xanmod.dpdk</li>
    <li>linuxKernel.packages.linux_xanmod.dpdk.doc</li>
    <li>linuxKernel.packages.linux_xanmod.dpdk.kmod</li>
    <li>linuxKernel.packages.linux_xanmod_latest.dpdk (linuxKernel.packages.linux_xanmod_stable.dpdk)</li>
    <li>linuxKernel.packages.linux_xanmod_latest.dpdk.doc (linuxKernel.packages.linux_xanmod_stable.dpdk.doc)</li>
    <li>linuxKernel.packages.linux_xanmod_latest.dpdk.kmod (linuxKernel.packages.linux_xanmod_stable.dpdk.kmod)</li>
    <li>spdk</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).