### PR TITLE
{wayfire, wayfire-plugins-extra}: 0.8.0 -> 0.8.1; wayfirePlugins.{focus-request,wayfire-shadows,wwp-switcher}: init

### DIFF
--- a/pkgs/applications/window-managers/wayfire/default.nix
+++ b/pkgs/applications/window-managers/wayfire/default.nix
@@ -45,7 +45,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    wf-config
     libGL
     libdrm
     libexecinfo
@@ -55,14 +54,15 @@ stdenv.mkDerivation (finalAttrs: {
     libxkbcommon
     wayland-protocols
     xorg.xcbutilwm
-    wayland
-    cairo
-    pango
     nlohmann_json
   ];
 
   propagatedBuildInputs = [
+    wf-config
     wlroots
+    wayland
+    cairo
+    pango
   ];
 
   nativeCheckInputs = [

--- a/pkgs/applications/window-managers/wayfire/default.nix
+++ b/pkgs/applications/window-managers/wayfire/default.nix
@@ -26,14 +26,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wayfire";
-  version = "0.8.0";
+  version = "0.8.1";
 
   src = fetchFromGitHub {
     owner = "WayfireWM";
     repo = "wayfire";
     rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-YI8N1rY71b2ulv7tAdah7sibG4qq3kY0/hyS0cls5to=";
+    hash = "sha256-OPGzPy0I6i3TvmA5KSWDb4Lsf66zM5X+Akckgs3wk2o=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/window-managers/wayfire/default.nix
+++ b/pkgs/applications/window-managers/wayfire/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, nixosTests
 , cmake
 , meson
 , ninja
@@ -82,6 +83,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   passthru.providedSessions = [ "wayfire" ];
+
+  passthru.tests.mate = nixosTests.mate-wayland;
 
   meta = {
     homepage = "https://wayfire.org/";

--- a/pkgs/applications/window-managers/wayfire/firedecor.nix
+++ b/pkgs/applications/window-managers/wayfire/firedecor.nix
@@ -5,17 +5,13 @@
 , ninja
 , pkg-config
 , boost
-, cairo
 , glib
 , libGL
 , libinput
 , librsvg
 , libxkbcommon
-, pango
 , udev
 , wayfire
-, wayland
-, wf-config
 , xcbutilwm
 , mate
 }:
@@ -39,17 +35,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     boost
-    cairo
     glib
     libGL
     libinput
     librsvg
     libxkbcommon
-    pango
     udev
     wayfire
-    wayland
-    wf-config
     xcbutilwm
   ];
 

--- a/pkgs/applications/window-managers/wayfire/focus-request.nix
+++ b/pkgs/applications/window-managers/wayfire/focus-request.nix
@@ -1,0 +1,58 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, meson
+, ninja
+, pkg-config
+, wayfire
+, wf-config
+, wayland
+, pango
+, libinput
+, libxkbcommon
+, librsvg
+, libGL
+, xcbutilwm
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "focus-request";
+  version = "0.8.0.2";
+
+  src = fetchFromGitLab {
+    owner = "wayfireplugins";
+    repo = "focus-request";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-v0kGT+KrtfFJ/hp1Dr8izKVj6UHhuW6udHFjWt1y9TY=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    wayfire
+    wf-config
+    wayland
+    pango
+    libinput
+    libxkbcommon
+    librsvg
+    libGL
+    xcbutilwm
+  ];
+
+  env = {
+    PKG_CONFIG_WAYFIRE_METADATADIR = "${placeholder "out"}/share/wayfire/metadata";
+  };
+
+  meta = {
+    homepage = "https://gitlab.com/wayfireplugins/focus-request";
+    description = "The wayfire plugin provides a mechanism to grant focus to views that make a focus self-request";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ rewine ];
+    inherit (wayfire.meta) platforms;
+  };
+})

