### PR TITLE
Single package fixpoint step 2: introduce `mkPackage`

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -465,8 +465,11 @@ rec {
 
       commonAttrs =
         {
-          inherit (drv) name system meta;
+          inherit (drv) name meta;
           inherit outputs;
+        }
+        // optionalAttrs (drv ? system) {
+          inherit (drv) system;
         }
         // optionalAttrs (drv._hydraAggregate or false) {
           _hydraAggregate = true;

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -170,7 +170,17 @@ rec {
       in
       if isAttrs result then
         result
-        // {
+        # Overriding `overrideDerivation` and `overrideAttrs` is a hack:
+        # `callPackage` shouldn't have to be aware of those functions and then
+        # fix them up, but it has to because the package arguments aren't part of
+        # the package fixpoint in `mkDerivation`.
+        #
+        # If the original package defines its own `override` method, but not
+        # `overrideDerivation`, we can assume it's a callPackage-aware `mkPackage`
+        # call.
+        # Otherwise, it is a legacy package, for which we still need to perform
+        # the hacky fixup.
+        // optionalAttrs (!(result ? override) || (result ? overrideDerivation)) {
           override = overrideArgs;
           overrideDerivation = fdrv: overrideResult (x: overrideDerivation x fdrv);
           ${if result ? overrideAttrs then "overrideAttrs" else null} =

--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -303,6 +303,10 @@ rec {
     if missingArgs == { } then
       if fargs ? mkPackage then
         if fargs != { mkPackage = false; } then
+          # If your file is e.g. an attrset with a package and something else,
+          # use `{ callPackage }: { foo = callPackage ({ mkPackage}: ...); ... }`
+          # Explaining that in the error message would be too verbose and confusing.
+          # TODO: link to docs
           throw ''
             callPackage: A package function that uses `mkPackage` must only have `{ mkPackage }:` as its arguments.
             Any other dependencies should be taken from the `mkPackage` callback.

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -80,7 +80,7 @@ let
       genericClosure readFile;
     inherit (self.fixedPoints) fix fix' converge extends composeExtensions
       composeManyExtensions makeExtensible makeExtensibleWithCustomName
-      toExtension;
+      encapsulate toExtension;
     inherit (self.attrsets) attrByPath hasAttrByPath setAttrByPath
       getAttrFromPath attrVals attrNames attrValues getAttrs catAttrs filterAttrs
       filterAttrsRecursive foldlAttrs foldAttrs collect nameValuePair mapAttrs

--- a/pkgs/build-support/node/build-npm-package/layer.nix
+++ b/pkgs/build-support/node/build-npm-package/layer.nix
@@ -1,0 +1,75 @@
+/**
+  `mkPackage` layer for building NPM packages.
+*/
+{
+  lib,
+  stdenv,
+  fetchNpmDeps,
+  buildPackages,
+  nodejs,
+  cctools,
+}:
+
+let
+  # The fetcher needs the unpack related attributes
+  fetchInherited = {
+    src = null;
+    srcs = null;
+    sourceRoot = null;
+    prePatch = null;
+    patches = null;
+    postPatch = null;
+    patchFlags = null;
+  };
+in
+this: old:
+let
+  inherit (this) deps name version;
+in
+{
+  deps = {
+    inherit (deps.nodejs) fetchNpmDeps;
+    npmHooks = buildPackages.npmHooks.override {
+      inherit (deps) nodejs;
+    };
+    inherit (deps.npmHooks) npmConfigHook npmBuildHook npmInstallHook;
+  } // old.deps;
+  /**
+    Arguments for fetchNpmDeps
+  */
+  npmFetch =
+    {
+      name = "${name}-${version}-npm-deps";
+      hash = throw "Please specify npmFetch.hash in the package definition of ${name}";
+      forceEmptyCache = false;
+      forceGitDeps = false;
+      patchFlags = "";
+      postPatch = "";
+      prePatch = "";
+    }
+    // builtins.intersectAttrs fetchInherited this.setup
+    // old.npmFetch;
+  setup = old.setup or { } // {
+    inherit (deps) nodejs;
+    npmDeps = fetchNpmDeps this.npmFetch;
+    npmPruneFlags = old.setup.npmPruneFlags or this.setup.npmInstallFlags or [ ];
+    npmBuildScript = "build";
+    nativeBuildInputs =
+      old.setup.nativeBuildInputs
+      ++ [
+        deps.nodejs
+        deps.npmConfigHook
+        deps.npmBuildHook
+        deps.npmInstallHook
+        deps.nodejs.python
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [ cctools ];
+    buildInputs = old.setup.buildInputs or [ ] ++ [ deps.nodejs ];
+    strictDeps = true;
+    # Stripping takes way too long with the amount of files required by a typical Node.js project.
+    dontStrip = old.dontStrip or true;
+  };
+  meta = (old.meta or { }) // {
+    platforms = old.meta.platforms or deps.nodejs.meta.platforms;
+  };
+}

--- a/pkgs/build-support/package/make-package.nix
+++ b/pkgs/build-support/package/make-package.nix
@@ -190,6 +190,8 @@ let
 
   layers.noop = _this: _old: { };
 
+  layers.buildNpmPackage = callPackage ../node/build-npm-package/layer.nix { };
+
   mkPackageWith =
     {
       # these are not overridable by the layer implementations - not suited for `deps`

--- a/pkgs/build-support/package/make-package.nix
+++ b/pkgs/build-support/package/make-package.nix
@@ -85,6 +85,8 @@ let
             }
           );
 
