### PR TITLE
papermc: fix version/hash override

### DIFF
--- a/pkgs/games/papermc/derivation.nix
+++ b/pkgs/games/papermc/derivation.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation {
       buildNum = builtins.elemAt version-split 1;
     in
     fetchurl {
-      url = "https://papermc.io/api/v2/projects/paper/versions/${mcVersion}/builds/${buildNum}/downloads/paper-${version}.jar";
+      url = "https://papermc.io/api/v2/projects/paper/versions/${mcVersion}/builds/${buildNum}/downloads/paper-${mcVersion}-${buildNum}.jar";
       inherit hash;
     };
 

--- a/pkgs/games/papermc/derivation.nix
+++ b/pkgs/games/papermc/derivation.nix
@@ -1,18 +1,18 @@
 { lib, stdenvNoCC, fetchurl, makeBinaryWrapper, jre, version, hash }:
 
-stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "papermc";
-  inherit version;
+  inherit version hash;
 
   src =
     let
-      version-split = lib.strings.splitString "-" version;
+      version-split = lib.strings.splitString "-" finalAttrs.version;
       mcVersion = builtins.elemAt version-split 0;
       buildNum = builtins.elemAt version-split 1;
     in
     fetchurl {
       url = "https://papermc.io/api/v2/projects/paper/versions/${mcVersion}/builds/${buildNum}/downloads/paper-${mcVersion}-${buildNum}.jar";
-      inherit hash;
+      inherit (finalAttrs) hash;
     };
 
   installPhase = ''
@@ -47,4 +47,4 @@ stdenvNoCC.mkDerivation {
     maintainers = with lib.maintainers; [ aaronjanse neonfuz MayNiklas ];
     mainProgram = "minecraft-server";
   };
-}
+})


### PR DESCRIPTION
## Description of changes

Version overrides for `papermc` were broken in https://github.com/NixOS/nixpkgs/pull/276292 because improvements from https://github.com/NixOS/nixpkgs/pull/256981 were erroneously reverted. This PR restores the `finalAttrs` change and includes `hash` as an attribute.

Version overrides now work as follows:

```nix
{
  services.minecraft-server.package = pkgs.papermc.overrideAttrs {
    version = "1.20.2-242";
    hash = "sha256-rJSgspLZz6LVGfeOuydCtL9Y4PKgrturfzOFzfxs540=";
  };
}
```

You can verify that the source URL is overridden correctly:

```
$ nix eval .#papermc --apply 'x: (x.overrideAttrs { version = "1.20.2-242"; hash = "sha256-rJSgspLZz6LVGfeOuydCtL9Y4PKgrturfzOFzfxs540="; }).src.url'
"https://papermc.io/api/v2/projects/paper/versions/1.20.2/builds/242/downloads/paper-1.20.2-242.jar"
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

## Ping maintainers

@aaronjanse @neonfuz @MayNiklas 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
