### PR TITLE
ocamlPackages.tyxml: 4.5.0 → 4.6.0

### DIFF
--- a/pkgs/development/ocaml-modules/eliom/default.nix
+++ b/pkgs/development/ocaml-modules/eliom/default.nix
@@ -1,6 +1,7 @@
 { buildDunePackage
 , lib
 , fetchFromGitHub
+, fetchpatch
 , which
 , ocsigen_server
 , lwt_react
@@ -24,6 +25,12 @@ buildDunePackage rec {
     repo = "eliom";
     rev = version;
     hash = "sha256-REOyxwnQqWOKywVYwN/WP22cNKZv5Nv0OpFVbNBPJN8=";
+  };
+
+  # Compatibility with tyxml 4.6.x
+  patches = fetchpatch {
+    url = "https://github.com/ocsigen/eliom/commit/9a6adcce3959a37b971890999331335d07f4f732.patch";
+    hash = "sha256-rgsqohSAHHljvag3c+HNGEgW9qwmqPq8qfTpX6vVKtg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/ocaml-modules/lwd/tyxml-lwd.nix
+++ b/pkgs/development/ocaml-modules/lwd/tyxml-lwd.nix
@@ -1,12 +1,17 @@
-{ lib, fetchurl, buildDunePackage, js_of_ocaml, js_of_ocaml-ppx, lwd, tyxml }:
+{ lib, fetchurl, fetchpatch, buildDunePackage, js_of_ocaml, js_of_ocaml-ppx, lwd, tyxml }:
 
 buildDunePackage {
   pname = "tyxml-lwd";
 
   inherit (lwd) version src;
 
+  # Compatibility with latest Tyxml (4.6.x)
+  patches = fetchpatch {
+    url = "https://github.com/let-def/lwd/commit/7f3364ec593b5ccf0d0294b97bcd1e28e4164691.patch";
+    hash = "sha256-W1HjExZxDKRwsrB9ZTkvHTMKO0K5iZl+FrNqPs6BPGU=";
+  };
+
   minimalOCamlVersion = "4.08";
-  duneVersion = "3";
 
   buildInputs = [ js_of_ocaml-ppx ];
   propagatedBuildInputs = [ js_of_ocaml lwd tyxml ];

--- a/pkgs/development/ocaml-modules/ocsigen-start/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-start/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchFromGitHub, ocaml, findlib, ocsigen-toolkit, pgocaml_ppx, safepass, yojson
+{ stdenv, lib, fetchFromGitHub, fetchpatch, ocaml, findlib, ocsigen-toolkit, pgocaml_ppx, safepass, yojson
 , cohttp-lwt-unix, eliom
 , resource-pooling
 , ocsigen-ppx-rpc
@@ -14,7 +14,13 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
-  patches = [ ./templates-dir.patch ];
+  patches = [ ./templates-dir.patch
+    # Compatibility with tyxml 4.6.x
+    (fetchpatch {
+       url = "https://github.com/ocsigen/ocsigen-start/commit/0b70506f94fcb2e06cb65ce0d6a28b9b84c695f3.patch";
+       hash = "sha256-p/VvIu9reI8lc9lxWiTrjZvn46vuF00QInYuWPtRVyk=";
+    })
+  ];
 
   src = fetchFromGitHub {
     owner = "ocsigen";

--- a/pkgs/development/ocaml-modules/tyxml/default.nix
+++ b/pkgs/development/ocaml-modules/tyxml/default.nix
@@ -2,13 +2,11 @@
 
 buildDunePackage rec {
   pname = "tyxml";
-  version = "4.5.0";
-
-  useDune2 = true;
+  version = "4.6.0";
 
   src = fetchurl {
     url = "https://github.com/ocsigen/tyxml/releases/download/${version}/tyxml-${version}.tbz";
-    sha256 = "0s30f72m457c3gbdmdwbx7ls9zg806nvm83aiz9qkpglbppwr6n6";
+    hash = "sha256-v+tnPGtOEgpOykxIRIrdR9w/jQLCtA9j/9zMTpHJAt0=";
   };
 
   propagatedBuildInputs = [ uutf re ];


### PR DESCRIPTION
## Description of changes

https://raw.githubusercontent.com/ocsigen/tyxml/4.6.0/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