+        internals = this;
+
         # TODO: Support legacy attrs like passthru?
         overrideAttrs =
           f:

--- a/pkgs/build-support/package/make-package.nix
+++ b/pkgs/build-support/package/make-package.nix
@@ -1,0 +1,181 @@
+{
+  lib,
+  callPackage,
+  stdenv,
+  config,
+  ...
+}:
+let
+  checkMeta = import ../../stdenv/generic/check-meta.nix {
+    inherit lib config;
+    # Nix itself uses the `system` field of a derivation to decide where
+    # to build it. This is a bit confusing for cross compilation.
+    inherit (stdenv) hostPlatform;
+  };
+
+  baseLayer = this: {
+    pos = builtins.unsafeGetAttrPos "name" this;
+    # TODO: drvAttrs won't be available in RFC 92 dynamic derivations or multi-derivation packages.
+    validity = checkMeta.assertValidity {
+      inherit (this.public) meta;
+      attrs = this.drvAttrs // {
+        inherit (this) meta;
+      };
+    };
+
+    # In the repl, use :p pkg.help
+    # Since https://github.com/NixOS/nix/pull/10208
+    help =
+      if this.deps == { } then
+        ''
+          # Overriding dependencies
+
+          This package does not have overridable dependencies using the .override attribute.
+
+        ''
+      else
+        ''
+          # Overriding dependencies
+
+          This package allows its dependencies to be overridden, using the .override
+          attribute. For example:
+
+              pkg.override (old: { dep = f old.dep; })
+
+          Instead of dep, you may set the following attributes:
+
+              ${lib.concatMapStringsSep ", " lib.strings.escapeNixIdentifier (lib.attrNames this.deps)}
+        '';
+
+    deps = { };
+
+    public =
+      builtins.intersectAttrs {
+        tests = null;
+        version = null;
+      } this
+      // {
+        /*
+          The marker for a [package attribute set](https://nixos.org/manual/nix/stable/glossary.html#package-attribute-set).
+          The value is "derivation" for historical reasons.
+        */
+        type = "derivation";
+
+        # FIXME: this assumes this.drvAttrs, which is a bad dependency on the
+        #        derivation layer
+        meta = checkMeta.commonMeta {
+          inherit (this) validity pos;
+          attrs = this.drvAttrs // {
+            inherit (this) meta;
+          };
+          references =
+            this.drvAttrs.nativeBuildInputs or [ ]
+            ++ this.drvAttrs.buildInputs or [ ]
+            ++ this.drvAttrs.propagatedNativeBuildInputs or [ ]
+            ++ this.drvAttrs.propagatedBuildInputs or [ ];
+        };
+
+        inherit (this) help name;
+
+        override =
+          f:
+          this.extend (
+            this: old: {
+              deps = old.deps // f old.deps;
+            }
+          );
+
+        overrideAttrs =
+          f:
+          this.extend (
+            this: old: {
+              setup =
+                old.setup
+                // (lib.toExtension f) (
+                  this.setup or { }
+                  // {
+                    finalPackage = this.public;
+                  }
+                ) old.setup or { };
+            }
+          );
+      };
+  };
+
+  layers.derivation =
+    { stdenv, ... }:
+    this: old:
+    let
+      outputs = lib.genAttrs (this.drvAttrs.outputs) (
+        outputName:
+        this.public
+        // {
+          outPath =
+            assert this.validity.handled;
+            this.drvOutAttrs.${outputName};
+          inherit outputName;
+          outputSpecified = true;
+        }
+      );
+    in
+    {
+      drvAttrs = stdenv.makeDerivationArgument (
+        (
+          if this ? version then
+            {
+              pname = this.name;
+              inherit (this) version;
+            }
+          else
+            {
+              inherit (this) name;
+            }
+        )
+        // this.setup
+      );
+      drvOutAttrs = builtins.derivationStrict this.drvAttrs;
+      public =
+        old.public
+        // rec {
+          outPath =
+            assert this.validity.handled;
+            this.drvOutAttrs.${outputName};
+          outputName = lib.head this.drvAttrs.outputs;
+          # legacy attribute for single-drv packages
+          drvPath =
+            assert this.validity.handled;
+            this.drvOutAttrs.drvPath;
+        }
+        // outputs;
+    };
+
+  layers.withDeps =
+    f: this: old:
+    let
+      spy = lib.setFunctionArgs (args: { inherit args; }) (lib.functionArgs f);
+      # TODO: make callPackage a parameter?
+      values = (callPackage spy { }).args;
+      old2 = old // {
+        deps = old.deps or { } // values;
+      };
+      r = f (lib.mapAttrs (name: value: this.deps.${name}) values);
+      r' = if lib.isList r then lib.composeManyExtensions r else r;
+    in
+    old2 // r' this old2;
+  # lib.composeExtensions f ({ })
+
+  # TODO: layers.meson
+  # TODO: layers.cmake
+  # TODO: layers.pkg-config
+  # TODO: layers.<some language>
+
+  mkPackage = f: lib.encapsulate (lib.extends f baseLayer);
+  mkPackageWithDeps = f: mkPackage (layers.withDeps f);
+in
+{
+  inherit
+    layers
+    mkPackage
+    mkPackageWithDeps
+    ;
+}

