### PR TITLE
autoAddDriverRunpathHook: init

### DIFF
--- a/pkgs/by-name/au/autoAddDriverRunpath/auto-add-driver-runpath-hook.sh
+++ b/pkgs/by-name/au/autoAddDriverRunpath/auto-add-driver-runpath-hook.sh
@@ -1,0 +1,14 @@
+# shellcheck shell=bash
+# Run addDriverRunpath on all dynamically linked, ELF files
+echo "Sourcing auto-add-driver-runpath-hook"
+
+if [ -n "${dontUseAutoAddOpenGLRunpath-}" ]; then
+  echo "dontUseAutoAddOpenGLRunpath has been deprecated, please use dontUseAutoAddDriverRunpath instead"
+fi
+
+# Respect old toggle value to allow for people to gracefully transition
+# See: https://github.com/NixOS/nixpkgs/issues/141803 for transition roadmap
+if [ -z "${dontUseAutoAddDriverRunpath-}" -a -z "${dontUseAutoAddOpenGLRunpath-}" ]; then
+  echo "Using autoAddDriverRunpath"
+  postFixupHooks+=("autoFixElfFiles addDriverRunpath")
+fi

--- a/pkgs/by-name/au/autoAddDriverRunpath/package.nix
+++ b/pkgs/by-name/au/autoAddDriverRunpath/package.nix
@@ -1,0 +1,6 @@
+{ addDriverRunpath, autoFixElfFiles, makeSetupHook }:
+
+makeSetupHook {
+  name = "auto-add-driver-runpath-hook";
+  propagatedBuildInputs = [ addDriverRunpath autoFixElfFiles ];
+} ./auto-add-driver-runpath-hook.sh

--- a/pkgs/by-name/au/autoFixElfFiles/auto-fix-elf-files.sh
+++ b/pkgs/by-name/au/autoFixElfFiles/auto-fix-elf-files.sh
@@ -1,0 +1,64 @@
+# shellcheck shell=bash
+# List all dynamically linked ELF files in the outputs and apply a generic fix
+# action provided as a parameter (currently used to add the CUDA or the
+# cuda_compat driver to the runpath of binaries)
+echo "Sourcing fix-elf-files.sh"
+
+# Returns the exit code of patchelf --print-rpath.
+# A return code of 0 (success) means the ELF file has a dynamic section, while
+# a non-zero return code means the ELF file is statically linked (or is not an
+# ELF file).
+elfHasDynamicSection() {
+  local libPath
+
+  if [[ $# -eq 0 ]]; then
+    echo "elfHasDynamicSection: no library path provided" >&2
+    exit 1
+  elif [[ $# -gt 1 ]]; then
+    echo "elfHasDynamicSection: too many arguments" >&2
+    exit 1
+  elif [[ "$1" == "" ]]; then
+    echo "elfHasDynamicSection: empty library path" >&2
+    exit 1
+  else
+    libPath="$1"
+    shift 1
+  fi
+
+  patchelf --print-rpath "$libPath" >& /dev/null
+  return $?
+}
+
+# Run a fix action on all dynamically linked ELF files in the outputs.
+autoFixElfFiles() {
+  local fixAction
+  local outputPaths
+
+  if [[ $# -eq 0 ]]; then
+    echo "autoFixElfFiles: no fix action provided" >&2
+    exit 1
+  elif [[ $# -gt 1 ]]; then
+    echo "autoFixElfFiles: too many arguments" >&2
+    exit 1
+  elif [[ "$1" == "" ]]; then
+    echo "autoFixElfFiles: empty fix action" >&2
+    exit 1
+  else
+    fixAction="$1"
+  fi
+
+  mapfile -t outputPaths < <(for o in $(getAllOutputNames); do echo "${!o}"; done)
+
+  find "${outputPaths[@]}" -type f -print0  | while IFS= read -rd "" f; do
+    if ! isELF "$f"; then
+      continue
+    elif elfHasDynamicSection "$f"; then
+      # patchelf returns an error on statically linked ELF files, and in
+      # practice fixing actions all involve patchelf
+      echo "autoFixElfFiles: using $fixAction to fix $f" >&2
+      $fixAction "$f"
+    elif (( "${NIX_DEBUG:-0}" >= 1 )); then
+      echo "autoFixElfFiles: skipping a statically-linked ELF file $f"
+    fi
+  done
+}

--- a/pkgs/by-name/au/autoFixElfFiles/package.nix
+++ b/pkgs/by-name/au/autoFixElfFiles/package.nix
@@ -1,0 +1,5 @@
+{ makeSetupHook }:
+
+makeSetupHook {
+  name = "auto-fix-elf-files";
+} ./auto-fix-elf-files.sh

--- a/pkgs/by-name/nv/nvidia-container-toolkit/package.nix
+++ b/pkgs/by-name/nv/nvidia-container-toolkit/package.nix
@@ -10,7 +10,7 @@
 , configTemplate ? null
 , configTemplatePath ? null
 , libnvidia-container
-, cudaPackages
+, autoAddDriverRunpath
 }:
 
 assert configTemplate != null -> (lib.isAttrs configTemplate && configTemplatePath == null);
@@ -87,7 +87,7 @@ buildGoModule rec {
   ];
 
   nativeBuildInputs = [
-    cudaPackages.autoAddDriverRunpath
+    autoAddDriverRunpath
     makeWrapper
   ];
 


### PR DESCRIPTION
## Description of changes

Subset of #297106, trying to make this easier to merge. As the other one also includes deprecation, which is much more prone to conflicts.

This is largely just a relocation and rename of the existing `cudaPackages.addOpenGLRunpathHook` to the top-level scope.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
