### PR TITLE
x509-limbo: init at unstable-2024-03-13

### DIFF
--- a/pkgs/by-name/x5/x509-limbo/package.nix
+++ b/pkgs/by-name/x5/x509-limbo/package.nix
@@ -1,0 +1,48 @@
+{ lib
+, fetchFromGitHub
+, python3
+, x509-limbo
+}:
+
+python3.pkgs.buildPythonPackage {
+  pname = "x509-limbo";
+  version = "unstable-2024-03-13";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "C2SP";
+    repo = "x509-limbo";
+    rev = "a04fb05cf132e1405f71c12616cf0aead829909a";
+    hash = "sha256-TA4ciHkXg/RKzcIs2bwpx7CxsQDyQMG636Rr74xPsBA=";
+  };
+
+  dependencies = with python3.pkgs; [
+    flit-core
+
+    requests
+    pydantic
+    jinja2
+    cryptography
+    pyopenssl
+    pyyaml
+    certvalidator
+    certifi
+  ];
+
+  postInstall = ''
+    mkdir -p $out/share
+    cp limbo.json $out/share/
+
+    wrapProgram $out/bin/limbo \
+      --append-flags "--limbo $out/share/limbo.json"
+  '';
+
+  meta = with lib; {
+    homepage = "https://x509-limbo.com/";
+    description = "A suite of testvectors for X.509 certificate path validation and tools for building them ";
+
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ baloo ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This adds the x509-limbo wrapper used to test x509 path validation implementations

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
