### PR TITLE
exiftool: 12.70 -> 12.80, add passthru.{tests.version,updateScript}

### DIFF
--- a/pkgs/development/perl-modules/ImageExifTool/default.nix
+++ b/pkgs/development/perl-modules/ImageExifTool/default.nix
@@ -1,9 +1,11 @@
 { lib
 , stdenv
 , buildPerlPackage
+, exiftool
 , fetchurl
 , gitUpdater
 , shortenPerlShebang
+, testers
 }:
 
 buildPerlPackage rec {
@@ -21,6 +23,11 @@ buildPerlPackage rec {
   '';
 
   passthru = {
+    tests.version = testers.testVersion {
+      inherit version;
+      command = "${lib.getExe exiftool} -ver";
+      package = exiftool;
+    };
     updateScript = gitUpdater {
       url = "https://github.com/exiftool/exiftool.git";
     };

--- a/pkgs/development/perl-modules/ImageExifTool/default.nix
+++ b/pkgs/development/perl-modules/ImageExifTool/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , buildPerlPackage
 , fetchurl
+, gitUpdater
 , shortenPerlShebang
 }:
 
@@ -18,6 +19,12 @@ buildPerlPackage rec {
   postInstall = lib.optionalString stdenv.isDarwin ''
     shortenPerlShebang $out/bin/exiftool
   '';
+
+  passthru = {
+    updateScript = gitUpdater {
+      url = "https://github.com/exiftool/exiftool.git";
+    };
+  };
 
   meta = {
     description = "A tool to read, write and edit EXIF meta information";

--- a/pkgs/development/perl-modules/ImageExifTool/default.nix
+++ b/pkgs/development/perl-modules/ImageExifTool/default.nix
@@ -10,11 +10,11 @@
 
 buildPerlPackage rec {
   pname = "Image-ExifTool";
-  version = "12.70";
+  version = "12.80";
 
   src = fetchurl {
     url = "https://exiftool.org/Image-ExifTool-${version}.tar.gz";
-    hash = "sha256-TLJSJEXMPj870TkExq6uraX8Wl4kmNerrSlX3LQsr/4=";
+    hash = "sha256-k9UinWyy++gGSTK9H1Pht81FH4hDzG7uZSBSjLLVeQY=";
   };
 
   nativeBuildInputs = lib.optional stdenv.isDarwin shortenPerlShebang;

--- a/pkgs/development/perl-modules/ImageExifTool/default.nix
+++ b/pkgs/development/perl-modules/ImageExifTool/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenv
+, buildPerlPackage
+, fetchurl
+, shortenPerlShebang
+}:
+
+buildPerlPackage rec {
+  pname = "Image-ExifTool";
+  version = "12.70";
+
+  src = fetchurl {
+    url = "https://exiftool.org/Image-ExifTool-${version}.tar.gz";
+    hash = "sha256-TLJSJEXMPj870TkExq6uraX8Wl4kmNerrSlX3LQsr/4=";
+  };
+
+  nativeBuildInputs = lib.optional stdenv.isDarwin shortenPerlShebang;
+  postInstall = lib.optionalString stdenv.isDarwin ''
+    shortenPerlShebang $out/bin/exiftool
+  '';
+
+  meta = {
+    description = "A tool to read, write and edit EXIF meta information";
+    longDescription = ''
+      ExifTool is a platform-independent Perl library plus a command-line
+      application for reading, writing and editing meta information in a wide
+      variety of files. ExifTool supports many different metadata formats
+      including EXIF, GPS, IPTC, XMP, JFIF, GeoTIFF, ICC Profile, Photoshop
+      IRB, FlashPix, AFCP and ID3, as well as the maker notes of many digital
+      cameras by Canon, Casio, DJI, FLIR, FujiFilm, GE, GoPro, HP,
+      JVC/Victor, Kodak, Leaf, Minolta/Konica-Minolta, Motorola, Nikon,
+      Nintendo, Olympus/Epson, Panasonic/Leica, Pentax/Asahi, Phase One,
+      Reconyx, Ricoh, Samsung, Sanyo, Sigma/Foveon and Sony.
+    '';
+    homepage = "https://exiftool.org/";
+    changelog = "https://exiftool.org/history.html";
+    license = with lib.licenses; [ gpl1Plus /* or */ artistic2 ];
+    maintainers = with lib.maintainers; [ kiloreux anthonyroussel ];
+    mainProgram = "exiftool";
+  };
+}

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -13205,40 +13205,7 @@ with self; {
     };
   };
 
-  ImageExifTool = buildPerlPackage rec {
-    pname = "Image-ExifTool";
-    version = "12.70";
-
-    src = fetchurl {
-      url = "https://exiftool.org/Image-ExifTool-${version}.tar.gz";
-      hash = "sha256-TLJSJEXMPj870TkExq6uraX8Wl4kmNerrSlX3LQsr/4=";
-    };
-
-    nativeBuildInputs = lib.optional stdenv.isDarwin shortenPerlShebang;
-    postInstall = lib.optionalString stdenv.isDarwin ''
-      shortenPerlShebang $out/bin/exiftool
-    '';
-
-    meta = {
-      description = "A tool to read, write and edit EXIF meta information";
-      longDescription = ''
-        ExifTool is a platform-independent Perl library plus a command-line
-        application for reading, writing and editing meta information in a wide
-        variety of files. ExifTool supports many different metadata formats
-        including EXIF, GPS, IPTC, XMP, JFIF, GeoTIFF, ICC Profile, Photoshop
-        IRB, FlashPix, AFCP and ID3, as well as the maker notes of many digital
-        cameras by Canon, Casio, DJI, FLIR, FujiFilm, GE, GoPro, HP,
-        JVC/Victor, Kodak, Leaf, Minolta/Konica-Minolta, Motorola, Nikon,
-        Nintendo, Olympus/Epson, Panasonic/Leica, Pentax/Asahi, Phase One,
-        Reconyx, Ricoh, Samsung, Sanyo, Sigma/Foveon and Sony.
-      '';
-      homepage = "https://exiftool.org/";
-      changelog = "https://exiftool.org/history.html";
-      license = with lib.licenses; [ gpl1Plus /* or */ artistic2 ];
-      maintainers = with maintainers; [ kiloreux anthonyroussel ];
-      mainProgram = "exiftool";
-    };
-  };
+  ImageExifTool = callPackage ../development/perl-modules/ImageExifTool { };
 
   Inline = buildPerlPackage {
     pname = "Inline";


### PR DESCRIPTION
## Description of changes

* Update package to latest version: https://github.com/exiftool/exiftool/compare/12.70...12.78
* Moved package to dedicated pkgs/development/perl-modules/ImageExifTool folder
  * I know this is not common for Perl packages to be located in this folder, but it is required to be able to add update script and tests because update scripts requires packages to be in their own dedicated file
* Added passthru.updateScript to update package with maintainers/scripts/update.nix
* Added passthru.tests.version to test final binary

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
