### PR TITLE
gdlauncher-carbon: init at 2.0.20

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22368,6 +22368,12 @@
     githubId = 4044033;
     name = "Thomas Sowell";
   };
+  TsubakiDev = {
+    email = "i@tsubakidev.cc";
+    github = "TsubakiDev";
+    githubId = 132794625;
+    name = "Daniel Wang";
+  };
   ttrei = {
     email = "reinis.taukulis@gmail.com";
     github = "ttrei";

--- a/pkgs/by-name/gd/gdlauncher-carbon/package.nix
+++ b/pkgs/by-name/gd/gdlauncher-carbon/package.nix
@@ -1,0 +1,135 @@
+{
+  lib,
+  stdenv,
+  appimageTools,
+  fetchurl,
+  graphicsmagick,
+  makeWrapper,
+  copyDesktopItems,
+  autoPatchelfHook,
+  xorg,
+  libpulseaudio,
+  libGL,
+  udev,
+  xdg-utils,
+  electron,
+  addDriverRunpath,
+  makeDesktopItem,
+
+  jdk8,
+  jdk17,
+  jdk21,
+  jdks ? [
+    jdk8
+    jdk17
+    jdk21
+  ],
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gdlauncher-carbon";
+  version = "2.0.20";
+
+  src = appimageTools.extract {
+    inherit (finalAttrs) pname version;
+    src = fetchurl {
+      url = "https://cdn-raw.gdl.gg/launcher/GDLauncher__${finalAttrs.version}__linux__x64.AppImage";
+      hash = "sha256-tI9RU8qO3MHbImOGw2Wl1dksNbhqrYFyGemqms8aAio=";
+    };
+  };
+
+  nativeBuildInputs = [
+    graphicsmagick
+    makeWrapper
+    copyDesktopItems
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    xorg.libxcb
+    stdenv.cc.cc.lib
+  ];
+
+  strictDeps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/gdlauncher-carbon/resources
+    cp -r $src/resources/{binaries,app.asar} $out/share/gdlauncher-carbon/resources/
+
+    # The provided icon is a bit large for some systems, so make smaller ones
+    for size in 48 96 128 256 512; do
+      gm convert $src/@gddesktop.png -resize ''${size}x''${size} icon_$size.png
+      install -D icon_$size.png $out/share/icons/hicolor/''${size}x''${size}/apps/gdlauncher-carbon.png
+    done
+
+    runHook postInstall
+  '';
+
+  postConfigure =
+    let
+      libPath = lib.makeLibraryPath [
+        xorg.libX11
+        xorg.libXext
+        xorg.libXcursor
+        xorg.libXrandr
+        xorg.libXxf86vm
+
+        # lwjgl
+        libpulseaudio
+        libGL
+        stdenv.cc.cc.lib
+
+        # oshi
+        udev
+      ];
+      binPath = lib.makeBinPath [
+        # Used for opening directories and URLs in the electron app
+        xdg-utils
+
+        # xorg.xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
+        xorg.xrandr
+      ];
+    in
+    ''
+      makeWrapper '${lib.getExe electron}' $out/bin/gdlauncher-carbon \
+        --prefix GDL_JAVA_PATH : ${lib.makeSearchPath "" jdks} \
+        --set LD_LIBRARY_PATH ${addDriverRunpath.driverLink}/lib:${libPath} \
+        --suffix PATH : "${binPath}" \
+        --set ELECTRON_FORCE_IS_PACKAGED 1 \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+        --add-flags $out/share/gdlauncher-carbon/resources/app.asar
+    '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      # Note the desktop file name should be GDLauncher to match the window's
+      # client id for window icon purposes on wayland.
+      name = "GDLauncher";
+      exec = "gdlauncher-carbon";
+      icon = "gdlauncher-carbon";
+      desktopName = "GDLauncher";
+      comment = finalAttrs.meta.description;
+      categories = [ "Game" ];
+      keywords = [
+        "launcher"
+        "mod manager"
+        "minecraft"
+      ];
+      mimeTypes = [ "x-scheme-handler/gdlauncher" ];
+    })
+  ];
+
+  meta = {
+    description = "Simple, yet powerful Minecraft custom launcher with a strong focus on the user experience";
+    homepage = "https://gdlauncher.com/";
+    license = lib.licenses.bsl11;
+    maintainers = with lib.maintainers; [
+      huantian
+      TsubakiDev
+    ];
+    platforms = lib.platforms.linux;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
## Description of changes
Package request issue: #269067

Packaged by extracting `app.asar` as well as binary blob from provided AppImage, and wrapping with our own electron.

Haven't done much testing, so putting this as a draft for now, just to get some eyes on this. I also haven't added any of the libraries that MC itself needs. I wonder if we could borrow some code from `prismlauncher`.

If wanted, we could also provide a derivation built from source; however as mentioned in the request issue thread, it won't have all the features as the pre-built version comes with an API key for their own servers.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
