### PR TITLE
Add the conda package manager

### DIFF
--- a/pkgs/by-name/li/libmamba/package.nix
+++ b/pkgs/by-name/li/libmamba/package.nix
@@ -1,0 +1,60 @@
+{
+  fetchFromGitHub,
+  lib,
+  stdenv,
+  cmake,
+  fmt,
+  spdlog,
+  tl-expected,
+  nlohmann_json,
+  yaml-cpp,
+  simdjson,
+  reproc,
+  libsolv,
+  curl,
+  libarchive,
+  zstd,
+  bzip2,
+  python3Packages,
+}:
+stdenv.mkDerivation rec {
+  pname = "libmamba";
+  version = "1.5.7";
+  src = fetchFromGitHub {
+    owner = "mamba-org";
+    repo = "mamba";
+    rev = "${pname}-${version}";
+    hash = "sha256-HfmvLi9IBWlaGAn2Ej4Bnm4b3l19jEXwNl5IUkdVxi0=";
+  };
+  nativeBuildInputs = [
+    cmake
+    python3Packages.python
+  ];
+  buildInputs = [
+    fmt
+    spdlog
+    tl-expected
+    nlohmann_json
+    yaml-cpp
+    simdjson
+    reproc
+    libsolv
+    curl
+    libarchive
+    zstd
+    bzip2
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_LIBMAMBA" true)
+    (lib.cmakeBool "BUILD_SHARED" true)
+  ];
+
+  meta = {
+    description = "The library for the fast Cross-Platform Package Manager";
+    homepage = "https://github.com/mamba-org/mamba";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.ericthemagician ];
+  };
+}

--- a/pkgs/development/libraries/libsolv/default.nix
+++ b/pkgs/development/libraries/libsolv/default.nix
@@ -13,6 +13,7 @@
 , withRpm ? !stdenv.isDarwin
 , rpm
 , db
+, withConda ? true
 }:
 
 stdenv.mkDerivation rec {
@@ -23,11 +24,12 @@ stdenv.mkDerivation rec {
     owner = "openSUSE";
     repo = "libsolv";
     rev = version;
-    sha256 = "sha256-cL7SDwCzXM2qJQfiu/3nfAiFbcFNn1YXD23Sl3n9nzY=";
+    hash = "sha256-cL7SDwCzXM2qJQfiu/3nfAiFbcFNn1YXD23Sl3n9nzY=";
   };
 
   cmakeFlags = [
     "-DENABLE_COMPLEX_DEPS=true"
+    (lib.cmakeBool "ENABLE_CONDA" withConda)
     "-DENABLE_LZMA_COMPRESSION=true"
     "-DENABLE_BZIP2_COMPRESSION=true"
     "-DENABLE_ZSTD_COMPRESSION=true"

--- a/pkgs/development/python-modules/conda-libmamba-solver/default.nix
+++ b/pkgs/development/python-modules/conda-libmamba-solver/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonRelaxDepsHook,
+  fetchFromGitHub,
+  libmambapy,
+  hatchling,
+  hatch-vcs,
+  boltons,
+}:
+buildPythonPackage rec {
+  pname = "conda-libmamba-solver";
+  version = "24.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    inherit pname version;
+    owner = "conda";
+    repo = "conda-libmamba-solver";
+    rev = version;
+    hash = "sha256-vsUYrDVNMKHd3mlaAFYCP4uPQ9HxeKsose5O8InaMcE=";
+  };
+
+  nativeBuildInputs = [ pythonRelaxDepsHook ];
+
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
+
+  dependencies = [
+    boltons
+    libmambapy
+  ];
+
+  # this package depends on conda for the import to run succesfully, but conda depends on this package to execute.
+  # pythonImportsCheck = [ "conda_libmamba_solver" ];
+
+  pythonRemoveDeps = [ "conda" ];
+
+  meta = {
+    description = "The libmamba based solver for conda.";
+    homepage = "https://github.com/conda/conda-libmamba-solver";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.ericthemagician ];
+  };
+}

