### PR TITLE
python311Packages.signify: 0.5.2 -> 0.6.0

### DIFF
--- a/pkgs/development/python-modules/signify/default.nix
+++ b/pkgs/development/python-modules/signify/default.nix
@@ -3,7 +3,6 @@
 , buildPythonPackage
 , certvalidator
 , fetchFromGitHub
-, fetchpatch2
 , mscerts
 , oscrypto
 , pyasn1
@@ -11,29 +10,22 @@
 , pytestCheckHook
 , pythonOlder
 , setuptools
+, typing-extensions
 }:
 
 buildPythonPackage rec {
   pname = "signify";
-  version = "0.5.2";
+  version = "0.6.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "ralphje";
     repo = "signify";
     rev = "refs/tags/v${version}";
-    hash = "sha256-+UhZF+QYuv8pq/sTu7GDPUrlPNNixFgVZL+L0ulj/ko=";
+    hash = "sha256-29SyzqtZ1cI+1xrSPLFr63vwB5st/9i5b3FYtJn6eok=";
   };
-
-  patches = [
-    # https://github.com/ralphje/signify/pull/42
-    (fetchpatch2 {
-      url = "https://github.com/ralphje/signify/commit/38cad57bf86f7498259b47bfef1354aec27c0955.patch";
-      hash = "sha256-dLmHSlj2Cj6jbbrZStgK2Rh/H5vOaIbi5lut5RAbd+s=";
-    })
-  ];
 
   nativeBuildInputs = [
     setuptools
@@ -46,6 +38,7 @@ buildPythonPackage rec {
     oscrypto
     pyasn1
     pyasn1-modules
+    typing-extensions
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/ralphje/signify/compare/refs/tags/v0.5.2...v0.6.0

Changelog: https://github.com/ralphje/signify/blob/refs/tags/v0.6.0/docs/changelog.rst



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
