### PR TITLE
ffmpeg: make version a regular parameter and use callPackage pattern

### DIFF
--- a/pkgs/development/libraries/ffmpeg/4.nix
+++ b/pkgs/development/libraries/ffmpeg/4.nix
@@ -1,29 +1,5 @@
 import ./generic.nix {
   version = "4.4.4";
   hash = "sha256-Q8bkuF/1uJfqttJJoObnnLX3BEduv+qxsvOrVhMvRjA=";
-  extraPatches = [
-    {
-      name = "libsvtav1-1.5.0-compat-compressed_ten_bit_format.patch";
-      url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/031f1561cd286596cdb374da32f8aa816ce3b135";
-      hash = "sha256-mSnmAkoNikDpxcN+A/hpB7mUbbtcMvm4tG6gZFuroe8=";
-    }
-    {
-        # Backport fix for binutils-2.41.
-        name = "binutils-2.41.patch";
-        url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/effadce6c756247ea8bae32dc13bb3e6f464f0eb";
-        hash = "sha256-vlBUMJ1bORQHRNpuzc5iXsTWwS/CN5BmGIA8g7H7mJE=";
-    }
-    # The upstream patch isn’t for ffmpeg 4, but it will apply with a few tweaks.
-    # Fixes a crash when built with clang 16 due to UB in ff_seek_frame_binary.
-    {
-      name = "utils-fix_crash_in_ff_seek_frame_binary.patch";
-      url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/ab792634197e364ca1bb194f9abe36836e42f12d";
-      hash = "sha256-UxZ4VneZpw+Q/UwkEUDNdb2nOx1QnMrZ40UagspNTxI=";
-      postFetch = ''
-        substituteInPlace "$out" \
-          --replace libavformat/seek.c libavformat/utils.c \
-          --replace 'const AVInputFormat *const ' 'const AVInputFormat *'
-      '';
-    }
-  ];
+  extraPatches = [ ];
 }

--- a/pkgs/development/libraries/ffmpeg/4.nix
+++ b/pkgs/development/libraries/ffmpeg/4.nix
@@ -1,5 +1,0 @@
-import ./generic.nix {
-  version = "4.4.4";
-  hash = "sha256-Q8bkuF/1uJfqttJJoObnnLX3BEduv+qxsvOrVhMvRjA=";
-  extraPatches = [ ];
-}

--- a/pkgs/development/libraries/ffmpeg/5.nix
+++ b/pkgs/development/libraries/ffmpeg/5.nix
@@ -1,6 +1,0 @@
-import ./generic.nix {
-  version = "5.1.4";
-  hash = "sha256-2jUL1/xGUf7aMooST2DW41KE7bC+BtgChXmj0sAJZ90=";
-  extraPatches = [
-  ];
-}

--- a/pkgs/development/libraries/ffmpeg/6.nix
+++ b/pkgs/development/libraries/ffmpeg/6.nix
@@ -1,6 +1,0 @@
-import ./generic.nix {
-  version = "6.1.1";
-  hash = "sha256-Q0c95hbCVUHQWPoh5uC8uzMylmB4BnWg+VhXEgSouzo=";
-  extraPatches = [
-  ];
-}

