### PR TITLE
Avoid top-level `with` in `pkgs/games`

### DIFF
--- a/pkgs/games/arx-libertatis/default.nix
+++ b/pkgs/games/arx-libertatis/default.nix
@@ -8,7 +8,15 @@
 ,   gdb  ? null
 }:
 
-with lib;
+let
+  inherit (lib)
+    licenses
+    maintainers
+    optionals
+    optionalString
+    platforms
+    ;
+in
 
 stdenv.mkDerivation rec {
   pname = "arx-libertatis";

--- a/pkgs/games/dwarf-fortress/default.nix
+++ b/pkgs/games/dwarf-fortress/default.nix
@@ -32,9 +32,16 @@
 # changes on later launches, but consider extending the wrapper with your
 # desired options instead.
 
-with lib;
-
 let
+  inherit (lib)
+    attrNames
+    getAttr
+    importJSON
+    listToAttrs
+    recurseIntoAttrs
+    replaceStrings
+    ;
+
   callPackage = newScope self;
 
   # The latest Dwarf Fortress version. Maintainers: when a new version comes
@@ -43,14 +50,14 @@ let
   latestVersion = "0.47.05";
 
   # Converts a version to a package name.
-  versionToName = version: "dwarf-fortress_${lib.replaceStrings ["."] ["_"] version}";
+  versionToName = version: "dwarf-fortress_${replaceStrings ["."] ["_"] version}";
 
   dwarf-therapist-original = libsForQt5.callPackage ./dwarf-therapist {
     texlive = texliveBasic.withPackages (ps: with ps; [ float caption wrapfig adjmulticol sidecap preprint enumitem ]);
   };
 
   # A map of names to each Dwarf Fortress package we know about.
-  df-games = lib.listToAttrs (map
+  df-games = listToAttrs (map
     (dfVersion: {
       name = versionToName dfVersion;
       value =
@@ -83,10 +90,10 @@ let
           jdk = jdk8; # TODO: remove override https://github.com/NixOS/nixpkgs/pull/89731
         };
     })
-    (lib.attrNames self.df-hashes));
+    (attrNames self.df-hashes));
 
   self = rec {
-    df-hashes = lib.importJSON ./game.json;
+    df-hashes = importJSON ./game.json;
 
     # Aliases for the latest Dwarf Fortress and the selected Therapist install
     dwarf-fortress = getAttr (versionToName latestVersion) df-games;

--- a/pkgs/games/dwarf-fortress/game.nix
+++ b/pkgs/games/dwarf-fortress/game.nix
@@ -13,9 +13,20 @@
 , df-hashes
 }:
 
-with lib;
-
 let
+  inherit (lib)
+    attrNames
+    elemAt
+    getAttr
+    getLib
+    hasAttr
+    licenses
+    maintainers
+    makeLibraryPath
+    optionalString
+    splitVersion
+    ;
+
   libpath = makeLibraryPath [ stdenv.cc.cc stdenv.cc.libc dwarf-fortress-unfuck SDL ];
 
   # Map Dwarf Fortress platform names to Nixpkgs platform names.

--- a/pkgs/games/dwarf-fortress/lazy-pack.nix
+++ b/pkgs/games/dwarf-fortress/lazy-pack.nix
@@ -25,9 +25,16 @@
 , enableSound ? true
 }:
 
-with lib;
-
 let
+  inherit (lib)
+    getAttr
+    hasAttr
+    licenses
+    maintainers
+    optional
+    platforms
+    ;
+
   dfGame = versionToName dfVersion;
   dwarf-fortress =
     if hasAttr dfGame df-games
@@ -43,10 +50,10 @@ buildEnv {
         enableIntro enableTruetype enableFPS enableTextMode enableSound;
     })
   ]
-  ++ lib.optional enableDwarfTherapist dwarf-therapist
-  ++ lib.optional enableLegendsBrowser legends-browser;
+  ++ optional enableDwarfTherapist dwarf-therapist
+  ++ optional enableLegendsBrowser legends-browser;
 
