### PR TITLE
agdaPackages._1lab: 2023-12-04 -> 2024-03-07

### DIFF
--- a/pkgs/development/libraries/agda/1lab/default.nix
+++ b/pkgs/development/libraries/agda/1lab/default.nix
@@ -2,13 +2,13 @@
 
 mkDerivation rec {
   pname = "1lab";
-  version = "unstable-2023-12-04";
+  version = "unstable-2024-03-07";
 
   src = fetchFromGitHub {
     owner = "plt-amy";
     repo = pname;
-    rev = "47c2a96220b4d14419e5ddb973bc1fa06933e723";
-    hash = "sha256-0U6s6sXdynk2IWRBDXBJCf7Gc+gE8AhR1PXZl0DS4yU=";
+    rev = "d698f21793c4815082c94d174b9eafae912abb1a";
+    hash = "sha256-v8avF9zNNz32kLuAacPdEVeUI9rjn6JCiWPzkXfzBS0=";
   };
 
   postPatch = ''
@@ -17,12 +17,20 @@ mkDerivation rec {
 
     # Remove verbosity options as they make Agda take longer and use more memory.
     shopt -s globstar extglob
-    sed -Ei '/OPTIONS/s/ -v ?[^ #]+//g' src/**/*.@(agda|lagda.md)
+    files=(src/**/*.@(agda|lagda.md))
+    sed -Ei '/OPTIONS/s/ -v ?[^ #]+//g' "''${files[@]}"
+
+    # Generate all-pages manually instead of building the build script.
+    mkdir -p _build
+    for f in "''${files[@]}"; do
+      f=''${f#src/} f=''${f%%.*} f=''${f//\//.}
+      echo "open import $f"
+    done > _build/all-pages.agda
   '';
 
   libraryName = "1lab";
   libraryFile = "1lab.agda-lib";
-  everythingFile = "src/index.lagda.md";
+  everythingFile = "_build/all-pages.agda";
 
   meta = with lib; {
     description =


### PR DESCRIPTION
The `index` module doesn't import everything, so we generate the list of all modules manually. This is simple enough and avoids having to build the Haskell build script.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
