### PR TITLE
llvm: Fix compiler-rt missing sanitizers when using useLLVM

### DIFF
--- a/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
@@ -12,6 +12,7 @@
 , python3
 , xcbuild
 , libllvm
+, libcxx
 , linuxHeaders
 , libxcrypt
 
@@ -33,6 +34,9 @@ let
   useLLVM = stdenv.hostPlatform.useLLVM or false;
   bareMetal = stdenv.hostPlatform.parsed.kernel.name == "none";
   haveLibc = stdenv.cc.libc != null;
+  # TODO: Make this account for GCC having libstdcxx, which will help
+  # use clean up the `cmakeFlags` rats nest below.
+  haveLibcxx = stdenv.cc.libcxx != null;
   isDarwinStatic = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isStatic && lib.versionAtLeast release_version "16";
   inherit (stdenv.hostPlatform) isMusl isAarch64;
 
@@ -46,7 +50,7 @@ let
       cp -r ${monorepoSrc}/${baseName} "$out"
     '' else src;
 
-  preConfigure = lib.optionalString (useLLVM && !haveLibc) ''
+  preConfigure = lib.optionalString (!haveLibc) ''
     cmakeFlagsArray+=(-DCMAKE_C_FLAGS="-nodefaultlibs -ffreestanding")
   '';
 in
