### PR TITLE
duckdb: 0.10.0 -> 0.10.1

### DIFF
--- a/pkgs/development/libraries/duckdb/default.nix
+++ b/pkgs/development/libraries/duckdb/default.nix
@@ -85,6 +85,7 @@ stdenv.mkDerivation rec {
         "test/sql/copy/parquet/delta_byte_array_multiple_pages.test"
         "test/sql/copy/csv/test_csv_httpfs_prepared.test"
         "test/sql/copy/csv/test_csv_httpfs.test"
+        "test/sql/copy/csv/test_mixed_lines.test"
         "test/sql/settings/test_disabled_file_system_httpfs.test"
         "test/sql/copy/csv/parallel/test_parallel_csv.test"
         "test/sql/copy/csv/parallel/csv_parallel_httpfs.test"

--- a/pkgs/development/libraries/duckdb/default.nix
+++ b/pkgs/development/libraries/duckdb/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , fetchFromGitHub
-, fetchpatch
 , substituteAll
 , cmake
 , ninja
@@ -18,13 +17,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "duckdb";
-  version = "0.10.0";
+  version = "0.10.1";
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-qGUq0iYTaLNHKqbXNLRmvqHMqunvIlP991IKb4qdSt4=";
+    hash = "sha256-/j/DaUzsfACI5Izr4lblkYmIEmKsOXr760UTwC0l/qg=";
   };
 
   patches = [
@@ -32,13 +31,6 @@ stdenv.mkDerivation rec {
     (substituteAll {
       src = ./version.patch;
       version = "v${version}";
-    })
-    # add missing file needed for httpfs compile
-    # remove on next update
-    (fetchpatch {
-      name = "missing-httpfs-file.patch";
-      url = "https://github.com/duckdb/duckdb/commit/3d7aa3ed46ecf5f18122559e385b75f1f5e9aba8.patch";
-      hash = "sha256-Q4IHCpMpxn86OquUZdEF7P0nHEPOcWS0TQijTkvBYbQ=";
     })
   ];
 

--- a/pkgs/development/libraries/duckdb/version.patch
+++ b/pkgs/development/libraries/duckdb/version.patch
@@ -1,58 +1,94 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 2b49e11288..0a4a69b9a0 100644
+index aebc060c3b..6655495411 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -244,52 +244,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "SunOS")
+@@ -241,79 +241,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "SunOS")
    set(SUN TRUE)
  endif()
  
