### PR TITLE
apptainer, singularity: add passthru.tests.manualTests.run-image-hello-cowsay

### DIFF
--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -26,6 +26,7 @@ in
 { lib
 , buildGoModule
 , runCommandLocal
+, substituteAll
   # Native build inputs
 , addDriverRunpath
 , makeWrapper
@@ -70,7 +71,6 @@ in
   # Whether to compile with SUID support
 , enableSuid ? false
 , starterSuidPath ? null
-, substituteAll
   # newuidmapPath and newgidmapPath are to support --fakeroot
   # where those SUID-ed executables are unavailable from the FHS system PATH.
   # Path to SUID-ed newuidmap executable

--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -53,6 +53,7 @@ in
 , squashfuse
   # Test dependencies
 , singularity-tools
+, writeShellScriptBin
 , cowsay
 , hello
   # Overridable configurations
@@ -279,6 +280,18 @@ in
         name = "hello-cowsay";
         contents = [ hello cowsay ];
         singularity = finalAttrs.finalPackage;
+      };
+      # Run the packages to test. E.g.
+      # nix run .#apptainer.manualTests.run-image-hello-cowsay
+      manualTests = lib.recurseIntoAttrs {
+        run-image-hello-cowsay =
+          let
+            image = finalAttrs.finalPackage.passthru.tests.image-hello-cowsay;
+            exe = lib.getExe finalAttrs.finalPackage;
+          in
+          writeShellScriptBin "test-run-image-hello-cowsay" ''
+            ${exe} exec ${image} hello | ${exe} exec ${image} cowsay
+          '';
       };
     };
     gpuChecks = lib.optionalAttrs (projectName == "apptainer") {


### PR DESCRIPTION
## Description of changes

This PR adds `passthru.manualTests.run-image-hello-cowsay` to `apptainer` and `singularity` to make image running test easier during the review process.

This PR also makes image running issues like #295809 more discoverable.

Cc: @GaetanLepage

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
