### PR TITLE
netket: init at 3.21.0

### DIFF
--- a/pkgs/development/python-modules/netket/default.nix
+++ b/pkgs/development/python-modules/netket/default.nix
@@ -1,0 +1,111 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools-scm,
+  hatchling,
+  hatch-vcs,
+  jax,
+  jaxlib,
+  numpy,
+  scipy,
+  tqdm,
+  numba,
+  igraph,
+  flax,
+  orjson,
+  optax,
+  beartype,
+  rich,
+  equinox,
+  plum-dispatch,
+  sparse,
+  einops,
+  pytestCheckHook,
+  pytest-xdist,
+  pytest-cov-stub,
+  pytest-json-report,
+  qutip,
+  networkx,
+  matplotlib,
+  pyscf,
+  tensorboardx,
+  h5py,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "netket";
+  version = "3.21.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "netket";
+    repo = "netket";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jpF3OoVDkGvns2XU3kyfCSjh/Nkqj6R5GKAGqWchrTg=";
+  };
+
+  build-system = [
+    setuptools-scm
+    hatchling
+    hatch-vcs
+  ];
+
+  dependencies = [
+    jax
+    jaxlib
+    numpy
+    scipy
+    tqdm
+    numba
+    igraph
+    flax
+    orjson
+    optax
+    beartype
+    rich
+    equinox
+    plum-dispatch
+    sparse
+    einops
+  ];
+
+  optional-dependencies = {
+    pyscf = [ pyscf ];
+    extra = [
+      tensorboardx
+      #openfermion # not packaged yet
+      h5py
+      qutip
+    ];
+  };
+
+  doCheck = false; # tests use up my ram, and they fail anyway
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-xdist
+    pytest-cov-stub
+    pytest-json-report
+    networkx
+    matplotlib
+  ];
+
+  # https://github.com/netket/netket/blob/v3.21.0/.github/workflows/CI.yml#L81-L83
+  env.NETKET_EXPERIMENTAL = "1";
+  pytestFlags = [
+    "--jax-cpu-disable-async-dispatch"
+    "--clear-cache-every"
+    "200"
+  ];
+
+  pythonImportsCheck = [ "netket" ];
+
+  meta = {
+    homepage = "https://www.netket.org";
+    changelog = "https://github.com/netket/netket/blob/v${finalAttrs.version}/CHANGELOG.md";
+    description = "Machine-learning toolbox for quantum physics";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+  };
+})

--- a/pkgs/development/python-modules/plum-dispatch/default.nix
+++ b/pkgs/development/python-modules/plum-dispatch/default.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  pythonAtLeast,
+  fetchPypi,
+  hatch,
+  hatch-vcs,
+  hatch-mypyc,
+  ipython,
+  numpy,
+  pytestCheckHook,
+  pytest-cov-stub,
+  sybil,
+  beartype,
+  typing-extensions,
+  rich,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "plum-dispatch";
+  version = "2.8.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "plum_dispatch";
+    inherit (finalAttrs) version;
+    hash = "sha256-RT/HvGfSo5SSyDSwDJTYFocdFItaCl0/SeK78jkeJhk=";
+  };
+
+  # https://github.com/beartype/plum/pull/225
+  disabled = pythonAtLeast "3.14";
+
+  build-system = [
+    hatch
+    hatch-vcs
+    hatch-mypyc
+  ];
+
+  dependencies = [
+    beartype
+    typing-extensions
+    rich
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    ipython
+    numpy
+    pytest-cov-stub
+    sybil
+  ];
+
+  disabledTests = lib.optional stdenv.hostPlatform.isDarwin "test_methodlist_repr";
+
+  pythonImportsCheck = [ "plum" ];
+
+  meta = {
+    homepage = "https://beartype.github.io/plum";
+    changelog = "https://github.com/beartype/plum/releases/tag/v${finalAttrs.version}";
+    description = "Multiple dispatch in Python";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12630,6 +12630,8 @@ self: super: with self; {
 
   plugwise = callPackage ../development/python-modules/plugwise { };
 
+  plum-dispatch = callPackage ../development/python-modules/plum-dispatch { };
+
   plum-py = callPackage ../development/python-modules/plum-py { };
 
   plumbum = callPackage ../development/python-modules/plumbum { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10990,6 +10990,8 @@ self: super: with self; {
 
   netio = callPackage ../development/python-modules/netio { };
 
+  netket = callPackage ../development/python-modules/netket { };
+
   netmap = callPackage ../development/python-modules/netmap { };
 
   netmiko = callPackage ../development/python-modules/netmiko { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add Python module [NetKet](https://www.netket.org): The Machine-Learning toolbox for Quantum Physics.

~~Currently a draft because I cannot have it work on CUDA due to some problems about `python3Packages.jaxlib` (#296737).~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
