### PR TITLE
Revert "roxterm: 3.14.3 -> 3.15.0"

### DIFF
--- a/pkgs/by-name/ro/roxterm/package.nix
+++ b/pkgs/by-name/ro/roxterm/package.nix
@@ -31,13 +31,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "roxterm";
-  version = "3.15.0";
+  version = "3.14.3";
 
   src = fetchFromGitHub {
     owner = "realh";
     repo = "roxterm";
     rev = finalAttrs.version;
-    hash = "sha256-mmfnpZTCsLJ4EPxsKZXeHBZnpvc2n1TCEPmiIHmnxKc=";
+    hash = "sha256-NSOGq3rN+9X4WA8Q0gMbZ9spO/dbZkzeo4zEno/Kgcs=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#291870

An issue was reported in https://github.com/NixOS/nixpkgs/pull/291870#issuecomment-2002646464, although it is not reproducible on my machine. Waiting for upstream response at realh/roxterm#258.