### PR TITLE
kubernetes-polaris: 8.5.5 -> 9.3.0

### DIFF
--- a/pkgs/tools/security/kubernetes-polaris/default.nix
+++ b/pkgs/tools/security/kubernetes-polaris/default.nix
@@ -1,17 +1,17 @@
-{ lib, buildGoModule, fetchFromGitHub, installShellFiles, packr, ... }:
+{ lib, buildGoModule, fetchFromGitHub, installShellFiles }:
 
 buildGoModule rec {
   pname = "kubernetes-polaris";
-  version = "8.5.5";
+  version = "9.3.0";
 
   src = fetchFromGitHub {
     owner = "FairwindsOps";
     repo = "polaris";
     rev = version;
-    sha256 = "sha256-DKfCXtFrZgmR0jiXwCD1iuwx/8aNEjwZ/fCQNeRhSu4=";
+    sha256 = "sha256-qJAhxwVM/tYdCWLL1snUYjXGfgdcHkBFrI9xBg1/EXU=";
   };
 
-  vendorHash = "sha256-ZWetW+Xar4BXXlR0iG+O/NRqYk41x+PPVCGis2W2Nkk=";
+  vendorHash = "sha256-6sxzRI22xiZOQds20iU5OsU+JqcNB2wOUrOZrOH1Sa4=";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -21,10 +21,6 @@ buildGoModule rec {
     "-X main.Version=${version}"
     "-X main.Commit=${version}"
   ];
-
-  preBuild = ''
-    ${packr}/bin/packr2 -v --ignore-imports
-  '';
 
   postInstall = ''
     installShellCompletion --cmd polaris \


### PR DESCRIPTION
## Description of changes

Updates kubernetes-polaris to 9.3.0.
This release includes migration from packr to go:embed, so we can remove this dependency.

pbsds edit: closes https://github.com/NixOS/nixpkgs/pull/340925

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
