### PR TITLE
etlegacy: refactor

### DIFF
--- a/pkgs/by-name/et/etlegacy-assets/package.nix
+++ b/pkgs/by-name/et/etlegacy-assets/package.nix
@@ -1,0 +1,52 @@
+{ lib
+, stdenv
+, fetchurl
+}:
+
+stdenv.mkDerivation {
+  pname = "etlegacy-assets";
+  version = "2.82.0";
+
+  srcs = let
+    fetchAsset = { asset, hash }: fetchurl {
+      url = "https://mirror.etlegacy.com/etmain/${asset}";
+      inherit hash;
+    };
+  in [
+    (fetchAsset {
+      asset = "pak0.pk3";
+      hash = "sha256-cSlmsg4GUj/oFBlRZQDkmchrK0/sgjhW3b0zP8s9JuU=";
+    })
+    (fetchAsset {
+      asset = "pak1.pk3";
+      hash = "sha256-VhD9dJAkQFtEJafOY5flgYe5QdIgku8R1IRLQn31Pl0=";
+    })
+    (fetchAsset {
+      asset = "pak2.pk3";
+      hash = "sha256-pIq3SaGhKrTZE3KGsfI9ZCwp2lmEWyuvyPZOBSzwbz4=";
+    })
+  ];
+
+  sourceRoot = ".";
+  unpackCmd = "cp -r $curSrc \${curSrc##*-}";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib/etlegacy/etmain
+    cp -r . $out/lib/etlegacy/etmain/
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "ET: Legacy assets only";
+    homepage = "https://etlegacy.com";
+    license = with lib.licenses; [ cc-by-nc-sa-30 ];
+    longDescription = ''
+      ET: Legacy, an open source project fully compatible client and server
+      for the popular online FPS game Wolfenstein: Enemy Territory - whose
+      gameplay is still considered unmatched by many, despite its great age.
+    '';
+    maintainers = with lib.maintainers; [ drupol ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/et/etlegacy-unwrapped/package.nix
+++ b/pkgs/by-name/et/etlegacy-unwrapped/package.nix
@@ -1,0 +1,114 @@
+{ lib
+, stdenv
+, writeShellApplication
+, fetchFromGitHub
+, cjson
+, cmake
+, git
+, makeBinaryWrapper
+, unzip
+, curl
+, freetype
+, glew
+, libjpeg
+, libogg
+, libpng
+, libtheora
+, lua5_4
+, minizip
+, openal
+, SDL2
+, sqlite
+, zlib
+}:
+let
+  version = "2.82.0";
+  fakeGit = writeShellApplication {
+    name = "git";
+
+    text = ''
+      if [ "$1" = "describe" ]; then
+        echo "${version}"
+      fi
+    '';
+  };
+in
+stdenv.mkDerivation {
+  pname = "etlegacy-unwrapped";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "etlegacy";
+    repo = "etlegacy";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-yNVVEa+3+Swm3hgwm9cSLV0K88E37TgVVjh1uUl8O2o=";
+  };
+
+  nativeBuildInputs = [
+    cjson
+    cmake
+    fakeGit
+    git
+    makeBinaryWrapper
+    unzip
+  ];
+
+  buildInputs = [
+    curl
+    freetype
+    glew
+    libjpeg
+    libogg
+    libpng
+    libtheora
+    lua5_4
+    minizip
+    openal
+    SDL2
+    sqlite
+    zlib
+  ];
+
+  preBuild = ''
+    # Required for build time to not be in 1980
+    export SOURCE_DATE_EPOCH=$(date +%s)
+    # This indicates the build was by a CI pipeline and prevents the resource
+    # files from being flagged as 'dirty' due to potentially being custom built.
+    export CI="true"
+  '';
+
+  cmakeFlags = [
+    "-DCROSS_COMPILE32=0"
+    "-DBUILD_SERVER=1"
+    "-DBUILD_CLIENT=1"
+    "-DBUNDLED_JPEG=0"
+    "-DBUNDLED_LIBS=0"
+    "-DINSTALL_EXTRA=0"
+    "-DINSTALL_OMNIBOT=0"
+    "-DINSTALL_GEOIP=0"
+    "-DINSTALL_WOLFADMIN=0"
+    "-DFEATURE_AUTOUPDATE=0"
+    "-DINSTALL_DEFAULT_BASEDIR=${placeholder "out"}/lib/etlegacy"
+    "-DINSTALL_DEFAULT_BINDIR=${placeholder "out"}/bin"
+  ];
+
+  postInstall = ''
+    makeWrapper $out/bin/etl.* $out/bin/etl
+    makeWrapper $out/bin/etlded.* $out/bin/etlded
+  '';
+
+  hardeningDisable = [ "fortify" ];
+
+  meta = {
+    description = "ET: Legacy is an open source project based on the code of Wolfenstein: Enemy Territory which was released in 2010 under the terms of the GPLv3 license";
+    homepage = "https://etlegacy.com";
+    license = with lib.licenses; [ gpl3Plus ];
+    longDescription = ''
+      ET: Legacy, an open source project fully compatible client and server
+      for the popular online FPS game Wolfenstein: Enemy Territory - whose
+      gameplay is still considered unmatched by many, despite its great age.
+    '';
+    maintainers = with lib.maintainers; [ ashleyghooper drupol ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/et/etlegacy/package.nix
+++ b/pkgs/by-name/et/etlegacy/package.nix
@@ -6,7 +6,7 @@
 , cjson
 , cmake
 , git
-, makeWrapper
+, makeBinaryWrapper
 , unzip
 , curl
 , freetype
@@ -71,7 +71,7 @@ stdenv.mkDerivation {
     cmake
     fakeGit
     git
-    makeWrapper
+    makeBinaryWrapper
     unzip
   ];
 

--- a/pkgs/by-name/et/etlegacy/package.nix
+++ b/pkgs/by-name/et/etlegacy/package.nix
@@ -1,134 +1,34 @@
 { lib
-, stdenv
-, fetchurl
-, writeShellApplication
-, fetchFromGitHub
-, cjson
-, cmake
-, git
+, symlinkJoin
+, etlegacy-assets
+, etlegacy-unwrapped
 , makeBinaryWrapper
-, unzip
-, curl
-, freetype
-, glew
-, libjpeg
-, libogg
-, libpng
-, libtheora
-, lua5_4
-, minizip
-, openal
-, SDL2
-, sqlite
-, zlib
 }:
-let
+
+symlinkJoin {
+  name = "etlegacy";
   version = "2.82.0";
-
-  fetchAsset = { asset, hash }: fetchurl {
-    url = "https://mirror.etlegacy.com/etmain/${asset}";
-    inherit hash;
-  };
-
-  pak0 = fetchAsset {
-    asset = "pak0.pk3";
-    hash = "sha256-cSlmsg4GUj/oFBlRZQDkmchrK0/sgjhW3b0zP8s9JuU=";
-  };
-
-  pak1 = fetchAsset {
-    asset = "pak1.pk3";
-    hash = "sha256-VhD9dJAkQFtEJafOY5flgYe5QdIgku8R1IRLQn31Pl0=";
-  };
-
-  pak2 = fetchAsset {
-    asset = "pak2.pk3";
-    hash = "sha256-pIq3SaGhKrTZE3KGsfI9ZCwp2lmEWyuvyPZOBSzwbz4=";
-  };
-
-  fakeGit = writeShellApplication {
-    name = "git";
-
-    text = ''
-      if [ "$1" = "describe" ]; then
-        echo "${version}"
-      fi
-    '';
-  };
-in
-stdenv.mkDerivation {
-  pname = "etlegacy";
-  inherit version;
-
-  src = fetchFromGitHub {
-    owner = "etlegacy";
-    repo = "etlegacy";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-yNVVEa+3+Swm3hgwm9cSLV0K88E37TgVVjh1uUl8O2o=";
-  };
+  paths = [
+    etlegacy-assets
+    etlegacy-unwrapped
+  ];
 
   nativeBuildInputs = [
-    cjson
-    cmake
-    fakeGit
-    git
     makeBinaryWrapper
-    unzip
   ];
 
-  buildInputs = [
-    curl
-    freetype
-    glew
-    libjpeg
-    libogg
-    libpng
-    libtheora
-    lua5_4
-    minizip
-    openal
-    SDL2
-    sqlite
-    zlib
-  ];
-
-  preBuild = ''
-    # Required for build time to not be in 1980
-    export SOURCE_DATE_EPOCH=$(date +%s)
-    # This indicates the build was by a CI pipeline and prevents the resource
-    # files from being flagged as 'dirty' due to potentially being custom built.
-    export CI="true"
+  postBuild = ''
+    rm -rf $out/bin/*
+    makeWrapper ${etlegacy-unwrapped}/bin/etl.* $out/bin/etl \
+      --add-flags "+set fs_basepath ${placeholder "out"}/lib/etlegacy"
+    makeWrapper ${etlegacy-unwrapped}/bin/etlded.* $out/bin/etlded \
+      --add-flags "+set fs_basepath ${placeholder "out"}/lib/etlegacy"
   '';
-
-  cmakeFlags = [
-    "-DCROSS_COMPILE32=0"
-    "-DBUILD_SERVER=1"
-    "-DBUILD_CLIENT=1"
-    "-DBUNDLED_JPEG=0"
-    "-DBUNDLED_LIBS=0"
-    "-DINSTALL_EXTRA=0"
-    "-DINSTALL_OMNIBOT=0"
-    "-DINSTALL_GEOIP=0"
-    "-DINSTALL_WOLFADMIN=0"
-    "-DFEATURE_AUTOUPDATE=0"
-    "-DINSTALL_DEFAULT_BASEDIR=${placeholder "out"}/lib/etlegacy"
-    "-DINSTALL_DEFAULT_BINDIR=${placeholder "out"}/bin"
-  ];
-
-  postInstall = ''
-    ln -s ${pak0} $out/lib/etlegacy/etmain/pak0.pk3
-    ln -s ${pak1} $out/lib/etlegacy/etmain/pak1.pk3
-    ln -s ${pak2} $out/lib/etlegacy/etmain/pak2.pk3
-
-    makeWrapper $out/bin/etl.* $out/bin/etl
-    makeWrapper $out/bin/etlded.* $out/bin/etlded
-  '';
-
-  hardeningDisable = [ "fortify" ];
 
   meta = {
     description = "ET: Legacy is an open source project based on the code of Wolfenstein: Enemy Territory which was released in 2010 under the terms of the GPLv3 license";
     homepage = "https://etlegacy.com";
-    license = with lib.licenses; [ gpl3Plus ];
+    license = with lib.licenses; [ gpl3Plus cc-by-nc-sa-30 ];
     longDescription = ''
       ET: Legacy, an open source project fully compatible client and server
       for the popular online FPS game Wolfenstein: Enemy Territory - whose

--- a/pkgs/by-name/et/etlegacy/package.nix
+++ b/pkgs/by-name/et/etlegacy/package.nix
@@ -128,7 +128,7 @@ stdenv.mkDerivation {
   meta = {
     description = "ET: Legacy is an open source project based on the code of Wolfenstein: Enemy Territory which was released in 2010 under the terms of the GPLv3 license";
     homepage = "https://etlegacy.com";
-    license = with lib.licenses; [ gpl3 cc-by-nc-sa-30 ];
+    license = with lib.licenses; [ gpl3Plus ];
     longDescription = ''
       ET: Legacy, an open source project fully compatible client and server
       for the popular online FPS game Wolfenstein: Enemy Territory - whose


### PR DESCRIPTION
This PR is originally made to make sure `etlegacy` doesn't compile locally and gets cached on `cache.nixos.org`.

The reason it is currently not cached is because of the `etlegacy` licence: `cc-by-nc-sa-30`.

To fix this issue, I've created two new derivations: `etlegacy-assets` and `etlegacy-base`. The later is licenced with `gpl3Plus`.
Those new derivations are now dependencies of `etlegacy` which basically does a `symlinkJoin`.

With this new setup, the derivation `etlegacy-base` will be properly cached, and no local compilation will be required any more. 

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
