### PR TITLE
[23.11] nixos/ollama: add ollama service to release notes

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2311.section.md
+++ b/nixos/doc/manual/release-notes/rl-2311.section.md
@@ -1096,6 +1096,8 @@ Make sure to also check the many updates in the [Nixpkgs library](#sec-release-2
   applications run faster by prefetching binaries and shared objects.
   Available as [services.preload](#opt-services.preload.enable).
 
+- [ollama](https://ollama.com), server for running large language models locally.
+
 ### Other Notable Changes {#sec-release-23.11-nixos-notable-changes}
 
 - The new option `system.switch.enable` was added. It is enabled by default.


### PR DESCRIPTION
## Description of changes

In #293404, I forgot to push a local change to my nixos fork. This reapplies that change, adding an entry to the stable release notes for the ollama service.