### PR TITLE
looking-glass-client: B6 -> B7-rc1

### DIFF
--- a/pkgs/applications/virtualization/looking-glass-client/0001-client-cmake-move-X11-config-directives-to-displayse.patch
+++ b/pkgs/applications/virtualization/looking-glass-client/0001-client-cmake-move-X11-config-directives-to-displayse.patch
@@ -1,0 +1,57 @@
+From: Geoffrey McRae <geoff@hostfission.com>
+Date: Wed, 13 Mar 2024 11:17:25 +1100
+Subject: [PATCH] [client] cmake: move X11 config directives to
+ `displayservers`
+
+---
+ client/CMakeLists.txt                | 7 -------
+ client/displayservers/CMakeLists.txt | 7 +++++++
+ 2 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git client/CMakeLists.txt client/CMakeLists.txt
+index 3755adcf..eeeb3eb0 100644
+--- client/CMakeLists.txt
++++ client/CMakeLists.txt
+@@ -42,19 +42,12 @@ add_feature_info(ENABLE_ASAN ENABLE_ASAN "AddressSanitizer support.")
+ option(ENABLE_UBSAN "Build with UndefinedBehaviorSanitizer" OFF)
+ add_feature_info(ENABLE_UBSAN ENABLE_UBSAN "UndefinedBehaviorSanitizer support.")
+
+-option(ENABLE_X11 "Build with X11 support" ON)
+-add_feature_info(ENABLE_X11 ENABLE_X11 "X11 support.")
+-
+ option(ENABLE_PIPEWIRE "Build with PipeWire audio output support" ON)
+ add_feature_info(ENABLE_PIPEWIRE ENABLE_PIPEWIRE "PipeWire audio support.")
+
+ option(ENABLE_PULSEAUDIO "Build with PulseAudio audio output support" ON)
+ add_feature_info(ENABLE_PULSEAUDIO ENABLE_PULSEAUDIO "PulseAudio audio support.")
+
+-if (NOT ENABLE_X11 AND NOT ENABLE_WAYLAND)
+-  message(FATAL_ERROR "Either ENABLE_X11 or ENABLE_WAYLAND must be on")
+-endif()
+-
+ add_compile_options(
+   "-Wall"
+   "-Wextra"
+diff --git client/displayservers/CMakeLists.txt client/displayservers/CMakeLists.txt
+index 5b5f827a..e7c4b25a 100644
+--- client/displayservers/CMakeLists.txt
++++ client/displayservers/CMakeLists.txt
+@@ -18,9 +18,16 @@ function(add_displayserver name)
+   add_subdirectory(${name})
+ endfunction()
+
++option(ENABLE_X11 "Build with X11 support" ON)
++add_feature_info(ENABLE_X11 ENABLE_X11 "X11 support.")
++
+ option(ENABLE_WAYLAND "Build with Wayland support" ON)
+ add_feature_info(ENABLE_WAYLAND ENABLE_WAYLAND "Wayland support.")
+
++if (NOT ENABLE_X11 AND NOT ENABLE_WAYLAND)
++  message(FATAL_ERROR "Either ENABLE_X11 or ENABLE_WAYLAND must be on")
++endif()
++
+ # Add/remove displayservers here!
+ if (ENABLE_WAYLAND)
+   add_displayserver(Wayland)
+--
+2.43.1

--- a/pkgs/applications/virtualization/looking-glass-client/default.nix
+++ b/pkgs/applications/virtualization/looking-glass-client/default.nix
@@ -31,7 +31,7 @@
 , pulseaudio
 , libsamplerate
 
-, openGLSupport ? false
+, openGLSupport ? true
 , xorgSupport ? true
 , waylandSupport ? true
 , pipewireSupport ? true

--- a/pkgs/applications/virtualization/looking-glass-client/default.nix
+++ b/pkgs/applications/virtualization/looking-glass-client/default.nix
@@ -59,10 +59,15 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  patches = [
+    # Fix failing cmake assertion when disabling X11 whithout explicitly enabling Wayland.
+    ./0001-client-cmake-move-X11-config-directives-to-displayse.patch
+  ];
+
   nativeBuildInputs = [ cmake pkg-config ];
 
-  buildInputs = [ libGL freefont_ttf spice-protocol expat libbfd nettle fontconfig libffi ]
-    ++ lib.optionals xorgSupport [ libX11 libxkbcommon libXi libXScrnSaver libXinerama libXcursor libXpresent libXext libXrandr libXdmcp ]
+  buildInputs = [ libX11 libGL freefont_ttf spice-protocol expat libbfd nettle fontconfig libffi ]
+    ++ lib.optionals xorgSupport [ libxkbcommon libXi libXScrnSaver libXinerama libXcursor libXpresent libXext libXrandr libXdmcp ]
     ++ lib.optionals waylandSupport [ libxkbcommon wayland wayland-protocols ]
     ++ lib.optionals pipewireSupport [ pipewire libsamplerate ]
     ++ lib.optionals pulseSupport [ pulseaudio libsamplerate ];
@@ -71,7 +76,6 @@ stdenv.mkDerivation rec {
     ++ lib.optionals (!openGLSupport) [ "-DENABLE_OPENGL=no" ]
     ++ lib.optionals (!xorgSupport) [ "-DENABLE_X11=no" ]
     ++ lib.optionals (!waylandSupport) [ "-DENABLE_WAYLAND=no" ]
-    ++ lib.optionals (waylandSupport) [ "-DENABLE_WAYLAND=yes" ]
     ++ lib.optionals (!pulseSupport) [ "-DENABLE_PULSEAUDIO=no" ]
     ++ lib.optionals (!pipewireSupport) [ "-DENABLE_PIPEWIRE=no" ];
 

--- a/pkgs/applications/virtualization/looking-glass-client/default.nix
+++ b/pkgs/applications/virtualization/looking-glass-client/default.nix
@@ -22,6 +22,7 @@
 , libXinerama
 , libXcursor
 , libXpresent
+, libXdmcp
 
 , wayland
 , wayland-protocols
@@ -30,6 +31,7 @@
 , pulseaudio
 , libsamplerate
 
+, openGLSupport ? false
 , xorgSupport ? true
 , waylandSupport ? true
 , pipewireSupport ? true
@@ -43,35 +45,35 @@ let
     type = "Application";
     exec = "looking-glass-client";
     icon = "lg-logo";
-    terminal = true;
   };
 in
 stdenv.mkDerivation rec {
   pname = "looking-glass-client";
-  version = "B6";
+  version = "B7-rc1";
 
   src = fetchFromGitHub {
     owner = "gnif";
     repo = "LookingGlass";
     rev = version;
-    sha256 = "sha256-6vYbNmNJBCoU23nVculac24tHqH7F4AZVftIjL93WJU=";
+    sha256 = "sha256-ne1Q+67+P8RHcTsqdiSSwkFf0g3pSNT91WN/lsSzssU=";
     fetchSubmodules = true;
   };
 
   nativeBuildInputs = [ cmake pkg-config ];
 
-  buildInputs = [ libGL libX11 freefont_ttf spice-protocol expat libbfd nettle fontconfig libffi ]
-    ++ lib.optionals xorgSupport [ libxkbcommon libXi libXScrnSaver libXinerama libXcursor libXpresent libXext libXrandr ]
+  buildInputs = [ libGL freefont_ttf spice-protocol expat libbfd nettle fontconfig libffi ]
+    ++ lib.optionals xorgSupport [ libX11 libxkbcommon libXi libXScrnSaver libXinerama libXcursor libXpresent libXext libXrandr libXdmcp ]
     ++ lib.optionals waylandSupport [ libxkbcommon wayland wayland-protocols ]
     ++ lib.optionals pipewireSupport [ pipewire libsamplerate ]
     ++ lib.optionals pulseSupport [ pulseaudio libsamplerate ];
 
   cmakeFlags = [ "-DOPTIMIZE_FOR_NATIVE=OFF" ]
-    ++ lib.optional (!xorgSupport) "-DENABLE_X11=no"
-    ++ lib.optional (!waylandSupport) "-DENABLE_WAYLAND=no"
-    ++ lib.optional (!pulseSupport) "-DENABLE_PULSEAUDIO=no"
-    ++ lib.optional (!pipewireSupport) "-DENABLE_PIPEWIRE=no";
-
+    ++ lib.optionals (!openGLSupport) [ "-DENABLE_OPENGL=no" ]
+    ++ lib.optionals (!xorgSupport) [ "-DENABLE_X11=no" ]
+    ++ lib.optionals (!waylandSupport) [ "-DENABLE_WAYLAND=no" ]
+    ++ lib.optionals (waylandSupport) [ "-DENABLE_WAYLAND=yes" ]
+    ++ lib.optionals (!pulseSupport) [ "-DENABLE_PULSEAUDIO=no" ]
+    ++ lib.optionals (!pipewireSupport) [ "-DENABLE_PIPEWIRE=no" ];
 
   postUnpack = ''
     echo ${src.rev} > source/VERSION


### PR DESCRIPTION
## Description of changes

- updated to https://github.com/gnif/LookingGlass/releases/tag/B7-rc1
- added build option for the legacy opengl rendere ~~and disabled it by default~~
- fixed wayland only build
- replaced usages of lib.optional with lib.optionals
- removed `terminal=true` from the desktop entry which prevented it from beeing launched from an application launcher (tested with wofi) 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
