### PR TITLE
home-assistant-custom-components.sensi: init at 1.3.1

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -26,5 +26,7 @@
 
   prometheus_sensor = callPackage ./prometheus_sensor {};
 
+  sensi = callPackage ./sensi {};
+
   waste_collection_schedule = callPackage ./waste_collection_schedule {};
 }

--- a/pkgs/servers/home-assistant/custom-components/sensi/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/sensi/default.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildHomeAssistantComponent,
+  websockets,
+}:
+buildHomeAssistantComponent rec {
+  owner = "iprak";
+  domain = "sensi";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = domain;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-RF182b6OBpoXfDsalwZntuaN8VxkQK2jy9qa0zNFQdI=";
+  };
+
+  propagatedBuildInputs = [
+    websockets
+  ];
+
+  meta = with lib; {
+    changelog = "https://github.com/iprak/sensi/releases/tag/v${version}";
+    description = "HomeAssistant integration for Sensi thermostat";
+    homepage = "https://github.com/iprak/sensi";
+    maintainers = with maintainers; [ ivan ];
+    license = licenses.mit;
+  };
+}


### PR DESCRIPTION
## Description of changes

This adds the Home Assistant integration https://github.com/iprak/sensi to nixpkgs. It controls Sensi thermostats via the Sensi servers (i.e. the cloud, not direct HomeKit connection).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I tested this manually on NixOS master with my Home Assistant by using

```
  services.home-assistant = {
    customComponents =
      with pkgs.home-assistant-custom-components; [
        sensi
      ];
  };
```

and adding the Sensi integration, with the refresh token copied out of the HTTP responses in Chrome (ctrl-shift-f `refresh_token`). The Sensi component appeared on my dashboard with a temperature and humidity reading.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