@@ -82,23 +86,32 @@ stdenv.mkDerivation ({
     "-DCMAKE_ASM_COMPILER_TARGET=${stdenv.hostPlatform.config}"
   ] ++ lib.optionals (haveLibc && stdenv.hostPlatform.libc == "glibc") [
     "-DSANITIZER_COMMON_CFLAGS=-I${libxcrypt}/include"
-  ] ++ lib.optionals ((useLLVM || bareMetal || isMusl || isAarch64) && (lib.versions.major release_version == "13")) [
+  ] ++ lib.optionals (useLLVM && haveLibc && stdenv.cc.libcxx == libcxx) [
+    "-DSANITIZER_CXX_ABI=libcxxabi"
+    "-DSANITIZER_CXX_ABI_LIBNAME=libcxxabi"
+    "-DCOMPILER_RT_USE_BUILTINS_LIBRARY=ON"
+  ] ++ lib.optionals ((!haveLibc || bareMetal || isMusl || isAarch64) && (lib.versions.major release_version == "13")) [
     "-DCOMPILER_RT_BUILD_LIBFUZZER=OFF"
-  ] ++ lib.optionals (useLLVM || bareMetal || isMusl || isDarwinStatic) [
+  ] ++ lib.optionals (useLLVM && haveLibc) [
+    "-DCOMPILER_RT_BUILD_SANITIZERS=ON"
+  ] ++ lib.optionals (!haveLibc || bareMetal || isMusl || isDarwinStatic) [
     "-DCOMPILER_RT_BUILD_SANITIZERS=OFF"
+  ] ++ lib.optionals ((useLLVM && !haveLibcxx) || !haveLibc || bareMetal || isMusl || isDarwinStatic) [
     "-DCOMPILER_RT_BUILD_XRAY=OFF"
     "-DCOMPILER_RT_BUILD_LIBFUZZER=OFF"
     "-DCOMPILER_RT_BUILD_MEMPROF=OFF"
     "-DCOMPILER_RT_BUILD_ORC=OFF" # may be possible to build with musl if necessary
-  ] ++ lib.optionals (useLLVM || bareMetal) [
+  ] ++ lib.optionals (useLLVM && haveLibc) [
+    "-DCOMPILER_RT_BUILD_PROFILE=ON"
+  ] ++ lib.optionals (!haveLibc || bareMetal) [
      "-DCOMPILER_RT_BUILD_PROFILE=OFF"
-  ] ++ lib.optionals ((useLLVM && !haveLibc) || bareMetal || isDarwinStatic) [
+  ] ++ lib.optionals (!haveLibc || bareMetal || isDarwinStatic) [
     "-DCMAKE_CXX_COMPILER_WORKS=ON"
-  ] ++ lib.optionals ((useLLVM && !haveLibc) || bareMetal) [
+  ] ++ lib.optionals (!haveLibc || bareMetal) [
     "-DCMAKE_C_COMPILER_WORKS=ON"
     "-DCOMPILER_RT_BAREMETAL_BUILD=ON"
     "-DCMAKE_SIZEOF_VOID_P=${toString (stdenv.hostPlatform.parsed.cpu.bits / 8)}"
-  ] ++ lib.optionals (useLLVM && !haveLibc) [
+  ] ++ lib.optionals (!haveLibc) [
     "-DCMAKE_C_FLAGS=-nodefaultlibs"
   ] ++ lib.optionals (useLLVM) [
     "-DCOMPILER_RT_BUILD_BUILTINS=ON"
@@ -133,7 +146,7 @@ stdenv.mkDerivation ({
   '' + lib.optionalString stdenv.isDarwin ''
     substituteInPlace cmake/config-ix.cmake \
       --replace 'set(COMPILER_RT_HAS_TSAN TRUE)' 'set(COMPILER_RT_HAS_TSAN FALSE)'
-  '' + lib.optionalString (useLLVM && !haveLibc) ((lib.optionalString (lib.versionAtLeast release_version "18") ''
+  '' + lib.optionalString (!haveLibc) ((lib.optionalString (lib.versionAtLeast release_version "18") ''
     substituteInPlace lib/builtins/aarch64/sme-libc-routines.c \
       --replace "<stdlib.h>" "<stddef.h>"
   '') + ''
@@ -185,8 +198,12 @@ stdenv.mkDerivation ({
     # "All of the code in the compiler-rt project is dual licensed under the MIT
     # license and the UIUC License (a BSD-like license)":
     license = with lib.licenses; [ mit ncsa ];
-    # compiler-rt requires a Clang stdenv on 32-bit RISC-V:
-    # https://reviews.llvm.org/D43106#1019077
-    broken = stdenv.hostPlatform.isRiscV32 && !stdenv.cc.isClang;
+    broken =
+      # compiler-rt requires a Clang stdenv on 32-bit RISC-V:
+      # https://reviews.llvm.org/D43106#1019077
+      (stdenv.hostPlatform.isRiscV32 && !stdenv.cc.isClang)
+      # emutls wants `<pthread.h>` which isn't avaiable (without exeprimental WASM threads proposal).
+      # `enable_execute_stack.c` Also doesn't sound like something WASM would support.
+      || (stdenv.hostPlatform.isWasm && haveLibc);
   };
 } // (if lib.versionOlder release_version "16" then { inherit preConfigure; } else {}))

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -5,6 +5,7 @@
   lib,
   stdenv,
   preLibcCrossHeaders,
+  libxcrypt,
   substitute,
   substituteAll,
   fetchFromGitHub,
@@ -114,6 +115,13 @@ let
         ln -s "${cc.lib}/lib/clang/${clangVersion}/include" "$rsrc"
         echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags
       '';
+      mkExtraBuildCommandsBasicRt =
+        cc:
+        mkExtraBuildCommands0 cc
+        + ''
+          ln -s "${targetLlvmLibraries.compiler-rt-no-libc.out}/lib" "$rsrc/lib"
+          ln -s "${targetLlvmLibraries.compiler-rt-no-libc.out}/share" "$rsrc/share"
+        '';
       mkExtraBuildCommands =
         cc:
         mkExtraBuildCommands0 cc
@@ -443,25 +451,76 @@ let
         }
       );
 
-      clangNoLibcxx = wrapCCWith (
+      clangWithLibcAndBasicRtAndLibcxx = wrapCCWith (
         rec {
           cc = tools.clang-unwrapped;
-          libcxx = null;
+          libcxx = targetLlvmLibraries.libcxx;
           bintools = bintools';
-          extraPackages = [ targetLlvmLibraries.compiler-rt ];
+          extraPackages =
+            [ targetLlvmLibraries.compiler-rt-no-libc ]
+            ++ lib.optionals (!stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD) [
+              targetLlvmLibraries.libunwind
+            ];
           extraBuildCommands =
-            lib.optionalString (lib.versions.major metadata.release_version == "13") ''
-              echo "-rtlib=compiler-rt" >> $out/nix-support/cc-cflags
-              echo "-B${targetLlvmLibraries.compiler-rt}/lib" >> $out/nix-support/cc-cflags
-              echo "-nostdlib++" >> $out/nix-support/cc-cflags
-            ''
-            + mkExtraBuildCommands cc;
+            lib.optionalString (lib.versions.major metadata.release_version == "13") (
+              ''
+                echo "-rtlib=compiler-rt -Wno-unused-command-line-argument" >> $out/nix-support/cc-cflags
+                echo "-B${targetLlvmLibraries.compiler-rt-no-libc}/lib" >> $out/nix-support/cc-cflags
+              ''
+              + lib.optionalString (!stdenv.targetPlatform.isWasm) ''
+                echo "--unwindlib=libunwind" >> $out/nix-support/cc-cflags
+                echo "-L${targetLlvmLibraries.libunwind}/lib" >> $out/nix-support/cc-ldflags
+              ''
+              + lib.optionalString (!stdenv.targetPlatform.isWasm && stdenv.targetPlatform.useLLVM or false) ''
+                echo "-lunwind" >> $out/nix-support/cc-ldflags
+              ''
+              + lib.optionalString stdenv.targetPlatform.isWasm ''
+                echo "-fno-exceptions" >> $out/nix-support/cc-cflags
+              ''
+            )
+            + mkExtraBuildCommandsBasicRt cc;
         }
         // lib.optionalAttrs (lib.versionAtLeast metadata.release_version "14") {
           nixSupport.cc-cflags =
             [
               "-rtlib=compiler-rt"
-              "-B${targetLlvmLibraries.compiler-rt}/lib"
+              "-Wno-unused-command-line-argument"
+              "-B${targetLlvmLibraries.compiler-rt-no-libc}/lib"
+            ]
+            ++ lib.optional (
+              !stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD
+            ) "--unwindlib=libunwind"
+            ++ lib.optional (
+              !stdenv.targetPlatform.isWasm
+              && !stdenv.targetPlatform.isFreeBSD
+              && stdenv.targetPlatform.useLLVM or false
+            ) "-lunwind"
+            ++ lib.optional stdenv.targetPlatform.isWasm "-fno-exceptions";
+          nixSupport.cc-ldflags = lib.optionals (
+            !stdenv.targetPlatform.isWasm && !stdenv.targetPlatform.isFreeBSD
+          ) [ "-L${targetLlvmLibraries.libunwind}/lib" ];
+        }
+      );
+
+      clangWithLibcAndBasicRt = wrapCCWith (
+        rec {
+          cc = tools.clang-unwrapped;
+          libcxx = null;
+          bintools = bintools';
+          extraPackages = [ targetLlvmLibraries.compiler-rt-no-libc ];
+          extraBuildCommands =
+            lib.optionalString (lib.versions.major metadata.release_version == "13") ''
+              echo "-rtlib=compiler-rt" >> $out/nix-support/cc-cflags
+              echo "-B${targetLlvmLibraries.compiler-rt-no-libc}/lib" >> $out/nix-support/cc-cflags
+              echo "-nostdlib++" >> $out/nix-support/cc-cflags
+            ''
+            + mkExtraBuildCommandsBasicRt cc;
+        }
+        // lib.optionalAttrs (lib.versionAtLeast metadata.release_version "14") {
+          nixSupport.cc-cflags =
+            [
+              "-rtlib=compiler-rt"
+              "-B${targetLlvmLibraries.compiler-rt-no-libc}/lib"
               "-nostdlib++"
             ]
             ++ lib.optional (
@@ -470,24 +529,24 @@ let
         }
       );
 
-      clangNoLibc = wrapCCWith (
+      clangNoLibcWithBasicRt = wrapCCWith (
         rec {
           cc = tools.clang-unwrapped;
           libcxx = null;
           bintools = bintoolsNoLibc';
-          extraPackages = [ targetLlvmLibraries.compiler-rt ];
+          extraPackages = [ targetLlvmLibraries.compiler-rt-no-libc ];
           extraBuildCommands =
             lib.optionalString (lib.versions.major metadata.release_version == "13") ''
               echo "-rtlib=compiler-rt" >> $out/nix-support/cc-cflags
-              echo "-B${targetLlvmLibraries.compiler-rt}/lib" >> $out/nix-support/cc-cflags
+              echo "-B${targetLlvmLibraries.compiler-rt-no-libc}/lib" >> $out/nix-support/cc-cflags
             ''
-            + mkExtraBuildCommands cc;
+            + mkExtraBuildCommandsBasicRt cc;
         }
         // lib.optionalAttrs (lib.versionAtLeast metadata.release_version "14") {
           nixSupport.cc-cflags =
             [
               "-rtlib=compiler-rt"
-              "-B${targetLlvmLibraries.compiler-rt}/lib"
+              "-B${targetLlvmLibraries.compiler-rt-no-libc}/lib"
             ]
             ++ lib.optional (
               lib.versionAtLeast metadata.release_version "15" && stdenv.targetPlatform.isWasm
@@ -495,7 +554,7 @@ let
         }
       );
 
-      clangNoCompilerRt = wrapCCWith (
+      clangNoLibcNoRt = wrapCCWith (
         rec {
           cc = tools.clang-unwrapped;
           libcxx = null;
@@ -516,6 +575,8 @@ let
         }
       );
 
+      # This is an "oddly ordered" bootstrap just for Darwin. Probably
+      # don't want it otherwise.
       clangNoCompilerRtWithLibc =
         wrapCCWith rec {
           cc = tools.clang-unwrapped;
@@ -527,6 +588,11 @@ let
         // lib.optionalAttrs (
           lib.versionAtLeast metadata.release_version "15" && stdenv.targetPlatform.isWasm
         ) { nixSupport.cc-cflags = [ "-fno-exceptions" ]; };
+
+      # Aliases
+      clangNoCompilerRt = tools.clangNoLibcNoRt;
+      clangNoLibc = tools.clangNoLibcWithBasicRt;
+      clangNoLibcxx = tools.clangWithLibcAndBasicRt;
     }
     // lib.optionalAttrs (lib.versionAtLeast metadata.release_version "15") {
       # TODO: pre-15: lldb/docs/index.rst:155:toctree contains reference to nonexisting document 'design/structureddataplugins'
@@ -601,40 +667,57 @@ let
         );
     in
     {
-      compiler-rt-libc = callPackage ./compiler-rt {
-        patches = compiler-rtPatches;
-        stdenv =
-          if
-            stdenv.hostPlatform.useLLVM or false
-            || (
+      compiler-rt-libc = callPackage ./compiler-rt (
+        let
+          # temp rename to avoid infinite recursion
+          stdenv =
+            if args.stdenv.hostPlatform.useLLVM or false then
+              overrideCC args.stdenv buildLlvmTools.clangWithLibcAndBasicRtAndLibcxx
+            else if
               lib.versionAtLeast metadata.release_version "16"
-              && stdenv.hostPlatform.isDarwin
-              && stdenv.hostPlatform.isStatic
-            )
-          then
-            overrideCC stdenv buildLlvmTools.clangNoCompilerRtWithLibc
-          else
-            args.stdenv;
-      };
+              && args.stdenv.hostPlatform.isDarwin
+              && args.stdenv.hostPlatform.isStatic
+            then
+              overrideCC args.stdenv buildLlvmTools.clangNoCompilerRtWithLibc
+            else
+              args.stdenv;
+        in
+        {
+          patches = compiler-rtPatches;
+          inherit stdenv;
+        }
+        // lib.optionalAttrs (stdenv.hostPlatform.useLLVM or false) {
+          libxcrypt = (libxcrypt.override { inherit stdenv; }).overrideAttrs (old: {
+            configureFlags = old.configureFlags ++ [ "--disable-symvers" ];
+          });
+        }
+      );
 
       compiler-rt-no-libc = callPackage ./compiler-rt {
         patches = compiler-rtPatches;
         stdenv =
-          if stdenv.hostPlatform.useLLVM or false then
-            overrideCC stdenv buildLlvmTools.clangNoCompilerRt
+          if stdenv.hostPlatform.isDarwin && stdenv.hostPlatform == stdenv.buildPlatform then
+            stdenv
           else
-            stdenv;
+            # TODO: make this branch unconditional next rebuild
+            overrideCC stdenv buildLlvmTools.clangNoLibcNoRt;
       };
 
-      # N.B. condition is safe because without useLLVM both are the same.
       compiler-rt =
         if
-          stdenv.hostPlatform.isAndroid
-          || (lib.versionAtLeast metadata.release_version "16" && stdenv.hostPlatform.isDarwin)
+          stdenv.hostPlatform.libc == null
+          # Building the with-libc compiler-rt and WASM doesn't yet work,
+          # because wasilibc doesn't provide some expected things. See
+          # compiler-rt's file for further details.
+          || stdenv.hostPlatform.isWasm
+          # Failing `#include <term.h>` in
+          # `lib/sanitizer_common/sanitizer_platform_limits_freebsd.cpp`
+          # sanitizers, not sure where to get it.
+          || stdenv.hostPlatform.isFreeBSD
         then
-          libraries.compiler-rt-libc
+          libraries.compiler-rt-no-libc
         else
-          libraries.compiler-rt-no-libc;
+          libraries.compiler-rt-libc;
 
       stdenv = overrideCC stdenv buildLlvmTools.clang;
 
@@ -698,7 +781,7 @@ let
                 )
                 # https://github.com/llvm/llvm-project/issues/64226
                 (metadata.getVersionFile "libcxx/0001-darwin-10.12-mbstate_t-fix.patch");
-          stdenv = overrideCC stdenv buildLlvmTools.clangNoLibcxx;
+          stdenv = overrideCC stdenv buildLlvmTools.clangWithLibcAndBasicRt;
         }
         // lib.optionalAttrs (lib.versionOlder metadata.release_version "14") {
           # TODO: remove this, causes LLVM 13 packages rebuild.
@@ -710,7 +793,7 @@ let
         patches = lib.optional (lib.versionOlder metadata.release_version "17") (
           metadata.getVersionFile "libunwind/gnu-install-dirs.patch"
         );
-        stdenv = overrideCC stdenv buildLlvmTools.clangNoLibcxx;
+        stdenv = overrideCC stdenv buildLlvmTools.clangWithLibcAndBasicRt;
       };
 
       openmp = callPackage ./openmp {


### PR DESCRIPTION
Attempts to address https://github.com/NixOS/nixpkgs/issues/97688 by refactoring the llvm/16 toolchain build to make more sense.

The build order is now:

{compiler-rt-no-libc}
{compiler-rt-no-libc, libc}
{compiler-rt-no-libc, libc, libc++}
{compiler-rt-no-libc, libc, libc++, compiler-rt-libc}
The names of the stages have been updated to reflect this.

This is a follow up for #267814 where I screwed up the rebase and managed to ping too many people. Apologies!

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
