### PR TITLE
libtins: 4.4 -> 4.5

### DIFF
--- a/pkgs/applications/networking/compactor/default.nix
+++ b/pkgs/applications/networking/compactor/default.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "dns-stats";
-    repo = pname;
+    repo = "compactor";
     rev = version;
     fetchSubmodules = true;
     hash = "sha256-5Z14suhO5ghhmZsSj4DsSoKm+ct2gQFO6qxhjmx4Xm4=";
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Tools to capture DNS traffic and record it in C-DNS files";
     homepage    = "https://dns-stats.org/";
-    changelog   = "https://github.com/dns-stats/${pname}/raw/${version}/ChangeLog.txt";
+    changelog   = "https://github.com/dns-stats/compactor/raw/${version}/ChangeLog.txt";
     license     = licenses.mpl20;
     maintainers = with maintainers; [ fdns ];
     platforms   = platforms.unix;

--- a/pkgs/development/libraries/libtins/default.nix
+++ b/pkgs/development/libraries/libtins/default.nix
@@ -12,7 +12,8 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    # Required for gtest 1.13+.
+    # Required for gtest 1.13+, see also upstream report at:
+    # https://github.com/mfontanini/libtins/issues/529
     ./0001-force-cpp-14.patch
   ];
 

--- a/pkgs/development/libraries/libtins/default.nix
+++ b/pkgs/development/libraries/libtins/default.nix
@@ -1,25 +1,17 @@
-{ boost, cmake, fetchFromGitHub, fetchpatch, gtest, libpcap, openssl, lib, stdenv }:
+{ boost, cmake, fetchFromGitHub, gtest, libpcap, openssl, lib, stdenv }:
 
 stdenv.mkDerivation rec {
   pname = "libtins";
-  version = "4.4";
+  version = "4.5";
 
   src = fetchFromGitHub {
     owner = "mfontanini";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-mXbinXh/CO0SZZ71+K+FozbHCCoi12+AIa2o+P0QmUw=";
+    sha256 = "sha256-zL4C2Cgs9Y3NebL8MPQBO5j8Bm6xhl8ZggQBPJLRn0o=";
   };
 
   patches = [
-    # Pull gcc-13 fixes:
-    #   https://github.com/mfontanini/libtins/pull/496
-    # TODO: remove when upgrade to the next version.
-    (fetchpatch {
-      name = "gcc-13.patch";
-      url = "https://github.com/mfontanini/libtins/commit/812be7966d445ec56e88eab512f8fd2d57152427.patch";
-      hash = "sha256-5RCFPe95r1CBrAocjTPR2SvUlgaGa1aBc8RazyxUj3M=";
-    })
     # Required for gtest 1.13+.
     ./0001-force-cpp-14.patch
   ];


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
