### PR TITLE
nuget-to-nix: Add support for nuget.config

### DIFF
--- a/doc/languages-frameworks/dotnet.section.md
+++ b/doc/languages-frameworks/dotnet.section.md
@@ -250,6 +250,12 @@ Which `nuget-to-nix` will generate an output similar to below
 ]
 ```
 
+If some of your packages are restored from non-standard sources provide path to your `nuget.config` file. If your source requires authentication, make sure you have `.netrc` file configured.
+
+```bash
+$ nuget-to-nix out $excludedPackages $src/nuget.config > deps.nix
+```
+
 Finally, you move the `deps.nix` file to the appropriate location to be used by `nugetDeps`, then you're all set!
 
 If you ever need to update the dependencies of a package, you instead do

--- a/pkgs/build-support/dotnet/nuget-to-nix/default.nix
+++ b/pkgs/build-support/dotnet/nuget-to-nix/default.nix
@@ -9,6 +9,7 @@
 , curl
 , gnugrep
 , gawk
+, gnused
 , dotnet-sdk
 }:
 
@@ -25,6 +26,7 @@ runCommandLocal "nuget-to-nix" {
       curl
       gnugrep
       gawk
+      gnused
       dotnet-sdk
     ];
   };

--- a/pkgs/build-support/dotnet/nuget-to-nix/nuget-to-nix.sh
+++ b/pkgs/build-support/dotnet/nuget-to-nix/nuget-to-nix.sh
@@ -8,7 +8,7 @@ export PATH="@binPath@"
 export LC_ALL=C
 
 if [ $# -eq 0 ]; then
-  >&2 echo "Usage: $0 <packages directory> [path to a file with a list of excluded packages] > deps.nix"
+  >&2 echo "Usage: $0 <packages directory> [path to a file with a list of excluded packages] [path to nuget.config file] > deps.nix"
   exit 1
 fi
 
@@ -18,12 +18,32 @@ trap 'rm -r "$tmp"' EXIT
 
 excluded_list=$(realpath "${2:-/dev/null}")
 
+nuget_config_path=$(realpath "${3:-/dev/null}")
+
+DELIMITER='§'
+nuget_list_command="dotnet nuget list source"
+declare -a package_source_mapping
+if [ -f "$nuget_config_path" ]; then
+  nuget_list_command="$nuget_list_command --configfile $nuget_config_path"
+  while read -r value; do
+    package_source_mapping+=($value)
+  done < <(xq -r --arg DELIMITER "$DELIMITER" '.configuration.packageSourceMapping[] |.[] | { "@key": ."@key", "package": (if (.package | type) == "array" then .package[] else .package end) } | { "package": .package["@pattern"], "source": ."@key" } | "\(.package)\($DELIMITER)\(.source)"  '  "$nuget_config_path")
+
+else
+  package_source_mapping=()
+fi
+
 export DOTNET_NOLOGO=1
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 
-mapfile -t sources < <(dotnet nuget list source --format short | awk '/^E / { print $2 }')
+declare -A sources
+sanitize_source_key() {
+   echo "$1" | sed 's/[^a-zA-Z0-9_]/_/g'
+}
+while IFS='=' read -r key value; do
+    sources[$(sanitize_source_key "$key")]="$value"
+done < <($nuget_list_command | awk '/^\s+[0-9]+\./ {name=$2} /https:\/\// {print name "=" $1}')
 
-declare -a remote_sources
 declare -A base_addresses
 
 for index in "${sources[@]}"; do
@@ -31,16 +51,41 @@ for index in "${sources[@]}"; do
         continue
     fi
 
-    remote_sources+=($index)
+    if index_response=$(curl --compressed --netrc -ifsL "$index" 2>"$tmp/error"); then
+      base_address=$( \
+        echo "$index_response" | \
+        awk '/^{/ {json=1} json' | \
+        jq -r '.resources[] | select(."@type" == "PackageBaseAddress/3.0.0")."@id"' | \
+        sed 's|/*$|/|')
 
-    base_address=$(
-    curl --compressed --netrc -fsL "$index" | \
-      jq -r '.resources[] | select(."@type" == "PackageBaseAddress/3.0.0")."@id"')
-    if [[ ! "$base_address" == */ ]]; then
-      base_address="$base_address/"
+      if [[ ! "$base_address" == */ ]]; then
+        base_address="$base_address/"
+      fi
+      base_addresses[$index]="$base_address"
+
+    else
+        echo "Remote resolution failed for $index with $(echo "$index_response" | awk 'NR==1{print $2}')"
     fi
-    base_addresses[$index]="$base_address"
 done
+
+get_source_by_key() {
+    local search_key="$1"
+    shopt -s nocasematch
+    for entry in "${package_source_mapping[@]}"; do
+        key="${entry%%"$DELIMITER"*}"
+        value="${entry#*"$DELIMITER"}"
+        if [[ "$search_key" =~ $key ]]; then
+             skey=$(sanitize_source_key "$value")
+             if [[ -v sources[$skey] ]]; then
+                 echo "${sources["$skey"]}"
+                 shopt -u nocasematch
+                 return
+             fi
+        fi
+    done
+    shopt -u nocasematch
+    echo https://api.nuget.org/v3/index.json
+}
 
 echo "{ fetchNuGet }: ["
 
@@ -62,31 +107,29 @@ for package in *; do
         continue
     fi
 
-    for source in "${remote_sources[@]}"; do
-      url="${base_addresses[$source]}$package/$version/$package.$version.nupkg"
-      if [[ "$source" == "$used_source" ]]; then
+    source=$(get_source_by_key "$package")
+    url="${base_addresses[$source]}$package/$version/$package.$version.nupkg"
+    if [[ "$source" == "$used_source" ]]; then
         sha256="$(nix-hash --type sha256 --flat --base32 "$version/$package.$version".nupkg)"
         found=true
-        break
-      else
+
+    else
         if sha256=$(nix-prefetch-url "$url" 2>"$tmp"/error); then
-          # If multiple remote sources are enabled, nuget will try them all
-          # concurrently and use the one that responds first. We always use the
-          # first source that has the package.
+          # If mapped source from the config file was different pull the package from default source
           echo "$package $version is available at $url, but was restored from $used_source" 1>&2
           found=true
-          break
+
         else
           if ! grep -q 'HTTP error 404' "$tmp/error"; then
             cat "$tmp/error" 1>&2
             exit 1
           fi
         fi
-      fi
-    done
+    fi
+
 
     if [[ $found = false ]]; then
-      echo "couldn't find $package $version" >&2
+      echo "Couldn't find $package $version at $source, have you forgotten to provide nuget.config path?" >&2
       exit 1
     fi
 


### PR DESCRIPTION
This PR implements parsing of `nuget.config` for package source mappings, enabling the tool to fetch packages from specified sources based on package patterns.

@nixos/dotnet

## Description of changes

Added third CLI parameter to the `nuget-to-nix` which accepts path to a `nuget.config`. Then it parses non-standard sources and their package mappings.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
