### PR TITLE
gh-copilot: init at 0.5.4-beta

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15036,6 +15036,12 @@
     github = "pennae";
     githubId = 82953136;
   };
+  perchun = {
+    name = "Perchun Pak";
+    email = "nixpkgs@perchun.it";
+    github = "PerchunPak";
+    githubId = 68118654;
+  };
   peret = {
     name = "Peter Retzlaff";
     github = "peret";

--- a/pkgs/by-name/gh/gh-copilot/package.nix
+++ b/pkgs/by-name/gh/gh-copilot/package.nix
@@ -1,0 +1,59 @@
+{ stdenv
+, lib
+, fetchurl
+}:
+let
+  inherit (stdenv.hostPlatform) system;
+  throwSystem = throw "Unsupported system: ${system}";
+
+  systemToPlatform = {
+    "x86_64-linux" = {
+      name = "linux-amd64";
+      hash = "sha256-FKzvERcVYkyy1aNYHZIftC2WvSHRxFqSG/g7gpTTvoo=";
+    };
+    "aarch64-linux" = {
+      name = "linux-arm64";
+      hash = "sha256-4vX9On0upgfjM/IL/UzQj5ioeVnSsd2rUgIz6w4szZM=";
+    };
+    "x86_64-darwin" = {
+      name = "darwin-amd64";
+      hash = "sha256-W4ElKXsMo47dVRNJEnLzH2rpvkua56lj/NkJd3R8CCE=";
+    };
+    "aarch64-darwin" = {
+      name = "darwin-arm64";
+      hash = "sha256-F2OA66h/ptkjLZ2oQgkbZlDo31YDZzhk5Pre36TkHvI=";
+    };
+  };
+  platform = systemToPlatform.${system} or throwSystem;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gh-copilot";
+  version = "0.5.4-beta";
+
+  src = fetchurl {
+    name = "gh-copilot";
+    url = "https://github.com/github/gh-copilot/releases/download/v${finalAttrs.version}/${platform.name}";
+    hash = platform.hash;
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -m755 -D $src $out/bin/gh-copilot
+
+    runHook postInstall
+  '';
+
+  meta = {
+    changelog = "https://github.com/github/gh-copilot/releases/tag/v${finalAttrs.version}";
+    description = "Ask for assistance right in your terminal.";
+    homepage = "https://github.com/github/gh-copilot";
+    license = lib.licenses.unfree;
+    mainProgram = "gh-copilot";
+    maintainers = with lib.maintainers; [ perchun ];
+    platforms = lib.attrNames systemToPlatform;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
As far as I understand, [@githubnext/github-copilot-cli on npm](https://www.npmjs.com/package/@githubnext/github-copilot-cli) was abandoned and rewritten in compiled language to be an integration for GitHub CLI. Unfortunately, this extension is not open-source, so I had to package the provided pre-built binaries.

The homepage is https://github.com/github/gh-copilot, though https://docs.github.com/en/copilot/github-copilot-in-the-cli might also interest you.

Closes #291551.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - I will run this package on my WIP NixOS VM, so if there are any bugs, I will try to fix them. For now, I verified that I can access `gh copilot suggest` (though thinking about how to do authorization declarative, so didn't really test the package).
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
