### PR TITLE
nixos/networkmanager: correct example

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -374,7 +374,7 @@ in
           };
         });
         default = [ ];
-        example = literalExpression ''[{ name = "03f0:4e1d"; script = "''${pkgs.modemmanager}/share/ModemManager/fcc-unlock.available.d/03f0:4e1d"; }]'';
+        example = literalExpression ''[{ id = "03f0:4e1d"; path = "''${pkgs.modemmanager}/share/ModemManager/fcc-unlock.available.d/03f0:4e1d"; }]'';
         description = lib.mdDoc ''
           List of FCC unlock scripts to enable on the system, behaving as described in
           https://modemmanager.org/docs/modemmanager/fcc-unlock/#integration-with-third-party-fcc-unlock-tools.


### PR DESCRIPTION
The example pertinent to `fccUnlockScripts` contains wrong (maybe old) key names possibly leading to trial/error while configuring the option. This issue can be avoided updating the example.

No need to test it as just example test was changed.