### PR TITLE
[staging-next] python311Packages.{python-lsp-black,pylint}: fix build

### DIFF
--- a/pkgs/development/python-modules/pylint/default.nix
+++ b/pkgs/development/python-modules/pylint/default.nix
@@ -96,6 +96,8 @@ buildPythonPackage rec {
     "test_save_and_load_not_a_linter_stats"
     # Truncated string expectation mismatch
     "test_truncated_compare"
+    # Probably related to pytest versions, see pylint-dev/pylint#9477 and pylint-dev/pylint#9483
+    "test_functional"
     # AssertionError: assert [('specializa..., 'Ancestor')] == [('aggregatio..., 'Ancestor')]
     "test_functional_relation_extraction"
   ] ++ lib.optionals stdenv.isDarwin [

--- a/pkgs/development/python-modules/python-lsp-black/default.nix
+++ b/pkgs/development/python-modules/python-lsp-black/default.nix
@@ -7,6 +7,7 @@
 , python-lsp-server
 , setuptools
 , tomli
+, fetchpatch
 }:
 
 buildPythonPackage rec {
@@ -21,6 +22,17 @@ buildPythonPackage rec {
     rev = "refs/tags/v${version}";
     hash = "sha256-nV6mePSWzfPW2RwXg/mxgzfT9wD95mmTuPnPEro1kEY=";
   };
+
+  patches =
+    /** fix test failure with black<24.2.0;
+        remove this patch once python-lsp-black>2.0.0 */
+    lib.optional
+      (with lib; (versionOlder version "2.0.1") && (versionAtLeast black.version "24.2.0"))
+      (fetchpatch {
+        url = "https://patch-diff.githubusercontent.com/raw/python-lsp/python-lsp-black/pull/56.patch";
+        hash = "sha256-38bYU27+xtA8Kq3appXTkNnkG5/XgrUJ2nQ5+yuSU2U=";
+      })
+    ++ [ ];
 
   nativeBuildInputs = [
     setuptools


### PR DESCRIPTION
## Description of changes

**Note:** this is targeted at staging-next.
**Status:** nixpkgs-review completed on [github actions](https://github.com/bryango/nix-build-action/actions/runs/8309178726/job/22740247940).

### python-lsp-black
Some tests are [broken in the current staging-next](https://hydra.nixos.org/job/nixpkgs/staging-next/python311Packages.python-lsp-black.x86_64-linux) due to black version bump to v24.2.0. [Upstream fix](https://github.com/python-lsp/python-lsp-black/pull/56) is already available and scheduled for the next release. Fetch the patch for now until upstream releases 2.0.1.

### pylint
This is a dependency of `python-lsp-black` and it is also [failing on staging-next](https://hydra.nixos.org/job/nixpkgs/staging-next/python311Packages.pylint.x86_64-linux).

Similar failures have been observed upstream, but the fix has not landed yet, so we disable the failing `test_functional` with a comment linked to the upstream issues.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
