### PR TITLE
Fix Flutter's reference to the `arch` binary on macOS

### DIFF
--- a/pkgs/development/compilers/flutter/artifacts/overrides/darwin.nix
+++ b/pkgs/development/compilers/flutter/artifacts/overrides/darwin.nix
@@ -1,14 +1,12 @@
-{ darwin }:
-{
-  buildInputs ? [ ],
-  ...
+{}:
+{ buildInputs ? [ ]
+, ...
 }:
 {
   postPatch = ''
     if [ "$pname" == "flutter-tools" ]; then
-      # Remove impure references to `arch` and use arm64 instead of arm64e.
+      # Use arm64 instead of arm64e.
       substituteInPlace lib/src/ios/xcodeproj.dart \
-        --replace-fail /usr/bin/arch '${darwin.adv_cmds}/bin/arch' \
         --replace-fail arm64e arm64
     fi
   '';

--- a/pkgs/development/compilers/flutter/flutter-tools.nix
+++ b/pkgs/development/compilers/flutter/flutter-tools.nix
@@ -9,7 +9,6 @@
 , flutterSrc
 , patches ? [ ]
 , pubspecLock
-, darwin
 }:
 
 buildDartApplication.override { inherit dart; } rec {
@@ -27,10 +26,9 @@ buildDartApplication.override { inherit dart; } rec {
   postPatch = ''
     popd
   ''
-  # Remove impure references to `arch` and use arm64 instead of arm64e.
+  # Use arm64 instead of arm64e.
   + lib.optionalString stdenv.isDarwin ''
     substituteInPlace lib/src/ios/xcodeproj.dart \
-      --replace-fail /usr/bin/arch '${darwin.adv_cmds}/bin/arch' \
       --replace-fail arm64e arm64
   '';
 


### PR DESCRIPTION
## Description of changes

`darwin.adv_cmds` contains no `arch` binary, the correct binary is instead provided via. `stdenv.hostPlatform.darwinArch`, for an example of how this is done elsewhere see [moarvm](https://github.com/NixOS/nixpkgs/blob/7355353390a62108cbe4992246fdba0ef6c65ec6/pkgs/development/interpreters/rakudo/moarvm.nix#L25). This mistake was introduced in https://github.com/NixOS/nixpkgs/pull/286750#issuecomment-1935147584, CC @reckenrode.

I'm with limited internet today, so have done this through the GitHub UI and haven't tested this locally (as I'd have to clone the `nixpkgs` repo). Feel free to squash the changes with a proper Git commit message, I think I failed to follow the guidelines on that.

Pinging package maintainers @babariviere @ericdallo @FlafyDev @hacker1024.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