-  meta = with lib; {
+  meta = {
     description = "An opinionated wrapper for Dwarf Fortress";
     maintainers = with maintainers; [ Baughn numinit ];
     license = licenses.mit;

--- a/pkgs/games/dwarf-fortress/themes/default.nix
+++ b/pkgs/games/dwarf-fortress/themes/default.nix
@@ -1,6 +1,15 @@
 { lib, fetchFromGitHub, ... }:
 
-with builtins;
+let
+  inherit (lib)
+    importJSON
+    licenses
+    listToAttrs
+    maintainers
+    platforms
+    readFile
+    ;
+in
 
 listToAttrs (map
   (v: {
@@ -11,11 +20,11 @@ listToAttrs (map
       repo = v.name;
       rev = v.version;
       sha256 = v.sha256;
-      meta = with lib; {
+      meta = {
         platforms = platforms.all;
         maintainers = [ maintainers.matthewbauer maintainers.shazow ];
         license = licenses.free;
       };
     };
   })
-  (fromJSON (readFile ./themes.json)))
+  (importJSON ./themes.json))

--- a/pkgs/games/dwarf-fortress/twbt/default.nix
+++ b/pkgs/games/dwarf-fortress/twbt/default.nix
@@ -5,9 +5,15 @@
 , dfVersion
 }:
 
-with lib;
-
 let
+  inherit (lib)
+    getAttr
+    hasAttr
+    licenses
+    maintainers
+    platforms
+    ;
+
   twbt-releases = {
     "0.44.10" = {
       twbtRelease = "6.49";
@@ -75,7 +81,7 @@ stdenvNoCC.mkDerivation rec {
     cp -a *.png $art/data/art/
   '';
 
-  meta = with lib; {
+  meta = {
     description = "A plugin for Dwarf Fortress / DFHack that improves various aspects the game interface";
     maintainers = with maintainers; [ Baughn numinit ];
     license = licenses.mit;

--- a/pkgs/games/dwarf-fortress/unfuck.nix
+++ b/pkgs/games/dwarf-fortress/unfuck.nix
@@ -19,9 +19,16 @@
 , pkg-config
 }:
 
-with lib;
-
 let
+  inherit (lib)
+    getAttr
+    hasAttr
+    licenses
+    maintainers
+    platforms
+    versionOlder
+    ;
+
   unfuck-releases = {
     "0.43.05" = {
       unfuckRelease = "0.43.05";
@@ -106,7 +113,7 @@ stdenv.mkDerivation {
     libGL
   ]
   # switched to gtk3 in 0.47.05
-  ++ (if lib.versionOlder release.unfuckRelease "0.47.05" then [
+  ++ (if versionOlder release.unfuckRelease "0.47.05" then [
     gtk2
   ] else [
     gtk3
@@ -124,7 +131,7 @@ stdenv.mkDerivation {
 
   passthru = { inherit dfVersion; };
 
-  meta = with lib; {
+  meta = {
     description = "Unfucked multimedia layer for Dwarf Fortress";
     homepage = "https://github.com/svenstaro/dwarf_fortress_unfuck";
     license = licenses.free;

--- a/pkgs/games/factorio/mods.nix
+++ b/pkgs/games/factorio/mods.nix
@@ -7,7 +7,7 @@
 , allRecommendedMods ? true
 , allOptionalMods ? false
 }:
-with lib;
+
 let
   modDrv = factorio-utils.modDrv { inherit allRecommendedMods allOptionalMods; };
 in

--- a/pkgs/games/factorio/utils.nix
+++ b/pkgs/games/factorio/utils.nix
@@ -1,7 +1,18 @@
 # This file provides a top-level function that will be used by both nixpkgs and nixos
 # to generate mod directories for use at runtime by factorio.
 { lib, stdenv }:
-with lib;
+let
+  inherit (lib)
+    flatten
+    head
+    optionals
+    optionalString
+    removeSuffix
+    replaceStrings
+    splitString
+    unique
+    ;
+in
 {
   mkModDirDrv = mods: modsDatFile: # a list of mod derivations
     let
@@ -18,7 +29,7 @@ with lib;
           # NB: there will only ever be a single zip file in each mod derivation's output dir
           ln -s $modDrv/*.zip $out
         done
-      '' + (lib.optionalString (modsDatFile != null) ''
+      '' + (optionalString (modsDatFile != null) ''
        cp ${modsDatFile} $out/mod-settings.dat
       '');
     };

--- a/pkgs/games/koboredux/default.nix
+++ b/pkgs/games/koboredux/default.nix
@@ -10,9 +10,16 @@
 , useProprietaryAssets ? true
 }:
 
-with lib;
-
 let
+  inherit (lib)
+    and
+    licenses
+    maintainers
+    optional
+    optionalString
+    platforms
+    ;
+
   pname = "koboredux";
   version = "0.7.5.1";
 

--- a/pkgs/games/lugaru/default.nix
+++ b/pkgs/games/lugaru/default.nix
@@ -1,7 +1,13 @@
 { lib, stdenv, fetchFromGitLab, cmake, openal, pkg-config, libogg,
   libvorbis, SDL2, makeWrapper, libpng, libjpeg_turbo, libGLU }:
 
-with lib;
+let
+  inherit (lib)
+    licenses
+    maintainers
+    platforms
+    ;
+in
 
 stdenv.mkDerivation rec {
 
@@ -26,6 +32,6 @@ stdenv.mkDerivation rec {
     homepage = "https://osslugaru.gitlab.io";
     maintainers = [ ];
     platforms = platforms.linux;
-    license = lib.licenses.gpl2Plus;
+    license = licenses.gpl2Plus;
   };
 }

--- a/pkgs/games/openra_2019/common.nix
+++ b/pkgs/games/openra_2019/common.nix
@@ -7,9 +7,16 @@
 , zenity
 }:
 
-with lib;
-
 let
+  inherit (lib)
+    licenses
+    maintainers
+    makeBinPath
+    makeLibraryPath
+    optional
+    platforms
+    ;
+
   path = makeBinPath ([ mono python3 ] ++ optional (zenity != null) zenity);
   rpath = makeLibraryPath [ lua freetype openal SDL2 ];
   mkdirp = makeSetupHook {

--- a/pkgs/games/tinyfugue/default.nix
+++ b/pkgs/games/tinyfugue/default.nix
@@ -3,9 +3,16 @@
 , sslSupport ? true
 }:
 
-with lib;
-
 assert sslSupport -> openssl != null;
+
+let
+  inherit (lib)
+    licenses
+    maintainers
+    optional
+    platforms
+    ;
+in
 
 stdenv.mkDerivation rec {
   pname = "tinyfugue";


### PR DESCRIPTION
## Description of changes

Using `with` at a top-level scope is [an anti-pattern](https://nix.dev/guides/best-practices#with-scopes). The tracking issue is #208242. This is a pure refactor: there is no functional change contained in this PR. In fact, `nixpkgs-review rev HEAD` reports nothing to build.

I used the refactor strategy that looks for the uses of names [coming from `lib`](https://gist.github.com/philiptaron/04326000d5ff20cb72c2805efd09701c). 

Following advice, I also preferred to inherit names from `lib` instead of `builtins` where there was a choice. I also preferred to inherit from `lib` in one place, rather than to have a mixture of `lib.thing` and `inherit (lib) thing`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).