### PR TITLE
xvfb-run: new update url

### DIFF
--- a/pkgs/tools/misc/xvfb-run/default.nix
+++ b/pkgs/tools/misc/xvfb-run/default.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenvNoCC
-, fetchFromGitHub
+, fetchFromGitLab
 , makeWrapper
 , xorgserver
 , getopt
@@ -13,15 +13,16 @@
 , installShellFiles
 , xterm
 }:
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation {
   pname = "xvfb-run";
-  version = "1+g87f6705";
+  version = "1+g842f671";
 
-  src = fetchFromGitHub {
+  src = fetchFromGitLab {
+    domain = "gitlab.archlinux.org";
     owner = "archlinux";
-    repo = "svntogit-packages";
-    rev = "87f67054c49b32511893acd22be94c47ecd44b4a";
-    sha256 = "sha256-KEg92RYgJd7naHFDKbdXEy075bt6NLcmX8VhQROHVPs=";
+    repo = "packaging/packages/xorg-server";
+    rev = "842f671c8b950e599a327e9abd4f01f65301203f";
+    sha256 = "sha256-2wy95ngMxNiZVMko0SVYi2bNR8y50hmFHyS+gpt4sd0=";
   };
 
   nativeBuildInputs = [ makeWrapper installShellFiles ];
@@ -32,8 +33,8 @@ stdenvNoCC.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    cp $src/trunk/xvfb-run $out/bin/xvfb-run
-    installManPage $src/trunk/xvfb-run.1
+    cp $src/xvfb-run $out/bin/xvfb-run
+    installManPage $src/xvfb-run.1
 
     chmod a+x $out/bin/xvfb-run
     patchShebangs $out/bin/xvfb-run

--- a/pkgs/tools/misc/xvfb-run/update.sh
+++ b/pkgs/tools/misc/xvfb-run/update.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl gnused nix-prefetch jq common-updater-scripts
+#!nix-shell -i bash -p jq common-updater-scripts nix-prefetch-git
 # shellcheck shell=bash
 
 set -e
 
-info=$(nix-prefetch-git --quiet --url "https://github.com/archlinux/svntogit-packages" --rev "refs/heads/packages/xorg-server")
+info=$(nix-prefetch-git --quiet --url "https://gitlab.archlinux.org/archlinux/packaging/packages/xorg-server.git" --rev "refs/heads/main")
 
 rev=$(jq -r '.rev' <<< "$info")
 sha256=$(nix hash to-sri --type sha256 "$(jq -r '.sha256' <<< "$info")")
 dir=$(jq -r '.path' <<< "$info")
 
-newXvfbsha=$(sha256sum "$dir/trunk/xvfb-run")
-oldXvfbsha=$(sha256sum "$(nix build --quiet ".#xvfb-run.src" --json --no-link | jq -r '.[].outputs.out')/trunk/xvfb-run")
+newXvfbsha=$(sha256sum "$dir/xvfb-run")
+oldXvfbsha=$(sha256sum "$(nix build --quiet ".#xvfb-run.src" --json --no-link | jq -r '.[].outputs.out')/xvfb-run")
 
 if [[ "$newXvfbsha" != "$oldXvfbsha" ]]; then
     (


### PR DESCRIPTION
## Description of changes

Was just going through the package because of the unusual version [as compared to other distros](https://repology.org/project/xvfb-run/versions). The version itself is fine I suppose since this package doesn't directly track the `xorg` packages as Arch does.

Just updating the outdated Arch repo link from which the script is obtained.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
