### PR TITLE
doc: write improved documentation for nixosOptionsDoc

### DIFF
--- a/nixos/lib/make-options-doc/default.nix
+++ b/nixos/lib/make-options-doc/default.nix
@@ -1,20 +1,109 @@
-/* Generate JSON, XML and DocBook documentation for given NixOS options.
+/**
+  Generates documentation for nix modules.
 
-   Minimal example:
+  # Outputs
 
-    { pkgs,  }:
+  This function offers the following outputs
 
-    let
-      eval = import (pkgs.path + "/nixos/lib/eval-config.nix") {
-        baseModules = [
-          ../module.nix
-        ];
-        modules = [];
-      };
-    in pkgs.nixosOptionsDoc {
-      options = eval.options;
+  ## optionsCommonMark
+
+  Documentation in CommonMark text format.
+
+  ## optionsJSON
+
+  JSON format suitable for further automated processing.
+
+  `example.json`
+  ```json
+  {
+    ...
+    "fileSystems.<name>.options": {
+      "declarations": ["nixos/modules/tasks/filesystems.nix"],
+      "default": {
+        "_type": "literalExpression",
+        "text": "[\n  \"defaults\"\n]"
+      },
+      "description": "Options used to mount the file system.",
+      "example": {
+        "_type": "literalExpression",
+        "text": "[\n  \"data=journal\"\n]"
+      },
+      "loc": ["fileSystems", "<name>", "options"],
+      "readOnly": false,
+      "type": "non-empty (list of string (with check: non-empty))"
+    },
+    ...
+  }
+  ```
+
+  Overall the following fields are available per option:
+
+  ```
+  declarations
+  description
+  loc
+  readOnly
+  type
+  default
+  example
+  relatedPackages
+  ```
+
+  ## optionsDocBook
+
+  deprecated since 23.11 and will be removed in 24.05.
+
+  ## optionsAsciiDoc
+
+  Documentation rendered as AsciiDoc. This is useful for e.g. man pages.
+
+  > Note: NixOS uses this to build the man-pages available via `man configuration.nix` on every NixOS machine.
+
+  ## optionsNix
+
+  - Raw options as Nix attribute set, with the same schema as `optionsJSON`.
+
+  # Example
+
+  A minimal usage example requires evaluating the included modules.
+
+  ## Example: NixOS configuration
+
+  > Note:
+  >
+  > `/nixos/lib/eval-config.nix` takes care to evaluate a NixOS-configuration.
+
+  ```nix
+  let
+    eval = import (pkgs.path + "/nixos/lib/eval-config.nix") {
+      # Overriden explizitly here, this would include all modules from NixOS otherwise.
+      # See: docs of eval-config.nix for more details
+      baseModules = [];
+      modules = [
+        ./module.nix
+      ];
+    };
+  in
+    pkgs.nixosOptionsDoc {
+      inherit (eval) options;
     }
+  ```
 
+  ## Example: Nix modules
+
+  Nix modules don't always represent a NixOS configuration.
+  In that case you can use `lib.evalModules` to evaluate the modules.
+
+  ```nix
+  let
+    eval = lib.evalModules {
+      modules = [];
+    };
+  in
+    pkgs.nixosOptionsDoc {
+      inherit (eval) options;
+    }
+  ```
 */
 { pkgs
 , lib

--- a/nixos/lib/make-options-doc/default.nix
+++ b/nixos/lib/make-options-doc/default.nix
@@ -1,9 +1,11 @@
 /**
-  Generates documentation for nix modules.
+  Generates documentation for [nix modules](https://nix.dev/tutorials/module-system/module-system.html).
+
+  It uses the declared `options` to generate documentation in various formats.
 
   # Outputs
 
-  This function offers the following outputs
+  This function returns an attribute set with the following entries.
 
   ## optionsCommonMark
 
@@ -31,22 +33,10 @@
       "loc": ["fileSystems", "<name>", "options"],
       "readOnly": false,
       "type": "non-empty (list of string (with check: non-empty))"
+      "relatedPackages": "- [`pkgs.tmux`](\n    https://search.nixos.org/packages?show=tmux&sort=relevance&query=tmux\n  )\n",
     },
     ...
   }
-  ```
-
-  Overall the following fields are available per option:
-
-  ```
-  declarations
-  description
-  loc
-  readOnly
-  type
-  default
-  example
-  relatedPackages
   ```
 
   ## optionsDocBook
@@ -57,14 +47,13 @@
 
   Documentation rendered as AsciiDoc. This is useful for e.g. man pages.
 
-  > Note: NixOS uses this to build the man-pages available via `man configuration.nix` on every NixOS machine.
+  > Note: NixOS itself uses this ouput to to build the configuration.nix man page"
 
   ## optionsNix
 
   All options as a Nix attribute set value, with the same schema as `optionsJSON`.
 
   # Example
-
 
   ## Example: NixOS configuration
 
@@ -87,7 +76,7 @@
 
   ## Example: non-NixOS modules
 
-  `lib.evalModules` can also be used to evaluate non-NixOS modules.
+  `nixosOptionsDoc` can also be used to build documentation for non-NixOS modules.
 
   ```nix
   let

--- a/nixos/lib/make-options-doc/default.nix
+++ b/nixos/lib/make-options-doc/default.nix
@@ -11,7 +11,7 @@
 
   ## optionsJSON
 
-  JSON format suitable for further automated processing.
+  All options in a JSON format suitable for further automated processing.
 
   `example.json`
   ```json
@@ -61,22 +61,18 @@
 
   ## optionsNix
 
-  - Raw options as Nix attribute set, with the same schema as `optionsJSON`.
+  All options as a Nix attribute set value, with the same schema as `optionsJSON`.
 
   # Example
 
-  A minimal usage example requires evaluating the included modules.
 
   ## Example: NixOS configuration
 
-  > Note:
-  >
-  > `/nixos/lib/eval-config.nix` takes care to evaluate a NixOS-configuration.
-
   ```nix
   let
+    # Evaluate a NixOS configuration
     eval = import (pkgs.path + "/nixos/lib/eval-config.nix") {
-      # Overriden explizitly here, this would include all modules from NixOS otherwise.
+      # Overriden explicitly here, this would include all modules from NixOS otherwise.
       # See: docs of eval-config.nix for more details
       baseModules = [];
       modules = [
@@ -89,15 +85,16 @@
     }
   ```
 
-  ## Example: Nix modules
+  ## Example: non-NixOS modules
 
-  Nix modules don't always represent a NixOS configuration.
-  In that case you can use `lib.evalModules` to evaluate the modules.
+  `lib.evalModules` can also be used to evaluate non-NixOS modules.
 
   ```nix
   let
     eval = lib.evalModules {
-      modules = [];
+      modules = [
+        ./module.nix
+      ];
     };
   in
     pkgs.nixosOptionsDoc {


### PR DESCRIPTION
## Description of changes

Improves the previous documentation by extending explaining concepts and restructuring it. 


This already makes use of doc-comments, though there is no way (yet) to display it in the manual.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