--- a/pkgs/by-name/he/hello/package.nix
+++ b/pkgs/by-name/he/hello/package.nix
@@ -46,6 +46,11 @@ mkPackage (
 
           run = callPackage ./test.nix { hello = this.public; };
         };
+        # Other packages and tests expect to reuse our src
+        /**
+          Fetched sources of GNU hello
+        */
+        inherit (this.setup) src;
       };
 
       meta = {

--- a/pkgs/by-name/he/hello/package.nix
+++ b/pkgs/by-name/he/hello/package.nix
@@ -1,59 +1,65 @@
-{
-  callPackage,
-  lib,
-  stdenv,
-  fetchurl,
-  nixos,
-  testers,
-  versionCheckHook,
-  hello,
-}:
+{ mkPackageWithDeps, layers }:
+mkPackageWithDeps (
+  {
+    stdenv,
+    fetchurl,
+    testers,
+    lib,
+    callPackage,
+    versionCheckHook,
+  }:
+  [
+    (layers.derivation { inherit stdenv; })
+    (this: old: {
+      name = "hello";
+      version = "2.12.1";
 
-stdenv.mkDerivation (finalAttrs: {
-  pname = "hello";
-  version = "2.12.1";
+      setup = old.setup or { } // {
+        src = fetchurl {
+          url = "mirror://gnu/hello/hello-${this.version}.tar.gz";
+          hash = "sha256-jZkUKv2SV28wsM18tCqNxoCZmLxdYH2Idh9RLibH2yA=";
+        };
 
-  src = fetchurl {
-    url = "mirror://gnu/hello/hello-${finalAttrs.version}.tar.gz";
-    hash = "sha256-jZkUKv2SV28wsM18tCqNxoCZmLxdYH2Idh9RLibH2yA=";
-  };
+        doCheck = true;
+        doInstallCheck = true;
+        nativeInstallCheckInputs = [
+          versionCheckHook
+        ];
 
-  # The GNU Hello `configure` script detects how to link libiconv but fails to actually make use of that.
-  # Unfortunately, this cannot be a patch to `Makefile.am` because `autoreconfHook` causes a gettext
-  # infrastructure mismatch error when trying to build `hello`.
-  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
-    NIX_LDFLAGS = "-liconv";
-  };
+        # Give hello some install checks for testing purpose.
+        postInstallCheck = ''
+          stat "''${!outputBin}/bin/${this.meta.mainProgram}"
+        '';
+      };
 
-  doCheck = true;
+      # The GNU Hello `configure` script detects how to link libiconv but fails to actually make use of that.
+      # Unfortunately, this cannot be a patch to `Makefile.am` because `autoreconfHook` causes a gettext
+      # infrastructure mismatch error when trying to build `hello`.
+      env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+        NIX_LDFLAGS = "-liconv";
+      };
 
-  doInstallCheck = true;
-  nativeInstallCheckInputs = [
-    versionCheckHook
-  ];
+      public = old.public // {
+        tests = {
+          version = testers.testVersion { package = this.public; };
 
-  # Give hello some install checks for testing purpose.
-  postInstallCheck = ''
-    stat "''${!outputBin}/bin/${finalAttrs.meta.mainProgram}"
-  '';
+          run = callPackage ./test.nix { hello = this.public; };
+        };
+      };
 
-  passthru.tests = {
-    version = testers.testVersion { package = hello; };
-  };
-
-  passthru.tests.run = callPackage ./test.nix { hello = finalAttrs.finalPackage; };
-
-  meta = {
-    description = "Program that produces a familiar, friendly greeting";
-    longDescription = ''
-      GNU Hello is a program that prints "Hello, world!" when you run it.
-      It is fully customizable.
-    '';
-    homepage = "https://www.gnu.org/software/hello/manual/";
-    changelog = "https://git.savannah.gnu.org/cgit/hello.git/plain/NEWS?h=v${finalAttrs.version}";
-    license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ stv0g ];
-    mainProgram = "hello";
-    platforms = lib.platforms.all;
-  };
-})
+      meta = {
+        description = "Program that produces a familiar, friendly greeting";
+        longDescription = ''
+          GNU Hello is a program that prints "Hello, world!" when you run it.
+          It is fully customizable.
+        '';
+        homepage = "https://www.gnu.org/software/hello/manual/";
+        changelog = "https://git.savannah.gnu.org/cgit/hello.git/plain/NEWS?h=v${this.version}";
+        license = lib.licenses.gpl3Plus;
+        maintainers = with lib.maintainers; [ stv0g ];
+        mainProgram = "hello";
+        platforms = lib.platforms.all;
+      };
+    })
+  ]
+)