--- a/pkgs/applications/window-managers/wayfire/plugins.nix
+++ b/pkgs/applications/window-managers/wayfire/plugins.nix
@@ -5,6 +5,7 @@ lib.makeScope pkgs.newScope (self:
     inherit (self) callPackage;
   in {
     firedecor = callPackage ./firedecor.nix { };
+    focus-request = callPackage ./focus-request.nix { };
     wayfire-plugins-extra = callPackage ./wayfire-plugins-extra.nix { };
     wayfire-shadows = callPackage ./wayfire-shadows.nix { };
     wcm = callPackage ./wcm.nix { };

--- a/pkgs/applications/window-managers/wayfire/plugins.nix
+++ b/pkgs/applications/window-managers/wayfire/plugins.nix
@@ -11,5 +11,6 @@ lib.makeScope pkgs.newScope (self:
     wcm = callPackage ./wcm.nix { };
     wf-shell = callPackage ./wf-shell.nix { };
     windecor = callPackage ./windecor.nix { };
+    wwp-switcher = callPackage ./wwp-switcher.nix { };
   }
 )

--- a/pkgs/applications/window-managers/wayfire/plugins.nix
+++ b/pkgs/applications/window-managers/wayfire/plugins.nix
@@ -6,6 +6,7 @@ lib.makeScope pkgs.newScope (self:
   in {
     firedecor = callPackage ./firedecor.nix { };
     wayfire-plugins-extra = callPackage ./wayfire-plugins-extra.nix { };
+    wayfire-shadows = callPackage ./wayfire-shadows.nix { };
     wcm = callPackage ./wcm.nix { };
     wf-shell = callPackage ./wf-shell.nix { };
     windecor = callPackage ./windecor.nix { };

--- a/pkgs/applications/window-managers/wayfire/wayfire-plugins-extra.nix
+++ b/pkgs/applications/window-managers/wayfire/wayfire-plugins-extra.nix
@@ -1,44 +1,30 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, fetchpatch
 , meson
 , ninja
 , pkg-config
 , wayfire
 , wf-config
-, gtkmm3
-, gtk-layer-shell
 , libevdev
 , libinput
 , libxkbcommon
+, nlohmann_json
 , xcbutilwm
+, gtkmm3
+, gtk-layer-shell
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wayfire-plugins-extra";
-  version = "0.8.0";
+  version = "0.8.1";
 
   src = fetchFromGitHub {
     owner = "WayfireWM";
     repo = "wayfire-plugins-extra";
     rev = "v${finalAttrs.version}";
-    fetchSubmodules = true;
-    hash = "sha256-OVyP1AgZ1d9DXFkbHnROwtSQIquEX5ccVIkcmCdDZtA=";
+    hash = "sha256-MF4tDzIZnnTXH2ZUxltIw1RP3pfRQFGrc/n9H47yW0g";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "check-dependency-libevdev.patch";
-      url = "https://github.com/WayfireWM/wayfire-plugins-extra/commit/f3bbf1fcbafd28016e36be7a5043bd82574ac9e4.patch";
-      hash = "sha256-8X1lpf8H8NuA845cIslahKDQKW/IA/KiMExU4Snk72o=";
-    })
-  ];
-
-  postPatch = ''
-    substituteInPlace metadata/meson.build \
-      --replace "wayfire.get_variable(pkgconfig: 'metadatadir')" "join_paths(get_option('prefix'), 'share/wayfire/metadata')"
-  '';
 
   nativeBuildInputs = [
     meson
@@ -52,12 +38,22 @@ stdenv.mkDerivation (finalAttrs: {
     libevdev
     libinput
     libxkbcommon
+    nlohmann_json
     xcbutilwm
     gtkmm3
     gtk-layer-shell
   ];
 
-  mesonFlags = [ "--sysconfdir /etc" ];
+  mesonFlags = [
+    # plugins in submodule, packaged individually
+    (lib.mesonBool "enable_windecor" false)
+    (lib.mesonBool "enable_wayfire_shadows" false)
+    (lib.mesonBool "enable_focus_request" false)
+  ];
+
+  env = {
+    PKG_CONFIG_WAYFIRE_METADATADIR = "${placeholder "out"}/share/wayfire/metadata";
+  };
 
   meta = {
     homepage = "https://github.com/WayfireWM/wayfire-plugins-extra";

--- a/pkgs/applications/window-managers/wayfire/wayfire-shadows.nix
+++ b/pkgs/applications/window-managers/wayfire/wayfire-shadows.nix
@@ -6,10 +6,6 @@
 , ninja
 , pkg-config
 , wayfire
-, wayland
-, wf-config
-, cairo
-, pango
 , libxkbcommon
 , libGL
 }:
@@ -33,10 +29,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     wayfire
-    wayland
-    wf-config
-    cairo
-    pango
     libxkbcommon
     libGL
   ];

--- a/pkgs/applications/window-managers/wayfire/wayfire-shadows.nix
+++ b/pkgs/applications/window-managers/wayfire/wayfire-shadows.nix
@@ -1,0 +1,57 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, unstableGitUpdater
+, meson
+, ninja
+, pkg-config
+, wayfire
+, wayland
+, wf-config
+, cairo
+, pango
+, libxkbcommon
+, libGL
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "wayfire-shadows";
+  version = "unstable-2023-09-09";
+
+  src = fetchFromGitHub {
+    owner = "timgott";
+    repo = "wayfire-shadows";
+    rev = "de3239501fcafd1aa8bd01d703aa9469900004c5";
+    hash = "sha256-oVlSzpddPDk6pbyLFMhAkuRffkYpinP7jRspVmfLfyA=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    wayfire
+    wayland
+    wf-config
+    cairo
+    pango
+    libxkbcommon
+    libGL
+  ];
+
+  env = {
+    PKG_CONFIG_WAYFIRE_METADATADIR = "${placeholder "out"}/share/wayfire/metadata";
+  };
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    homepage = "https://github.com/timgott/wayfire-shadows";
+    description = "Wayfire plugin that adds window shadows";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ rewine ];
+    inherit (wayfire.meta) platforms;
+  };
+})

