### PR TITLE
psst: Fix autoupdate script

### DIFF
--- a/pkgs/applications/audio/psst/default.nix
+++ b/pkgs/applications/audio/psst/default.nix
@@ -16,7 +16,7 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "psst";
-  version = "unstable-2024-03-04";
+  version = "unstable-2024-02-11";
 
   src = fetchFromGitHub {
     owner = "jpochyla";

--- a/pkgs/applications/audio/psst/update.sh
+++ b/pkgs/applications/audio/psst/update.sh
@@ -21,13 +21,10 @@ rev="$1"
 set -euo pipefail
 
 if [ -z "$rev" ]; then
-    response="$(wget -O- "${TOKEN_ARGS[@]}" "https://api.github.com/repos/jpochyla/psst/commits?per_page=1")"
-    rev="$(jq -r '.[0].sha' <<< "$response")"
-    date="$(jq -r '.[0].commit.author.date' <<< "$response" | cut -dT -f1)"
-else
-    response="$(wget -O- "${TOKEN_ARGS[@]}" "https://api.github.com/repos/jpochyla/psst/commits/$rev")"
-    date="$(jq -r '.commit.author.date' <<< "$response" | cut -dT -f1)"
+    rev="$(wget -O- "${TOKEN_ARGS[@]}" "https://api.github.com/repos/jpochyla/psst/commits?per_page=1" | jq -r '.[0].sha')"
 fi
+
+date="$(wget -O- "${TOKEN_ARGS[@]}" "https://api.github.com/repos/jpochyla/psst/commits/$rev" | jq -r '.commit.author.date' | cut -dT -f1)"
 
 version="unstable-$date"
 

--- a/pkgs/applications/audio/psst/update.sh
+++ b/pkgs/applications/audio/psst/update.sh
@@ -21,10 +21,15 @@ rev="$1"
 set -euo pipefail
 
 if [ -z "$rev" ]; then
-    rev="$(wget -O- "${TOKEN_ARGS[@]}" "https://api.github.com/repos/jpochyla/psst/commits?per_page=1" | jq -r '.[0].sha')"
+    response="$(wget -O- "${TOKEN_ARGS[@]}" "https://api.github.com/repos/jpochyla/psst/commits?per_page=1")"
+    rev="$(jq -r '.[0].sha' <<< "$response")"
+    date="$(jq -r '.[0].commit.author.date' <<< "$response" | cut -dT -f1)"
+else
+    response="$(wget -O- "${TOKEN_ARGS[@]}" "https://api.github.com/repos/jpochyla/psst/commits/$rev")"
+    date="$(jq -r '.commit.author.date' <<< "$response" | cut -dT -f1)"
 fi
 
-version="unstable-$(date +%F)"
+version="unstable-$date"
 
 # Sources
 src_hash=$(nix-prefetch-github jpochyla psst --rev "$rev" | jq -r .hash)


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The current update script that is used by @r-ryantm sets the package version to `unstable-$(date +%F)`. When I initially added psst, I [was told to](https://github.com/NixOS/nixpkgs/pull/151479#discussion_r817549368) set the package name to the date of the last commit:

> `unstable-XXXX-XX-XX` and replace XXXX-XX-XX with the date of the commit.

The current state of the update script will create update PRs that only update the package version even if nothing actually changed, such as https://github.com/NixOS/nixpkgs/pull/295215.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
`update.sh` now extracts the date from the GitHub API response and uses this value for the nixpkgs version.

One thing that remains unclear to me, is how we should handle the current diverging state. At the time of writing this PR, the [latest commit in jpochyla/psst](https://github.com/jpochyla/psst/commits/master/) is jpochyla/psst@0cb4f6964b5ba771182ccfe005260a86a494ef92 from 2024-02-11. So when running the script now, it would generate the nixkpgs version `unstable-2024-02-11` which is behind the (false) current nixpkgs version of `unstable-2024-03-04`. I'm not sure what will happen if @r-ryantm runs the script again. Would it generate a new PR for psst with an older version? Should we also include a check in `update.sh` to abort early, if the latest rev in the remote repo is the same as the one in nixpkgs?

Pinging relevant users: @peterhoeg, @ambroisie and @ryantm (especialy for my last question since I'm not sure how nixpkgs-update works in detail)

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
