### PR TITLE
boxbuddy: init at 2.1.3

### DIFF
--- a/pkgs/by-name/bo/boxbuddy/package.nix
+++ b/pkgs/by-name/bo/boxbuddy/package.nix
@@ -1,0 +1,61 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, wrapGAppsHook4
+, libadwaita
+, distrobox
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "boxbuddy";
+  version = "2.1.3";
+
+  src = fetchFromGitHub {
+    owner = "Dvlv";
+    repo = "BoxBuddyRS";
+    rev = version;
+    hash = "sha256-Jl9WhMqb40Olub5eV7Meu5DJi+bzWhPf3DCRPe4CMfo=";
+  };
+
+  cargoHash = "sha256-HN+yGODTRXRa3AsBOuRVOnnU2pxBZfy0zlnCWs2oQCI=";
+
+  # The software assumes it is installed either in flatpak or in the home directory
+  # so the xdg data path needs to be patched here
+  postPatch = ''
+    substituteInPlace src/utils.rs \
+      --replace-fail '{data_home}/locale' "$out/share/locale" \
+      --replace-fail '{data_home}/icons/boxbuddy/{}' "$out/share/icons/boxbuddy/{}"
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    libadwaita
+  ];
+
+  postInstall = ''
+    cp icons/* ./
+    XDG_DATA_HOME=$out/share INSTALL_DIR=$out ./scripts/install.sh
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : ${lib.makeBinPath [ distrobox ]}
+    )
+  '';
+
+  doCheck = false; # No checks defined
+
+  meta = with lib; {
+    description = "An unofficial GUI for managing your Distroboxes, written with GTK4 + Libadwaita";
+    homepage = "https://dvlv.github.io/BoxBuddyRS";
+    license = licenses.mit;
+    mainProgram = "boxbuddy-rs";
+    maintainers = with maintainers; [ aleksana ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes

Tested

![image](https://github.com/NixOS/nixpkgs/assets/42209822/3d42e074-7c94-48dc-9ea0-ef5815e7338f)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
