### PR TITLE
make-derivation.nix: Factor out `makeDerivationArgument`

### DIFF
--- a/pkgs/build-support/lib/cmake.nix
+++ b/pkgs/build-support/lib/cmake.nix
@@ -1,0 +1,30 @@
+{ stdenv, lib }:
+
+let
+  inherit (lib) findFirst isString optional optionals;
+
+  makeCMakeFlags = { cmakeFlags ? [], ... }:
+    cmakeFlags
+    ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) ([
+      "-DCMAKE_SYSTEM_NAME=${findFirst isString "Generic" (optional (!stdenv.hostPlatform.isRedox) stdenv.hostPlatform.uname.system)}"
+    ] ++ optionals (stdenv.hostPlatform.uname.processor != null) [
+      "-DCMAKE_SYSTEM_PROCESSOR=${stdenv.hostPlatform.uname.processor}"
+    ] ++ optionals (stdenv.hostPlatform.uname.release != null) [
+      "-DCMAKE_SYSTEM_VERSION=${stdenv.hostPlatform.uname.release}"
+    ] ++ optionals (stdenv.hostPlatform.isDarwin) [
+      "-DCMAKE_OSX_ARCHITECTURES=${stdenv.hostPlatform.darwinArch}"
+    ] ++ optionals (stdenv.buildPlatform.uname.system != null) [
+      "-DCMAKE_HOST_SYSTEM_NAME=${stdenv.buildPlatform.uname.system}"
+    ] ++ optionals (stdenv.buildPlatform.uname.processor != null) [
+      "-DCMAKE_HOST_SYSTEM_PROCESSOR=${stdenv.buildPlatform.uname.processor}"
+    ] ++ optionals (stdenv.buildPlatform.uname.release != null) [
+      "-DCMAKE_HOST_SYSTEM_VERSION=${stdenv.buildPlatform.uname.release}"
+    ] ++ optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+      "-DCMAKE_CROSSCOMPILING_EMULATOR=env"
+    ] ++ optionals stdenv.hostPlatform.isStatic [
+      "-DCMAKE_LINK_SEARCH_START_STATIC=ON"
+    ]);
+in
+{
+  inherit makeCMakeFlags;
+}

--- a/pkgs/build-support/lib/meson.nix
+++ b/pkgs/build-support/lib/meson.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib }:
+
+let
+  inherit (lib) boolToString optionals;
+
+  # See https://mesonbuild.com/Reference-tables.html#cpu-families
+  cpuFamily = platform: with platform;
+    /**/ if isAarch32 then "arm"
+    else if isx86_32  then "x86"
+    else platform.uname.processor;
+
+  makeMesonFlags = { mesonFlags ? [], ... }:
+    let
+      crossFile = builtins.toFile "cross-file.conf" ''
+        [properties]
+        bindgen_clang_arguments = ['-target', '${stdenv.targetPlatform.config}']
+        needs_exe_wrapper = ${boolToString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform)}
+
+        [host_machine]
+        system = '${stdenv.targetPlatform.parsed.kernel.name}'
+        cpu_family = '${cpuFamily stdenv.targetPlatform}'
+        cpu = '${stdenv.targetPlatform.parsed.cpu.name}'
+        endian = ${if stdenv.targetPlatform.isLittleEndian then "'little'" else "'big'"}
+
+        [binaries]
+        llvm-config = 'llvm-config-native'
+        rust = ['rustc', '--target', '${stdenv.targetPlatform.rust.rustcTargetSpec}']
+      '';
+      crossFlags = optionals (stdenv.hostPlatform != stdenv.buildPlatform) [ "--cross-file=${crossFile}" ];
+    in crossFlags ++ mesonFlags;
+
+in
+{
+  inherit makeMesonFlags;
+}

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -6,7 +6,7 @@
 
 let
   # N.B. Keep in sync with default arg for stdenv/generic.
