### PR TITLE
ibus-engines.mozc-ut: package ut dictionary

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15682,6 +15682,12 @@
     githubId = 74465;
     name = "James Fargher";
   };
+  programmerino = {
+    email = "davis.davalos.delosh@gmail.com";
+    github = "programmerino";
+    githubId = 17630263;
+    name = "Davis Davalos-DeLosh";
+  };
   progval = {
     email = "progval+nix@progval.net";
     github = "progval";

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-mozc/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-mozc/default.nix
@@ -1,36 +1,87 @@
-{ lib
-, buildBazelPackage
-, fetchFromGitHub
-, qt6
-, pkg-config
-, bazel
-, ibus
-, unzip
-, xdg-utils
-}:
-let
+{
+  lib,
+  buildBazelPackage,
+  fetchFromGitHub,
+  fetchFromGitLab,
+  fetchurl,
+  qt6,
+  pkg-config,
+  bazel,
+  ibus,
+  unzip,
+  python3,
+  xdg-utils,
+  ruby,
+  glibcLocales,
+  useUTDictionaries ? false,
+}: let
+  _zipcode_rel = "202110";
   zip-codes = fetchFromGitHub {
     owner = "musjj";
     repo = "jp-zip-codes";
     rev = "a1eed9bae0ba909c8c8f5387008b08ff490f5e57";
     hash = "sha256-VfI8qAMPPCC2H4vjm4a6sAmSwc1YkXlMyLm1cnufvrU=";
   };
+  fcitx5-mozc-ut = fetchFromGitLab {
+    owner = "BrLi";
+    repo = "brli-aur";
+    rev = "1b929f03a07e3b8104158367471cde14fafe0c82";
+    hash = "sha256-270sSOJIw1SNTIMla3jTXK6VnSFeQjLyfadUayYxtZQ=";
+  };
+  merge-ut-dictionaries = fetchFromGitHub {
+    name = "merge-ut-dictionaries";
+    owner = "utuhiro78";
+    repo = "merge-ut-dictionaries";
+    rev = "a3d6fc4005aff2092657ebca98b9de226e1c617f";
+    hash = "sha256-UK29ACZUK9zGfzW7C85uMw2aF5Gk+0aDeUdNV71PY+0=";
+  };
+  jawiki = let
+    date = "20240301";
+  in
+    fetchurl {
+      url = "https://dumps.wikimedia.org/jawiki/${date}/jawiki-${date}-all-titles-in-ns0.gz";
+      hash = "sha256-tq/sKAPZ/NLplOLoVWp2ZdWzK/F7TVA9FTCYKfvFuZU=";
+    };
+  getDict = name: rev: hash: let
+    repo = fetchFromGitHub {
+      inherit rev hash;
+      owner = "utuhiro78";
+      repo = "mozcdic-ut-${name}";
+    };
+  in "${repo}/mozcdic-ut-${name}.txt.tar.bz2";
 in
 buildBazelPackage rec {
   pname = "ibus-mozc";
   version = "2.29.5268.102";
 
-  src = fetchFromGitHub {
-    owner = "google";
-    repo = "mozc";
-    rev = version;
-    hash = "sha256-B7hG8OUaQ1jmmcOPApJlPVcB8h1Rw06W5LAzlTzI9rU=";
-    fetchSubmodules = true;
-  };
+  srcs =
+    [
+      (fetchFromGitHub {
+        owner = "google";
+        repo = "mozc";
+        rev = version;
+        hash = "sha256-B7hG8OUaQ1jmmcOPApJlPVcB8h1Rw06W5LAzlTzI9rU=";
+        fetchSubmodules = true;
+      })
+    ]
+    ++ lib.optional useUTDictionaries [
+      "${fcitx5-mozc-ut}/x-ken-all-${_zipcode_rel}.zip"
+      "${fcitx5-mozc-ut}/jigyosyo-${_zipcode_rel}.zip"
+      merge-ut-dictionaries
+      (getDict "alt-cannadic" "4e548e6356b874c76e8db438bf4d8a0b452f2435" "sha256-4gzqVoCIhC0k3mh0qbEr8yYttz9YR0fItkFNlu7cYOY=")
+      (getDict "edict2" "16283aa0c2d394a3a000eca4fa3e95eb365698c6" "sha256-H4Y6RGFZBQodpB4cM3o3MPFJGs/xMvbIB/c8CazY1b4=")
+      (getDict "jawiki" "bd82687d32ae838f1e163d3d2c6ad18740af53f2" "sha256-AjNNV1V5fTMhlR2Nv6g+zNuCCLmPlQUJtUw7JigQKdM=")
+      (getDict "neologd" "bf9d0d217107f2fb2e7d1a26648ef429d9fdcd27" "sha256-e0iM5fohwpNNhPl9CjkD753/Rgatg7GdwN0NSvlN94c=")
+      (getDict "personal-names" "6cc099cefc928bc37854c538e030114df3d5b42d" "sha256-PqbS6VC70IaHJqxP9518zTTZuvXggAsRGeYPiN5T0XU=")
+      (getDict "place-names" "a847a02e0137ab9e2fdbbaaf120826f870408ca6" "sha256-B0kW8Wa/nCT4KEYl2Rz6gQcj0Po3GxU6i42unHhgZeU=")
+      (getDict "skk-jisyo" "ee94f6546ce52edfeec0fd203030f52d4d99656f" "sha256-RXxO878ZBkxenrdo7cFom5NjM0m7CdYQk0dFu/HPp/Y=")
+      (getDict "sudachidict" "55f61c3fca81dec661c36c73eb29b2631c8ed618" "sha256-gNnBcuVU1M7rllfZXIrLg7WYUhKqPJsUjR8Scnq3Fw8=")
+    ];
+  sourceRoot = "source";
 
-  nativeBuildInputs = [ qt6.wrapQtAppsHook pkg-config unzip ];
+  nativeBuildInputs = [qt6.wrapQtAppsHook pkg-config unzip] ++ lib.optional useUTDictionaries [python3 ruby glibcLocales];
 
-  buildInputs = [ ibus qt6.qtbase ];
+  buildInputs = [ibus qt6.qtbase];
 
   dontAddBazelOpts = true;
   removeRulesCC = false;
@@ -59,17 +110,42 @@ buildBazelPackage rec {
       --replace-fail "https://www.post.japanpost.jp/zipcode/dl/jigyosyo/zip/jigyosyo.zip" "file://${zip-codes}/jigyosyo.zip"
   '';
 
-  preConfigure = ''
-    cd src
-  '';
+  preConfigure =
+    ''
+      srcdir="$(dirname "$PWD")"
+      cd src
+    ''
+    + lib.optionalString useUTDictionaries ''
+      PYTHONPATH="$PWD:$PYTHONPATH" python3 dictionary/gen_zip_code_seed.py --zip_code="$srcdir/x-ken-all.csv" --jigyosyo="$srcdir/JIGYOSYO.CSV" >> data/dictionary_oss/dictionary09.txt
+      cd $srcdir/merge-ut-dictionaries/src
+      chmod +w $PWD
+      for dict in $srcdir/mozcdic-ut-*; do
+        cat "$dict" >> mozcdic-ut.txt
+      done
+      sed '/^`wget*/d' -i count_word_hits.rb
+      sed "s,https://raw.githubusercontent.com/google/mozc/master,$srcdir/source," -i remove_duplicate_ut_entries.rb
+      cp ${jawiki} ./jawiki-latest-all-titles-in-ns0.gz
+      export LANG=en_US.UTF-8
+      export LANGUAGE=en_US.UTF-8
+      export LC_ALL=en_US.UTF-8
+      ruby remove_duplicate_ut_entries.rb mozcdic-ut.txt
+      ruby count_word_hits.rb
+      ruby apply_word_hits.rb mozcdic-ut.txt
+      cat mozcdic-ut.txt >> "$srcdir/source/src/data/dictionary_oss/dictionary00.txt"
+      cd $srcdir/source/src
+    '';
 
-  buildAttrs.installPhase = ''
-    runHook preInstall
+  buildAttrs = {
+    PYTHONUTF8 = 1;
 
-    unzip bazel-bin/unix/mozc.zip -x "tmp/*" -d /
+    installPhase = ''
+      runHook preInstall
 
-    runHook postInstall
-  '';
+      unzip bazel-bin/unix/mozc.zip -x "tmp/*" -d /
+
+      runHook postInstall
+    '';
+  };
 
   passthru = {
     inherit zip-codes;
@@ -81,6 +157,6 @@ buildBazelPackage rec {
     homepage = "https://github.com/google/mozc";
     license = licenses.free;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ gebner ericsagnes pineapplehunter ];
+    maintainers = with maintainers; [ gebner ericsagnes pineapplehunter programmerino ];
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6996,6 +6996,10 @@ with pkgs;
 
     mozc = callPackage ../tools/inputmethods/ibus-engines/ibus-mozc { };
 
+    mozc-ut = callPackage ../tools/inputmethods/ibus-engines/ibus-mozc {
+      useUTDictionaries = true;
+    };
+
     openbangla-keyboard = libsForQt5.callPackage ../applications/misc/openbangla-keyboard { withIbusSupport = true; };
 
     rime = callPackage ../tools/inputmethods/ibus-engines/ibus-rime { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Pretty similar rationale to #189728, but for IBus. It's modeled very closely to the [ibus-mozc-ut-full](https://aur.archlinux.org/packages/ibus-mozc-ut-full) AUR package.

Creates a new package `ibus-engines.mozc-ut` which enables a new UT dictionaries option.

This is my first contribution to nixpkgs, so there's a good chance I'm not following best practices, please let me know if there is anything wrong.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
