### PR TITLE
magma: fix test libs with static builds; fix 2.6.x build error

### DIFF
--- a/pkgs/development/libraries/science/math/magma/generic.nix
+++ b/pkgs/development/libraries/science/math/magma/generic.nix
@@ -182,7 +182,7 @@ stdenv.mkDerivation {
     # because it has no files to install.
     + ''
       install -Dm755 ./testing/testing_* ./sparse/testing/testing_* -t "$test/bin/"
-      install -Dm755 ./lib/libtester.so ./lib/liblapacktest.so -t "$test/lib/"
+      install -Dm755 ./lib/lib*test*.* -t "$test/lib/"
     ''
     # All of the test executables and libraries will have a reference to the build directory in their RPATH, which we
     # must remove. We do this by shrinking the RPATH to only include the Nix store. The autoPatchelfHook will take care

--- a/pkgs/development/libraries/science/math/magma/generic.nix
+++ b/pkgs/development/libraries/science/math/magma/generic.nix
@@ -8,11 +8,11 @@
 { autoPatchelfHook
 , blas
 , cmake
+, cudaPackages_11 ? null
 , cudaPackages
 , cudaSupport ? config.cudaSupport
 , fetchurl
 , gfortran
-, cudaCapabilities ? cudaPackages.cudaFlags.cudaCapabilities
 , gpuTargets ? [ ] # Non-CUDA targets, that is HIP
 , rocmPackages
 , lapack
@@ -32,8 +32,17 @@
 
 let
   inherit (lib) lists strings trivial;
-  inherit (cudaPackages) cudaAtLeast cudaFlags cudaOlder;
   inherit (magmaRelease) version hash supportedGpuTargets;
+
+  # Per https://icl.utk.edu/magma/downloads, support for CUDA 12 wasn't added until 2.7.1.
+  # If we're building a version prior to that, use the latest release of the 11.x series.
+  effectiveCudaPackages =
+    if strings.versionOlder version "2.7.1"
+    then cudaPackages_11
+    else cudaPackages;
+
+  inherit (effectiveCudaPackages) cudaAtLeast cudaFlags cudaOlder;
+  inherit (cudaFlags) cudaCapabilities;
 
   # NOTE: The lists.subtractLists function is perhaps a bit unintuitive. It subtracts the elements
   #   of the first list *from* the second list. That means:
@@ -115,7 +124,7 @@ stdenv.mkDerivation {
     ninja
     gfortran
   ] ++ lists.optionals cudaSupport [
-    cudaPackages.cuda_nvcc
+    effectiveCudaPackages.cuda_nvcc
   ];
 
   buildInputs = [
@@ -123,7 +132,7 @@ stdenv.mkDerivation {
     lapack
     blas
     python3
-  ] ++ lists.optionals cudaSupport (with cudaPackages; [
+  ] ++ lists.optionals cudaSupport (with effectiveCudaPackages; [
     cuda_cudart.dev # cuda_runtime.h
     cuda_cudart.lib # cudart
     cuda_cudart.static # cudart_static
@@ -173,6 +182,7 @@ stdenv.mkDerivation {
     # TODO(@connorbaker): This should be handled by having CMakeLists.txt install them, but such a patch is
     # out of the scope of the PR which introduces the `test` output: https://github.com/NixOS/nixpkgs/pull/283777.
     # See https://github.com/NixOS/nixpkgs/pull/283777#discussion_r1482125034 for more information.
+    # Such work is tracked by https://github.com/NixOS/nixpkgs/issues/296286.
     ''
       install -Dm755 ../testing/run_{tests,summarize}.py -t "$test/bin/"
     ''
@@ -196,7 +206,8 @@ stdenv.mkDerivation {
     '';
 
   passthru = {
-    inherit cudaPackages cudaSupport rocmSupport gpuTargets;
+    inherit cudaSupport rocmSupport gpuTargets;
+    cudaPackages = effectiveCudaPackages;
   };
 
   meta = with lib; {
@@ -210,6 +221,7 @@ stdenv.mkDerivation {
     broken =
       !(cudaSupport || rocmSupport) # At least one back-end enabled
       || (cudaSupport && rocmSupport) # Mutually exclusive
-      || (cudaSupport && cudaOlder "9.0");
+      || (cudaSupport && cudaOlder "9.0")
+      || (cudaSupport && strings.versionOlder version "2.7.1" && cudaPackages_11 == null);
   };
 }


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixup required by #283777, which specifically copied dynamic libraries that are not present in a static build. This caused breakage for the PyTorch CUDA build because it uses a static build of Magma.

Additionally, fixes an error caused by trying to build MAGMA 2.6.x with CUDA 12 -- MAGMA 2.7.1 was the first to add support for CUDA 12 (per changelogs on https://icl.utk.edu/magma/downloads).

Fixes #296293.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
