### PR TITLE
protonmail-bridge-gui: init at 3.9.1

### DIFF
--- a/pkgs/applications/networking/protonmail-bridge/default.nix
+++ b/pkgs/applications/networking/protonmail-bridge/default.nix
@@ -41,13 +41,12 @@ buildGoModule rec {
     install -Dm444 dist/bridge.svg $out/share/icons/hicolor/scalable/apps/protonmail-bridge.svg
   '';
 
-  meta = with lib; {
-    homepage = "https://github.com/ProtonMail/proton-bridge";
+  meta = {
     changelog = "https://github.com/ProtonMail/proton-bridge/blob/${src.rev}/Changelog.md";
-    downloadPage = "https://github.com/ProtonMail/proton-bridge/releases";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ mrfreezeex ];
     description = "Use your ProtonMail account with your local e-mail client";
+    downloadPage = "https://github.com/ProtonMail/proton-bridge/releases";
+    homepage = "https://github.com/ProtonMail/proton-bridge";
+    license = lib.licenses.gpl3Plus;
     longDescription = ''
       An application that runs on your computer in the background and seamlessly encrypts
       and decrypts your mail as it enters and leaves your computer.
@@ -55,5 +54,6 @@ buildGoModule rec {
       To work, use secret-service freedesktop.org API (e.g. Gnome keyring) or pass.
     '';
     mainProgram = "protonmail-bridge";
+    maintainers = with lib.maintainers; [ mrfreezeex daniel-fahey ];
   };
 }

--- a/pkgs/applications/networking/protonmail-bridge/default.nix
+++ b/pkgs/applications/networking/protonmail-bridge/default.nix
@@ -37,8 +37,6 @@ buildGoModule rec {
 
   postInstall = ''
     mv $out/bin/Desktop-Bridge $out/bin/protonmail-bridge # The cli is named like that in other distro packages
-    install -Dm444 dist/proton-bridge.desktop -t $out/share/applications
-    install -Dm444 dist/bridge.svg $out/share/icons/hicolor/scalable/apps/protonmail-bridge.svg
   '';
 
   meta = {

--- a/pkgs/by-name/pr/protonmail-bridge-gui/package.nix
+++ b/pkgs/by-name/pr/protonmail-bridge-gui/package.nix
@@ -1,0 +1,113 @@
+{ lib
+, stdenv
+, pkg-config
+, libsecret
+, cmake
+, ninja
+, qt6
+, grpc
+, protobuf
+, zlib
+, gtest
+, sentry-native
+, protonmail-bridge
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "protonmail-bridge-gui";
+
+  inherit (protonmail-bridge) version src;
+
+  patches = [
+    # Use `gtest` from Nixpkgs to allow an offline build
+    ./use-nix-googletest.patch
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+    ninja
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qtwayland
+    qt6.qtsvg
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    libsecret
+    grpc
+    protobuf
+    zlib
+    gtest
+    sentry-native
+  ];
+
+  sourceRoot = "${finalAttrs.src.name}/internal/frontend/bridge-gui";
+
+  postPatch = ''
+    # Bypass `vcpkg` by deleting lines that `include` BridgeSetup.cmake
+    find . -type f -name "CMakeLists.txt" -exec sed -i "/BridgeSetup\\.cmake/d" {} \;
+
+    # Use the available ICU version
+    sed -i "s/libicu\(i18n\|uc\|data\)\.so\.56/libicu\1.so/g" bridge-gui/DeployLinux.cmake
+
+    # Create a Desktop Entry that uses a `protonmail-bridge-gui` binary without upstream's launcher
+    sed "s/^\(Icon\|Exec\)=.*$/\1=protonmail-bridge-gui/" ../../../dist/proton-bridge.desktop > proton-bridge-gui.desktop
+
+    # Also update `StartupWMClass` to match the GUI binary's `wmclass` (Wayland app id)
+    sed -i "s/^\(StartupWMClass=\)Proton Mail Bridge$/\1ch.proton.bridge-gui/" proton-bridge-gui.desktop
+
+    # Don't build `bridge-gui-tester`
+    sed -i "/add_subdirectory(bridge-gui-tester)/d" CMakeLists.txt
+  '';
+
+  preConfigure = ''
+    cmakeFlagsArray+=(
+      "-DCMAKE_BUILD_TYPE=Release"
+      "-DBRIDGE_APP_FULL_NAME=Proton Mail Bridge"
+      "-DBRIDGE_VENDOR=Proton AG"
+      "-DBRIDGE_REVISION=${finalAttrs.src.rev}"
+      "-DBRIDGE_TAG=${finalAttrs.version}"
+      "-DBRIDGE_BUILD_ENV=Nix"
+      "-DBRIDGE_APP_VERSION=${finalAttrs.version}"
+    )
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # Install the GUI binary
+    install -Dm755 bridge-gui/bridge-gui $out/lib/bridge-gui
+
+    # Symlink the backend binary from the protonmail-bridge (CLI) package
+    ln -s ${protonmail-bridge}/bin/protonmail-bridge $out/lib/bridge
+
+    # Symlink the GUI binary
+    mkdir -p $out/bin
+    ln -s $out/lib/bridge-gui $out/bin/protonmail-bridge-gui
+
+    # Install desktop assets
+    install -Dm644 ../proton-bridge-gui.desktop -t $out/share/applications
+    install -Dm644 ../../../../dist/bridge.svg $out/share/icons/hicolor/scalable/apps/protonmail-bridge-gui.svg
+
+    runHook postInstall
+  '';
+
+  meta = {
+    changelog = "https://github.com/ProtonMail/proton-bridge/blob/${finalAttrs.src.rev}/Changelog.md";
+    description = "Qt-based GUI to use your ProtonMail account with your local e-mail client";
+    downloadPage = "https://github.com/ProtonMail/proton-bridge/releases";
+    homepage = "https://github.com/ProtonMail/proton-bridge";
+    license = lib.licenses.gpl3Plus;
+    longDescription = ''
+      Provides a GUI application that runs in the background and seamlessly encrypts
+      and decrypts your mail as it enters and leaves your computer.
+
+      To work, use secret-service freedesktop.org API (e.g. Gnome keyring) or pass.
+    '';
+    mainProgram = "protonmail-bridge-gui";
+    maintainers = with lib.maintainers; [ daniel-fahey ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/pr/protonmail-bridge-gui/use-nix-googletest.patch
+++ b/pkgs/by-name/pr/protonmail-bridge-gui/use-nix-googletest.patch
@@ -1,0 +1,23 @@
+diff --git a/bridgepp/CMakeLists.txt b/bridgepp/CMakeLists.txt
+index f4a0a553..02d631dc 100644
+--- a/bridgepp/CMakeLists.txt
++++ b/bridgepp/CMakeLists.txt
+@@ -172,16 +172,8 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
+     cmake_policy(SET CMP0135 NEW) # avoid warning DOWNLOAD_EXTRACT_TIMESTAMP
+ endif ()
+ 
+-include(FetchContent)
+-FetchContent_Declare(
+-    googletest
+-    URL https://github.com/google/googletest/archive/b796f7d44681514f58a683a3a71ff17c94edb0c1.zip
+-)
+-
+-# For Windows: Prevent overriding the parent project's compiler/linker settings
+-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+-
+-FetchContent_MakeAvailable(googletest)
++# Use find_package to use the gtest package provided by Nix
++find_package(GTest REQUIRED)
+ 
+ enable_testing()
+ 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds an optional GUI to Proton Mail Bridge (`pname = protonmail-bridge-gui`) [reusing (and preserving) the existing CLI package as its backend (`pname = protonmail-bridge`)](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/networking/protonmail-bridge/default.nix). It is built from a patched source using CMake and Qt 6. It also fixes #255523.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
