### PR TITLE
libdbiDrivers: take upstream patch to prevent Gnucash buffer overflow triggered by glibc 2.38 fortification

### DIFF
--- a/pkgs/development/libraries/libdbi-drivers/default.nix
+++ b/pkgs/development/libraries/libdbi-drivers/default.nix
@@ -16,6 +16,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libdbi sqlite postgresql ] ++ lib.optional (libmysqlclient != null) libmysqlclient;
 
+  patches = [
+    # https://sourceforge.net/p/libdbi-drivers/libdbi-drivers/ci/24f48b86c8988ee3aaebc5f303d71e9d789f77b6
+    ./libdbi-drivers-0.9.0-buffer_overflow.patch
+  ];
+
   postPatch = ''
     sed -i '/SQLITE3_LIBS/ s/-lsqlite/-lsqlite3/' configure;
   '';

--- a/pkgs/development/libraries/libdbi-drivers/default.nix
+++ b/pkgs/development/libraries/libdbi-drivers/default.nix
@@ -46,6 +46,11 @@ stdenv.mkDerivation rec {
     "--with-pgsql_libdir=${postgresql.lib}/lib"
   ];
 
+  env.NIX_CFLAGS_COMPILE = toString (lib.optionals stdenv.cc.isClang [
+    "-Wno-error=incompatible-function-pointer-types"
+    "-Wno-error=int-conversion"
+  ]);
+
   installFlags = [ "DESTDIR=\${out}" ];
 
   postInstall = ''

--- a/pkgs/development/libraries/libdbi-drivers/libdbi-drivers-0.9.0-buffer_overflow.patch
+++ b/pkgs/development/libraries/libdbi-drivers/libdbi-drivers-0.9.0-buffer_overflow.patch
@@ -1,0 +1,11 @@
+--- a/drivers/sqlite3/dbd_sqlite3.c
++++ b/drivers/sqlite3/dbd_sqlite3.c
+@@ -1451,7 +1451,7 @@ static int getTables(char** tables, int
+ 		    break;
+ 		  }
+ 
+-		  word_lower[item-start+1];
++		  char word_lower[item-start+1];
+ 		  strncpy(word_lower,start,item-start);
+ 		  word_lower[item-start] = '\0';
+ 		  int i = 0;


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Inspired by https://bugs.gnucash.org/show_bug.cgi?id=799244 , this PR pulls in the changes from [an unreleased commit](https://sourceforge.net/p/libdbi-drivers/libdbi-drivers/ci/24f48b86c8988ee3aaebc5f303d71e9d789f77b6/) upstream (from 2014!) that avoids a buffer overflow which causes Gnucash to crash when opening its sqlite file. This latent crash was not triggered until https://github.com/NixOS/nixpkgs/commit/e86152986c6e6c563ced037c91403318d5a8b447#diff-13888aa5b47cc92e7297ecd09e3a477abe57cbf432956271a3f75f9bd6ffeb8fR139 , where `--enable-fortify-source` was used with glibc 2.38.

This is also identical to work done in Fedora (in https://src.fedoraproject.org/rpms/libdbi-drivers/pull-request/2) in response to a very similar Gnucash bug (https://bugs.gnucash.org/show_bug.cgi?id=798881).

 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
    - this appears to only affect `gnucash libdbiDrivers libdbiDriversBase`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
