### PR TITLE
blender: enable USD support; openusd: cleanup

### DIFF
--- a/pkgs/applications/misc/blender/default.nix
+++ b/pkgs/applications/misc/blender/default.nix
@@ -84,6 +84,7 @@
 let
   python3Packages = python310Packages;
   python3 = python3Packages.python;
+  pyPkgsOpenusd = python3Packages.openusd.override { withOsl = false; };
 
   libdecor' = libdecor.overrideAttrs (old: {
     # Blender uses private APIs, need to patch to expose them
@@ -166,6 +167,7 @@ stdenv.mkDerivation (finalAttrs: {
       "-DWITH_PYTHON_INSTALL_REQUESTS=OFF"
       "-DWITH_SDL=OFF"
       "-DWITH_TBB=ON"
+      "-DWITH_USD=ON"
 
       # Blender supplies its own FindAlembic.cmake (incompatible with the Alembic-supplied config file)
       "-DALEMBIC_INCLUDE_DIR=${lib.getDev alembic}/include"
@@ -232,6 +234,7 @@ stdenv.mkDerivation (finalAttrs: {
       (opensubdiv.override { inherit cudaSupport; })
       potrace
       pugixml
+      pyPkgsOpenusd
       python3
       tbb
       zlib
@@ -287,6 +290,7 @@ stdenv.mkDerivation (finalAttrs: {
       ps.numpy
       ps.requests
       ps.zstandard
+      pyPkgsOpenusd
     ];
 
   blenderExecutable =

--- a/pkgs/development/python-modules/openusd/default.nix
+++ b/pkgs/development/python-modules/openusd/default.nix
@@ -33,8 +33,8 @@
   tbb,
   withDocs ? false,
   withOsl ? true,
-  withTools ? true,
-  withUsdView ? true,
+  withTools ? false,
+  withUsdView ? false,
   writeShellScriptBin,
 }:
 

--- a/pkgs/development/python-modules/openusd/default.nix
+++ b/pkgs/development/python-modules/openusd/default.nix
@@ -84,6 +84,7 @@ buildPythonPackage rec {
     [
       cmake
       ninja
+      setuptools
     ]
     ++ lib.optionals withDocs [
       git
@@ -125,7 +126,6 @@ buildPythonPackage rec {
       jinja2
       numpy
       pyopengl
-      setuptools
     ]
     ++ lib.optionals (withTools || withUsdView) [
       pyside-tools-uic

--- a/pkgs/development/python-modules/openusd/default.nix
+++ b/pkgs/development/python-modules/openusd/default.nix
@@ -1,35 +1,37 @@
-{ buildPythonPackage
-, fetchFromGitHub
-, lib
-, writeShellScriptBin
-, cmake
-, doxygen
-, draco
-, graphviz-nox
-, ninja
-, setuptools
-, pyqt6
-, pyopengl
-, jinja2
-, pyside6
-, boost
-, numpy
-, git
-, tbb
-, opensubdiv
-, openimageio
-, opencolorio
-, osl
-, ptex
-, embree
-, alembic
-, imath
-, flex
-, bison
-, qt6
-, python
-, darwin
+{
+  alembic,
+  bison,
+  boost,
+  buildPythonPackage,
+  cmake,
+  darwin,
+  doxygen,
+  draco,
+  embree,
+  fetchFromGitHub,
+  flex,
+  git,
+  graphviz-nox,
+  imath,
+  jinja2,
+  lib,
+  ninja,
+  numpy,
+  opencolorio,
+  openimageio,
+  opensubdiv,
+  osl,
+  ptex,
+  pyopengl,
+  pyqt6,
+  pyside6,
+  python,
+  qt6,
+  setuptools,
+  tbb,
+  writeShellScriptBin,
 }:
+
 let
   # Matches the pyside6-uic implementation
   # https://code.qt.io/cgit/pyside/pyside-setup.git/tree/sources/pyside-tools/pyside_tool.py?id=e501cad66146a49c7a259579c7bb94bc93a67a08#n82
@@ -37,9 +39,11 @@ let
     exec ${qt6.qtbase}/libexec/uic -g python "$@"
   '';
 in
+
 buildPythonPackage rec {
   pname = "OpenUSD";
   version = "23.11";
+
   src = fetchFromGitHub {
     owner = "PixarAnimationStudios";
     repo = pname;
@@ -47,73 +51,75 @@ buildPythonPackage rec {
     hash = "sha256-5zQrfB14kXs75WbL3s4eyhxELglhLNxU2L2aVXiyVjg=";
   };
 
-  stdenv = if python.stdenv.isDarwin then
-    darwin.apple_sdk_11_0.stdenv
-  else
-    python.stdenv;
+  stdenv = if python.stdenv.isDarwin then darwin.apple_sdk_11_0.stdenv else python.stdenv;
 
-  outputs = ["out" "doc"];
+  outputs = [
+    "out"
+    "doc"
+  ];
 
   format = "other";
 
-  propagatedBuildInputs = [
-    setuptools
-    pyqt6
-    pyopengl
-    jinja2
-    pyside6
-    pyside-tools-uic
-    boost
-    numpy
-  ];
-
   cmakeFlags = [
-    "-DPXR_BUILD_EXAMPLES=OFF"
-    "-DPXR_BUILD_TUTORIALS=OFF"
-    "-DPXR_BUILD_USD_TOOLS=ON"
-    "-DPXR_BUILD_IMAGING=ON"
-    "-DPXR_BUILD_USD_IMAGING=ON"
-    "-DPXR_BUILD_USDVIEW=ON"
-    "-DPXR_BUILD_DOCUMENTATION=ON"
-    "-DPXR_BUILD_PYTHON_DOCUMENTATION=ON"
-    "-DPXR_BUILD_EMBREE_PLUGIN=ON"
     "-DPXR_BUILD_ALEMBIC_PLUGIN=ON"
+    "-DPXR_BUILD_DOCUMENTATION=ON"
     "-DPXR_BUILD_DRACO_PLUGIN=ON"
+    "-DPXR_BUILD_EMBREE_PLUGIN=ON"
+    "-DPXR_BUILD_EXAMPLES=OFF"
+    "-DPXR_BUILD_IMAGING=ON"
     "-DPXR_BUILD_MONOLITHIC=ON" # Seems to be commonly linked to monolithically
+    "-DPXR_BUILD_PYTHON_DOCUMENTATION=ON"
+    "-DPXR_BUILD_TUTORIALS=OFF"
+    "-DPXR_BUILD_USDVIEW=ON"
+    "-DPXR_BUILD_USD_IMAGING=ON"
+    "-DPXR_BUILD_USD_TOOLS=ON"
     (lib.cmakeBool "PXR_ENABLE_OSL_SUPPORT" (!stdenv.isDarwin))
   ];
 
   nativeBuildInputs = [
     cmake
-    ninja
-    git
-    qt6.wrapQtAppsHook
     doxygen
+    git
     graphviz-nox
+    ninja
+    qt6.wrapQtAppsHook
   ];
-  buildInputs = [
-    tbb
-    opensubdiv
-    openimageio
-    opencolorio
-    osl
-    ptex
-    embree
-    alembic.dev
-    imath
-    flex
-    bison
-    boost
-    draco
-    qt6.qtbase
-  ]
-    ++ lib.optionals stdenv.isLinux [ qt6.qtwayland ]
-    ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk_11_0.frameworks; [
-      Cocoa
-    ])
-  ;
 
-  pythonImportsCheck = [ "pxr" "pxr.Usd" ];
+  buildInputs =
+    [
+      alembic.dev
+      bison
+      boost
+      draco
+      embree
+      flex
+      imath
+      opencolorio
+      openimageio
+      opensubdiv
+      osl
+      ptex
+      qt6.qtbase
+      tbb
+    ]
+    ++ lib.optionals stdenv.isLinux [ qt6.qtwayland ]
+    ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk_11_0.frameworks; [ Cocoa ]);
+
+  propagatedBuildInputs = [
+    boost
+    jinja2
+    numpy
+    pyopengl
+    pyqt6
+    pyside-tools-uic
+    pyside6
+    setuptools
+  ];
+
+  pythonImportsCheck = [
+    "pxr"
+    "pxr.Usd"
+  ];
 
   postInstall = ''
     # Make python lib properly accessible

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2001,6 +2001,11 @@ with pkgs;
 
   openbugs = pkgsi686Linux.callPackage ../applications/science/machine-learning/openbugs { };
 
+  openusd = python3Packages.openusd.override {
+    withTools = true;
+    withUsdView = true;
+  };
+
   osquery = callPackage ../tools/system/osquery { };
 
   paperview = callPackage ../tools/X11/paperview { };


### PR DESCRIPTION
## Description of changes

Please see individual commits messages for elaboration.


diff-closures:
```
blender: +1364.7 KiB
boost: +163238.0 KiB
draco: ∅ → 1.5.7, +17465.0 KiB
gle: ∅ → 3.1.0, +862.1 KiB
libimagequant: ∅ → 4.3.0, +10394.5 KiB
python3.10-OpenUSD: ∅ → 23.11, +160663.1 KiB
python3.10-defusedxml: ∅ → 0.7.1, +134.7 KiB
python3.10-jinja2: ∅ → 3.1.3, +1333.5 KiB
python3.10-markupsafe: ∅ → 2.1.5, +71.7 KiB
python3.10-olefile: ∅ → 0.46, +230.8 KiB
python3.10-pillow: ∅ → 10.2.0, +3334.4 KiB
python3.10-pyopengl: ∅ → 3.1.7, +18725.9 KiB
```

## Things done

Have tested Blender can:

- Import USD files (note there is missing functionality for some files, fixed in upcoming Blender 4.1)
- `import pxr.Usd` in Blender Python console

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>5 packages built:</summary>
  <ul>
    <li>blender</li>
    <li>blender-hip</li>
    <li>openusd</li>
    <li>python311Packages.openusd</li>
    <li>python312Packages.openusd</li>
  </ul>
</details>

---

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
