### PR TITLE
nixos/repart-image: refactor to use mkDerivation instead of runCommand

### DIFF
--- a/nixos/modules/image/repart-image.nix
+++ b/nixos/modules/image/repart-image.nix
@@ -2,8 +2,8 @@
 # NixOS module that can be imported.
 
 { lib
+, stdenvNoCC
 , runCommand
-, runCommandLocal
 , python3
 , black
 , ruff
@@ -26,15 +26,18 @@
 , xz
 
   # arguments
+, name
+, version
 , imageFileBasename
 , compression
 , fileSystems
-, partitions
+, partitionsJSON
 , split
 , seed
 , definitionsDirectory
 , sectorSize
 , mkfsEnv ? {}
+, createEmpty ? true
 }:
 
 let
@@ -50,11 +53,6 @@ let
     black --check --diff $out
     ruff --line-length 88 $out
     mypy --strict $out
-  '';
-
-  amendedRepartDefinitions = runCommandLocal "amended-repart.d" {} ''
-    definitions=$(${amendRepartDefinitions} ${partitions} ${definitionsDirectory})
-    cp -r $definitions $out
   '';
 
   fileSystemToolMapping = {
@@ -78,53 +76,88 @@ let
     "xz" = "xz --keep --verbose --threads=0 -${toString compression.level}";
   }."${compression.algorithm}";
 in
-
-runCommand imageFileBasename
-{
+  stdenvNoCC.mkDerivation (finalAttrs:
+  (if (version != null)
+  then { pname = name; inherit version; }
+  else { inherit name;  }
+  ) // {
   __structuredAttrs = true;
 
   nativeBuildInputs = [
     systemd
     fakeroot
     util-linux
+  ] ++ lib.optionals (compression.enable) [
     compressionPkg
   ] ++ fileSystemTools;
 
   env = mkfsEnv;
 
+  inherit partitionsJSON definitionsDirectory;
+
+  # relative path to the repart definitions that are read by systemd-repart
+  finalRepartDefinitions = "repart.d";
+
   systemdRepartFlags = [
     "--dry-run=no"
-    "--empty=create"
     "--size=auto"
     "--seed=${seed}"
-    "--definitions=${amendedRepartDefinitions}"
+    "--definitions=${finalAttrs.finalRepartDefinitions}"
     "--split=${lib.boolToString split}"
     "--json=pretty"
+  ] ++ lib.optionals createEmpty [
+    "--empty=create"
   ] ++ lib.optionals (sectorSize != null) [
     "--sector-size=${toString sectorSize}"
   ];
 
-  passthru = {
-    inherit amendRepartDefinitions amendedRepartDefinitions;
-  };
-} ''
-  mkdir -p $out
-  cd $out
+  dontUnpack = true;
+  dontConfigure = true;
+  doCheck = false;
 
-  echo "Building image with systemd-repart..."
-  unshare --map-root-user fakeroot systemd-repart \
-    ''${systemdRepartFlags[@]} \
-    ${imageFileBasename}.raw \
-    | tee repart-output.json
+  patchPhase = ''
+    runHook prePatch
 
+    amendedRepartDefinitionsDir=$(${amendRepartDefinitions} $partitionsJSON $definitionsDirectory)
+    ln -vs $amendedRepartDefinitionsDir $finalRepartDefinitions
+
+    runHook postPatch
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    echo "Building image with systemd-repart..."
+    unshare --map-root-user fakeroot systemd-repart \
+      ''${systemdRepartFlags[@]} \
+      ${imageFileBasename}.raw \
+      | tee repart-output.json
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+  ''
   # Compression is implemented in the same derivation as opposed to in a
   # separate derivation to allow users to save disk space. Disk images are
   # already very space intensive so we want to allow users to mitigate this.
-  if ${lib.boolToString compression.enable}; then
+  + lib.optionalString compression.enable
+  ''
     for f in ${imageFileBasename}*; do
       echo "Compressing $f with ${compression.algorithm}..."
       # Keep the original file when compressing and only delete it afterwards
       ${compressionCommand} $f && rm $f
     done
-  fi
-''
+  '' + ''
+    mv -v repart-output.json ${imageFileBasename}* $out
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit amendRepartDefinitions;
+  };
+})

--- a/nixos/modules/image/repart.nix
+++ b/nixos/modules/image/repart.nix
@@ -286,7 +286,7 @@ in
         inherit fileSystems definitionsDirectory partitionsJSON mkfsEnv;
       };
 
-    meta.maintainers = with lib.maintainers; [ nikstur ];
+    meta.maintainers = with lib.maintainers; [ nikstur willibutz ];
 
   };
 }

--- a/nixos/modules/image/repart.nix
+++ b/nixos/modules/image/repart.nix
@@ -211,6 +211,15 @@ in
       '';
     };
 
