### PR TITLE
lib.options.filterOptions

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -145,7 +145,7 @@ let
       scrubOptionValue literalExpression literalExample
       showOption showOptionWithDefLocs showFiles
       unknownModule mkOption mkPackageOption mkPackageOptionMD
-      mdDoc literalMD;
+      mdDoc literalMD filterOptions;
     inherit (self.types) isType setType defaultTypeMerge defaultFunctor
       isOptionType mkOptionType;
     inherit (self.asserts)

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -2154,4 +2154,53 @@ runTests {
     };
     expected = "c";
   };
+
+  testFilterOptionsEmpty = {
+    expr = filterOptions (p: o: true) {};
+    expected = {};
+  };
+
+  testFilterOptionsNoFilter = {
+    expr = filterOptions (p: o: true) {foo-1 = mkOption {};};
+    expected = {foo-1 = mkOption {};};
+  };
+
+  testFilterOptionsFilter = {
+    expr = filterOptions (p: o: hasPrefix "foo-" o.description) {
+      foo-1 = mkOption {description = "foo-1";};
+      bar-1 = mkOption {description = "bar-1";};
+    };
+    expected = {
+      foo-1 = mkOption {description = "foo-1";};
+    };
+  };
+
+  testFilterOptionsFilterDeep = {
+    expr = filterOptions (p: o: o.description == "foo") {
+      nested.foo = mkOption {description = "foo";};
+      nested.bar = mkOption {description = "bar";};
+    };
+    expected.nested.foo = mkOption {description = "foo";};
+  };
+
+  testFilterOptionsFilterPath = {
+    expr = filterOptions (p: o: elem "foo" p) {
+      nested.foo = mkOption {};
+      nested.bar = mkOption {};
+    };
+    expected.nested.foo = mkOption {};
+  };
+
+  testFilterOptionsNoEmptyBranches = {
+    expr = filterOptions (p: o: elem "foo" p) {
+      foo.a = mkOption {};
+      bar.a = mkOption {};
+    };
+    expected.foo.a = mkOption {};
+  };
+
+  testFilterOptionsNonAttrsetValuesPassthrough = {
+    expr = filterOptions (p: o: false) { a = []; };
+    expected.a = [];
+  };
 }


### PR DESCRIPTION
Co-authored-by: Samyak S Sarnayak <samyak201@gmail.com>

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
