### PR TITLE
k3s: fix update script for 1.26, 1.27

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/1_26/chart-versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_26/chart-versions.nix
@@ -1,10 +1,10 @@
 {
     traefik-crd  = {
-        url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-21.2.1+up21.2.0.tgz";
-        sha256 = "05j3vyikb7g2z2i07rij9h4ki5lb2hb2rynpiqfd4l1y5qm0qhw9";
+        url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-25.0.2+up25.0.0.tgz";
+        sha256 = "0jygzsn5pxzf7423x5iqfffgx5xvm7c7hfck46y7vpv1fdkiipcq";
     };
     traefik = {
-        url = "https://k3s.io/k3s-charts/assets/traefik/traefik-21.2.1+up21.2.0.tgz";
-        sha256 = "0gvz0yzph2893scd0q10b938yc7f36b3zqs57pkjgqqpl1d0nwhg";
+        url = "https://k3s.io/k3s-charts/assets/traefik/traefik-25.0.2+up25.0.0.tgz";
+        sha256 = "1g9n19lnqdkmbbr3rnbwc854awha0kqqfwyxanyx1lg5ww8ldp89";
     };
 }

--- a/pkgs/applications/networking/cluster/k3s/1_26/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_26/versions.nix
@@ -1,14 +1,14 @@
 {
-  k3sVersion = "1.26.9+k3s1";
-  k3sCommit = "4e217286a7ea41b82f1b67ab851d444ecf9a0f9b";
-  k3sRepoSha256 = "1rf2gzf3ilcd1gc6d4k1w6cficr70x8lwzcq81njpz72dr6883z3";
-  k3sVendorHash = "sha256-heCQNRaa0qFNkL69KEiIH2qEg+pukgS+fLOSWcwFddA=";
+  k3sVersion = "1.26.14+k3s1";
+  k3sCommit = "c7e6922aa84369b3c0d28bb800e67bb162895a1c";
+  k3sRepoSha256 = "1spvyyzk711g4ik1pv21xaasy7va5l5gcvbfkamfv4ijn0wz4mjx";
+  k3sVendorHash = "sha256-ursq2Vq1J9MdkwDl3kKioxizhR46yo2urNc3VpwVH2A=";
   chartVersions = import ./chart-versions.nix;
   k3sRootVersion = "0.12.2";
   k3sRootSha256 = "1gjynvr350qni5mskgm7pcc7alss4gms4jmkiv453vs8mmma9c9k";
-  k3sCNIVersion = "1.3.0-k3s1";
-  k3sCNISha256 = "0zma9g4wvdnhs9igs03xlx15bk2nq56j73zns9xgqmfiixd9c9av";
-  containerdVersion = "1.7.6-k3s1.26";
-  containerdSha256 = "1bj7nggfmkrrgm5yk08p665z1mw1y376k4g3vjbkqldfglzpx7sq";
+  k3sCNIVersion = "1.4.0-k3s2";
+  k3sCNISha256 = "17dg6jgjx18nrlyfmkv14dhzxsljz4774zgwz5dchxcf38bvarqa";
+  containerdVersion = "1.7.11-k3s2.26";
+  containerdSha256 = "0413a81kzb05xkklwyngg8g6a0w4icsi938rim69jmr2sijc89ww";
   criCtlVersion = "1.26.0-rc.0-k3s1";
 }

