### PR TITLE
Catppuccin: add thunderbird and bump various themes

### DIFF
--- a/pkgs/data/themes/catppuccin/default.nix
+++ b/pkgs/data/themes/catppuccin/default.nix
@@ -1,5 +1,5 @@
 let
-  validThemes = [ "bat" "bottom" "btop" "grub" "hyprland" "k9s" "kvantum" "lazygit" "plymouth" "qt5ct" "refind" "rofi" "starship" "waybar" ];
+  validThemes = [ "bat" "bottom" "btop" "grub" "hyprland" "k9s" "kvantum" "lazygit" "plymouth" "qt5ct" "refind" "rofi" "starship" "thunderbird" "waybar" ];
 in
 { fetchFromGitHub
 , lib
@@ -120,6 +120,14 @@ let
       hash = "sha256-nsRuxQFKbQkyEI4TXgvAjcroVdG+heKX5Pauq/4Ota0=";
     };
 
+    thunderbird = fetchFromGitHub {
+      name = "thunderbird";
+      owner = "catppuccin";
+      repo = "thunderbird";
+      rev = "d61882ad9fd35909a75da6bb95fca38db552135c";
+      hash = "sha256-wn8//8lHScbbB1nEiDY8DphnLUMKZBFMc1GPaTRjTOY=";
+    };
+
     waybar = fetchFromGitHub {
       name = "waybar";
       owner = "catppuccin";
@@ -207,6 +215,10 @@ stdenvNoCC.mkDerivation {
   '' + lib.optionalString (lib.elem "starship" themeList) ''
     mkdir -p $out/starship
     cp ${sources.starship}/palettes/${variant}.toml $out/starship/
+
+  '' + lib.optionalString (lib.elem "thunderbird" themeList) ''
+    mkdir -p $out/thunderbird
+    cp ${sources.thunderbird}/themes/${variant}/${variant}-${accent}.xpi $out/thunderbird/
 
   '' + lib.optionalString (lib.elem "waybar" themeList) ''
     mkdir -p $out/waybar

--- a/pkgs/data/themes/catppuccin/default.nix
+++ b/pkgs/data/themes/catppuccin/default.nix
@@ -60,8 +60,8 @@ let
       name = "k9s";
       owner = "catppuccin";
       repo = "k9s";
-      rev = "516f44dd1a6680357cb30d96f7e656b653aa5059";
-      hash = "sha256-PtBJRBNbLkj7D2ko7ebpEjbfK9Ywjs7zbE+Y8FQVEfA=";
+      rev = "590a762110ad4b6ceff274265f2fe174c576ce96";
+      hash = "sha256-EBDciL3F6xVFXvND+5duT+OiVDWKkFMWbOOSruQ0lus=";
     };
 
     kvantum = fetchFromGitHub {
@@ -174,7 +174,8 @@ stdenvNoCC.mkDerivation {
 
   '' + lib.optionalString (lib.elem "k9s" themeList) ''
     mkdir -p $out/k9s
-    cp "${sources.k9s}/dist/${variant}.yml" "$out/k9s/"
+    cp "${sources.k9s}/dist/catppuccin-${variant}.yaml" "$out/k9s/"
+    cp "${sources.k9s}/dist/catppuccin-${variant}-transparent.yaml" "$out/k9s/"
 
   '' + lib.optionalString (lib.elem "kvantum" themeList) ''
     mkdir -p $out/share/Kvantum

--- a/pkgs/data/themes/catppuccin/default.nix
+++ b/pkgs/data/themes/catppuccin/default.nix
@@ -84,8 +84,8 @@ let
       name = "plymouth";
       owner = "catppuccin";
       repo = "plymouth";
-      rev = "d4105cf336599653783c34c4a2d6ca8c93f9281c";
-      hash = "sha256-quBSH8hx3gD7y1JNWAKQdTk3CmO4t1kVo4cOGbeWlNE=";
+      rev = "67759fbe15eb9490d096ef8014d9f92fc5748fe7";
+      hash = "sha256-IzoyVOi44Uay7DTfzR9RdRLSjORsdBM4pPrgeXk5YMI=";
     };
 
     qt5ct = fetchFromGitHub {

--- a/pkgs/data/themes/catppuccin/default.nix
+++ b/pkgs/data/themes/catppuccin/default.nix
@@ -20,8 +20,8 @@ let
       name = "bat";
       owner = "catppuccin";
       repo = "bat";
-      rev = "ba4d16880d63e656acced2b7d4e034e4a93f74b1";
-      hash = "sha256-6WVKQErGdaqb++oaXnY3i6/GuH2FhTgK0v4TN4Y0Wbw=";
+      rev = "2bafe4454d8db28491e9087ff3a1382c336e7d27";
+      hash = "sha256-yHt3oIjUnljARaihalcWSNldtaJfVDfmfiecYfbzGs0=";
     };
 
     bottom = fetchFromGitHub {
@@ -135,7 +135,7 @@ lib.checkListOfEnum "${pname}: themes" validThemes themeList
 
 stdenvNoCC.mkDerivation {
   inherit pname;
-  version = "unstable-2023-10-09";
+  version = "unstable-2024-03-12";
 
   srcs = selectedSources;
 
@@ -154,7 +154,7 @@ stdenvNoCC.mkDerivation {
 
   '' + lib.optionalString (lib.elem "bat" themeList) ''
     mkdir -p $out/bat
-    cp "${sources.bat}/Catppuccin-${variant}.tmTheme" "$out/bat/"
+    cp "${sources.bat}/themes/Catppuccin "$capitalizedVariant".tmTheme" "$out/bat/"
 
   '' + lib.optionalString (lib.elem "btop" themeList) ''
     mkdir -p $out/btop

--- a/pkgs/data/themes/catppuccin/default.nix
+++ b/pkgs/data/themes/catppuccin/default.nix
@@ -76,8 +76,8 @@ let
       name = "lazygit";
       owner = "catppuccin";
       repo = "lazygit";
-      rev = "0543c28e8af1a935f8c512ad9451facbcc17d8a8";
-      hash = "sha256-OVihY5E+elPKag2H4RyWiSv+MdIqHtfGNM3/1u2ik6U=";
+      rev = "v2.0.0";
+      hash = "sha256-gM0HplHhcpvtpmIVdlX/p59h0v+ihKEidS1imqPYlBg=";
     };
 
     plymouth = fetchFromGitHub {
@@ -183,8 +183,8 @@ stdenvNoCC.mkDerivation {
 
   '' + lib.optionalString (lib.elem "lazygit" themeList) ''
     mkdir -p $out/lazygit/{themes,themes-mergable}
-    cp "${sources.lazygit}/themes/${variant}/${variant}-${accent}.yml" "$out/lazygit/themes/"
-    cp "${sources.lazygit}/themes-mergable/${variant}/${variant}-${accent}.yml" "$out/lazygit/themes-mergable/"
+    cp "${sources.lazygit}/themes/${variant}/${accent}.yml" "$out/lazygit/themes/"
+    cp "${sources.lazygit}/themes-mergable/${variant}/${accent}.yml" "$out/lazygit/themes-mergable/"
 
   '' + lib.optionalString (lib.elem "plymouth" themeList) ''
     mkdir -p $out/share/plymouth/themes/catppuccin-${variant}


### PR DESCRIPTION
## Description of changes

Breaking Changes: 

- K9s 
  - variant.yml -> catppuccin-variant.yaml
  - Addition of transparent variation
- Bat 
  - Catppuccin-variant.tmTheme -> Catppuccin Variant.tmTheme
- Lazygit
  -  variant-accent.yml -> accent.yml

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
