### PR TITLE
python311Packages.systembridgeconnector: 4.0.3 -> 4.0.4

### DIFF
--- a/pkgs/development/python-modules/systembridgeconnector/default.nix
+++ b/pkgs/development/python-modules/systembridgeconnector/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "systembridgeconnector";
-  version = "4.0.3";
+  version = "4.0.4";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -23,19 +23,20 @@ buildPythonPackage rec {
     owner = "timmo001";
     repo = "system-bridge-connector";
     rev = "refs/tags/${version}";
-    hash = "sha256-AjdWDEotz5AUo+auxBqXu7EMv/Kt97DZ6vOrFunZ2Fw=";
+    hash = "sha256-Guh9qbRLp+b2SuFgBx7jf16vRShuHJBi3WOVn9Akce8=";
   };
 
   patches = [
-    (fetchpatch2 {
-      url = "https://github.com/timmo001/system-bridge-connector/commit/a9030cf175ab4b51d77010de89e83cbb426448c2.patch";
-      hash = "sha256-0N8knoaEvymSvC92BxDKR0j52oasvOzWosFtHMI2Qmc=";
-    })
     (fetchpatch2 {
       url = "https://github.com/timmo001/system-bridge-connector/commit/25aa172775ee983dc4a29b8dda880aefbad70040.patch";
       hash = "sha256-PedW1S1gZmWkS4sJBqSAx3aoA1KppYS5Xlhoaxqkcd4=";
     })
   ];
+
+  postPatch = ''
+    substituteInPlace systembridgeconnector/_version.py \
+      --replace-fail ", dev=0" ""
+  '';
 
   nativeBuildInputs = [
     setuptools

--- a/pkgs/development/python-modules/systembridgemodels/default.nix
+++ b/pkgs/development/python-modules/systembridgemodels/default.nix
@@ -2,7 +2,6 @@
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
-, fetchpatch2
 , setuptools
 , incremental
 , pytestCheckHook
@@ -10,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "systembridgemodels";
-  version = "4.0.1";
+  version = "4.0.3";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -19,15 +18,13 @@ buildPythonPackage rec {
     owner = "timmo001";
     repo = "system-bridge-models";
     rev = "refs/tags/${version}";
-    hash = "sha256-9k85tqJO/YtkYncfNQBelmDkd3SYtf6SHURfumvqUo0=";
+    hash = "sha256-5rbj58E8iDu2Rjf0k9Y1UoF3hbN7ntkx6dm20HYpw6I=";
   };
 
-  patches = [
-    (fetchpatch2 {
-      url = "https://github.com/timmo001/system-bridge-models/commit/82fcee37cb302bc77384165b2ce10f2234c2a14a.patch";
-      hash = "sha256-tZSaWVUPCJmuzkae9LBTdyZ3UINMvrSMbdS5AvbId8Q=";
-    })
-  ];
+  postPatch = ''
+    substituteInPlace systembridgemodels/_version.py \
+      --replace-fail ", dev=0" ""
+  '';
 
   nativeBuildInputs = [
     setuptools


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/timmo001/system-bridge-connector/compare/refs/tags/4.0.3...4.0.4

Changelog: https://github.com/timmo001/system-bridge-connector/releases/tag/4.0.4
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
