### PR TITLE
Scripted stage 1 efi hibernation

### DIFF
--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -227,6 +227,10 @@ for o in $(cat /proc/cmdline); do
         boot.panic_on_fail|stage1panic=1)
             panicOnFail=1
             ;;
+	resume=*)
+	    set -- $(IFS==; echo $o)
+	    resumeDevice=$2
+	    ;;
         root=*)
             # If a root device is specified on the kernel command
             # line, make it available through the symlink /dev/root.
@@ -475,29 +479,15 @@ lustrateRoot () {
 
 
 if test -e /sys/power/resume -a -e /sys/power/disk; then
-    if test -n "@resumeDevice@" && waitDevice "@resumeDevice@"; then
-        resumeDev="@resumeDevice@"
-        resumeInfo="$(udevadm info -q property "$resumeDev" )"
-    else
-        for sd in @resumeDevices@; do
-            # Try to detect resume device. According to Ubuntu bug:
-            # https://bugs.launchpad.net/ubuntu/+source/pm-utils/+bug/923326/comments/1
-            # when there are multiple swap devices, we can't know where the hibernate
-            # image will reside. We can check all of them for swsuspend blkid.
-            if waitDevice "$sd"; then
-                resumeInfo="$(udevadm info -q property "$sd")"
-                if [ "$(echo "$resumeInfo" | sed -n 's/^ID_FS_TYPE=//p')" = "swsuspend" ]; then
-                    resumeDev="$sd"
-                    break
-                fi
-            fi
-        done
+    if test -n "$resumeDevice"; then
+        waitDevice "$resumeDevice"
+    elif modprobe efivarfs && mount -t efivarfs efivarfs /sys/firmware/efi/efivars && test -e /sys/firmware/efi/efivars/HibernateLocation-8cf2644b-4b0b-428f-9387-6d876050dc67; then
+	export GCONV_PATH=@extraUtils@/lib/gconv
+        UUID=$(dd status=none bs=1 skip=4 < /sys/firmware/efi/efivars/HibernateLocation-8cf2644b-4b0b-428f-9387-6d876050dc67 | iconv -f UTF-16 -t UTF-8 | jq -r .uuid) \
+	    && waitDevice "/dev/disk/by-uuid/$UUID"
     fi
-    if test -n "$resumeDev"; then
-        resumeMajor="$(echo "$resumeInfo" | sed -n 's/^MAJOR=//p')"
-        resumeMinor="$(echo "$resumeInfo" | sed -n 's/^MINOR=//p')"
-        echo "$resumeMajor:$resumeMinor" > /sys/power/resume 2> /dev/null || echo "failed to resume..."
-    fi
+
+    systemd-hibernate-resume
 fi
 
 @postResumeCommands@

--- a/nixos/modules/system/boot/stage-1-init.sh
+++ b/nixos/modules/system/boot/stage-1-init.sh
@@ -100,22 +100,7 @@ waitDevice() {
     # alas...  So just wait for a few seconds for the device to
     # appear.
     for dev in $device; do
-        if test ! -e $dev; then
-            echo -n "waiting for device $dev to appear..."
-            try=20
-            while [ $try -gt 0 ]; do
-                sleep 1
-                # also re-try lvm activation now that new block devices might have appeared
-                lvm vgchange -ay
-                # and tell udev to create nodes for the new LVs
-                udevadm trigger --action=add
-                if test -e $dev; then break; fi
-                echo -n "."
-                try=$((try - 1))
-            done
-            echo
-            [ $try -ne 0 ]
-        fi
+	udevadm wait --timeout=20 "$dev"
     done
 }
 

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -146,6 +146,13 @@ let
       copy_bin_and_libs ${pkgs.kmod}/bin/kmod
       ln -sf kmod $out/bin/modprobe
 
+      # Hibernation
+      copy_bin_and_libs ${lib.getBin pkgs.stdenv.cc.libc}/bin/iconv
+      mkdir -p $out/lib/gconv
+      cp ${pkgs.stdenv.cc.libc.out}/lib/gconv/UTF-16.so $out/lib/gconv
+      copy_bin_and_libs ${pkgs.jq}/bin/jq
+      copy_bin_and_libs ${config.systemd.package}/lib/systemd/systemd-hibernate-resume
+
       # Copy multipath.
       ${optionalString config.services.multipath.enable ''
         copy_bin_and_libs ${config.services.multipath.package}/bin/multipath
@@ -206,6 +213,21 @@ let
         echo "patching $i..."
         patchelf --set-rpath $out/lib $i
       done
+      cp ${pkgs.writeText "gconv-modules" ''
+        alias   UTF16//                 UTF-16//
+        module  UTF-16//                INTERNAL                UTF-16          1
+        module  INTERNAL                UTF-16//                UTF-16          1
+
+        #       from                    to                      module          cost
+        alias   UTF16LE//               UTF-16LE//
+        module  UTF-16LE//              INTERNAL                UTF-16          1
+        module  INTERNAL                UTF-16LE//              UTF-16          1
+
+        #       from                    to                      module          cost
+        alias   UTF16BE//               UTF-16BE//
+        module  UTF-16BE//              INTERNAL                UTF-16          1
+        module  INTERNAL                UTF-16BE//              UTF-16          1
+      ''} $out/lib/gconv/gconv-modules
 
       if [ -z "${toString (pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform)}" ]; then
       # Make sure that the patchelf'ed binaries still work.
@@ -309,20 +331,12 @@ let
 
     inherit linkUnits udevRules extraUtils;
 
-    inherit (config.boot) resumeDevice;
-
     inherit (config.system.nixos) distroName;
 
     inherit (config.system.build) earlyMountScript;
 
     inherit (config.boot.initrd) checkJournalingFS verbose
       preLVMCommands preDeviceCommands postDeviceCommands postResumeCommands postMountCommands preFailCommands kernelModules;
-
-    resumeDevices = map (sd: if sd ? device then sd.device else "/dev/disk/by-label/${sd.label}")
-                    (filter (sd: hasPrefix "/dev/" sd.device && !sd.randomEncryption.enable
-                             # Don't include zram devices
-                             && !(hasPrefix "/dev/zram" sd.device)
-                            ) config.swapDevices);
 
     fsInfo =
       let f = fs: [ fs.mountPoint (if fs.device != null then fs.device else "/dev/disk/by-label/${fs.label}") fs.fsType (builtins.concatStringsSep "," fs.options) ];
@@ -351,6 +365,12 @@ let
         }
         { object = "${modulesClosure}/lib";
           symlink = "/lib";
+        }
+        { object = "${config.boot.initrd.osRelease}";
+          symlink = "/etc/os-release";
+        }
+        { object = "${config.boot.initrd.osRelease}";
+          symlink = "/etc/initrd-release";
         }
         { object = pkgs.runCommand "initrd-kmod-blacklist-ubuntu" {
               src = "${pkgs.kmod-blacklist-ubuntu}/modprobe.conf";

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -673,7 +673,11 @@ in
     # https://github.com/systemd/systemd/pull/12226
     boot.kernel.sysctl."kernel.pid_max" = mkIf pkgs.stdenv.is64bit (lib.mkDefault 4194304);
 
-    boot.kernelParams = optional (!cfg.enableUnifiedCgroupHierarchy) "systemd.unified_cgroup_hierarchy=0";
+    boot.kernelParams = lib.mkMerge [
+      (lib.mkIf (!cfg.enableUnifiedCgroupHierarchy) [ "systemd.unified_cgroup_hierarchy=0" ])
+      (lib.mkIf (config.boot.resumeDevice != "") [ "resume=${config.boot.resumeDevice}" ])
+    ];
+    boot.initrd.availableKernelModules = lib.optional cfg.package.withEfi "efivarfs";
 
     # Avoid potentially degraded system state due to
     # "Userspace Out-Of-Memory (OOM) Killer was skipped because of a failed condition check (ConditionControlGroupController=v2)."

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -389,12 +389,11 @@ in {
       "autofs"
       # systemd-cryptenroll
     ] ++ lib.optional cfg.enableTpm2 "tpm-tis"
-    ++ lib.optional (cfg.enableTpm2 && !(pkgs.stdenv.hostPlatform.isRiscV64 || pkgs.stdenv.hostPlatform.isArmv7)) "tpm-crb"
-    ++ lib.optional cfg.package.withEfi "efivarfs";
+    ++ lib.optional (cfg.enableTpm2 && !(pkgs.stdenv.hostPlatform.isRiscV64 || pkgs.stdenv.hostPlatform.isArmv7)) "tpm-crb";
 
     boot.kernelParams = [
       "root=${config.boot.initrd.systemd.root}"
-    ] ++ lib.optional (config.boot.resumeDevice != "") "resume=${config.boot.resumeDevice}";
+    ];
 
     boot.initrd.systemd = {
       initrdBin = [pkgs.bash pkgs.coreutils cfg.package.kmod cfg.package];


### PR DESCRIPTION
Systemd won't allow you to hibernate without EFI anyway, unless you use 'resume=', so this doesn't affect the functionality for anyone.

## Description of changes

It's a stupid change. Why did I make it? I'm not really sure. I don't actually have any plans to maintain scripted initrd beyond the bare minimum. But it seems useful and it works. In fact I think it probably works better than what we did before.

It's kinda dumb to use a systemd binary like this, and pulling in iconv and jq has... who knows what consequences to the initrd size. Hence this being a draft.

Oh and for good measure here's a reckless commit to change how `waitDevice` works because the way it worked before was crazy. Does it handle LVM quite right? I have no idea. I tossed it in here because this PR's probably not getting merged with or without it anyway.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
