### PR TITLE
tectonic: --inherit-argv0 in the wrapper

### DIFF
--- a/pkgs/tools/typesetting/tectonic/tests.nix
+++ b/pkgs/tools/typesetting/tectonic/tests.nix
@@ -90,4 +90,10 @@ lib.mapAttrs networkRequiringTestPkg {
     tectonic -X new
     cat Tectonic.toml | grep "${tectonic.bundleUrl}"
   '';
+
+  /** test that the `nextonic -> tectonic` symlink is working as intended */
+  nextonic = ''
+    nextonic new 2>&1 \
+      | grep '"version 2" Tectonic command-line interface activated'
+  '';
 }

--- a/pkgs/tools/typesetting/tectonic/wrapper.nix
+++ b/pkgs/tools/typesetting/tectonic/wrapper.nix
@@ -46,7 +46,8 @@ symlinkJoin {
   + ''
     makeWrapper ${lib.getBin tectonic-unwrapped}/bin/tectonic $out/bin/tectonic \
       --prefix PATH : "${lib.getBin biber-for-tectonic}/bin" \
-      --add-flags "--web-bundle ${tectonic.passthru.bundleUrl}"
+      --add-flags "--web-bundle ${tectonic.passthru.bundleUrl}" \
+      --inherit-argv0 ## make sure binary name e.g. `nextonic` is passed along
     ln -s $out/bin/tectonic $out/bin/nextonic
   '';
 


### PR DESCRIPTION
## Description of changes

The `nextonic` symlink was not working as intended because our tectonic wrapper did not correctly pass along the executable name. This is fixed by adding --inherit-argv0 to `makeWrapper`.

A test is also added to prevent breakage in the future.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux https://github.com/bryango/nix-build-action/actions/runs/8250021922/job/22563750891
  - [x] aarch64-linux https://github.com/bryango/nix-build-action/actions/runs/8250021914/job/22563750951
  - [x] x86_64-darwin https://github.com/bryango/nix-build-action/actions/runs/8250021922/job/22563751288
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
