### PR TITLE
texlive.pkgs."texlive.infra": fix missing texlive.tlpdb

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/fixed-hashes.nix
+++ b/pkgs/tools/typesetting/tex/texlive/fixed-hashes.nix
@@ -3785,7 +3785,7 @@ texlive-scripts-69407={run="12y5mpwin93asvl0anqs170zixvb29vjakwgagvylhg1ns27lrdc
 texlive-scripts-extra-62517={run="193v0r4i3p4psn5b4q0ggpgaazwn6jadjlzh5gjm3igg9k73i1wj";doc="1izzy295pmxrg0sf2szxxahxm6s8bfi960mbs9z6vy7m5j1szxwl";};
 texlive-sr-54594={doc="0icavs9jkcr5b5cx5kv202k95j0ydgby9lqrw8wm9h936mbn9bkj";};
 texlive-zh-cn-54490={doc="1r8n9k1cy7798g1rg1hyj6g945j9649c5hhqf8hm7a7abzx7w6ll";};
-"texlive.infra-68903.tlpdb69413"={run="1ig9nsyhhgv9vr5hhvzj3asqz75fdjrvgyj1s2z8rbng0y45x8nv";doc="0d6ij3bgna15i5fkg4xwi7155wz891625sy6qh4jfjmi9sda9p2n";tlpkg="07qvyhgbbl4cddhn4wqh1ivp1ifpw5hwv05xywl62zc1swag317x";};
+"texlive.infra-68903.tlpdb69413"={run="1ig9nsyhhgv9vr5hhvzj3asqz75fdjrvgyj1s2z8rbng0y45x8nv";doc="0d6ij3bgna15i5fkg4xwi7155wz891625sy6qh4jfjmi9sda9p2n";tlpkg="141qqpf1kg65kr5rw2rrzspcyhgp9dgndz2md9snqpbspmd92jws";};
 texliveonfly-55777={run="03i9pzqv2dz4z9nlq60kzwiyfvzhhaalhczqa9146jp4wvcib9l3";doc="1fsabzkbcrk42rsp8ssx0kvap31y1rqnkq582129946q3njvmylx";};
 texloganalyser-54526={run="0icav63nll0lj85cqlbg1lx1r6ysjf1lyv5bydxr3flr1c7yqx2r";doc="1s7952n2brrz3s1qca9r5qk8fnjlmrmrn8b06dhjxdb7wdqis6g0";};
 texlogfilter-62792={run="19sxpfyfp2knv8q13sgka5kw74vplr0fnf5c9m599h5kb7v4pcys";doc="1wwhdm7b2rwp9qjpivj3wflwf6q4lcxbc3r52g9c68w7d492v7al";};

--- a/pkgs/tools/typesetting/tex/texlive/tlpdb-overrides.nix
+++ b/pkgs/tools/typesetting/tex/texlive/tlpdb-overrides.nix
@@ -417,7 +417,7 @@ in lib.recursiveUpdate orig rec {
 
     # add minimal texlive.tlpdb
     postUnpack = ''
-      if [[ "$tlType" == "tlpkg" ]] ; then
+      if [[ -d "$out"/TeXLive ]] ; then
         xzcat "${tlpdbxz}" | sed -n -e '/^name \(00texlive.config\|00texlive.installation\)$/,/^$/p' > "$out"/texlive.tlpdb
       fi
     '';


### PR DESCRIPTION
## Description of changes
The `postUnpack` script that adds texlive.tlpdb to texlive.infra was not working because of the change from `tlType` to `tlOutputName`, the PR adds it back.

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
