### PR TITLE
Add ngscopeclient (scopehal-apps) oscilloscope software and FFTS fast fourier transform library as a package

### DIFF
--- a/pkgs/applications/science/electronics/scopehal-apps/default.nix
+++ b/pkgs/applications/science/electronics/scopehal-apps/default.nix
@@ -1,0 +1,76 @@
+{ stdenv, breakpointHook, fetchFromGitHub, makeWrapper,
+  cmake, git, lib, pkg-config,
+  libsigcxx, gtkmm3, cairomm, yaml-cpp, catch2, glfw, libtirpc, liblxi,
+  glew, libllvm, libdrm, elfutils, libxcb, zstd, libxshmfence, xcbutilkeysyms,
+  systemd,
+  shaderc, vulkan-headers, vulkan-loader, vulkan-tools, glslang, spirv-tools,
+  ffts,
+  ... }:
+stdenv.mkDerivation rec {
+  pname = "scopehal-apps";
+  version = "b589830";
+
+  src = fetchFromGitHub {
+    owner = "ngscopeclient";
+    repo = "scopehal-apps";
+    rev = "b58983056b0b6a628c97e6fbf57be3cc010717d4";
+    hash = "sha256-r07Ko9YTR5sd4Yuz8daoQU2BS3pUCkmGDVS5KzTU/bA=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake git makeWrapper ];
+  buildInputs = [
+    pkg-config
+    libsigcxx
+    gtkmm3
+    cairomm
+    yaml-cpp
+    catch2
+    glfw
+    libtirpc
+    liblxi
+    glew
+    libllvm
+    libdrm
+    elfutils
+    libxcb
+    zstd
+    libxshmfence
+    xcbutilkeysyms
+    systemd
+    vulkan-headers
+    vulkan-loader
+    vulkan-tools
+    spirv-tools
+    glslang
+    shaderc
+    ffts
+ ];
+
+  libraryPaths =
+    let
+      outPathOf = x: if (builtins.hasAttr "lib" x)
+                      then x.lib.outPath
+                      else x.out.outPath;
+      libAppend = x: "${outPathOf x}/lib";
+    in
+      builtins.concatStringsSep ":" (map libAppend buildInputs);
+
+  cmakeFlags = [
+    "-DCURRENT_GIT_VERSION=${lib.substring 0 7 src.rev}"
+    "-Wno-deprecated"
+  ];
+
+  postInstall = ''
+    ln -s $out/share $out/bin/
+    mv -v $out/bin/ngscopeclient $out/bin/ngscopeclient-unwrapped
+    makeWrapper $out/bin/ngscopeclient-unwrapped $out/bin/ngscopeclient --set LD_LIBRARY_PATH="${libraryPaths}"
+  '';
+
+  meta = with lib; {
+    homepage = "https://www.ngscopeclient.org/";
+    license = licenses.bsd3;
+    maintainers = with lib.maintainers; [ thoughtpolice hansfbaier ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/libraries/ffts/default.nix
+++ b/pkgs/development/libraries/ffts/default.nix
@@ -1,0 +1,31 @@
+{ stdenv, cmake, git, lib, fetchFromGitHub,
+  ... }:
+stdenv.mkDerivation rec {
+  pname = "ffts";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "anthonix";
+    repo = "ffts";
+    rev = "fe86885ecafd0d16eb122f3212403d1d5a86e24e";
+    hash = "sha256-arBXkEbKGd0y6XpyynUSFQmNs7fndhEK7y1NNZI9MnI=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [ cmake git ];
+  buildInputs = [  ];
+
+  cmakeFlags = [
+    "-DCURRENT_GIT_VERSION=${lib.substring 0 7 src.rev}"
+    "-DENABLE_SHARED=ON"
+    "-Wno-deprecated"
+  ];
+
+  meta = with lib; {
+    description = "The Fastest Fourier Transform in the South";
+    homepage = "http://anthonix.com/ffts";
+    license = licenses.mit;
+    maintainers = with lib.maintainers; [ thoughtpolice hansfbaier ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description of changes
This packages the ngscopeclient app (project scopehal-apps)
https://www.ngscopeclient.org/
and its dependency:
This packages the FFTS fast fourier transform library:
https://github.com/anthonix/ffts

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
