### PR TITLE
nixos/fcitx: fix usage of booleans for settings

### DIFF
--- a/nixos/modules/i18n/input-method/fcitx5.nix
+++ b/nixos/modules/i18n/input-method/fcitx5.nix
@@ -10,6 +10,12 @@ let
     then pkgs.qt6Packages.fcitx5-with-addons.override { inherit (cfg) addons; }
     else pkgs.libsForQt5.fcitx5-with-addons.override { inherit (cfg) addons; };
   settingsFormat = pkgs.formats.ini { };
+  mkKeyValue = lib.generators.mkKeyValueDefault {
+    mkValueString = v:
+      if true == v then "True"
+      else if false == v then "False"
+      else lib.generators.mkValueStringDefault { } v;
+  } "=";
 in
 {
   options = {
@@ -127,12 +133,12 @@ in
         };
       in
       lib.attrsets.mergeAttrsList [
-        (optionalFile "config" (lib.generators.toINI { }) cfg.settings.globalOptions)
-        (optionalFile "profile" (lib.generators.toINI { }) cfg.settings.inputMethod)
+        (optionalFile "config" (lib.generators.toINI { inherit mkKeyValue; }) cfg.settings.globalOptions)
+        (optionalFile "profile" (lib.generators.toINI { inherit mkKeyValue; }) cfg.settings.inputMethod)
         (lib.concatMapAttrs
           (name: value: optionalFile
             "conf/${name}.conf"
-            (lib.generators.toINIWithGlobalSection { })
+            (lib.generators.toINIWithGlobalSection { inherit mkKeyValue; })
             value)
           cfg.settings.addons)
       ];

--- a/nixos/modules/i18n/input-method/fcitx5.nix
+++ b/nixos/modules/i18n/input-method/fcitx5.nix
@@ -9,6 +9,16 @@ let
   cfg = imcfg.fcitx5;
   fcitx5Package = pkgs.qt6Packages.fcitx5-with-addons.override { inherit (cfg) addons; };
   settingsFormat = pkgs.formats.ini { };
+  mkKeyValue = lib.generators.mkKeyValueDefault {
+    mkValueString =
+      v:
+      if true == v then
+        "True"
+      else if false == v then
+        "False"
+      else
+        lib.generators.mkValueStringDefault { } v;
+  } "=";
 in
 {
   options = {
@@ -131,10 +141,13 @@ in
           };
       in
       lib.attrsets.mergeAttrsList [
-        (optionalFile "config" (lib.generators.toINI { }) cfg.settings.globalOptions)
-        (optionalFile "profile" (lib.generators.toINI { }) cfg.settings.inputMethod)
+        (optionalFile "config" (lib.generators.toINI { inherit mkKeyValue; }) cfg.settings.globalOptions)
+        (optionalFile "profile" (lib.generators.toINI { inherit mkKeyValue; }) cfg.settings.inputMethod)
         (lib.concatMapAttrs (
-          name: value: optionalFile "conf/${name}.conf" (lib.generators.toINIWithGlobalSection { }) value
+          name: value:
+          optionalFile "conf/${name}.conf" (lib.generators.toINIWithGlobalSection {
+            inherit mkKeyValue;
+          }) value
         ) cfg.settings.addons)
       ];
 

--- a/nixos/tests/fcitx5/default.nix
+++ b/nixos/tests/fcitx5/default.nix
@@ -37,7 +37,7 @@
         ];
         fcitx5.settings = {
           globalOptions = {
-            "Hotkey"."EnumerateSkipFirst" = "False";
+            "Hotkey"."EnumerateSkipFirst" = false;
             "Hotkey/TriggerKeys"."0" = "Control+space";
             "Hotkey/EnumerateForwardKeys"."0" = "Alt+Shift_L";
             "Hotkey/EnumerateBackwardKeys"."0" = "Alt+Shift_R";


### PR DESCRIPTION
fcitx5 ini files should have capitalized boolean values vs the generators.toINI's lowercase true / false

fixes #295398 

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
