### PR TITLE
texlive.withPackages: do not override .out, .all attributes

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
@@ -172,7 +172,6 @@ let
 
   # emulate split output derivation
   splitOutputs = {
-    out = out // { outputSpecified = true; };
     texmfdist = texmfdist // { outputSpecified = true; };
     texmfroot = texmfroot // { outputSpecified = true; };
   } // (lib.genAttrs pkgList.nonEnvOutputs (outName: (buildEnv {
@@ -186,9 +185,9 @@ let
     inherit meta passthru;
   }).overrideAttrs { outputs = [ outName ]; } // { outputSpecified = true; }));
 
-  passthru = lib.optionalAttrs (! __combine) (splitOutputs // {
-    all = builtins.attrValues splitOutputs;
-  }) // {
+  passthru = {
+    # these are not part of pkgList.nonEnvOutputs and must be exported in passthru
+    inherit (splitOutputs) texmfdist texmfroot;
     # This is set primarily to help find-tarballs.nix to do its job
     requiredTeXPackages = builtins.filter lib.isDerivation (pkgList.bin ++ pkgList.nonbin
       ++ lib.optionals (! __fromCombineWrapper)


### PR DESCRIPTION
## Description of changes
The `.out`, `.all` attributes should never be modified to avoid interfering with standard interfaces such as `.overrideAttrs`. For instance, `.overrideAttrs` would not change the value of `.out`, breaking all sorts of things, including nix-shell.

Messing around with the outputs using `passthru` was a *really bad idea*. By the looks of it, this is the last piece of code related to it. I am temporarily leaving `texmfdist`, `texmfroot` in place, but they will disappear with the new refactor (they will become normal derivation arguments).

## Things done
- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
