### PR TITLE
[23.11] python311Packages.onnx: add patches for CVE-2024-27318 & CVE-2024-27319

### DIFF
--- a/pkgs/development/python-modules/onnx/1.14.1-CVE-2024-27318.patch
+++ b/pkgs/development/python-modules/onnx/1.14.1-CVE-2024-27318.patch
@@ -1,0 +1,369 @@
+Based on upstream 66b7fb630903fdcf3e83b6b6d56d82e904264a20, adjusted to
+apply to 1.14.1, avoid implicit inclusion of changes from other
+intermediate commits & make test work
+
+diff --git a/onnx/checker.cc b/onnx/checker.cc
+index 37d6abd3..53bb0d63 100644
+--- a/onnx/checker.cc
++++ b/onnx/checker.cc
+@@ -4,7 +4,6 @@
+ 
+ #include "onnx/checker.h"
+ #include "onnx/common/file_utils.h"
+-#include "onnx/common/path.h"
+ #include "onnx/defs/schema.h"
+ #include "onnx/defs/tensor_proto_util.h"
+ #include "onnx/proto_utils.h"
+@@ -129,85 +128,7 @@ void check_tensor(const TensorProto& tensor, const CheckerContext& ctx) {
+     for (const StringStringEntryProto& entry : tensor.external_data()) {
+       if (entry.has_key() && entry.has_value() && entry.key() == "location") {
+         has_location = true;
+-#ifdef _WIN32
+-        auto file_path = std::filesystem::path(utf8str_to_wstring(entry.value()));
+-        if (file_path.is_absolute()) {
+-          fail_check(
+-              "Location of external TensorProto ( tensor name: ",
+-              tensor.name(),
+-              ") should be a relative path, but it is an absolute path: ",
+-              entry.value());
+-        }
+-        auto relative_path = file_path.lexically_normal().make_preferred().wstring();
+-        // Check that normalized relative path contains ".." on Windows.
+-        if (relative_path.find(L"..", 0) != std::string::npos) {
+-          fail_check(
+-              "Data of TensorProto ( tensor name: ",
+-              tensor.name(),
+-              ") should be file inside the ",
+-              ctx.get_model_dir(),
+-              ", but the '",
+-              entry.value(),
+-              "' points outside the directory");
+-        }
+-        std::wstring data_path = path_join(utf8str_to_wstring(ctx.get_model_dir()), relative_path);
+-        struct _stat64 buff;
+-        if (_wstat64(data_path.c_str(), &buff) != 0) {
+-          fail_check(
+-              "Data of TensorProto ( tensor name: ",
+-              tensor.name(),
+-              ") should be stored in ",
+-              entry.value(),
+-              ", but it doesn't exist or is not accessible.");
+-        }
+-#else // POSIX
+-        if (entry.value().empty()) {
+-          fail_check("Location of external TensorProto ( tensor name: ", tensor.name(), ") should not be empty.");
+-        } else if (entry.value()[0] == '/') {
+-          fail_check(
+-              "Location of external TensorProto ( tensor name: ",
+-              tensor.name(),
+-              ") should be a relative path, but it is an absolute path: ",
+-              entry.value());
+-        }
+-        std::string relative_path = clean_relative_path(entry.value());
+-        // Check that normalized relative path contains ".." on POSIX
+-        if (relative_path.find("..", 0) != std::string::npos) {
+-          fail_check(
+-              "Data of TensorProto ( tensor name: ",
+-              tensor.name(),
+-              ") should be file inside the ",
+-              ctx.get_model_dir(),
+-              ", but the '",
+-              entry.value(),
+-              "' points outside the directory");
+-        }
+-        std::string data_path = path_join(ctx.get_model_dir(), relative_path);
+-        // use stat64 to check whether the file exists
+-#if defined(__APPLE__) || defined(__wasm__)
+-        struct stat buffer; // APPLE does not have stat64
+-        if (stat((data_path).c_str(), &buffer) != 0) {
+-#else
+-        struct stat64 buffer; // All POSIX except APPLE have stat64
+-        if (stat64((data_path).c_str(), &buffer) != 0) {
+-#endif
+-          fail_check(
+-              "Data of TensorProto ( tensor name: ",
+-              tensor.name(),
+-              ") should be stored in ",
+-              data_path,
+-              ", but it doesn't exist or is not accessible.");
+-        }
+-        // Do not allow symlinks or directories.
+-        if (!S_ISREG(buffer.st_mode)) {
+-          fail_check(
+-              "Data of TensorProto ( tensor name: ",
+-              tensor.name(),
+-              ") should be stored in ",
+-              data_path,
+-              ", but it is not regular file.");
+-        }
+-#endif
++        resolve_external_data_location(ctx.get_model_dir(), entry.value(), tensor.name());
+       }
+     }
+     if (!has_location) {
+@@ -1045,6 +966,93 @@ void check_model(const ModelProto& model, bool full_check) {
+   }
+ }
+ 
++std::string resolve_external_data_location(
++    const std::string& base_dir,
++    const std::string& location,
++    const std::string& tensor_name) {
++#ifdef _WIN32
++  auto file_path = std::filesystem::path(utf8str_to_wstring(location));
++  if (file_path.is_absolute()) {
++    fail_check(
++        "Location of external TensorProto ( tensor name: ",
++        tensor_name,
++        ") should be a relative path, but it is an absolute path: ",
++        location);
++  }
++  auto relative_path = file_path.lexically_normal().make_preferred().wstring();
++  // Check that normalized relative path contains ".." on Windows.
++  if (relative_path.find(L"..", 0) != std::string::npos) {
++    fail_check(
++        "Data of TensorProto ( tensor name: ",
++        tensor_name,
++        ") should be file inside the ",
++        base_dir,
++        ", but the '",
++        location,
++        "' points outside the directory");
++  }
++  std::wstring data_path = path_join(utf8str_to_wstring(base_dir), relative_path);
++  struct _stat64 buff;
++  if (_wstat64(data_path.c_str(), &buff) != 0) {
++    fail_check(
++        "Data of TensorProto ( tensor name: ",
++        tensor_name,
++        ") should be stored in ",
++        location,
++        ", but it doesn't exist or is not accessible.");
++  }
++  return wstring_to_utf8str(data_path);
++#else // POSIX
++  if (location.empty()) {
++    fail_check("Location of external TensorProto ( tensor name: ", tensor_name, ") should not be empty.");
++  } else if (location[0] == '/') {
++    fail_check(
++        "Location of external TensorProto ( tensor name: ",
++        tensor_name,
++        ") should be a relative path, but it is an absolute path: ",
++        location);
++  }
++  std::string relative_path = clean_relative_path(location);
++  // Check that normalized relative path contains ".." on POSIX
++  if (relative_path.find("..", 0) != std::string::npos) {
++    fail_check(
++        "Data of TensorProto ( tensor name: ",
++        tensor_name,
++        ") should be file inside the ",
++        base_dir,
++        ", but the '",
++        location,
++        "' points outside the directory");
++  }
++  std::string data_path = path_join(base_dir, relative_path);
++  // use stat64 to check whether the file exists
++#if defined(__APPLE__) || defined(__wasm__)
++  struct stat buffer; // APPLE does not have stat64
++  if (stat((data_path).c_str(), &buffer) != 0) {
++#else
++  struct stat64 buffer; // All POSIX except APPLE have stat64
++  if (stat64((data_path).c_str(), &buffer) != 0) {
++#endif
++    fail_check(
++        "Data of TensorProto ( tensor name: ",
++        tensor_name,
++        ") should be stored in ",
++        data_path,
++        ", but it doesn't exist or is not accessible.");
++  }
++  // Do not allow symlinks or directories.
++  if (!S_ISREG(buffer.st_mode)) {
++    fail_check(
++        "Data of TensorProto ( tensor name: ",
++        tensor_name,
++        ") should be stored in ",
++        data_path,
++        ", but it is not regular file.");
++  }
++  return data_path;
++#endif
++}
++
+ std::set<std::string> experimental_ops = {
+     "ATen",
+     "Affine",
+diff --git a/onnx/checker.h b/onnx/checker.h
+index 54fe19aa..55c0028c 100644
+--- a/onnx/checker.h
++++ b/onnx/checker.h
+@@ -148,7 +148,10 @@ void check_model_local_functions(
+ 
+ void check_model(const ModelProto& model, bool full_check = false);
+ void check_model(const std::string& model_path, bool full_check = false);
+-
++std::string resolve_external_data_location(
++    const std::string& base_dir,
++    const std::string& location,
++    const std::string& tensor_name);
+ bool check_is_experimental_op(const NodeProto& node);
+ 
+ } // namespace checker
+diff --git a/onnx/common/path.h b/onnx/common/path.h
+index d06eef90..fc692152 100644
+--- a/onnx/common/path.h
++++ b/onnx/common/path.h
+@@ -29,11 +29,22 @@ inline std::wstring utf8str_to_wstring(const std::string& utf8str) {
+   if (utf8str.size() > INT_MAX) {
+     fail_check("utf8str_to_wstring: string is too long for converting to wstring.");
+   }
+-  int size_required = MultiByteToWideChar(CP_UTF8, 0, utf8str.c_str(), (int)utf8str.size(), NULL, 0);
++  int size_required = MultiByteToWideChar(CP_UTF8, 0, utf8str.c_str(), static_cast<int>(utf8str.size()), NULL, 0);
+   std::wstring ws_str(size_required, 0);
+-  MultiByteToWideChar(CP_UTF8, 0, utf8str.c_str(), (int)utf8str.size(), &ws_str[0], size_required);
++  MultiByteToWideChar(CP_UTF8, 0, utf8str.c_str(), static_cast<int>(utf8str.size()), &ws_str[0], size_required);
+   return ws_str;
+ }
++inline std::string wstring_to_utf8str(const std::wstring& ws_str) {
++  if (ws_str.size() > INT_MAX) {
++    fail_check("wstring_to_utf8str: string is too long for converting to UTF-8.");
++  }
++  int size_required =
++      WideCharToMultiByte(CP_UTF8, 0, ws_str.c_str(), static_cast<int>(ws_str.size()), NULL, 0, NULL, NULL);
++  std::string utf8str(size_required, 0);
++  WideCharToMultiByte(
++      CP_UTF8, 0, ws_str.c_str(), static_cast<int>(ws_str.size()), &utf8str[0], size_required, NULL, NULL);
++  return utf8str;
++}
+ 
+ #else
+ std::string path_join(const std::string& origin, const std::string& append);
+diff --git a/onnx/cpp2py_export.cc b/onnx/cpp2py_export.cc
+index 656f8fa7..dd53b197 100644
+--- a/onnx/cpp2py_export.cc
++++ b/onnx/cpp2py_export.cc
+@@ -538,6 +538,8 @@ PYBIND11_MODULE(onnx_cpp2py_export, onnx_cpp2py_export) {
+       "path"_a,
+       "full_check"_a = false);
+ 
++  checker.def("_resolve_external_data_location", &checker::resolve_external_data_location);
++
+   // Submodule `version_converter`
+   auto version_converter = onnx_cpp2py_export.def_submodule("version_converter");
+   version_converter.doc() = "VersionConverter submodule";
+diff --git a/onnx/external_data_helper.py b/onnx/external_data_helper.py
+index cfb97d06..992c324b 100644
+--- a/onnx/external_data_helper.py
++++ b/onnx/external_data_helper.py
+@@ -8,6 +8,7 @@ import uuid
+ from itertools import chain
+ from typing import Callable, Iterable, Optional
+ 
++import onnx.onnx_cpp2py_export.checker as c_checker
+ from onnx.onnx_pb import AttributeProto, GraphProto, ModelProto, TensorProto
+ 
+ 
+@@ -39,9 +40,9 @@ def load_external_data_for_tensor(tensor: TensorProto, base_dir: str) -> None:
+         base_dir: directory that contains the external data.
+     """
+     info = ExternalDataInfo(tensor)
+-    file_location = _sanitize_path(info.location)
+-    external_data_file_path = os.path.join(base_dir, file_location)
+-
++    external_data_file_path = c_checker._resolve_external_data_location(  # type: ignore[attr-defined]
++        base_dir, info.location, tensor.name
++    )
+     with open(external_data_file_path, "rb") as data_file:
+         if info.offset:
+             data_file.seek(info.offset)
+@@ -254,14 +255,6 @@ def _get_attribute_tensors(onnx_model_proto: ModelProto) -> Iterable[TensorProto
+     yield from _get_attribute_tensors_from_graph(onnx_model_proto.graph)
+ 
+ 
+-def _sanitize_path(path: str) -> str:
+-    """Remove path components which would allow traversing up a directory tree from a base path.
+-
+-    Note: This method is currently very basic and should be expanded.
+-    """
+-    return path.lstrip("/.")
+-
+-
+ def _is_valid_filename(filename: str) -> bool:
+     """Utility to check whether the provided filename is valid."""
+     exp = re.compile('^[^<>:;,?"*|/]+$')
+diff --git a/onnx/test/test_external_data.py b/onnx/test/test_external_data.py
+index b4303b4a..9e1cf008 100644
+--- a/onnx/test/test_external_data.py
++++ b/onnx/test/test_external_data.py
+@@ -1,6 +1,8 @@
+ # Copyright (c) ONNX Project Contributors
+ 
+ # SPDX-License-Identifier: Apache-2.0
++
++import itertools
+ import os
+ import shutil
+ import tempfile
+@@ -9,6 +11,7 @@ import uuid
+ from typing import Any, List, Tuple
+ 
+ import numpy as np
++import parameterized
+ 
+ import onnx
+ from onnx import ModelProto, TensorProto, checker, helper, shape_inference
+@@ -186,6 +189,52 @@ class TestLoadExternalDataSingleFile(TestLoadExternalDataBase):
+         attribute_tensor = new_model.graph.node[0].attribute[0].t
+         self.assertTrue(np.allclose(to_array(attribute_tensor), self.attribute_value))
+ 
++    @parameterized.parameterized.expand(itertools.product((True, False), (True, False)))
++    def test_save_external_invalid_single_file_data_and_check(
++        self, use_absolute_path: bool, use_model_path: bool
++    ) -> None:
++        model = onnx.load_model(self.model_filename)
++
++        model_dir = os.path.join(self.temp_dir, "save_copy")
++        os.mkdir(model_dir)
++
++        traversal_external_data_dir = os.path.join(
++            self.temp_dir, "invlid_external_data"
++        )
++        os.mkdir(traversal_external_data_dir)
++
++        if use_absolute_path:
++            traversal_external_data_location = os.path.join(
++                traversal_external_data_dir, "tensors.bin"
++            )
++        else:
++            traversal_external_data_location = "../invlid_external_data/tensors.bin"
++
++        external_data_dir = os.path.join(self.temp_dir, "external_data")
++        os.mkdir(external_data_dir)
++        new_model_filepath = os.path.join(model_dir, "model.onnx")
++
++        def convert_model_to_external_data_no_check(model: ModelProto, location: str):
++            for tensor in model.graph.initializer:
++                if tensor.HasField("raw_data"):
++                    set_external_data(tensor, location)
++
++        convert_model_to_external_data_no_check(
++            model,
++            location=traversal_external_data_location,
++        )
++
++        onnx.save_model(model, new_model_filepath)
++        if use_model_path:
++            with self.assertRaises(onnx.checker.ValidationError):
++                _ = onnx.load_model(new_model_filepath)
++        else:
++            onnx_model = onnx.load_model(
++                new_model_filepath, load_external_data=False
++            )
++            with self.assertRaises(onnx.checker.ValidationError):
++                load_external_data_for_model(onnx_model, external_data_dir)
++
+ 
+ class TestSaveAllTensorsAsExternalData(TestLoadExternalDataBase):
+     def setUp(self) -> None:

--- a/pkgs/development/python-modules/onnx/1.14.1-CVE-2024-27319.patch
+++ b/pkgs/development/python-modules/onnx/1.14.1-CVE-2024-27319.patch
@@ -1,0 +1,42 @@
+Based on upstream 08a399ba75a805b7813ab8936b91d0e274b08287, adjusted to
+apply to 1.14.1
+
+diff --git a/onnx/common/assertions.cc b/onnx/common/assertions.cc
+index a21e55da..d567c187 100644
+--- a/onnx/common/assertions.cc
++++ b/onnx/common/assertions.cc
+@@ -8,6 +8,8 @@
+ // Adventurous users should note that the APIs will probably change.
+ 
+ #include "onnx/common/assertions.h"
++
++#include <array>
+ #include <cstdarg>
+ #include <cstdio>
+ #include "onnx/common/common.h"
+@@ -15,16 +17,20 @@
+ namespace ONNX_NAMESPACE {
+ 
+ std::string barf(const char* fmt, ...) {
+-  char msg[2048];
++  constexpr size_t buffer_size = 2048;
++  std::array<char, buffer_size> msg{};
+   va_list args;
+ 
+   va_start(args, fmt);
+-  // Although vsnprintf might have vulnerability issue while using format string with overflowed length,
+-  // it should be safe here to use fixed length for buffer "msg". No further checking is needed.
+-  vsnprintf(msg, 2048, fmt, args);
++
++  // use fixed length for buffer "msg" to avoid buffer overflow
++  vsnprintf(static_cast<char*>(msg.data()), msg.size() - 1, fmt, args);
++
++  // ensure null-terminated string to avoid out of bounds read
++  msg.back() = '\0';
+   va_end(args);
+ 
+-  return std::string(msg);
++  return std::string(msg.data());
+ }
+ 
+ void throw_assert_error(std::string& msg) {

--- a/pkgs/development/python-modules/onnx/default.nix
+++ b/pkgs/development/python-modules/onnx/default.nix
@@ -3,6 +3,7 @@
 , buildPythonPackage
 , cmake
 , fetchFromGitHub
+, fetchpatch
 , gtest
 , nbval
 , numpy
@@ -31,6 +32,11 @@ in buildPythonPackage rec {
     rev = "refs/tags/v${version}";
     hash = "sha256-ZVSdk6LeAiZpQrrzLxphMbc1b3rNUMpcxcXPP8s/5tE=";
   };
+
+  patches = [
+    ./1.14.1-CVE-2024-27318.patch
+    ./1.14.1-CVE-2024-27319.patch
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/development/python-modules/pytorch-pfn-extras/default.nix
+++ b/pkgs/development/python-modules/pytorch-pfn-extras/default.nix
@@ -1,5 +1,6 @@
 { buildPythonPackage
 , fetchFromGitHub
+, fetchpatch
 , lib
 , numpy
 , onnx
@@ -21,6 +22,14 @@ buildPythonPackage rec {
     rev = "refs/tags/v${version}";
     hash = "sha256-juoLw/qfq4YF7opyR7cTYCVzUa9pXVvQnvGntcQhBr4=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "onnx-CVE-2024-27318-fix-compat.patch";
+      url = "https://github.com/pfnet/pytorch-pfn-extras/commit/730085cbbabcbd8209c93587d7dc3a54c51b5189.patch";
+      hash = "sha256-0ILOi6mLI62vW5C8qigYugR1Ikkt/3HngfPaBSgQk1g=";
+    })
+  ];
 
   propagatedBuildInputs = [ numpy packaging torch typing-extensions ];
 


### PR DESCRIPTION
## Description of changes

https://nvd.nist.gov/vuln/detail/CVE-2024-27318
https://nvd.nist.gov/vuln/detail/CVE-2024-27319

Replacement for #295952 - patches needed a bit more adjustment to apply to 1.14.1.

Unstable addressed in #295144

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
