### PR TITLE
check-by-name: Update .envrc to avoid using deprecated command

### DIFF
--- a/pkgs/test/nixpkgs-check-by-name/.envrc
+++ b/pkgs/test/nixpkgs-check-by-name/.envrc
@@ -1,7 +1,1 @@
-if has nix_direnv_watch_file; then
-  nix_direnv_watch_file default.nix shell.nix
-else
-  watch_file default.nix shell.nix
-fi
-
 use nix


### PR DESCRIPTION
@infinisil I hope this isn't too trivial of a change! I'm new to contributing to nixpkgs and am not familiar with how much CI is going to get triggered by making a PR on master.

I tried to follow the branch and commit style I saw on some of your previous PRs / commits.

## Description of changes

Noticed the following warning:

```
direnv: `nix_direnv_watch_file` is deprecated - use `watch_file`
```

Which seems to come from here:

https://github.com/nix-community/nix-direnv/blob/6455f38a8dcf731dccd69aabef3f85ac962bfa8d/direnvrc#L207

So this commit just updates the `.envrc` to use the new command by default.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
