### PR TITLE
bitwarden-desktop: 2024.2.0 -> 2024.3.0

### DIFF
--- a/pkgs/by-name/bi/bitwarden-desktop/electron-builder-package-lock.patch
+++ b/pkgs/by-name/bi/bitwarden-desktop/electron-builder-package-lock.patch
@@ -1,0 +1,28 @@
+From 0629bb5b90e54491263e371bc5594e9f97ba0af4 Mon Sep 17 00:00:00 2001
+From: Andrew Marshall <andrew@johnandrewmarshall.com>
+Date: Tue, 12 Mar 2024 11:48:15 -0400
+Subject: [PATCH] Fix using unlocked dependencies in electron-builder
+
+electron-builder will perform its "installing production dependencies"
+step using this package.json, and without the package-lock.json, NPM
+will try to fetch package metadata to install the latest, unlocked
+dependencies.
+---
+ apps/desktop/webpack.main.js | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/apps/desktop/webpack.main.js b/apps/desktop/webpack.main.js
+index 9d683457d9..0ad707956e 100644
+--- a/apps/desktop/webpack.main.js
++++ b/apps/desktop/webpack.main.js
+@@ -70,6 +70,7 @@ const main = {
+     new CopyWebpackPlugin({
+       patterns: [
+         "./src/package.json",
++        "./src/package-lock.json",
+         { from: "./src/images", to: "images" },
+         { from: "./src/locales", to: "locales" },
+       ],
+-- 
+2.43.2
+


### PR DESCRIPTION
The now-removed patch is in this release.

Notably, upstream commit e2ca52a3ff7bceb282f266fe49b974ca0c401358 has given quite a bit of grief here. They changed
`apps/desktop/src/package.json` to add an external dependency for the first time, but neglected to update the corresponding `package-lock.json`. However, simply updating that is not enough as the build process does not copy it into the `apps/desktop/build` dir where `electron-builder` is ultimately run in, and it is `electron-builder` in its "installing production dependencies" step that performs an `npm install` in that directory.

Diff: https://github.com/bitwarden/clients/compare/desktop-v2024.2.0...desktop-v2024.3.0

Changelog: https://github.com/bitwarden/clients/releases/tag/desktop-v2024.3.0

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
