### PR TITLE
iio-hyprland: init at 0-unstable-2024-07-24; nixos/iio-hyprland: init module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22779,6 +22779,11 @@
     name = "Yusuf Bera Ertan";
     keys = [ { fingerprint = "9270 66BD 8125 A45B 4AC4 0326 6180 7181 F60E FCB2"; } ];
   };
+  yusuf-duran = {
+    github = "yusuf-duran";
+    githubId = 37774475;
+    name = "Yusuf Duran";
+  };
   yuu = {
     email = "yuunix@grrlz.net";
     matrix = "@yuu:matrix.org";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -214,6 +214,7 @@
   ./programs/iay.nix
   ./programs/iftop.nix
   ./programs/i3lock.nix
+  ./programs/iio-hyprland.nix
   ./programs/immersed-vr.nix
   ./programs/iotop.nix
   ./programs/java.nix

--- a/nixos/modules/programs/iio-hyprland.nix
+++ b/nixos/modules/programs/iio-hyprland.nix
@@ -1,0 +1,24 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.iio-hyprland;
+in
+{
+  options = {
+    programs.iio-hyprland = {
+      enable = lib.mkEnableOption "iio-hyprland and iio-sensor-proxy";
+      package = lib.mkPackageOption pkgs "iio-hyprland" { };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    hardware.sensor.iio.enable = lib.mkDefault true;
+
+    environment.systemPackages = [ cfg.package ];
+  };
+  meta.maintainers = with lib.maintainers; [ yusuf-duran ];
+}

--- a/pkgs/by-name/ii/iio-hyprland/package.nix
+++ b/pkgs/by-name/ii/iio-hyprland/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  unstableGitUpdater,
+  meson,
+  cmake,
+  pkg-config,
+  dbus,
+  ninja,
+}:
+
+stdenv.mkDerivation {
+  pname = "iio-hyprland";
+  version = "0-unstable-2024-07-24";
+
+  src = fetchFromGitHub {
+    owner = "JeanSchoeller";
+    repo = "iio-hyprland";
+    rev = "bbf59e10cbf293e64b765864a324e971fcc06125";
+    hash = "sha256-9tB29tP3ZQ2tU2c+FrWrGqSm70ZrJP8H9WZKzHx55zI=";
+  };
+
+  buildInputs = [ dbus ];
+  nativeBuildInputs = [
+    meson
+    cmake
+    pkg-config
+    ninja
+  ];
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Listens to iio-sensor-proxy and automatically changes Hyprland output orientation";
+    homepage = "https://github.com/JeanSchoeller/iio-hyprland/tree/master";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ yusuf-duran ];
+    platforms = lib.platforms.linux;
+    mainProgram = "iio-hyprland";
+  };
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Listens to iio-sensor-proxy and automatically changes Hyprland output orientation.
Based on:
https://github.com/JeanSchoeller/iio-hyprland
WIth extra patch from:
https://github.com/short-circuit/iio-hyprland/commit/f13242bbdf4a0d062683bf23b2431bb72e2e6ab9

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