--- a/pkgs/development/python-modules/conda-package-handling/default.nix
+++ b/pkgs/development/python-modules/conda-package-handling/default.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  conda-package-streaming,
+}:
+buildPythonPackage rec {
+  pname = "conda-package-handling";
+  version = "2.2.0";
+  src = fetchFromGitHub {
+    owner = "conda";
+    repo = "conda-package-handling";
+    rev = version;
+    hash = "sha256-WeGfmT6lLwcwhheLBPMFcVMudY+zPsvTuXuOsiEAorQ=";
+  };
+
+  pyproject = true;
+  build-system = [ setuptools ];
+  dependencies = [ conda-package-streaming ];
+
+  pythonImportsCheck = [ "conda_package_handling" ];
+
+  meta = {
+    description = "Create and extract conda packages of various formats";
+    homepage = "https://github.com/conda/conda-package-handling";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.ericthemagician ];
+  };
+}

--- a/pkgs/development/python-modules/conda-package-streaming/default.nix
+++ b/pkgs/development/python-modules/conda-package-streaming/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  flit-core,
+  requests,
+  zstandard,
+}:
+buildPythonPackage rec {
+  pname = "conda-package-streaming";
+  version = "0.9.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "conda";
+    repo = "conda-package-streaming";
+    rev = "v${version}";
+    hash = "sha256-UTql2M+9eFDuHOwLYYKJ751wEcOfLJYzfU6+WF8Je2g=";
+  };
+
+  build-system = [ flit-core ];
+  dependencies = [
+    requests
+    zstandard
+  ];
+
+  pythonImportsCheck = [ "conda_package_streaming" ];
+
+  meta = {
+    description = "An efficient library to read from new and old format .conda and .tar.bz2 conda packages.";
+    homepage = "https://github.com/conda/conda-package-streaming";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.ericthemagician ];
+  };
+}

