### PR TITLE
cudaPackages/aliases: init

### DIFF
--- a/pkgs/development/cuda-modules/aliases.nix
+++ b/pkgs/development/cuda-modules/aliases.nix
@@ -1,0 +1,4 @@
+# Packges which have been deprecated or removed from cudaPackages
+final: prev: {
+
+}

--- a/pkgs/top-level/cuda-packages.nix
+++ b/pkgs/top-level/cuda-packages.nix
@@ -26,6 +26,7 @@
   lib,
   newScope,
   pkgs,
+  config,
   __attrsFailEvaluation ? true,
 }:
 let
@@ -85,7 +86,7 @@ let
       (strings.replaceStrings ["."] ["_"] (versions.majorMinor version))
     ];
 
-  composedExtension = fixedPoints.composeManyExtensions [
+  composedExtension = fixedPoints.composeManyExtensions ([
     (import ../development/cuda-modules/setup-hooks/extension.nix)
     (callPackage ../development/cuda-modules/cuda/extension.nix {inherit cudaVersion;})
     (callPackage ../development/cuda-modules/cuda/overrides.nix {inherit cudaVersion;})
@@ -108,7 +109,9 @@ let
     })
     (callPackage ../development/cuda-modules/cuda-samples/extension.nix {inherit cudaVersion;})
     (callPackage ../development/cuda-modules/cuda-library-samples/extension.nix {})
-  ];
+  ] ++ lib.optionals config.allowAliases [
+    (import ../development/cuda-modules/aliases.nix)
+  ]);
 
   cudaPackages = customisation.makeScope newScope (
     fixedPoints.extends composedExtension passthruFunction


### PR DESCRIPTION
## Description of changes

Allow for CUDA packages to be deprecated through aliases. The immediate goal would be to deprecate `cudaPackages.autoAddOpenGLRunpath` in favor of `pkgs.autoAddDriverRunpath`. This should be compatible with further deprecation as well.

Taken from  #297106

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
