### PR TITLE
astral: make deterministic and clean up

### DIFF
--- a/pkgs/applications/science/biology/astral/make-deterministic.patch
+++ b/pkgs/applications/science/biology/astral/make-deterministic.patch
@@ -1,0 +1,21 @@
+diff --git a/make.sh b/make.sh
+index 3ff6529..937b1a2 100644
+--- a/make.sh
++++ b/make.sh
+@@ -17,6 +17,8 @@ jar cvfm ../astral.$version.jar ../manifest.text phylonet/util/BitSet.* phylonet
+ 
+ cd ..
+ 
++strip-nondeterminism --type jar astral.$version.jar
++
+ chmod +x astral.$version.jar
+ sed -e "s/__astral.jar__/astral.$version.jar/g" -e "s/__astral.zip__/Astral.$version.zip/g" README.template.md > README.md
+ sed -e "s/__astral.jar__/astral.$version.jar/g" -e "s/__astral.zip__/Astral.$version.zip/g" astral-tutorial-template.md > astral-tutorial.md
+@@ -32,6 +34,7 @@ ln -s ../astral-tutorial.pdf .
+ cd ..
+ rm -f Astral.$version.zip
+ zip -r Astral.$version.zip Astral 
++strip-nondeterminism --type zip Astral.$version.zip
+ 
+ set +x
+ echo "


### PR DESCRIPTION
## Description of changes

Tracking issue: https://github.com/NixOS/nixpkgs/issues/278518

This PR adds a patch to the `astral` package which makes it deterministic.
Recently https://github.com/NixOS/nixpkgs/pull/296549 was merged which would provide a way to strip `.jar` files automatically of their timestamps. However this package also provides a distribution zip file in its outputs, which contains a the a jar file inside. The `patchJavaArchivesHook` cannot see this jar file, so it doesn't patch it.
Internally the hook uses `strip-nondeterminism`. The new patch utilizes this tool to strip the `.jar` file right after building and it strips the `.zip` file as well.

The other changes in this PR include the following:
- use `finalAttrs` instead of `rec`
  - the `${version}` expressions became a bit long. If anyone has an issue with this, I'll change it to use `*`
- use `hash` instead of `sha256` in the fetcher
- remove `jre` from `nativeBuildInputs`
- add missing `runHook` calls
- use `install` instead of `mkdir` and `cp` where possible

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: reaction to pull requests you find important.