--- a/pkgs/development/python-modules/conda/0001-conda_exe.patch
+++ b/pkgs/development/python-modules/conda/0001-conda_exe.patch
@@ -1,0 +1,51 @@
+--- a/conda/base/context.py
++++ b/conda/base/context.py
+@@ -754,7 +754,7 @@
+
+     @property
+     def conda_prefix(self):
+-        return abspath(sys.prefix)
++        return expand("~/.conda")
+
+     @property
+     @deprecated(
+@@ -787,28 +787,17 @@
+         The vars can refer to each other if necessary since the dict is ordered.
+         None means unset it.
+         """
+-        if context.dev:
+-            return {
+-                "CONDA_EXE": sys.executable,
+-                # do not confuse with os.path.join, we are joining paths with ; or : delimiters
+-                "PYTHONPATH": os.pathsep.join(
+-                    (CONDA_SOURCE_ROOT, os.environ.get("PYTHONPATH", ""))
+-                ),
+-                "_CE_M": "-m",
+-                "_CE_CONDA": "conda",
+-                "CONDA_PYTHON_EXE": sys.executable,
+-            }
+-        else:
+-            bin_dir = "Scripts" if on_win else "bin"
+-            exe = "conda.exe" if on_win else "conda"
+-            # I was going to use None to indicate a variable to unset, but that gets tricky with
+-            # error-on-undefined.
+-            return {
+-                "CONDA_EXE": os.path.join(sys.prefix, bin_dir, exe),
+-                "_CE_M": "",
+-                "_CE_CONDA": "",
+-                "CONDA_PYTHON_EXE": sys.executable,
+-            }
++        import sys
++        return {
++            "CONDA_EXE": sys.executable,
++            # do not confuse with os.path.join, we are joining paths with ; or : delimiters
++            "PYTHONPATH": os.pathsep.join(
++                [CONDA_SOURCE_ROOT, os.environ.get("PYTHONPATH", "")] + [path for path in sys.path if "site-packages" in path]
++            ),
++            "_CE_M": "-m",
++            "_CE_CONDA": "conda",
++            "CONDA_PYTHON_EXE": sys.executable,
++        }
+
+     @memoizedproperty
+     def channel_alias(self):

--- a/pkgs/development/python-modules/libmambapy/default.nix
+++ b/pkgs/development/python-modules/libmambapy/default.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  fetchFromGitHub,
+  pythonPackages,
+  buildPythonPackage,
+  cmake,
+  ninja,
+  libmamba,
+  pybind11,
+  setuptools,
+  fmt,
+  spdlog,
+  tl-expected,
+  nlohmann_json,
+  yaml-cpp,
+  reproc,
+  libsolv,
+  curl,
+  zstd,
+  bzip2,
+  wheel,
+}:
+buildPythonPackage rec {
+  pname = "libmambapy";
+  version = "1.5.7";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mamba-org";
+    repo = "mamba";
+    rev = "${pname}-${version}";
+    hash = "sha256-HfmvLi9IBWlaGAn2Ej4Bnm4b3l19jEXwNl5IUkdVxi0=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  buildInputs = [
+    (libmamba.override { python3Packages = pythonPackages; })
+    pybind11
+    fmt
+    spdlog
+    tl-expected
+    nlohmann_json
+    yaml-cpp
+    reproc
+    libsolv
+    curl
+    zstd
+    bzip2
+  ];
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  # patch needed to fix setuptools errors
+  # see these for reference
+  # https://stackoverflow.com/questions/72294299/multiple-top-level-packages-discovered-in-a-flat-layout
+  # https://github.com/pypa/setuptools/issues/3197#issuecomment-1078770109
+  postPatch = ''
+    substituteInPlace libmambapy/setup.py --replace-warn  "setuptools.setup()" "setuptools.setup(py_modules=[])"
+  '';
+
+  cmakeFlags = [
+    "-GNinja"
+    (lib.cmakeBool "BUILD_LIBMAMBAPY" true)
+  ];
+
+  buildPhase = ''
+    ninjaBuildPhase
+    cp -r libmambapy ../libmambapy
+    cd ../libmambapy
+    pypaBuildPhase
+  '';
+
+  pythonRemoveDeps = [ "scikit-build" ];
+
+  pythonImportsCheck = [
+    "libmambapy"
+    "libmambapy.bindings"
+  ];
+
+  meta = {
+    description = "The python library for the fast Cross-Platform Package Manager";
+    homepage = "https://github.com/mamba-org/mamba";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.ericthemagician ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2396,6 +2396,8 @@ self: super: with self; {
 
   conda-libmamba-solver = callPackage ../development/python-modules/conda-libmamba-solver { };
 
+  conda-package-handling = callPackage ../development/python-modules/conda-package-handling { };
+
   conda-package-streaming = callPackage ../development/python-modules/conda-package-streaming { };
 
   confection = callPackage ../development/python-modules/confection { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6607,6 +6607,8 @@ self: super: with self; {
     inherit (pkgs) lzfse;
   };
 
+  libmambapy = callPackage ../development/python-modules/libmambapy { };
+
   libmodulemd = lib.pipe pkgs.libmodulemd [
     toPythonModule
     (p:

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2394,6 +2394,8 @@ self: super: with self; {
 
   conda = callPackage ../development/python-modules/conda { };
 
+  conda-libmamba-solver = callPackage ../development/python-modules/conda-libmamba-solver { };
+
   confection = callPackage ../development/python-modules/confection { };
 
   configargparse = callPackage ../development/python-modules/configargparse { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2396,6 +2396,8 @@ self: super: with self; {
 
   conda-libmamba-solver = callPackage ../development/python-modules/conda-libmamba-solver { };
 
+  conda-package-streaming = callPackage ../development/python-modules/conda-package-streaming { };
+
   confection = callPackage ../development/python-modules/confection { };
 
   configargparse = callPackage ../development/python-modules/configargparse { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I wanted to add a newer version of the conda package manager without breaking the existing conda package manager.

There is one at the top-level and that one is based on downloading miniconda and setting up a FHS.  This one introduces some patches `libsolv` and `conda` itself to make it work in the context of nix without needing the FHS hierarchy.

After some initial discussions with some maintainers, the default conda package has now been replaced this PR, which does not depend on the FHS. @jluttine  @bhipple

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
