### PR TITLE
ivsc-firmware: add a1_prod symbolic links to fix ipu6 webcams 

### DIFF
--- a/pkgs/os-specific/linux/firmware/ivsc-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/ivsc-firmware/default.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation {
     install -D ./LICENSE $out/share/doc
 
     mkdir -p $out/lib/firmware/vsc/soc_a1_prod
+    # According to Intel's documentation for prod platform the a1_prod postfix is need it (https://github.com/intel/ivsc-firmware)
+    # This fixes ipu6 webcams
     for file in $out/lib/firmware/vsc/*.bin; do
       ln -sf "$file" "$out/lib/firmware/vsc/soc_a1_prod/$(basename "$file" .bin)_a1_prod.bin"
     done

--- a/pkgs/os-specific/linux/firmware/ivsc-firmware/default.nix
+++ b/pkgs/os-specific/linux/firmware/ivsc-firmware/default.nix
@@ -23,6 +23,11 @@ stdenv.mkDerivation {
     cp --no-preserve=mode --recursive ./firmware/* $out/lib/firmware/vsc/
     install -D ./LICENSE $out/share/doc
 
+    mkdir -p $out/lib/firmware/vsc/soc_a1_prod
+    for file in $out/lib/firmware/vsc/*.bin; do
+      ln -sf "$file" "$out/lib/firmware/vsc/soc_a1_prod/$(basename "$file" .bin)_a1_prod.bin"
+    done
+
     runHook postInstall
   '';
 


### PR DESCRIPTION
## Description of changes

According to intel's [documentation](https://github.com/intel/ivsc-firmware) for prod platform the a1_prod postfix is need it, this change will add symbolic links that add such postfix. 
related to issue #281373 and https://discourse.nixos.org/t/missing-ivsc-firmware-on-dell-xps-13-plus-9320/36724 not having such links will make ipu6 webcams to fail. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
