### PR TITLE
nixos/tests/incus: add storage test and exercise zfs integration

### DIFF
--- a/nixos/tests/incus/default.nix
+++ b/nixos/tests/incus/default.nix
@@ -14,6 +14,7 @@
   openvswitch = import ./openvswitch.nix { inherit system pkgs; };
   preseed = import ./preseed.nix { inherit system pkgs; };
   socket-activated = import ./socket-activated.nix { inherit system pkgs; };
+  storage = import ./storage.nix { inherit system pkgs; };
   ui = import ./ui.nix {inherit system pkgs;};
   virtual-machine = handleTestOn [ "x86_64-linux" ] ./virtual-machine.nix { inherit system pkgs; };
 }

--- a/nixos/tests/incus/storage.nix
+++ b/nixos/tests/incus/storage.nix
@@ -1,0 +1,46 @@
+import ../make-test-python.nix (
+  { pkgs, lib, ... }:
+
+  {
+    name = "incus-storage";
+
+    meta = {
+      maintainers = lib.teams.lxc.members;
+    };
+
+    nodes.machine =
+      { lib, ... }:
+      {
+        boot.supportedFilesystems = [ "zfs" ];
+        boot.zfs.forceImportRoot = false;
+        environment.systemPackages = [ pkgs.parted ];
+        networking.hostId = "01234567";
+        networking.nftables.enable = true;
+
+        virtualisation = {
+          emptyDiskImages = [ 2048 ];
+          incus.enable = true;
+        };
+      };
+
+    testScript = ''
+      machine.wait_for_unit("incus.service")
+
+      with subtest("Verify zfs pool created and usable"):
+        machine.succeed(
+            "zpool status",
+            "parted --script /dev/vdb mklabel gpt",
+            "zpool create zfs_pool /dev/vdb",
+        )
+
+        machine.succeed("incus storage create zfs_pool zfs source=zfs_pool/incus")
+        machine.succeed("zfs list zfs_pool/incus")
+        machine.succeed("incus storage volume create zfs_pool test_fs --type filesystem")
+        machine.succeed("incus storage volume create zfs_pool test_vol --type block")
+        machine.succeed("incus storage show zfs_pool")
+        machine.succeed("incus storage volume list zfs_pool")
+        machine.succeed("incus storage volume show zfs_pool test_fs")
+        machine.succeed("incus storage volume show zfs_pool test_vol")
+    '';
+  }
+)


### PR DESCRIPTION
## Description of changes

zfs support is automatically enabled when added to supportedFilesystems, but we weren't testing this code path before. I named this test storage in the hope that in the future the other storage drivers can be added.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