--- a/pkgs/by-name/he/hello/package.nix
+++ b/pkgs/by-name/he/hello/package.nix
@@ -1,9 +1,10 @@
-{ mkPackageWithDeps, layers }:
-mkPackageWithDeps (
+{ mkPackage }:
+mkPackage (
   {
     stdenv,
     fetchurl,
     testers,
+    layers,
     lib,
     callPackage,
     versionCheckHook,

--- a/pkgs/by-name/ne/netlify-cli/package.nix
+++ b/pkgs/by-name/ne/netlify-cli/package.nix
@@ -32,7 +32,7 @@ mkPackage (
           owner = "netlify";
           repo = "cli";
           tag = "v${this.version}";
-          hash = "sha256-fK+Z6bqnaqSYXgO0lUbGALZeCiAnvMd6LkMSH7JB7J8=";
+          hash = "sha256-LGnFVg7c+CMgjxkVdy/rdoo6uU5HaOwGKRDHRe5Hz3Y=";
         };
       };
 

--- a/pkgs/by-name/ne/netlify-cli/package.nix
+++ b/pkgs/by-name/ne/netlify-cli/package.nix
@@ -1,43 +1,58 @@
-{
-  buildNpmPackage,
-  callPackage,
-  fetchFromGitHub,
-  lib,
-  nix-update-script,
-  nodejs,
-  pkg-config,
-  vips,
-}:
+{ mkPackage }:
+mkPackage (
+  {
+    lib,
+    layers,
+    stdenv,
+    fetchFromGitHub,
+    nix-update-script,
+    pkg-config,
+    vips,
+    callPackage,
+    testers,
+    nodejs_20,
+    ...
+  }:
+  [
+    (layers.derivation { inherit stdenv; })
+    (this: old: {
+      name = "netlify-cli";
+      version = "18.0.0";
 
-buildNpmPackage rec {
-  pname = "netlify-cli";
-  version = "18.0.0";
+      deps = old.deps // {
+        nodejs = nodejs_20;
+      };
 
-  src = fetchFromGitHub {
-    owner = "netlify";
-    repo = "cli";
-    tag = "v${version}";
-    hash = "sha256-LGnFVg7c+CMgjxkVdy/rdoo6uU5HaOwGKRDHRe5Hz3Y=";
-  };
+      npmFetch.hash = "sha256-ONLkCbmmY45/sRwaGUWhA187YVtCcdPVnD7ZMFoQ2Y0=";
 
-  npmDepsHash = "sha256-ONLkCbmmY45/sRwaGUWhA187YVtCcdPVnD7ZMFoQ2Y0=";
+      setup = {
+        buildInputs = [ vips ];
+        nativeBuildInputs = [ pkg-config ];
+        src = fetchFromGitHub {
+          owner = "netlify";
+          repo = "cli";
+          tag = "v${this.version}";
+          hash = "sha256-fK+Z6bqnaqSYXgO0lUbGALZeCiAnvMd6LkMSH7JB7J8=";
+        };
+      };
 
-  inherit nodejs;
+      public = old.public // {
+        tests = {
+          version = testers.testVersion { package = this.public; };
+          run = callPackage ./test.nix { netlify-cli = this.public; };
+        };
+        updateScript = nix-update-script { };
+      };
 
-  buildInputs = [ vips ];
-  nativeBuildInputs = [ pkg-config ];
-
-  passthru = {
-    tests.test = callPackage ./test.nix { };
-    updateScript = nix-update-script { };
-  };
-
-  meta = {
-    description = "Netlify command line tool";
-    homepage = "https://github.com/netlify/cli";
-    changelog = "https://github.com/netlify/cli/blob/v${version}/CHANGELOG.md";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ roberth ];
-    mainProgram = "netlify";
-  };
-}
+      meta = {
+        description = "Netlify command line tool";
+        homepage = "https://github.com/netlify/cli";
+        changelog = "https://github.com/netlify/cli/blob/v${this.version}/CHANGELOG.md";
+        license = lib.licenses.mit;
+        maintainers = with lib.maintainers; [ roberth ];
+        mainProgram = "netlify";
+      };
+    })
+    layers.buildNpmPackage
+  ]
+)

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -63,6 +63,10 @@ let
       # This is convient to have as a parameter so the stdenv "adapters" work better
       mkDerivationFromStdenv ?
         stdenv: (import ./make-derivation.nix { inherit lib config; } stdenv).mkDerivation,
