### PR TITLE
perf_data_converter: init at unstable-2024-03-12

### DIFF
--- a/pkgs/by-name/pe/perf_data_converter/package.nix
+++ b/pkgs/by-name/pe/perf_data_converter/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  buildBazelPackage,
+  fetchFromGitHub,
+  fetchpatch,
+  bazel_6,
+  jdk,
+  elfutils,
+  libcap,
+}:
+
+buildBazelPackage rec {
+  pname = "perf_data_converter";
+  version = "0-unstable-2024-03-12";
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "perf_data_converter";
+    rev = "e1cfe1e7e5d8cf3b728a166bf02d4227c82801eb";
+    hash = "sha256-Y3tBLH2jf1f28o6RK2inq9FulKc66qcqwKmxYdFC5tA=";
+  };
+
+  bazel = bazel_6;
+  bazelFlags = [
+    "--java_runtime_version=local_jdk"
+    "--tool_java_runtime_version=local_jdk"
+  ];
+
+  fetchAttrs = {
+    sha256 = "sha256-IauQ4zEn9YHppLgW+4XjPv4N5IZlEkp//tE/Dy7k28s=";
+  };
+
+  nativeBuildInputs = [ jdk ];
+
+  buildInputs = [
+    elfutils
+    libcap
+  ];
+
+  removeRulesCC = false;
+
+  bazelBuildFlags = [ "-c opt" ];
+  bazelTargets = [ "src:perf_to_profile" ];
+
+  bazelTestTargets = [ "src:all" ];
+
+  buildAttrs = {
+    installPhase = ''
+      runHook preInstall
+      install -Dm555 -t "$out/bin" bazel-bin/src/perf_to_profile
+      runHook postInstall
+    '';
+  };
+
+  meta = with lib; {
+    description = "Tool to convert Linux perf files to the profile.proto format used by pprof";
+    homepage = "https://github.com/google/perf_data_converter";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ hzeller ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
perf data converter is a utility program used by pprof to be able to read linux perf.data files (and then display as tree, flamegraph, ...).

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
