### PR TITLE
portablemc: init at 4.3.0

### DIFF
--- a/pkgs/by-name/po/portablemc/package.nix
+++ b/pkgs/by-name/po/portablemc/package.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  stdenv,
+  python3Packages,
+  fetchFromGitHub,
+  installShellFiles,
+  jre,
+
+  libX11,
+  libXext,
+  libXcursor,
+  libXrandr,
+  libXxf86vm,
+  libpulseaudio,
+  libGL,
+  glfw,
+  openal,
+  udev,
+
+  textToSpeechSupport ? stdenv.isLinux,
+  flite,
+}:
+
+let
+  # Copied from the `prismlauncher` package
+  runtimeLibs = [
+    libX11
+    libXext
+    libXcursor
+    libXrandr
+    libXxf86vm
+
+    # lwjgl
+    libpulseaudio
+    libGL
+    glfw
+    openal
+    stdenv.cc.cc.lib
+
+    # oshi
+    udev
+  ] ++ lib.optional textToSpeechSupport flite;
+in
+python3Packages.buildPythonApplication rec {
+  pname = "portablemc";
+  version = "4.3.0";
+  pyproject = true;
+
+  disabled = python3Packages.pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "mindstorm38";
+    repo = "portablemc";
+    rev = "v${version}";
+    hash = "sha256-jCv4ncXUWbkWlBZr3P1hNeVpdQzY9HtrFz+pmKknL0I=";
+  };
+
+  patches = [
+    # Use the jre package provided by nixpkgs by default
+    ./use-builtin-java.patch
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  build-system = [ python3Packages.poetry-core ];
+
+  dependencies = [ python3Packages.certifi ];
+
+  # Note: Tests use networking, so we don't run them
+
+  postInstall = ''
+    installShellCompletion --cmd portablemc \
+        --bash <($out/bin/portablemc show completion bash) \
+        --zsh <($out/bin/portablemc show completion zsh)
+  '';
+
+  preFixup = ''
+    makeWrapperArgs+=(
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath runtimeLibs}
+      --prefix PATH : ${lib.makeBinPath [ jre ]}
+    )
+  '';
+
+  meta = {
+    homepage = "https://github.com/mindstorm38/portablemc";
+    description = "A fast, reliable and cross-platform command-line Minecraft launcher and API for developers";
+    longDescription = ''
+      A fast, reliable and cross-platform command-line Minecraft launcher and API for developers.
+      Including fast and easy installation of common mod loaders such as Fabric, Forge, NeoForge and Quilt.
+      This launcher is compatible with the standard Minecraft directories.
+    '';
+    changelog = "https://github.com/mindstorm38/portablemc/releases/tag/${src.rev}";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "portablemc";
+    maintainers = with lib.maintainers; [ tomasajt ];
+  };
+}

--- a/pkgs/by-name/po/portablemc/use-builtin-java.patch
+++ b/pkgs/by-name/po/portablemc/use-builtin-java.patch
@@ -1,0 +1,47 @@
+diff --git a/portablemc/standard.py b/portablemc/standard.py
+index f59c55d..0f017e1 100644
+--- a/portablemc/standard.py
++++ b/portablemc/standard.py
+@@ -843,6 +843,8 @@ class Version:
+         if jvm_major_version is not None and not isinstance(jvm_major_version, int):
+             raise ValueError("metadata: /javaVersion/majorVersion must be an integer")
+ 
++        return self._resolve_builtin_jvm(watcher, JvmNotFoundError.UNSUPPORTED_ARCH, jvm_major_version)
++
+         if platform.system() == "Linux" and platform.libc_ver()[0] != "glibc":
+             return self._resolve_builtin_jvm(watcher, JvmNotFoundError.UNSUPPORTED_LIBC, jvm_major_version)
+ 
+@@ -926,31 +928,10 @@ class Version:
+         builtin_path = shutil.which(jvm_bin_filename)
+         if builtin_path is None:
+             raise JvmNotFoundError(reason)
+-        
+-        try:
+-            
+-            # Get version of the JVM.
+-            process = Popen([builtin_path, "-version"], bufsize=1, stdout=PIPE, stderr=STDOUT, universal_newlines=True)
+-            stdout, _stderr = process.communicate(timeout=1)
+-
+-            version_start = stdout.index(f"1.{major_version}" if major_version <= 8 else str(major_version))
+-            version = None
+-            
+-            # Parse version by getting all character that are numeric or '.'.
+-            for i, ch in enumerate(stdout[version_start:]):
+-                if not ch.isnumeric() and ch not in (".", "_"):
+-                    version = stdout[version_start:i]
+-                    break
+-            
+-            if version is None:
+-                raise ValueError()
+-
+-        except (TimeoutExpired, ValueError):
+-            raise JvmNotFoundError(JvmNotFoundError.BUILTIN_INVALID_VERSION)
+ 
+         self._jvm_path = Path(builtin_path)
+-        self._jvm_version = version
+-        watcher.handle(JvmLoadedEvent(version, JvmLoadedEvent.BUILTIN))
++        self._jvm_version = "nixpkgs"
++        watcher.handle(JvmLoadedEvent("nixpkgs", JvmLoadedEvent.BUILTIN))
+ 
+     def _download(self, watcher: Watcher) -> None:
+         


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/291558

This PR adds 1 package: `portablemc`

I patched the package to use the latest `jre` version by default. It seems to be able to run older versions of minecraft fine, but I am not sure if it breaks modded APIs or not. In any case, one can always just override the `jre` field with the java version they want.

I copied the runtime dependency list from `prismlauncher`. I also brought over the `textToSpeechSupport` toggle. Note that I didn't bring over `gamemodeSupport` and `controllerSupport`, because I couldn't really test those. Maybe someone with more experience can do it later.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
