### PR TITLE
breitbandmessung: 3.3.0 -> 3.6.0

### DIFF
--- a/pkgs/applications/networking/breitbandmessung/default.nix
+++ b/pkgs/applications/networking/breitbandmessung/default.nix
@@ -3,7 +3,7 @@
 , fetchurl
 , asar
 , dpkg
-, electron_24
+, electron
 , makeWrapper
 , nixosTests
 , undmg
@@ -12,14 +12,11 @@
 let
   inherit (stdenv.hostPlatform) system;
 
-  version = "3.3.0";
+  sources = import ./sources.nix;
 
   systemArgs = rec {
-    x86_64-linux = rec {
-      src = fetchurl {
-        url = "https://download.breitbandmessung.de/bbm/Breitbandmessung-${version}-linux.deb";
-        sha256 = "sha256-12mbdxklje9msnRtNk1RAtIg3OCybev/vUersDZj2i4=";
-      };
+    x86_64-linux = {
+      src = fetchurl sources.x86_64-linux;
 
       nativeBuildInputs = [
         asar
@@ -49,7 +46,7 @@ let
         }
         EOF
 
-        makeWrapper ${electron_24}/bin/electron $out/bin/breitbandmessung \
+        makeWrapper ${electron}/bin/electron $out/bin/breitbandmessung \
           --add-flags $out/share/breitbandmessung/resources/build/electron.js
 
         # Fix the desktop link
@@ -59,10 +56,7 @@ let
     };
 
     x86_64-darwin = {
-      src = fetchurl {
-        url = "https://download.breitbandmessung.de/bbm/Breitbandmessung-${version}-mac.dmg";
-        sha256 = "sha256-a27R/N13i4qU2znTKz+LGxSdgSzJ0MzIHeiPHyRd65k=";
-      };
+      src = fetchurl sources.x86_64-darwin;
 
       nativeBuildInputs = [ undmg ];
 
@@ -79,9 +73,10 @@ let
 in
 stdenv.mkDerivation ({
   pname = "breitbandmessung";
-  inherit version;
+  inherit (sources) version;
 
   passthru.tests = { inherit (nixosTests) breitbandmessung; };
+  passthru.updateScript = ./update.sh;
 
   meta = with lib; {
     description = "Broadband internet speed test app from the german Bundesnetzagentur";

--- a/pkgs/applications/networking/breitbandmessung/sources.nix
+++ b/pkgs/applications/networking/breitbandmessung/sources.nix
@@ -1,0 +1,11 @@
+{
+  version = "3.6.0";
+  x86_64-linux = {
+    url = "https://download.breitbandmessung.de/bbm/Breitbandmessung-3.6.0-linux.deb";
+    sha256 = "sha256-jUp4Q9tiR/WLkTNHz97j0eE/WwcfFF3ut0S9N4M75Oc=";
+  };
+  x86_64-darwin = {
+    url = "https://download.breitbandmessung.de/bbm/Breitbandmessung-3.6.0-mac.dmg";
+    sha256 = "sha256-ZvTig1/fm1GRoOYuTRBiZ8j4CRbZSa95q6a0sxo39Gs=";
+  };
+}

--- a/pkgs/applications/networking/breitbandmessung/update.sh
+++ b/pkgs/applications/networking/breitbandmessung/update.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq nix ripgrep
+
+set -xeu -o pipefail
+
+PACKAGE_DIR="$(realpath "$(dirname "$0")")"
+
+current="$(nix eval -f "$PACKAGE_DIR/sources.nix" --raw version || :)"
+latest="$(curl -sS https://breitbandmessung.de/desktop-app | \
+  rg '.*Aktuelle Version der Desktop-App lautet:\s*([.0-9]+).*' -r '$1')"
+
+if [[ $current != $latest ]]; then
+  linux_hash="$(nix store prefetch-file --json https://download.breitbandmessung.de/bbm/Breitbandmessung-${latest}-linux.deb | jq -r .hash)"
+  darwin_hash="$(nix store prefetch-file --json https://download.breitbandmessung.de/bbm/Breitbandmessung-${latest}-mac.dmg | jq -r .hash)"
+
+  cat <<EOF >"$PACKAGE_DIR/sources.nix"
+{
+  version = "${latest}";
+  x86_64-linux = {
+    url = "https://download.breitbandmessung.de/bbm/Breitbandmessung-${latest}-linux.deb";
+    sha256 = "${linux_hash}";
+  };
+  x86_64-darwin = {
+    url = "https://download.breitbandmessung.de/bbm/Breitbandmessung-${latest}-mac.dmg";
+    sha256 = "${darwin_hash}";
+  };
+}
+EOF
+fi


### PR DESCRIPTION
## Description of changes

- Unpin electron version:
  Upstream updates usually fix electron incompatibilities and we also have a test which can detect them. (#295770)
- Add updater script:
  It scrapes the upstream website for the current version number. Lets hope the website structure doesn't change too much.
- Update to the latest version


<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I can't test on darwin currently, but the dmg folder structure is the same between versions, so I suspect it will work.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
   `breitbandmessung.tests.breitbandmessung`
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
