### PR TITLE
Revert "sarasa-gothic: 1.0.5 -> 1.0.6"

### DIFF
--- a/pkgs/data/fonts/sarasa-gothic/default.nix
+++ b/pkgs/data/fonts/sarasa-gothic/default.nix
@@ -2,13 +2,13 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "sarasa-gothic";
-  version = "1.0.6";
+  version = "1.0.5";
 
   src = fetchurl {
     # Use the 'ttc' files here for a smaller closure size.
     # (Using 'ttf' files gives a closure size about 15x larger, as of November 2021.)
     url = "https://github.com/be5invis/Sarasa-Gothic/releases/download/v${version}/Sarasa-TTC-${version}.7z";
-    hash = "sha256-zoQilSAd5BpLCbTxU0Baupdc1VUxENvNEc9phFVFUoo=";
+    hash = "sha256-OPoX6GNCilA8Lj9kLO6RHapU7mpZTiNa/8LL72TG1Wk=";
   };
 
   sourceRoot = ".";


### PR DESCRIPTION
Reverts NixOS/nixpkgs#294879 @ChengCat  This doesn't compile since the url [https://github.com/be5invis/Sarasa-Gothic/releases/download/v1.0.6/Sarasa-TTC-v1.0.6.7z](url) returns 404. The robot needs to be altered. @ryantm 