### PR TITLE
nixos/tests/phosh: check phosh-mobile-settings starts

### DIFF
--- a/nixos/tests/phosh.nix
+++ b/nixos/tests/phosh.nix
@@ -25,6 +25,10 @@ in {
         };
       };
 
+      environment.systemPackages = [
+        pkgs.phosh-mobile-settings
+      ];
+
       systemd.services.phosh = {
         environment = {
           # Accelerated graphics fail on phoc 0.20 (wlroots 0.15)
@@ -63,8 +67,13 @@ in {
         phone.screenshot("03launcher")
 
     with subtest("Check the on-screen keyboard shows"):
-        phone.send_chars("setting", delay=0.2)
+        phone.send_chars("mobile setting", delay=0.2)
         phone.wait_for_text("123") # A button on the OSK
         phone.screenshot("04osk")
+
+    with subtest("Check mobile-phosh-settings starts"):
+       phone.send_chars("\n")
+       phone.wait_for_text("Tweak advanced mobile settings");
+       phone.screenshot("05settings")
   '';
 })

--- a/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
+++ b/pkgs/applications/window-managers/phosh/phosh-mobile-settings.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchurl
+, nixosTests
 , directoryListingUpdater
 , meson
 , ninja
@@ -59,7 +60,10 @@ stdenv.mkDerivation rec {
     ln -s '${phosh}/lib/phosh' "$out/lib/phosh"
   '';
 
-  passthru.updateScript = directoryListingUpdater { };
+  passthru = {
+    tests.phosh = nixosTests.phosh;
+    updateScript = directoryListingUpdater { };
+  };
 
   meta = with lib; {
     description = "A settings app for mobile specific things";


### PR DESCRIPTION
## Description of changes

Add `phosh-mobile-settings` to `nixosTests.phosh`.

These two applications are coupled enough that it makes sense to test phosh-mobile-settings starts in Phosh, and trigger nixosTests.phosh on phosh-mobile-settings upgrades.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
