### PR TITLE
proton-ge-bin: init at 9-1, nixos/steam: use steamcompattool output for extraCompatPackages

### DIFF
--- a/nixos/modules/programs/steam.nix
+++ b/nixos/modules/programs/steam.nix
@@ -44,8 +44,8 @@ in {
       '';
       apply = steam: steam.override (prev: {
         extraEnv = (lib.optionalAttrs (cfg.extraCompatPackages != [ ]) {
-            STEAM_EXTRA_COMPAT_TOOLS_PATHS = makeBinPath cfg.extraCompatPackages;
-          }) // (prev.extraEnv or {});
+          STEAM_EXTRA_COMPAT_TOOLS_PATHS = makeSearchPathOutput "steamcompattool" "" cfg.extraCompatPackages;
+        }) // (prev.extraEnv or {});
         extraLibraries = pkgs: let
           prevLibs = if prev ? extraLibraries then prev.extraLibraries pkgs else [ ];
           additionalLibs = with config.hardware.opengl;
@@ -77,7 +77,9 @@ in {
       description = lib.mdDoc ''
         Extra packages to be used as compatibility tools for Steam on Linux. Packages will be included
         in the `STEAM_EXTRA_COMPAT_TOOLS_PATHS` environmental variable. For more information see
-        <https://github.com/ValveSoftware/steam-for-linux/issues/6310">.
+        https://github.com/ValveSoftware/steam-for-linux/issues/6310.
+
+        These packages must be Steam compatibility tools that have a `steamcompattool` output.
       '';
     };
 

--- a/nixos/modules/programs/steam.nix
+++ b/nixos/modules/programs/steam.nix
@@ -74,6 +74,11 @@ in {
     extraCompatPackages = mkOption {
       type = types.listOf types.package;
       default = [ ];
+      example = literalExpression ''
+        with pkgs; [
+          proton-ge-bin
+        ]
+      '';
       description = lib.mdDoc ''
         Extra packages to be used as compatibility tools for Steam on Linux. Packages will be included
         in the `STEAM_EXTRA_COMPAT_TOOLS_PATHS` environmental variable. For more information see

--- a/pkgs/by-name/pr/proton-ge-bin/package.nix
+++ b/pkgs/by-name/pr/proton-ge-bin/package.nix
@@ -1,24 +1,26 @@
 { lib
 , stdenvNoCC
-, fetchurl
+, fetchzip
 , writeScript
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "proton-ge-bin";
   version = "GE-Proton9-1";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/${finalAttrs.version}/${finalAttrs.version}.tar.gz";
-    hash = "sha256-wCIffeayOy3kEwmIKB7e+NrliuSpKXoVYC334fxVB3U=";
+    hash = "sha256-odpzRlzW7MJGRcorRNo784Rh97ssViO70/1azHRggf0=";
   };
 
   outputs = [ "out" "steamcompattool" ];
 
   buildCommand = ''
     runHook preBuild
-    mkdir -p $out $steamcompattool
 
-    tar -C $steamcompattool --strip=1 -x -f $src
+    # Intentionally empty
+    mkdir -p $out
+
+    ln -s $src $steamcompattool
 
     runHook postBuild
   '';

--- a/pkgs/by-name/pr/proton-ge-bin/package.nix
+++ b/pkgs/by-name/pr/proton-ge-bin/package.nix
@@ -17,8 +17,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   buildCommand = ''
     runHook preBuild
 
-    # Intentionally empty
-    mkdir -p $out
+    # Make it impossible to add to an environment. You should use the appropriate NixOS option.
+    # Also leave some breadcrumbs in the file.
+    echo "${finalAttrs.pname} should not be installed into environments. Please use programs.steam.extraCompatPackages instead." > $out
 
     ln -s $src $steamcompattool
 
@@ -42,7 +43,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "Compatibility tool for Steam Play based on Wine and additional components";
+    description = ''
+      Compatibility tool for Steam Play based on Wine and additional components.
+
+      (This is intended for use in the `programs.steam.extraCompatPackages` option only.)
+    '';
     homepage = "https://github.com/GloriousEggroll/proton-ge-custom";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ NotAShelf shawn8901 ];

--- a/pkgs/by-name/pr/proton-ge-bin/package.nix
+++ b/pkgs/by-name/pr/proton-ge-bin/package.nix
@@ -1,0 +1,50 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, writeScript
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "proton-ge-bin";
+  version = "GE-Proton9-1";
+
+  src = fetchurl {
+    url = "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/${finalAttrs.version}/${finalAttrs.version}.tar.gz";
+    hash = "sha256-wCIffeayOy3kEwmIKB7e+NrliuSpKXoVYC334fxVB3U=";
+  };
+
+  buildCommand = ''
+    runHook preBuild
+    mkdir -p $out/{bin,opt}
+    tar -C $out/opt --strip=1 -x -f $src
+    ln -s $out/opt/toolmanifest.vdf $out/bin/toolmanifest.vdf
+    install -Dm644 $out/opt/compatibilitytool.vdf $out/bin/compatibilitytool.vdf
+    substituteInPlace $out/bin/compatibilitytool.vdf \
+      --replace-fail '"install_path" "."' '"install_path" "${placeholder "out"}/opt"'
+    runHook postBuild
+  '';
+
+  /*
+    We use the created releases, and not the tags, for the update script as nix-update loads releases.atom
+    that contains both. Sometimes upstream pushes the tags but the Github releases don't get created due to
+    CI errors. Last time this happened was on 8-33, where a tag was created but no releases were created.
+    As of 2024-03-13, there have been no announcements indicating that the CI has been fixed, and thus
+    we avoid nix-update-script and use our own update script instead.
+    See: <https://github.com/NixOS/nixpkgs/pull/294532#issuecomment-1987359650>
+  */
+  passthru.updateScript = writeScript "update-proton-ge" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl jq common-updater-scripts
+    repo="https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases"
+    version="$(curl -sL "$repo" | jq 'map(select(.prerelease == false)) | .[0].tag_name' --raw-output)"
+    update-source-version proton-ge-bin "$version"
+  '';
+
+  meta = {
+    description = "Compatibility tool for Steam Play based on Wine and additional components";
+    homepage = "https://github.com/GloriousEggroll/proton-ge-custom";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ NotAShelf shawn8901 ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/pr/proton-ge-bin/package.nix
+++ b/pkgs/by-name/pr/proton-ge-bin/package.nix
@@ -12,14 +12,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-wCIffeayOy3kEwmIKB7e+NrliuSpKXoVYC334fxVB3U=";
   };
 
+  outputs = [ "out" "steamcompattool" ];
+
   buildCommand = ''
     runHook preBuild
-    mkdir -p $out/{bin,opt}
-    tar -C $out/opt --strip=1 -x -f $src
-    ln -s $out/opt/toolmanifest.vdf $out/bin/toolmanifest.vdf
-    install -Dm644 $out/opt/compatibilitytool.vdf $out/bin/compatibilitytool.vdf
-    substituteInPlace $out/bin/compatibilitytool.vdf \
-      --replace-fail '"install_path" "."' '"install_path" "${placeholder "out"}/opt"'
+    mkdir -p $out $steamcompattool
+
+    tar -C $steamcompattool --strip=1 -x -f $src
+
     runHook postBuild
   '';
 

--- a/pkgs/games/steam/fhsenv.nix
+++ b/pkgs/games/steam/fhsenv.nix
@@ -309,6 +309,7 @@ in buildFHSEnv rec {
       description = "Steam dependencies (dummy package, do not use)";
     };
 
+  passthru.steamargs = args;
   passthru.run = buildFHSEnv {
     name = "steam-run";
 


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Alternative to https://github.com/NixOS/nixpkgs/pull/295785

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
