### PR TITLE
budgiePlugins.budgie-media-player-applet: 1.0.0-unstable-2023-12-31 -> 1.0.1

### DIFF
--- a/pkgs/desktops/budgie/plugins/budgie-media-player-applet/default.nix
+++ b/pkgs/desktops/budgie/plugins/budgie-media-player-applet/default.nix
@@ -7,15 +7,15 @@
 , python3Packages
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "budgie-media-player-applet";
-  version = "1.0.0-unstable-2023-12-31";
+  version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "zalesyc";
     repo = "budgie-media-player-applet";
-    rev = "24500be1e0a1f92968df80f8befdf896723ba8ee";
-    hash = "sha256-jQgkE6vv8PIcB0MJgfsQvzMRkkMU51Gqefoa2G6YJCw=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-E4aD7/SJNvWe6B3iX8fUZeZj14+uxjn0s+30BhU0dxE=";
   };
 
   nativeBuildInputs = [
@@ -31,8 +31,8 @@ stdenv.mkDerivation {
   ];
 
   postPatch = ''
-    substituteInPlace meson.build --replace "/usr" "$out"
-    substituteInPlace meson_post_install.py --replace '"/", "usr"' "\"$out\""
+    substituteInPlace meson.build --replace-fail "/usr" "$out"
+    substituteInPlace meson_post_install.py --replace-fail '"/", "usr"' "\"$out\""
   '';
 
   postFixup = ''
@@ -47,4 +47,4 @@ stdenv.mkDerivation {
     platforms = lib.platforms.linux;
     maintainers = lib.teams.budgie.members;
   };
-}
+})


### PR DESCRIPTION

https://github.com/zalesyc/budgie-media-player-applet/compare/24500be1e0a1f92968df80f8befdf896723ba8ee...v1.0.1


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


