### PR TITLE
rockcraft: init at 1.2.2

### DIFF
--- a/pkgs/by-name/ro/rockcraft/package.nix
+++ b/pkgs/by-name/ro/rockcraft/package.nix
@@ -1,0 +1,58 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+, dpkg
+, nix-update-script
+, python3
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "rockcraft";
+  version = "1.2.2";
+
+  src = fetchFromGitHub {
+    owner = "canonical";
+    repo = "rockcraft";
+    rev = "refs/tags/${version}";
+    hash = "sha256-f6qLvk5cebHjZx51nJYYAwILGCTyj6FKlb3HGt6iz4M=";
+  };
+
+  postPatch = ''
+    substituteInPlace rockcraft/__init__.py \
+      --replace-fail "dev" "${version}"
+  '';
+
+  propagatedBuildInputs = with python3Packages; [
+    craft-application-1
+    craft-archives
+    spdx-lookup
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytest-check
+    pytest-mock
+    pytest-subprocess
+    pytestCheckHook
+  ] ++ [
+    dpkg
+  ];
+
+  preCheck = ''
+    mkdir -p check-phase
+    export HOME="$(pwd)/check-phase"
+  '';
+
+  disabledTests = [ "test_expand_extensions" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "rockcraft";
+    description = "Create OCI images using the language from Snapcraft and Charmcraft";
+    homepage = "https://github.com/canonical/rockcraft";
+    changelog = "https://github.com/canonical/rockcraft/releases/tag/${version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ jnsgruk ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/craft-application-1/default.nix
+++ b/pkgs/development/python-modules/craft-application-1/default.nix
@@ -1,0 +1,84 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, nix-update-script
+, craft-cli
+, craft-parts
+, craft-providers
+, pydantic-yaml-0
+, pyyaml
+, setuptools
+, setuptools-scm
+, pytestCheckHook
+, pytest-check
+, pytest-mock
+, hypothesis
+}:
+
+buildPythonPackage rec {
+  pname = "craft-application-1";
+  version = "1.2.1";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "canonical";
+    repo = "craft-application";
+    rev = "refs/tags/${version}";
+    hash = "sha256-CXZEWVoE66dlQJp4G8tinufjyaDJaH1Muxz/qd/81oA=";
+  };
+
+  postPatch = ''
+    substituteInPlace craft_application/__init__.py \
+      --replace-fail "dev" "${version}"
+
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools==67.7.2" "setuptools"
+  '';
+
+  nativeBuildInputs = [
+    setuptools
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    craft-cli
+    craft-parts
+    craft-providers
+    pydantic-yaml-0
+    pyyaml
+  ];
+
+  pythonImportsCheck = [
+    "craft_application"
+  ];
+
+  nativeCheckInputs = [
+    hypothesis
+    pytest-check
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  pytestFlagsArray = [ "tests/unit" ];
+
+  disabledTests = [
+    "test_to_yaml_file"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "The basis for Canonical craft applications";
+    homepage = "https://github.com/canonical/craft-application";
+    changelog = "https://github.com/canonical/craft-application/releases/tag/${version}";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ jnsgruk ];
+    platforms = lib.platforms.linux;
+  };
+}
+

--- a/pkgs/development/python-modules/craft-archives/default.nix
+++ b/pkgs/development/python-modules/craft-archives/default.nix
@@ -1,0 +1,74 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, nix-update-script
+, launchpadlib
+, lazr-restfulclient
+, overrides
+, pydantic_1
+, setuptools
+, setuptools-scm
+, tabulate
+, pytest-check
+, pytest-mock
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "craft-archives";
+  version = "1.1.3";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "canonical";
+    repo = "craft-archives";
+    rev = "refs/tags/${version}";
+    hash = "sha256-ZUqMjbOsHwzZyn0NsSTlZTljzagYEirWKEGatXVL43g=";
+  };
+
+  postPatch = ''
+    substituteInPlace craft_archives/__init__.py \
+      --replace-fail "dev" "${version}"
+
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools==67.7.2" "setuptools"
+  '';
+
+  nativeBuildInputs = [
+    setuptools
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    launchpadlib
+    lazr-restfulclient
+    overrides
+    pydantic_1
+    tabulate
+  ];
+
+  pythonImportsCheck = [
+    "craft_archives"
+  ];
+
+  nativeCheckInputs = [
+    pytest-check
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "tests/unit" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A library for handling archives/repositories in Canonical craft applications";
+    homepage = "https://github.com/canonical/craft-archives";
+    changelog = "https://github.com/canonical/craft-archives/releases/tag/${version}";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ jnsgruk ];
+    platforms = lib.platforms.linux;
+  };
+}
+

