### PR TITLE
irods: 4.3.0 -> 4.3.1 + fix pam auth

### DIFF
--- a/pkgs/tools/filesystems/irods/common.nix
+++ b/pkgs/tools/filesystems/irods/common.nix
@@ -26,6 +26,7 @@
     "-DIRODS_LINUX_DISTRIBUTION_VERSION_MAJOR=1.0"
     "-DCPACK_GENERATOR=TGZ"
     "-DCMAKE_CXX_FLAGS=-I${lib.getDev libcxx}/include/c++/v1"
+    "-DPAM_LIBRARY=${pam}/lib/libpam.so"
   ];
 
   postPatch = ''

--- a/pkgs/tools/filesystems/irods/default.nix
+++ b/pkgs/tools/filesystems/irods/default.nix
@@ -19,14 +19,14 @@ rec {
 
   # irods: libs and server package
   irods = stdenv.mkDerivation (finalAttrs: common // {
-    version = "4.3.0";
+    version = "4.3.1";
     pname = "irods";
 
     src = fetchFromGitHub {
       owner = "irods";
       repo = "irods";
       rev = finalAttrs.version;
-      sha256 = "sha256-rceDGFpfoFIByzDOtgNIo9JRoVd0syM21MjEKoZUQaE=";
+      sha256 = "sha256-gWgNY8+zD2lRCV5ydOTF0qAgZ1dlQSQKxtdw+U235vg=";
       fetchSubmodules = true;
     };
 
@@ -35,10 +35,10 @@ rec {
 
     postPatch = common.postPatch + ''
       patchShebangs ./test
-      substituteInPlace plugins/database/CMakeLists.txt --replace "COMMAND cpp" "COMMAND ${gcc.cc}/bin/cpp"
+      substituteInPlace plugins/database/CMakeLists.txt --replace-fail "COMMAND cpp" "COMMAND ${gcc.cc}/bin/cpp"
       for file in unit_tests/cmake/test_config/*.cmake
       do
-        substituteInPlace $file --replace "CATCH2}/include" "CATCH2}/include/catch2"
+        substituteInPlace $file --replace-quiet "CATCH2}/include" "CATCH2}/include/catch2"
       done
       export cmakeFlags="$cmakeFlags
         -DCMAKE_EXE_LINKER_FLAGS=-Wl,-rpath,$out/lib
@@ -46,7 +46,7 @@ rec {
         -DCMAKE_SHARED_LINKER_FLAGS=-Wl,-rpath,$out/lib
         "
 
-      substituteInPlace server/auth/CMakeLists.txt --replace SETUID ""
+      substituteInPlace server/auth/CMakeLists.txt --replace-fail SETUID ""
     '';
 
     meta = common.meta // {
@@ -57,14 +57,14 @@ rec {
 
   # icommands (CLI) package, depends on the irods package
   irods-icommands = stdenv.mkDerivation (finalAttrs: common // {
-    version = "4.3.0";
+    version = "4.3.1";
     pname = "irods-icommands";
 
     src = fetchFromGitHub {
       owner = "irods";
       repo = "irods_client_icommands";
       rev = finalAttrs.version;
-      sha256 = "sha256-90q1GPkoEUoiQXM6cA+DWwth7g8v93V471r9jm+l9aw=";
+      sha256 = "sha256-BjBg13KrCGRLOtGnp23qXOLudLctvu2gJ7wxHFjM5Ug=";
     };
 
     buildInputs = common.buildInputs ++ [ irods ];


### PR DESCRIPTION
## Description of changes

Pam authentication was not working because of libpam not being linked.
+ upgrade to 4.3.1

Changelog: https://irods.org/2023/10/irods-4-3-1-is-released/

Tested on a production system, with pam authentication

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
