### PR TITLE
nixosTests.networking: split router into a separate file and remove `with lib;` antipattern

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -581,8 +581,8 @@ in {
   netbird = handleTest ./netbird.nix {};
   neo4j = handleTest ./neo4j.nix {};
   netdata = handleTest ./netdata.nix {};
-  networking.networkd = handleTest ./networking.nix { networkd = true; };
-  networking.scripted = handleTest ./networking.nix { networkd = false; };
+  networking.scripted = handleTest ./networking/networkd-and-scripted.nix { networkd = false; };
+  networking.networkd = handleTest ./networking/networkd-and-scripted.nix { networkd = true; };
   netbox_3_6 = handleTest ./web-apps/netbox.nix { netbox = pkgs.netbox_3_6; };
   netbox_3_7 = handleTest ./web-apps/netbox.nix { netbox = pkgs.netbox_3_7; };
   netbox-upgrade = handleTest ./web-apps/netbox-upgrade.nix {};

--- a/nixos/tests/networking/router.nix
+++ b/nixos/tests/networking/router.nix
@@ -1,0 +1,82 @@
+{ networkd }: { config, pkgs, ... }:
+  let
+    inherit (pkgs) lib;
+    qemu-common = import ../../lib/qemu-common.nix { inherit lib pkgs; };
+    vlanIfs = lib.range 1 (lib.length config.virtualisation.vlans);
+  in {
+    environment.systemPackages = [ pkgs.iptables ]; # to debug firewall rules
+    virtualisation.vlans = [ 1 2 3 ];
+    boot.kernel.sysctl."net.ipv6.conf.all.forwarding" = true;
+    networking = {
+      useDHCP = false;
+      useNetworkd = networkd;
+      firewall.checkReversePath = true;
+      firewall.allowedUDPPorts = [ 547 ];
+      interfaces = lib.mkOverride 0 (lib.listToAttrs (lib.forEach vlanIfs (n:
+        lib.nameValuePair "eth${toString n}" {
+          ipv4.addresses = [ { address = "192.168.${toString n}.1"; prefixLength = 24; } ];
+          ipv6.addresses = [ { address = "fd00:1234:5678:${toString n}::1"; prefixLength = 64; } ];
+        })));
+    };
+    services.kea = {
+      dhcp4 = {
+        enable = true;
+        settings = {
+          interfaces-config = {
+            interfaces = map (n: "eth${toString n}") vlanIfs;
+            dhcp-socket-type = "raw";
+            service-sockets-require-all = true;
+            service-sockets-max-retries = 5;
+            service-sockets-retry-wait-time = 2500;
+          };
+          subnet4 = map (n: {
+            id = n;
+            subnet = "192.168.${toString n}.0/24";
+            pools = [{ pool = "192.168.${toString n}.3 - 192.168.${toString n}.254"; }];
+            option-data = [
+              { data = "192.168.${toString n}.1"; name = "routers"; }
+              { data = "192.168.${toString n}.1"; name = "domain-name-servers"; }
+            ];
+
+            reservations = [{
+              hw-address = qemu-common.qemuNicMac n 1;
+              hostname = "client${toString n}";
+              ip-address = "192.168.${toString n}.2";
+            }];
+          }) vlanIfs;
+        };
+      };
+      dhcp6 = {
+        enable = true;
+        settings = {
+          interfaces-config = {
+            interfaces = map (n: "eth${toString n}") vlanIfs;
+            service-sockets-require-all = true;
+            service-sockets-max-retries = 5;
+            service-sockets-retry-wait-time = 2500;
+          };
+
+          subnet6 = map (n: {
+            id = n;
+            subnet = "fd00:1234:5678:${toString n}::/64";
+            interface = "eth${toString n}";
+            pools = [{ pool = "fd00:1234:5678:${toString n}::2-fd00:1234:5678:${toString n}::2"; }];
+          }) vlanIfs;
+        };
+      };
+    };
+    services.radvd = {
+      enable = true;
+      config = lib.flip lib.concatMapStrings vlanIfs (n: ''
+        interface eth${toString n} {
+          AdvSendAdvert on;
+          AdvManagedFlag on;
+          AdvOtherConfigFlag on;
+
+          prefix fd00:1234:5678:${toString n}::/64 {
+            AdvAutonomous off;
+          };
+        };
+      '');
+    };
+  }


### PR DESCRIPTION
split up #292472 as requested in https://github.com/NixOS/nixpkgs/pull/292472#discussion_r1518991641 (yes I know this change does more, please tell me if I should split it up further)

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