--- a/pkgs/development/libraries/ffmpeg/default.nix
+++ b/pkgs/development/libraries/ffmpeg/default.nix
@@ -1,0 +1,58 @@
+{ callPackage, darwin }:
+
+let
+  mkFFmpeg =
+    initArgs: ffmpegVariant:
+    callPackage ./generic.nix (
+      {
+        inherit (darwin.apple_sdk.frameworks)
+          Cocoa
+          CoreServices
+          CoreAudio
+          CoreMedia
+          AVFoundation
+          MediaToolbox
+          VideoDecodeAcceleration
+          VideoToolbox
+          ;
+      }
+      // (initArgs // { inherit ffmpegVariant; })
+    );
+
+  v4 = {
+    version = "4.4.4";
+    hash = "sha256-Q8bkuF/1uJfqttJJoObnnLX3BEduv+qxsvOrVhMvRjA=";
+  };
+
+  v5 = {
+    version = "5.1.4";
+    hash = "sha256-2jUL1/xGUf7aMooST2DW41KE7bC+BtgChXmj0sAJZ90=";
+  };
+
+  v6 = {
+    version = "6.1.1";
+    hash = "sha256-Q0c95hbCVUHQWPoh5uC8uzMylmB4BnWg+VhXEgSouzo=";
+  };
+in
+
+rec {
+  ffmpeg_4 = mkFFmpeg v4 "small";
+  ffmpeg_4-headless = mkFFmpeg v4 "headless";
+  ffmpeg_4-full = mkFFmpeg v4 "full";
+
+  ffmpeg_5 = mkFFmpeg v5 "small";
+  ffmpeg_5-headless = mkFFmpeg v5 "headless";
+  ffmpeg_5-full = mkFFmpeg v5 "full";
+
+  ffmpeg_6 = mkFFmpeg v6 "small";
+  ffmpeg_6-headless = mkFFmpeg v6 "headless";
+  ffmpeg_6-full = mkFFmpeg v6 "full";
+
+  # Please make sure this is updated to the latest version on the next major
+  # update to ffmpeg
+  # Packages which use ffmpeg as a library, should pin to the relevant major
+  # version number which the upstream support.
+  ffmpeg = ffmpeg_6;
+  ffmpeg-headless = ffmpeg_6-headless;
+  ffmpeg-full = ffmpeg_6-full;
+}

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -391,14 +391,14 @@ stdenv.mkDerivation (finalAttrs: {
         '';
       }
     ]
