### PR TITLE
python312Packages.bidict: minor fixes

### DIFF
--- a/pkgs/development/python-modules/bidict/default.nix
+++ b/pkgs/development/python-modules/bidict/default.nix
@@ -2,16 +2,12 @@
 , buildPythonPackage
 , fetchFromGitHub
 , setuptools
-, sphinx
 , hypothesis
-, py
 , pytest-xdist
 , pytestCheckHook
-, pytest-benchmark
-, sortedcollections
-, sortedcontainers
 , typing-extensions
 , pythonOlder
+, wheel
 }:
 
 buildPythonPackage rec {
@@ -19,7 +15,7 @@ buildPythonPackage rec {
   version = "0.23.1";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "jab";
@@ -28,31 +24,31 @@ buildPythonPackage rec {
     hash = "sha256-WE0YaRT4a/byvU2pzcByuf1DfMlOpYA9i0PPrKXsS+M=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
-  ];
-
-  propagatedBuildInputs = [
-    sphinx
+    wheel
   ];
 
   nativeCheckInputs = [
     hypothesis
-    py
     pytest-xdist
     pytestCheckHook
-    pytest-benchmark
-    sortedcollections
-    sortedcontainers
     typing-extensions
+  ];
+
+  pytestFlagsArray = [
+    # Pass -c /dev/null so that pytest does not use the bundled pytest.ini, which adds
+    # options to run additional integration tests that are overkill for our purposes.
+    "-c"
+    "/dev/null"
   ];
 
   pythonImportsCheck = [ "bidict" ];
 
   meta = with lib; {
-    homepage = "https://github.com/jab/bidict";
-    changelog = "https://github.com/jab/bidict/blob/v${version}/CHANGELOG.rst";
-    description = "Efficient, Pythonic bidirectional map data structures and related functionality";
+    homepage = "https://bidict.readthedocs.io";
+    changelog = "https://bidict.readthedocs.io/changelog.html";
+    description = "The bidirectional mapping library for Python.";
     license = licenses.mpl20;
     maintainers = with maintainers; [ jakewaksbaum ];
   };


### PR DESCRIPTION
I am the author and maintainer of bidict. I noticed some issues with the nix package for it and thought I'd contribute some fixes (see below). This is my first PR to nixpkgs and I hope to contribute more in the future.


## Description of changes

* Correct minimum supported Python version.

  Bidict 0.23.1 (which nixpkgs recently updated to) dropped support for Python < 3.8.

  Ref: https://bidict.readthedocs.io/changelog.html

* Skip unnecessary integration tests.

  * Don't build and test the Sphinx docs or benchmarks, as this is overkill.
  * Drop associated dependencies from `nativeCheckInputs` now that they're not needed.

* Drop `py` dependency from nativeCheckInputs. `pytest` no longer depends on `py`.

  Ref: https://docs.pytest.org/en/7.4.x/changelog.html#deprecations

* Fix metadata:

  * Update outdated description string.

  * Use better homepage and changelog links.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
