### PR TITLE
stackit-cli: init at 0.1.0-prerelease.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4728,6 +4728,12 @@
     githubId = 4956158;
     name = "Robin Stumm";
   };
+  DerRockWolf = {
+    email = "git@rockwolf.eu";
+    github = "DerRockWolf";
+    githubId = 50499906;
+    name = "DerRockWolf";
+  };
   DerTim1 = {
     email = "tim.digel@active-group.de";
     github = "DerTim1";

--- a/pkgs/by-name/st/stackit-cli/package.nix
+++ b/pkgs/by-name/st/stackit-cli/package.nix
@@ -1,0 +1,80 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+, makeWrapper
+, less
+, xdg-utils
+, testers
+, runCommand
+, stackit-cli
+}:
+
+buildGoModule rec {
+  pname = "stackit-cli";
+  version = "0.1.0-prerelease.2";
+
+  src = fetchFromGitHub {
+    owner = "stackitcloud";
+    repo = "stackit-cli";
+    rev = "v${version}";
+    hash = "sha256-GS3ZXarhXs1xuVmiLPMrrzXnO79R1+2va0x7N7CKNjQ=";
+  };
+
+  vendorHash = "sha256-Cill5hq8KVeKGRX2u9oIudi/s8XHIW5C8sgbTshrLY4=";
+
+  subPackages = [ "." ];
+
+  CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+  ];
+
+  nativeBuildInputs = [ installShellFiles makeWrapper ];
+
+  preCheck = ''
+    export HOME=$TMPDIR # needed because the binary always creates a dir & config file
+  '';
+
+  postInstall = ''
+    export HOME=$TMPDIR # needed because the binary always creates a dir & config file
+    mv $out/bin/{${pname},stackit} # rename the binary
+
+    installShellCompletion --cmd stackit --bash <($out/bin/stackit completion bash)
+    installShellCompletion --cmd stackit --zsh <($out/bin/stackit completion zsh)
+    installShellCompletion --cmd stackit --fish <($out/bin/stackit completion fish)
+    # Use this instead, once https://github.com/stackitcloud/stackit-cli/issues/153 is fixed:
+    # installShellCompletion --cmd stackit \
+    #   --bash <($out/bin/stackit completion bash) \
+    #   --zsh  <($out/bin/stackit completion zsh)  \
+    #   --fish <($out/bin/stackit completion fish)
+    # Ensure that all 3 completion scripts exist AND have content (should be kept for regression testing)
+    [ $(find $out/share -not -empty -type f | wc -l) -eq 3 ]
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/stackit \
+      --suffix PATH : ${lib.makeBinPath [ less xdg-utils ]}
+  '';
+
+  nativeCheckInputs = [ less ];
+
+  passthru.tests = {
+    version = testers.testVersion {
+      package = stackit-cli;
+      command = "HOME=$TMPDIR stackit --version";
+    };
+  };
+
+  meta = with lib; {
+    description = "CLI to manage STACKIT cloud services";
+    homepage = "https://github.com/stackitcloud/stackit-cli";
+    changelog = "https://github.com/stackitcloud/stackit-cli/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ DerRockWolf ];
+    mainProgram = "stackit";
+  };
+}


### PR DESCRIPTION
## Description of changes

- 1a823eded68a0ae3c9de2592929478adb2d425f2 add me to maintainers
- 87a29e06108020cbbd0c8f9e0e334abe34a10391 add new package: `stackit-cli`
  - The STACKIT CLI is a CLI to manage STACKIT cloud services
    - STACKIT website: https://www.stackit.de/en/
    - CLI repo: https://github.com/stackitcloud/stackit-cli (currently in beta with active development)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

## One minor question

I have one question about how one should ideally handle a package with multiple binaries:
This package has multiple `main` packages (`stackit` & `scripts`), however end users are only interested in using `stackit`.
Therefore, I've used `subPackages = [ "." ];` which only builds the desired package, but as a result of that it would be the only package for which tests are run (if it would actually have unit tests).

Should I use `excludedPackages = [ "scripts" ];` instead of `subPackages` to build & test all packages?

Would it then be a good idea to add another test to `passthru.tests` which ensures that only the desired binaries (`stackit`) are included in the output?

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
