### PR TITLE
trexio: init at 2.4.2

### DIFF
--- a/pkgs/by-name/tr/trexio/package.nix
+++ b/pkgs/by-name/tr/trexio/package.nix
@@ -1,0 +1,50 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, gfortran
+, hdf5
+, python3
+, emacs
+, swig
+}:
+
+stdenv.mkDerivation rec {
+  pname = "trexio";
+  version = "2.4.2";
+
+  src = fetchFromGitHub {
+    owner = "TREX-CoE";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-SE5cylLThpwDWyAcQZgawcdYGc/8iiIwL6EyQ+hOIYY=";
+  };
+
+  postPatch = ''
+    patchShebangs tools/*
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    gfortran
+    emacs
+    swig
+    python3
+  ];
+
+  buildInputs = [
+    hdf5
+  ];
+
+  outputs = [ "out" "dev" ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "File format and library for the storage of quantum chemical wave functions";
+    homepage = "https://trex-coe.github.io/trexio/";
+    downloadPage = "https://github.com/TREX-CoE/trexio";
+    license = licenses.bsd3;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}


### PR DESCRIPTION
## Description of changes
Adds the TRexIO library for a unified approach for handling quantum chemical wave function data in a cross-language and cross-program way. https://trex-coe.github.io/trexio/

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
