### PR TITLE
laurel: 0.6.0 -> 0.6.1

### DIFF
--- a/pkgs/servers/monitoring/laurel/default.nix
+++ b/pkgs/servers/monitoring/laurel/default.nix
@@ -1,33 +1,21 @@
 { acl
 , fetchFromGitHub
-, fetchpatch
 , lib
 , rustPlatform
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "laurel";
-  version = "0.6.0";
+  version = "0.6.1";
 
   src = fetchFromGitHub {
     owner = "threathunters-io";
     repo = "laurel";
     rev = "refs/tags/v${version}";
-    hash = "sha256-lWVrp0ytomrQBSDuQCMFJpSuAuwjSYPwoE4yh/WO2ls=";
+    hash = "sha256-dGgBcugIQ3ZPnqyTw6wRMN2PZLm6GqobeFZ1/uzMKbs=";
   };
 
-  cargoHash = "sha256-GY7vpst+Epsy/x/ths6pwtGQgM6Bx0KI+NsCMFCBujE=";
-
-  cargoPatches = [
-    # Upstream forgot to bump the Cargo.lock before tagging the release.
-    # This patch is the first commit immediately after the tag fixing this mistake.
-    # Needs to be removed next release.
-    (fetchpatch {
-      name = "Cargo-lock-version-bump.patch";
-      url = "https://github.com/threathunters-io/laurel/commit/f38393d1098e8f75394f83ad3da5c1160fb96652.patch";
-      hash = "sha256-x+7p21X38KYqLclFtGnLO5nOHz819+XTaSPMvDbSo/I=";
-    })
-  ];
+  cargoHash = "sha256-8JNLssWTCfwrfQ/jg/rj7BUo9bCNCsM2RDwPI7cacRw=";
 
   nativeBuildInputs = [ rustPlatform.bindgenHook ];
   buildInputs = [ acl ];


### PR DESCRIPTION
## Description of changes

https://github.com/threathunters-io/laurel/releases/tag/v0.6.1

diff: https://github.com/threathunters-io/laurel/compare/v0.6.0...v0.6.1

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