--- a/pkgs/development/python-modules/craft-cli/default.nix
+++ b/pkgs/development/python-modules/craft-cli/default.nix
@@ -1,0 +1,69 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, nix-update-script
+, platformdirs
+, pydantic_1
+, pyyaml
+, setuptools
+, setuptools-scm
+, pytest-check
+, pytest-mock
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "craft-cli";
+  version = "2.5.1";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "canonical";
+    repo = "craft-cli";
+    rev = "refs/tags/${version}";
+    hash = "sha256-yEKF04OPu4paRrghAP78r9hu6cqkUy6z/V7cHNys82I=";
+  };
+
+  postPatch = ''
+    substituteInPlace craft_cli/__init__.py \
+      --replace-fail "dev" "${version}"
+
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools==67.7.2" "setuptools"
+  '';
+
+  nativeBuildInputs = [
+    setuptools
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    platformdirs
+    pydantic_1
+    pyyaml
+  ];
+
+  pythonImportsCheck = [
+    "craft_cli"
+  ];
+
+  nativeCheckInputs = [
+    pytest-check
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "tests/unit" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A CLI builder for Canonical's CLI Guidelines";
+    homepage = "https://github.com/canonical/craft-cli";
+    changelog = "https://github.com/canonical/craft-cli/releases/tag/${version}";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ jnsgruk ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/craft-grammar/default.nix
+++ b/pkgs/development/python-modules/craft-grammar/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, nix-update-script
+, overrides
+, setuptools
+, pytest-check
+, pytest-mock
+, pytestCheckHook
+, pydantic_1
+, pyyaml
+}:
+
+buildPythonPackage rec {
+  pname = "craft-grammar";
+  version = "1.1.2";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "canonical";
+    repo = "craft-grammar";
+    rev = "refs/tags/${version}";
+    hash = "sha256-23KLIO2yHXGe/zb3B8LirJsh+LY9z0c5ZGtF392Kszo";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    overrides
+  ];
+
+  pythonImportsCheck = [
+    "craft_grammar"
+  ];
+
+  nativeCheckInputs = [
+    pydantic_1
+    pytestCheckHook
+    pyyaml
+  ];
+
+  pytestFlagsArray = [ "tests/unit" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Advanced grammar for Canonical's craft-parts library";
+    homepage = "https://github.com/canonical/craft-grammar";
+    changelog = "https://github.com/canonical/craft-grammar/releases/tag/${version}";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ jnsgruk ];
+    platforms = lib.platforms.linux;
+  };
+}
+

