### PR TITLE
catch2_3: fix build on riscv

### DIFF
--- a/pkgs/development/libraries/catch2/3.nix
+++ b/pkgs/development/libraries/catch2/3.nix
@@ -31,9 +31,12 @@ stdenv.mkDerivation rec {
     "-DCMAKE_CTEST_ARGUMENTS=-E;ApprovalTests"
   ];
 
-  # Tests fail on x86_32 if compiled with x87 floats: https://github.com/catchorg/Catch2/issues/2796
   env = lib.optionalAttrs stdenv.isx86_32 {
+    # Tests fail on x86_32 if compiled with x87 floats: https://github.com/catchorg/Catch2/issues/2796
     NIX_CFLAGS_COMPILE = "-msse2 -mfpmath=sse";
+  } // lib.optionalAttrs (stdenv.hostPlatform.isRiscV || stdenv.hostPlatform.isAarch32) {
+    # Build failure caused by -Werror: https://github.com/catchorg/Catch2/issues/2808
+    NIX_CFLAGS_COMPILE = "-Wno-error=cast-align";
   };
 
   doCheck = true;


### PR DESCRIPTION
## Description of changes

The build fails because of treating warnings as errors. Hence, this PR conditionally disables treating the `cast-align` warning as an error on risc-v platforms. The failure has been reported to upstream https://github.com/catchorg/Catch2/issues/2808. The version 2 package `catch2` builds fine, so this only concerns the version 3 package `catch2_3`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

<details><summary>Build failure log</summary>

```
In file included from /build/source/tests/SelfTest/UsageTests/Benchmark.tests.cpp:12:
/build/source/src/catch2/../catch2/benchmark/catch_constructor.hpp: In instantiation of 'T& Catch::Benchmark::Detail::ObjectStorage<T, Destruct>::stored_object() [with T = std::__cxx11::basic>
/build/source/src/catch2/../catch2/benchmark/catch_constructor.hpp:46:34:   required from 'std::enable_if_t<AllowManualDestruction> Catch::Benchmark::Detail::ObjectStorage<T, Destruct>::destr>
/build/source/tests/SelfTest/UsageTests/Benchmark.tests.cpp:153:59:   required from here
/build/source/src/catch2/../catch2/benchmark/catch_constructor.hpp:61:46: error: cast from 'unsigned char*' to 'std::__cxx11::basic_string<char>*' increases required alignment of target type >
   61 |                 T& stored_object() { return *reinterpret_cast<T*>( data ); }
      |                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 95%] Building CXX object tests/CMakeFiles/SelfTest.dir/SelfTest/UsageTests/ToStringTuple.tests.cpp.o
/build/source/src/catch2/../catch2/benchmark/catch_constructor.hpp: In instantiation of 'T& Catch::Benchmark::Detail::ObjectStorage<T, Destruct>::stored_object() [with T = std::__cxx11::basic>
/build/source/src/catch2/../catch2/benchmark/catch_constructor.hpp:46:34:   required from 'std::enable_if_t<AllowManualDestruction> Catch::Benchmark::Detail::ObjectStorage<T, Destruct>::destr>
/build/source/src/catch2/../catch2/benchmark/catch_constructor.hpp:52:97:   required from 'void Catch::Benchmark::Detail::ObjectStorage<T, Destruct>::destruct_on_exit(std::enable_if_t<Destruc>
/build/source/src/catch2/../catch2/benchmark/catch_constructor.hpp:35:55:   required from 'Catch::Benchmark::Detail::ObjectStorage<T, Destruct>::~ObjectStorage() [with T = std::__cxx11::basic>
/nix/store/cfzgy3clx7m8ramfismjlzab8c48dw28-gcc-13.2.0/include/c++/13.2.0/bits/stl_construct.h:151:22:   required from 'constexpr void std::_Destroy(_Tp*) [with _Tp = Catch::Benchmark::Detail>
/nix/store/cfzgy3clx7m8ramfismjlzab8c48dw28-gcc-13.2.0/include/c++/13.2.0/bits/stl_construct.h:163:19:   required from 'static void std::_Destroy_aux<<anonymous> >::__destroy(_ForwardIterator>
/nix/store/cfzgy3clx7m8ramfismjlzab8c48dw28-gcc-13.2.0/include/c++/13.2.0/bits/stl_construct.h:196:11:   required from 'void std::_Destroy(_ForwardIterator, _ForwardIterator) [with _ForwardIt>
/nix/store/cfzgy3clx7m8ramfismjlzab8c48dw28-gcc-13.2.0/include/c++/13.2.0/bits/alloc_traits.h:947:20:   required from 'void std::_Destroy(_ForwardIterator, _ForwardIterator, allocator<_T2>&) >
/nix/store/cfzgy3clx7m8ramfismjlzab8c48dw28-gcc-13.2.0/include/c++/13.2.0/bits/stl_vector.h:732:15:   required from 'std::vector<_Tp, _Alloc>::~vector() [with _Tp = Catch::Benchmark::Detail::>
/build/source/tests/SelfTest/UsageTests/Benchmark.tests.cpp:145:89:   required from here
/build/source/src/catch2/../catch2/benchmark/catch_constructor.hpp:61:46: error: cast from 'unsigned char*' to 'std::__cxx11::basic_string<char>*' increases required alignment of target type >
```
</details> 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] riscv64-linux
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
