### PR TITLE
hdfview: make deterministic

### DIFF
--- a/pkgs/tools/misc/hdfview/default.nix
+++ b/pkgs/tools/misc/hdfview/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, ant, jdk, hdf4, hdf5, makeDesktopItem, copyDesktopItems }:
+{ lib, stdenv, fetchurl, ant, jdk, hdf4, hdf5, makeDesktopItem, copyDesktopItems, strip-nondeterminism, stripJavaArchivesHook }:
 
 stdenv.mkDerivation rec {
   pname = "hdfview";
@@ -14,12 +14,16 @@ stdenv.mkDerivation rec {
     ./0001-Hardcode-isUbuntu-false-to-avoid-hostname-dependency.patch
     # Disable signing on macOS
     ./disable-mac-signing.patch
+    # Remove timestamp comment from generated versions.properties file
+    ./remove-properties-timestamp.patch
   ];
 
   nativeBuildInputs = [
     ant
     jdk
     copyDesktopItems
+    strip-nondeterminism
+    stripJavaArchivesHook
   ];
 
   HDFLIBS = (hdf4.override { javaSupport = true; }).out;
@@ -62,6 +66,11 @@ stdenv.mkDerivation rec {
     cp -a build/dist/HDFView.app $out/Applications/
   '' + ''
     runHook postInstall
+  '';
+
+  preFixup = ''
+    # Remove build timestamp from javadoc files
+    find $out/lib/app{,/mods}/doc/javadocs -name "*.html" -exec strip-nondeterminism --type javadoc {} +
   '';
 
   meta = {

--- a/pkgs/tools/misc/hdfview/remove-properties-timestamp.patch
+++ b/pkgs/tools/misc/hdfview/remove-properties-timestamp.patch
@@ -1,0 +1,14 @@
+diff --git a/build.xml b/build.xml
+index fcc4931..2afeb6c 100644
+--- a/build.xml
++++ b/build.xml
+@@ -345,6 +345,9 @@
+             <entry key="HDF5_VERSION" value="${hdf5.version}"/>
+             <entry key="HDFVIEW_VERSION" value="${app.version}"/>
+         </propertyfile>
++        <exec executable="sed" failonerror="true">
++            <arg line="-i /#/d ${classes.dir}/hdf/versions.properties" />
++        </exec>
+     </target>
+ 
+     <target name="compile" depends="clean, create-property-file, compileobj, compilehdf4, compilefits, compilenc2, compilehdf5">


### PR DESCRIPTION
## Description of changes

Tracking issue: https://github.com/NixOS/nixpkgs/issues/278518

This PR does some extra work on the `hdfview` package to make it deterministic.
Other than using `stripJavaArchivesHook` the PR adds a patch file which removes a timestamp comment from the `versions.properties` file and it also uses `strip-nondeterminism` to patch the generated javadoc files as well. These were enoguh to make it deterministic.

I could replace `stripJavaArchivesHook` with just `strip-nondetermininsm --type jar` because most of the jar files are not built, but the hook doesn't add too much to the build time.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
