### PR TITLE
Get GHC 9.8 working on M3 macs

### DIFF
--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -316,6 +316,8 @@ in {
           packages.ghc963
         else if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
           packages.ghc963
+        else if stdenv.hostPlatform.isDarwin then
+          packages.ghc964
         else
           packages.ghc963Binary;
       inherit (buildPackages.python3Packages) sphinx;


### PR DESCRIPTION
## Description of changes

GHC 9.8 cannot currently be built on M3 Macs because it relies on GHC 9.6.3 (through hadrian) which is broken due to https://gitlab.haskell.org/ghc/ghc/-/issues/23746 

Error I get when building GHC 9.8:

```
marc@Marcs-M3-Max ihp-pro % nix develop --impure
warning: Git tree '/Users/marc/digitallyinduced/ihp-pro' is dirty
error: builder for '/nix/store/25yjia69f7has5h7fyic684d2yff5xh6-shake-0.19.8.drv' failed with exit code 1;
       last 10 log lines:
       >       _Ls1ehn_info in Cloud.o
       >       _Ls2xX0_info in Derived.o
       >       _Ls2zGK_info in Files.o
       >       _Lsa90_info in libHShashable-1.4.3.0-A9LFXpiwTxs1MJiRE3ofES.a(Class.o)
       >       _LcdzG_info in libHShashable-1.4.3.0-A9LFXpiwTxs1MJiRE3ofES.a(Class.o)
       >       _Lsb7C_info in libHShashable-1.4.3.0-A9LFXpiwTxs1MJiRE3ofES.a(Class.o)
       >       ...
       > ld: symbol(s) not found for architecture arm64
       > clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
       > ghc-9.6.3: `clang' failed in phase `Linker'. (Exit code: 1)
       For full logs, run 'nix log /nix/store/25yjia69f7has5h7fyic684d2yff5xh6-shake-0.19.8.drv'.
error: 1 dependencies of derivation '/nix/store/ip40rpl4k8j249glnayc7h0nhmafq15y-hadrian-9.8.2.drv' failed to build
error: 1 dependencies of derivation '/nix/store/h2awpp00v44srnga8w4l50irnb4bj537-ghc-9.8.2.drv' failed to build
error: 1 dependencies of derivation '/nix/store/3j78g9px9vzy1mb9cg3ixy9rwlvqbv1b-ghc-9.8.2-with-packages.drv' failed to build
error: 1 dependencies of derivation '/nix/store/gx4g8x0s58prd42qxppgqvi4wldaqblh-haskell-language-server-2.6.0.0.drv' failed to build
error: 1 dependencies of derivation '/nix/store/a2c2zc4znl9pkgfxls7n2i5i9z6dk2pb-devenv-profile.drv' failed to build
error: 1 dependencies of derivation '/nix/store/84w08nzwnnihgrbcgrs5jb59jsk8vw1b-devenv-shell-env.drv' failed to build
marc@Marcs-M3-Max ihp-pro % github .
```

The fix for that linker error is in GHC 9.6.4. So by upgrading the GHC version we should have things working again.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
