### PR TITLE
tmuxPlugins.tmux-window-name: init at unstable

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19200,6 +19200,12 @@
     githubId = 137805;
     name = "Alexander Tsvyashchenko";
   };
+  ndom91 = {
+    email = "nix@ndo.dev";
+    github = "ndom91";
+    githubId = 7415984;
+    name = "Nico Domino";
+  };
   nealfennimore = {
     email = "hi@neal.codes";
     github = "nealfennimore";

--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -1236,7 +1236,7 @@ in
     '';
     meta = with lib; {
       homepage = "https://github.com/ofirgall/tmux-window-name";
-      description = "A plugin to name your tmux windows smartly, like IDE's";
+      description = "Tmux plugin to name your windows smartly, like IDE's";
       license = licenses.mit;
       platforms = platforms.unix;
       maintainers = with maintainers; [ ndom91 ];

--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -1203,6 +1203,45 @@ in
       maintainers = with lib.maintainers; [ szaffarano ];
     };
   };
+
+  tmux-window-name = mkTmuxPlugin {
+    pluginName = "tmux-window-name";
+    version = "2024-03-08";
+    src = fetchFromGitHub {
+      owner = "ofirgall";
+      repo = "tmux-window-name";
+      rev = "34026b6f442ceb07628bf25ae1b04a0cd475e9ae";
+      sha256 = "sha256-BNgxLk/BkaQkGlB4g2WKVs39y4VHL1Y2TdTEoBy7yo0=";
+    };
+    nativeBuildInputs = [ pkgs.makeWrapper ];
+    rtpFilePath = "tmux_window_name.tmux";
+    postInstall = ''
+      # Update USR_BIN_REMOVER with .nix-profile PATH
+      sed -i "s|^USR_BIN_REMOVER.*|USR_BIN_REMOVER = (r\'^/home/${config.home.username}/.nix-profile/bin/(.+)( --.*)?\', r\'\\\g<1>\')|" $target/scripts/rename_session_windows.py
+
+      # Update substitute_sets with .nix-profile PATHs
+      sed -i "s|^\ssubstitute_sets: List.*|    substitute_sets: List[Tuple] = field(default_factory=lambda: [(\'/home/${config.home.username}/.nix-profile/bin/(.+) --.*\', \'\\\g<1>\'), (r\'.+ipython([32])\', r\'ipython\\\g<1>\'), USR_BIN_REMOVER, (r\'(bash) (.+)/(.+[ $])(.+)\', \'\\\g<3>\\\g<4>\')])|" $target/scripts/rename_session_windows.py
+
+      # Update dir_programs with .nix-profile PATH for applications
+      sed -i "s|^\sdir_programs: List.*|    dir_programs: List[str] = field(default_factory=lambda: [['/home/${config.home.username}/.nix-profile/bin/vim', '/home/${config.home.username}/.nix-profile/bin/vi', '/home/${config.home.username}/.nix-profile/bin/git', '/home/${config.home.username}/.nix-profile/bin/nvim']])|" $target/scripts/rename_session_windows.py
+
+      for f in tmux_window_name.tmux scripts/rename_session_windows.py; do
+        wrapProgram $target/$f \
+          --prefix PATH : ${lib.makeBinPath [(pkgs.python3.withPackages (p: with p; [
+              libtmux
+              pip
+            ]))
+          ]}
+      done
+    '';
+    meta = with lib; {
+      homepage = "https://github.com/ofirgall/tmux-window-name";
+      description = "A plugin to name your tmux windows smartly, like IDE's";
+      license = licenses.mit;
+      platforms = platforms.unix;
+      maintainers = with maintainers; [ ndom91 ];
+    };
+  };
 }
 // lib.optionalAttrs config.allowAliases {
   mkDerivation = throw "tmuxPlugins.mkDerivation is deprecated, use tmuxPlugins.mkTmuxPlugin instead"; # added 2021-03-14

--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -1227,11 +1227,16 @@ in
 
       for f in tmux_window_name.tmux scripts/rename_session_windows.py; do
         wrapProgram $target/$f \
