### PR TITLE
julia.withPackages: fix artifact builds by removing extraneous env-vars

### DIFF
--- a/pkgs/development/julia-modules/python/extract_artifacts.py
+++ b/pkgs/development/julia-modules/python/extract_artifacts.py
@@ -79,6 +79,10 @@ def get_archive_derivation(uuid, artifact_name, url, sha256):
           url = "{url}";
           sha256 = "{sha256}";
         }};
+        preUnpack = ''
+          mkdir unpacked
+          cd unpacked
+        '';
         sourceRoot = ".";
         dontConfigure = true;
         dontBuild = true;


### PR DESCRIPTION
## Description of changes

It turns out the derivation we've been using for archive-like Julia artifacts has been introducing an `env-vars` file into the output. I don't know why this is happening, but it causes problems for some artifacts. I first noticed this with the [TZJData.jl](https://github.com/JuliaTime/TZJData.jl/blob/main/Artifacts.toml) package, which downloads an artifact containing a directory of time zone databases. When we put an `env-vars` file in this folder, some code in `TimeZones.jl` tries to read it as a time zone database and crashes.

Maybe there's a cleaner way to keep `stdenv.mkDerivation` from creating the `env-vars` file?

This brings our test failures from **52** down to **39** out of the top 1000 packages. So this PR brings our success rate from **94.8**% to **96.1**%.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
