### PR TITLE
lib.foldl': avoid unnecessary function call

### DIFF
--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -254,13 +254,11 @@ rec {
   foldl' =
     op:
     acc:
-    list:
-
     # The builtin `foldl'` is a bit lazier than one might expect.
     # See https://github.com/NixOS/nix/pull/7158.
     # In particular, the initial accumulator value is not forced before the first iteration starts.
     builtins.seq acc
-      (builtins.foldl' op acc list);
+      (builtins.foldl' op acc);
 
   /**
     Map with index starting from 0

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -228,7 +228,15 @@ rec {
 
     `acc`
 
-    : The initial accumulator value
+    : The initial accumulator value.
+
+      The accumulator value is evaluated in any case before the first iteration starts.
+
+      To avoid evaluation even before the `list` argument is given an eta expansion can be used:
+
+      ```nix
+      list: lib.foldl' op acc list
+      ```
 
     `list`
 


### PR DESCRIPTION
## Description of changes

By removing the explicit eta wrapping with `list` we can save a function call here.

As a performance benchmark i ran a nested foldl' on a 1000 x 1000 matrix. (Just summing up the numbers) As expected observing 1000 less function calls to the nested foldl' 

before:

```json
{
  "cpuTime": 0.1041790023446083,
  "envs": {
    "bytes": 72144128,
    "elements": 3006008,
    "number": 3006004
  },
  "gc": {
    "heapSize": 402915328,
    "totalBytes": 200372352
  },
  "list": {
    "bytes": 8008016,
    "concats": 0,
    "elements": 1001002
  },
  "nrAvoided": 7008,
  "nrFunctionCalls": 3006003,
  "nrLookups": 3003,
  "nrOpUpdateValuesCopied": 0,
  "nrOpUpdates": 0,
  "nrPrimOpCalls": 3003,
  "nrThunks": 3007,
  "sets": {
    "bytes": 2256,
    "elements": 137,
    "number": 4
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 16,
    "Env": 16,
    "Value": 24
  },
  "symbols": {
    "bytes": 2346,
    "number": 260
  },
  "values": {
    "bytes": 72123072,
    "number": 3005128
  }
}
```` 

After: 

```json
{
  "cpuTime": 0.07409100234508514,
  "envs": {
    "bytes": 72120104,
    "elements": 3005007,
    "number": 3005003
  },
  "gc": {
    "heapSize": 402915328,
    "totalBytes": 200405120
  },
  "list": {
    "bytes": 8008016,
    "concats": 0,
    "elements": 1001002
  },
  "nrAvoided": 6007,
  "nrFunctionCalls": 3005002,
  "nrLookups": 3003,
  "nrOpUpdateValuesCopied": 0,
  "nrOpUpdates": 0,
  "nrPrimOpCalls": 3003,
  "nrThunks": 3007,
  "sets": {
    "bytes": 2256,
    "elements": 137,
    "number": 4
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 16,
    "Env": 16,
    "Value": 24
  },
  "symbols": {
    "bytes": 2346,
    "number": 260
  },
  "values": {
    "bytes": 72171120,
    "number": 3007130
  }
}
```

Not sure if it is worth merging. Impacts on nested foldl' (inside of other loops) should be more noticeable than on non-nested ones. 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
