### PR TITLE
python311Packages.graphviz: 0.20.1 -> 0.20.2

### DIFF
--- a/pkgs/development/python-modules/graphviz/default.nix
+++ b/pkgs/development/python-modules/graphviz/default.nix
@@ -3,7 +3,6 @@
 , buildPythonPackage
 , pythonOlder
 , fetchFromGitHub
-, fetchpatch
 , substituteAll
 , graphviz-nox
 , xdg-utils
@@ -18,17 +17,17 @@
 
 buildPythonPackage rec {
   pname = "graphviz";
-  version = "0.20.1";
+  version = "0.20.2";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.8";
 
   # patch does not apply to PyPI tarball due to different line endings
   src = fetchFromGitHub {
     owner = "xflr6";
     repo = "graphviz";
     rev = version;
-    hash = "sha256-plhWG9mE9DoTMg7mWCvFLAgtBx01LAgJ0gQ/mqBU3yc=";
+    hash = "sha256-q5y4QPBCtA1kMhxbOECodSeubj2bULnnNDrZZfxiry4=";
   };
 
   patches = [
@@ -36,12 +35,6 @@ buildPythonPackage rec {
       src = ./paths.patch;
       graphviz = graphviz-nox;
       xdgutils = xdg-utils;
-    })
-    # https://github.com/xflr6/graphviz/issues/209
-    (fetchpatch {
-      name = "fix-tests-with-python312.patch";
-      url = "https://github.com/xflr6/graphviz/commit/5ce9fc5de4f2284baa27d7a8d68ab0885d032868.patch";
-      hash = "sha256-jREPACSc4aoHY3G+39e8Axqajw4eeKkAeVu2s40v1nI=";
     })
   ];
 

--- a/pkgs/development/python-modules/graphviz/paths.patch
+++ b/pkgs/development/python-modules/graphviz/paths.patch
@@ -1,5 +1,5 @@
 diff --git a/graphviz/backend/dot_command.py b/graphviz/backend/dot_command.py
-index 60654bd..2c62b47 100644
+index 3a62a85..a38bb9b 100644
 --- a/graphviz/backend/dot_command.py
 +++ b/graphviz/backend/dot_command.py
 @@ -9,7 +9,7 @@ from .. import parameters
@@ -38,20 +38,20 @@ index fde74a6..6f29b68 100644
      kwargs = {'stderr': subprocess.DEVNULL} if quiet else {}
      subprocess.Popen(cmd, **kwargs)
 diff --git a/tests/_common.py b/tests/_common.py
-index 87b4cbd..4188beb 100644
+index edc1309..42d730c 100644
 --- a/tests/_common.py
 +++ b/tests/_common.py
-@@ -14,9 +14,9 @@ __all__ = ['EXPECTED_DOT_BINARY', 'EXPECTED_UNFLATTEN_BINARY',
+@@ -14,9 +14,9 @@ __all__ = ['EXPECTED_DOT_BINARY',
             'as_cwd',
             'check_startupinfo', 'StartupinfoMatcher']
  
--EXPECTED_DOT_BINARY = _compat.make_subprocess_arg(pathlib.Path('dot'))
-+EXPECTED_DOT_BINARY = _compat.make_subprocess_arg(pathlib.Path('@graphviz@/bin/dot'))
+-EXPECTED_DOT_BINARY = pathlib.Path('dot')
++EXPECTED_DOT_BINARY = pathlib.Path('@graphviz@/bin/dot')
  
--EXPECTED_UNFLATTEN_BINARY = _compat.make_subprocess_arg(pathlib.Path('unflatten'))
-+EXPECTED_UNFLATTEN_BINARY = _compat.make_subprocess_arg(pathlib.Path('@graphviz@/bin/unflatten'))
+-EXPECTED_UNFLATTEN_BINARY = pathlib.Path('unflatten')
++EXPECTED_UNFLATTEN_BINARY = pathlib.Path('@graphviz@/bin/unflatten')
  
- EXPECTED_DEFAULT_ENCODING = 'utf-8'
+ EXPECTED_DEFAULT_ENGINE = 'dot'
  
 diff --git a/tests/backend/test_execute.py b/tests/backend/test_execute.py
 index 2cb853a..8093dfe 100644


### PR DESCRIPTION
## Description of changes
Diff: https://github.com/xflr6/graphviz/compare/0.20.1...0.20.2

Changelog: https://github.com/xflr6/graphviz/blob/0.20.2/CHANGES.rst



<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