+    finalPartitions = lib.mkOption {
+      type = lib.types.attrs;
+      internal = true;
+      readOnly = true;
+      description = lib.mdDoc ''
+        Convenience option to access partitions with added closures.
+      '';
+    };
+
   };
 
   config = {
@@ -224,6 +233,16 @@ in
             "zstd" = ".zst";
             "xz" = ".xz";
           }."${cfg.compression.algorithm}";
+
+        makeClosure = paths: pkgs.closureInfo { rootPaths = paths; };
+
+        # Add the closure of the provided Nix store paths to cfg.partitions so
+        # that amend-repart-definitions.py can read it.
+        addClosure = _name: partitionConfig: partitionConfig // (
+          lib.optionalAttrs
+            (partitionConfig.storePaths or [ ] != [ ])
+            { closure = "${makeClosure partitionConfig.storePaths}/store-paths"; }
+        );
       in
       {
         name = lib.mkIf (config.system.image.id != null) (lib.mkOptionDefault config.system.image.id);
@@ -239,6 +258,8 @@ in
             "xz" = 3;
           }."${cfg.compression.algorithm}";
         };
+
+        finalPartitions = lib.mapAttrs addClosure cfg.partitions;
       };
 
     system.build.image =
@@ -247,26 +268,15 @@ in
           (f: f != null)
           (lib.mapAttrsToList (_n: v: v.repartConfig.Format or null) cfg.partitions);
 
-        makeClosure = paths: pkgs.closureInfo { rootPaths = paths; };
-
-        # Add the closure of the provided Nix store paths to cfg.partitions so
-        # that amend-repart-definitions.py can read it.
-        addClosure = _name: partitionConfig: partitionConfig // (
-          lib.optionalAttrs
-            (partitionConfig.storePaths or [ ] != [ ])
-            { closure = "${makeClosure partitionConfig.storePaths}/store-paths"; }
-        );
-
-        finalPartitions = lib.mapAttrs addClosure cfg.partitions;
 
         format = pkgs.formats.ini { };
 
         definitionsDirectory = utils.systemdUtils.lib.definitions
           "repart.d"
           format
-          (lib.mapAttrs (_n: v: { Partition = v.repartConfig; }) finalPartitions);
+          (lib.mapAttrs (_n: v: { Partition = v.repartConfig; }) cfg.finalPartitions);
 
-        partitionsJSON = pkgs.writeText "partitions.json" (builtins.toJSON finalPartitions);
+        partitionsJSON = pkgs.writeText "partitions.json" (builtins.toJSON cfg.finalPartitions);
 
         mkfsEnv = mkfsOptionsToEnv cfg.mkfsOptions;
       in

--- a/nixos/modules/image/repart.nix
+++ b/nixos/modules/image/repart.nix
@@ -266,14 +266,14 @@ in
           format
           (lib.mapAttrs (_n: v: { Partition = v.repartConfig; }) finalPartitions);
 
-        partitions = pkgs.writeText "partitions.json" (builtins.toJSON finalPartitions);
+        partitionsJSON = pkgs.writeText "partitions.json" (builtins.toJSON finalPartitions);
 
         mkfsEnv = mkfsOptionsToEnv cfg.mkfsOptions;
       in
       pkgs.callPackage ./repart-image.nix {
         systemd = cfg.package;
-        inherit (cfg) imageFileBasename compression split seed sectorSize;
-        inherit fileSystems definitionsDirectory partitions mkfsEnv;
+        inherit (cfg) name version imageFileBasename compression split seed sectorSize;
+        inherit fileSystems definitionsDirectory partitionsJSON mkfsEnv;
       };
 
     meta.maintainers = with lib.maintainers; [ nikstur ];


### PR DESCRIPTION
## Description of changes

As a follow-up to https://github.com/NixOS/nixpkgs/pull/294096 this
should further improve the flexibility around building OS images with
systemd-repart:

* Previously the attribute set `compression` needed to be fully
  populated, including `algorithm` and `level` because
  `compression.enable` was evaluated by bash, after being interpolated
  as strings into the `buildCommand`. Now it's sufficient to pass
  `compression.enable = false` to the builder, e.g. in `overrideAttrs`,
  to disable the compression.
* Using mkDerivation allows for much more customization than the
  previously used `runCommand`, making use of phases and pre/post hooks.
  This is especially helpful for building multiple images from the same
  system configuration, e.g. to build an image `Y` based on a partially
  built raw image `X`,  by injecting a UKI that depends on `X` into a
  defered ESP.
* Before this change it was non-trivial to conduct further manipulations
  on the amended repart definitions. Now, the definitions that
  systemd-repart uses to build the image can be easily manipulated in
  `postPatch` or `preBuild`.

Aside from this, the build is now executed in the build directory, rather
than `$out`. This allows references to relative paths in the build
environment to be used, especially for `--definitions`, which previously
required an absolute path.

Also `finalPartitions` is now accessible through an internal option and
I added myself as maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).