### PR TITLE
libipuz: init at 0.4.5; crosswords: init at 0.3.12 

### DIFF
--- a/pkgs/by-name/cr/crosswords/package.nix
+++ b/pkgs/by-name/cr/crosswords/package.nix
@@ -1,0 +1,50 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, meson
+, ninja
+, pkg-config
+, wrapGAppsHook4
+, desktop-file-utils
+, libadwaita
+, isocodes
+, json-glib
+, libipuz
+}:
+
+stdenv.mkDerivation rec {
+  pname = "crosswords";
+  version = "0.3.12";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "jrb";
+    repo = "crosswords";
+    rev = version;
+    hash = "sha256-3RL2LJdIHmDAjXaxqsE0n5UQMsuBJWEMoyAEoSBemR0=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+    desktop-file-utils
+  ];
+
+  buildInputs = [
+    libadwaita
+    isocodes
+    json-glib
+    libipuz
+  ];
+
+  meta = with lib; {
+    description = "A Crossword player and editor for GNOME";
+    homepage = "https://gitlab.gnome.org/jrb/crosswords";
+    license = licenses.gpl3Plus;
+    mainProgram = "crosswords";
+    maintainers = with maintainers; [ aleksana ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/by-name/li/libipuz/package.nix
+++ b/pkgs/by-name/li/libipuz/package.nix
@@ -1,0 +1,42 @@
+{ lib
+, stdenv
+, fetchFromGitLab
+, meson
+, ninja
+, pkg-config
+, glib
+, json-glib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libipuz";
+  version = "0.4.5";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "jrb";
+    repo = "libipuz";
+    rev = version;
+    hash = "sha256-psC2cFqSTlToCtCxwosXyJbmX/96AEI0xqzXtlc/HQE=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    glib
+  ];
+
+  buildInputs = [
+    glib
+    json-glib
+  ];
+
+  meta = with lib; {
+    description = "Library for parsing .ipuz puzzle files";
+    homepage = "https://gitlab.gnome.org/jrb/libipuz";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ aleksana ];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
## Description of changes

Tested

![image](https://github.com/NixOS/nixpkgs/assets/42209822/bc22ddbb-502a-418c-bd42-5df7d3ee4a2c)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