-    ++ (lib.optional (lib.versionAtLeast finalAttrs.version "6" && lib.versionOlder finalAttrs.version "6.1")
+    ++ (lib.optional (lib.versionAtLeast version "6" && lib.versionOlder version "6.1")
       { # this can be removed post 6.1
         name = "fix_aacps_tablegen";
         url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/814178f92647be2411516bbb82f48532373d2554";
         hash = "sha256-FQV9/PiarPXCm45ldtCsxGHjlrriL8DKpn1LaKJ8owI=";
       }
     )
-    ++ (lib.optional (lib.versionAtLeast finalAttrs.version "6.1" && lib.versionOlder finalAttrs.version "6.2")
+    ++ (lib.optional (lib.versionAtLeast version "6.1" && lib.versionOlder version "6.2")
       { # this can be removed post 6.1
         name = "fix_build_failure_due_to_PropertyKey_EncoderID";
         url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/cb049d377f54f6b747667a93e4b719380c3e9475";
@@ -459,7 +459,7 @@ stdenv.mkDerivation (finalAttrs: {
     (enableFeature buildAvdevice "avdevice")
     (enableFeature buildAvfilter "avfilter")
     (enableFeature buildAvformat "avformat")
-  ] ++ optionals (lib.versionOlder finalAttrs.version "5") [
+  ] ++ optionals (lib.versionOlder version "5") [
     # Ffmpeg > 4 doesn't know about the flag anymore
     (enableFeature buildAvresample "avresample")
   ] ++ [
@@ -490,7 +490,7 @@ stdenv.mkDerivation (finalAttrs: {
      */
     (enableFeature withAlsa "alsa")
     (enableFeature withAom "libaom")
-  ] ++ optionals (versionAtLeast finalAttrs.version "6.1") [
+  ] ++ optionals (versionAtLeast version "6.1") [
     (enableFeature withAribcaption "libaribcaption")
   ] ++ [
     (enableFeature withAss "libass")
@@ -515,7 +515,7 @@ stdenv.mkDerivation (finalAttrs: {
     (enableFeature withGme "libgme")
     (enableFeature withGnutls "gnutls")
     (enableFeature withGsm "libgsm")
-  ] ++ optionals (versionAtLeast finalAttrs.version "6.1") [
+  ] ++ optionals (versionAtLeast version "6.1") [
     (enableFeature withHarfbuzz "libharfbuzz")
   ] ++ [
     (enableFeature withIconv "iconv")
@@ -538,7 +538,7 @@ stdenv.mkDerivation (finalAttrs: {
     (enableFeature withOpenjpeg "libopenjpeg")
     (enableFeature withOpenmpt "libopenmpt")
     (enableFeature withOpus "libopus")
-  ] ++ optionals (versionAtLeast finalAttrs.version "5.0") [
+  ] ++ optionals (versionAtLeast version "5.0") [
     (enableFeature withPlacebo "libplacebo")
   ] ++ [
     (enableFeature withPulse "libpulse")
@@ -546,7 +546,7 @@ stdenv.mkDerivation (finalAttrs: {
     (enableFeature withRtmp "librtmp")
     (enableFeature withSamba "libsmbclient")
     (enableFeature withSdl2 "sdl2")
-  ] ++ optionals (versionAtLeast finalAttrs.version "5.0") [
+  ] ++ optionals (versionAtLeast version "5.0") [
     (enableFeature withShaderc "libshaderc")
   ] ++ [
     (enableFeature withSoxr "libsoxr")
@@ -644,7 +644,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optionals withModplug [ libmodplug ]
   ++ optionals withMp3lame [ lame ]
   ++ optionals withMysofa [ libmysofa ]
-  ++ optionals (withNvdec || withNvenc) [ (if (lib.versionAtLeast finalAttrs.version "6") then nv-codec-headers-12 else nv-codec-headers) ]
+  ++ optionals (withNvdec || withNvenc) [ (if (lib.versionAtLeast version "6") then nv-codec-headers-12 else nv-codec-headers) ]
   ++ optionals withOgg [ libogg ]
   ++ optionals withOpenal [ openal ]
   ++ optionals withOpencl [ ocl-icd opencl-headers ]
@@ -654,7 +654,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optionals withOpenjpeg [ openjpeg ]
   ++ optionals withOpenmpt [ libopenmpt ]
   ++ optionals withOpus [ libopus ]
-  ++ optionals withPlacebo [ (if (lib.versionAtLeast finalAttrs.version "6.1") then libplacebo else libplacebo_5) vulkan-headers ]
+  ++ optionals withPlacebo [ (if (lib.versionAtLeast version "6.1") then libplacebo else libplacebo_5) vulkan-headers ]
   ++ optionals withPulse [ libpulseaudio ]
   ++ optionals withRav1e [ rav1e ]
   ++ optionals withRtmp [ rtmpdump ]
@@ -753,7 +753,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = with lib; {
     description = "A complete, cross-platform solution to record, convert and stream audio and video";
     homepage = "https://www.ffmpeg.org/";
-    changelog = "https://github.com/FFmpeg/FFmpeg/blob/n${finalAttrs.version}/Changelog";
+    changelog = "https://github.com/FFmpeg/FFmpeg/blob/n${version}/Changelog";
     longDescription = ''
       FFmpeg is the leading multimedia framework, able to decode, encode, transcode,
       mux, demux, stream, filter and play pretty much anything that humans and machines

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -305,7 +305,7 @@
  */
 
 let
-  inherit (lib) optional optionals optionalString enableFeature versionAtLeast;
+  inherit (lib) optional optionals optionalString enableFeature versionOlder versionAtLeast;
 in
 
 
@@ -363,6 +363,31 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   patches = map (patch: fetchpatch patch) (extraPatches
+    ++ optionals (versionOlder version "5") [
+      {
+        name = "libsvtav1-1.5.0-compat-compressed_ten_bit_format.patch";
+        url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/031f1561cd286596cdb374da32f8aa816ce3b135";
+        hash = "sha256-mSnmAkoNikDpxcN+A/hpB7mUbbtcMvm4tG6gZFuroe8=";
+      }
+      {
+        # Backport fix for binutils-2.41.
+        name = "binutils-2.41.patch";
+        url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/effadce6c756247ea8bae32dc13bb3e6f464f0eb";
+        hash = "sha256-vlBUMJ1bORQHRNpuzc5iXsTWwS/CN5BmGIA8g7H7mJE=";
+      }
+      # The upstream patch isn’t for ffmpeg 4, but it will apply with a few tweaks.
+      # Fixes a crash when built with clang 16 due to UB in ff_seek_frame_binary.
+      {
+        name = "utils-fix_crash_in_ff_seek_frame_binary.patch";
+        url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/ab792634197e364ca1bb194f9abe36836e42f12d";
+        hash = "sha256-UxZ4VneZpw+Q/UwkEUDNdb2nOx1QnMrZ40UagspNTxI=";
+        postFetch = ''
+          substituteInPlace "$out" \
+            --replace libavformat/seek.c libavformat/utils.c \
+            --replace 'const AVInputFormat *const ' 'const AVInputFormat *'
+        '';
+      }
+    ]
     ++ (lib.optional (lib.versionAtLeast finalAttrs.version "6" && lib.versionOlder finalAttrs.version "6.1")
       { # this can be removed post 6.1
         name = "fix_aacps_tablegen";

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -1,6 +1,14 @@
-{ version, hash, extraPatches ? [] }:
-
 { lib, stdenv, buildPackages, removeReferencesTo, addOpenGLRunpath, pkg-config, perl, texinfo, yasm
+
+  # You can fetch any upstream version using this derivation by specifying version and hash
+  # NOTICE: Always use this argument to override the version. Do not use overrideAttrs.
+, version # ffmpeg ABI version. Also declare this if you're overriding the source.
+, hash ? "" # hash of the upstream source for the given ABI version
+, source ? fetchgit {
+    url = "https://git.ffmpeg.org/ffmpeg.git";
+    rev = "n${version}";
+    inherit hash;
+  }
 
 , ffmpegVariant ? "small" # Decides which dependencies are enabled by default
 
@@ -346,12 +354,7 @@ assert buildSwscale -> buildAvutil;
 stdenv.mkDerivation (finalAttrs: {
   pname = "ffmpeg" + (optionalString (ffmpegVariant != "small") "-${ffmpegVariant}");
   inherit version;
-
-  src = fetchgit {
-    url = "https://git.ffmpeg.org/ffmpeg.git";
-    rev = "n${finalAttrs.version}";
-    inherit hash;
-  };
+  src = source;
 
   postPatch = ''
     patchShebangs .
@@ -362,7 +365,7 @@ stdenv.mkDerivation (finalAttrs: {
       --replace /usr/local/lib/frei0r-1 ${frei0r}/lib/frei0r-1
   '';
 
-  patches = map (patch: fetchpatch patch) (extraPatches
+  patches = map (patch: fetchpatch patch) ([ ]
     ++ optionals (versionOlder version "5") [
       {
         name = "libsvtav1-1.5.0-compat-compressed_ten_bit_format.patch";

--- a/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
+++ b/pkgs/development/libraries/jellyfin-ffmpeg/default.nix
@@ -3,16 +3,20 @@
 , lib
 }:
 
-ffmpeg_6-full.overrideAttrs (old: rec {
-  pname = "jellyfin-ffmpeg";
+let
   version = "6.0.1-3";
+in
 
-  src = fetchFromGitHub {
+(ffmpeg_6-full.override {
+  inherit version; # Important! This sets the ABI.
+  source = fetchFromGitHub {
     owner = "jellyfin";
     repo = "jellyfin-ffmpeg";
     rev = "v${version}";
     hash = "sha256-UINiXO61nB/AL0HJJy7G7emujakk/mQv81aUioyJz0Y=";
   };
+}).overrideAttrs (old: {
+  pname = "jellyfin-ffmpeg";
 
   # Clobber upstream patches as they don't apply to the Jellyfin fork
   patches = [];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -20960,50 +20960,19 @@ with pkgs;
 
   linbox = callPackage ../development/libraries/linbox { };
 
-  ffmpeg_4 = callPackage ../development/libraries/ffmpeg/4.nix {
-    inherit (darwin.apple_sdk.frameworks)
-      Cocoa CoreServices CoreAudio CoreMedia AVFoundation MediaToolbox
-      VideoDecodeAcceleration VideoToolbox;
-  };
-  ffmpeg_4-headless = ffmpeg_4.override {
-    ffmpegVariant = "headless";
-  };
-  ffmpeg_4-full = ffmpeg_4.override {
-    ffmpegVariant = "full";
-  };
-
-  ffmpeg_5 = callPackage ../development/libraries/ffmpeg/5.nix {
-    inherit (darwin.apple_sdk.frameworks)
-      Cocoa CoreServices CoreAudio CoreMedia AVFoundation MediaToolbox
-      VideoDecodeAcceleration VideoToolbox;
-  };
-  ffmpeg_5-headless = ffmpeg_5.override {
-    ffmpegVariant = "headless";
-  };
-  ffmpeg_5-full = ffmpeg_5.override {
-    ffmpegVariant = "full";
-  };
-
-  ffmpeg_6 = callPackage ../development/libraries/ffmpeg/6.nix {
-     inherit (darwin.apple_sdk.frameworks)
-      Cocoa CoreServices CoreAudio CoreMedia AVFoundation MediaToolbox
-      VideoDecodeAcceleration VideoToolbox;
-  };
-  ffmpeg_6-headless = ffmpeg_6.override {
-    ffmpegVariant = "headless";
-  };
-  ffmpeg_6-full = ffmpeg_6.override {
-    ffmpegVariant = "full";
-  };
-
-  # Aliases
-  # Please make sure this is updated to the latest version on the next major
-  # update to ffmpeg
-  # Packages which use ffmpeg as a library, should pin to the relevant major
-  # version number which the upstream support.
-  ffmpeg = ffmpeg_6;
-  ffmpeg-headless = ffmpeg_6-headless;
-  ffmpeg-full = ffmpeg_6-full;
+  inherit (callPackage ../development/libraries/ffmpeg { })
+    ffmpeg_4
+    ffmpeg_4-headless
+    ffmpeg_4-full
+    ffmpeg_5
+    ffmpeg_5-headless
+    ffmpeg_5-full
+    ffmpeg_6
+    ffmpeg_6-headless
+    ffmpeg_6-full
+    ffmpeg
+    ffmpeg-headless
+    ffmpeg-full;
 
   ffmpegthumbnailer = callPackage ../development/libraries/ffmpegthumbnailer { };
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is (to my knowledge) a novel pattern that is similar to how
callPackages (note the s) is used. Whereas callPackages would try to make the
arguments of default.nix overrideable, this instead exposes the individual
packages' arguments.

This pattern is a lot more robust than the custom import pattern I had
implemented here before.

It also moves the implementation detail out of all-packages which is great.

Making the version part of the interface allows overriders to declare a
different ABI. Doing so via overrideAttrs would not affect the flags in the
arguments; effectively retaining the overridden package's ABI.

See https://github.com/NixOS/nixpkgs/issues/280645 for an instance of that.

By overriding the arguments using

    ffmpeg.override { version = "..."; ... }

the ABI will now be overridden as expected.

This means you could theoretically turn ffmpeg_5-full into ffmpeg_4-headless by overriding it with

    {
      version = "4.4.4";
      hash = ...;
      ffmpegVariant = "headless";
    }

Having these implicit parameters be explicit parameters feels a lot cleaner and
neater to work with.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