-          --prefix PATH : ${lib.makeBinPath [(pkgs.python3.withPackages (p: with p; [
-              libtmux
-              pip
-            ]))
-          ]}
+          --prefix PATH : ${
+            lib.makeBinPath [
+              (pkgs.python3.withPackages (
+                p: with p; [
+                  libtmux
+                  pip
+                ]
+              ))
+            ]
+          }
       done
     '';
     meta = with lib; {

--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -1216,14 +1216,13 @@ in
     nativeBuildInputs = [ pkgs.makeWrapper ];
     rtpFilePath = "tmux_window_name.tmux";
     postInstall = ''
-      # Update USR_BIN_REMOVER with .nix-profile PATH
-      sed -i "s|^USR_BIN_REMOVER.*|USR_BIN_REMOVER = (r\'^/home/${config.home.username}/.nix-profile/bin/(.+)( --.*)?\', r\'\\\g<1>\')|" $target/scripts/rename_session_windows.py
+      script=$target/scripts/rename_session_windows.py
 
-      # Update substitute_sets with .nix-profile PATHs
-      sed -i "s|^\ssubstitute_sets: List.*|    substitute_sets: List[Tuple] = field(default_factory=lambda: [(\'/home/${config.home.username}/.nix-profile/bin/(.+) --.*\', \'\\\g<1>\'), (r\'.+ipython([32])\', r\'ipython\\\g<1>\'), USR_BIN_REMOVER, (r\'(bash) (.+)/(.+[ $])(.+)\', \'\\\g<3>\\\g<4>\')])|" $target/scripts/rename_session_windows.py
-
-      # Update dir_programs with .nix-profile PATH for applications
-      sed -i "s|^\sdir_programs: List.*|    dir_programs: List[str] = field(default_factory=lambda: [['/home/${config.home.username}/.nix-profile/bin/vim', '/home/${config.home.username}/.nix-profile/bin/vi', '/home/${config.home.username}/.nix-profile/bin/git', '/home/${config.home.username}/.nix-profile/bin/nvim']])|" $target/scripts/rename_session_windows.py
+      sed -i \
+        -e 's|^USR_BIN_REMOVER.*|USR_BIN_REMOVER = (r"^" + os.path.expanduser("~") + r"/.nix-profile/bin/(.+)( --.*)?", r"\\g<1>")|' \
+        -e 's|^\(\s*\)substitute_sets: List.*|\1substitute_sets: List[Tuple] = field(default_factory=lambda: [(os.path.expanduser("~") + r"/.nix-profile/bin/(.+) --.*", r"\\g<1>"), (r".+ipython([32])", r"ipython\\g<1>"), USR_BIN_REMOVER, (r"(bash) (.+)/(.+[ $])(.+)", r"\\g<3>\\g<4>")])|' \
+        -e 's|^\(\s*\)dir_programs: List.*|\1dir_programs: List[str] = field(default_factory=lambda: [os.path.expanduser("~") + "/.nix-profile/bin/" + p for p in ["vim", "vi", "git", "nvim"]])|' \
+        $script
 
       for f in tmux_window_name.tmux scripts/rename_session_windows.py; do
         wrapProgram $target/$f \


### PR DESCRIPTION
## Description of changes

- Adds [tmux-window-name](https://github.com/ofirgall/tmux-window-name/tree/master) tmux plugin to `tmuxPlugins`.
- This plugin automatically renames windows based on the active windows active process and/or current working directory.
- This plugin requires interacting with the python `libtmux`, whose path is hardcoded into the shipped python scripts. So I did a few `sed` replacements in the `postInstall` step to patch for NixOS.
	- First, the entry file runs `python3 -m pip list` to check whether `libtmux` is available. This is handled by the wrapped script and its python env
	- Then, since its point is to check the running process and modify tmux window names to the respective applications, it required changes of the path it checks for the binaries, for example, to `$HOME/.nix-profile/bin/*` in a few places. 
	- It does a good bit of regex replacement to get the active program, active path, etc. so those needed patching as well
	
	
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
