### PR TITLE
ndstrim: init at 0.2.1

### DIFF
--- a/pkgs/by-name/nd/ndstrim/package.nix
+++ b/pkgs/by-name/nd/ndstrim/package.nix
@@ -1,0 +1,50 @@
+{ lib
+, fetchFromGitHub
+, fetchpatch
+, rustPlatform
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "ndstrim";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "Nemris";
+    repo = "ndstrim";
+    rev = "v${version}";
+    hash = "sha256-KgtejBbFg6+klc8OpCs1CIb+7uVPCtP0/EM671vxauk=";
+  };
+
+  patches = [
+    # https://github.com/Nemris/ndstrim/pull/1
+    (fetchpatch {
+      name = "update-cargo-lock.patch";
+      url = "https://github.com/Nemris/ndstrim/commit/8147bb31a8fb5765f33562957a61cb6ddbe65513.patch";
+      hash = "sha256-HsCc5un9dg0gRkRjwxtjms0cugqWhcTthGfcF50EgYA=";
+    })
+  ];
+
+  cargoHash = "sha256-k5SlsIWHEZaYwk5cmLb1QMs3lk0VGGwiGd1TSQJC3Ss=";
+
+  # TODO: remove this after upstream merge above patch.
+  # Without the workaround below the build results in the following error:
+  # Validating consistency between /build/source/Cargo.lock and /build/ndstrim-0.2.1-vendor.tar.gz/Cargo.lock
+  # <hash>
+  # < version = "0.2.1"
+  # ---
+  # > version = "0.1.0"
+  #
+  # ERROR: cargoHash or cargoSha256 is out of date
+  postPatch = ''
+    cargoSetupPostPatchHook() { true; }
+  '';
+
+  meta = with lib; {
+    description = "Trim the excess padding found in Nintendo DS(i) ROMs";
+    homepage = "https://github.com/Nemris/ndstrim";
+    license = licenses.mit;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ thiagokokada ];
+    mainProgram = "ndstrim";
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
