### PR TITLE
nixos/nix: Fix example for `nix.settings` option

### DIFF
--- a/nixos/modules/config/nix.nix
+++ b/nixos/modules/config/nix.nix
@@ -352,7 +352,7 @@ in
             show-trace = true;
 
             system-features = [ "big-parallel" "kvm" "recursive-nix" ];
-            sandbox-paths = { "/bin/sh" = "''${pkgs.busybox-sandbox-shell.out}/bin/busybox"; };
+            sandbox-paths = [ "/bin/sh=''${pkgs.busybox-sandbox-shell.out}/bin/busybox" ];
           }
         '';
         description = lib.mdDoc ''


### PR DESCRIPTION
## Description of changes

Attribute sets aren't valid option values, needs to be a list.
In the future we could also adjust the module to accept attribute sets as well, but for now let's just have a correct example.

This was discovered [in Nix Hour 66](https://www.youtube.com/live/BX4rUwglszo?feature=shared&t=1774) :)

## Things done

- Built the NixOS manual successfully and checked that it looks correct
- Verified that the example works

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
