### PR TITLE
zookeeper: 3.7.2 -> 3.9.2

### DIFF
--- a/pkgs/development/libraries/zookeeper_mt/default.nix
+++ b/pkgs/development/libraries/zookeeper_mt/default.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://apache/zookeeper/${zookeeper.pname}-${version}/apache-${zookeeper.pname}-${version}.tar.gz";
-    hash = "sha512-V1SFPtSytFZMyiR/cgwLA9zPUK5xuarP3leQCQiSfelUHnYMB+R6ZQfSHMHD9t+URvLc+KRFSriLTzethspkpA==";
+    hash = "sha512-G6Yw9HBF43QCw8FTLnJ7boCjUYwaQVQAT4wXqUowSlzox1cUPH5+8ZYMBxToJCbr0ppmz22t0uKsHRUI/IDAPQ==";
   };
 
   sourceRoot = "apache-${zookeeper.pname}-${version}/zookeeper-client/zookeeper-client-c";

--- a/pkgs/servers/zookeeper/default.nix
+++ b/pkgs/servers/zookeeper/default.nix
@@ -1,16 +1,16 @@
 { lib, stdenv, fetchurl, jdk11_headless, makeWrapper, nixosTests, bash, coreutils }:
 let
-  # Latest supported LTS JDK for Zookeeper 3.7:
-  # https://zookeeper.apache.org/doc/r3.7.2/zookeeperAdmin.html#sc_requiredSoftware
+  # Latest supported LTS JDK for Zookeeper 3.9:
+  # https://zookeeper.apache.org/doc/r3.9.2/zookeeperAdmin.html#sc_requiredSoftware
   jre = jdk11_headless;
 in
 stdenv.mkDerivation rec {
   pname = "zookeeper";
-  version = "3.7.2";
+  version = "3.9.2";
 
   src = fetchurl {
     url = "mirror://apache/zookeeper/${pname}-${version}/apache-${pname}-${version}-bin.tar.gz";
-    hash = "sha512-avv8GvyLk3AoG9mGLzfbscuV7FS7LtQ3GDGqXA8Iz+53UFC9V85fwINuYa8n7tnwB29UuYmX3Q4VFZGWBW5S6g==";
+    hash = "sha512-K1rgLWGKJ8qM1UkkhV1TRCY7fZ3udgGB+dZrr6kjAyTSrTF4aJXwZUyWncONSj0Ad/dMw3a1i1+i+5S+satEXw==";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -20,14 +20,11 @@ stdenv.mkDerivation rec {
     runHook preInstall
     mkdir -p $out
     cp -R conf docs lib $out
-    # Without this, zkCli.sh tries creating a log file in the Nix store.
-    substituteInPlace $out/conf/log4j.properties \
-        --replace 'INFO, RFAAUDIT' 'INFO, CONSOLE'
     mkdir -p $out/bin
     cp -R bin/{zkCli,zkCleanup,zkEnv,zkServer,zkSnapShotToolkit,zkTxnLogToolkit}.sh $out/bin
     patchShebangs $out/bin
     substituteInPlace $out/bin/zkServer.sh \
-        --replace /bin/echo ${coreutils}/bin/echo
+        --replace-fail /bin/echo ${coreutils}/bin/echo
     for i in $out/bin/{zkCli,zkCleanup,zkServer,zkSnapShotToolkit,zkTxnLogToolkit}.sh; do
       wrapProgram $i \
         --set JAVA_HOME "${jre}" \
@@ -47,8 +44,10 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     homepage = "https://zookeeper.apache.org";
     description = "Apache Zookeeper";
+    changelog = "https://zookeeper.apache.org/doc/r${version}/releasenotes.html";
     license = licenses.asl20;
     maintainers = with maintainers; [ nathan-gs pradeepchhetri ztzg ];
     platforms = platforms.unix;
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
   };
 }


### PR DESCRIPTION
## Description of changes

Fixes CVE-2024-23944
https://www.openwall.com/lists/oss-security/2024/03/14/2

Release notes:
https://zookeeper.apache.org/doc/r3.9.2/releasenotes.html https://zookeeper.apache.org/doc/r3.8.0/releasenotes.html
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