--- a/pkgs/applications/window-managers/wayfire/wcm.nix
+++ b/pkgs/applications/window-managers/wayfire/wcm.nix
@@ -4,11 +4,9 @@
 , meson
 , ninja
 , pkg-config
-, wayland
 , wrapGAppsHook
 , wayfire
 , wf-shell
-, wf-config
 , wayland-scanner
 , wayland-protocols
 , gtk3
@@ -40,9 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     wayfire
-    wf-config
     wf-shell
-    wayland
     wayland-protocols
     gtk3
     gtkmm3

--- a/pkgs/applications/window-managers/wayfire/wf-shell.nix
+++ b/pkgs/applications/window-managers/wayfire/wf-shell.nix
@@ -6,7 +6,6 @@
 , pkg-config
 , wayland-scanner
 , wayfire
-, wf-config
 , alsa-lib
 , gtkmm3
 , gtk-layer-shell
@@ -35,7 +34,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     wayfire
-    wf-config
     alsa-lib
     gtkmm3
     gtk-layer-shell

--- a/pkgs/applications/window-managers/wayfire/windecor.nix
+++ b/pkgs/applications/window-managers/wayfire/windecor.nix
@@ -5,9 +5,6 @@
 , ninja
 , pkg-config
 , wayfire
-, wf-config
-, wayland
-, pango
 , eudev
 , libinput
 , libxkbcommon
@@ -40,9 +37,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     wayfire
-    wf-config
-    wayland
-    pango
     eudev
     libinput
     libxkbcommon

--- a/pkgs/applications/window-managers/wayfire/wwp-switcher.nix
+++ b/pkgs/applications/window-managers/wayfire/wwp-switcher.nix
@@ -6,10 +6,6 @@
 , ninja
 , pkg-config
 , wayfire
-, wayland
-, wf-config
-, cairo
-, pango
 , libxkbcommon
 , libGL
 , libinput
@@ -37,10 +33,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     wayfire
-    wayland
-    wf-config
-    cairo
-    pango
     libxkbcommon
     libGL
     libinput

--- a/pkgs/applications/window-managers/wayfire/wwp-switcher.nix
+++ b/pkgs/applications/window-managers/wayfire/wwp-switcher.nix
@@ -1,0 +1,65 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, unstableGitUpdater
+, meson
+, ninja
+, pkg-config
+, wayfire
+, wayland
+, wf-config
+, cairo
+, pango
+, libxkbcommon
+, libGL
+, libinput
+, gtk3
+, glibmm
+, xcbutilwm
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "wwp-switcher";
+  version = "unstable-2023-09-09";
+
+  src = fetchFromGitHub {
+    owner = "wb9688";
+    repo = "wwp-switcher";
+    rev = "04711a0db133a899f507a86e81897296b793b4f3";
+    hash = "sha256-qMyEhSZJNxAoaELKI2h1v59QJnKJzFa76Q4/WtZqpIU";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    wayfire
+    wayland
+    wf-config
+    cairo
+    pango
+    libxkbcommon
+    libGL
+    libinput
+    gtk3
+    glibmm
+    xcbutilwm
+  ];
+
+  env = {
+    PKG_CONFIG_WAYFIRE_METADATADIR = "${placeholder "out"}/share/wayfire/metadata";
+  };
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    homepage = "https://github.com/wb9688/wwp-switcher";
+    description = "A plugin to switch active window";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ rewine ];
+    inherit (wayfire.meta) platforms;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -35902,7 +35902,7 @@ with pkgs;
   weave-gitops = callPackage ../applications/networking/cluster/weave-gitops { };
 
   wayfire = callPackage ../applications/window-managers/wayfire/default.nix {
-    wlroots = wlroots_0_16;
+    wlroots = wlroots_0_17;
   };
   wf-config = callPackage ../applications/window-managers/wayfire/wf-config.nix { };
 


### PR DESCRIPTION
## Description of changes
https://github.com/WayfireWM/wayfire/releases/tag/v0.8.1
https://github.com/WayfireWM/wayfire-plugins-extra/releases/tag/v0.8.1
close: https://github.com/NixOS/nixpkgs/issues/296005
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
