### PR TITLE
drawterm: unstable-2024-02-18 -> unstable-2024-03-20

### DIFF
--- a/nixos/tests/drawterm.nix
+++ b/nixos/tests/drawterm.nix
@@ -38,11 +38,24 @@ let
         def drawterm_running():
             machine.succeed("pgrep drawterm")
 
+        # cage is a bit wonky here.
+        # it seems to lag behind drawing
+        # and somehow needs a single input character
+        # in order to get the first prompt to show up.
+        # This is not present in any other compositor
+        # as far as I know, and after spending a couple
+        # hours with the upstream source trying to deduce
+        # how to perhaps fix it, I figured just polling is OK.
+        @polling_condition
+        def cpu_shown_up():
+            machine.send_chars(".")
+            machine.wait_for_text("cpu", 1)
+
         start_all()
 
         machine.wait_for_unit("graphical.target")
         drawterm_running.wait() # type: ignore[union-attr]
-        machine.wait_for_text("cpu")
+        cpu_shown_up.wait() # type: ignore[union-attr]
         machine.send_chars("cpu\n")
         machine.wait_for_text("auth")
         machine.send_chars("cpu\n")

--- a/pkgs/tools/admin/drawterm/default.nix
+++ b/pkgs/tools/admin/drawterm/default.nix
@@ -19,13 +19,13 @@
 
 stdenv.mkDerivation {
   pname = "drawterm";
-  version = "unstable-2024-02-18";
+  version = "unstable-2024-03-20";
 
   src = fetchFrom9Front {
     owner = "plan9front";
     repo = "drawterm";
-    rev = "bcf1eb425dd4c90a3bfcd004f6aee3854259da78";
-    hash = "sha256-aUQ6ay2ky9NzVUZvWyHc/GqPlCdhGpXTY8GGytJSC6g=";
+    rev = "77b464a5d5648bb646467111b8faf719cd5c46b6";
+    hash = "sha256-3J/Fa3NXxUieEqRcCepGdd0ktxQFKhyY4z8Pvcq94Kw=";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
## Description of changes

A follow up from https://github.com/NixOS/nixpkgs/pull/295244, as the nixos tests surfaced a bug w.r.t. client side decorations. This is the same update with an almost perfect working fix. There is still some oddity with cage specifically that required some modifications to the test script to get working.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