+
+      # TODO: unify with the above
+      makeDerivationArgumentFromStdenv ?
+        stdenv: (import ./make-derivation.nix { inherit lib config; } stdenv).makeDerivationArgument,
     }:
 
     let
@@ -200,6 +204,8 @@ let
       inherit (hostPlatform) system;
 
       mkDerivation = mkDerivationFromStdenv stdenv;
+
+      makeDerivationArgument = makeDerivationArgumentFromStdenv stdenv;
 
       inherit fetchurlBoot;
 

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -677,4 +677,5 @@ extendDerivation
 in
 {
   inherit mkDerivation;
+  inherit makeDerivationArgument;
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4333,10 +4333,6 @@ with pkgs;
     };
   });
 
-  netlify-cli = callPackage ../by-name/ne/netlify-cli/package.nix {
-    nodejs = nodejs_20;
-  };
-
   netpbm = callPackage ../tools/graphics/netpbm { };
 
   networkmanager = callPackage ../tools/networking/networkmanager { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -118,7 +118,6 @@ with pkgs;
   inherit (import ../build-support/package/make-package.nix { inherit callPackage config lib stdenv; })
     layers
     mkPackage
-    mkPackageWithDeps
     ;
 
   ### Nixpkgs maintainer tools

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -115,6 +115,12 @@ with pkgs;
       import ./pkg-config/defaultPkgConfigPackages.nix pkgs
     ) // { __attrsFailEvaluation = true; };
 
