### PR TITLE
qlcplus: 4.12.3 -> 4.13.0

### DIFF
--- a/pkgs/applications/misc/qlcplus/default.nix
+++ b/pkgs/applications/misc/qlcplus/default.nix
@@ -1,30 +1,22 @@
 { lib, mkDerivation, fetchFromGitHub, fetchpatch, qmake, pkg-config, udev
-, qtmultimedia, qtscript, alsa-lib, ola, libftdi1, libusb-compat-0_1
+, qtmultimedia, qtscript, qtserialport, alsa-lib, ola, libftdi1, libusb-compat-0_1
 , libsndfile, libmad
 }:
 
 mkDerivation rec {
   pname = "qlcplus";
-  version = "4.12.3";
+  version = "4.13.0";
 
   src = fetchFromGitHub {
     owner = "mcallegari";
     repo = "qlcplus";
     rev = "QLC+_${version}";
-    sha256 = "PB1Y8N1TrJMcS7A2e1nKjsUlAxOYjdJqBhbyuDCAbGs=";
+    sha256 = "11av9hg6l0pb1lmlw35v1v2q9mmqz65yfaq01454y5qlmsbxpgkp";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "qt5.15-deprecation-fixes.patch";
-      url = "https://github.com/mcallegari/qlcplus/commit/e4ce4b0226715876e8e9e3b23785d43689b2bb64.patch";
-      sha256 = "1zhrg6ava1nyc97xcx75r02zzkxmar0973w4jwkm5ch3iqa8bqnh";
-    })
-  ];
 
   nativeBuildInputs = [ qmake pkg-config ];
   buildInputs = [
-    udev qtmultimedia qtscript alsa-lib ola libftdi1 libusb-compat-0_1 libsndfile libmad
+    udev qtmultimedia qtscript qtserialport alsa-lib ola libftdi1 libusb-compat-0_1 libsndfile libmad
   ];
 
   qmakeFlags = [ "INSTALLROOT=$(out)" ];


### PR DESCRIPTION
## Description of changes

Changelog: https://github.com/mcallegari/qlcplus/blob/master/debian/changelog

The previously included patch is part of the release since 4.12.4, so it doesn't need to be specified separately anymore.

Also, as far as I can tell, unless it is specifically aimed at the future 5.0.0 release, issue #187049 can be closed, as this package already exists.

_Edit 1: I must've messed something up, as I have built this yesterday on my desktop, but it doesn't currently build on my laptop. 🤔 I'll convert it to a draft while I figure it out._

_Edit 2: Well, it seems like I have somehow built an earlier version by mistake yesterday... Sorry for the noise, I'll try to clean this up!_

_Edit 3: After adding `qtserialport` as a build input, it seems to work for me now._

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
