### PR TITLE
wxGTK32: repro build and disable rpath

### DIFF
--- a/pkgs/development/libraries/wxwidgets/wxGTK32.nix
+++ b/pkgs/development/libraries/wxwidgets/wxGTK32.nix
@@ -109,6 +109,8 @@ stdenv.mkDerivation rec {
     "--disable-monolithic"
     "--enable-mediactrl"
     "--with-nanosvg"
+    "--disable-rpath"
+    "--enable-repro-build"
     (if compat28 then "--enable-compat28" else "--disable-compat28")
     (if compat30 then "--enable-compat30" else "--disable-compat30")
   ] ++ lib.optional unicode "--enable-unicode"


### PR DESCRIPTION
## Description of changes

2 minor config changes
the `--disable-rpath` one was found necessary in building from their current master
(due to retaining the build directory in rpath, and patchPhase not being able to remove it)
and will presumably become necessary on the next release

and the `--enable-repro-build` just sounds like the right thing for us :)

a fair few things depend on this, so there were a few breakages in there
but i don't think any of them are due to these changes

```
1 package marked as broken and skipped:
springLobby

13 packages failed to build:
erlang-ls klipper-firmware klipper-flash meerk40t meerk40t.dist python312Packages.humblewx python312Packages.humblewx.dist python312Packages.kicad python312Packages.pcbnew-transition python312Packages.pcbnew-transition.dist python312Packages.soapysdr-with-plugins python312Packages.wxpython ut1999
```
(that was done on top of my kicad-8 PR that includes fixing the `kicad-unstable` build)

i'm mostly PRing this because it seems like the `--disable-rpath` could become necessary
and i don't want the fix to get lost

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
