### PR TITLE
code-server: 4.19.1 -> 4.22.1

### DIFF
--- a/pkgs/servers/code-server/default.nix
+++ b/pkgs/servers/code-server/default.nix
@@ -71,18 +71,18 @@ let
   # To compute the commit when upgrading this derivation, do:
   # `$ git rev-parse <git-rev>` where <git-rev> is the git revision of the `src`
   # Example: `$ git rev-parse v4.16.1`
-  commit = "0c98611e6b43803a9d5dba222d7023b569abfb49";
+  commit = "760d1318e98945d05133c6121f99541ca7a39bf8";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "code-server";
-  version = "4.19.1";
+  version = "4.22.1";
 
   src = fetchFromGitHub {
     owner = "coder";
     repo = "code-server";
     rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-J+6zuqVf1YKQjiRiqO4867DEwYzZsgQYgbsRXPo2hwY=";
+    hash = "sha256-rudK3cPbRB4aDUbGU2miYil9VlPOCNuvneWkChdQS+I=";
   };
 
   yarnCache = stdenv.mkDerivation {
@@ -114,7 +114,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     outputHashMode = "recursive";
     outputHashAlgo = "sha256";
-    outputHash = "sha256-g2rwB+PuWuYgrzIuW0ngia7cdPMC8s7ffBEkbmPPzB4=";
+    outputHash = "sha256-ZipQjEOyfsn3soL+Dd6OomS0ykg8TWTTF61vVbdOcSI=";
   };
 
   nativeBuildInputs = [
@@ -130,9 +130,12 @@ stdenv.mkDerivation (finalAttrs: {
     quilt
   ];
 
-  buildInputs = lib.optionals (!stdenv.isDarwin) [ libsecret ]
-    ++ (with xorg; [ libX11 libxkbfile ])
-    ++ lib.optionals stdenv.isDarwin [
+  buildInputs = [
+    xorg.libX11
+    xorg.libxkbfile
+  ] ++ lib.optionals (!stdenv.isDarwin) [
+    libsecret
+  ] ++ lib.optionals stdenv.isDarwin [
     AppKit
     Cocoa
     CoreServices
@@ -154,9 +157,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     # inject git commit
     substituteInPlace ./ci/build/build-vscode.sh \
-      --replace '$(git rev-parse HEAD)' "${commit}"
+      --replace-fail '$(git rev-parse HEAD)' "${commit}"
     substituteInPlace ./ci/build/build-release.sh \
-      --replace '$(git rev-parse HEAD)' "${commit}"
+      --replace-fail '$(git rev-parse HEAD)' "${commit}"
   '';
 
   configurePhase = ''


### PR DESCRIPTION
Currently broken, here's the compilation log:

<details>

```
code-server> Done in 4.56s.
code-server> yarn run v1.22.22
code-server> warning You don't appear to have an internet connection. Try the --offline flag to use the cache for registry queries.
code-server> $ ./ci/build/build-vscode.sh
code-server> warning You don't appear to have an internet connection. Try the --offline flag to use the cache for registry queries.
code-server> $ node --max-old-space-size=8192 ./node_modules/gulp/bin/gulp.js vscode-reh-web-linux-x64-min
code-server> {"type":"warning","data":"You don't appear to have an internet connection. Try the --offline flag to use the cache for registry queries."}
code-server> {"type":"warning","data":"You don't appear to have an internet connection. Try the --offline flag to use the cache for registry queries."}
code-server> {"type":"warning","data":"You don't appear to have an internet connection. Try the --offline flag to use the cache for registry queries."}
code-server> {"type":"warning","data":"You don't appear to have an internet connection. Try the --offline flag to use the cache for registry queries."}
code-server> {"type":"warning","data":"You don't appear to have an internet connection. Try the --offline flag to use the cache for registry queries."}
code-server> {"type":"warning","data":"You don't appear to have an internet connection. Try the --offline flag to use the cache for registry queries."}
code-server> [08:25:52] Using gulpfile ~/lib/vscode/gulpfile.js
code-server> [08:25:52] Starting 'vscode-reh-web-linux-x64-min'...
code-server> [08:25:52] Starting clean-out-build ...
code-server> [08:25:52] Finished clean-out-build after 9 ms
code-server> [08:25:52] Starting build-web-node-paths ...
code-server> [08:25:52] Finished build-web-node-paths after 2 ms
code-server> [08:25:52] Starting compile-api-proposal-names ...
code-server> [08:25:52] Starting compilation api-proposal-names...
code-server> [08:25:52] Finished compilation api-proposal-names with 0 errors after 54 ms
code-server> [08:25:52] Finished compile-api-proposal-names after 61 ms
code-server> [08:25:52] Starting compile-src ...
code-server> [08:26:04] [mangler] Done collecting. Classes: 7495. Exported symbols: 9034
code-server> [08:26:06] [mangler] Done creating class replacements
code-server> [08:26:06] [mangler] Starting prepare rename edits
code-server> [08:26:06] Starting compilation...
code-server> [08:59:38] [mangler] Done preparing edits: 3623 files
code-server> [08:59:44] [mangler] Done: 4569.959kb saved, memory-usage: {"total_heap_size":1984024576,"total_heap_size_executable":9936896,"total_physical_size":1983557632,"total_available_size":6702055896,"used_heap_size":1896727232,"heap_size_limit":8640266240,"malloced_memory":2285096,"peak_malloced_memory":14252448,"does_zap_garbage":0,"number_of_native_contexts":2,"number_of_detached_contexts":0,"total_global_handles_size":4562944,"used_global_handles_size":1843520,"external_memory":89231414}
code-server> [09:02:35] Finished compilation with 0 errors after 2189182 ms
code-server> [09:02:35] Finished compile-src after 2202986 ms
code-server> [09:02:35] Starting compile-build ...
code-server> [09:02:35] Finished compile-build after 15 ms
code-server> [09:02:35] Starting clean-extensions-build ...
code-server> [09:02:35] Finished clean-extensions-build after 2 ms
code-server> [09:02:35] Starting bundle-marketplace-extensions-build ...
code-server> [09:02:35] Finished bundle-marketplace-extensions-build after 3 ms
code-server> [09:02:35] Starting bundle-extensions-build ...
code-server> {"type":"warning","data":"You don't appear to have an internet connection. Try the --offline flag to use the cache for registry queries."}
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server>  INFO  Detected presence of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
code-server> [09:03:11] Bundled extension: simple-browser/extension.webpack.config.js...
code-server> [09:03:11] Bundled extension: debug-auto-launch/extension.webpack.config.js...
code-server> [09:03:11] Bundled extension: gulp/extension.webpack.config.js...
code-server> [09:03:11] Bundled extension: grunt/extension.webpack.config.js...
code-server> [09:03:11] Bundled extension: jake/extension.webpack.config.js...
code-server> [09:03:11] Bundled extension: debug-server-ready/extension.webpack.config.js...
code-server> [09:03:12] Bundled extension: tunnel-forwarding/extension.webpack.config.js...
code-server> [09:03:12] Bundled extension: search-result/extension.webpack.config.js...
code-server> [09:03:17] Bundled extension: git-base/extension.webpack.config.js...
code-server> [09:03:19] Bundled extension: references-view/extension.webpack.config.js...
code-server> [09:03:21] Bundled extension: markdown-math/extension.webpack.config.js...
code-server> [09:03:21] Bundled extension: media-preview/extension.webpack.config.js...
code-server> [09:03:26] Bundled extension: php-language-features/extension.webpack.config.js...
code-server> [09:03:26] Bundled extension: ipynb/extension.webpack.config.js...
code-server> [09:03:30] Bundled extension: extension-editing/extension.webpack.config.js...
code-server> [09:03:37] Bundled extension: emmet/extension.webpack.config.js...
code-server> [09:03:44] Bundled extension: merge-conflict/extension.webpack.config.js...
code-server> [09:03:46] Bundled extension: npm/extension.webpack.config.js...
code-server> [09:03:48] Bundled extension: microsoft-authentication/extension.webpack.config.js...
code-server> [09:03:50] Bundled extension: css-language-features/extension.webpack.config.js...
code-server> [09:04:15] Bundled extension: configuration-editing/extension.webpack.config.js...
code-server> [09:04:15] Bundled extension: git/extension.webpack.config.js...
code-server> [09:04:16] Bundled extension: github/extension.webpack.config.js...
code-server> [09:04:16] Bundled extension: css-language-features/server/extension.webpack.config.js...
code-server> [09:04:16] Bundled extension: html-language-features/extension.webpack.config.js...
code-server> [09:04:17] Bundled extension: json-language-features/extension.webpack.config.js...
code-server> [09:04:17] Bundled extension: json-language-features/server/extension.webpack.config.js...
code-server> [09:04:17] Bundled extension: html-language-features/server/extension.webpack.config.js...
code-server> [09:04:17] Bundled extension: github-authentication/extension.webpack.config.js...
code-server> [09:04:17] Bundled extension: markdown-language-features/server/extension.webpack.config.js...
code-server> [09:04:19] Bundled extension: markdown-language-features/extension.webpack.config.js...
code-server> [09:04:19] Bundled extension: typescript-language-features/extension.webpack.config.js...
code-server> [09:04:19] Finished bundle-extensions-build after 103671 ms
code-server> [09:04:19] Starting compile-extensions-build ...
code-server> [09:04:19] Finished compile-extensions-build after 0 ms
code-server> [09:04:19] Starting compile-extension-media-build ...
code-server> [09:04:19] Finished esbuilding extension media /build/source/lib/vscode/extensions/markdown-language-features/esbuild-preview.js with 0 errors.
code-server> [09:04:19] Finished esbuilding extension media /build/source/lib/vscode/extensions/ipynb/esbuild.js with 0 errors.
code-server> [09:04:19] Finished esbuilding extension media /build/source/lib/vscode/extensions/notebook-renderers/esbuild.js with 0 errors.
code-server> [09:04:19] Finished esbuilding extension media /build/source/lib/vscode/extensions/markdown-language-features/esbuild-notebook.js with 0 errors.
code-server> [09:04:19] Finished esbuilding extension media /build/source/lib/vscode/extensions/simple-browser/esbuild-preview.js with 0 errors.
code-server> [09:04:19] Finished esbuilding extension media /build/source/lib/vscode/extensions/markdown-math/esbuild.js with 0 errors.
code-server> [09:04:19] Finished compile-extension-media-build after 226 ms
code-server> [09:04:19] Starting clean-out-vscode-reh-web ...
code-server> [09:04:19] Finished clean-out-vscode-reh-web after 1 ms
code-server> [09:04:19] Starting optimize-vscode-reh-web ...
code-server> [09:04:49] Finished optimize-vscode-reh-web after 29278 ms
code-server> [09:04:49] Starting clean-out-vscode-reh-web-min ...
code-server> [09:04:49] Finished clean-out-vscode-reh-web-min after 1 ms
code-server> [09:04:49] Starting minify-vscode-reh-web ...
code-server> Browserslist: caniuse-lite is outdated. Please run:
code-server> npx browserslist@latest --update-db
code-server> Why you should do it regularly:
code-server> https://github.com/browserslist/browserslist#browsers-data-updating
code-server> ▲ [WARNING] The "??" operator here will always return the left operand [suspicious-nullish-coalescing]
code-server>     out-vscode-reh-web/vs/workbench/workbench.web.main.js:376251:99:
code-server>       376251 │ ...fer.active.cursorX + 4 : xterm.buffer.active.cursorX + 1 ?? 0,
code-server>              ╵                                                             ~~
code-server>   The left operand of the "??" operator here will never be null or undefined, so it will always be returned. This usually indicates a bug in your code:
code-server>     out-vscode-reh-web/vs/workbench/workbench.web.main.js:376251:67:
code-server>       376251 │ ...fer.active.cursorX + 4 : xterm.buffer.active.cursorX + 1 ?? 0,
code-server>              ╵                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
code-server> ▲ [WARNING] The "??" operator here will always return the left operand [suspicious-nullish-coalescing]
code-server>     out-vscode-reh-web/vs/workbench/workbench.web.main.js:431271:79:
code-server>       431271 │ ...getLineCount() * lineHeight) ?? editor.getContentHeight(); ...
code-server>              ╵                                 ~~
code-server>   The left operand of the "??" operator here will never be null or undefined, so it will always be returned. This usually indicates a bug in your code:
code-server>     out-vscode-reh-web/vs/workbench/workbench.web.main.js:431271:31:
code-server>       431271 │ ...Height = (editor.getModel()?.getLineCount() * lineHeight) ?...
code-server>              ╵              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
code-server> ▲ [WARNING] The "??" operator here will always return the left operand [suspicious-nullish-coalescing]
code-server>     out-vscode-reh-web/vs/workbench/workbench.web.main.js:474534:96:
code-server>       474534 │ ...Experience === 1 /* WelcomeExperience.ForWorkspace */ ?? true;
code-server>              ╵                                                          ~~
code-server>   The left operand of the "??" operator here will never be null or undefined, so it will always be returned. This usually indicates a bug in your code:
code-server>     out-vscode-reh-web/vs/workbench/workbench.web.main.js:474534:19:
code-server>       474534 │ ...   return this.viewModel?.welcomeExperience === 1 /* Welcom...
code-server>              ╵              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
code-server> ▲ [WARNING] The "??" operator here will always return the left operand [suspicious-nullish-coalescing]
code-server>     out-vscode-reh-web/vs/workbench/workbench.web.main.js:495193:141:
code-server>       495193 │ ...tributedEditor.id)?.supportsMultipleEditorsPerDocument ?? true
code-server>              ╵                                                           ~~
code-server>   The left operand of the "??" operator here will never be null or undefined, so it will always be returned. This usually indicates a bug in your code:
code-server>     out-vscode-reh-web/vs/workbench/workbench.web.main.js:495193:49:
code-server>       495193 │ ...ce: () => !this.getCustomEditorCapabilities(contributedEdit...
code-server>              ╵              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
code-server> ▲ [WARNING] The "??" operator here will always return the left operand [suspicious-nullish-coalescing]
code-server>     out-vscode-reh-web/vs/workbench/workbench.web.main.js:496027:59:
code-server>       496027 │ ...  return !item?.handle.startsWith('vscode-command:') ?? false;
code-server>              ╵                                                         ~~
code-server>   The left operand of the "??" operator here will never be null or undefined, so it will always be returned. This usually indicates a bug in your code:
code-server>     out-vscode-reh-web/vs/workbench/workbench.web.main.js:496027:15:
code-server>       496027 │ ...   return !item?.handle.startsWith('vscode-command:') ?? fa...
code-server>              ╵              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
code-server> ▲ [WARNING] The "??" operator here will always return the left operand [suspicious-nullish-coalescing]
code-server>     out-vscode-reh-web/vs/workbench/workbench.web.main.js:534034:119:
code-server>       534034 │ ... === 'object' ? markdown.isTrusted?.enabledCommands : [] ?? []
code-server>              ╵                                                             ~~
code-server>   The left operand of the "??" operator here will never be null or undefined, so it will always be returned. This usually indicates a bug in your code:
code-server>     out-vscode-reh-web/vs/workbench/workbench.web.main.js:534034:116:
code-server>       534034 │ ... === 'object' ? markdown.isTrusted?.enabledCommands : [] ?? []
code-server>              ╵                                                          ~~
code-server> [09:04:57] Finished minify-vscode-reh-web after 8626 ms
code-server> [09:04:57] Starting clean-vscode-reh-web-linux-x64 ...
code-server> [09:04:57] Finished clean-vscode-reh-web-linux-x64 after 1 ms
code-server> [09:04:57] Starting vscode-reh-web-linux-x64-min-ci ...
code-server> {"type":"warning","data":"You don't appear to have an internet connection. Try the --offline flag to use the cache for registry queries."}
code-server> [09:05:04] Finished vscode-reh-web-linux-x64-min-ci after 7097 ms
code-server> [09:05:04] Starting vscode-reh-web-linux-x64-min ...
code-server> [09:05:04] Finished vscode-reh-web-linux-x64-min after 0 ms
code-server> [09:05:04] Finished 'vscode-reh-web-linux-x64-min' after 39 min
code-server> "760d1318e98945d05133c6121f99541ca7a39bf8"
code-server> Done in 2356.45s.
code-server> yarn run v1.22.22
code-server> warning You don't appear to have an internet connection. Try the --offline flag to use the cache for registry queries.
code-server> $ ./ci/build/build-release.sh
code-server> npm notice created a lockfile as npm-shrinkwrap.json with version 3
code-server> npm notice created a lockfile as npm-shrinkwrap.json with version 3
code-server> npm notice created a lockfile as npm-shrinkwrap.json with version 3
code-server> Done in 2.53s.
code-server> buildPhase completed in 40 minutes 29 seconds
code-server> Running phase: glibPreInstallPhase
code-server> Running phase: installPhase
code-server> yarn install v1.22.22
code-server> info No lockfile found.
code-server> warning npm-shrinkwrap.json found. This will not be updated or respected. See https://yarnpkg.com/en/docs/migrating-from-npm for more information.
code-server> [1/5] Validating package.json...
code-server> [2/5] Resolving packages...
code-server> warning Resolution field "qs@6.9.7" is incompatible with requested version "qs@6.7.0"
code-server> warning Resolution field "qs@6.9.7" is incompatible with requested version "qs@6.7.0"
code-server> [3/5] Fetching packages...
code-server> [] 0/507[4/5] Linking dependencies...
code-server> [] 507/507[] 0/187[] 0/1982[] 632/1982[] 1399/1982[] 0/351[5/5] Building fresh packages...
code-server> [] 351/351success Saved lockfile.
code-server> $ sh ./postinstall.sh
code-server> Installing Code dependencies...
code-server> User agent: yarn/1.22.22 npm/? node/v18.19.1 linux x64
code-server> yarn install v1.22.22
code-server> warning You don't appear to have an internet connection. Try the --offline flag to use the cache for registry queries.
code-server> info No lockfile found.
code-server> warning npm-shrinkwrap.json found. This will not be updated or respected. See https://yarnpkg.com/en/docs/migrating-from-npm for more information.
code-server> [1/4] Resolving packages...
code-server> error Error: getaddrinfo EAI_AGAIN registry.yarnpkg.com
code-server>     at GetAddrInfoReqWrap.onlookup [as oncomplete] (node:dns:107:26)
code-server> info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
code-server> You may not have the required dependencies to build the native modules.
code-server> Please see https://github.com/coder/code-server/blob/main/docs/npm.md
code-server> error Command failed with exit code 1.
code-server> info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
code-server> 
error: builder for '/nix/store/l3n5g81y624v5d95q87aa3721xgzinvy-code-server-4.22.1.drv' failed with exit code 1;
       last 25 log lines:
warning npm-shrinkwrap.json found. This will not be updated or respected. See https://yarnpkg.com/en/docs/migrating-from-npm for more information.
[1/5] Validating package.json...
[2/5] Resolving packages...
warning Resolution field "qs@6.9.7" is incompatible with requested version "qs@6.7.0"
warning Resolution field "qs@6.9.7" is incompatible with requested version "qs@6.7.0"
[3/5] Fetching packages...
[4/5] Linking dependencies...
[5/5] Building fresh packages...
success Saved lockfile.
$ sh ./postinstall.sh
       > Installing Code dependencies...
       > User agent: yarn/1.22.22 npm/? node/v18.19.1 linux x64
yarn install v1.22.22
warning You don't appear to have an internet connection. Try the --offline flag to use the cache for registry queries.
info No lockfile found.
warning npm-shrinkwrap.json found. This will not be updated or respected. See https://yarnpkg.com/en/docs/migrating-from-npm for more information.
[1/4] Resolving packages...
error Error: getaddrinfo EAI_AGAIN registry.yarnpkg.com
       >     at GetAddrInfoReqWrap.onlookup [as oncomplete] (node:dns:107:26)
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
You may not have the required dependencies to build the native modules.
       > Please see https://github.com/coder/code-server/blob/main/docs/npm.md
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

       For full logs, run 'nix log /nix/store/l3n5g81y624v5d95q87aa3721xgzinvy-code-server-4.22.1.drv'.
```

</details>

@code-asher Can you help us on getting 4.22.1 working again?


## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