--find_package(Git)
--if(Git_FOUND)
--  if (NOT DEFINED GIT_COMMIT_HASH)
--    execute_process(
+-
+-if (OVERRIDE_GIT_DESCRIBE)
+-  if (OVERRIDE_GIT_DESCRIBE MATCHES "^v[0-9]+\.[0-9]+\.[0-9]+\-[0-9]+\-g[a-f0-9]+$")
+-    set(GIT_DESCRIBE "${OVERRIDE_GIT_DESCRIBE}")
+-  elseif(OVERRIDE_GIT_DESCRIBE MATCHES "^v[0-9]+\.[0-9]+\.[0-9]+$")
+-    find_package(Git)
+-    if(Git_FOUND)
+-      execute_process(
 -            COMMAND ${GIT_EXECUTABLE} log -1 --format=%h
 -            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 -            RESULT_VARIABLE GIT_RESULT
 -            OUTPUT_VARIABLE GIT_COMMIT_HASH
 -            OUTPUT_STRIP_TRAILING_WHITESPACE)
+-        set(GIT_DESCRIBE "${OVERRIDE_GIT_DESCRIBE}-0-g${GIT_COMMIT_HASH}")
+-    else()
+-      set(GIT_DESCRIBE "${OVERRIDE_GIT_DESCRIBE}-0-g0123456789")
+-    endif()
+-  else()
+-    message(FATAL_ERROR "Provided OVERRIDE_GIT_DESCRIBE '${OVERRIDE_GIT_DESCRIBE}' do not match supported versions, either fully specified 'vX.Y.Z-N-gGITHASH123' or version only 'vX.Y.Z'")
 -  endif()
--  execute_process(
--          COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0
--          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
--          OUTPUT_VARIABLE GIT_LAST_TAG
--          OUTPUT_STRIP_TRAILING_WHITESPACE)
--  execute_process(
+-else()
+-  find_package(Git)
+-  if(Git_FOUND)
+-     if (NOT DEFINED GIT_COMMIT_HASH)
+-     execute_process(
+-            COMMAND ${GIT_EXECUTABLE} log -1 --format=%h
+-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+-            RESULT_VARIABLE GIT_RESULT
+-            OUTPUT_VARIABLE GIT_COMMIT_HASH
+-            OUTPUT_STRIP_TRAILING_WHITESPACE)
+-    endif()
+-    execute_process(
 -          COMMAND ${GIT_EXECUTABLE} describe --tags --long
 -          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
--          OUTPUT_VARIABLE GIT_ITERATION
+-          OUTPUT_VARIABLE GIT_DESCRIBE
 -          OUTPUT_STRIP_TRAILING_WHITESPACE)
--else()
--  message("Git NOT FOUND")
+-  else()
+-    message("Git NOT FOUND and EXTERNAL_GIT_DESCRIBE not provided, continuing with dummy version v0.0.1")
+-    set(GIT_DESCRIBE "v0.0.1-0-g0123456789")
+-  endif()
 -endif()
 -
--if(GIT_RESULT EQUAL "0")
--  string(REGEX REPLACE "v([0-9]+).[0-9]+.[0-9]+" "\\1" DUCKDB_MAJOR_VERSION "${GIT_LAST_TAG}")
--  string(REGEX REPLACE "v[0-9]+.([0-9]+).[0-9]+" "\\1" DUCKDB_MINOR_VERSION "${GIT_LAST_TAG}")
--  string(REGEX REPLACE "v[0-9]+.[0-9]+.([0-9]+)" "\\1" DUCKDB_PATCH_VERSION "${GIT_LAST_TAG}")
--  string(REGEX REPLACE ".*-([0-9]+)-.*" "\\1" DUCKDB_DEV_ITERATION "${GIT_ITERATION}")
+-string(REGEX REPLACE "v([0-9]+)\.[0-9]+\.[0-9]+\-.*" "\\1" DUCKDB_MAJOR_VERSION "${GIT_DESCRIBE}")
+-string(REGEX REPLACE "v[0-9]+\.([0-9]+)\.[0-9]+\-.*" "\\1" DUCKDB_MINOR_VERSION "${GIT_DESCRIBE}")
+-string(REGEX REPLACE "v[0-9]+\.[0-9]+\.([0-9]+)\-.*" "\\1" DUCKDB_PATCH_VERSION "${GIT_DESCRIBE}")
+-string(REGEX REPLACE "v[0-9]+\.[0-9]+\.[0-9]+\-([0-9]+)\-g.*" "\\1" DUCKDB_DEV_ITERATION "${GIT_DESCRIBE}")
+-if (NOT DEFINED GIT_COMMIT_HASH)
+-  string(REGEX REPLACE "v[0-9]+\.[0-9]+\.[0-9]+\-[0-9]+\-g([a-f0-9]+)" "\\1" GIT_COMMIT_HASH "${GIT_DESCRIBE}")
+-endif()
 -
--  if(DUCKDB_DEV_ITERATION EQUAL 0)
--    # on a tag; directly use the version
--    set(DUCKDB_VERSION "${GIT_LAST_TAG}")
--  else()
--    # not on a tag, increment the patch version by one and add a -devX suffix
--    math(EXPR DUCKDB_PATCH_VERSION "${DUCKDB_PATCH_VERSION}+1")
--    set(DUCKDB_VERSION "v${DUCKDB_MAJOR_VERSION}.${DUCKDB_MINOR_VERSION}.${DUCKDB_PATCH_VERSION}-dev${DUCKDB_DEV_ITERATION}")
--  endif()
+-string(LENGTH "${GIT_COMMIT_HASH}" LENGTH_GIT_COMMIT_HASH)
+-if (NOT ${LENGTH_GIT_COMMIT_HASH} EQUAL 10)
+-   message(STATUS "GIT_COMMIT_HASH has lenght ${LENGTH_GIT_COMMIT_HASH} different than the expected 10")
+-endif()
+-
+-string(SUBSTRING "${GIT_COMMIT_HASH}" 0 10 GIT_COMMIT_HASH)
+-
+-if(DUCKDB_DEV_ITERATION EQUAL 0)
+-  # on a tag; directly use the version
+-  set(DUCKDB_VERSION "v${DUCKDB_MAJOR_VERSION}.${DUCKDB_MINOR_VERSION}.${DUCKDB_PATCH_VERSION}")
 -else()
--  # fallback for when building from tarball
--  set(DUCKDB_MAJOR_VERSION 0)
--  set(DUCKDB_MINOR_VERSION 0)
--  set(DUCKDB_PATCH_VERSION 1)
--  set(DUCKDB_DEV_ITERATION 0)
+-  # not on a tag, increment the patch version by one and add a -devX suffix
+-  math(EXPR DUCKDB_PATCH_VERSION "${DUCKDB_PATCH_VERSION}+1")
 -  set(DUCKDB_VERSION "v${DUCKDB_MAJOR_VERSION}.${DUCKDB_MINOR_VERSION}.${DUCKDB_PATCH_VERSION}-dev${DUCKDB_DEV_ITERATION}")
 -endif()
-+set(DUCKDB_VERSION "@version@")
+-
+-string(REGEX MATCH ".*dev.*" DUCKDB_EXTENSION_FOLDER_IS_VERSION "${DUCKDB_VERSION}")
+-
+-if(DUCKDB_EXTENSION_FOLDER_IS_VERSION AND NOT GIT_COMMIT_HASH STREQUAL "")
+-  set(DUCKDB_NORMALIZED_VERSION "${GIT_COMMIT_HASH}")
+-else()
+-  set(DUCKDB_NORMALIZED_VERSION "${DUCKDB_VERSION}")
+-endif()
++set(DUCKDB_NORMALIZED_VERSION "@version@")
  
- message(STATUS "git hash ${GIT_COMMIT_HASH}, version ${DUCKDB_VERSION}")
+ if(EMSCRIPTEN)
+   set(EXTENSION_POSTFIX "duckdb_extension.wasm")
+@@ -321,8 +249,6 @@ else()
+   set(EXTENSION_POSTFIX "duckdb_extension")
+ endif()
  
+-message(STATUS "git hash ${GIT_COMMIT_HASH}, version ${DUCKDB_VERSION}, extension folder ${DUCKDB_NORMALIZED_VERSION}")
+-
+ option(AMALGAMATION_BUILD
+        "Build from the amalgamation files, rather than from the normal sources."
+        FALSE)

--- a/pkgs/development/libraries/duckdb/version.patch
+++ b/pkgs/development/libraries/duckdb/version.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index aebc060c3b..6655495411 100644
+index aebc060c3b..1619da22b9 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -241,79 +241,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "SunOS")
+@@ -241,79 +241,8 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "SunOS")
    set(SUN TRUE)
  endif()
  
