### PR TITLE
protoc-gen-prost-crate: 0.3.1 -> 0.4.0

### DIFF
--- a/pkgs/development/tools/protoc-gen-prost-crate/default.nix
+++ b/pkgs/development/tools/protoc-gen-prost-crate/default.nix
@@ -6,14 +6,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "protoc-gen-prost-crate";
-  version = "0.3.1";
+  version = "0.4.0";
 
   src = fetchCrate {
     inherit pname version;
-    sha256 = "sha256-MtGeU2PnVYPXb3nly2UaryjmjMz1lxcvYDjFiwf58FA=";
+    sha256 = "sha256-+TSZ2QstAF8DXsHunV/nQyqF++0bFud1ZWJQEI3JEwc=";
   };
 
-  cargoSha256 = "sha256-dcKJRX/iHIWEmBD2nTMyQozxld8b7dhxxB85quPUysg=";
+  cargoSha256 = "sha256-KbErgnXG11ngzLVSktuyUAupYs1ZD64z3plKVtzLx1A=";
 
   meta = with lib; {
     description = "A protoc plugin that generates Cargo crates and include files for `protoc-gen-prost`";


### PR DESCRIPTION
## Description of changes

https://github.com/neoeinstein/protoc-gen-prost/blob/protoc-gen-prost-crate-v0.4.0/CHANGELOG.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
