### PR TITLE
raven-haskell jailbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -78,6 +78,7 @@ self: super: {
   # Too strict bound on base, believe it or not.
   # https://github.com/judah/terminfo/pull/55#issuecomment-1876894232
   terminfo_0_4_1_6 = doJailbreak super.terminfo_0_4_1_6;
+  raven-haskell = doJailbreak super.raven-haskell; # aeson <2.2
 
   #
   # Test suite issues


### PR DESCRIPTION
## Description of changes

Without this jailbreak I get the following error on GHC9.8:

```
error: builder for '/nix/store/8260d4bjqyvszxdi771ax0y8ls6ys8f2-raven-haskell-0.1.4.1.drv' failed with exit code 1;
       last 10 log lines:
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > configureFlags: --verbose --prefix=/nix/store/2bclikayh2pc49jg1bzn42yrnmaa1wg5-raven-haskell-0.1.4.1 --libdir=$prefix/lib/$compiler/lib --libsubdir=$abi/$libname --docdir=/nix/store/10f4dbwdrqy1q9ndf1gr0x9p6mkj26l1-raven-haskell-0.1.4.1-doc/share/doc/raven-haskell-0.1.4.1 --with-gcc=clang --package-db=/private/tmp/nix-build-raven-haskell-0.1.4.1.drv-0/tmp.tuLDRw4WAL/package.conf.d --ghc-options=-j16 --enable-library-profiling --profiling-detail=exported-functions --disable-profiling --enable-shared --disable-coverage --enable-static --disable-executable-dynamic --disable-tests --disable-benchmarks --enable-library-vanilla --disable-library-for-ghci --disable-split-sections --enable-library-stripping --enable-executable-stripping --ghc-options=-haddock --extra-lib-dirs=/nix/store/iz66rbm4c48m920zjiic3sc8ghl8pvgs-ncurses-6.4/lib --extra-lib-dirs=/nix/store/0z3mx40zc1b2zf8yjlrkk0iyps3yxlil-libffi-3.4.6/lib --extra-lib-dirs=/nix/store/5kg229dp8nb6a2m0hv7g1zl725kxp0nn-gmp-with-cxx-6.3.0/lib --extra-include-dirs=/nix/store/n7hyb4xfwjdcm87gbisck8pl9c2mp1qs-libiconv-50/include --extra-lib-dirs=/nix/store/n7hyb4xfwjdcm87gbisck8pl9c2mp1qs-libiconv-50/lib --extra-include-dirs=/nix/store/rjgv94p1nnj02v0f9r2jpann9x02b4vw-libcxx-16.0.6-dev/include --extra-lib-dirs=/nix/store/j3yw5w8pbdv4argnmx7i4i0lvglnh7ll-libcxx-16.0.6/lib --extra-include-dirs=/nix/store/s6hsrbxn6wfws552x9jbn4agjz71ps3x-libcxxabi-16.0.6-dev/include --extra-lib-dirs=/nix/store/g9x4r8l8hjk3vfj26k90p3rjc6g8j3i6-libcxxabi-16.0.6/lib --extra-include-dirs=/nix/store/rbjxdnzf9kc1in1n1ca7phddg80h55xd-compiler-rt-libc-16.0.6-dev/include --extra-lib-dirs=/nix/store/v7rhm5d36dn6bgcbdc4w3dg8ym3vxb5d-compiler-rt-libc-16.0.6/lib --extra-lib-dirs=/nix/store/7y2jn8rdygiy22rzy66wsz4gvrfn5hh6-apple-framework-CoreFoundation-11.0.0/lib --extra-framework-dirs=/nix/store/7y2jn8rdygiy22rzy66wsz4gvrfn5hh6-apple-framework-CoreFoundation-11.0.0/Library/Frameworks --extra-include-dirs=/nix/store/cii11dfrz126yb3d03aqyahwq3fanl1g-libobjc-11.0.0/include --extra-lib-dirs=/nix/store/cii11dfrz126yb3d03aqyahwq3fanl1g-libobjc-11.0.0/lib
       > Using Parsec parser
       > Configuring raven-haskell-0.1.4.1...
       > CallStack (from HasCallStack):
       >   withMetadata, called at libraries/Cabal/Cabal/src/Distribution/Simple/Utils.hs:368:14 in Cabal-3.10.2.0-inplace:Distribution.Simple.Utils
       > Error: Setup: Encountered missing or private dependencies:
       > aeson <2.2
       >
       For full logs, run 'nix log /nix/store/8260d4bjqyvszxdi771ax0y8ls6ys8f2-raven-haskell-0.1.4.1.drv'.
error: 1 dependencies of derivation '/nix/store/aj0zbdbhh4knmh7s4h0pflbi35sja5yg-ghc-9.8.2-with-packages.drv' failed to build
error: 1 dependencies of derivation '/nix/store/fp6jl6rxc8h9778n57klqd7z16qrwpvp-devenv-profile.drv' failed to build
error: 1 dependencies of derivation '/nix/store/hbv7g8x9g2dqli40fswk2x2a8pq9yc12-devenv-shell-env.drv' failed to build

```

On GHC9.4 it was working fine

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
