### PR TITLE
 libajantv2: Add hint about new upstream/build failure with obs-studio  / remove me as maintainer

### DIFF
--- a/pkgs/development/libraries/libajantv2/default.nix
+++ b/pkgs/development/libraries/libajantv2/default.nix
@@ -6,6 +6,9 @@
 , pkg-config
 }:
 
+# Warning: We are aware that the upstream changed and there are new release, 
+# this got initally packaged for obs-studio which appears to fail to build even upstream with the new version.
+# https://github.com/NixOS/nixpkgs/pull/296191 / https://github.com/NixOS/nixpkgs/pull/296191
 stdenv.mkDerivation rec {
   pname = "libajantv2";
   version = "16.2-bugfix5";

--- a/pkgs/development/libraries/libajantv2/default.nix
+++ b/pkgs/development/libraries/libajantv2/default.nix
@@ -6,9 +6,9 @@
 , pkg-config
 }:
 
-# Warning: We are aware that the upstream changed and there are new release, 
+# Warning: We are aware that the upstream changed and there are new releases,
 # this got initally packaged for obs-studio which appears to fail to build even upstream with the new version.
-# https://github.com/NixOS/nixpkgs/pull/296191 / https://github.com/NixOS/nixpkgs/pull/296191
+# https://github.com/NixOS/nixpkgs/pull/296191 / https://github.com/obsproject/obs-studio/pull/10037
 stdenv.mkDerivation rec {
   pname = "libajantv2";
   version = "16.2-bugfix5";
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     description = "AJA NTV2 Open Source Static Libs and Headers for building applications that only wish to statically link against";
     homepage = "https://github.com/aja-video/ntv2";
     license = with licenses; [ mit ];
-    maintainers = with maintainers; [ sebtm ];
+    maintainers = with maintainers; [];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
## Description of changes
As discussed here: https://github.com/NixOS/nixpkgs/pull/296191#issuecomment-2002083036 add warning after failed attempt to build against new-upstream.

As I currently don't really use obs, I would like to remove myself from maintainers - I still have subscribed to the obs-issue and might fix but not actively looking into maintaining it further ✌🏻 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
