### PR TITLE
update mountpoint-s3 license to match upstream

### DIFF
--- a/pkgs/by-name/mo/mountpoint-s3/package.nix
+++ b/pkgs/by-name/mo/mountpoint-s3/package.nix
@@ -52,7 +52,7 @@ rustPlatform.buildRustPackage rec {
   meta = with lib; {
     homepage = "https://github.com/awslabs/mountpoint-s3";
     description = "A simple, high-throughput file client for mounting an Amazon S3 bucket as a local file system.";
-    license = licenses.amazonsl;
+    license = licenses.asl20;
     maintainers = with maintainers; [ lblasc ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
## Description of changes

Update the license in the derivation for mountpoint-s3.  The upstream github repo shows that the license for this is Apache 2.0 and it has not been updated/changed since initial commit. https://github.com/awslabs/mountpoint-s3/blob/main/LICENSE