+  inherit (import ../build-support/package/make-package.nix { inherit callPackage config lib stdenv; })
+    layers
+    mkPackage
+    mkPackageWithDeps
+    ;
+
   ### Nixpkgs maintainer tools
 
   nix-generate-from-cpan = callPackage ../../maintainers/scripts/nix-generate-from-cpan.nix { };


### PR DESCRIPTION
## Description of changes

This provides an alternative to `mkDerivation` - a different interface which solves a significant number of problems.

- Proposal: #273815

- Includes: #158781 

- Follows #295378

Features and problems solved:
- Remove the buggy separation between
- Decouple [derivations](https://nix.dev/manual/nix/2.25/glossary#gloss-derivation) from [package attrsets](https://nix.dev/manual/nix/2.25/glossary#package-attribute-set) (specifically `mkPackage` will be usable with alternatives to `layers.derivation`)
  - Facilitate multi-derivation packages, e.g. separate `doc` output to improve bootstrapping and avoid some rebuilds
  - Facilitate [RFC 92 dynamic derivations](https://github.com/NixOS/rfcs/blob/master/rfcs/0092-plan-dynamism.md) packages
  - https://github.com/NixOS/nix/issues/6507
- Clean up the interface of packages
  - Make attributes more relevant
  - Incentivize more explicit interfaces, more knowable public interface
  - Successor of https://github.com/NixOS/nixpkgs/pull/217243
- Ability to have overridable package variables that do not affect the derivation and aren't in `passthru`
  - Makes derivation attributes intentional
- Modularity
  - Language integrations in `layers` can be combined, e.g. python + javascript in a single derivation


TODO
- [ ] Port this [fileset layer](https://github.com/NixOS/nix/pull/10995/files#diff-1904adb2564cf5e20a791943a2f426eb6c9525ef341476e729c9325797e8c96bR16-R37). It will be nicer, not having to "unset" things for `derivation`.
- [ ] rename `setup`, i.e. where known stdenv/setup/mkDerivation arguments go
- [ ] rebase the old `mkDerivation` interface on top of this?


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