--- a/pkgs/development/python-modules/craft-parts/bash-path.patch
+++ b/pkgs/development/python-modules/craft-parts/bash-path.patch
@@ -1,0 +1,41 @@
+diff --git a/craft_parts/executor/step_handler.py b/craft_parts/executor/step_handler.py
+index 404df69..f90e2ac 100644
+--- a/craft_parts/executor/step_handler.py
++++ b/craft_parts/executor/step_handler.py
+@@ -243,8 +243,9 @@ class StepHandler:
+                 print(script, file=script_file)
+                 script_file.flush()
+                 script_file.seek(0)
++                import shutil
+                 process = subprocess.Popen(  # pylint: disable=consider-using-with
+-                    ["/bin/bash"],
++                    [shutil.which("bash")],
+                     stdin=script_file,
+                     cwd=work_dir,
+                     stdout=self._stdout,
+@@ -394,7 +395,8 @@ def _create_and_run_script(
+ ) -> None:
+     """Create a script with step-specific commands and execute it."""
+     with script_path.open("w") as run_file:
+-        print("#!/bin/bash", file=run_file)
++        import shutil
++        print(f"#!{shutil.which('bash')}", file=run_file)
+         print("set -euo pipefail", file=run_file)
+ 
+         if build_environment_script_path:
+diff --git a/craft_parts/plugins/validator.py b/craft_parts/plugins/validator.py
+index b8d8f11..fce0e72 100644
+--- a/craft_parts/plugins/validator.py
++++ b/craft_parts/plugins/validator.py
+@@ -142,9 +142,9 @@ class PluginEnvironmentValidator:
+             print(self._env, file=env_file)
+             print(cmd, file=env_file)
+             env_file.flush()
+-
++            import shutil
+             proc = subprocess.run(
+-                ["/bin/bash", env_file.name],
++                [shutil.which("bash"), env_file.name],
+                 check=True,
+                 capture_output=True,
+                 text=True,

--- a/pkgs/development/python-modules/craft-parts/default.nix
+++ b/pkgs/development/python-modules/craft-parts/default.nix
@@ -1,0 +1,119 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, nix-update-script
+, overrides
+, pydantic_1
+, pydantic-yaml-0
+, pyxdg
+, pyyaml
+, requests
+, requests-unixsocket
+, types-pyyaml
+, urllib3
+, pytestCheckHook
+, pytest-check
+, pytest-mock
+, pytest-subprocess
+, requests-mock
+, hypothesis
+, git
+, squashfsTools
+, setuptools
+, setuptools-scm
+}:
+
+buildPythonPackage rec {
+  pname = "craft-parts";
+  version = "1.26.2";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "canonical";
+    repo = "craft-parts";
+    rev = "refs/tags/${version}";
+    hash = "sha256-wHv0JWffS916RK4Kgk+FuRthx+ajh0Ka4DBwGrLdUBs=";
+  };
+
+  patches = [
+    ./bash-path.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail "pydantic-yaml[pyyaml]>=0.11.0,<1.0.0" "pydantic-yaml[pyyaml]" \
+      --replace-fail "urllib3<2" "urllib3"
+  '';
+
+  nativeBuildInputs = [
+    setuptools
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    overrides
+    pydantic_1
+    pydantic-yaml-0
+    pyxdg
+    pyyaml
+    requests
+    requests-unixsocket
+    types-pyyaml
+    urllib3
+  ];
+
+  pythonImportsCheck = [
+    "craft_parts"
+  ];
+
+  nativeCheckInputs = [
+    git
+    hypothesis
+    pytest-check
+    pytest-mock
+    pytest-subprocess
+    pytestCheckHook
+    requests-mock
+    squashfsTools
+  ];
+
+  pytestFlagsArray = [ "tests/unit" ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  disabledTests = [
+    # Relies upon paths not present in Nix (like /bin/bash)
+    "test_run_builtin_build"
+    "test_run_prime"
+    "test_get_build_packages_with_source_type"
+    "test_get_build_packages"
+  ];
+
+  disabledTestPaths = [
+    # Relies upon filesystem extended attributes, and suid/guid bits
+    "tests/unit/sources/test_base.py"
+    "tests/unit/packages/test_base.py"
+    "tests/unit/state_manager"
+    "tests/unit/test_xattrs.py"
+    "tests/unit/packages/test_normalize.py"
+    # Relies upon presence of apt/dpkg.
+    "tests/unit/packages/test_apt_cache.py"
+    "tests/unit/packages/test_deb.py"
+    "tests/unit/packages/test_chisel.py"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Software artifact parts builder from Canonical";
+    homepage = "https://github.com/canonical/craft-parts";
+    changelog = "https://github.com/canonical/craft-parts/releases/tag/${version}";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ jnsgruk ];
+    platforms = lib.platforms.linux;
+  };
+}
+

--- a/pkgs/development/python-modules/craft-providers/default.nix
+++ b/pkgs/development/python-modules/craft-providers/default.nix
@@ -1,0 +1,111 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, nix-update-script
+, packaging
+, platformdirs
+, pydantic_1
+, pyyaml
+, requests-unixsocket
+, setuptools
+, setuptools-scm
+, urllib3
+, pytest-check
+, pytest-mock
+, pytestCheckHook
+, responses
+, freezegun
+, pytest-subprocess
+, pytest-logdog
+}:
+
+buildPythonPackage rec {
+  pname = "craft-providers";
+  version = "1.23.0";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "canonical";
+    repo = "craft-providers";
+    rev = "refs/tags/${version}";
+    hash = "sha256-9ZoNgpuGytwozRsw0wnS3d2UBOIsh3VI/uzB1RD2Zac=";
+  };
+
+  patches = [
+    ./inject-snaps.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace craft_providers/lxd/installer.py \
+      --replace-fail "/var/snap/lxd/common/lxd/unix.socket" "/var/lib/lxd/unix.socket"
+
+    substituteInPlace craft_providers/__init__.py \
+      --replace-fail "dev" "${version}"
+
+    # The urllib3 incompat: https://github.com/msabramo/requests-unixsocket/pull/69
+    # This is already patched in nixpkgs.
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools==67.8.0" "setuptools" \
+      --replace-fail "urllib3<2" "urllib3"
+  '';
+
+  nativeBuildInputs = [
+    setuptools
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    packaging
+    platformdirs
+    pydantic_1
+    pyyaml
+    requests-unixsocket
+    urllib3
+  ];
+
+  pythonImportsCheck = [
+    "craft_providers"
+  ];
+
+  nativeCheckInputs = [
+    freezegun
+    pytest-check
+    pytest-mock
+    pytest-subprocess
+    pytest-logdog
+    pytestCheckHook
+    responses
+  ];
+
+  preCheck = ''
+    mkdir -p check-phase
+    export HOME="$(pwd)/check-phase"
+  '';
+
+  pytestFlagsArray = [ "tests/unit" ];
+
+  disabledTestPaths = [
+    # Relies upon "logassert" python package which isn't in nixpkgs
+    "tests/unit/bases/test_ubuntu_buildd.py"
+    "tests/unit/bases/test_centos_7.py"
+    "tests/unit/bases/test_almalinux.py"
+    "tests/unit/actions/test_snap_installer.py"
+    # Relies upon "pytest-time" python package which isn't in nixpkgs
+    "tests/unit/multipass"
+    "tests/unit/lxd"
+    "tests/unit/test_base.py"
+    "tests/unit/util/test_retry.py"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Interfaces for instantiating and controlling a variety of build environments";
+    homepage = "https://github.com/canonical/craft-providers";
+    changelog = "https://github.com/canonical/craft-providers/releases/tag/${version}";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ jnsgruk ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/craft-providers/inject-snaps.patch
+++ b/pkgs/development/python-modules/craft-providers/inject-snaps.patch
@@ -1,0 +1,58 @@
+diff --git a/craft_providers/base.py b/craft_providers/base.py
+index 3c914a2..d9c2cf9 100644
+--- a/craft_providers/base.py
++++ b/craft_providers/base.py
+@@ -655,37 +655,22 @@ class Base(ABC):
+                     ),
+                 )
+ 
+-            if snap.channel:
+-                try:
+-                    snap_installer.install_from_store(
+-                        executor=executor,
+-                        snap_name=snap.name,
+-                        channel=snap.channel,
+-                        classic=snap.classic,
+-                    )
+-                except SnapInstallationError as error:
+-                    raise BaseConfigurationError(
+-                        brief=(
+-                            f"failed to install snap {snap.name!r} from store"
+-                            f" channel {snap.channel!r} in target environment."
+-                        ),
+-                        details=error.details,
+-                    ) from error
+-            else:
+-                try:
+-                    snap_installer.inject_from_host(
+-                        executor=executor,
+-                        snap_name=snap.name,
+-                        classic=snap.classic,
+-                    )
+-                except SnapInstallationError as error:
+-                    raise BaseConfigurationError(
+-                        brief=(
+-                            f"failed to inject host's snap {snap.name!r} "
+-                            "into target environment."
+-                        ),
+-                        details=error.details,
+-                    ) from error
++            try:
++                channel = "latest/edge" if snap.name == "rockcraft" else "latest/stable"
++                snap_installer.install_from_store(
++                    executor=executor,
++                    snap_name=snap.name,
++                    channel=channel,
++                    classic=snap.classic,
++                )
++            except SnapInstallationError as error:
++                raise BaseConfigurationError(
++                    brief=(
++                        f"failed to install snap {snap.name!r} from store"
++                        f" channel {channel!r} in target environment."
++                    ),
++                    details=error.details,
++                ) from error
+ 
+     def wait_until_ready(self, executor: Executor) -> None:
+         """Wait until base instance is ready.

--- a/pkgs/development/python-modules/pydantic-yaml-0/default.nix
+++ b/pkgs/development/python-modules/pydantic-yaml-0/default.nix
@@ -1,0 +1,68 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, nix-update-script
+, deprecated
+, importlib-metadata
+, pydantic_1
+, ruamel-yaml
+, semver
+, types-deprecated
+, setuptools
+, setuptools-scm
+, pytest-mock
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "pydantic_yaml-0";
+  version = "0.11.2";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "NowanIlfideme";
+    repo = "pydantic-yaml";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-AeUyVav0/k4Fz69Qizn4hcJKoi/CDR9eUan/nJhWsDY=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/pydantic_yaml/version.py \
+      --replace-fail "0.0.0" "${version}"
+  '';
+
+  nativeBuildInputs = [
+    setuptools
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    deprecated
+    importlib-metadata
+    pydantic_1
+    ruamel-yaml
+    semver
+    types-deprecated
+  ];
+
+  pythonImportsCheck = [
+    "pydantic_yaml"
+  ];
+
+  nativeCheckInputs = [
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A small helper library that adds some YAML capabilities to pydantic";
+    homepage = "https://github.com/NowanIlfideme/pydantic-yaml";
+    changelog = "https://github.com/NowanIlfideme/pydantic-yaml/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jnsgruk ];
+  };
+}
+

--- a/pkgs/development/python-modules/snap-helpers/default.nix
+++ b/pkgs/development/python-modules/snap-helpers/default.nix
@@ -1,0 +1,52 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, nix-update-script
+, pyyaml
+, setuptools
+, pytestCheckHook
+, pytest-mock
+}:
+
+buildPythonPackage rec {
+  pname = "snap-helpers";
+  version = "0.4.2";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "albertodonato";
+    repo = "snap-helpers";
+    rev = "refs/tags/${version}";
+    hash = "sha256-7JBvrD4WNOcFSVx3xauk4JgiVGKWuUEdUMRlH7mudE4=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    pyyaml
+  ];
+
+  pythonImportsCheck = [
+    "snaphelpers"
+  ];
+
+  nativeCheckInputs = [
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Interact with snap configuration and properties from inside a snap.";
+    homepage = "https://github.com/albertodonato/snap-helpers";
+    changelog = "https://github.com/albertodonato/snap-helpers/releases/tag/${version}";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ jnsgruk ];
+    platforms = lib.platforms.linux;
+  };
+}
+

--- a/pkgs/development/python-modules/spdx-lookup/default.nix
+++ b/pkgs/development/python-modules/spdx-lookup/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, nix-update-script
+, spdx
+}:
+
+buildPythonPackage rec {
+  pname = "spdx-lookup";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "bbqsrc";
+    repo = "spdx-lookup-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-jtzhqRAj1BWdU8AuR7Gr343mL5alLXhi+SyCkCI5AAU=";
+  };
+
+  propagatedBuildInputs = [
+    spdx
+  ];
+
+  pythonImportsCheck = [
+    "spdx_lookup"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "SPDX license list query tool";
+    homepage = "https://github.com/bbqsrc/spdx-lookup-python";
+    changelog = "https://github.com/bbqsrc/spdx-lookup-python/releases/tag/v${version}";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ jnsgruk ];
+  };
+}
+

--- a/pkgs/development/python-modules/spdx/default.nix
+++ b/pkgs/development/python-modules/spdx/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, nix-update-script
+}:
+
+buildPythonPackage rec {
+  pname = "spdx";
+  version = "2.5";
+
+  src = fetchFromGitHub {
+    owner = "bbqsrc";
+    repo = "spdx-python";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-lfTgAX4Wl01xrvLA12ZUqjah7ZiLafMAU+yNNdVkRk0=";
+  };
+
+  pythonImportsCheck = [
+    "spdx"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "SPDX license list database";
+    homepage = "https://github.com/bbqsrc/spdx-python";
+    changelog = "https://github.com/bbqsrc/spdx-python/releases/tag/v${version}";
+    license = lib.licenses.cc0;
+    maintainers = with lib.maintainers; [ jnsgruk ];
+  };
+}
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13842,6 +13842,8 @@ self: super: with self; {
 
   spatial-image = callPackage ../development/python-modules/spatial-image { };
 
+  spdx = callPackage ../development/python-modules/spdx { };
+
   spdx-tools = callPackage ../development/python-modules/spdx-tools { };
 
   speaklater = callPackage ../development/python-modules/speaklater { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2447,6 +2447,8 @@ self: super: with self; {
 
   cpyparsing = callPackage ../development/python-modules/cpyparsing { };
 
+  craft-grammar = callPackage ../development/python-modules/craft-grammar { };
+
   craft-parts = callPackage ../development/python-modules/craft-parts { };
 
   craft-providers = callPackage ../development/python-modules/craft-providers { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10529,6 +10529,8 @@ self: super: with self; {
 
   pydantic-settings = callPackage ../development/python-modules/pydantic-settings { };
 
+  pydantic-yaml-0 = callPackage ../development/python-modules/pydantic-yaml-0 { };
+
   pydash = callPackage ../development/python-modules/pydash { };
 
   pydata-google-auth = callPackage ../development/python-modules/pydata-google-auth { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2447,6 +2447,8 @@ self: super: with self; {
 
   cpyparsing = callPackage ../development/python-modules/cpyparsing { };
 
+  craft-application-1 = callPackage ../development/python-modules/craft-application-1 { };
+
   craft-archives = callPackage ../development/python-modules/craft-archives { };
 
   craft-cli = callPackage ../development/python-modules/craft-cli { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13718,6 +13718,8 @@ self: super: with self; {
 
   snakeviz = callPackage ../development/python-modules/snakeviz { };
 
+  snap-helpers = callPackage ../development/python-modules/snap-helpers { };
+
   snapcast = callPackage ../development/python-modules/snapcast { };
 
   snapshottest = callPackage ../development/python-modules/snapshottest { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2447,6 +2447,8 @@ self: super: with self; {
 
   cpyparsing = callPackage ../development/python-modules/cpyparsing { };
 
+  craft-cli = callPackage ../development/python-modules/craft-cli { };
+
   craft-grammar = callPackage ../development/python-modules/craft-grammar { };
 
   craft-parts = callPackage ../development/python-modules/craft-parts { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2447,6 +2447,8 @@ self: super: with self; {
 
   cpyparsing = callPackage ../development/python-modules/cpyparsing { };
 
+  craft-providers = callPackage ../development/python-modules/craft-providers { };
+
   cram = callPackage ../development/python-modules/cram { };
 
   cramjam = callPackage ../development/python-modules/cramjam { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2447,6 +2447,8 @@ self: super: with self; {
 
   cpyparsing = callPackage ../development/python-modules/cpyparsing { };
 
+  craft-archives = callPackage ../development/python-modules/craft-archives { };
+
   craft-cli = callPackage ../development/python-modules/craft-cli { };
 
   craft-grammar = callPackage ../development/python-modules/craft-grammar { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2447,6 +2447,8 @@ self: super: with self; {
 
   cpyparsing = callPackage ../development/python-modules/cpyparsing { };
 
+  craft-parts = callPackage ../development/python-modules/craft-parts { };
+
   craft-providers = callPackage ../development/python-modules/craft-providers { };
 
   cram = callPackage ../development/python-modules/cram { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13844,6 +13844,8 @@ self: super: with self; {
 
   spdx = callPackage ../development/python-modules/spdx { };
 
+  spdx-lookup = callPackage ../development/python-modules/spdx-lookup { };
+
   spdx-tools = callPackage ../development/python-modules/spdx-tools { };
 
   speaklater = callPackage ../development/python-modules/speaklater { };


### PR DESCRIPTION
## Description of changes

This PR introduces the [`rockcraft`](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/) application, which is a tool for building OCI container images.

Before the `rockcraft` package itself is added, there are some more commits adding the required Python libraries. I will follow this PR with more for `snapcraft` and `charmcraft` - hence why I have introduced `_0` and `_1` variants of packages, as those rely on different versions at this time.

I have been maintaining these in my own flake, and they've been stable for some time: https://github.com/jnsgruk/crafts-flake.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
