### PR TITLE
[Backport release-23.11] gotosocial: 0.14.1 -> 0.14.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2432,6 +2432,12 @@
     github = "blaggacao";
     githubId = 7548295;
   };
+  blakesmith = {
+    name = "Blake Smith";
+    email = "blakesmith0@gmail.com";
+    github = "blakesmith";
+    githubId = 44368;
+  };
   blankparticle = {
     name = "BlankParticle";
     email = "blankparticle@gmail.com";

--- a/nixos/modules/services/web-apps/gotosocial.nix
+++ b/nixos/modules/services/web-apps/gotosocial.nix
@@ -27,7 +27,7 @@ let
 in
 {
   meta.doc = ./gotosocial.md;
-  meta.maintainers = with lib.maintainers; [ misuzu ];
+  meta.maintainers = with lib.maintainers; [ misuzu blakesmith ];
 
   options.services.gotosocial = {
     enable = lib.mkEnableOption (lib.mdDoc "ActivityPub social network server");

--- a/nixos/tests/web-apps/gotosocial.nix
+++ b/nixos/tests/web-apps/gotosocial.nix
@@ -1,7 +1,7 @@
 { lib, ... }:
 {
   name = "gotosocial";
-  meta.maintainers = with lib.maintainers; [ misuzu ];
+  meta.maintainers = with lib.maintainers; [ misuzu blakesmith ];
 
   nodes.machine = { pkgs, ... }: {
     environment.systemPackages = [ pkgs.jq ];

--- a/pkgs/servers/gotosocial/default.nix
+++ b/pkgs/servers/gotosocial/default.nix
@@ -43,8 +43,18 @@ buildGoModule rec {
   # tests are working only on x86_64-linux
   doCheck = stdenv.isLinux && stdenv.isx86_64;
 
-  # flaky test
-  checkFlags = [ "-skip=^TestPage/minID,_maxID_and_limit_set$" ];
+  checkFlags =
+    let
+      # flaky / broken tests
+      skippedTests = [
+        # See: https://github.com/superseriousbusiness/gotosocial/issues/2651
+        "TestPage/minID,_maxID_and_limit_set"
+        # See: https://github.com/superseriousbusiness/gotosocial/pull/2760. Stop skipping
+        # this test when fixed for go 1.21.8 and above
+        "TestValidationTestSuite/TestValidateEmail"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   passthru.tests.gotosocial = nixosTests.gotosocial;
 

--- a/pkgs/servers/gotosocial/default.nix
+++ b/pkgs/servers/gotosocial/default.nix
@@ -9,11 +9,11 @@ let
   owner = "superseriousbusiness";
   repo = "gotosocial";
 
-  version = "0.14.1";
+  version = "0.14.2";
 
   web-assets = fetchurl {
     url = "https://github.com/${owner}/${repo}/releases/download/v${version}/${repo}_${version}_web-assets.tar.gz";
-    hash = "sha256-cNO0LuTzgx3CAP+qjTBZ9Fgs4jrH3ypZREpKKipOJDA=";
+    hash = "sha256-3aSOP8BTHdlODQnZr6DOZuybLl+02SWgP9YZ21guAPU=";
   };
 in
 buildGoModule rec {
@@ -23,7 +23,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     inherit owner repo;
     rev = "refs/tags/v${version}";
-    hash = "sha256-gXriCpLPFBzIWm0xKE2LdT3+VWLNwJAHtT9ZuYO3sDI=";
+    hash = "sha256-oeOxP9FkGsOH66Uk946H0b/zggz536YvRRuo1cINxSM=";
   };
 
   vendorHash = null;
@@ -59,7 +59,7 @@ buildGoModule rec {
       advertised to! A light-weight alternative to Mastodon
       and Pleroma, with support for clients!
     '';
-    maintainers = with maintainers; [ misuzu ];
+    maintainers = with maintainers; [ misuzu blakesmith ];
     license = licenses.agpl3Only;
   };
 }


### PR DESCRIPTION
Manual backport to release-23.11, from https://github.com/NixOS/nixpkgs/pull/295199, due to incorrectly formatted commit messages. Declined bot based backport is here: https://github.com/NixOS/nixpkgs/pull/295534