### PR TITLE
sunshine: 0.22.0 -> 0.22.2

### DIFF
--- a/pkgs/servers/sunshine/default.nix
+++ b/pkgs/servers/sunshine/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , autoPatchelfHook
 , makeWrapper
 , buildNpmPackage
@@ -50,32 +49,26 @@ let
 in
 stdenv'.mkDerivation rec {
   pname = "sunshine";
-  version = "0.22.0";
+  version = "0.22.2";
 
   src = fetchFromGitHub {
     owner = "LizardByte";
     repo = "Sunshine";
     rev = "v${version}";
-    sha256 = "sha256-O9U4zP1o6yWtzk+2DW7ueimvsTuajLY8IETlvCT4jTE=";
+    sha256 = "sha256-So8fX0XQoW2cdTWWENoE07EU6e8vvjeTpizLoaDTjeg=";
     fetchSubmodules = true;
   };
 
   patches = [
     # remove npm install as it needs internet access -- handled separately below
     ./dont-build-webui.patch
-    # revert https://github.com/LizardByte/Sunshine/pull/2046 - let cmake install handle udev and systemd files
-    (fetchpatch {
-      url = "https://github.com/LizardByte/Sunshine/commit/0d4dfcd708c0027b7d8827a03163858800fa79fa.patch";
-      hash = "sha256-77NtfX0zB7ty92AyFOz9wJoa1jHshlNbPQ7NOpqUuYo=";
-      revert = true;
-    })
   ];
 
   # build webui
   ui = buildNpmPackage {
     inherit src version;
     pname = "sunshine-ui";
-    npmDepsHash = "sha256-jAZUu2CfcqhC2xMiZYpY7KPCRVFQgT/kgUvSI+5Cpkc=";
+    npmDepsHash = "sha256-0487ntbJZ20MZHezQ+Z3EJkidF3Dgoh/mynYwR7k/+I=";
 
     # use generated package-lock.json as upstream does not provide one
     postPatch = ''
@@ -152,17 +145,21 @@ stdenv'.mkDerivation rec {
 
   cmakeFlags = [
     "-Wno-dev"
+    # upstream tries to use systemd and udev packages to find these directories in FHS; set the paths explicitly instead
+    (lib.cmakeFeature "UDEV_RULES_INSTALL_DIR" "lib/udev/rules.d")
+    (lib.cmakeFeature "SYSTEMD_USER_UNIT_INSTALL_DIR" "lib/systemd/user")
   ];
 
   postPatch = ''
-    # fix hardcoded libevdev path
-    substituteInPlace cmake/compile_definitions/linux.cmake \
-      --replace '/usr/include/libevdev-1.0' '${libevdev}/include/libevdev-1.0'
+    # remove upstream dependency on systemd and udev
+    substituteInPlace cmake/packaging/linux.cmake \
+      --replace-fail 'find_package(Systemd)' "" \
+      --replace-fail 'find_package(Udev)' ""
 
     substituteInPlace packaging/linux/sunshine.desktop \
-      --replace '@PROJECT_NAME@' 'Sunshine' \
-      --replace '@PROJECT_DESCRIPTION@' 'Self-hosted game stream host for Moonlight' \
-      --replace '/usr/bin/env systemctl start --u sunshine' 'sunshine'
+      --subst-var-by PROJECT_NAME 'Sunshine' \
+      --subst-var-by PROJECT_DESCRIPTION 'Self-hosted game stream host for Moonlight' \
+      --replace-fail '/usr/bin/env systemctl start --u sunshine' 'sunshine'
   '';
 
   preBuild = ''

--- a/pkgs/servers/sunshine/dont-build-webui.patch
+++ b/pkgs/servers/sunshine/dont-build-webui.patch
@@ -1,14 +1,14 @@
 diff --git a/cmake/targets/common.cmake b/cmake/targets/common.cmake
-index 3dd629e..acec58d 100644
+index 9f2ce08..8c32b8f 100644
 --- a/cmake/targets/common.cmake
 +++ b/cmake/targets/common.cmake
-@@ -37,8 +37,4 @@ endif()
- 
- target_compile_options(sunshine PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${SUNSHINE_COMPILE_OPTIONS}>;$<$<COMPILE_LANGUAGE:CUDA>:${SUNSHINE_COMPILE_OPTIONS_CUDA};-std=c++17>)  # cmake-lint: disable=C0301
+@@ -48,8 +48,4 @@ else()
+     set(NPM_BUILD_HOMEBREW "")
+ endif()
  
 -#WebUI build
 -add_custom_target(web-ui ALL
 -        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
 -        COMMENT "Installing NPM Dependencies and Building the Web UI"
--        COMMAND bash -c \"npm install && SUNSHINE_SOURCE_ASSETS_DIR=${SUNSHINE_SOURCE_ASSETS_DIR} SUNSHINE_ASSETS_DIR=${CMAKE_BINARY_DIR} npm run build\") # cmake-lint: disable=C0301
+-        COMMAND bash -c \"npm install && SUNSHINE_BUILD_HOMEBREW=${NPM_BUILD_HOMEBREW} SUNSHINE_SOURCE_ASSETS_DIR=${NPM_SOURCE_ASSETS_DIR} SUNSHINE_ASSETS_DIR=${NPM_ASSETS_DIR} npm run build\") # cmake-lint: disable=C0301
 +

--- a/pkgs/servers/sunshine/package-lock.json
+++ b/pkgs/servers/sunshine/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Sunshine",
+  "name": "sunshine",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -790,9 +790,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.3.tgz",
+      "integrity": "sha512-H/5Vyeo/I1hqIdOS0m1Q63OPr0yFdZLaiVkr8ap/WyIVGdU3PyoOV/HXY8+PJE2M43+n11FY5zWQnNRNnD1UFg==",
       "engines": {
         "node": ">=0.10.0"
       }


### PR DESCRIPTION
## Description of changes

https://github.com/LizardByte/Sunshine/compare/v0.22.0...v0.22.2

- Replace reverting upstream patch (no longer usable) with CMake flags to handle installation of udev and systemd files
- Update `substituteInPlace` syntax
- Remove no longer needed substitution for `libevdev`
- Bump `npm build` removal patch

Closes #296122 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
