### PR TITLE
home-assistant-custom-components.moonraker: init at v1.1.1

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -18,6 +18,8 @@
 
   miele = callPackage ./miele {};
 
+  moonraker = callPackage ./moonraker {};
+
   omnik_inverter = callPackage ./omnik_inverter {};
 
   prometheus_sensor = callPackage ./prometheus_sensor {};

--- a/pkgs/servers/home-assistant/custom-components/moonraker/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/moonraker/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, fetchFromGitHub
+, buildHomeAssistantComponent
+, moonraker-api
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "marcolivierarsenault";
+  domain = "moonraker";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "marcolivierarsenault";
+    repo = "moonraker-home-assistant";
+    rev = "refs/tags/${version}";
+    hash = "sha256-jxMi4hmSVBU9ztoHxFINoJo8klirfo6j7gWty7FXFkQ=";
+  };
+
+  propagatedBuildInputs = [
+    moonraker-api
+  ];
+
+  #skip phases with nothing to do
+  dontConfigure = true;
+  dontBuild = true;
+  doCheck = false;
+
+  meta = with lib; {
+    changelog = "https://github.com/marcolivierarsenault/moonraker-home-assistant/releases/tag/${version}";
+    description = "Custom integration for Moonraker and Klipper in Home Assistant";
+    homepage = "https://github.com/marcolivierarsenault/moonraker-home-assistant";
+    maintainers = with maintainers; [ _9R ];
+    license = licenses.mit;
+  };
+}


### PR DESCRIPTION
## Description of changes

Inits [moonraker-home-assistant](https://github.com/marcolivierarsenault/moonraker-home-assistant) custom component at v1.1.1
Tested with HomeAssistant 24.3.0.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
