### PR TITLE
[Backport release-23.11] tutanota-desktop: 3.118.27 -> 3.122.5, use appimage

### DIFF
--- a/pkgs/applications/networking/mailreaders/tutanota-desktop/default.nix
+++ b/pkgs/applications/networking/mailreaders/tutanota-desktop/default.nix
@@ -1,61 +1,37 @@
-{ stdenv, lib, fetchurl, makeDesktopItem, copyDesktopItems, makeWrapper,
-electron, libsecret }:
+{ lib
+, appimageTools
+, fetchurl
+}:
 
-stdenv.mkDerivation rec {
+appimageTools.wrapType2 rec {
   pname = "tutanota-desktop";
-  version = "3.118.27";
+  version = "3.122.5";
 
   src = fetchurl {
-    url = "https://github.com/tutao/tutanota/releases/download/tutanota-desktop-release-${version}/${pname}-${version}-unpacked-linux.tar.gz";
-    name = "tutanota-desktop-${version}.tar.gz";
-    hash = "sha256-z2Ir8O7IDiE7cYuLshpMQMnOJanaECUvKlUEyPayIPo=";
+    url = "https://github.com/tutao/tutanota/releases/download/tutanota-desktop-release-${version}/tutanota-desktop-linux.AppImage";
+    hash = "sha256-3M53Re6FbxEXHBl5KBLDjZg0uTIv8JIT0DlawNRPXBc=";
   };
 
-  nativeBuildInputs = [
-    copyDesktopItems
-    makeWrapper
-  ];
+  extraPkgs = pkgs: (appimageTools.defaultFhsEnvArgs.multiPkgs pkgs) ++ [ pkgs.libsecret ];
 
-  dontConfigure = true;
-  dontBuild = true;
+  extraInstallCommands =
+    let appimageContents = appimageTools.extract { inherit pname version src; };
+    in ''
+      mv $out/bin/${pname}-${version} $out/bin/${pname}
 
-  desktopItems = makeDesktopItem {
-    name = pname;
-    exec = "tutanota-desktop";
-    icon = "tutanota-desktop";
-    comment = meta.description;
-    desktopName = "Tutanota Desktop";
-    genericName = "Email Reader";
-  };
+      install -Dm 444 ${appimageContents}/tutanota-desktop.desktop -t $out/share/applications
+      install -Dm 444 ${appimageContents}/tutanota-desktop.png -t $out/share/pixmaps
 
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/bin $out/opt/tutanota-desktop $out/share/tutanota-desktop
-
-    cp -r ./ $out/opt/tutanota-desktop
-    mv $out/opt/tutanota-desktop/{locales,resources} $out/share/tutanota-desktop
-
-    for icon_size in 64 512; do
-      icon=resources/icons/icon/$icon_size.png
-      path=$out/share/icons/hicolor/$icon_size'x'$icon_size/apps/tutanota-desktop.png
-      install -Dm644 $icon $path
-    done
-
-    makeWrapper ${electron}/bin/electron \
-      $out/bin/tutanota-desktop \
-      --add-flags $out/share/tutanota-desktop/resources/app.asar \
-      --run "mkdir -p /tmp/tutanota" \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libsecret stdenv.cc.cc.lib ]}
-
-    runHook postInstall
-  '';
+      substituteInPlace $out/share/applications/tutanota-desktop.desktop \
+        --replace 'Exec=AppRun' 'Exec=${pname}'
+    '';
 
   meta = with lib; {
-    description = "Tutanota official desktop client";
-    homepage = "https://tutanota.com/";
+    description = "Tuta official desktop client";
+    homepage = "https://tuta.com/";
     changelog = "https://github.com/tutao/tutanota/releases/tag/tutanota-desktop-release-${version}";
     license = licenses.gpl3Only;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     maintainers = with maintainers; [ wolfangaukang ];
     mainProgram = "tutanota-desktop";
     platforms = [ "x86_64-linux" ];


### PR DESCRIPTION
## Description of changes

Backport of #278953 by @WolfangAukang.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
