### PR TITLE
lib: use explicit name imports in `lib/systems`

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -1,7 +1,25 @@
 { lib }:
-  let inherit (lib.attrsets) mapAttrs; in
 
-rec {
+let
+  inherit (lib)
+    any
+    filterAttrs
+    foldl
+    hasInfix
+    isFunction
+    isList
+    isString
+    mapAttrs
+    optional
+    optionalAttrs
+    optionalString
+    removeSuffix
+    replaceStrings
+    toUpper
+    ;
+
+  inherit (lib.strings) toJSON;
+
   doubles = import ./doubles.nix { inherit lib; };
   parse = import ./parse.nix { inherit lib; };
   inspect = import ./inspect.nix { inherit lib; };
@@ -24,7 +42,7 @@ rec {
     both arguments have been `elaborate`-d.
   */
   equals =
-    let removeFunctions = a: lib.filterAttrs (_: v: !builtins.isFunction v) a;
+    let removeFunctions = a: filterAttrs (_: v: !isFunction v) a;
     in a: b: removeFunctions a == removeFunctions b;
 
   /* List of all Nix system doubles the nixpkgs flake will expose the package set
@@ -41,7 +59,7 @@ rec {
   # clearly preferred, and to prevent cycles. A simpler fixed point where the RHS
   # always just used `final.*` would fail on both counts.
   elaborate = args': let
-    args = if lib.isString args' then { system = args'; }
+    args = if isString args' then { system = args'; }
            else args';
 
     # TODO: deprecate args.rustc in favour of args.rust after 23.05 is EOL.
@@ -96,7 +114,7 @@ rec {
         then "lib64"
         else "lib"
       else null;
-      extensions = lib.optionalAttrs final.hasSharedLibraries {
+      extensions = optionalAttrs final.hasSharedLibraries {
         sharedLibrary =
           if      final.isDarwin  then ".dylib"
           else if final.isWindows then ".dll"
@@ -134,9 +152,9 @@ rec {
          # uname -m
          processor =
            if final.isPower64
-           then "ppc64${lib.optionalString final.isLittleEndian "le"}"
+           then "ppc64${optionalString final.isLittleEndian "le"}"
            else if final.isPower
-           then "ppc${lib.optionalString final.isLittleEndian "le"}"
+           then "ppc${optionalString final.isLittleEndian "le"}"
            else if final.isMips64
            then "mips64"  # endianness is *not* included on mips64
            else final.parsed.cpu.name;
@@ -202,8 +220,8 @@ rec {
         else if final.isS390 && !final.isS390x then null
         else if final.isx86_64 then "x86_64"
         else if final.isx86 then "i386"
-        else if final.isMips64n32 then "mipsn32${lib.optionalString final.isLittleEndian "el"}"
-        else if final.isMips64 then "mips64${lib.optionalString final.isLittleEndian "el"}"
+        else if final.isMips64n32 then "mipsn32${optionalString final.isLittleEndian "el"}"
+        else if final.isMips64 then "mips64${optionalString final.isLittleEndian "el"}"
         else final.uname.processor;
 
       # Name used by UEFI for architectures.
@@ -255,7 +273,7 @@ rec {
           if pkgs.stdenv.hostPlatform.canExecute final
           then "${pkgs.runtimeShell} -c '\"$@\"' --"
           else if final.isWindows
-          then "${wine}/bin/wine${lib.optionalString (final.parsed.cpu.bits == 64) "64"}"
+          then "${wine}/bin/wine${optionalString (final.parsed.cpu.bits == 64) "64"}"
           else if final.isLinux && pkgs.stdenv.hostPlatform.isLinux && final.qemuArch != null
           then "${qemu-user}/bin/qemu-${final.qemuArch}"
           else if final.isWasi
@@ -306,10 +324,10 @@ rec {
                   let
                     f = args.rustc.platform.target-family;
                   in
-                    if builtins.isList f then f else [ f ]
+                    if isList f then f else [ f ]
                 )
-              else lib.optional final.isUnix "unix"
-                   ++ lib.optional final.isWindows "windows";
+              else optional final.isUnix "unix"
+                   ++ optional final.isWindows "windows";
 
             # https://doc.rust-lang.org/reference/conditional-compilation.html#target_vendor
             vendor = let
@@ -333,13 +351,13 @@ rec {
             vendor_ = final.rust.platform.vendor;
           # TODO: deprecate args.rustc in favour of args.rust after 23.05 is EOL.
           in args.rust.rustcTarget or args.rustc.config
-            or "${cpu_}-${vendor_}-${kernel.name}${lib.optionalString (abi.name != "unknown") "-${abi.name}"}";
+            or "${cpu_}-${vendor_}-${kernel.name}${optionalString (abi.name != "unknown") "-${abi.name}"}";
 
           # The name of the rust target if it is standard, or the json file
           # containing the custom target spec.
           rustcTargetSpec = rust.rustcTargetSpec or (
             /**/ if rust ? platform
-            then builtins.toFile (final.rust.rustcTarget + ".json") (builtins.toJSON rust.platform)
+            then builtins.toFile (final.rust.rustcTarget + ".json") (toJSON rust.platform)
             else final.rust.rustcTarget);
 
           # The name of the rust target if it is standard, or the
@@ -348,7 +366,7 @@ rec {
           #
           # This is the name used by Cargo for target subdirectories.
           cargoShortTarget =
-            lib.removeSuffix ".json" (baseNameOf "${final.rust.rustcTargetSpec}");
+            removeSuffix ".json" (baseNameOf "${final.rust.rustcTargetSpec}");
 
           # When used as part of an environment variable name, triples are
           # uppercased and have all hyphens replaced by underscores:
@@ -356,17 +374,17 @@ rec {
           # https://github.com/rust-lang/cargo/pull/9169
           # https://github.com/rust-lang/cargo/issues/8285#issuecomment-634202431
           cargoEnvVarTarget =
-            lib.strings.replaceStrings ["-"] ["_"]
-              (lib.strings.toUpper final.rust.cargoShortTarget);
+            replaceStrings ["-"] ["_"]
+              (toUpper final.rust.cargoShortTarget);
 
           # True if the target is no_std
           # https://github.com/rust-lang/rust/blob/2e44c17c12cec45b6a682b1e53a04ac5b5fcc9d2/src/bootstrap/config.rs#L415-L421
           isNoStdTarget =
-            builtins.any (t: lib.hasInfix t final.rust.rustcTarget) ["-none" "nvptx" "switch" "-uefi"];
+            any (t: hasInfix t final.rust.rustcTarget) ["-none" "nvptx" "switch" "-uefi"];
         };
       };
   in assert final.useAndroidPrebuilt -> final.isAndroid;
-     assert lib.foldl
+     assert foldl
        (pass: { assertion, message }:
          if assertion final
          then pass
@@ -374,4 +392,20 @@ rec {
        true
        (final.parsed.abi.assertions or []);
     final;
+
+in
+
+# Everything in this attrset is the public interface of the file.
+{
+  inherit
+    architectures
+    doubles
+    elaborate
+    equals
+    examples
+    flakeExposed
+    inspect
+    parse
+    platforms
+    ;
 }

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -1,9 +1,21 @@
 { lib }:
 
-with lib.attrsets;
-with lib.lists;
-
 let
+  inherit (lib)
+    any
+    attrValues
+    concatMap
+    filter
+    hasPrefix
+    isList
+    mapAttrs
+    matchAttrs
+    recursiveUpdateUntil
+    toList
+    ;
+
+  inherit (lib.strings) toJSON;
+
   inherit (lib.systems.parse)
     kernels
     kernelFamilies
@@ -12,7 +24,7 @@ let
     execFormats
     ;
 
-  abis = lib.mapAttrs (_: abi: builtins.removeAttrs abi [ "assertions" ]) lib.systems.parse.abis;
+  abis = mapAttrs (_: abi: removeAttrs abi [ "assertions" ]) lib.systems.parse.abis;
 in
 
 rec {
@@ -41,8 +53,8 @@ rec {
     isx86          = { cpu = { family = "x86"; }; };
     isAarch32      = { cpu = { family = "arm"; bits = 32; }; };
     isArmv7        = map ({ arch, ... }: { cpu = { inherit arch; }; })
-                       (lib.filter (cpu: lib.hasPrefix "armv7" cpu.arch or "")
-                         (lib.attrValues cpuTypes));
+                       (filter (cpu: hasPrefix "armv7" cpu.arch or "")
+                         (attrValues cpuTypes));
     isAarch64      = { cpu = { family = "arm"; bits = 64; }; };
     isAarch        = { cpu = { family = "arm"; }; };
     isMicroBlaze   = { cpu = { family = "microblaze"; }; };
@@ -120,19 +132,19 @@ rec {
     let
       # patterns can be either a list or a (bare) singleton; turn
       # them into singletons for uniform handling
-      pat1 = lib.toList pat1_;
-      pat2 = lib.toList pat2_;
+      pat1 = toList pat1_;
+      pat2 = toList pat2_;
     in
-      lib.concatMap (attr1:
+      concatMap (attr1:
         map (attr2:
-          lib.recursiveUpdateUntil
+          recursiveUpdateUntil
             (path: subattr1: subattr2:
               if (builtins.intersectAttrs subattr1 subattr2) == {} || subattr1 == subattr2
               then true
               else throw ''
                 pattern conflict at path ${toString path}:
-                  ${builtins.toJSON subattr1}
-                  ${builtins.toJSON subattr2}
+                  ${toJSON subattr1}
+                  ${toJSON subattr2}
                 '')
             attr1
             attr2
@@ -141,7 +153,7 @@ rec {
         pat1;
 
   matchAnyAttrs = patterns:
-    if builtins.isList patterns then attrs: any (pattern: matchAttrs pattern attrs) patterns
+    if isList patterns then attrs: any (pattern: matchAttrs pattern attrs) patterns
     else matchAttrs patterns;
 
   predicates = mapAttrs (_: matchAnyAttrs) patterns;

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -1,10 +1,19 @@
 { lib }:
-with lib.systems.parse;
+
 with lib.attrsets;
 with lib.lists;
 
-let abis_ = abis; in
-let abis = lib.mapAttrs (_: abi: builtins.removeAttrs abi [ "assertions" ]) abis_; in
+let
+  inherit (lib.systems.parse)
+    kernels
+    kernelFamilies
+    significantBytes
+    cpuTypes
+    execFormats
+    ;
+
+  abis = lib.mapAttrs (_: abi: builtins.removeAttrs abi [ "assertions" ]) lib.systems.parse.abis;
+in
 
 rec {
   # these patterns are to be matched against {host,build,target}Platform.parsed

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -1,5 +1,5 @@
 { lib }:
-with import ./parse.nix { inherit lib; };
+with lib.systems.parse;
 with lib.attrsets;
 with lib.lists;
 

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -19,7 +19,7 @@ with lib.lists;
 with lib.types;
 with lib.attrsets;
 with lib.strings;
-with (import ./inspect.nix { inherit lib; }).predicates;
+with lib.systems.inspect.predicates;
 
 let
   inherit (lib.options) mergeOneOption;

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -19,9 +19,16 @@ with lib.lists;
 with lib.types;
 with lib.attrsets;
 with lib.strings;
-with lib.systems.inspect.predicates;
 
 let
+  inherit (lib.systems.inspect.predicates)
+    isAarch32
+    isBigEndian
+    isDarwin
+    isLinux
+    isPower64
+    isWindows
+    ;
   inherit (lib.options) mergeOneOption;
 
   setTypes = type:

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -15,12 +15,26 @@
 # systems that overlap with existing ones and won't notice something amiss.
 #
 { lib }:
-with lib.lists;
-with lib.types;
-with lib.attrsets;
-with lib.strings;
 
 let
+  inherit (lib)
+    all
+    any
+    attrValues
+    elem
+    elemAt
+    hasPrefix
+    id
+    length
+    mapAttrs
+    mergeOneOption
+    optionalString
+    splitString
+    versionAtLeast
+    ;
+
+  inherit (lib.strings) match;
+
   inherit (lib.systems.inspect.predicates)
     isAarch32
     isBigEndian
@@ -29,7 +43,17 @@ let
     isPower64
     isWindows
     ;
-  inherit (lib.options) mergeOneOption;
+
+  inherit (lib.types)
+    enum
+    float
+    isType
+    mkOptionType
+    number
+    setType
+    string
+    types
+    ;
 
   setTypes = type:
     mapAttrs (name: value:
@@ -40,10 +64,10 @@ let
   # regex `e?abi.*$` when determining the validity of a triple.  In
   # other words, `i386-linuxabichickenlips` is a valid triple.
   removeAbiSuffix = x:
-    let match = builtins.match "(.*)e?abi.*" x;
-    in if match==null
+    let found = match "(.*)e?abi.*" x;
+    in if found == null
        then x
-       else lib.elemAt match 0;
+       else elemAt found 0;
 
 in
 
@@ -83,7 +107,7 @@ rec {
 
   types.cpuType = enum (attrValues cpuTypes);
 
-  cpuTypes = with significantBytes; setTypes types.openCpuType {
+  cpuTypes = let inherit (significantBytes) bigEndian littleEndian; in setTypes types.openCpuType {
     arm      = { bits = 32; significantByte = littleEndian; family = "arm"; };
     armv5tel = { bits = 32; significantByte = littleEndian; family = "arm"; version = "5"; arch = "armv5t"; };
     armv6m   = { bits = 32; significantByte = littleEndian; family = "arm"; version = "6"; arch = "armv6-m"; };
@@ -173,7 +197,7 @@ rec {
   # Note: Since 22.11 the archs of a mode switching CPU are no longer considered
   # pairwise compatible. Mode switching implies that binaries built for A
   # and B respectively can't be executed at the same time.
-  isCompatible = a: b: with cpuTypes; lib.any lib.id [
+  isCompatible = with cpuTypes; a: b: any id [
     # x86
     (b == i386 && isCompatible a i486)
     (b == i486 && isCompatible a i586)
@@ -294,7 +318,10 @@ rec {
 
   types.kernel = enum (attrValues kernels);
 
-  kernels = with execFormats; with kernelFamilies; setTypes types.openKernel {
+  kernels = let
+    inherit (execFormats) elf pe wasm unknown macho;
+    inherit (kernelFamilies) bsd darwin;
+  in setTypes types.openKernel {
     # TODO(@Ericson2314): Don't want to mass-rebuild yet to keeping 'darwin' as
     # the normalized name for macOS.
     macos    = { execFormat = macho;   families = { inherit darwin; }; name = "darwin"; };
@@ -366,7 +393,7 @@ rec {
             The "gnu" ABI is ambiguous on 32-bit ARM. Use "gnueabi" or "gnueabihf" instead.
           '';
         }
-        { assertion = platform: with platform; !(isPower64 && isBigEndian);
+        { assertion = platform: !(platform.isPower64 && platform.isBigEndian);
           message = ''
             The "gnu" ABI is ambiguous on big-endian 64-bit PowerPC. Use "gnuabielfv2" or "gnuabielfv1" instead.
           '';
@@ -487,7 +514,7 @@ rec {
         /**/ if args ? abi       then getAbi args.abi
         else if isLinux parsed || isWindows parsed then
           if isAarch32 parsed then
-            if lib.versionAtLeast (parsed.cpu.version or "0") "6"
+            if versionAtLeast (parsed.cpu.version or "0") "6"
             then abis.gnueabihf
             else abis.gnueabi
           # Default ppc64 BE to ELFv2
@@ -498,7 +525,7 @@ rec {
 
   in mkSystem parsed;
 
-  mkSystemFromString = s: mkSystemFromSkeleton (mkSkeletonFromList (lib.splitString "-" s));
+  mkSystemFromString = s: mkSystemFromSkeleton (mkSkeletonFromList (splitString "-" s));
 
   kernelName = kernel:
     kernel.name + toString (kernel.version or "");
@@ -510,10 +537,10 @@ rec {
 
   tripleFromSystem = { cpu, vendor, kernel, abi, ... } @ sys: assert isSystem sys; let
     optExecFormat =
-      lib.optionalString (kernel.name == "netbsd" &&
+      optionalString (kernel.name == "netbsd" &&
                           gnuNetBSDDefaultExecFormat cpu != kernel.execFormat)
         kernel.execFormat.name;
-    optAbi = lib.optionalString (abi != abis.unknown) "-${abi.name}";
+    optAbi = optionalString (abi != abis.unknown) "-${abi.name}";
   in "${cpu.name}-${vendor.name}-${kernelName kernel}${optExecFormat}${optAbi}";
 
   ################################################################################


### PR DESCRIPTION
## Description of changes

Using `with` at a top-level scope is [an anti-pattern](https://nix.dev/guides/best-practices#with-scopes). The tracking issue is https://github.com/NixOS/nixpkgs/issues/208242. This is a pure refactor: there is no functional change contained in this PR.

The tests found issues when I intentionally introduced them and obviously continue to pass.

Related: 
- https://github.com/NixOS/nixpkgs/pull/293901
- https://github.com/NixOS/nixpkgs/pull/294906

## Things done

- [x] Tested, as applicable:
  - [x] `nix-instantiate --strict --eval lib/tests/misc.nix`
  - [x] `lib/tests/modules.sh`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).