### PR TITLE
electrum: updater: use keys from source github repository

### DIFF
--- a/pkgs/applications/misc/electrum/update.nix
+++ b/pkgs/applications/misc/electrum/update.nix
@@ -4,6 +4,7 @@
 , bash
 , coreutils
 , curl
+, fetchurl
 , gnugrep
 , gnupg
 , gnused
@@ -13,7 +14,22 @@
 let
   downloadPageUrl = "https://download.electrum.org";
 
-  signingKeys = ["6694 D8DE 7BE8 EE56 31BE D950 2BD5 824B 7F94 70E6"];
+  signingKeys = lib.lists.map fetchurl [
+    {
+      url = "https://github.com/spesmilo/electrum/raw/master/pubkeys/Emzy.asc";
+      hash = "sha256-QG0cM6AKlSKFacVlhcso/xvrooUdF7oqoppyezt0hjE=";
+    }
+    {
+      url = "https://github.com/spesmilo/electrum/raw/master/pubkeys/ThomasV.asc";
+      hash = "sha256-37ApVZlI+2EevxQIKXVKVpktt1Ls3UbWq4dfio2ORdo=";
+    }
+    {
+      url = "https://github.com/spesmilo/electrum/raw/master/pubkeys/sombernight_releasekey.asc";
+      hash = "sha256-GgdPJ9TB5hh5SPCcTZURfqXkrU4qwl0dCci52V/wpdQ=";
+    }
+  ];
+
+  gpgImportPaths = lib.concatStringsSep " " signingKeys;
 in
 
 writeScript "update-electrum" ''
@@ -48,7 +64,7 @@ sigFile=$srcFile.asc
 export GNUPGHOME=$PWD/gnupg
 mkdir -m 700 -p "$GNUPGHOME"
 
-gpg --batch --recv-keys ${lib.concatStringsSep " " (map (x: "'${x}'") signingKeys)}
+gpg --batch --import ${gpgImportPaths}
 gpg --batch --verify "$sigFile" "$srcFile"
 
 sha256=$(nix-prefetch-url --type sha256 "file://$PWD/$srcFile")


### PR DESCRIPTION
## Description of changes

According to https://r.ryantm.com/log/electrum/, autoupdater never worked before. Retrieved key was never imported with a note:

```
gpg: key 2BD5824B7F9470E6: new key but contains no user ID - skipped
```

also, for some time, electrum sources are signed with multiple keys.

This patch fetches the keys from the [source repository](https://github.com/spesmilo/electrum/tree/master/pubkeys).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
