### PR TITLE
Avoid top-level `with` in `pkgs/build-support`

### DIFF
--- a/pkgs/build-support/agda/default.nix
+++ b/pkgs/build-support/agda/default.nix
@@ -2,14 +2,28 @@
 
 { stdenv, lib, self, Agda, runCommand, makeWrapper, writeText, ghcWithPackages, nixosTests }:
 
-with lib.strings;
-
 let
+  inherit (lib)
+    attrValues
+    elem
+    filter
+    filterAttrs
+    isAttrs
+    isList
+    platforms
+    ;
+
+  inherit (lib.strings)
+    concatMapStrings
+    concatMapStringsSep
+    optionalString
+    ;
+
   withPackages' = {
     pkgs,
     ghc ? ghcWithPackages (p: with p; [ ieee754 ])
   }: let
-    pkgs' = if builtins.isList pkgs then pkgs else pkgs self;
+    pkgs' = if isList pkgs then pkgs else pkgs self;
     library-file = writeText "libraries" ''
       ${(concatMapStringsSep "\n" (p: "${p}/${p.libraryFile}") pkgs')}
     '';
@@ -23,7 +37,7 @@ let
       inherit withPackages;
       tests = {
         inherit (nixosTests) agda;
-        allPackages = withPackages (lib.filter self.lib.isUnbrokenAgdaPackage (lib.attrValues self));
+        allPackages = withPackages (filter self.lib.isUnbrokenAgdaPackage (attrValues self));
       };
     };
     inherit (Agda) meta;
@@ -36,7 +50,7 @@ let
     ln -s ${Agda}/bin/agda-mode $out/bin/agda-mode
     ''; # Local interfaces has been added for now: See https://github.com/agda/agda/issues/4526
 
-  withPackages = arg: if builtins.isAttrs arg then withPackages' arg else withPackages' { pkgs = arg; };
+  withPackages = arg: if isAttrs arg then withPackages' arg else withPackages' { pkgs = arg; };
 
   extensions = [
     "agda"
@@ -63,7 +77,7 @@ let
     , extraExtensions ? []
     , ...
     }: let
-      agdaWithArgs = withPackages (builtins.filter (p: p ? isAgdaDerivation) buildInputs);
+      agdaWithArgs = withPackages (filter (p: p ? isAgdaDerivation) buildInputs);
       includePathArgs = concatMapStrings (path: "-i" + path + " ") (includePaths ++ [(dirOf everythingFile)]);
     in
       {
@@ -91,13 +105,13 @@ let
         # darwin, it seems that there is no standard such locale; luckily,
         # the referenced issue doesn't seem to surface on darwin. Hence let's
         # set this only on non-darwin.
-        LC_ALL = lib.optionalString (!stdenv.isDarwin) "C.UTF-8";
+        LC_ALL = optionalString (!stdenv.isDarwin) "C.UTF-8";
 
-        meta = if meta.broken or false then meta // { hydraPlatforms = lib.platforms.none; } else meta;
+        meta = if meta.broken or false then meta // { hydraPlatforms = platforms.none; } else meta;
 
         # Retrieve all packages from the finished package set that have the current package as a dependency and build them
-        passthru.tests = with builtins;
-          lib.filterAttrs (name: pkg: self.lib.isUnbrokenAgdaPackage pkg && elem pname (map (pkg: pkg.pname) pkg.buildInputs)) self;
+        passthru.tests =
+          filterAttrs (name: pkg: self.lib.isUnbrokenAgdaPackage pkg && elem pname (map (pkg: pkg.pname) pkg.buildInputs)) self;
       };
 in
 {

--- a/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
@@ -31,10 +31,20 @@
 
 assert (pname != null || version != null) -> (name == null && pname != null); # You must declare either a name or pname + version (preferred).
 
-with builtins;
 let
+  inherit (lib)
+    concatLines
+    concatStringsSep
+    escapeShellArgs
+    filter
+    optionalString
+    splitString
+    ;
+
+  inherit (lib.attrsets) removeAttrs;
+
   pname = if args ? name && args.name != null then args.name else args.pname;
-  versionStr = lib.optionalString (version != null) ("-" + version);
+  versionStr = optionalString (version != null) ("-" + version);
   name = pname + versionStr;
 
   buildFHSEnv = callPackage ./buildFHSEnv.nix { };
@@ -116,10 +126,10 @@ let
     exec ${run} "$@"
   '';
 
-  indentLines = str: lib.concatLines (map (s: "  " + s) (filter (s: s != "") (lib.splitString "\n" str)));
+  indentLines = str: concatLines (map (s: "  " + s) (filter (s: s != "") (splitString "\n" str)));
   bwrapCmd = { initArgs ? "" }: ''
     ${extraPreBwrapCmds}
-    ignored=(/nix /dev /proc /etc ${lib.optionalString privateTmp "/tmp"})
+    ignored=(/nix /dev /proc /etc ${optionalString privateTmp "/tmp"})
     ro_mounts=()
     symlinks=()
     etc_ignored=()
@@ -156,7 +166,7 @@ let
       ro_mounts+=(--ro-bind /etc /.host-etc)
     fi
 
-    for i in ${lib.escapeShellArgs etcBindEntries}; do
+    for i in ${escapeShellArgs etcBindEntries}; do
       if [[ "''${etc_ignored[@]}" =~ "$i" ]]; then
         continue
       fi
@@ -187,7 +197,7 @@ let
       x11_args+=(--ro-bind-try "$local_socket" "$local_socket")
     fi
 
-    ${lib.optionalString privateTmp ''
+    ${optionalString privateTmp ''
     # sddm places XAUTHORITY in /tmp
     if [[ "$XAUTHORITY" == /tmp/* ]]; then
       x11_args+=(--ro-bind-try "$XAUTHORITY" "$XAUTHORITY")
@@ -212,15 +222,15 @@ let
       --dev-bind /dev /dev
       --proc /proc
       --chdir "$(pwd)"
-      ${lib.optionalString unshareUser "--unshare-user"}
-      ${lib.optionalString unshareIpc "--unshare-ipc"}
-      ${lib.optionalString unsharePid "--unshare-pid"}
-      ${lib.optionalString unshareNet "--unshare-net"}
-      ${lib.optionalString unshareUts "--unshare-uts"}
-      ${lib.optionalString unshareCgroup "--unshare-cgroup"}
-      ${lib.optionalString dieWithParent "--die-with-parent"}
+      ${optionalString unshareUser "--unshare-user"}
+      ${optionalString unshareIpc "--unshare-ipc"}
+      ${optionalString unsharePid "--unshare-pid"}
+      ${optionalString unshareNet "--unshare-net"}
+      ${optionalString unshareUts "--unshare-uts"}
+      ${optionalString unshareCgroup "--unshare-cgroup"}
+      ${optionalString dieWithParent "--die-with-parent"}
       --ro-bind /nix /nix
-      ${lib.optionalString privateTmp "--tmpfs /tmp"}
+      ${optionalString privateTmp "--tmpfs /tmp"}
       # Our glibc will look for the cache in its own path in `/nix/store`.
       # As such, we need a cache to exist there, because pressure-vessel
       # depends on the existence of an ld cache. However, adding one
@@ -234,7 +244,7 @@ let
       --symlink /etc/ld.so.cache ${glibc}/etc/ld.so.cache \
       --ro-bind ${glibc}/etc/rpc ${glibc}/etc/rpc \
       --remount-ro ${glibc}/etc \
-  '' + lib.optionalString (stdenv.isx86_64 && stdenv.isLinux) (indentLines ''
+  '' + optionalString (stdenv.isx86_64 && stdenv.isLinux) (indentLines ''
       --tmpfs ${pkgsi686Linux.glibc}/etc \
       --symlink /etc/ld.so.conf ${pkgsi686Linux.glibc}/etc/ld.so.conf \
       --symlink /etc/ld.so.cache ${pkgsi686Linux.glibc}/etc/ld.so.cache \

--- a/pkgs/build-support/coq/default.nix
+++ b/pkgs/build-support/coq/default.nix
@@ -1,10 +1,33 @@
 { lib, stdenv, coqPackages, coq, which, fetchzip }@args:
-let lib = import ./extra-lib.nix {inherit (args) lib;}; in
-with builtins; with lib;
+
 let
+  lib = import ./extra-lib.nix {
+    inherit (args) lib;
+  };
+
+  inherit (lib)
+    concatStringsSep
+    flip
+    foldl
+    isFunction
+    isString
+    optional
+    optionalAttrs
+    optionals
+    optionalString
+    pred
+    remove
+    switch
+    versions
+    ;
+
+  inherit (lib.attrsets) removeAttrs;
+  inherit (lib.strings) match;
+
   isGitHubDomain = d: match "^github.*" d != null;
   isGitLabDomain = d: match "^gitlab.*" d != null;
 in
+
 { pname,
   version ? null,
   fetcher ? null,

--- a/pkgs/build-support/coq/extra-lib.nix
+++ b/pkgs/build-support/coq/extra-lib.nix
@@ -1,5 +1,25 @@
 { lib }:
-with builtins; with lib; recursiveUpdate lib (rec {
+
+let
+  inherit (lib)
+    all
+    concatStringsSep
+    findFirst
+    flip
+    getAttr
+    head
+    isFunction
+    length
+    recursiveUpdate
+    splitVersion
+    tail
+    take
+    versionAtLeast
+    versionOlder
+    zipListsWith
+    ;
+in
+recursiveUpdate lib (rec {
 
   versions =
     let

--- a/pkgs/build-support/coq/meta-fetch/default.nix
+++ b/pkgs/build-support/coq/meta-fetch/default.nix
@@ -1,8 +1,33 @@
 { lib, stdenv, fetchzip }@args:
-let lib' = lib; in
-let lib = import ../extra-lib.nix {lib = lib';}; in
-with builtins; with lib;
+
 let
+  lib = import ../extra-lib.nix {
+    inherit (args) lib;
+  };
+
+  inherit (lib)
+    attrNames
+    fakeSha256
+    filter
+    findFirst
+    head
+    isAttrs
+    isPath
+    isString
+    last
+    length
+    optionalAttrs
+    pathExists
+    pred
+    sort
+    switch
+    switch-if
+    versionAtLeast
+    versions
+    ;
+
+  inherit (lib.strings) match split;
+
   default-fetcher = {domain ? "github.com", owner ? "", repo, rev, name ? "source", sha256 ? null, ...}@args:
     let ext = if args?sha256 then "zip" else "tar.gz";
         fmt = if args?sha256 then "zip" else "tarball";
@@ -17,7 +42,7 @@ let
           { cond = (match "(www.)?mpi-sws.org" domain) != null;
             out = "https://www.mpi-sws.org/~${owner}/${repo}/download/${repo}-${rev}.${ext}";}
         ] (throw "meta-fetch: no fetcher found for domain ${domain} on ${rev}");
-        fetch = x: if args?sha256 then fetchzip (x // { inherit sha256; }) else fetchTarball x;
+        fetch = x: if args?sha256 then fetchzip (x // { inherit sha256; }) else builtins.fetchTarball x;
     in fetch { inherit url ; };
 in
 {
@@ -38,11 +63,12 @@ switch arg [
   { case = isNull;       out = { version = "broken"; src = ""; broken = true; }; }
   { case = isPathString; out = { version = "dev"; src = arg; }; }
   { case = pred.union isVersion isShortVersion;
-    out = let v = if isVersion arg then arg else shortVersion arg; in
-      let
-        given-sha256 = release.${v}.sha256 or "";
-        sha256 = if given-sha256 == "" then lib.fakeSha256 else given-sha256;
-        rv = release.${v} // { inherit sha256; }; in
+    out = let
+      v = if isVersion arg then arg else shortVersion arg;
+      given-sha256 = release.${v}.sha256 or "";
+      sha256 = if given-sha256 == "" then fakeSha256 else given-sha256;
+      rv = release.${v} // { inherit sha256; };
+    in
       {
         version = rv.version or v;
         src = rv.src or fetcher (location // { rev = releaseRev v; } // rv);

--- a/pkgs/build-support/fetchrepoproject/default.nix
+++ b/pkgs/build-support/fetchrepoproject/default.nix
@@ -9,9 +9,14 @@
 assert repoRepoRev != "" -> repoRepoURL != "";
 assert createMirror -> !useArchive;
 
-with lib;
-
 let
+  inherit (lib)
+    concatMapStringsSep
+    concatStringsSep
+    fetchers
+    optionalString
+    ;
+
   extraRepoInitFlags = [
     (optionalString (repoRepoURL != "") "--repo-url=${repoRepoURL}")
     (optionalString (repoRepoRev != "") "--repo-branch=${repoRepoRev}")

--- a/pkgs/build-support/fetchsourcehut/default.nix
+++ b/pkgs/build-support/fetchsourcehut/default.nix
@@ -1,6 +1,14 @@
 { fetchgit, fetchhg, fetchzip, lib }:
 
-lib.makeOverridable (
+let
+  inherit (lib)
+    assertOneOf
+    makeOverridable
+    optionalString
+    ;
+in
+
+makeOverridable (
 { owner
 , repo, rev
 , domain ? "sr.ht"
@@ -10,9 +18,7 @@ lib.makeOverridable (
 , ... # For hash agility
 } @ args:
 
-with lib;
-
-assert (lib.assertOneOf "vc" vc [ "hg" "git" ]);
+assert (assertOneOf "vc" vc [ "hg" "git" ]);
 
 let
   urlFor = resource: "https://${resource}.${domain}/${owner}/${repo}";

--- a/pkgs/build-support/pkg-config-wrapper/default.nix
+++ b/pkgs/build-support/pkg-config-wrapper/default.nix
@@ -10,9 +10,17 @@
 , extraPackages ? [], extraBuildCommands ? ""
 }:
 
-with lib;
-
 let
+  inherit (lib)
+    attrByPath
+    getBin
+    optional
+    optionalAttrs
+    optionals
+    optionalString
+    replaceStrings
+    ;
+
   stdenv = stdenvNoCC;
   inherit (stdenv) hostPlatform targetPlatform;
 
@@ -20,7 +28,7 @@ let
   #
   # TODO(@Ericson2314) Make unconditional, or optional but always true by
   # default.
-  targetPrefix = lib.optionalString (targetPlatform != hostPlatform)
+  targetPrefix = optionalString (targetPlatform != hostPlatform)
                                         (targetPlatform.config + "-");
 
   # See description in cc-wrapper.
@@ -49,7 +57,7 @@ stdenv.mkDerivation {
   dontUnpack = true;
 
   # Additional flags passed to pkg-config.
-  addFlags = lib.optional stdenv.targetPlatform.isStatic "--static";
+  addFlags = optional stdenv.targetPlatform.isStatic "--static";
 
   installPhase =
     ''
@@ -119,10 +127,10 @@ stdenv.mkDerivation {
   };
 
   meta =
-    let pkg-config_ = lib.optionalAttrs (pkg-config != null) pkg-config; in
-    (lib.optionalAttrs (pkg-config_ ? meta) (removeAttrs pkg-config.meta ["priority"])) //
+    let pkg-config_ = optionalAttrs (pkg-config != null) pkg-config; in
+    (optionalAttrs (pkg-config_ ? meta) (removeAttrs pkg-config.meta ["priority"])) //
     { description =
-        lib.attrByPath ["meta" "description"] "pkg-config" pkg-config_
+        attrByPath ["meta" "description"] "pkg-config" pkg-config_
         + " (wrapper script)";
       priority = 10;
   };

--- a/pkgs/build-support/release/default.nix
+++ b/pkgs/build-support/release/default.nix
@@ -1,6 +1,24 @@
 { lib, pkgs }:
 
-with pkgs;
+let
+  inherit (lib) optionalString;
+
+  inherit (pkgs)
+    autoconf
+    automake
+    checkinstall
+    clang-analyzer
+    cov-build
+    enableGCOVInstrumentation
+    lcov
+    libtool
+    makeGCOVReport
+    runCommand
+    stdenv
+    vmTools
+    xz
+    ;
+in
 
 rec {
 
@@ -91,7 +109,7 @@ rec {
       dontConfigure = true;
       dontBuild = true;
 
-      patchPhase = lib.optionalString isNixOS ''
+      patchPhase = optionalString isNixOS ''
         touch .update-on-nixos-rebuild
       '';
 

--- a/pkgs/build-support/vm/test.nix
+++ b/pkgs/build-support/vm/test.nix
@@ -1,5 +1,21 @@
-with import ../../.. { };
-with vmTools;
+let
+  pkgs = import ../../.. { };
+
+  inherit (pkgs)
+    hello
+    patchelf
+    pcmanfm
+    stdenv
+    ;
+
+  inherit (pkgs.vmTools)
+    buildRPM
+    diskImages
+    makeImageTestScript
+    runInLinuxImage
+    runInLinuxVM
+    ;
+in
 
 {
 

--- a/pkgs/build-support/writers/test.nix
+++ b/pkgs/build-support/writers/test.nix
@@ -11,8 +11,38 @@
 
 # If you are reading this, you can test these writers by running: nix-build . -A tests.writers
 
-with writers;
 let
+  inherit (lib) getExe recurseIntoAttrs;
+
+  inherit (writers)
+    makeFSharpWriter
+    writeBash
+    writeBashBin
+    writeDash
+    writeDashBin
+    writeFish
+    writeFishBin
+    writeFSharp
+    writeHaskell
+    writeHaskellBin
+    writeJS
+    writeJSBin
+    writeJSON
+    writeLua
+    writeNu
+    writePerl
+    writePerlBin
+    writePyPy3
+    writePython3
+    writePython3Bin
+    writeRuby
+    writeRust
+    writeRustBin
+    writeText
+    writeTOML
+    writeYAML
+    ;
+
   expectSuccess = test:
     runCommand "run-${test.name}" {} ''
       if [[ "$(${test})" != success ]]; then
@@ -25,7 +55,7 @@ let
 
   expectSuccessBin = test:
     runCommand "run-${test.name}" {} ''
-      if [[ "$(${lib.getExe test})" != success ]]; then
+      if [[ "$(${getExe test})" != success ]]; then
         echo 'test ${test.name} failed'
         exit 1
       fi
@@ -39,8 +69,8 @@ let
     in
     testers.testEqualContents { expected = expectedFile; actual = file; assertion = "${file.name} matches"; };
 in
-lib.recurseIntoAttrs {
-  bin = lib.recurseIntoAttrs {
+recurseIntoAttrs {
+  bin = recurseIntoAttrs {
     bash = expectSuccessBin (writeBashBin "test-writers-bash-bin" ''
      if [[ "test" == "test" ]]; then echo "success"; fi
     '');
@@ -140,7 +170,7 @@ lib.recurseIntoAttrs {
     #'');
   };
 
-  simple = lib.recurseIntoAttrs {
+  simple = recurseIntoAttrs {
     bash = expectSuccess (writeBash "test-writers-bash" ''
      if [[ "test" == "test" ]]; then echo "success"; fi
     '');
@@ -265,7 +295,7 @@ lib.recurseIntoAttrs {
     '');
   };
 
-  path = lib.recurseIntoAttrs {
+  path = recurseIntoAttrs {
     bash = expectSuccess (writeBash "test-writers-bash-path" (writeText "test" ''
       if [[ "test" == "test" ]]; then echo "success"; fi
     ''));
@@ -306,7 +336,7 @@ lib.recurseIntoAttrs {
     };
   };
 
-  wrapping = lib.recurseIntoAttrs {
+  wrapping = recurseIntoAttrs {
     bash-bin = expectSuccessBin (
       writeBashBin "test-writers-wrapping-bash-bin"
         {


### PR DESCRIPTION
## Description of changes

Using `with` at a top-level scope is [an anti-pattern](https://nix.dev/guides/best-practices#with-scopes). The tracking issue is #208242. This is a pure refactor: there is no functional change contained in this PR.

I used the refactor strategy that looks for the uses of names [coming from `lib`](https://gist.github.com/philiptaron/04326000d5ff20cb72c2805efd09701c). 

Following advice, I also preferred to inherit names from `lib` instead of `builtins` where there was a choice. I also preferred to inherit from `lib` in one place, rather than to have a mixture of `lib.thing` and `inherit (lib) thing`.

<del>In [`pkgs/build-support/coq/extra-lib.nix`](https://github.com/NixOS/nixpkgs/commit/8b84f3ace020939bd4a88df8e5b56a77180c22aa), I removed the use of `with` and `rec` entirely.</del> I undid this change.

This PR targets staging, rather than master, as the contents of these files near the root of most of the Nixpkgs graph, but I guess I should have targeted master since there are no rebuilds.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of ~all~ many packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).