### PR TITLE
python312Packages.diffimg: fix test

### DIFF
--- a/pkgs/development/python-modules/diffimg/default.nix
+++ b/pkgs/development/python-modules/diffimg/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , pillow
 , unittestCheckHook
+, pythonAtLeast
 }:
 
 buildPythonPackage rec {
@@ -21,7 +22,10 @@ buildPythonPackage rec {
   # fix offered to upstream https://github.com/nicolashahn/diffimg/pull/6
   postPatch = ''
     substituteInPlace diffimg/test.py \
-      --replace "from diff import diff" "from diffimg.diff import diff"
+      --replace-warn "from diff import diff" "from diffimg.diff import diff"
+  '' + lib.optionalString (pythonAtLeast "3.12") ''
+    substituteInPlace diffimg/test.py \
+      --replace-warn "3503192421617232" "3503192421617233"
   '';
 
   propagatedBuildInputs = [


### PR DESCRIPTION
python 3.12 seems to yield a very slightly different result
  change is the least significant digit of a ratio, seems safe

and upgrade to --replace-warn while i'm here

found via #291134 but shouldn't block it

affected line:
https://github.com/nicolashahn/diffimg/blob/b82f0bb416f100f9105ccccf1995872b29302461/diffimg/test.py#L80

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
