### PR TITLE
gphoto2: Add option for group name

### DIFF
--- a/nixos/modules/programs/gphoto2.nix
+++ b/nixos/modules/programs/gphoto2.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 {
   meta.maintainers = [ lib.maintainers.league ];
@@ -23,6 +28,6 @@
   config = lib.mkIf config.programs.gphoto2.enable {
     services.udev.packages = [ pkgs.libgphoto2 ];
     environment.systemPackages = [ pkgs.gphoto2 ];
-    users.groups.camera = {};
+    users.groups.camera = { };
   };
 }

--- a/nixos/modules/programs/gphoto2.nix
+++ b/nixos/modules/programs/gphoto2.nix
@@ -1,10 +1,14 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
-
+let
+  cfg = config.programs.gphoto2;
+  opt = options.programs.gphoto2;
+in
 {
   meta.maintainers = [ lib.maintainers.league ];
 
@@ -14,20 +18,28 @@
       enable = lib.mkOption {
         default = false;
         type = lib.types.bool;
-        description = ''
-          Whether to configure system to use gphoto2.
-          To grant digital camera access to a user, the user must
-          be part of the camera group:
-          `users.users.alice.extraGroups = ["camera"];`
-        '';
+        description = "Whether to configure system to use gphoto2.";
       };
+      group = lib.mkOption {
+        description = ''
+          Group created when gphoto2 is enabled.
+
+          To grant digital camera access to a user, the user must be part of this group:
+          `users.users.alice.extraGroups = [ config.programs.gphoto2.group ];`.
+        '';
+        type = lib.types.str;
+        default = cfg.libgphoto2Package.group;
+        defaultText = lib.literalExpression "config.programs.gphoto2.libgphoto2Package.group";
+        readOnly = true;
+      };
+      libgphoto2Package = lib.mkPackageOption pkgs "libgphoto2" { };
     };
   };
 
   ###### implementation
-  config = lib.mkIf config.programs.gphoto2.enable {
-    services.udev.packages = [ pkgs.libgphoto2 ];
+  config = lib.mkIf cfg.enable {
+    services.udev.packages = [ opt.libgphoto2Package.default ];
     environment.systemPackages = [ pkgs.gphoto2 ];
-    users.groups.camera = { };
+    users.groups."${cfg.group}" = { };
   };
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -499,6 +499,7 @@ in {
   gotenberg = handleTest ./gotenberg.nix {};
   gotify-server = handleTest ./gotify-server.nix {};
   gotosocial = runTest ./web-apps/gotosocial.nix;
+  gphoto2 = runTest ./gphoto2.nix;
   grafana = handleTest ./grafana {};
   grafana-agent = handleTest ./grafana-agent.nix {};
   graphite = handleTest ./graphite.nix {};

--- a/pkgs/by-name/li/libgphoto2/package.nix
+++ b/pkgs/by-name/li/libgphoto2/package.nix
@@ -1,18 +1,19 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, buildPackages
-, autoreconfHook
-, pkg-config
-, gettext
-, libusb1
-, libtool
-, libexif
-, libgphoto2
-, libjpeg
-, curl
-, libxml2
-, gd
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  buildPackages,
+  autoreconfHook,
+  pkg-config,
+  gettext,
+  libusb1,
+  libtool,
+  libexif,
+  libgphoto2,
+  libjpeg,
+  curl,
+  libxml2,
+  gd,
 }:
 
 stdenv.mkDerivation rec {
@@ -56,10 +57,7 @@ stdenv.mkDerivation rec {
   postInstall =
     let
       executablePrefix =
-        if stdenv.buildPlatform == stdenv.hostPlatform then
-          "$out"
-        else
-          buildPackages.libgphoto2;
+        if stdenv.buildPlatform == stdenv.hostPlatform then "$out" else buildPackages.libgphoto2;
     in
     ''
       mkdir -p $out/lib/udev/{rules.d,hwdb.d}

--- a/pkgs/by-name/li/libgphoto2/package.nix
+++ b/pkgs/by-name/li/libgphoto2/package.nix
@@ -62,12 +62,14 @@ stdenv.mkDerivation rec {
     ''
       mkdir -p $out/lib/udev/{rules.d,hwdb.d}
       ${executablePrefix}/lib/libgphoto2/print-camera-list \
-          udev-rules version 201 group camera \
+          udev-rules version 201 group ${passthru.group} \
           >$out/lib/udev/rules.d/40-libgphoto2.rules
       ${executablePrefix}/lib/libgphoto2/print-camera-list \
-          hwdb version 201 group camera \
+          hwdb version 201 group ${passthru.group} \
           >$out/lib/udev/hwdb.d/20-gphoto.hwdb
     '';
+
+  passthru.group = "camera";
 
   meta = {
     homepage = "http://www.gphoto.org/proj/libgphoto2/";


### PR DESCRIPTION
## Description of changes

Enables referencing it in configuration dynamically, rather than with a magic string.

Closes #294871.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
