### PR TITLE
uni-sync: init at 0.2.0, nixos/uni-sync: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -113,6 +113,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
 
 - [Mealie](https://nightly.mealie.io/), a self-hosted recipe manager and meal planner with a RestAPI backend and a reactive frontend application built in NuxtJS for a pleasant user experience for the whole family. Available as [services.mealie](#opt-services.mealie.enable)
 
+- [Uni-Sync](https://github.com/EightB1ts/uni-sync), a synchronization tool for Lian Li Uni Controllers. Available as [hardware.uni-sync](#opt-hardware.uni-sync.enable)
+
 ## Backward Incompatibilities {#sec-release-24.05-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/hardware/uni-sync.nix
+++ b/nixos/modules/hardware/uni-sync.nix
@@ -1,0 +1,117 @@
+{ config
+, lib
+, pkgs
+, ...
+}:
+with lib; let
+  cfg = config.hardware.uni-sync;
+in
+{
+  meta.maintainers = with maintainers; [ yunfachi ];
+
+  options.hardware.uni-sync = {
+    enable = mkEnableOption (mdDoc "udev rules and software for Lian Li Uni Controllers");
+    package = mkPackageOption pkgs "uni-sync" { };
+
+    devices = mkOption {
+      default = [ ];
+      example = literalExpression ''
+        [
+          {
+            device_id = "VID:1111/PID:11111/SN:1111111111";
+            sync_rgb = true;
+            channels = [
+              {
+                mode = "PWM";
+              }
+              {
+                mode = "Manual";
+                speed = 100;
+              }
+              {
+                mode = "Manual";
+                speed = 54;
+              }
+              {
+                mode = "Manual";
+                speed = 0;
+              }
+            ];
+          }
+          {
+            device_id = "VID:1010/PID:10101/SN:1010101010";
+            sync_rgb = false;
+            channels = [
+              {
+                mode = "Manual";
+                speed = 0;
+              }
+            ];
+          }
+        ]
+      '';
+      description = mdDoc "List of controllers with their configurations.";
+      type = types.listOf (types.submodule {
+        options = {
+          device_id = mkOption {
+            type = types.str;
+            example = "VID:1111/PID:11111/SN:1111111111";
+            description = mdDoc "Unique device ID displayed at each startup.";
+          };
+          sync_rgb = mkOption {
+            type = types.bool;
+            default = false;
+            example = true;
+            description = mdDoc "Enable ARGB header sync.";
+          };
+          channels = mkOption {
+            default = [ ];
+            example = literalExpression ''
+              [
+                {
+                  mode = "PWM";
+                }
+                {
+                  mode = "Manual";
+                  speed = 100;
+                }
+                {
+                  mode = "Manual";
+                  speed = 54;
+                }
+                {
+                  mode = "Manual";
+                  speed = 0;
+                }
+              ]
+            '';
+            description = mdDoc "List of channels connected to the controller.";
+            type = types.listOf (types.submodule {
+              options = {
+                mode = mkOption {
+                  type = types.enum [ "Manual" "PWM" ];
+                  default = "Manual";
+                  example = "PWM";
+                  description = mdDoc "\"PWM\" to enable PWM sync. \"Manual\" to set speed.";
+                };
+                speed = mkOption {
+                  type = types.int;
+                  default = "50";
+                  example = "100";
+                  description = mdDoc "Fan speed as percentage (clamped between 0 and 100).";
+                };
+              };
+            });
+          };
+        };
+      });
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.etc."uni-sync/uni-sync.json".text = mkIf (cfg.devices != [ ]) (builtins.toJSON { configs = cfg.devices; });
+
+    environment.systemPackages = [ cfg.package ];
+    services.udev.packages = [ cfg.package ];
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -98,6 +98,7 @@
   ./hardware/tuxedo-keyboard.nix
   ./hardware/ubertooth.nix
   ./hardware/uinput.nix
+  ./hardware/uni-sync.nix
   ./hardware/usb-modeswitch.nix
   ./hardware/usb-storage.nix
   ./hardware/video/amdgpu-pro.nix

--- a/pkgs/by-name/un/uni-sync/config_path.patch
+++ b/pkgs/by-name/un/uni-sync/config_path.patch
@@ -1,0 +1,38 @@
+diff --git a/src/main.rs b/src/main.rs
+index 357a33b..7073497 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -1,4 +1,4 @@
+-use std::env;
++use std::path::PathBuf;
+ 
+ mod devices;
+ 
+@@ -8,12 +8,23 @@ fn main() -> Result<(), std::io::Error> {
+         configs: vec![]
+     };
+ 
+-    let mut config_path = env::current_exe()?;
+-    config_path.pop();
+-    config_path.push("uni-sync.json");
++    let mut config_path = PathBuf::from("/etc/uni-sync/uni-sync.json");
+ 
+     if !config_path.exists() {
+-        std::fs::write(&config_path, serde_json::to_string_pretty(&configs).unwrap())?;
++        match std::fs::create_dir_all(config_path.parent().unwrap()) {
++            Ok(result) => result,
++            Err(_) => {
++                println!("Please run uni-sync with elevated permissions.");
++                std::process::exit(0);
++            }
++        };
++        match std::fs::write(&config_path, serde_json::to_string_pretty(&configs).unwrap()) {
++            Ok(result) => result,
++            Err(_) => {
++                println!("Please run uni-sync with elevated permissions.");
++                std::process::exit(0);
++            }
++        };
+     }
+ 
+     let config_content = std::fs::read_to_string(&config_path).unwrap();

--- a/pkgs/by-name/un/uni-sync/ignore_read-only_filesystem.patch
+++ b/pkgs/by-name/un/uni-sync/ignore_read-only_filesystem.patch
@@ -1,0 +1,14 @@
+diff --git a/src/main.rs b/src/main.rs
+index f07cc64..357a33b 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -20,7 +20,7 @@ fn main() -> Result<(), std::io::Error> {
+     configs = serde_json::from_str::<devices::Configs>(&config_content).unwrap();
+ 
+     let new_configs = devices::run(configs);
+-    std::fs::write(&config_path, serde_json::to_string_pretty(&new_configs).unwrap())?;
++    std::fs::write(&config_path, serde_json::to_string_pretty(&new_configs).unwrap());
+ 
+     Ok(())
+ }
+\ No newline at end of file

--- a/pkgs/by-name/un/uni-sync/package.nix
+++ b/pkgs/by-name/un/uni-sync/package.nix
@@ -1,0 +1,35 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, pkg-config
+, libudev-zero
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "uni-sync";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "EightB1ts";
+    repo = pname;
+    rev = "ca349942c06fabcc028ce24e79fc6ce7c758452b";
+    hash = "sha256-K2zX3rKtTaKO6q76xlxX+rDLL0gEsJ2l8x/s1vsp+ZQ=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libudev-zero ];
+
+  patches = [
+    ./config_path.patch
+    ./ignore_read-only_filesystem.patch
+  ];
+
+  cargoHash = "sha256-DdmjP0h15cXkHJZxvOcINgoZ/EhTgu/7iYb+bgsIXxU=";
+
+  meta = with lib; {
+    description = "A synchronization tool for Lian Li Uni Controllers";
+    homepage = "https://github.com/EightB1ts/uni-sync";
+    license = licenses.mit;
+    maintainers = with maintainers; [ yunfachi ];
+    mainProgram = "uni-sync";
+  };
+}


### PR DESCRIPTION
## Description of changes

https://github.com/EightB1ts/uni-sync
A Synchronization Tool for Lian Li Fan Controllers

In rev, I used a hash instead of a version, since there are no tags present in the repository.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
