### PR TITLE
nixos/lib/make-disk-image.nix: fix to reserve correct number of inodes

### DIFF
--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -580,6 +580,9 @@ let
           # Then increase the required space to account for the reserved blocks.
           fudge=$(compute_fudge $diskUsage)
           requiredFilesystemSpace=$(( diskUsage + fudge ))
+          # Similarly, increase the required inodes count.
+          fudgeInodes=$(compute_fudge $numInodes)
+          requiredInodes=$(( numInodes + fudgeInodes ))
 
           # Round up to the nearest block size.
           # This ensures whole $blockSize bytes block sizes in the filesystem
@@ -597,7 +600,9 @@ let
 
           printf "Automatic disk size...\n"
           printf "  Closure space use: %d bytes\n" $diskUsage
-          printf "  fudge: %d bytes\n" $fudge
+          printf "  Closure inodes use: %d\n" $requiredInodes
+          printf "  fudge (space): %d bytes\n" $fudge
+          printf "  fudge (inodes): %d\n" $fudgeInodes
           printf "  Filesystem size needed: %d bytes\n" $requiredFilesystemSpace
           printf "  Additional space: %d bytes\n" $additionalSpace
           printf "  Disk image size: %d bytes\n" $diskSize
@@ -616,11 +621,11 @@ let
           # Get start & length of the root partition in sectors to $START and $SECTORS.
           eval $(partx $diskImage -o START,SECTORS --nr ${rootPartition} --pairs)
 
-          mkfs.${fsType} -b ${blockSize} -F -L ${label} $diskImage -E offset=$(sectorsToBytes $START) $(sectorsToKilobytes $SECTORS)K
+          mkfs.${fsType} -b ${blockSize} -N $requiredInodes -F -L ${label} $diskImage -E offset=$(sectorsToBytes $START) $(sectorsToKilobytes $SECTORS)K
         ''
       else
         ''
-          mkfs.${fsType} -b ${blockSize} -F -L ${label} $diskImage
+          mkfs.${fsType} -b ${blockSize} -N $requiredInodes -F -L ${label} $diskImage
         ''
     }
 

--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -530,6 +530,12 @@ let
     bootSize=$(round_to_nearest $(numfmt --from=iec '${bootSize}') $mebibyte)
     bootSizeMiB=$(( bootSize / 1024 / 1024 ))MiB
 
+    # Inodes number required for automatic space calculation + setting via mkfs -N
+    numInodes=$(find . | wc -l)
+    # Add fudge factor for inodes (reuse the fudge factor used for $diskUsage)
+    fudgeInodes=$(compute_fudge $numInodes)
+    requiredInodes=$(( numInodes + fudgeInodes ))
+
     ${
       if diskSize == "auto" then
         ''
@@ -573,16 +579,11 @@ let
 
           # Compute required space in filesystem blocks
           diskUsage=$(find . ! -type d -print0 | du --files0-from=- --apparent-size --count-links --block-size "${blockSize}" | cut -f1 | sum_lines)
-          # Each inode takes space!
-          numInodes=$(find . | wc -l)
           # Convert to bytes, inodes take two blocks each!
           diskUsage=$(( (diskUsage + 2 * numInodes) * ${blockSize} ))
           # Then increase the required space to account for the reserved blocks.
           fudge=$(compute_fudge $diskUsage)
           requiredFilesystemSpace=$(( diskUsage + fudge ))
-          # Similarly, increase the required inodes count.
-          fudgeInodes=$(compute_fudge $numInodes)
-          requiredInodes=$(( numInodes + fudgeInodes ))
 
           # Round up to the nearest block size.
           # This ensures whole $blockSize bytes block sizes in the filesystem
@@ -600,16 +601,21 @@ let
 
           printf "Automatic disk size...\n"
           printf "  Closure space use: %d bytes\n" $diskUsage
-          printf "  Closure inodes use: %d\n" $requiredInodes
+          printf "  Closure inodes use: %d\n" $numInodes
           printf "  fudge (space): %d bytes\n" $fudge
           printf "  fudge (inodes): %d\n" $fudgeInodes
           printf "  Filesystem size needed: %d bytes\n" $requiredFilesystemSpace
+          printf "  Inodes number needed: %d\n" $requiredInodes
           printf "  Additional space: %d bytes\n" $additionalSpace
           printf "  Disk image size: %d bytes\n" $diskSize
         ''
       else
         ''
           truncate -s ${toString diskSize}M $diskImage
+          printf "Fixed disk size: %dM\n" ${toString diskSize}
+          printf "  Closure inodes use: %d\n" $numInodes
+          printf "  fudge (inodes): %d\n" $fudgeInodes
+          printf "  Inodes number needed: %d\n" $requiredInodes
         ''
     }
 


### PR DESCRIPTION
## Description of changes

Fixes #292737.

If disk size computation is set to auto in `nixos/lib/make-disk-image.nix`, it [computes the required space](https://github.com/NixOS/nixpkgs/blob/985140986aa3c543d5ec84afa5c470081ec07b78/nixos/lib/make-disk-image.nix#L474-L490) for the disk image by measuring the closure size that is to be copied onto the image. This computation takes into account the [number of required inodes](https://github.com/NixOS/nixpkgs/blob/985140986aa3c543d5ec84afa5c470081ec07b78/nixos/lib/make-disk-image.nix#L477-L479). However, when creating the disk image, the number of required inodes is not explicitly specified, so that [`mkfs.${fsType}`](https://github.com/NixOS/nixpkgs/blob/985140986aa3c543d5ec84afa5c470081ec07b78/nixos/lib/make-disk-image.nix#L511-L513) uses the default inode ratio (which seems to be 1 inode for every 16384 bytes for `ext4`). This might be too low; see for example the failing example flake given in #292737. In that case, builds may fail with the error `cptofs failed. diskSize might be too small for closure.` during the call to [`cp2fs`](https://github.com/pitkling/nixpkgs/blob/2dbc8f62d8af7a1ab962e4b20d12b25ddcb86ced/nixos/lib/make-disk-image.nix#L516-L521).

Similar issues can appear for fixed, manually set disk sizes (see, e.g., https://github.com/NixOS/nixpkgs/pull/295874#issuecomment-4025136825).

To avoid this, this pull request sets the number of inodes (multiplied with a factor `compute_fudge` that was already used in the storage calculation to add some margin) explicitly during the call to [`mkfs.${fsType}`](https://github.com/NixOS/nixpkgs/blob/985140986aa3c543d5ec84afa5c470081ec07b78/nixos/lib/make-disk-image.nix#L511-L513) using the `-N` flag of `mkfs.ext4`. It also adds some additional logging output concerning the number of calculated inodes.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
