### PR TITLE
nixos/postgresql: turn `settings` into a submodule

### DIFF
--- a/nixos/modules/services/databases/postgresql.md
+++ b/nixos/modules/services/databases/postgresql.md
@@ -118,7 +118,7 @@ are already created.
       before = "service1.service";
       after = "postgresql.service";
       serviceConfig.User = "postgres";
-      environment.PSQL = "psql --port=${toString services.postgresql.port}";
+      environment.PSQL = "psql --port=${toString services.postgresql.settings.port}";
       path = [ postgresql ];
       script = ''
         $PSQL service1 -c 'GRANT SELECT ON ALL TABLES IN SCHEMA public TO "extraUser1"'
@@ -139,7 +139,7 @@ are already created.
 
 ```nix
   {
-    environment.PSQL = "psql --port=${toString services.postgresql.port}";
+    environment.PSQL = "psql --port=${toString services.postgresql.settings.port}";
     path = [ postgresql ];
     systemd.services."service1".preStart = ''
       $PSQL -c 'GRANT SELECT ON ALL TABLES IN SCHEMA public TO "extraUser1"'
@@ -159,7 +159,7 @@ are already created.
       before = "service1.service";
       after = "postgresql.service";
       serviceConfig.User = "service1";
-      environment.PSQL = "psql --port=${toString services.postgresql.port}";
+      environment.PSQL = "psql --port=${toString services.postgresql.settings.port}";
       path = [ postgresql ];
       script = ''
         $PSQL -c 'GRANT SELECT ON ALL TABLES IN SCHEMA public TO "extraUser1"'

--- a/nixos/modules/services/misc/forgejo.nix
+++ b/nixos/modules/services/misc/forgejo.nix
@@ -114,11 +114,11 @@ in
 
         port = mkOption {
           type = types.port;
-          default = if !usePostgresql then 3306 else pg.port;
+          default = if usePostgresql then pg.settings.port else 3306;
           defaultText = literalExpression ''
             if config.${opt.database.type} != "postgresql"
             then 3306
-            else config.${options.services.postgresql.port}
+            else 5432
           '';
           description = mdDoc "Database host port.";
         };

--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -100,11 +100,11 @@ in
 
         port = mkOption {
           type = types.port;
-          default = if !usePostgresql then 3306 else pg.port;
+          default = if usePostgresql then pg.settings.port else 3306;
           defaultText = literalExpression ''
             if config.${opt.database.type} != "postgresql"
             then 3306
-            else config.${options.services.postgresql.port}
+            else 5432
           '';
           description = lib.mdDoc "Database host port.";
         };

--- a/nixos/modules/services/monitoring/zabbix-proxy.nix
+++ b/nixos/modules/services/monitoring/zabbix-proxy.nix
@@ -103,11 +103,11 @@ in
 
         port = mkOption {
           type = types.port;
-          default = if cfg.database.type == "mysql" then mysql.port else pgsql.port;
+          default = if cfg.database.type == "mysql" then mysql.port else pgsql.services.port;
           defaultText = literalExpression ''
             if config.${opt.database.type} == "mysql"
             then config.${options.services.mysql.port}
-            else config.${options.services.postgresql.port}
+            else config.services.postgresql.settings.port
           '';
           description = lib.mdDoc "Database host port.";
         };

--- a/nixos/modules/services/monitoring/zabbix-server.nix
+++ b/nixos/modules/services/monitoring/zabbix-server.nix
@@ -95,11 +95,11 @@ in
 
         port = mkOption {
           type = types.port;
-          default = if cfg.database.type == "mysql" then mysql.port else pgsql.port;
+          default = if cfg.database.type == "mysql" then mysql.port else pgsql.settings.port;
           defaultText = literalExpression ''
             if config.${opt.database.type} == "mysql"
             then config.${options.services.mysql.port}
-            else config.${options.services.postgresql.port}
+            else config.services.postgresql.settings.port
           '';
           description = lib.mdDoc "Database host port.";
         };

--- a/nixos/modules/services/web-apps/invidious.nix
+++ b/nixos/modules/services/web-apps/invidious.nix
@@ -346,8 +346,8 @@ in
 
       port = lib.mkOption {
         type = types.port;
-        default = options.services.postgresql.port.default;
-        defaultText = lib.literalExpression "options.services.postgresql.port.default";
+        default = config.services.postgresql.settings.port;
+        defaultText = lib.literalExpression "config.services.postgresql.settings.port";
         description = lib.mdDoc ''
           The port of the database Invidious should use.
 

--- a/nixos/modules/services/web-apps/zabbix.nix
+++ b/nixos/modules/services/web-apps/zabbix.nix
@@ -76,11 +76,11 @@ in
           type = types.port;
           default =
             if cfg.database.type == "mysql" then config.services.mysql.port
-            else if cfg.database.type == "pgsql" then config.services.postgresql.port
+            else if cfg.database.type == "pgsql" then config.services.postgresql.settings.port
             else 1521;
           defaultText = literalExpression ''
             if config.${opt.database.type} == "mysql" then config.${options.services.mysql.port}
-            else if config.${opt.database.type} == "pgsql" then config.${options.services.postgresql.port}
+            else if config.${opt.database.type} == "pgsql" then config.services.postgresql.settings.port
             else 1521
           '';
           description = lib.mdDoc "Database host port.";

--- a/nixos/tests/invidious.nix
+++ b/nixos/tests/invidious.nix
@@ -18,7 +18,7 @@ import ./make-test-python.nix ({ pkgs, ... }: {
           host invidious invidious samenet scram-sha-256
         '';
       };
-      networking.firewall.allowedTCPPorts = [ config.services.postgresql.port ];
+      networking.firewall.allowedTCPPorts = [ config.services.postgresql.settings.port ];
     };
     machine = { config, lib, pkgs, ... }: {
       services.invidious = {

--- a/nixos/tests/miniflux.nix
+++ b/nixos/tests/miniflux.nix
@@ -76,7 +76,7 @@ in
       systemd.services.postgresql.postStart = lib.mkAfter ''
         $PSQL -tAd miniflux -c 'CREATE EXTENSION hstore;'
       '';
-      networking.firewall.allowedTCPPorts = [ config.services.postgresql.port ];
+      networking.firewall.allowedTCPPorts = [ config.services.postgresql.settings.port ];
     };
     externalDb = { ... }: {
       security.apparmor.enable = true;

--- a/nixos/tests/pg_anonymizer.nix
+++ b/nixos/tests/pg_anonymizer.nix
@@ -7,7 +7,7 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
     services.postgresql = {
       enable = true;
       extraPlugins = ps: [ ps.anonymizer ];
-      settings.shared_preload_libraries = "anon";
+      settings.shared_preload_libraries = [ "anon" ];
     };
   };
 

--- a/nixos/tests/pgmanage.nix
+++ b/nixos/tests/pgmanage.nix
@@ -21,7 +21,7 @@ in
         pgmanage = {
           enable = true;
           connections = {
-            ${conn} = "hostaddr=127.0.0.1 port=${toString config.services.postgresql.port} dbname=postgres";
+            ${conn} = "hostaddr=127.0.0.1 port=${toString config.services.postgresql.settings.port} dbname=postgres";
           };
         };
       };

--- a/nixos/tests/web-apps/mastodon/remote-databases.nix
+++ b/nixos/tests/web-apps/mastodon/remote-databases.nix
@@ -33,7 +33,7 @@ in
         extraHosts = hosts;
         firewall.allowedTCPPorts = [
           config.services.redis.servers.mastodon.port
-          config.services.postgresql.port
+          config.services.postgresql.settings.port
         ];
       };
 


### PR DESCRIPTION

## Description of changes
The main idea behind that was to be able to do more sophisticated merging for stuff that goes into `postgresql.conf`: `shared_preload_libraries` is a comma-separated list in a `types.str` and thus not mergeable. With this change, the option accepts both a comma-separated string xor a list of strings.

This can be implemented rather quick using `coercedTo` + freeform modules. The interface still behaves equally, but it allows to merge declarations for this option together.

One side-effect was that I had to change the `attrsOf (oneOf ...)` part into a submodule to allow declaring options for certain things. While at it, I decided to move `log_line_prefix` and `port` into this structure as well.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