--- a/pkgs/applications/networking/cluster/k3s/1_27/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_27/versions.nix
@@ -1,13 +1,13 @@
 {
-  k3sVersion = "1.27.9+k3s1";
-  k3sCommit = "2c249a39358bd36438ab53aedef5487d950fd558";
-  k3sRepoSha256 = "16zcp1ih34zpz6115ivbcs49n5yikgj8mpiv177jvvb2vakmkgv6";
-  k3sVendorHash = "sha256-zvoBN1mErSXovv/xVzjntHyZjVyCfPzsOdlcTSIwKus=";
+  k3sVersion = "1.27.11+k3s1";
+  k3sCommit = "06d6bc80b469a61e5e90438b1f2639cd136a89e7";
+  k3sRepoSha256 = "0qkm8yqs9p34kb5k2q0j5wiykj78qc12n65n0clas5by23jrqcqa";
+  k3sVendorHash = "sha256-+z8pr30+28puv7yjA7ZvW++I0ipNEmen2OhCxFMzYOY=";
   chartVersions = import ./chart-versions.nix;
   k3sRootVersion = "0.12.2";
   k3sRootSha256 = "1gjynvr350qni5mskgm7pcc7alss4gms4jmkiv453vs8mmma9c9k";
-  k3sCNIVersion = "1.3.0-k3s1";
-  k3sCNISha256 = "0zma9g4wvdnhs9igs03xlx15bk2nq56j73zns9xgqmfiixd9c9av";
+  k3sCNIVersion = "1.4.0-k3s2";
+  k3sCNISha256 = "17dg6jgjx18nrlyfmkv14dhzxsljz4774zgwz5dchxcf38bvarqa";
   containerdVersion = "1.7.11-k3s2.27";
   containerdSha256 = "0xjxc5dgh3drk2glvcabd885damjffp9r4cs0cm1zgnrrbhlipra";
   criCtlVersion = "1.26.0-rc.0-k3s1";

--- a/pkgs/applications/networking/cluster/k3s/builder.nix
+++ b/pkgs/applications/networking/cluster/k3s/builder.nix
@@ -187,13 +187,12 @@ let
 
     patches =
       # Disable: Add runtime checking of golang version
-      lib.optional (lib.versionAtLeast k3sVersion "1.28")
-        (fetchpatch {
-          # https://github.com/k3s-io/k3s/pull/9054
-          url = "https://github.com/k3s-io/k3s/commit/b297996b9252b02e56e9425f55f6becbf6bb7832.patch";
-          hash = "sha256-xBOY2jnLhT9dtVKtq26V9QUnuX1q6E/9UcO9IaU719U=";
-          revert = true;
-        });
+      (fetchpatch {
+        # https://github.com/k3s-io/k3s/pull/9054
+        url = "https://github.com/k3s-io/k3s/commit/b297996b9252b02e56e9425f55f6becbf6bb7832.patch";
+        hash = "sha256-xBOY2jnLhT9dtVKtq26V9QUnuX1q6E/9UcO9IaU719U=";
+        revert = true;
+      });
 
     nativeBuildInputs = [ pkg-config ];
     buildInputs = [ libseccomp sqlite.dev ];

--- a/pkgs/applications/networking/cluster/k3s/update-script.sh
+++ b/pkgs/applications/networking/cluster/k3s/update-script.sh
@@ -25,8 +25,8 @@ LATEST_TAG_NAME=$(jq 'map(.tag_name)' ${LATEST_TAG_RAWFILE} | \
 K3S_VERSION=$(echo ${LATEST_TAG_NAME} | sed 's/^v//')
 
 K3S_COMMIT=$(curl --silent -f ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} \
-    https://api.github.com/repos/k3s-io/k3s/tags \
-    | jq -r "map(select(.name == \"${LATEST_TAG_NAME}\")) | .[0] | .commit.sha")
+    https://api.github.com/repos/k3s-io/k3s/git/refs/tags \
+    | jq -r "map(select(.ref == \"refs/tags/${LATEST_TAG_NAME}\")) | .[0] | .object.sha")
 
 K3S_REPO_SHA256=$(nix-prefetch-url --quiet --unpack https://github.com/k3s-io/k3s/archive/refs/tags/${LATEST_TAG_NAME}.tar.gz)
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -32547,10 +32547,8 @@ with pkgs;
   jwm-settings-manager = callPackage ../applications/window-managers/jwm/jwm-settings-manager.nix { };
 
   inherit (callPackage ../applications/networking/cluster/k3s {
-    buildGoModule = buildGo120Module;
-  }) k3s_1_26 k3s_1_27 k3s_1_28;
-  inherit (callPackage ../applications/networking/cluster/k3s { }) k3s_1_29;
-
+    buildGoModule = buildGo121Module;
+  }) k3s_1_26 k3s_1_27 k3s_1_28 k3s_1_29;
   k3s = k3s_1_29;
 
   k3sup = callPackage ../applications/networking/cluster/k3sup { };


### PR DESCRIPTION
k3s: fix update script for 1.26, 1.27
k3s: pin go version to k3s go.mod
k3s: remove restriction on runtime checking of golang version
k3s_1_27: 1.27.9+k3s1 -> 1.27.11+k3s1
k3s_1_26: 1.26.9+k3s1 -> 1.26.14+k3s1

In nixpkgs, to update:
> pkgs/applications/networking/cluster/k3s/update-script.sh "26"
> pkgs/applications/networking/cluster/k3s/update-script.sh "27"

To test build:
> nix build .#k3s_1_27.passthru.tests.{single-node,multi-node,etcd}
> nix build .#k3s_1_26.passthru.tests.{single-node,multi-node,etcd}