### PR TITLE
grocy: 4.0.3 -> 4.2.0, build from sources

### DIFF
--- a/pkgs/servers/grocy/0001-Define-configs-with-env-vars.patch
+++ b/pkgs/servers/grocy/0001-Define-configs-with-env-vars.patch
@@ -11,7 +11,7 @@ Subject: [PATCH 1/2] Define configs with env vars
  4 files changed, 6 insertions(+), 6 deletions(-)
 
 diff --git a/app.php b/app.php
-index bc5b1b39..26f7687e 100644
+index bc5b1b3..26f7687 100644
 --- a/app.php
 +++ b/app.php
 @@ -12,7 +12,7 @@ use Slim\Views\Blade;
@@ -41,11 +41,24 @@ index bc5b1b39..26f7687e 100644
  
  ob_clean(); // No response output before here
  $app->run();
+diff --git a/controllers/BaseApiController.php b/controllers/BaseApiController.php
+index 5941e348..e5b02af4 100644
+--- a/controllers/BaseApiController.php
++++ b/controllers/BaseApiController.php
+@@ -162,7 +162,7 @@ class BaseApiController extends BaseController
+ 		if (self::$htmlPurifierInstance == null)
+ 		{
+ 			$htmlPurifierConfig = \HTMLPurifier_Config::createDefault();
+-			$htmlPurifierConfig->set('Cache.SerializerPath', GROCY_DATAPATH . '/viewcache');
++			$htmlPurifierConfig->set('Cache.SerializerPath', getenv('GROCY_CACHE_DIR'));
+ 			$htmlPurifierConfig->set('HTML.Allowed', 'div,b,strong,i,em,u,a[href|title|target],iframe[src|width|height|frameborder],ul,ol,li,p[style],br,span[style],img[style|width|height|alt|src],table[border|width|style],tbody,tr,td,th,blockquote,*[style|class|id],h1,h2,h3,h4,h5,h6');
+ 			$htmlPurifierConfig->set('Attr.EnableID', true);
+ 			$htmlPurifierConfig->set('HTML.SafeIframe', true);
 diff --git a/services/DatabaseService.php b/services/DatabaseService.php
-index 4a05bda1..ce41ed17 100644
+index ba79a73..12a851a 100644
 --- a/services/DatabaseService.php
 +++ b/services/DatabaseService.php
-@@ -125,6 +125,6 @@ class DatabaseService
+@@ -137,6 +137,6 @@ class DatabaseService
  			return GROCY_DATAPATH . '/grocy_' . $dbSuffix . '.db';
  		}
  
@@ -54,7 +67,7 @@ index 4a05bda1..ce41ed17 100644
  	}
  }
 diff --git a/services/FilesService.php b/services/FilesService.php
-index 7d070350..a6dd4b08 100644
+index 7d07035..a6dd4b0 100644
 --- a/services/FilesService.php
 +++ b/services/FilesService.php
 @@ -10,7 +10,7 @@ class FilesService extends BaseService
@@ -67,18 +80,18 @@ index 7d070350..a6dd4b08 100644
  		{
  			mkdir($this->StoragePath);
 diff --git a/services/StockService.php b/services/StockService.php
-index 7265e82b..13af591a 100644
+index 9f034a5..fd3c0b7 100644
 --- a/services/StockService.php
 +++ b/services/StockService.php
-@@ -1761,7 +1761,7 @@ class StockService extends BaseService
+@@ -1707,7 +1707,7 @@ class StockService extends BaseService
  			throw new \Exception('No barcode lookup plugin defined');
  		}
  
 -		$path = GROCY_DATAPATH . "/plugins/$pluginName.php";
 +		$path = getenv('GROCY_PLUGIN_DIR') . "/$pluginName.php";
