### PR TITLE
gcc: link $lib/lib -> $lib/$targetConfig correctly and consistently

### DIFF
--- a/pkgs/development/compilers/gcc/common/builder.nix
+++ b/pkgs/development/compilers/gcc/common/builder.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , enableMultilib
+, targetConfig
 }:
 
 let
@@ -195,6 +196,13 @@ originalAttrs: (stdenv.mkDerivation (finalAttrs: originalAttrs // {
   preInstall = ''
     mkdir -p "$out/''${targetConfig}/lib"
     mkdir -p "''${!outputLib}/''${targetConfig}/lib"
+  '' +
+  # if cross-compiling, link from $lib/lib to $lib/${targetConfig}.
+  # since native-compiles have $lib/lib as a directory (not a
+  # symlink), this ensures that in every case we can assume that
+  # $lib/lib contains the .so files
+  lib.optionalString (with stdenv; targetPlatform.config != hostPlatform.config) ''
+    ln -Ts "''${!outputLib}/''${targetConfig}/lib" $lib/lib
   '' +
   # Make `lib64` symlinks to `lib`.
   lib.optionalString (!enableMultilib && stdenv.hostPlatform.is64bit && !stdenv.hostPlatform.isMips64n32) ''

--- a/pkgs/development/compilers/gcc/common/libgcc.nix
+++ b/pkgs/development/compilers/gcc/common/libgcc.nix
@@ -83,10 +83,6 @@ in
     lib.optionalString (!langC) ''
       rm -f $out/lib/libgcc_s.so*
     ''
-    + lib.optionalString (hostPlatform != targetPlatform) ''
-      mkdir -p $lib/lib/
-      ln -s ${targetPlatformSlash}lib $lib/lib
-    ''
 
     # TODO(amjoseph): remove the `libgcc_s.so` symlinks below and replace them
     # with a `-L${gccForLibs.libgcc}/lib` in cc-wrapper's

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -103,6 +103,7 @@ let inherit version;
     disableBootstrap = atLeast11 && !stdenv.hostPlatform.isDarwin && (atLeast12 -> !profiledCompiler);
 
     inherit (stdenv) buildPlatform hostPlatform targetPlatform;
+    targetConfig = if targetPlatform != hostPlatform then targetPlatform.config else null;
 
     patches = callFile ./patches {};
 
@@ -124,6 +125,7 @@ let inherit version;
         buildPlatform
         hostPlatform
         targetPlatform
+        targetConfig
         patches
         crossMingw
         stageNameAddon
@@ -329,7 +331,7 @@ lib.pipe ((callFile ./common/builder.nix {}) ({
     ++ optional (is7 && targetPlatform.isAarch64) "--enable-fix-cortex-a53-843419"
     ++ optional (is7 && targetPlatform.isNetBSD) "--disable-libcilkrts";
 
-  targetConfig = if targetPlatform != hostPlatform then targetPlatform.config else null;
+  inherit targetConfig;
 
   buildFlags =
     # we do not yet have Nix-driven profiling


### PR DESCRIPTION
> [!Note]
>
> This PR is a re-upload of #282236 (part of https://github.com/NixOS/nixpkgs/issues/284796)

> When native-compiling, gcc will install libraries into:
> 
>   /nix/store/...-$targetConfig-gcc-$version-lib/lib
> 
> When cross-compiling, gcc will install libraries into:
> 
>   /nix/store/...-$targetConfig-gcc-$version-lib/$targetConfig
> 
> When cross-compiling, we intended to create a link from $lib/lib to $lib/$targetConfig, so that downstream users can always safely assume that "${lib.getLib stdenv.cc.cc}/lib" is where the gcc libraries are, regardless of whether `stdenv.cc.cc` is a cross compiler or a native compiler.
> 
> Unfortunately, there were two problems with how we were trying to create these links:
> 
> 1. The link would be created only when `enableLibGccOutput==true`
> 
> 2. The link was being created from the incorrect source `$lib/lib/lib` instead of `$lib/lib`.
> 
> Both of these mistakes are my fault.  This commit corrects them by creating the link using `ln -Ts` (which is more predictable) and by creating the link from `gcc/common/builder.nix` rather than from `gcc/common/libgcc.nix`.
> 
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

