### PR TITLE
kodiPackages.jellycon: init at 0.8.0

### DIFF
--- a/pkgs/applications/video/kodi/addons/jellycon/default.nix
+++ b/pkgs/applications/video/kodi/addons/jellycon/default.nix
@@ -1,0 +1,55 @@
+{ lib, addonDir, buildKodiAddon, fetchFromGitHub, kodi, requests, dateutil, six, kodi-six, signals, websocket }:
+let
+  python = kodi.pythonPackages.python.withPackages (p: with p; [ pyyaml ]);
+in
+buildKodiAddon rec {
+  pname = "jellycon";
+  namespace = "plugin.video.jellycon";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "jellyfin";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-60my7Y60KV5WWALQiamnmAJZJi82cV21rIGYPiV7T+A=";
+  };
+
+  nativeBuildInputs = [
+    python
+  ];
+
+  prePatch = ''
+    # ZIP does not support timestamps before 1980 - https://bugs.python.org/issue34097
+    substituteInPlace build.py \
+      --replace "with zipfile.ZipFile(f'{target}/{archive_name}', 'w') as z:" "with zipfile.ZipFile(f'{target}/{archive_name}', 'w', strict_timestamps=False) as z:"
+  '';
+
+  buildPhase = ''
+    ${python}/bin/python3 build.py --version=py3
+  '';
+
+  postInstall = ''
+    mv /build/source/addon.xml $out${addonDir}/${namespace}/
+  '';
+
+  propagatedBuildInputs = [
+    requests
+    dateutil
+    six
+    kodi-six
+    signals
+    websocket
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/jellyfin/jellycon";
+    description = "A lightweight Kodi add-on for Jellyfin";
+    longDescription = ''
+      JellyCon is a lightweight Kodi add-on that lets you browse and play media
+      files directly from your Jellyfin server within the Kodi interface. It can
+      easily switch between multiple user accounts at will.
+    '';
+    license = licenses.gpl2Only;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -79,6 +79,8 @@ let
 
     libretro-snes9x = callPackage ../applications/video/kodi/addons/libretro-snes9x { inherit snes9x; };
 
+    jellycon = callPackage ../applications/video/kodi/addons/jellycon { };
+
     jellyfin = callPackage ../applications/video/kodi/addons/jellyfin { };
 
     joystick = callPackage ../applications/video/kodi/addons/joystick { };


### PR DESCRIPTION
## Description of changes
Add kodi addon [jellyCon](https://github.com/jellyfin/jellycon/), which is a lightweight kodi addon for Jellyfin [compared to Jellyfin for Kodi](https://jellyfin.org/docs/general/clients/kodi/#add-on-repository).
It does not sync metadata to local Kodi database, behaving more like a standard Kodi streaming add-on.
It also allows easier switching between multiple Jellyfin servers or users. 
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
