### PR TITLE
gauge: add plugin support

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -401,6 +401,10 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
   upgrade NetBox by changing `services.netbox.package`. Database migrations
   will be run automatically.
 
+- `gauge` now supports installing plugins using nix. For the old imperative approach, switch to `gauge-unwrapped`.
+  You can load plugins from an existing gauge manifest file using `gauge.fromManifest ./path/to/manifest.json` or
+  specify plugins in nix using `gauge.withPlugins (p: with p; [ js html-report xml-report ])`.
+
 - `firefox-devedition`, `firefox-beta`, `firefox-esr` executable file names for now match their package names, which is consistent with the `firefox-*-bin` packages. The desktop entries are also updated so that you can have multiple editions of firefox in your app launcher.
 
 - switch-to-configuration does not directly call systemd-tmpfiles anymore.

--- a/pkgs/development/tools/gauge/default.nix
+++ b/pkgs/development/tools/gauge/default.nix
@@ -4,6 +4,12 @@ buildGoModule rec {
   pname = "gauge";
   version = "1.6.6";
 
+  patches = [
+    # adds a check which adds an error message when trying to
+    # install plugins imperatively when using the wrapper
+    ./nix-check.patch
+  ];
+
   src = fetchFromGitHub {
     owner = "getgauge";
     repo = "gauge";

--- a/pkgs/development/tools/gauge/default.nix
+++ b/pkgs/development/tools/gauge/default.nix
@@ -26,6 +26,6 @@ buildGoModule rec {
     mainProgram = "gauge";
     homepage = "https://gauge.org";
     license = licenses.asl20;
-    maintainers = [ maintainers.vdemeester ];
+    maintainers = with maintainers; [ vdemeester marie ];
   };
 }

--- a/pkgs/development/tools/gauge/nix-check.patch
+++ b/pkgs/development/tools/gauge/nix-check.patch
@@ -1,0 +1,50 @@
+diff --git a/plugin/install/install.go b/plugin/install/install.go
+index 60c61550..d7573c2d 100644
+--- a/plugin/install/install.go
++++ b/plugin/install/install.go
+@@ -151,6 +151,7 @@ func isOSCompatible(zipfile string) bool {
+ 
+ // InstallPluginFromZipFile installs plugin from given zip file
+ func InstallPluginFromZipFile(zipFile string, pluginName string) InstallResult {
++	CheckForNixStore(fmt.Sprintf("Tried to install the plugin `%s`.", pluginName))
+ 	if !isPlatformIndependent(zipFile) && !isOSCompatible(zipFile) {
+ 		err := fmt.Errorf("provided plugin is not compatible with OS %s %s", runtime.GOOS, runtime.GOARCH)
+ 		return installError(err)
+@@ -314,6 +315,7 @@ func runPlatformCommands(commands platformSpecificCommand, workingDir string) er
+ // UninstallPlugin uninstall the given plugin of the given uninstallVersion
+ // If uninstallVersion is not specified, it uninstalls all the versions of given plugin
+ func UninstallPlugin(pluginName string, uninstallVersion string) {
++	CheckForNixStore(fmt.Sprintf("Tried to uninstall the plugin `%s`.", pluginName))
+ 	pluginsHome, err := common.GetPrimaryPluginsInstallDir()
+ 	if err != nil {
+ 		logger.Fatalf(true, "Failed to uninstall plugin %s. %s", pluginName, err.Error())
+@@ -518,6 +520,7 @@ func AllPlugins(silent, languageOnly bool) {
+ 
+ // UpdatePlugins updates all the currently installed plugins to its latest version
+ func UpdatePlugins(silent bool) {
++	CheckForNixStore("Tried to update plugins")
+ 	var failedPlugin []string
+ 	pluginInfos, err := pluginInfo.GetPluginsInfo()
+ 	if err != nil {
+@@ -673,3 +676,21 @@ func AddPluginToProject(pluginName string) error {
+ 	logger.Infof(true, "Plugin %s was successfully added to the project\n", pluginName)
+ 	return nil
+ }
++
++func CheckForNixStore(message string) error {
++	installDir, err := common.GetPrimaryPluginsInstallDir()
++	if err != nil {
++		return err
++	}
++	if strings.HasPrefix(installDir, "/nix/store") {
++
++		// check if we're installing in the sandbox
++		if os.Getenv("NIX_GAUGE_IN_SANDBOX") == "true" {
++			return nil
++		}
++		logger.Errorf(true, "%s\ngauge is installed with nix.\nPlease install plugins using nix or use the `gauge-unwrapped` package.", message)
++		os.Exit(1)
++
++	}
++	return nil
++}

--- a/pkgs/development/tools/gauge/plugins/default.nix
+++ b/pkgs/development/tools/gauge/plugins/default.nix
@@ -1,0 +1,6 @@
+{ lib, pkgs }:
+lib.makeScope pkgs.newScope (final: let
+  inherit (final) callPackage;
+in {
+  makeGaugePlugin = callPackage ./make-gauge-plugin.nix { };
+})

--- a/pkgs/development/tools/gauge/plugins/default.nix
+++ b/pkgs/development/tools/gauge/plugins/default.nix
@@ -6,4 +6,5 @@ in {
   dotnet = callPackage ./dotnet { };
   html-report = callPackage ./html-report { };
   java = callPackage ./java { };
+  ruby = callPackage ./ruby { };
 })

--- a/pkgs/development/tools/gauge/plugins/default.nix
+++ b/pkgs/development/tools/gauge/plugins/default.nix
@@ -9,4 +9,5 @@ in {
   js = callPackage ./js { };
   ruby = callPackage ./ruby { };
   go = callPackage ./go { };
+  screenshot = callPackage ./screenshot { };
 })

--- a/pkgs/development/tools/gauge/plugins/default.nix
+++ b/pkgs/development/tools/gauge/plugins/default.nix
@@ -8,4 +8,5 @@ in {
   java = callPackage ./java { };
   js = callPackage ./js { };
   ruby = callPackage ./ruby { };
+  go = callPackage ./go { };
 })

--- a/pkgs/development/tools/gauge/plugins/default.nix
+++ b/pkgs/development/tools/gauge/plugins/default.nix
@@ -6,5 +6,6 @@ in {
   dotnet = callPackage ./dotnet { };
   html-report = callPackage ./html-report { };
   java = callPackage ./java { };
+  js = callPackage ./js { };
   ruby = callPackage ./ruby { };
 })

--- a/pkgs/development/tools/gauge/plugins/default.nix
+++ b/pkgs/development/tools/gauge/plugins/default.nix
@@ -3,5 +3,6 @@ lib.makeScope pkgs.newScope (final: let
   inherit (final) callPackage;
 in {
   makeGaugePlugin = callPackage ./make-gauge-plugin.nix { };
+  html-report = callPackage ./html-report { };
   java = callPackage ./java { };
 })

--- a/pkgs/development/tools/gauge/plugins/default.nix
+++ b/pkgs/development/tools/gauge/plugins/default.nix
@@ -10,4 +10,5 @@ in {
   ruby = callPackage ./ruby { };
   go = callPackage ./go { };
   screenshot = callPackage ./screenshot { };
+  xml-report = callPackage ./xml-report { };
 })

--- a/pkgs/development/tools/gauge/plugins/default.nix
+++ b/pkgs/development/tools/gauge/plugins/default.nix
@@ -3,6 +3,7 @@ lib.makeScope pkgs.newScope (final: let
   inherit (final) callPackage;
 in {
   makeGaugePlugin = callPackage ./make-gauge-plugin.nix { };
+  dotnet = callPackage ./dotnet { };
   html-report = callPackage ./html-report { };
   java = callPackage ./java { };
 })

--- a/pkgs/development/tools/gauge/plugins/default.nix
+++ b/pkgs/development/tools/gauge/plugins/default.nix
@@ -3,4 +3,5 @@ lib.makeScope pkgs.newScope (final: let
   inherit (final) callPackage;
 in {
   makeGaugePlugin = callPackage ./make-gauge-plugin.nix { };
+  java = callPackage ./java { };
 })

--- a/pkgs/development/tools/gauge/plugins/dotnet/data.json
+++ b/pkgs/development/tools/gauge/plugins/dotnet/data.json
@@ -1,0 +1,5 @@
+{
+  "version": "0.5.7",
+  "url": "https://github.com/getgauge/gauge-dotnet/releases/download/v0.5.7/gauge-dotnet-0.5.7.zip",
+  "hash": "sha256-VKs25WzS0UZAeCg91f/f6ZOGH28PulUvyDSc/dbJeoE="
+}

--- a/pkgs/development/tools/gauge/plugins/dotnet/default.nix
+++ b/pkgs/development/tools/gauge/plugins/dotnet/default.nix
@@ -1,0 +1,22 @@
+{ lib
+, makeGaugePlugin
+, gauge-unwrapped
+}:
+
+makeGaugePlugin {
+  pname = "dotnet";
+  data = lib.importJSON ./data.json;
+
+  repo = "getgauge/gauge-dotnet";
+  releasePrefix = "gauge-dotnet-";
+  isCrossArch = true;
+
+  meta = {
+    description = "Gauge plugin that lets you write tests in C#";
+    homepage = "https://github.com/getgauge/gauge-dotnet/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ marie ];
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    inherit (gauge-unwrapped.meta) platforms;
+  };
+}

--- a/pkgs/development/tools/gauge/plugins/go/data.json
+++ b/pkgs/development/tools/gauge/plugins/go/data.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.4.0",
+  "aarch64-darwin": {
+    "url": "https://github.com/getgauge-contrib/gauge-go/releases/download/v0.4.0/gauge-go-0.4.0-darwin.arm64.zip",
+    "hash": "sha256-tMo3+gQPnldCARm0WB7UYSMwaVpz90N2BiTzmvIFTg0="
+  },
+  "x86_64-darwin": {
+    "url": "https://github.com/getgauge-contrib/gauge-go/releases/download/v0.4.0/gauge-go-0.4.0-darwin.x86_64.zip",
+    "hash": "sha256-zfrEDRyflvvp4Hf2+42RL+5ooY0iBU0bkO2caOAGp74="
+  },
+  "x86_64-linux": {
+    "url": "https://github.com/getgauge-contrib/gauge-go/releases/download/v0.4.0/gauge-go-0.4.0-linux.x86_64.zip",
+    "hash": "sha256-JEHjk51vYCFAcj9xant2vBU3BZI0krYbfZk9ALjdIs0="
+  }
+}

--- a/pkgs/development/tools/gauge/plugins/go/default.nix
+++ b/pkgs/development/tools/gauge/plugins/go/default.nix
@@ -1,0 +1,19 @@
+{ lib
+, makeGaugePlugin
+}:
+makeGaugePlugin {
+  pname = "go";
+  data = lib.importJSON ./data.json;
+
+  repo = "getgauge-contrib/gauge-go";
+  releasePrefix = "gauge-go-";
+
+  meta = {
+    description = "Gauge plugin that lets you write tests in Go";
+    homepage = "https://github.com/getgauge-contrib/gauge-go";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ marie ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = [ "aarch64-darwin" "x86_64-darwin" "x86_64-linux" ];
+  };
+}

--- a/pkgs/development/tools/gauge/plugins/html-report/data.json
+++ b/pkgs/development/tools/gauge/plugins/html-report/data.json
@@ -1,0 +1,19 @@
+{
+  "version": "4.3.1",
+  "aarch64-darwin": {
+    "url": "https://github.com/getgauge/html-report/releases/download/v4.3.1/html-report-4.3.1-darwin.arm64.zip",
+    "hash": "sha256-OovQxwi4NGrdbKYGfMLgqQ9BuT1gvl7NFu5aTrA2HWw="
+  },
+  "x86_64-darwin": {
+    "url": "https://github.com/getgauge/html-report/releases/download/v4.3.1/html-report-4.3.1-darwin.x86_64.zip",
+    "hash": "sha256-oOJE3VJH8Cwbvdc2kTs0dHjNb2r35tXTP18EAts6XYs="
+  },
+  "aarch64-linux": {
+    "url": "https://github.com/getgauge/html-report/releases/download/v4.3.1/html-report-4.3.1-linux.arm64.zip",
+    "hash": "sha256-ZhNPGKuB08V/fxJCOya/uHUNlVT223WEPX6BrOhxPc8="
+  },
+  "x86_64-linux": {
+    "url": "https://github.com/getgauge/html-report/releases/download/v4.3.1/html-report-4.3.1-linux.x86_64.zip",
+    "hash": "sha256-insNiAbJM5Xc/GY6UTgMJgYU6vnBzKC13aBlgq3GBpo="
+  }
+}

--- a/pkgs/development/tools/gauge/plugins/html-report/default.nix
+++ b/pkgs/development/tools/gauge/plugins/html-report/default.nix
@@ -1,0 +1,19 @@
+{ lib
+, makeGaugePlugin
+}:
+makeGaugePlugin {
+  pname = "html-report";
+  data = lib.importJSON ./data.json;
+
+  repo = "getgauge/html-report";
+  releasePrefix = "html-report-";
+
+  meta = {
+    description = "HTML report generation plugin for Gauge";
+    homepage = "https://github.com/getgauge/html-report/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ marie ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = [ "aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/development/tools/gauge/plugins/java/data.json
+++ b/pkgs/development/tools/gauge/plugins/java/data.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.10.3",
+  "aarch64-darwin": {
+    "url": "https://github.com/getgauge/gauge-java/releases/download/v0.10.3/gauge-java-0.10.3-darwin.arm64.zip",
+    "hash": "sha256-Hs9ZNupj0s7YRjRZibphr7m5YjOj3MTgx/hqAbWyY6I="
+  },
+  "x86_64-darwin": {
+    "url": "https://github.com/getgauge/gauge-java/releases/download/v0.10.3/gauge-java-0.10.3-darwin.x86_64.zip",
+    "hash": "sha256-Hj/Lkwsx/RvyMiJO8dI6vFpIvvyhOA2Un5deC1syYY4="
+  },
+  "aarch64-linux": {
+    "url": "https://github.com/getgauge/gauge-java/releases/download/v0.10.3/gauge-java-0.10.3-linux.arm64.zip",
+    "hash": "sha256-XJqP2eew+aI1jFaDzsJhfML8Ft+adFJrHURF8F391Pc="
+  },
+  "x86_64-linux": {
+    "url": "https://github.com/getgauge/gauge-java/releases/download/v0.10.3/gauge-java-0.10.3-linux.x86_64.zip",
+    "hash": "sha256-sMyWhAGo6oa7MsqK8xApdrwhZo8NkSTIRbsCu5LW3ls="
+  }
+}

--- a/pkgs/development/tools/gauge/plugins/java/default.nix
+++ b/pkgs/development/tools/gauge/plugins/java/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, makeGaugePlugin
+}:
+makeGaugePlugin {
+  pname = "java";
+  data = lib.importJSON ./data.json;
+
+  repo = "getgauge/gauge-java";
+  releasePrefix = "gauge-java-";
+
+  meta = {
+    description = "Gauge plugin that lets you write tests in Java";
+    homepage = "https://github.com/getgauge/gauge-java/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ marie ];
+    sourceProvenance = with lib.sourceTypes; [
+      # Native binary written in go
+      binaryNativeCode
+      # Jar files
+      binaryBytecode
+    ];
+    platforms = [ "aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/development/tools/gauge/plugins/js/default.nix
+++ b/pkgs/development/tools/gauge/plugins/js/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, nodejs
+, buildNpmPackage
+, fetchFromGitHub
+, unzip
+, gauge-unwrapped
+}:
+buildNpmPackage rec {
+  pname = "gauge-plugin-js";
+  version = "4.0.1";
+
+  src = fetchFromGitHub {
+    owner = "getgauge";
+    repo = "gauge-js";
+    rev = "v${version}";
+    hash = "sha256-qCn4EKndd0eM3X0+aLrCwvmEG5fgUfpVm76cg/n7B84=";
+    fetchSubmodules = true;
+  };
+
+  npmDepsHash = "sha256-5XkFwCFqNMe5xc/Tx69uUV7KMtgY7Z3zE7hbtxYqRf0=";
+  npmBuildScript = "package";
+
+  buildInputs = [ nodejs ];
+  nativeBuildInputs = [ unzip ];
+
+  postPatch = ''
+    patchShebangs index.js
+  '';
+
+  installPhase = ''
+    mkdir -p $out/share/gauge-plugins/js/${version}
+    unzip deploy/gauge-js-${version}.zip -d $out/share/gauge-plugins/js/${version}
+  '';
+
+  meta = {
+    description = "Gauge plugin that lets you write tests in JavaScript";
+    homepage = "https://github.com/getgauge/gauge-js/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ marie ];
+    inherit (gauge-unwrapped.meta) platforms;
+  };
+}

--- a/pkgs/development/tools/gauge/plugins/make-gauge-plugin.nix
+++ b/pkgs/development/tools/gauge/plugins/make-gauge-plugin.nix
@@ -1,0 +1,94 @@
+{ stdenvNoCC
+, fetchzip
+, lib
+, writeScript
+}:
+
+{ pname
+, data
+, repo
+, releasePrefix
+, isCrossArch ? false
+, meta
+, ...
+} @ args:
+let
+  otherArgs = lib.attrsets.removeAttrs args [ "pname" "data" "repo" "releasePrefix" "isMultiArch" ];
+  inherit (stdenvNoCC.hostPlatform) system;
+  inherit (if isCrossArch then data else data.${system}) url hash;
+  # Upstream uses a different naming scheme for platforms
+  systemMap = {
+    "x86_64-darwin" = "darwin.x86_64";
+    "aarch64-darwin" = "darwin.arm64";
+    "aarch64-linux" = "linux.arm64";
+    "x86_64-linux" = "linux.x86_64";
+  };
+in
+stdenvNoCC.mkDerivation (finalAttrs: (lib.recursiveUpdate {
+  pname = "gauge-plugin-${pname}";
+  inherit (data) version;
+
+  src = fetchzip {
+    inherit url hash;
+    stripRoot = false;
+  };
+
+  installPhase = ''
+    mkdir -p "$out/share/gauge-plugins/${pname}/${finalAttrs.version}"
+    cp -r . "$out/share/gauge-plugins/${pname}/${finalAttrs.version}"
+  '';
+
+  passthru.updateScript = writeScript "update-${finalAttrs.pname}" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl nix-prefetch yq-go
+
+    set -e
+
+    dirname="pkgs/development/tools/gauge/plugins/${pname}"
+
+    currentVersion=$(nix eval --raw -f default.nix gaugePlugins.${pname}.version)
+
+    latestTag=$(curl -s ''${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} https://api.github.com/repos/${repo}/releases/latest | yq ".tag_name")
+    latestVersion="$(expr $latestTag : 'v\(.*\)')"
+
+    tempfile=$(mktemp)
+
+    if [[ "$FORCE_UPDATE" != "true" && "$currentVersion" == "$latestVersion" ]]; then
+        echo "gauge-${pname} is up-to-date: ''${currentVersion}"
+        exit 0
+    fi
+
+    yq -iPoj "{ \"version\": \"$latestVersion\" }" "$tempfile"
+
+    updateSystem() {
+        system=$1
+        url=$2
+
+        echo "Fetching hash for $system"
+        hash=$(nix-prefetch-url --type sha256 $url --unpack)
+        sriHash="$(nix hash to-sri --type sha256 $hash)"
+
+        yq -iPoj '. + { "$system": { "url": "$url", "hash": "$sriHash" } }' "$tempfile"
+    }
+
+    updateSingle() {
+        url=$1
+
+        echo "Fetching hash"
+        hash=$(nix-prefetch-url --type sha256 $url --unpack)
+        sriHash="$(nix hash to-sri --type sha256 $hash)"
+
+        yq -iPoj '. + { "url": "$url", "hash": "$sriHash" }' "$tempfile"
+    }
+
+    baseUrl="https://github.com/${repo}/releases/download/$latestTag/${releasePrefix}$latestVersion"
+
+    ${if isCrossArch then
+        "updateSingle \${baseUrl}.zip"
+      else
+        lib.concatStringsSep "\n" (map (platform: ''updateSystem "${platform}" "''${baseUrl}-${systemMap.${platform}}.zip"'') meta.platforms)
+    }
+
+    mv "$tempfile" "$dirname/data.json"
+  '';
+} otherArgs))

--- a/pkgs/development/tools/gauge/plugins/ruby/data.json
+++ b/pkgs/development/tools/gauge/plugins/ruby/data.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.8.0",
+  "aarch64-darwin": {
+    "url": "https://github.com/getgauge/gauge-ruby/releases/download/v0.8.0/gauge-ruby-0.8.0-darwin.arm64.zip",
+    "hash": "sha256-HQ7reuC7dQUMbhEzUBiEelPmFBsFJBHe42lmFufkZJY="
+  },
+  "x86_64-darwin": {
+    "url": "https://github.com/getgauge/gauge-ruby/releases/download/v0.8.0/gauge-ruby-0.8.0-darwin.x86_64.zip",
+    "hash": "sha256-poxT9wYgs21GRx/eVvD7jA1T0VBDEHgH0Zv941pZcKA="
+  },
+  "aarch64-linux": {
+    "url": "https://github.com/getgauge/gauge-ruby/releases/download/v0.8.0/gauge-ruby-0.8.0-linux.arm64.zip",
+    "hash": "sha256-SAEHPaWScux6C05jQBfDuLBN2J22Df9eKVM46kWawiU="
+  },
+  "x86_64-linux": {
+    "url": "https://github.com/getgauge/gauge-ruby/releases/download/v0.8.0/gauge-ruby-0.8.0-linux.x86_64.zip",
+    "hash": "sha256-aXLDK/7phdsX0CmIuxfK39mdrjGo2IpwYBL7uolP5Mk="
+  }
+}

--- a/pkgs/development/tools/gauge/plugins/ruby/default.nix
+++ b/pkgs/development/tools/gauge/plugins/ruby/default.nix
@@ -1,0 +1,19 @@
+{ lib
+, makeGaugePlugin
+}:
+makeGaugePlugin {
+  pname = "ruby";
+  data = lib.importJSON ./data.json;
+
+  repo = "getgauge/gauge-ruby";
+  releasePrefix = "gauge-ruby-";
+
+  meta = {
+    description = "Gauge plugin that lets you write tests in Ruby";
+    homepage = "https://github.com/getgauge/gauge-ruby/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ marie ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [ "aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/development/tools/gauge/plugins/screenshot/data.json
+++ b/pkgs/development/tools/gauge/plugins/screenshot/data.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.2.0",
+  "x86_64-darwin": {
+    "url": "https://github.com/getgauge/gauge_screenshot/releases/download/v0.2.0/screenshot-0.2.0-darwin.x86_64.zip",
+    "hash": "sha256-7bFuInEYAQ+fN12HTazQNfqpz5DAkYNCjUJbaj0DYb4="
+  },
+  "aarch64-darwin": {
+    "url": "https://github.com/getgauge/gauge_screenshot/releases/download/v0.2.0/screenshot-0.2.0-darwin.arm64.zip",
+    "hash": "sha256-Ly6iHBc2PfeFkKkZIkyD2JD5+EpFNL4SDjzG1oMpKfA="
+  },
+  "aarch64-linux": {
+    "url": "https://github.com/getgauge/gauge_screenshot/releases/download/v0.2.0/screenshot-0.2.0-linux.arm64.zip",
+    "hash": "sha256-Pzfnhs4H0MmeBIhrZElFmvC+PuabLNU/pftVdIu4+LI="
+  },
+  "x86_64-linux": {
+    "url": "https://github.com/getgauge/gauge_screenshot/releases/download/v0.2.0/screenshot-0.2.0-linux.x86_64.zip",
+    "hash": "sha256-Wpuq3aSgbIhd4WuJx4SMv+NbEZMVIpAOUMdKV2xxd7c="
+  }
+}

--- a/pkgs/development/tools/gauge/plugins/screenshot/default.nix
+++ b/pkgs/development/tools/gauge/plugins/screenshot/default.nix
@@ -1,0 +1,19 @@
+{ lib
+, makeGaugePlugin
+}:
+makeGaugePlugin {
+  pname = "screenshot";
+  data = lib.importJSON ./data.json;
+
+  repo = "getgauge/gauge_screenshot";
+  releasePrefix = "screenshot-";
+
+  meta = {
+    description = "Gauge plugin to take screenshots";
+    homepage = "https://github.com/getgauge/gauge_screenshot/";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ marie ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [ "x86_64-darwin" "aarch64-darwin" "aarch64-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/development/tools/gauge/plugins/xml-report/data.json
+++ b/pkgs/development/tools/gauge/plugins/xml-report/data.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.5.1",
+  "x86_64-darwin": {
+    "url": "https://github.com/getgauge/xml-report/releases/download/v0.5.1/xml-report-0.5.1-darwin.x86_64.zip",
+    "hash": "sha256-xLz9GFeXeZcLXa5P7DeiBljK3n7HKvsm/eJFEw5w+hU="
+  },
+  "aarch64-darwin": {
+    "url": "https://github.com/getgauge/xml-report/releases/download/v0.5.1/xml-report-0.5.1-darwin.arm64.zip",
+    "hash": "sha256-P8nqS22OibtAOpbn8G8WwfJ0vvAM/3IC6F0Nd/HfO5s="
+  },
+  "aarch64-linux": {
+    "url": "https://github.com/getgauge/xml-report/releases/download/v0.5.1/xml-report-0.5.1-linux.arm64.zip",
+    "hash": "sha256-ORMWXiahT8TAusqIPQSZm5t5r3p5jqLAKNghYw+tOYI="
+  },
+  "x86_64-linux": {
+    "url": "https://github.com/getgauge/xml-report/releases/download/v0.5.1/xml-report-0.5.1-linux.x86_64.zip",
+    "hash": "sha256-y0vpS09GlRKKPr7UwY+YAR8xwjQYnYf6TFkeT3SXwco="
+  }
+}

--- a/pkgs/development/tools/gauge/plugins/xml-report/default.nix
+++ b/pkgs/development/tools/gauge/plugins/xml-report/default.nix
@@ -1,0 +1,19 @@
+{ lib
+, makeGaugePlugin
+}:
+makeGaugePlugin {
+  pname = "xml-report";
+  data = lib.importJSON ./data.json;
+
+  repo = "getgauge/xml-report";
+  releasePrefix = "xml-report-";
+
+  meta = {
+    description = "XML report generation plugin for Gauge";
+    homepage = "https://github.com/getgauge/xml-report/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ marie ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = [ "x86_64-darwin" "aarch64-darwin" "aarch64-linux" "x86_64-linux" ];
+  };
+}

--- a/pkgs/development/tools/gauge/wrapper.nix
+++ b/pkgs/development/tools/gauge/wrapper.nix
@@ -1,0 +1,48 @@
+{ gauge-unwrapped
+, makeWrapper
+, stdenvNoCC
+, lib
+, xorg
+, gaugePlugins
+, plugins ? []
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "gauge-wrapped";
+  inherit (gauge-unwrapped) version;
+
+  dontUnpack = true;
+
+  installPhase = ''
+    mkdir -p $out{bin,/share/gauge/{plugins,config}}
+    export NIX_GAUGE_IN_SANDBOX=true
+    export GAUGE_HOME=$(mktemp -d)
+
+    # run gauge to create config files
+    cd $(mktemp -d)
+    gauge init js || true
+
+    mkdir -p "$out/share/gauge/config"
+    mv "$GAUGE_HOME"/config/{gauge,template}.properties "$out/share/gauge/config"
+
+    export GAUGE_HOME="$out/share/gauge"
+
+    ${lib.concatMapStringsSep "\n" (plugin: ''
+      for plugin in "$(ls ${plugin}/share/gauge-plugins)"; do
+        echo Installing gauge plugin $plugin
+        mkdir -p "$GAUGE_HOME/plugins/$plugin"
+        # Use lndir here
+        # gauge checks for a directory, which fails if it's a symlink
+        # It's easier to link this with lndir, than patching an upstream dependency
+        lndir "${plugin}/share/gauge-plugins/$plugin" "$GAUGE_HOME/plugins/$plugin"
+      done
+    '') plugins}
+
+    makeWrapper ${gauge-unwrapped}/bin/gauge $out/bin/gauge \
+      --set GAUGE_HOME "$GAUGE_HOME"
+  '';
+
+  nativeBuildInputs = [ gauge-unwrapped makeWrapper xorg.lndir ];
+
+  inherit (gauge-unwrapped) meta;
+}

--- a/pkgs/development/tools/gauge/wrapper.nix
+++ b/pkgs/development/tools/gauge/wrapper.nix
@@ -45,7 +45,15 @@ stdenvNoCC.mkDerivation {
 
   nativeBuildInputs = [ gauge-unwrapped makeWrapper xorg.lndir ];
 
-  passthru.withPlugins = f: gauge.override { plugins = f gaugePlugins; };
+  passthru = {
+    withPlugins = f: gauge.override { plugins = f gaugePlugins; };
+    fromManifest = path:
+      let
+        manifest = lib.importJSON path;
+        requiredPlugins = with manifest; [ Language ] ++ Plugins;
+        manifestPlugins = plugins: map (name: plugins.${name} or (throw "Gauge plugin ${name} is not available!")) requiredPlugins;
+      in gauge.withPlugins manifestPlugins;
+  };
 
   inherit (gauge-unwrapped) meta;
 }

--- a/pkgs/development/tools/gauge/wrapper.nix
+++ b/pkgs/development/tools/gauge/wrapper.nix
@@ -1,4 +1,5 @@
 { gauge-unwrapped
+, gauge
 , makeWrapper
 , stdenvNoCC
 , lib
@@ -43,6 +44,8 @@ stdenvNoCC.mkDerivation {
   '';
 
   nativeBuildInputs = [ gauge-unwrapped makeWrapper xorg.lndir ];
+
+  passthru.withPlugins = f: gauge.override { plugins = f gaugePlugins; };
 
   inherit (gauge-unwrapped) meta;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8339,6 +8339,7 @@ with pkgs;
   gau = callPackage ../tools/security/gau { };
 
   gauge = callPackage ../development/tools/gauge { };
+  gaugePlugins = recurseIntoAttrs (callPackage ../development/tools/gauge/plugins {});
 
   gawd = python3Packages.toPythonApplication python3Packages.gawd;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8338,7 +8338,8 @@ with pkgs;
 
   gau = callPackage ../tools/security/gau { };
 
-  gauge = callPackage ../development/tools/gauge { };
+  gauge-unwrapped = callPackage ../development/tools/gauge { };
+  gauge = callPackage ../development/tools/gauge/wrapper.nix { };
   gaugePlugins = recurseIntoAttrs (callPackage ../development/tools/gauge/plugins {});
 
   gawd = python3Packages.toPythonApplication python3Packages.gawd;


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds nix managed plugin support to gauge.

Allows to get a gauge with installed plugins using `gauge.withPlugins (p: with p; [ js html-report ])`
Also allows reading plugins from a gauge manifest.json file: `gauge.fromManifest ./manifest.json`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
