### PR TITLE
electrum: 4.5.3 -> 4.5.4

### DIFF
--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -9,10 +9,27 @@
 , enableQt ? true
 , callPackage
 , qtwayland
+, fetchPypi
 }:
 
 let
   version = "4.5.3";
+
+  python = python3.override {
+    self = python;
+    packageOverrides = self: super: {
+      # Pin ledger-bitcoin to 0.2.1
+      ledger-bitcoin = super.ledger-bitcoin.overridePythonAttrs (oldAttrs: rec {
+        version = "0.2.1";
+        format = "pyproject";
+        src = fetchPypi {
+          pname = "ledger_bitcoin";
+          inherit version;
+          hash = "sha256-AWl/q2MzzspNIo6yf30S92PgM/Ygsb+1lJsg7Asztso=";
+        };
+      });
+    };
+  };
 
   libsecp256k1_name =
     if stdenv.isLinux then "libsecp256k1.so.{v}"
@@ -39,7 +56,7 @@ let
 
 in
 
-python3.pkgs.buildPythonApplication {
+python.pkgs.buildPythonApplication {
   pname = "electrum";
   inherit version;
 
@@ -56,7 +73,7 @@ python3.pkgs.buildPythonApplication {
   nativeBuildInputs = lib.optionals enableQt [ wrapQtAppsHook ];
   buildInputs = lib.optional (stdenv.isLinux && enableQt) qtwayland;
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = with python.pkgs; [
     aiohttp
     aiohttp-socks
     aiorpcx
@@ -85,7 +102,7 @@ python3.pkgs.buildPythonApplication {
     qdarkstyle
   ];
 
-  checkInputs = with python3.pkgs; lib.optionals enableQt [
+  checkInputs = with python.pkgs; lib.optionals enableQt [
     pyqt6
   ];
 
@@ -117,7 +134,7 @@ python3.pkgs.buildPythonApplication {
     wrapQtApp $out/bin/electrum
   '';
 
-  nativeCheckInputs = with python3.pkgs; [ pytestCheckHook pyaes pycryptodomex ];
+  nativeCheckInputs = with python.pkgs; [ pytestCheckHook pyaes pycryptodomex ];
 
   pytestFlagsArray = [ "tests" ];
 

--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -140,7 +140,7 @@ python3.pkgs.buildPythonApplication {
     changelog = "https://github.com/spesmilo/electrum/blob/master/RELEASE-NOTES";
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = with maintainers; [ joachifm np prusnak ];
+    maintainers = with maintainers; [ joachifm np prusnak chewblacka ];
     mainProgram = "electrum";
   };
 }

--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -13,7 +13,7 @@
 }:
 
 let
-  version = "4.5.3";
+  version = "4.5.4";
 
   python = python3.override {
     self = python;
@@ -46,7 +46,7 @@ let
     owner = "spesmilo";
     repo = "electrum";
     rev = version;
-    sha256 = "sha256-Lr6ynHAbyaiaxYAWU5j5Wh5acxO5HkP1/jpnFrL4j68=";
+    sha256 = "sha256-fDu2PlEQOF7ftlS6dYw15S2XiAx+D/bng4zC9ELj6uk=";
 
     postFetch = ''
       mv $out ./all
@@ -62,7 +62,7 @@ python.pkgs.buildPythonApplication {
 
   src = fetchurl {
     url = "https://download.electrum.org/${version}/Electrum-${version}.tar.gz";
-    sha256 = "sha256-kej0msc7SB+51ad5xZrT8MMEY5rfYOGqum6RO1gBH5s=";
+    sha256 = "sha256-lDuwXhOjcbCx8x/oIoigrklDwCbhn1trf5lDf/X/1Qc=";
   };
 
   postUnpack = ''

--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -97,6 +97,9 @@ python.pkgs.buildPythonApplication {
     ckcc-protocol
     keepkey
     trezor
+    bitbox02
+    cbor
+    pyserial
   ] ++ lib.optionals enableQt [
     pyqt5
     qdarkstyle


### PR DESCRIPTION
## Description of changes
- Added myself to package maintainers
- Added `safet` 0.1.4 to python packages (https://github.com/dArkjON/python-safet)
- Electrum - added missing hardware dependencies:
	`bitbox02`
	`cbor`
	`pyserial`
	`safet`
- Electrum - pinned `ledger-bitcoin` version to 0.2.1 (0.3.0 in the repos doesn't work)
- Electrum - updated version from 4.5.3 -> 4.5.4 (https://github.com/dArkjON/python-safet)

Closes https://github.com/NixOS/nixpkgs/issues/296216

### To test:
Run electrum. Create a new wallet. Standard wallet. Use a hardware device

Before update you get the following error message:

```
Debug message
  bitbox02: (error getting device infos)
    Missing libraries for bitbox02.
        ImportError()
    Make sure you install it with python3
  jade: (error getting device infos)
    Missing libraries for jade.
        ModuleNotFoundError("No module named 'cbor'")
    Make sure you install it with python3
  ledger: (error getting device infos)
    Library version for 'ledger' is incompatible.
    Installed: 0.3.0, Needed: 0.2.0 <= x < 0.3.0
    Make sure you install it with python3
  safe_t: (error getting device infos)
    Missing libraries for safe_t.
        ModuleNotFoundError("No module named 'safetlib'")
    Make sure you install it with python3
```
After update & fixes, all errors are resolved.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
