### PR TITLE
Avoid top-level `with` in `pkgs/development/compilers/gcc`

### DIFF
--- a/pkgs/development/compilers/gcc/common/meta.nix
+++ b/pkgs/development/compilers/gcc/common/meta.nix
@@ -1,6 +1,15 @@
 { lib, version, }:
 
-with lib; {
+let
+  inherit (lib)
+    licenses
+    maintainers
+    platforms
+    teams
+    versionOlder
+    ;
+in
+{
   homepage = "https://gcc.gnu.org/";
   license = licenses.gpl3Plus; # runtime support libraries are typically LGPLv3+
   description = "GNU Compiler Collection, version ${version}";

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, targetPackages, fetchurl, fetchpatch, noSysDirs
+{ lib, stdenv, targetPackages, fetchurl, fetchpatch, fetchFromGitHub, noSysDirs
 , langC ? true, langCC ? true, langFortran ? false
 , langAda ? false
 , langObjC ? stdenv.targetPlatform.isDarwin
@@ -48,19 +48,37 @@
 }:
 
 let
-  versions = import ./versions.nix;
-  version = versions.fromMajorMinor majorMinorVersion;
+  inherit (lib)
+    callPackageWith
+    filter
+    getBin
+    maintainers
+    makeLibraryPath
+    makeSearchPathOutput
+    mapAttrs
+    optional
+    optionalAttrs
+    optionals
+    optionalString
+    pipe
+    platforms
+    versionAtLeast
+    versions
+    ;
 
-  majorVersion = lib.versions.major version;
-  atLeast13 = lib.versionAtLeast version "13";
-  atLeast12 = lib.versionAtLeast version "12";
-  atLeast11 = lib.versionAtLeast version "11";
-  atLeast10 = lib.versionAtLeast version "10";
-  atLeast9  = lib.versionAtLeast version  "9";
-  atLeast8  = lib.versionAtLeast version  "8";
-  atLeast7  = lib.versionAtLeast version  "7";
-  atLeast6  = lib.versionAtLeast version  "6";
-  atLeast49 = lib.versionAtLeast version  "4.9";
+  gccVersions = import ./versions.nix;
+  version = gccVersions.fromMajorMinor majorMinorVersion;
+
+  majorVersion = versions.major version;
+  atLeast13 = versionAtLeast version "13";
+  atLeast12 = versionAtLeast version "12";
+  atLeast11 = versionAtLeast version "11";
+  atLeast10 = versionAtLeast version "10";
+  atLeast9  = versionAtLeast version  "9";
+  atLeast8  = versionAtLeast version  "8";
+  atLeast7  = versionAtLeast version  "7";
+  atLeast6  = versionAtLeast version  "6";
+  atLeast49 = versionAtLeast version  "4.9";
   is13 = majorVersion == "13";
   is12 = majorVersion == "12";
   is11 = majorVersion == "11";
@@ -69,37 +87,9 @@ let
   is8  = majorVersion == "8";
   is7  = majorVersion == "7";
   is6  = majorVersion == "6";
-  is49 = majorVersion == "4" && lib.versions.minor version == "9";
-  is48 = majorVersion == "4" && lib.versions.minor version == "8";
-in
+  is49 = majorVersion == "4" && versions.minor version == "9";
+  is48 = majorVersion == "4" && versions.minor version == "8";
 
-# We enable the isl cloog backend.
-assert !atLeast6 -> (cloog != null -> isl != null);
-
-assert langJava -> !atLeast7 && zip != null && unzip != null && zlib != null && boehmgc != null && perl != null;  # for `--enable-java-home'
-
-# Make sure we get GNU sed.
-assert stdenv.buildPlatform.isDarwin -> gnused != null;
-
-# The go frontend is written in c++
-assert langGo -> langCC;
-assert (atLeast6 && !is7 && !is8) -> (langAda -> gnat-bootstrap != null);
-
-# TODO: fixup D bootstapping, probably by using gdc11 (and maybe other changes).
-#   error: GDC is required to build d
-assert atLeast12 -> !langD;
-
-# threadsCross is just for MinGW
-assert threadsCross != {} -> stdenv.targetPlatform.isWindows;
-
-# profiledCompiler builds inject non-determinism in one of the compilation stages.
-# If turned on, we can't provide reproducible builds anymore
-assert reproducibleBuild -> profiledCompiler == false;
-
-with lib;
-with builtins;
-
-let inherit version;
     disableBootstrap = atLeast11 && !stdenv.hostPlatform.isDarwin && (atLeast12 -> !profiledCompiler);
 
     inherit (stdenv) buildPlatform hostPlatform targetPlatform;
@@ -116,7 +106,7 @@ let inherit version;
       libX11 libXt libSM libICE libXtst libXrender libXrandr libXi
       xorgproto
     ];
-    callFile = lib.callPackageWith ({
+    callFile = callPackageWith ({
       # lets
       inherit
         majorVersion
@@ -180,7 +170,7 @@ let inherit version;
         zip
         zlib
       ;
-    } // lib.optionalAttrs (!atLeast7) {
+    } // optionalAttrs (!atLeast7) {
       inherit
         boehmgc
         flex
@@ -223,10 +213,33 @@ let inherit version;
 
 in
 
+# We enable the isl cloog backend.
+assert !atLeast6 -> (cloog != null -> isl != null);
+
+assert langJava -> !atLeast7 && zip != null && unzip != null && zlib != null && boehmgc != null && perl != null;  # for `--enable-java-home'
+
+# Make sure we get GNU sed.
+assert stdenv.buildPlatform.isDarwin -> gnused != null;
+
+# The go frontend is written in c++
+assert langGo -> langCC;
+assert (atLeast6 && !is7 && !is8) -> (langAda -> gnat-bootstrap != null);
+
+# TODO: fixup D bootstapping, probably by using gdc11 (and maybe other changes).
+#   error: GDC is required to build d
+assert atLeast12 -> !langD;
+
+# threadsCross is just for MinGW
+assert threadsCross != {} -> stdenv.targetPlatform.isWindows;
+
+# profiledCompiler builds inject non-determinism in one of the compilation stages.
+# If turned on, we can't provide reproducible builds anymore
+assert reproducibleBuild -> profiledCompiler == false;
+
 # We need all these X libraries when building AWT with GTK.
 assert !atLeast7 -> (x11Support -> (filter (x: x == null) ([ gtk2 libart_lgpl ] ++ xlibs)) == []);
 
-lib.pipe ((callFile ./common/builder.nix {}) ({
+pipe ((callFile ./common/builder.nix {}) ({
   pname = "${crossNameAddon}${name}";
   inherit version;
 
@@ -247,14 +260,14 @@ lib.pipe ((callFile ./common/builder.nix {}) ({
           then "mirror://gnu/gcc/gcc-${version}/gcc-${version}.tar.xz"
           else "mirror://gnu/gcc/gcc-${version}/gcc-${version}.tar.bz2";
     ${if is10 || is11 || is13 then "hash" else "sha256"} =
-      versions.srcHashForVersion version;
+      gccVersions.srcHashForVersion version;
   };
 
   inherit patches;
 
   outputs =
     if atLeast7
-    then [ "out" "man" "info" ] ++ lib.optional (!langJit) "lib"
+    then [ "out" "man" "info" ] ++ optional (!langJit) "lib"
     else if atLeast49 && (langJava || langGo || (if atLeast6 then langJit else targetPlatform.isDarwin)) then ["out" "man" "info"]
     else [ "out" "lib" "man" "info" ];
 
@@ -263,9 +276,9 @@ lib.pipe ((callFile ./common/builder.nix {}) ({
   libc_dev = stdenv.cc.libc_dev;
 
   hardeningDisable = [ "format" "pie" ]
-  ++ lib.optionals (is11 && langAda) [ "fortify3" ];
+  ++ optionals (is11 && langAda) [ "fortify3" ];
 
-  postPatch = lib.optionalString atLeast7 ''
+  postPatch = optionalString atLeast7 ''
     configureScripts=$(find . -name configure)
     for configureScript in $configureScripts; do
       patchShebangs $configureScript
@@ -273,8 +286,8 @@ lib.pipe ((callFile ./common/builder.nix {}) ({
   ''
   # This should kill all the stdinc frameworks that gcc and friends like to
   # insert into default search paths.
-  + lib.optionalString (atLeast6 && hostPlatform.isDarwin) ''
-    substituteInPlace gcc/config/darwin-c.c${lib.optionalString atLeast12 "c"} \
+  + optionalString (atLeast6 && hostPlatform.isDarwin) ''
+    substituteInPlace gcc/config/darwin-c.c${optionalString atLeast12 "c"} \
       --replace 'if (stdinc)' 'if (0)'
 
     substituteInPlace libgcc/config/t-slibgcc-darwin \
@@ -284,7 +297,7 @@ lib.pipe ((callFile ./common/builder.nix {}) ({
       --replace "-install_name \\\$rpath/\\\$soname" "-install_name ''${!outputLib}/lib/\\\$soname"
   ''
   + (
-    lib.optionalString (targetPlatform != hostPlatform || stdenv.cc.libc != null)
+    optionalString (targetPlatform != hostPlatform || stdenv.cc.libc != null)
       # On NixOS, use the right path to the dynamic linker instead of
       # `/lib/ld*.so'.
       (let
@@ -294,18 +307,18 @@ lib.pipe ((callFile ./common/builder.nix {}) ({
         '' echo "fixing the {GLIBC,UCLIBC,MUSL}_DYNAMIC_LINKER macros..."
            for header in "gcc/config/"*-gnu.h "gcc/config/"*"/"*.h
            do
-             grep -q ${lib.optionalString (!atLeast6) "LIBC"}_DYNAMIC_LINKER "$header" || continue
+             grep -q ${optionalString (!atLeast6) "LIBC"}_DYNAMIC_LINKER "$header" || continue
              echo "  fixing $header..."
              sed -i "$header" \
                  -e 's|define[[:blank:]]*\([UCG]\+\)LIBC_DYNAMIC_LINKER\([0-9]*\)[[:blank:]]"\([^\"]\+\)"$|define \1LIBC_DYNAMIC_LINKER\2 "${libc.out}\3"|g' \
                  -e 's|define[[:blank:]]*MUSL_DYNAMIC_LINKER\([0-9]*\)[[:blank:]]"\([^\"]\+\)"$|define MUSL_DYNAMIC_LINKER\1 "${libc.out}\2"|g'
              done
-        '' + lib.optionalString (atLeast6 && targetPlatform.libc == "musl") ''
+        '' + optionalString (atLeast6 && targetPlatform.libc == "musl") ''
            sed -i gcc/config/linux.h -e '1i#undef LOCAL_INCLUDE_DIR'
         ''
         )
     ))
-      + lib.optionalString (atLeast7 && targetPlatform.isAvr) (''
+      + optionalString (atLeast7 && targetPlatform.isAvr) (''
             makeFlagsArray+=(
                '-s' # workaround for hitting hydra log limit
                'LIMITS_H_TEST=false'
@@ -317,7 +330,7 @@ lib.pipe ((callFile ./common/builder.nix {}) ({
 
   inherit (callFile ./common/dependencies.nix { }) depsBuildBuild nativeBuildInputs depsBuildTarget buildInputs depsTargetTarget;
 
-  preConfigure = (callFile ./common/pre-configure.nix { }) + lib.optionalString atLeast10 ''
+  preConfigure = (callFile ./common/pre-configure.nix { }) + optionalString atLeast10 ''
     ln -sf ${libxcrypt}/include/crypt.h libsanitizer/sanitizer_common/crypt.h
   '';
 
@@ -336,9 +349,9 @@ lib.pipe ((callFile ./common/builder.nix {}) ({
     assert atLeast12 -> (profiledCompiler -> !disableBootstrap);
     if atLeast11
     then let target =
-               lib.optionalString (profiledCompiler) "profiled" +
-               lib.optionalString (targetPlatform == hostPlatform && hostPlatform == buildPlatform && !disableBootstrap) "bootstrap";
-         in lib.optional (target != "") target
+               optionalString (profiledCompiler) "profiled" +
+               optionalString (targetPlatform == hostPlatform && hostPlatform == buildPlatform && !disableBootstrap) "bootstrap";
+         in optional (target != "") target
     else
       optional
         (targetPlatform == hostPlatform && hostPlatform == buildPlatform)
@@ -392,24 +405,24 @@ lib.pipe ((callFile ./common/builder.nix {}) ({
       EXTRA_LDFLAGS_FOR_TARGET
       ;
   } // optionalAttrs is7 {
-    NIX_CFLAGS_COMPILE = lib.optionalString (stdenv.cc.isClang && langFortran) "-Wno-unused-command-line-argument"
+    NIX_CFLAGS_COMPILE = optionalString (stdenv.cc.isClang && langFortran) "-Wno-unused-command-line-argument"
       # Downgrade register storage class specifier errors to warnings when building a cross compiler from a clang stdenv.
-      + lib.optionalString (stdenv.cc.isClang && targetPlatform != hostPlatform) " -Wno-register";
+      + optionalString (stdenv.cc.isClang && targetPlatform != hostPlatform) " -Wno-register";
   } // optionalAttrs (!is7 && !atLeast12 && stdenv.cc.isClang && targetPlatform != hostPlatform) {
     NIX_CFLAGS_COMPILE = "-Wno-register";
   } // optionalAttrs (!atLeast7) {
     inherit langJava;
   } // optionalAttrs atLeast6 {
-    NIX_LDFLAGS = lib.optionalString hostPlatform.isSunOS "-lm";
+    NIX_LDFLAGS = optionalString hostPlatform.isSunOS "-lm";
   });
 
   passthru = {
     inherit langC langCC langObjC langObjCpp langAda langFortran langGo langD langJava version;
     isGNU = true;
-    hardeningUnsupportedFlags = lib.optional is48 "stackprotector"
-      ++ lib.optional (!atLeast11) "zerocallusedregs"
-      ++ lib.optionals (!atLeast12) [ "fortify3" "trivialautovarinit" ]
-      ++ lib.optionals (langFortran) [ "fortify" "format" ];
+    hardeningUnsupportedFlags = optional is48 "stackprotector"
+      ++ optional (!atLeast11) "zerocallusedregs"
+      ++ optionals (!atLeast12) [ "fortify3" "trivialautovarinit" ]
+      ++ optionals (langFortran) [ "fortify" "format" ];
   };
 
   enableParallelBuilding = true;
@@ -424,19 +437,19 @@ lib.pipe ((callFile ./common/builder.nix {}) ({
       platforms
       maintainers
     ;
-  } // lib.optionalAttrs (!atLeast11) {
+  } // optionalAttrs (!atLeast11) {
     badPlatforms =
       # avr-gcc8 is maintained for the `qmk` package
       if (is8 && targetPlatform.isAvr) then []
       else if !(is48 || is49) then [ "aarch64-darwin" ]
-      else lib.platforms.darwin;
-  } // lib.optionalAttrs is11 {
+      else platforms.darwin;
+  } // optionalAttrs is11 {
     badPlatforms = if targetPlatform != hostPlatform then [ "aarch64-darwin" ] else [ ];
   };
-} // lib.optionalAttrs (!atLeast10 && stdenv.targetPlatform.isDarwin) {
+} // optionalAttrs (!atLeast10 && stdenv.targetPlatform.isDarwin) {
   # GCC <10 requires default cctools `strip` instead of `llvm-strip` used by Darwin bintools.
   preBuild = ''
-    makeFlagsArray+=('STRIP=${lib.getBin darwin.cctools-port}/bin/${stdenv.cc.targetPrefix}strip')
+    makeFlagsArray+=('STRIP=${getBin darwin.cctools-port}/bin/${stdenv.cc.targetPrefix}strip')
   '';
 } // optionalAttrs (!atLeast8) {
   doCheck = false; # requires a lot of tools, causes a dependency cycle for stdenv


### PR DESCRIPTION
## Description of changes

Using `with` at a top-level scope is [an anti-pattern](https://nix.dev/guides/best-practices#with-scopes). The tracking issue is #208242. This is a pure refactor: there is no functional change contained in this PR, though spot the bug fix where `fetchFromGitHub` wasn't injected!

I used the refactor strategy that looks for the uses of names [coming from `lib`](https://gist.github.com/philiptaron/04326000d5ff20cb72c2805efd09701c). 

Following advice, I also preferred to inherit names from `lib` instead of `builtins` where there was a choice. I also preferred to inherit from `lib` in one place, rather than to have a mixture of `lib.thing` and `inherit (lib) thing`.

For the assertions, I moved them into one block.

I really wanted to fix the indentation, but I didn't.

This PR targets staging, rather than master, as the contents of these files near the root of most of the Nixpkgs graph, but I guess I should have targeted master since there are no rebuilds.

See also:
- https://github.com/NixOS/nixpkgs/pull/297289

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).