### PR TITLE
protoc-gen-{tonic,prost,prost-{serde,crate}}: * -> latest

### DIFF
--- a/pkgs/development/tools/protoc-gen-prost-crate/default.nix
+++ b/pkgs/development/tools/protoc-gen-prost-crate/default.nix
@@ -6,14 +6,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "protoc-gen-prost-crate";
-  version = "0.3.1";
+  version = "0.4.0";
 
   src = fetchCrate {
     inherit pname version;
-    sha256 = "sha256-MtGeU2PnVYPXb3nly2UaryjmjMz1lxcvYDjFiwf58FA=";
+    sha256 = "sha256-+TSZ2QstAF8DXsHunV/nQyqF++0bFud1ZWJQEI3JEwc=";
   };
 
-  cargoSha256 = "sha256-dcKJRX/iHIWEmBD2nTMyQozxld8b7dhxxB85quPUysg=";
+  cargoSha256 = "sha256-KbErgnXG11ngzLVSktuyUAupYs1ZD64z3plKVtzLx1A=";
 
   meta = with lib; {
     description = "A protoc plugin that generates Cargo crates and include files for `protoc-gen-prost`";

--- a/pkgs/development/tools/protoc-gen-prost-serde/default.nix
+++ b/pkgs/development/tools/protoc-gen-prost-serde/default.nix
@@ -6,14 +6,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "protoc-gen-prost-serde";
-  version = "0.2.3";
+  version = "0.3.0";
 
   src = fetchCrate {
     inherit pname version;
-    sha256 = "sha256-V2Z6m9y/bBwrr1mgKXKZjVg+LqTe+GalN/AeaICyE64=";
+    sha256 = "sha256-O2Mpft31ZQncqETWzwD73I1nX1Wt5XVHcTJUk5qhRLY=";
   };
 
-  cargoSha256 = "sha256-l27+Rs4TYIJXZVLj7Tjw8M5+7ivWEY0TXbLtbuzwxLw=";
+  cargoSha256 = "sha256-aUWmNS3jF1I0NLApBn3GMMv6ID9mM/j7r7sPFCsFIuw=";
 
   meta = with lib; {
     description = "A protoc plugin that generates serde serialization implementations for `protoc-gen-prost`";

--- a/pkgs/development/tools/protoc-gen-prost/default.nix
+++ b/pkgs/development/tools/protoc-gen-prost/default.nix
@@ -6,14 +6,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "protoc-gen-prost";
-  version = "0.2.3";
+  version = "0.3.1";
 
   src = fetchCrate {
     inherit pname version;
-    sha256 = "sha256-QTt5mSUe41r2fxrgWj1l6fHC/utMVIgMi2ySsdGyl/Y=";
+    sha256 = "sha256-ma9sdt3/uq06BMELwsNadMkiEfstQhA4DAQEPdizZJM=";
   };
 
-  cargoSha256 = "sha256-ghXcyxG9zqUOFKGvUza29OgC3XiEtesqsAsfI/lFT08=";
+  cargoSha256 = "sha256-pJDrwX5uDIrycxtmbds8l4wadZE0RdgmNpMwVkUGJDs=";
 
   meta = with lib; {
     description = "Protocol Buffers compiler plugin powered by Prost";

--- a/pkgs/development/tools/protoc-gen-tonic/default.nix
+++ b/pkgs/development/tools/protoc-gen-tonic/default.nix
@@ -6,14 +6,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "protoc-gen-tonic";
-  version = "0.3.0";
+  version = "0.4.0";
 
   src = fetchCrate {
     inherit pname version;
-    sha256 = "sha256-jgU1XvUxIrZ72dLNPqDGHCONMlHsjW4k4vkO626iqxs=";
+    sha256 = "sha256-3qz1ea9lEsZjhWNA0lcwqsPkNmjj2ZBljqNRr5/2lKM=";
   };
 
-  cargoSha256 = "sha256-FrkvL/uJitMkSyOytVSmlwr26yMVM12S2n+EaSw11CE=";
+  cargoSha256 = "sha256-nUsRoDaP+omZdOTnaxvHbJT1uNGtyfgXyEFZbp/CeYA=";
 
   meta = with lib; {
     description = "A protoc plugin that generates Tonic gRPC server and client code using the Prost code generation engine";


### PR DESCRIPTION
## Description of changes

- `protoc-gen-prost` 0.2.3 -> 0.3.1
- `protoc-gen-prost-serde` 0.2.3 -> 0.3.0
- `protoc-gen-prost-crate` 0.3.1 -> 0.4.0
- `protoc-gen-tonic` 0.3.0 -> 0.4.0

https://github.com/neoeinstein/protoc-gen-prost/blob/f70c820c20841011e014ea6c019c878b0d03d5d7/CHANGELOG.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
