### PR TITLE
haskellPackages.cpython: unbreak and add @sheepforce as maintainer

### DIFF
--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -1018,7 +1018,6 @@ broken-packages:
   - cplusplus-th # failure in job https://hydra.nixos.org/build/233204461 at 2023-09-02
   - cps-except # failure in job https://hydra.nixos.org/build/252711064 at 2024-03-16
   - cpuperf # failure in job https://hydra.nixos.org/build/233252964 at 2023-09-02
-  - cpython # failure in job https://hydra.nixos.org/build/233255188 at 2023-09-02
   - cql-io # failure in job https://hydra.nixos.org/build/233245286 at 2023-09-02
   - cqrs-core # failure in job https://hydra.nixos.org/build/233192102 at 2023-09-02
   - crack # failure in job https://hydra.nixos.org/build/233229111 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -350,6 +350,7 @@ package-maintainers:
     - mpi-hs-store
     - mpi-hs-cereal
     - mpi-hs-binary
+    - cpython
   shlok:
     - streamly-archive
     - streamly-lmdb


### PR DESCRIPTION
## Description of changes
Unbreaks the cpython package after upstream compatibility with Python >= 3.8 was enabled https://github.com/zsedem/haskell-cpython/pull/21

I've removed the entry from `broken.yaml` but was entirely sure if another step is required :)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