- 
  		if (file_exists($path))
  		{
+ 			require_once $path;
 -- 
-2.41.0
+2.42.0
 

--- a/pkgs/servers/grocy/0002-Remove-check-for-config-file-as-it-s-stored-in-etc-g.patch
+++ b/pkgs/servers/grocy/0002-Remove-check-for-config-file-as-it-s-stored-in-etc-g.patch
@@ -8,10 +8,10 @@ Subject: [PATCH 2/2] Remove check for config-file as it's stored in /etc/grocy
  1 file changed, 1 deletion(-)
 
 diff --git a/helpers/PrerequisiteChecker.php b/helpers/PrerequisiteChecker.php
-index da431b4b..6b878627 100644
+index 8e12a5c..37b433d 100644
 --- a/helpers/PrerequisiteChecker.php
 +++ b/helpers/PrerequisiteChecker.php
-@@ -17,7 +17,6 @@ class PrerequisiteChecker
+@@ -18,7 +18,6 @@ class PrerequisiteChecker
  	public function checkRequirements()
  	{
  		self::checkForPhpVersion();
@@ -20,5 +20,4 @@ index da431b4b..6b878627 100644
  		self::checkForComposer();
  		self::checkForPhpExtensions();
 -- 
-2.41.0
-
+2.42.0

--- a/pkgs/servers/grocy/default.nix
+++ b/pkgs/servers/grocy/default.nix
@@ -1,35 +1,66 @@
-{ lib, stdenv, fetchurl, unzip, nixosTests }:
+{ lib
+, fetchFromGitHub
+, fetchYarnDeps
+, php
+, yarn
+, fixup-yarn-lock
+, nixosTests
+}:
 
-stdenv.mkDerivation rec {
+php.buildComposerProject (finalAttrs: {
   pname = "grocy";
-  version = "4.0.3";
+  version = "4.2.0";
 
-  src = fetchurl {
-    url = "https://github.com/grocy/grocy/releases/download/v${version}/grocy_${version}.zip";
-    hash = "sha256-KBTsi634SolgA01eRthMuWx7DIF7rhvJSPxiHyuKSR8=";
+  src = fetchFromGitHub {
+    owner = "grocy";
+    repo = "grocy";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-aX3DMy9Jv8rNp1/VIvUtNXYXGBrCgBMs5GsDf4XXSj0=";
   };
 
-  nativeBuildInputs = [ unzip ];
-  unpackPhase = ''
-    unzip ${src} -d .
-  '';
+  vendorHash = "sha256-KaYvA0Rd4pd1s/L8QbVUgkE+SjH+jv4+6RvIaGOpews=";
+
+  offlineCache = fetchYarnDeps {
+    yarnLock = finalAttrs.src + "/yarn.lock";
+    hash = "sha256-UvWY8+qSRvzJbm7z3CmLyeUHxemzNUB7dHYP95ZVtcI=";
+  };
+
+  nativeBuildInputs = [
+    yarn
+    fixup-yarn-lock
+  ];
+
+  # Upstream composer.json file is missing the name, description and license fields
+  composerStrictValidation = false;
 
   # NOTE: if patches are created from a git checkout, those should be modified
-  # with `unixdos` to make sure those apply here.
+  # with `unix2dos` to make sure those apply here.
   patches = [
     ./0001-Define-configs-with-env-vars.patch
     ./0002-Remove-check-for-config-file-as-it-s-stored-in-etc-g.patch
   ];
-  patchFlags = [ "--binary" "-p1" ];
 
-  dontBuild = true;
+  configurePhase = ''
+    runHook preConfigure
 
-  passthru.tests = { inherit (nixosTests) grocy; };
+    export HOME=$(mktemp -d)
+    yarn config --offline set yarn-offline-mirror $offlineCache
+    fixup-yarn-lock yarn.lock
+    yarn install --offline --frozen-lockfile --no-progress --non-interactive
+
+    runHook postConfigure
+  '';
 
   installPhase = ''
-    mkdir -p $out/
-    cp -R . $out/
+    runHook preInstall
+
+    mv $out/share/php/grocy/* $out
+    rm -r $out/share
+
+    runHook postInstall
   '';
+
+  passthru.tests = { inherit (nixosTests) grocy; };
 
   meta = with lib; {
     license = licenses.mit;
@@ -37,4 +68,4 @@ stdenv.mkDerivation rec {
     description = "ERP beyond your fridge - grocy is a web-based self-hosted groceries & household management solution for your home";
     homepage = "https://grocy.info/";
   };
-}
+})


### PR DESCRIPTION
## Description of changes

The adjusted patch have been taken from #288602.

Changes:
https://github.com/grocy/grocy/releases/tag/v4.1.0
https://github.com/grocy/grocy/releases/tag/v4.2.0
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
  </ul>
</details>
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>grocy</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
