### PR TITLE
bazecor: add wayland support

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7218,6 +7218,12 @@
     githubId = 37017396;
     name = "gbtb";
   };
+  gcleroux = {
+    email = "guillaume@cleroux.dev";
+    github = "gcleroux";
+    githubId = 73357644;
+    name = "Guillaume Cléroux";
+  };
   gdamjan = {
     email = "gdamjan@gmail.com";
     matrix = "@gdamjan:spodeli.org";

--- a/pkgs/applications/misc/bazecor/default.nix
+++ b/pkgs/applications/misc/bazecor/default.nix
@@ -51,7 +51,10 @@ appimageTools.wrapAppImage rec {
     changelog = "https://github.com/Dygmalab/Bazecor/releases/tag/v${version}";
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ amesgen ];
+    maintainers = with lib.maintainers; [
+      amesgen
+      gcleroux
+    ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "bazecor";
   };

--- a/pkgs/applications/misc/bazecor/default.nix
+++ b/pkgs/applications/misc/bazecor/default.nix
@@ -1,12 +1,12 @@
-{ lib
-, appimageTools
-, fetchurl
+{
+  lib,
+  appimageTools,
+  fetchurl,
+  makeWrapper,
 }:
-
-appimageTools.wrapAppImage rec {
+let
   pname = "bazecor";
   version = "1.3.11";
-
   src = appimageTools.extract {
     inherit pname version;
     src = fetchurl {
@@ -18,11 +18,14 @@ appimageTools.wrapAppImage rec {
     postExtract = ''
       substituteInPlace \
         $out/usr/lib/bazecor/resources/app/.webpack/main/index.js \
-        --replace \
+        --replace-fail \
           'checkUdev=()=>{try{if(c.default.existsSync(f))return c.default.readFileSync(f,"utf-8").trim()===l.trim()}catch(e){console.error(e)}return!1}' \
           'checkUdev=()=>{return 1}'
     '';
   };
+in
+appimageTools.wrapAppImage {
+  inherit pname version src;
 
   # also make sure to update the udev rules in ./10-dygma.rules; most recently
   # taken from
@@ -35,14 +38,18 @@ appimageTools.wrapAppImage rec {
   # to allow non-root modifications to the keyboards.
 
   extraInstallCommands = ''
-    install -m 444 -D ${src}/Bazecor.desktop -t $out/share/applications
-    substituteInPlace $out/share/applications/Bazecor.desktop \
-      --replace 'Exec=Bazecor' 'Exec=bazecor'
+    source "${makeWrapper}/nix-support/setup-hook"
+    wrapProgram $out/bin/bazecor \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
 
+    install -m 444 -D ${src}/Bazecor.desktop -t $out/share/applications
     install -m 444 -D ${src}/bazecor.png -t $out/share/pixmaps
 
     mkdir -p $out/lib/udev/rules.d
-    ln -s --target-directory=$out/lib/udev/rules.d ${./10-dygma.rules}
+    install -m 444 -D ${./10-dygma.rules} $out/lib/udev/rules.d/10-dygma.rules
+
+    substituteInPlace $out/share/applications/Bazecor.desktop \
+      --replace-fail 'Exec=Bazecor' 'Exec=bazecor'
   '';
 
   meta = {


### PR DESCRIPTION
## Description of changes

* Add wayland support
* Refactor `default.nix` to fit the [nixpkgs docs](https://nixos.org/manual/nixpkgs/unstable/#sec-pkgs-appimageTools)

Let met preface this PR by saying: Thank you @amesgen for your work on the Bazecor package!

This PR was meant to simply add wayland support to the current package, but looking at the source files
I tought I would refactor `default.nix` to fit the current `nixpkgs` docs linked above. If you feel like this is out of
scope for this PR, I can happily split it.

~When testing wayland, I found that the AppImage would often crash on startup.
Looking deeper into it, it looks like it is a [common issue](https://github.com/Dygmalab/Bazecor/issues/683). Since the current version of `Bazecor` is flaky *(pun very much intended)*, I chose to make my work disabled by default.~

EDIT: `Bazecor` seems fine on wayland now. Enabling by default.

Lastly, I saw on Discord that you were looking for a maintainer with a defy keyboard. I will happily throw my name in the hat if you will have me! 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
