### PR TITLE
vim-language-server: init at 2.3.1

### DIFF
--- a/pkgs/by-name/vi/vim-language-server/package.json
+++ b/pkgs/by-name/vi/vim-language-server/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "vim-language-server",
+  "version": "2.3.1",
+  "description": "vim language server",
+  "keywords": [
+    "viml",
+    "vim",
+    "lsp",
+    "language",
+    "server",
+    "autocomplete"
+  ],
+  "main": "./out/index.js",
+  "repository": "https://github.com/iamcco/vim-language-server",
+  "author": "iamcco <ooiss@qq.com>",
+  "license": "MIT",
+  "scripts": {
+    "build-docs": "rm ./src/docs/builtin-docs.json && ./bin/build-docs.js",
+    "build": "rm -rf ./out && webpack",
+    "watch": "webpack -w",
+    "test": "mocha test/src/**/*.ts --require ts-node/register",
+    "lint": "tslint -c tslint.json --format verbose {.,test}/src/**/*.ts src/index.ts",
+    "fix": "tslint -c tslint.json --fix {.,test}/src/**/*.ts src/index.ts"
+  },
+  "bin": {
+    "vim-language-server": "./bin/index.js"
+  },
+  "devDependencies": {
+    "@types/mocha": "^7.0.2",
+    "@types/node": "^11.13.6",
+    "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
+    "fast-glob": "^3.2.4",
+    "findup": "^0.1.5",
+    "mocha": "^7.1.2",
+    "rxjs": "^6.6.7",
+    "rxjs-operators": "^1.1.3",
+    "shvl": "^2.0.0",
+    "ts-loader": "^8.1.0",
+    "ts-node": "^9.1.1",
+    "tslint": "^6.1.3",
+    "typescript": "^4.2.3",
+    "vscode-languageserver": "^7.0.0",
+    "vscode-languageserver-textdocument": "^1.0.1",
+    "vscode-uri": "^3.0.2",
+    "webpack": "^5.30.0",
+    "webpack-cli": "^4.6.0"
+  }
+}

--- a/pkgs/by-name/vi/vim-language-server/package.nix
+++ b/pkgs/by-name/vi/vim-language-server/package.nix
@@ -1,0 +1,43 @@
+{ lib
+, mkYarnPackage
+, fetchFromGitHub
+, fetchYarnDeps
+}:
+
+mkYarnPackage rec {
+  pname = "vim-language-server";
+  version = "2.3.1";
+
+  src = fetchFromGitHub {
+    owner = "iamcco";
+    repo = "vim-language-server";
+    rev = "v${version}";
+    hash = "sha256-NfBKNCTvCMIJrSiTlCG+LtVoMBMdCc3rzpDb9Vp2CGM=";
+  };
+
+  packageJSON = ./package.json;
+  offlineCache = fetchYarnDeps {
+    yarnLock = src + "/yarn.lock";
+    hash = "sha256-mo8urQaWIHu33+r0Y7mL9mJ/aSe/5CihuIetTeDHEUQ=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    export HOME=$(mktemp -d)
+    # https://stackoverflow.com/a/69699772/4935114
+    env NODE_OPTIONS=--openssl-legacy-provider yarn --offline build
+
+    runHook postBuild
+  '';
+
+  doDist = false;
+
+  meta = with lib; {
+    description = "VImScript language server, LSP for vim script";
+    homepage = "https://github.com/iamcco/vim-language-server";
+    license = licenses.mit;
+    maintainers = with maintainers; [ doronbehar ];
+    mainProgram = "vim-language-server";
+  };
+}


### PR DESCRIPTION
###### Motivation for this change


###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
