### PR TITLE
fsuae: strip .dat archive for determinism

### DIFF
--- a/pkgs/by-name/fs/fsuae/package.nix
+++ b/pkgs/by-name/fs/fsuae/package.nix
@@ -12,6 +12,7 @@
 , lua
 , openal
 , pkg-config
+, strip-nondeterminism
 , stdenv
 , zip
 , zlib
@@ -31,6 +32,7 @@ stdenv.mkDerivation (finalAttrs:{
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
+    strip-nondeterminism
     zip
   ];
 
@@ -49,6 +51,11 @@ stdenv.mkDerivation (finalAttrs:{
   ];
 
   strictDeps = true;
+
+  # Make sure that the build timestamp is not included in the archive
+  postFixup = ''
+    strip-nondeterminism --type zip $out/share/fs-uae/fs-uae.dat
+  '';
 
   meta = {
     homepage = "https://fs-uae.net";


### PR DESCRIPTION
## Description of changes

Closes https://github.com/NixOS/nixpkgs/issues/296946

This PR makes the build of `fsuae` deterministic.
This is achieved by adding a `postPatch` hook to the derivation which calls `strip-nondeterminism` on the generated `.dat` file (a ZIP archive) that was reported to be non-deterministic.

How to check if it works:
```sh
# Build the package once
nix build .#fsuae
# Make sure building again yields the same result
nix build .#fsuae --rebuild
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
