### PR TITLE
zziplib: 0.13.72 -> 0.13.74

### DIFF
--- a/pkgs/development/libraries/zziplib/default.nix
+++ b/pkgs/development/libraries/zziplib/default.nix
@@ -13,35 +13,14 @@
 
 stdenv.mkDerivation rec {
   pname = "zziplib";
-  version = "0.13.72";
+  version = "0.13.74";
 
   src = fetchFromGitHub {
     owner = "gdraheim";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-Ht3fBgdrTm4mCi5uhgQPNtpGzADoRVOpSuGPsIS6y0Q=";
+    hash = "sha256-MjqGHzb+dsAq2PrcBhU3sv4eMX3afkgFWUbhDp+5o/s=";
   };
-
-  patches = [
-    # apply https://github.com/gdraheim/zziplib/pull/113
-    (fetchpatch {
-      url = "https://github.com/gdraheim/zziplib/commit/82a7773cd17828a3b0a4f5f552ae80c1cc8777c7.diff";
-      sha256 = "0ifqdzxwb5d19mziy9j6lhl8wj95jpxzm0d2c6y3bgwa931avd3y";
-    })
-    (fetchpatch {
-      url = "https://github.com/gdraheim/zziplib/commit/1cd611514c5f9559eb9dfc191d678dfc991f66db.diff";
-      sha256 = "11w9qa46xq49l113k266dnv8izzdk1fq4y54yy5w8zps8zd3xfny";
-    })
-    (fetchpatch {
-      url = "https://github.com/gdraheim/zziplib/commit/e47b1e1da952a92f917db6fb19485b8a0b1a42f3.diff";
-      sha256 = "0d032hkmi3s3db12z2zbppl2swa3gdpbj0c6w13ylv2g2ixglrwg";
-    })
-    # Fixes invalid pointer conversions that cause compilation to fail with clang 15+
-    (fetchpatch {
-      url = "https://github.com/gdraheim/zziplib/commit/38e4d5f561318fa825e6544c2ef55ac5899c81b0.diff";
-      sha256 = "sha256-VJuFyiPhuAZlDxmNHBty+JbYwG85ea5u2sv7HZRHMwo=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
## Description of changes

Changes: https://github.com/gdraheim/zziplib/blob/master/ChangeLog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
