### PR TITLE
python312Packages.whoosh: normalize pname

### DIFF
--- a/pkgs/development/python-modules/whoosh/default.nix
+++ b/pkgs/development/python-modules/whoosh/default.nix
@@ -1,10 +1,11 @@
 { lib, buildPythonPackage, fetchPypi, pytest }:
 
 buildPythonPackage rec {
-  pname = "Whoosh";
+  pname = "whoosh";
   version = "2.7.4";
   src = fetchPypi {
-    inherit pname version;
+    pname = "Whoosh";
+    inherit version;
     sha256 = "10qsqdjpbc85fykc1vgcs8xwbgn4l2l52c8d83xf1q59pwyn79bw";
   };
 

--- a/pkgs/development/python-modules/whoosh/default.nix
+++ b/pkgs/development/python-modules/whoosh/default.nix
@@ -1,31 +1,51 @@
-{ lib, buildPythonPackage, fetchPypi, pytest }:
+{ lib
+, buildPythonPackage
+, fetchPypi
+, pytestCheckHook
+, pythonOlder
+, setuptools
+}:
 
 buildPythonPackage rec {
   pname = "whoosh";
   version = "2.7.4";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
   src = fetchPypi {
     pname = "Whoosh";
     inherit version;
-    sha256 = "10qsqdjpbc85fykc1vgcs8xwbgn4l2l52c8d83xf1q59pwyn79bw";
+    hash = "sha256-fKVjPb+p4OD6QA0xUaigxL7FO9Ls7cCmdwWxdWXDGoM=";
   };
 
-  nativeCheckInputs = [ pytest ];
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
   # Wrong encoding
   postPatch = ''
     rm tests/test_reading.py
-    substituteInPlace setup.cfg --replace "[pytest]" "[tool:pytest]"
-  '';
-  checkPhase =  ''
-    # FIXME: test_minimize_dfa fails on python 3.6
-    py.test -k "not test_timelimit and not test_minimize_dfa"
+    substituteInPlace setup.cfg \
+      --replace-fail "[pytest]" "[tool:pytest]"
   '';
 
+  pythonImportsCheck = [
+    "whoosh"
+  ];
+
+  disabledTests = [
+    "test_minimize_dfa"
+  ];
+
   meta = with lib; {
-    description = "Fast, pure-Python full text indexing, search, and spell
-checking library.";
-    homepage    = "https://bitbucket.org/mchaput/whoosh";
-    license     = licenses.bsd2;
+    description = "Fast, pure-Python full text indexing, search, and spell checking library";
+    homepage = "https://github.com/mchaput/whoosh";
+    license = licenses.bsd2;
     maintainers = with maintainers; [ ];
   };
 }


### PR DESCRIPTION
## Description of changes

part of #245383

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