@@ -79,11 +79,12 @@ index aebc060c3b..6655495411 100644
 -else()
 -  set(DUCKDB_NORMALIZED_VERSION "${DUCKDB_VERSION}")
 -endif()
++set(DUCKDB_VERSION "@version@")
 +set(DUCKDB_NORMALIZED_VERSION "@version@")
  
  if(EMSCRIPTEN)
    set(EXTENSION_POSTFIX "duckdb_extension.wasm")
-@@ -321,8 +249,6 @@ else()
+@@ -321,8 +250,6 @@ else()
    set(EXTENSION_POSTFIX "duckdb_extension")
  endif()
  

--- a/pkgs/development/python-modules/duckdb/default.nix
+++ b/pkgs/development/python-modules/duckdb/default.nix
@@ -25,7 +25,8 @@ buildPythonPackage rec {
     # 2. default to extension autoload & autoinstall disabled
     substituteInPlace setup.py \
       --replace-fail "ParallelCompile()" 'ParallelCompile("NIX_BUILD_CORES")' \
-      --replace-fail "define_macros.extend([('DUCKDB_EXTENSION_AUTOLOAD_DEFAULT', '1'), ('DUCKDB_EXTENSION_AUTOINSTALL_DEFAULT', '1')])" ""
+      --replace-fail "define_macros.extend([('DUCKDB_EXTENSION_AUTOLOAD_DEFAULT', '1'), ('DUCKDB_EXTENSION_AUTOINSTALL_DEFAULT', '1')])" "" \
+      --replace 'version=get_version()' 'version="${version}"'
   '';
 
   env = {


### PR DESCRIPTION
- **duckdb: 0.10.0 -> 0.10.1**
- **duckdb: skip test that uses the internet**
- **duckdb: patch version too**

## Description of changes

Bumps duckdb from 0.10.0 to 0.10.1.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
