### PR TITLE
python311Packages.debugpy: 1.8.0 -> 1.8.1

### DIFF
--- a/pkgs/development/python-modules/debugpy/default.nix
+++ b/pkgs/development/python-modules/debugpy/default.nix
@@ -5,15 +5,17 @@
 , fetchFromGitHub
 , substituteAll
 , gdb
-, django
-, flask
-, gevent
-, psutil
-, pytest-timeout
-, pytest-xdist
+, lldb
 , pytestCheckHook
+, pytest-xdist
+, pytest-timeout
+, importlib-metadata
+, psutil
+, django
 , requests
-, llvmPackages
+, gevent
+, numpy
+, flask
 }:
 
 buildPythonPackage rec {
@@ -21,7 +23,7 @@ buildPythonPackage rec {
   version = "1.8.1";
   format = "setuptools";
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "microsoft";
@@ -46,6 +48,12 @@ buildPythonPackage rec {
     # To avoid this issue, debugpy should be installed using python.withPackages:
     # python.withPackages (ps: with ps; [ debugpy ])
     ./fix-test-pythonpath.patch
+
+    # Attach pid tests are disabled by default on windows & macos,
+    # but are also flaky on linux:
+    # - https://github.com/NixOS/nixpkgs/issues/262000
+    # - https://github.com/NixOS/nixpkgs/issues/251045
+    ./skip-attach-pid-tests.patch
   ] ++ lib.optionals stdenv.isLinux [
     # Hard code GDB path (used to attach to process)
     (substituteAll {
@@ -56,7 +64,7 @@ buildPythonPackage rec {
     # Hard code LLDB path (used to attach to process)
     (substituteAll {
       src = ./hardcode-lldb.patch;
-      inherit (llvmPackages) lldb;
+      inherit lldb;
     })
   ];
 
@@ -66,24 +74,31 @@ buildPythonPackage rec {
     set -x
     cd src/debugpy/_vendored/pydevd/pydevd_attach_to_process
     rm *.so *.dylib *.dll *.exe *.pdb
-    ${stdenv.cc}/bin/c++ linux_and_mac/attach.cpp -Ilinux_and_mac -fPIC -nostartfiles ${{
+    $CXX linux_and_mac/attach.cpp -Ilinux_and_mac -std=c++11 -fPIC -nostartfiles ${{
       "x86_64-linux"   = "-shared -o attach_linux_amd64.so";
       "i686-linux"     = "-shared -o attach_linux_x86.so";
       "aarch64-linux"  = "-shared -o attach_linux_arm64.so";
-      "x86_64-darwin"  = "-std=c++11 -lc -D_REENTRANT -dynamiclib -o attach_x86_64.dylib";
-      "i686-darwin"    = "-std=c++11 -lc -D_REENTRANT -dynamiclib -o attach_x86.dylib";
-      "aarch64-darwin" = "-std=c++11 -lc -D_REENTRANT -dynamiclib -o attach_arm64.dylib";
+      "x86_64-darwin"  = "-D_REENTRANT -dynamiclib -lc -o attach_x86_64.dylib";
+      "i686-darwin"    = "-D_REENTRANT -dynamiclib -lc -o attach_x86.dylib";
+      "aarch64-darwin" = "-D_REENTRANT -dynamiclib -lc -o attach_arm64.dylib";
     }.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}")}
   )'';
 
   nativeCheckInputs = [
+    ## Used to run the tests:
+    pytestCheckHook
+    pytest-xdist
+    pytest-timeout
+
+    ## Used by test helpers:
+    importlib-metadata
+    psutil
+
+    ## Used in Python code that is run/debugged by the tests:
     django
     flask
     gevent
-    psutil
-    pytest-timeout
-    pytest-xdist
-    pytestCheckHook
+    numpy
     requests
   ];
 
@@ -106,13 +121,6 @@ buildPythonPackage rec {
 
   # Fixes hanging tests on Darwin
   __darwinAllowLocalNetworking = true;
-
-  disabledTests = [
-    # testsuite gets stuck at this one
-    "test_attach_pid_client"
-  ];
-  # TODO? https://github.com/NixOS/nixpkgs/issues/262000
-  doCheck = !stdenv.isLinux;
 
   pythonImportsCheck = [
     "debugpy"

--- a/pkgs/development/python-modules/debugpy/fix-test-pythonpath.patch
+++ b/pkgs/development/python-modules/debugpy/fix-test-pythonpath.patch
@@ -1,12 +1,12 @@
 diff --git a/tests/debug/session.py b/tests/debug/session.py
-index 7dacc1f9..f303e20a 100644
+index d0921956..459c89c0 100644
 --- a/tests/debug/session.py
 +++ b/tests/debug/session.py
-@@ -631,6 +631,7 @@ class Session(object):
+@@ -704,6 +704,7 @@ class Session(object):
          if "PYTHONPATH" in self.config.env:
              # If specified, launcher will use it in lieu of PYTHONPATH it inherited
              # from the adapter when spawning debuggee, so we need to adjust again.
 +            self.config.env.prepend_to("PYTHONPATH", os.environ["PYTHONPATH"])
              self.config.env.prepend_to("PYTHONPATH", DEBUGGEE_PYTHONPATH.strpath)
-         return self._request_start("launch")
  
+         # Adapter is going to start listening for server and spawn the launcher at

--- a/pkgs/development/python-modules/debugpy/hardcode-gdb.patch
+++ b/pkgs/development/python-modules/debugpy/hardcode-gdb.patch
@@ -1,8 +1,8 @@
 diff --git a/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py b/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
-index ed43e370..d3d6669a 100644
+index 85f3353b..56fab577 100644
 --- a/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
 +++ b/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
-@@ -404,7 +404,7 @@ def run_python_code_linux(pid, python_code, connect_debugger_tracing=False, show
+@@ -410,7 +410,7 @@ def run_python_code_linux(pid, python_code, connect_debugger_tracing=False, show
      is_debug = 0
      # Note that the space in the beginning of each line in the multi-line is important!
      cmd = [

--- a/pkgs/development/python-modules/debugpy/hardcode-lldb.patch
+++ b/pkgs/development/python-modules/debugpy/hardcode-lldb.patch
@@ -1,8 +1,8 @@
 diff --git a/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py b/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
-index d3d6669a..2ded8d9c 100644
+index 56fab577..989ede03 100644
 --- a/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
 +++ b/src/debugpy/_vendored/pydevd/pydevd_attach_to_process/add_code_to_python_process.py
-@@ -494,7 +494,7 @@ def run_python_code_mac(pid, python_code, connect_debugger_tracing=False, show_d
+@@ -500,7 +500,7 @@ def run_python_code_mac(pid, python_code, connect_debugger_tracing=False, show_d
      is_debug = 0
      # Note that the space in the beginning of each line in the multi-line is important!
      cmd = [

--- a/pkgs/development/python-modules/debugpy/hardcode-version.patch
+++ b/pkgs/development/python-modules/debugpy/hardcode-version.patch
@@ -1,5 +1,5 @@
 diff --git a/setup.py b/setup.py
-index 3abc811b..91354604 100644
+index 1bfba237..414bb4d5 100644
 --- a/setup.py
 +++ b/setup.py
 @@ -12,7 +12,6 @@ import sys

--- a/pkgs/development/python-modules/debugpy/skip-attach-pid-tests.patch
+++ b/pkgs/development/python-modules/debugpy/skip-attach-pid-tests.patch
@@ -1,0 +1,27 @@
+diff --git a/tests/debug/runners.py b/tests/debug/runners.py
+index dc60d0ae..cf4a06a3 100644
+--- a/tests/debug/runners.py
++++ b/tests/debug/runners.py
+@@ -163,7 +163,7 @@ def _attach_common_config(session, target, cwd):
+ @_runner
+ @contextlib.contextmanager
+ def attach_pid(session, target, cwd=None, wait=True):
+-    if wait and not sys.platform.startswith("linux"):
++    if wait:
+         pytest.skip("https://github.com/microsoft/ptvsd/issues/1926")
+ 
+     log.info("Attaching {0} to {1} by PID.", session, target)
+diff --git a/tests/debugpy/test_attach.py b/tests/debugpy/test_attach.py
+index afabc1ac..2fff3982 100644
+--- a/tests/debugpy/test_attach.py
++++ b/tests/debugpy/test_attach.py
+@@ -151,8 +151,7 @@ def test_reattach(pyfile, target, run):
+ 
+ 
+ @pytest.mark.parametrize("pid_type", ["int", "str"])
+-@pytest.mark.skipif(
+-    not sys.platform.startswith("linux"),
++@pytest.mark.skip(
+     reason="https://github.com/microsoft/debugpy/issues/311",
+ )
+ def test_attach_pid_client(pyfile, target, pid_type):


### PR DESCRIPTION
## Description of changes

https://github.com/microsoft/debugpy/releases/tag/v1.8.1

Also adds a patch to disable all the attach_pid tests on Linux, fixing #262000. (They are disabled by default on Windows & macOS)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
