### PR TITLE
valgrind: Mark ppc64 w/ ELFv2 as unsupported

### DIFF
--- a/pkgs/development/tools/analysis/valgrind/default.nix
+++ b/pkgs/development/tools/analysis/valgrind/default.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation rec {
     # Fix build on ELFv2 powerpc64
     # https://bugs.kde.org/show_bug.cgi?id=398883
     (fetchurl {
-      url = "https://github.com/void-linux/void-packages/raw/3e16b4606235885463fc9ab45b4c120f1a51aa28/srcpkgs/valgrind/patches/elfv2-ppc64-be.patch";
-      sha256 = "NV/F+5aqFZz7+OF5oN5MUTpThv4H5PEY9sBgnnWohQY=";
+      url = "https://git.adelielinux.org/adelie/packages/-/raw/f9558def812134e8c40d4d71d5c1cb7f998a4c48/user/valgrind/0001-Ensure-ELFv2-is-supported-on-PPC64.patch";
+      hash = "sha256-ESjJWnjLXcu75y1TYpDK022CFc8lcdt4ISvxu8wXlxM=";
     })
     # Fix checks on Musl.
     # https://bugs.kde.org/show_bug.cgi?id=453929
@@ -87,7 +87,8 @@ stdenv.mkDerivation rec {
     lib.optional stdenv.hostPlatform.isx86_64 "--enable-only64bit"
     ++ lib.optional stdenv.hostPlatform.isDarwin "--with-xcodedir=${xnu}/include";
 
-  doCheck = true;
+  # PPC64 ELFv2 patch does not fix tests
+  doCheck = !(with stdenv.hostPlatform; isPower64 && isAbiElfv2);
 
   postInstall = ''
     for i in $out/libexec/valgrind/*.supp; do
@@ -131,7 +132,15 @@ stdenv.mkDerivation rec {
     platforms = with lib.platforms; lib.intersectLists
       (x86 ++ power ++ s390x ++ armv7 ++ aarch64 ++ mips)
       (darwin ++ freebsd ++ illumos ++ linux);
-    badPlatforms = [ lib.systems.inspect.platformPatterns.isStatic ];
+    badPlatforms = with lib.systems.inspect; [
+      platformPatterns.isStatic
+    ]
+    # We can build for PPC64 ELFv2, but analysing any PPC64 ELFv2 binary produced by Nixpkgs causes many issues: https://github.com/NixOS/nixpkgs/pull/295906
+    # Effectively unusable with Nixpkgs binaries
+    ++ (map
+      (variant: lib.recursiveUpdate (lib.recursiveUpdate patterns.isPower64 patterns.isBigEndian) variant)
+      patterns.isAbiElfv2
+    );
     broken = stdenv.isDarwin; # https://hydra.nixos.org/build/128521440/nixlog/2
   };
 }


### PR DESCRIPTION
## Description of changes

- Tests are still failing due to ELFv1 hardcoding
- We can build for ppc64 ELFv2, but running the resulting valgrind binary on anything Nixpkgs produces results in
  - a SIGSEGV with glibc
    - many reports of uninitialised value usage inside glibc
    - the process terminating on a SIGSEGV with "Bad permissions for mapped region" inside glibc
    - valgrind itself crashing with a SIGSEGV in do_syscall_WRK
  - a slightly more graceful crash of valgrind with musl
    - similar reports of uninitialised value usage inside musl
    - valgrind exits upon encountering "the impossible"

---

<details>
  <summary>Details on debugging</summary>

Here is a [full log](https://github.com/NixOS/nixpkgs/files/14602927/hello-valgrind.log) of `valgrind <hello>/bin/hello` (both ELFv2). Lots of `Conditional jump or move depends on uninitialised value(s)` & `Use of uninitialised value of size`, ending in
```
==215556== Process terminating with default action of signal 11 (SIGSEGV)
==215556==  Bad permissions for mapped region at address 0x4067F00
==215556==    at 0x4067F00: ??? (in /nix/store/13mhdf5x574x9wnrjpdk79k8ir52fw5n-glibc-2.38-44/lib/ld64.so.2)
==215556==    by 0x401E41B: _dl_relocate_object (in /nix/store/13mhdf5x574x9wnrjpdk79k8ir52fw5n-glibc-2.38-44/lib/ld64.so.2)
==215556==    by 0x403492B: dl_main (in /nix/store/13mhdf5x574x9wnrjpdk79k8ir52fw5n-glibc-2.38-44/lib/ld64.so.2)
==215556==    by 0x403016F: _dl_sysdep_start (in /nix/store/13mhdf5x574x9wnrjpdk79k8ir52fw5n-glibc-2.38-44/lib/ld64.so.2)
==215556==    by 0x4031957: _dl_start_final (in /nix/store/13mhdf5x574x9wnrjpdk79k8ir52fw5n-glibc-2.38-44/lib/ld64.so.2)
==215556==    by 0x403207B: _dl_start (in /nix/store/13mhdf5x574x9wnrjpdk79k8ir52fw5n-glibc-2.38-44/lib/ld64.so.2)
==215556==    by 0x4030C37: (below main) (in /nix/store/13mhdf5x574x9wnrjpdk79k8ir52fw5n-glibc-2.38-44/lib/ld64.so.2)
==215556== 
==215556== HEAP SUMMARY:
==215556==     in use at exit: 0 bytes in 0 blocks
==215556==   total heap usage: 0 allocs, 0 frees, 0 bytes allocated
==215556== 
==215556== All heap blocks were freed -- no leaks are possible
==215556== 
==215556== Use --track-origins=yes to see where uninitialised values come from
==215556== For lists of detected and suppressed errors, rerun with: -s
==215556== ERROR SUMMARY: 4055 errors from 341 contexts (suppressed: 73 from 3)
fish: Job 1, '/nix/store/0ym9av408mv66ycgwlih…' terminated by signal SIGSEGV (Segmentation fault)
```

This works fine on ELFv1 (ELFv1 valgrind, on ELFv1 hello):
```
==217386== Memcheck, a memory error detector
==217386== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==217386== Using Valgrind-3.22.0 and LibVEX; rerun with -h for copyright info
==217386== Command: /nix/store/g2q9l4c7al2yzg3l4hhv7j1sl1d03mcc-hello-powerpc64-unknown-linux-gnuabielfv1-2.12.1/bin/hello
==217386== 
Hello, world!
==217386== 
==217386== HEAP SUMMARY:
==217386==     in use at exit: 0 bytes in 0 blocks
==217386==   total heap usage: 6 allocs, 6 frees, 5,318 bytes allocated
==217386== 
==217386== All heap blocks were freed -- no leaks are possible
==217386== 
==217386== For lists of detected and suppressed errors, rerun with: -s
==217386== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

So I've arrived at the conclusion that this just doesn't work.

</details>

Adding this platform to `badPlatforms` lets us use `lib.meta.availableOn` in other derivations (i.e. libdrm, which already uses it).

---

~~Draft, because I still wanna try installing Adélie Linux on my hardware and give the valgrind there a test ([which is where this patch seems to originate from](https://git.adelielinux.org/adelie/packages/-/blob/14ff2b81cc8f03e97af4dab6b33953fc6752772e/user/valgrind/0001-Ensure-ELFv2-is-supported-on-PPC64.patch)). If it works there, then I'll try to dig deeper into this.~~
Edit: See follow-up comments for results of that.

CC @alyssais, did the resulting binary work when you added the patch in https://github.com/NixOS/nixpkgs/pull/213341? I tried locally undoing just the valgrind bumps since then, but the binary still completely fails.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
