### PR TITLE
vlc-bittorrent: init at 2.15.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10245,6 +10245,7 @@
     name = "Keshav Kini";
   };
   kintrix = {
+    email = "kintrix007@proton.me";
     github = "kintrix007";
     githubId = 60898798;
     name = "kintrix";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10244,6 +10244,11 @@
     githubId = 691290;
     name = "Keshav Kini";
   };
+  kintrix = {
+    github = "kintrix007";
+    githubId = 60898798;
+    name = "kintrix";
+  };
   kinzoku = {
     email = "kinzokudev4869@gmail.com";
     github = "kinzoku-dev";

--- a/pkgs/by-name/vl/vlc-bittorrent/package.nix
+++ b/pkgs/by-name/vl/vlc-bittorrent/package.nix
@@ -1,0 +1,55 @@
+{ lib
+, autoconf-archive
+, autoreconfHook
+, boost
+, fetchFromGitHub
+, libtorrent-rasterbar
+, libvlc
+, openssl
+, pkg-config
+, stdenv
+}:
+
+# VLC does not know where the vlc-bittorrent package is installed.
+# make sure to have something like:
+#   environment.variables.VLC_PLUGIN_PATH = "${pkgs.vlc-bittorrent}";
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vlc-bittorrent";
+  version = "2.15.0";
+
+  src = fetchFromGitHub {
+    owner = "johang";
+    repo = "vlc-bittorrent";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-7FHeQYHbMKZJ3yeHqxTTAUwghTje+gEX8gSEJzfG5sQ=";
+  };
+
+  nativeBuildInputs = [
+    autoconf-archive
+    autoreconfHook
+    pkg-config
+  ];
+
+  buildInputs = [
+    boost
+    libtorrent-rasterbar
+    libvlc
+    openssl
+  ];
+
+  strictDeps = true;
+
+  # It's a library, should not have a desktop file
+  postFixup = ''
+    rm -r $out/share/
+  '';
+
+  meta = with lib; {
+    description = "A bittorrent plugin for VLC";
+    homepage = "https://github.com/johang/vlc-bittorrent";
+    license = licenses.gpl3Plus;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.kintrix ];
+  };
+})


### PR DESCRIPTION
## Description of changes

Adds vlc-bittorrent package. By default VLC cannot recognize that it is installed, since it is at a random nix store path. Normally vlc-bittorrent has a desktop file to launch VLC with the plugin added, but this is not gonna work, since upstream specifies an *absolute* path to `/usr/bin/vlc` in the `Exec` field. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
