### PR TITLE
svp: restore mpv vf-del option for compatibility with svp

### DIFF
--- a/pkgs/by-name/sv/svp/mpv.nix
+++ b/pkgs/by-name/sv/svp/mpv.nix
@@ -10,9 +10,18 @@ let
   ];
 in
 wrapMpv
-  (mpv-unwrapped.override {
+  ((mpv-unwrapped.override {
     vapoursynthSupport = true;
-  })
+  }).overrideAttrs (old: {
+    patches =
+      (old.patches or [ ])
+      ++ [
+        # Credit to @xrun1
+        # https://github.com/NixOS/nixpkgs/issues/295429
+        # https://github.com/xrun1/mpv-svp-fix
+        ./xrun1-restore-vf-del-option.patch
+      ];
+  }))
 {
   extraMakeWrapperArgs = [
     # Add paths to required libraries

--- a/pkgs/by-name/sv/svp/package.nix
+++ b/pkgs/by-name/sv/svp/package.nix
@@ -20,9 +20,12 @@
 , vapoursynth
 , xdg-utils
 , xorg
+  # MPV dependencies for easier override
+, mpv-unwrapped
+, wrapMpv
 }:
 let
-  mpvForSVP = callPackage ./mpv.nix { };
+  mpvForSVP = callPackage ./mpv.nix { inherit mpv-unwrapped wrapMpv; };
 
   # Script provided by GitHub user @xrun1
   # https://github.com/xddxdd/nur-packages/issues/31#issuecomment-1812591688

--- a/pkgs/by-name/sv/svp/xrun1-restore-vf-del-option.patch
+++ b/pkgs/by-name/sv/svp/xrun1-restore-vf-del-option.patch
@@ -1,0 +1,193 @@
+diff --git a/options/m_option.c b/options/m_option.c
+index 02dea2bf3c..64f9b999b8 100644
+--- a/options/m_option.c
++++ b/options/m_option.c
+@@ -1297,10 +1297,11 @@ const m_option_type_t m_option_type_string = {
+ #define OP_NONE 0
+ #define OP_ADD 1
+ #define OP_PRE 2
+-#define OP_CLR 3
+-#define OP_TOGGLE 4
+-#define OP_APPEND 5
+-#define OP_REMOVE 6
++#define OP_DEL 3
++#define OP_CLR 4
++#define OP_TOGGLE 5
++#define OP_APPEND 6
++#define OP_REMOVE 7
+ 
+ static void free_str_list(void *dst)
+ {
+@@ -1342,6 +1343,55 @@ static int str_list_add(char **add, int n, void *dst, int pre)
+     return 1;
+ }
+ 
++static int str_list_del(struct mp_log *log, char **del, int n, void *dst)
++{
++    char **lst, *ep;
++    int i, ln, s;
++    long idx;
++
++    lst = VAL(dst);
++
++    for (ln = 0; lst && lst[ln]; ln++)
++        /**/;
++    s = ln;
++
++    for (i = 0; del[i] != NULL; i++) {
++        idx = strtol(del[i], &ep, 0);
++        if (*ep) {
++            mp_err(log, "Invalid index: %s\n", del[i]);
++            talloc_free(del[i]);
++            continue;
++        }
++        talloc_free(del[i]);
++        if (idx < 0 || idx >= ln) {
++            mp_err(log, "Index %ld is out of range.\n", idx);
++            continue;
++        } else if (!lst[idx])
++            continue;
++        talloc_free(lst[idx]);
++        lst[idx] = NULL;
++        s--;
++    }
++    talloc_free(del);
++
++    if (s == 0) {
++        talloc_free(lst);
++        VAL(dst) = NULL;
++        return 1;
++    }
++
++    // Don't bother shrinking the list allocation
++    for (i = 0, n = 0; i < ln; i++) {
++        if (!lst[i])
++            continue;
++        lst[n] = lst[i];
++        n++;
++    }
++    lst[s] = NULL;
++
++    return 1;
++}
++
+ static struct bstr get_nextsep(struct bstr *ptr, char sep, bool modify)
+ {
+     struct bstr str = *ptr;
+@@ -1388,6 +1438,11 @@ static int parse_str_list_impl(struct mp_log *log, const m_option_t *opt,
+         multi = false;
+     } else if (bstr_endswith0(name, "-pre")) {
+         op = OP_PRE;
++    } else if (bstr_endswith0(name, "-del")) {
++        op = OP_DEL;
++        mp_warn(log, "Option %.*s: -del is deprecated! "
++                "Use -remove (removes by content instead of by index).\n",
++                BSTR_P(name));
+     } else if (bstr_endswith0(name, "-clr")) {
+         op = OP_CLR;
+     } else if (bstr_endswith0(name, "-set")) {
+@@ -1475,6 +1530,8 @@ static int parse_str_list_impl(struct mp_log *log, const m_option_t *opt,
+         return str_list_add(res, n, dst, 0);
+     case OP_PRE:
+         return str_list_add(res, n, dst, 1);
++    case OP_DEL:
++        return str_list_del(log, res, n, dst);
+     }
+ 
+     if (VAL(dst))
+@@ -3280,7 +3337,8 @@ done: ;
+ // Parse a single entry for -vf-remove (return 0 if not applicable)
+ // mark_del is bounded by the number of items in dst
+ static int parse_obj_settings_del(struct mp_log *log, struct bstr opt_name,
+-                                  struct bstr *param, void *dst, bool *mark_del)
++                                  struct bstr *param, int op,
++                                  void *dst, bool *mark_del)
+ {
+     bstr s = *param;
+     if (bstr_eatstart0(&s, "@")) {
+@@ -3304,7 +3362,30 @@ static int parse_obj_settings_del(struct mp_log *log, struct bstr opt_name,
+         *param = s;
+         return 1;
+     }
+-    return 0;
++
++    if (op == OP_REMOVE)
++        return 0;
++
++    bstr rest;
++    long long id = bstrtoll(s, &rest, 0);
++    if (rest.len == s.len)
++        return 0;
++
++    if (dst) {
++        int num = obj_settings_list_num_items(VAL(dst));
++        if (id < 0)
++            id = num + id;
++
++        if (id >= 0 && id < num) {
++            mark_del[id] = true;
++        } else {
++            mp_warn(log, "Option %.*s: Index %lld is out of range.\n",
++                    BSTR_P(opt_name), id);
++        }
++    }
++
++    *param = rest;
++    return 1;
+ }
+ 
+ static int parse_obj_settings_list(struct mp_log *log, const m_option_t *opt,
+@@ -3326,6 +3407,11 @@ static int parse_obj_settings_list(struct mp_log *log, const m_option_t *opt,
+         op = OP_NONE;
+     } else if (bstr_endswith0(name, "-pre")) {
+         op = OP_PRE;
++    } else if (bstr_endswith0(name, "-del")) {
++        op = OP_DEL;
++        mp_warn(log, "Option %.*s: -del is deprecated! "
++                "Use -remove (removes by content instead of by index).\n",
++                BSTR_P(name));
+     } else if (bstr_endswith0(name, "-remove")) {
+         op = OP_REMOVE;
+     } else if (bstr_endswith0(name, "-clr")) {
+@@ -3385,7 +3471,7 @@ static int parse_obj_settings_list(struct mp_log *log, const m_option_t *opt,
+         if (dst)
+             free_obj_settings_list(dst);
+         return 0;
+-    } else if (op == OP_REMOVE) {
++    } else if (op == OP_DEL || op == OP_REMOVE) {
+         mark_del = talloc_zero_array(NULL, bool, num_items + 1);
+     }
+ 
+@@ -3394,8 +3480,8 @@ static int parse_obj_settings_list(struct mp_log *log, const m_option_t *opt,
+ 
+     while (param.len > 0) {
+         int r = 0;
+-        if (op == OP_REMOVE)
+-            r = parse_obj_settings_del(log, name, &param, dst, mark_del);
++        if (op == OP_DEL || op == OP_REMOVE)
++            r = parse_obj_settings_del(log, name, &param, op, dst, mark_del);
+         if (r == 0) {
+             r = parse_obj_settings(log, name, op, &param, ol, dst ? &res : NULL);
+         }
+@@ -3489,15 +3575,19 @@ static int parse_obj_settings_list(struct mp_log *log, const m_option_t *opt,
+                 }
+             }
+             talloc_free(res);
+-        } else if (op == OP_REMOVE) {
++        } else if (op == OP_DEL || op == OP_REMOVE) {
+             for (int n = num_items - 1; n >= 0; n--) {
+                 if (mark_del[n])
+                     obj_settings_list_del_at(&list, n);
+             }
+             for (int n = 0; res && res[n].name; n++) {
+                 int found = obj_settings_find_by_content(list, &res[n]);
+-                if (found >= 0)
++                if (found < 0) {
++                    if (op == OP_DEL)
++                        mp_warn(log, "Option %.*s: Item not found\n", BSTR_P(name));
++                } else {
+                     obj_settings_list_del_at(&list, found);
++                }
+             }
+             free_obj_settings_list(&res);
+         } else {


### PR DESCRIPTION
## Description of changes

mpv 0.37.0 removed the `vf-del` option which SVP relies on. This PR adds a patch to mpv to restore that option.

Credit to @xrun1 for the fix.

Fix #295429 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
