### PR TITLE
autobloody: init at 0.1.8, python311Packages.bloodyad: init at 1.1.1

### DIFF
--- a/pkgs/by-name/au/autobloody/package.nix
+++ b/pkgs/by-name/au/autobloody/package.nix
@@ -1,0 +1,46 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "autobloody";
+  version = "0.1.8";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "CravateRouge";
+    repo = "autobloody";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-0MwhdT9GYLcrdZSqszx1DC9lyz8K61lJZZCzeFfWB0E=";
+  };
+
+  nativeBuildInputs = with python3.pkgs; [
+    hatchling
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    bloodyad
+    neo4j
+  ];
+
+  # Tests require a test file which is not available in the current release
+  doCheck = false;
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "autobloody"
+  ];
+
+  meta = with lib; {
+    description = "Tool to automatically exploit Active Directory privilege escalation paths";
+    homepage = "https://github.com/CravateRouge/autobloody";
+    changelog = "https://github.com/CravateRouge/autobloody/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+    mainProgram = "autobloody";
+  };
+}

--- a/pkgs/development/python-modules/bloodyad/default.nix
+++ b/pkgs/development/python-modules/bloodyad/default.nix
@@ -1,0 +1,64 @@
+{ lib
+, buildPythonPackage
+, cryptography
+, fetchFromGitHub
+, gssapi
+, hatchling
+, ldap3
+, pyasn1
+, pytestCheckHook
+, pythonOlder
+, winacl
+}:
+
+buildPythonPackage rec {
+  pname = "bloodyad";
+  version = "1.1.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "CravateRouge";
+    repo = "bloodyAD";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-wnq+HTAPnC7pSGI2iytSyHmdqtUq2pUnNwZnsGX8CL4=";
+  };
+
+  nativeBuildInputs = [
+    hatchling
+  ];
+
+  propagatedBuildInputs = [
+    cryptography
+    gssapi
+    ldap3
+    pyasn1
+    winacl
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "bloodyAD"
+  ];
+
+  disabledTests = [
+    # Tests require network access
+    "test_01AuthCreateUser"
+    "test_02SearchAndGetChildAndGetWritable"
+    "test_03UacOwnerGenericShadowGroupPasswordDCSync"
+    "test_04ComputerRbcdGetSetAttribute"
+    "test_06AddRemoveGetDnsRecord"
+  ];
+
+  meta = with lib; {
+    description = "Module for Active Directory Privilege Escalations";
+    homepage = "https://github.com/CravateRouge/bloodyAD";
+    changelog = "https://github.com/CravateRouge/bloodyAD/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1593,6 +1593,8 @@ self: super: with self; {
 
   bloodhound-py = callPackage ../development/python-modules/bloodhound-py { };
 
+  bloodyad = callPackage ../development/python-modules/bloodyad { };
+
   blosc2 = callPackage ../development/python-modules/blosc2 { };
 
   bluecurrent-api = callPackage ../development/python-modules/bluecurrent-api { };


### PR DESCRIPTION
## Description of changes
Tool to automatically exploit Active Directory privilege escalation paths

https://github.com/CravateRouge/autobloody

Related to https://github.com/NixOS/nixpkgs/issues/81418

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
