### PR TITLE
gopass: 1.15.11 -> 1.15.12

### DIFF
--- a/pkgs/tools/security/gopass/default.nix
+++ b/pkgs/tools/security/gopass/default.nix
@@ -13,7 +13,7 @@
 
 buildGoModule rec {
   pname = "gopass";
-  version = "1.15.11";
+  version = "1.15.12";
 
   nativeBuildInputs = [ installShellFiles makeWrapper ];
 
@@ -21,10 +21,10 @@ buildGoModule rec {
     owner = "gopasspw";
     repo = "gopass";
     rev = "v${version}";
-    hash = "sha256-wgrZkRRMEWA9Lk9eW+iGi+dZNYfDVhRu1phimZC079c=";
+    hash = "sha256-sg3I/h0mkkWmK4GD1yoX14gM2oqwRjMXpX3KULHFJsg=";
   };
 
-  vendorHash = "sha256-TvohrwSFVv5ylVRd6jPdRDyRRhqqWa0xey9KN9vtyY8=";
+  vendorHash = "sha256-jbwtxOfBL/5aXdWcsXZ5HQi83Oy00SSnLcvuWeCPBug=";
 
   subPackages = [ "." ];
 

--- a/pkgs/tools/security/gopass/git-credential.nix
+++ b/pkgs/tools/security/gopass/git-credential.nix
@@ -2,21 +2,30 @@
 , makeWrapper
 , buildGoModule
 , fetchFromGitHub
+, fetchpatch
 , gopass
 }:
 
 buildGoModule rec {
   pname = "git-credential-gopass";
-  version = "1.15.11";
+  version = "1.15.12";
 
   src = fetchFromGitHub {
     owner = "gopasspw";
     repo = "git-credential-gopass";
     rev = "v${version}";
-    hash = "sha256-qnWgrpcj3DZQu5haP/5xqoO7eogkRjBmc8XpgFFNT6I=";
+    hash = "sha256-5j5+so4LT3x+epEZf9OVn/kLNHBk2ENQxxRrzbziEA4=";
   };
 
-  vendorHash = "sha256-bit4+YgQ+Y/TA2q7KdZwYTE3ZKBwL6tUam+tHzBMiQw=";
+  patches = [
+    # go mod tidy. Remove with next release
+    (fetchpatch {
+      url = "https://github.com/gopasspw/git-credential-gopass/commit/88d11d2b1b49f00b7fba9a917cf90f7ea14c9d1b.patch";
+      hash = "sha256-mXxI9GXan0zYL8msL83VLqxOp4oAOwMyCOFaUOLAg5E=";
+    })
+  ];
+
+  vendorHash = "sha256-y1PH0+tt/kcHw2I4LWD2XfLud3JtsYqrRd/yVRPdaTA=";
 
   subPackages = [ "." ];
 

--- a/pkgs/tools/security/gopass/hibp.nix
+++ b/pkgs/tools/security/gopass/hibp.nix
@@ -2,21 +2,30 @@
 , makeWrapper
 , buildGoModule
 , fetchFromGitHub
+, fetchpatch
 , gopass
 }:
 
 buildGoModule rec {
   pname = "gopass-hibp";
-  version = "1.15.11";
+  version = "1.15.12";
 
   src = fetchFromGitHub {
     owner = "gopasspw";
     repo = "gopass-hibp";
     rev = "v${version}";
-    hash = "sha256-2XhvUIa8RxQ6CAKPGpL8/rBiJSX/WsSGtIpaHLIBM1E=";
+    hash = "sha256-5BnCaxF2XZ4f26KsTbapcZ2+Ii58nR/14pCj0c0QLKE=";
   };
 
-  vendorHash = "sha256-i9PUqircNf+jz5gcr3rVIR4tD9/bkV2h6LiDFhjiLaw=";
+  patches = [
+    # go mod tidy. Remove with next release
+    (fetchpatch {
+      url = "https://github.com/gopasspw/gopass-hibp/commit/cdfdbc6da154874c74d7c8fc83bb11a98dd8fd81.patch";
+      hash = "sha256-jCzg3c8EizhoRYvWUZCys6/q2ChVWy/psPofNGIYdxs=";
+    })
+  ];
+
+  vendorHash = "sha256-GLqtwUg3fa1okdPoQBkF+ygpm8GLmDyIyUiC7/TTTaE=";
 
   subPackages = [ "." ];
 

--- a/pkgs/tools/security/gopass/jsonapi.nix
+++ b/pkgs/tools/security/gopass/jsonapi.nix
@@ -2,22 +2,31 @@
 , makeWrapper
 , buildGoModule
 , fetchFromGitHub
+, fetchpatch
 , installShellFiles
 , gopass
 }:
 
 buildGoModule rec {
   pname = "gopass-jsonapi";
-  version = "1.15.11";
+  version = "1.15.12";
 
   src = fetchFromGitHub {
     owner = "gopasspw";
     repo = "gopass-jsonapi";
     rev = "v${version}";
-    hash = "sha256-wJlnm+sgFg55LW4RWGjcT538DgNhJtFjwgwgqwLWH50=";
+    hash = "sha256-sR+48MRBHj3XpKLp/AOGf2H4ltZD1fHlIA2HPYSHdp0=";
   };
 
-  vendorHash = "sha256-qRmPO2WM9RD43twl5a47IT3xC1LGFwNF99ojIU2xg6A=";
+  patches = [
+    # go mod tidy. Remove with next release
+    (fetchpatch {
+      url = "https://github.com/gopasspw/gopass-jsonapi/commit/cab33faab113d0c9702ebaa14cde13e5ccd465d2.patch";
+      hash = "sha256-IoxU5r1k0Y6N+PKAZH8LEO/fXHjryx5y58RRFeHP7Bc=";
+    })
+  ];
+
+  vendorHash = "sha256-2JADTyBgAK2j524G+ksKLJC255PmvMViFFCwmgtXZzA=";
 
   subPackages = [ "." ];
 

--- a/pkgs/tools/security/gopass/summon.nix
+++ b/pkgs/tools/security/gopass/summon.nix
@@ -2,21 +2,30 @@
 , makeWrapper
 , buildGoModule
 , fetchFromGitHub
+, fetchpatch
 , gopass
 }:
 
 buildGoModule rec {
   pname = "gopass-summon-provider";
-  version = "1.15.11";
+  version = "1.15.12";
 
   src = fetchFromGitHub {
     owner = "gopasspw";
     repo = "gopass-summon-provider";
     rev = "v${version}";
-    hash = "sha256-rbfzmr6HtGUBCjO9jkocSghTAN+aNXTsSsMC38HqgW0=";
+    hash = "sha256-gvgHqeVB+4d8UJhMv3CYYidttCcaRPkgI7PXasv7pCI=";
   };
 
-  vendorHash = "sha256-bit4+YgQ+Y/TA2q7KdZwYTE3ZKBwL6tUam+tHzBMiQw=";
+  patches = [
+    # go mod tidy. Remove with next release
+    (fetchpatch {
+      url = "https://github.com/gopasspw/gopass-summon-provider/commit/b3085cab14588cb6a5a383033947d9266fe0cd56.patch";
+      hash = "sha256-8mvJqejqmuOloj9mW9zzsE/Xr0DtPhJeDItzVFVv4+c=";
+    })
+  ];
+
+  vendorHash = "sha256-y1PH0+tt/kcHw2I4LWD2XfLud3JtsYqrRd/yVRPdaTA=";
 
   subPackages = [ "." ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4026,7 +4026,9 @@ with pkgs;
 
   go-audit = callPackage ../tools/system/go-audit { };
 
-  gopass = callPackage ../tools/security/gopass { };
+  gopass = callPackage ../tools/security/gopass {
+    buildGoModule = buildGo122Module;
+  };
 
   gopass-hibp = callPackage ../tools/security/gopass/hibp.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4030,7 +4030,9 @@ with pkgs;
     buildGoModule = buildGo122Module;
   };
 
-  gopass-hibp = callPackage ../tools/security/gopass/hibp.nix { };
+  gopass-hibp = callPackage ../tools/security/gopass/hibp.nix {
+    buildGoModule = buildGo122Module;
+  };
 
   gopass-jsonapi = callPackage ../tools/security/gopass/jsonapi.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4040,7 +4040,9 @@ with pkgs;
 
   git-credential-gopass = callPackage ../tools/security/gopass/git-credential.nix { };
 
-  gopass-summon-provider = callPackage ../tools/security/gopass/summon.nix { };
+  gopass-summon-provider = callPackage ../tools/security/gopass/summon.nix {
+    buildGoModule = buildGo122Module;
+  };
 
   gosh = callPackage ../tools/security/gosh { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4034,7 +4034,9 @@ with pkgs;
     buildGoModule = buildGo122Module;
   };
 
-  gopass-jsonapi = callPackage ../tools/security/gopass/jsonapi.nix { };
+  gopass-jsonapi = callPackage ../tools/security/gopass/jsonapi.nix {
+    buildGoModule = buildGo122Module;
+  };
 
   git-credential-gopass = callPackage ../tools/security/gopass/git-credential.nix { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4038,7 +4038,9 @@ with pkgs;
     buildGoModule = buildGo122Module;
   };
 
-  git-credential-gopass = callPackage ../tools/security/gopass/git-credential.nix { };
+  git-credential-gopass = callPackage ../tools/security/gopass/git-credential.nix {
+    buildGoModule = buildGo122Module;
+  };
 
   gopass-summon-provider = callPackage ../tools/security/gopass/summon.nix {
     buildGoModule = buildGo122Module;


### PR DESCRIPTION
Diff: https://github.com/gopasspw/gopass/compare/v1.15.11...v1.15.12

Changelog: https://github.com/gopasspw/gopass/blob/v1.15.12/CHANGELOG.md
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
