### PR TITLE
python311Packages.extract-msg: init at 0.48.2

### DIFF
--- a/pkgs/development/python-modules/compressed-rtf/default.nix
+++ b/pkgs/development/python-modules/compressed-rtf/default.nix
@@ -1,0 +1,46 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pytestCheckHook
+, pythonOlder
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "compressed-rtf";
+  version = "1.0.6-unstable-2023-10-15";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "delimitry";
+    repo = "compressed_rtf";
+    # https://github.com/delimitry/compressed_rtf/issues/15
+    rev = "581400c1b4c69ab0d944cfb5ca82c32059bbcc96";
+    hash = "sha256-ivvND+cOCAmRyO8yL0+WhFY/2OkrJ+E/o4xWWd7ivHA=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "compressed_rtf"
+  ];
+
+  pytestFlagsArray = [
+    "tests/tests.py"
+  ];
+
+  meta = with lib; {
+    description = "Compressed Rich Text Format (RTF) compression and decompression";
+    homepage = "https://github.com/delimitry/compressed_rtf";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/ebcdic/default.nix
+++ b/pkgs/development/python-modules/ebcdic/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, pythonOlder
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "ebcdic";
+  version = "1.1.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "roskakori";
+    repo = "CodecMapper";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-gRyZychcF3wYocgVbdF255cSuZh/cl8X0WH/Iplkmxc=";
+  };
+
+  sourceRoot = "${src.name}/${pname}";
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # https://github.com/roskakori/CodecMapper/issues/18
+    "test_can_lookup_ebcdic_codec"
+    "test_can_recode_euro_sign"
+    "test_has_codecs"
+    "test_has_ignored_codec_names"
+  ];
+
+  pythonImportsCheck = [
+    "ebcdic"
+  ];
+
+  meta = with lib; {
+    description = "Additional EBCDIC codecs";
+    homepage = "https://github.com/roskakori/CodecMapper/tree/master/ebcdic";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/extract-msg/default.nix
+++ b/pkgs/development/python-modules/extract-msg/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, beautifulsoup4
+, buildPythonPackage
+, compressed-rtf
+, ebcdic
+, fetchFromGitHub
+, olefile
+, pytestCheckHook
+, pythonOlder
+, pythonRelaxDepsHook
+, red-black-tree-mod
+, rtfde
+, setuptools
+, tzlocal
+}:
+
+buildPythonPackage rec {
+  pname = "extract-msg";
+  version = "0.48.2";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "TeamMsgExtractor";
+    repo = "msg-extractor";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-qCOi4CRBGF5MuGcHVUk+zb76pchZXbE1cBUIlzl9++w=";
+  };
+
+  pythonRelaxDeps = [
+    "olefile"
+    "red-black-tree-mod"
+  ];
+
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    beautifulsoup4
+    compressed-rtf
+    ebcdic
+    olefile
+    red-black-tree-mod
+    rtfde
+    tzlocal
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "extract_msg"
+  ];
+
+  pytestFlagsArray = [
+    "extract_msg_tests/*.py"
+  ];
+
+  meta = with lib; {
+    description = "Extracts emails and attachments saved in Microsoft Outlook's .msg files";
+    homepage = "https://github.com/TeamMsgExtractor/msg-extractor";
+    changelog = "https://github.com/TeamMsgExtractor/msg-extractor/blob/${version}/CHANGELOG.md";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/red-black-tree-mod/default.nix
+++ b/pkgs/development/python-modules/red-black-tree-mod/default.nix
@@ -1,0 +1,38 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+, pythonOlder
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "red-black-tree-mod";
+  version = "1.22";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-OONlKQOiv5Y3nCfCCCygt7kFFYZi3X7wyX9P2TqaqQg=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  # Module has no test
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "red_black_dict_mod"
+  ];
+
+  meta = with lib; {
+    description = "Flexible python implementation of red black trees";
+    homepage = "https://stromberg.dnsalias.org/~strombrg/red-black-tree-mod/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/rtfde/default.nix
+++ b/pkgs/development/python-modules/rtfde/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, lark
+, lxml
+, oletools
+, pytestCheckHook
+, pythonOlder
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "rtfde";
+  version = "0.1.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "seamustuohy";
+    repo = "RTFDE";
+    rev = "refs/tags/${version}";
+    hash = "sha256-ai9JQ3gphY/IievBNdHiblIpc0IPS9wp7CVvBIRzG/4=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    lark
+    oletools
+  ];
+
+  nativeCheckInputs = [
+    lxml
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "RTFDE"
+  ];
+
+  meta = with lib; {
+    description = "Library for extracting encapsulated HTML and plain text content from the RTF bodies";
+    homepage = "https://github.com/seamustuohy/RTFDE";
+    changelog = "https://github.com/seamustuohy/RTFDE/releases/tag/${version}";
+    license = licenses.lgpl3Only;
+    maintainers = with maintainers; [ fab ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3602,6 +3602,8 @@ self: super: with self; {
 
   ebaysdk = callPackage ../development/python-modules/ebaysdk { };
 
+  ebcdic = callPackage ../development/python-modules/ebcdic { };
+
   ebooklib = callPackage ../development/python-modules/ebooklib { };
 
   ec2instanceconnectcli = callPackage ../tools/virtualization/ec2instanceconnectcli { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6929,6 +6929,8 @@ self: super: with self; {
 
   mailmanclient = callPackage ../development/python-modules/mailmanclient { };
 
+  rtfde = callPackage ../development/python-modules/rtfde { };
+
   rtfunicode = callPackage ../development/python-modules/rtfunicode { };
 
   rtmixer = callPackage ../development/python-modules/rtmixer { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3904,6 +3904,8 @@ self: super: with self; {
 
   exitcode = callPackage ../development/python-modules/exitcode { };
 
+  extract-msg = callPackage ../development/python-modules/extract-msg { };
+
   extractcode = callPackage ../development/python-modules/extractcode { };
 
   extractcode-7z = callPackage ../development/python-modules/extractcode/7z.nix {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2353,6 +2353,8 @@ self: super: with self; {
 
   compressai = callPackage ../development/python-modules/compressai { };
 
+  compressed-rtf = callPackage ../development/python-modules/compressed-rtf { };
+
   concurrent-log-handler = callPackage ../development/python-modules/concurrent-log-handler { };
 
   conda = callPackage ../development/python-modules/conda { };
@@ -6941,7 +6943,7 @@ self: super: with self; {
 
   mako = callPackage ../development/python-modules/mako { };
 
-  malduck= callPackage ../development/python-modules/malduck { };
+  malduck = callPackage ../development/python-modules/malduck { };
 
   managesieve = callPackage ../development/python-modules/managesieve { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12774,6 +12774,8 @@ self: super: with self; {
 
   recursive-pth-loader = toPythonModule (callPackage ../development/python-modules/recursive-pth-loader { });
 
+  red-black-tree-mod = callPackage ../development/python-modules/red-black-tree-mod { };
+
   redbaron = callPackage ../development/python-modules/redbaron { };
 
   redis = callPackage ../development/python-modules/redis { };


### PR DESCRIPTION
## Description of changes
Extracts emails and attachments saved in Microsoft Outlook's .msg files

https://github.com/TeamMsgExtractor/msg-extractor

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