-  defaultMkDerivationFromStdenv = import ./generic/make-derivation.nix { inherit lib config; };
+  defaultMkDerivationFromStdenv = stdenv: (import ./generic/make-derivation.nix { inherit lib config; } stdenv).mkDerivation;
 
   # Low level function to help with overriding `mkDerivationFromStdenv`. One
   # gives it the old stdenv arguments and a "continuation" function, and

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -52,7 +52,7 @@ argsStdenv@{ name ? "stdenv", preHook ? "", initialPath
 
 , # The implementation of `mkDerivation`, parameterized with the final stdenv so we can tie the knot.
   # This is convient to have as a parameter so the stdenv "adapters" work better
-  mkDerivationFromStdenv ? import ./make-derivation.nix { inherit lib config; }
+  mkDerivationFromStdenv ? stdenv: (import ./make-derivation.nix { inherit lib config; } stdenv).mkDerivation
 }:
 
 let

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -609,4 +609,6 @@ extendDerivation
   (derivation (derivationArg // optionalAttrs envIsExportable checkedEnv));
 
 in
-  mkDerivation
+{
+  inherit mkDerivation;
+}

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -40,6 +40,12 @@ let
     unique
   ;
 
+  mkDerivation =
+    fnOrAttrs:
+      if builtins.isFunction fnOrAttrs
+      then makeDerivationExtensible fnOrAttrs
+      else makeDerivationExtensibleConst fnOrAttrs;
+
   checkMeta = import ./check-meta.nix {
     inherit lib config;
     # Nix itself uses the `system` field of a derivation to decide where
@@ -603,7 +609,4 @@ extendDerivation
   (derivation (derivationArg // optionalAttrs envIsExportable checkedEnv));
 
 in
-  fnOrAttrs:
-    if builtins.isFunction fnOrAttrs
-    then makeDerivationExtensible fnOrAttrs
-    else makeDerivationExtensibleConst fnOrAttrs
+  mkDerivation

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -133,6 +133,13 @@ let
     "sandboxProfile" "propagatedSandboxProfile"
   ];
 
+  # Turn a derivation into its outPath without a string context attached.
+  # See the comment at the usage site.
+  unsafeDerivationToUntrackedOutpath = drv:
+    if isDerivation drv
+    then builtins.unsafeDiscardStringContext drv.outPath
+    else drv;
+
   makeDerivationArgument =
 
 
@@ -241,13 +248,6 @@ let
 
   separateDebugInfo' = separateDebugInfo && stdenv.hostPlatform.isLinux;
   outputs' = outputs ++ optional separateDebugInfo' "debug";
-
-  # Turn a derivation into its outPath without a string context attached.
-  # See the comment at the usage site.
-  unsafeDerivationToUntrackedOutpath = drv:
-    if isDerivation drv
-    then builtins.unsafeDiscardStringContext drv.outPath
-    else drv;
 
   noNonNativeDeps = builtins.length (depsBuildTarget ++ depsBuildTargetPropagated
                                   ++ depsHostHost ++ depsHostHostPropagated

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -124,6 +124,15 @@ let
     "zerocallusedregs"
   ];
 
+  removedOrReplacedAttrNames = [
+    "checkInputs" "installCheckInputs"
+    "nativeCheckInputs" "nativeInstallCheckInputs"
+    "__contentAddressed"
+    "__darwinAllowLocalNetworking"
+    "__impureHostDeps" "__propagatedImpureHostDeps"
+    "sandboxProfile" "propagatedSandboxProfile"
+  ];
+
   makeDerivationArgument =
 
 
@@ -316,13 +325,7 @@ else let
   ];
 
   derivationArg =
-    removeAttrs attrs [
-       "checkInputs" "installCheckInputs"
-       "nativeCheckInputs" "nativeInstallCheckInputs"
-       "__contentAddressed"
-       "__darwinAllowLocalNetworking"
-       "__impureHostDeps" "__propagatedImpureHostDeps"
-       "sandboxProfile" "propagatedSandboxProfile"]
+    removeAttrs attrs removedOrReplacedAttrNames
     // (optionalAttrs (attrs ? name || (attrs ? pname && attrs ? version)) {
       name =
         let

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -9,7 +9,6 @@ let
     assertMsg
     attrNames
     boolToString
-    chooseDevOutputs
     concatLists
     concatMap
     concatMapStrings
@@ -20,6 +19,7 @@ let
     filter
     findFirst
     flip
+    getDev
     head
     imap1
     isAttrs
@@ -283,32 +283,32 @@ else let
 
   outputs = outputs';
 
-  dependencies = map (map chooseDevOutputs) [
+  dependencies = [
     [
-      (map (drv: drv.__spliced.buildBuild or drv) (checkDependencyList "depsBuildBuild" depsBuildBuild))
-      (map (drv: drv.__spliced.buildHost or drv) (checkDependencyList "nativeBuildInputs" nativeBuildInputs'))
-      (map (drv: drv.__spliced.buildTarget or drv) (checkDependencyList "depsBuildTarget" depsBuildTarget))
+      (map (drv: getDev drv.__spliced.buildBuild or drv) (checkDependencyList "depsBuildBuild" depsBuildBuild))
+      (map (drv: getDev drv.__spliced.buildHost or drv) (checkDependencyList "nativeBuildInputs" nativeBuildInputs'))
+      (map (drv: getDev drv.__spliced.buildTarget or drv) (checkDependencyList "depsBuildTarget" depsBuildTarget))
     ]
     [
-      (map (drv: drv.__spliced.hostHost or drv) (checkDependencyList "depsHostHost" depsHostHost))
-      (map (drv: drv.__spliced.hostTarget or drv) (checkDependencyList "buildInputs" buildInputs'))
+      (map (drv: getDev drv.__spliced.hostHost or drv) (checkDependencyList "depsHostHost" depsHostHost))
+      (map (drv: getDev drv.__spliced.hostTarget or drv) (checkDependencyList "buildInputs" buildInputs'))
     ]
     [
-      (map (drv: drv.__spliced.targetTarget or drv) (checkDependencyList "depsTargetTarget" depsTargetTarget))
+      (map (drv: getDev drv.__spliced.targetTarget or drv) (checkDependencyList "depsTargetTarget" depsTargetTarget))
     ]
   ];
-  propagatedDependencies = map (map chooseDevOutputs) [
+  propagatedDependencies = [
     [
-      (map (drv: drv.__spliced.buildBuild or drv) (checkDependencyList "depsBuildBuildPropagated" depsBuildBuildPropagated))
-      (map (drv: drv.__spliced.buildHost or drv) (checkDependencyList "propagatedNativeBuildInputs" propagatedNativeBuildInputs))
-      (map (drv: drv.__spliced.buildTarget or drv) (checkDependencyList "depsBuildTargetPropagated" depsBuildTargetPropagated))
+      (map (drv: getDev drv.__spliced.buildBuild or drv) (checkDependencyList "depsBuildBuildPropagated" depsBuildBuildPropagated))
+      (map (drv: getDev drv.__spliced.buildHost or drv) (checkDependencyList "propagatedNativeBuildInputs" propagatedNativeBuildInputs))
+      (map (drv: getDev drv.__spliced.buildTarget or drv) (checkDependencyList "depsBuildTargetPropagated" depsBuildTargetPropagated))
     ]
     [
-      (map (drv: drv.__spliced.hostHost or drv) (checkDependencyList "depsHostHostPropagated" depsHostHostPropagated))
-      (map (drv: drv.__spliced.hostTarget or drv) (checkDependencyList "propagatedBuildInputs" propagatedBuildInputs))
+      (map (drv: getDev drv.__spliced.hostHost or drv) (checkDependencyList "depsHostHostPropagated" depsHostHostPropagated))
+      (map (drv: getDev drv.__spliced.hostTarget or drv) (checkDependencyList "propagatedBuildInputs" propagatedBuildInputs))
     ]
     [
-      (map (drv: drv.__spliced.targetTarget or drv) (checkDependencyList "depsTargetTargetPropagated" depsTargetTargetPropagated))
+      (map (drv: getDev drv.__spliced.targetTarget or drv) (checkDependencyList "depsTargetTargetPropagated" depsTargetTargetPropagated))
     ]
   ];
 

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -110,6 +110,20 @@ let
           makeDerivationExtensible (self: attrs // (if builtins.isFunction f0 || f0?__functor then f self attrs else f0)))
       attrs;
 
+  knownHardeningFlags = [
+    "bindnow"
+    "format"
+    "fortify"
+    "fortify3"
+    "pic"
+    "pie"
+    "relro"
+    "stackprotector"
+    "strictoverflow"
+    "trivialautovarinit"
+    "zerocallusedregs"
+  ];
+
   makeDerivationArgument =
 
 
@@ -235,19 +249,6 @@ let
     # disabling fortify implies fortify3 should also be disabled
     then unique (hardeningDisable ++ [ "fortify3" ])
     else hardeningDisable;
-  knownHardeningFlags = [
-    "bindnow"
-    "format"
-    "fortify"
-    "fortify3"
-    "pic"
-    "pie"
-    "relro"
-    "stackprotector"
-    "strictoverflow"
-    "trivialautovarinit"
-    "zerocallusedregs"
-  ];
   defaultHardeningFlags =
     (if stdenv.hasCC then stdenv.cc else {}).defaultHardeningFlags or
       # fallback safe-ish set of flags

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -18,7 +18,6 @@ let
     extendDerivation
     filter
     findFirst
-    flip
     getDev
     head
     imap1
@@ -261,10 +260,13 @@ let
   erroneousHardeningFlags = subtractLists knownHardeningFlags (hardeningEnable ++ remove "all" hardeningDisable);
 
   checkDependencyList = checkDependencyList' [];
-  checkDependencyList' = positions: name: deps: flip imap1 deps (index: dep:
-    if isDerivation dep || dep == null || builtins.isString dep || builtins.isPath dep then dep
-    else if isList dep then checkDependencyList' ([index] ++ positions) name dep
-    else throw "Dependency is not of a valid type: ${concatMapStrings (ix: "element ${toString ix} of ") ([index] ++ positions)}${name} for ${attrs.name or attrs.pname}");
+  checkDependencyList' = positions: name: deps:
+    imap1
+      (index: dep:
+        if isDerivation dep || dep == null || builtins.isString dep || builtins.isPath dep then dep
+        else if isList dep then checkDependencyList' ([index] ++ positions) name dep
+        else throw "Dependency is not of a valid type: ${concatMapStrings (ix: "element ${toString ix} of ") ([index] ++ positions)}${name} for ${attrs.name or attrs.pname}")
+      deps;
 in if builtins.length erroneousHardeningFlags != 0
 then abort ("mkDerivation was called with unsupported hardening flags: " + lib.generators.toPretty {} {
   inherit erroneousHardeningFlags hardeningDisable hardeningEnable knownHardeningFlags;

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -136,8 +136,9 @@ let
   makeDerivationArgument =
 
 
-# `mkDerivation` wraps the builtin `derivation` function to
-# produce derivations that use this stdenv and its shell.
+# `makeDerivationArgument` is responsible for the `mkDerivation` arguments that
+# affect the actual derivation, excluding a few behaviors that are not
+# essential, and specific to `mkDerivation`: `env`, `cmakeFlags`, `mesonFlags`.
 #
 # See also:
 #
@@ -490,6 +491,11 @@ mkDerivationSimple = overrideAttrs:
 # `mkDerivation` wraps the builtin `derivation` function to
 # produce derivations that use this stdenv and its shell.
 #
+# Internally, it delegates most of its behavior to `makeDerivationArgument`,
+# except for the `env`, `cmakeFlags`, and `mesonFlags` attributes, as well
+# as the attributes `meta` and `passthru` that affect [package attributes],
+# and not the derivation itself.
+#
 # See also:
 #
 # * https://nixos.org/nixpkgs/manual/#sec-using-stdenv
@@ -497,6 +503,8 @@ mkDerivationSimple = overrideAttrs:
 #
 # * https://nixos.org/manual/nix/stable/expressions/derivations.html#derivations
 #   Explanation about derivations in general
+#
+# * [package attributes]: https://nixos.org/manual/nix/stable/glossary#package-attribute-set
 {
 
 # Configure Phase


### PR DESCRIPTION
## Motivation

Refactor and improve performance.

The refactor is good in its own right, and may serve as a step towards https://github.com/NixOS/nixpkgs/issues/273815 as well as modularization that eventually benefits RFC 92 dynamic derivations and multi-derivation packages (e.g. separate derivation for the `doc` output).

Performance
- -4% cpu time, based on ofborg stats across 2 runs, which may have some noise
- supported by reduction in total allocation, but slightly diminished by final heap size
- metrics correlating to number of operations are generally down, such as function calls

## Review by commit

- Commits 1 and 2 change the structure of the file to return an attrset "library" of one function.

- [Commits 3 and 4](https://github.com/NixOS/nixpkgs/compare/de516f6f130ff744c14dc1c58fbb428fa4bb3794...954d9ce64bc515746949b2bf37e58c9934be86db) were developed in #295105 with a more meticulous commit history, but reapplied "in one go" using the original file text for a cleaner diff and git blame. I.e. the small, safe steps can be traced back there.

- The subsequent commits are individual pure refactors without changes in behavior.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
