### PR TITLE
proton-ge-bin: init at init at 9-1

### DIFF
--- a/pkgs/by-name/pr/proton-ge-bin/package.nix
+++ b/pkgs/by-name/pr/proton-ge-bin/package.nix
@@ -1,0 +1,50 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, writeScript
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "proton-ge-bin";
+  version = "GE-Proton9-1";
+
+  src = fetchurl {
+    url = "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/${finalAttrs.version}/${finalAttrs.version}.tar.gz";
+    hash = "sha256-wCIffeayOy3kEwmIKB7e+NrliuSpKXoVYC334fxVB3U=";
+  };
+
+  buildCommand = ''
+    runHook preBuild
+    mkdir -p $out/{bin,opt}
+    tar -C $out/opt --strip=1 -x -f $src
+    ln -s $out/opt/toolmanifest.vdf $out/bin/toolmanifest.vdf
+    install -Dm644 $out/opt/compatibilitytool.vdf $out/bin/compatibilitytool.vdf
+    substituteInPlace $out/bin/compatibilitytool.vdf \
+      --replace-fail '"install_path" "."' '"install_path" "${placeholder "out"}/opt"'
+    runHook postBuild
+  '';
+
+  /*
+    We use the created releases, and not the tags, for the update script as nix-update loads releases.atom
+    that contains both. Sometimes upstream pushes the tags but the Github releases don't get created due to
+    CI errors. Last time this happened was on 8-32, where a tag was created but no releases were created.
+    As of 2024-03-13, there have been no announcements indicating that the CI has been fixed, and thus
+    we avoid nix-update-script and use our own update script instead.
+    See: <https://github.com/NixOS/nixpkgs/pull/294532#issuecomment-1987359650>
+  */
+  passthru.updateScript = writeScript "update-proton-ge" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl jq common-updater-scripts
+    repo="https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases"
+    version="$(curl -sL "$repo" | jq 'map(select(.prerelease == false)) | .[0].tag_name' --raw-output)"
+    update-source-version proton-ge-custom "$version"
+  '';
+
+  meta = {
+    description = "Compatibility tool for Steam Play based on Wine and additional components";
+    homepage = "https://github.com/GloriousEggroll/proton-ge-custom";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ NotAShelf shawn8901 ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Seeing `extraCompatPackages` is now a steam module option as of #293564, I think it's nice to put proton-ge-custom in nixpkgs instead of forcing to get them from random NUR repositories or package locally.

Tested on x86_64-linux. Haven't got any other hardware to test on right now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
