### PR TITLE
Avoid top-level `with` in `pkgs/development`

### DIFF
--- a/pkgs/development/compilers/dotnet/combine-deps.nix
+++ b/pkgs/development/compilers/dotnet/combine-deps.nix
@@ -4,11 +4,22 @@
   otherRids,
   pkgs ? import ../../../.. {}
 }:
-with pkgs.lib;
 let
   inherit (pkgs) writeText;
 
+  inherit (pkgs.lib)
+    concatMap
+    concatMapStringsSep
+    generators
+    optionals
+    replaceStrings
+    sortOn
+    strings
+    unique
+    ;
+
   fns = map (file: import file) list;
+
   packages = unique
     (concatMap (fn: fn { fetchNuGet = package: package; }) fns);
 

--- a/pkgs/development/coq-modules/coq-elpi/default.nix
+++ b/pkgs/development/coq-modules/coq-elpi/default.nix
@@ -1,7 +1,13 @@
 { lib, mkCoqDerivation, which, coq, version ? null }:
 
-with builtins; with lib; let
-  elpi = coq.ocamlPackages.elpi.override (lib.switch coq.coq-version [
+let
+  inherit (lib)
+    licenses
+    maintainers
+    switch
+    ;
+
+  elpi = coq.ocamlPackages.elpi.override (switch coq.coq-version [
     { case = "8.11"; out = { version = "1.11.4"; };}
     { case = "8.12"; out = { version = "1.12.0"; };}
     { case = "8.13"; out = { version = "1.13.7"; };}

--- a/pkgs/development/coq-modules/mathcomp-analysis/default.nix
+++ b/pkgs/development/coq-modules/mathcomp-analysis/default.nix
@@ -4,8 +4,25 @@
   hierarchy-builder,
   single ? false,
   coqPackages, coq, version ? null }@args:
-with builtins // lib;
+
 let
+  inherit (lib)
+    elem
+    genAttrs
+    head
+    licenses
+    maintainers
+    optionalAttrs
+    optionals
+    pred
+    recurseIntoAttrs
+    splitList
+    switch
+    versions
+    ;
+
+  inherit (lib.versions) range;
+
   repo  = "analysis";
   owner = "math-comp";
 
@@ -28,7 +45,7 @@ let
   release."0.3.1".sha256 = "1iad288yvrjv8ahl9v18vfblgqb1l5z6ax644w49w9hwxs93f2k8";
   release."0.2.3".sha256 = "0p9mr8g1qma6h10qf7014dv98ln90dfkwn76ynagpww7qap8s966";
 
-  defaultVersion = with versions; lib.switch [ coq.version mathcomp.version ]  [
+  defaultVersion = switch [ coq.version mathcomp.version ]  [
       { cases = [ (range "8.17" "8.19") (range "2.0.0" "2.2.0") ]; out = "1.0.0"; }
       { cases = [ (range "8.17" "8.19") (range "1.17.0" "1.19.0") ]; out = "0.7.0"; }
       { cases = [ (range "8.17" "8.18") (range "1.15.0" "1.18.0") ]; out = "0.6.7"; }
@@ -50,7 +67,7 @@ let
   mathcomp_ = package: let
       classical-deps = [ mathcomp.algebra mathcomp-finmap ];
       analysis-deps = [ mathcomp.field mathcomp-bigenough ];
-      intra-deps = lib.optionals (package != "single") (map mathcomp_ (head (splitList (lib.pred.equal package) packages)));
+      intra-deps = optionals (package != "single") (map mathcomp_ (head (splitList (pred.equal package) packages)));
       pkgpath = if package == "single" then "."
         else if package == "analysis" then "theories" else "${package}";
       pname = if package == "single" then "mathcomp-analysis-single"

--- a/pkgs/development/coq-modules/mathcomp/default.nix
+++ b/pkgs/development/coq-modules/mathcomp/default.nix
@@ -13,12 +13,30 @@
 { lib, ncurses, graphviz, lua, fetchzip,
   mkCoqDerivation, recurseIntoAttrs, withDoc ? false, single ? false,
   coqPackages, coq, hierarchy-builder, version ? null }@args:
-with builtins // lib;
+
 let
+  inherit (lib)
+    genAttrs
+    head
+    licenses
+    maintainers
+    optional
+    optionalAttrs
+    optionals
+    optionalString
+    pred
+    recurseIntoAttrs
+    splitList
+    switch
+    versions
+    ;
+
+  inherit (lib.versions) range;
+
   repo  = "math-comp";
   owner = "math-comp";
   withDoc = single && (args.withDoc or false);
-  defaultVersion = with versions; lib.switch coq.coq-version [
+  defaultVersion = switch coq.coq-version [
       { case = range "8.19" "8.19"; out = "1.19.0"; }
       { case = range "8.17" "8.18"; out = "1.18.0"; }
       { case = range "8.15" "8.18"; out = "1.17.0"; }
@@ -63,7 +81,7 @@ let
   packages = [ "ssreflect" "fingroup" "algebra" "solvable" "field" "character" "all" ];
 
   mathcomp_ = package: let
-      mathcomp-deps = lib.optionals (package != "single") (map mathcomp_ (head (splitList (lib.pred.equal package) packages)));
+      mathcomp-deps = optionals (package != "single") (map mathcomp_ (head (splitList (pred.equal package) packages)));
       pkgpath = if package == "single" then "mathcomp" else "mathcomp/${package}";
       pname = if package == "single" then "mathcomp" else "mathcomp-${package}";
       pkgallMake = ''

--- a/pkgs/development/coq-modules/metacoq/default.nix
+++ b/pkgs/development/coq-modules/metacoq/default.nix
@@ -1,11 +1,28 @@
 { lib, fetchzip,
   mkCoqDerivation, recurseIntoAttrs,  single ? false,
   coqPackages, coq, equations, version ? null }@args:
-with builtins // lib;
+
 let
+  inherit (lib)
+    elem
+    genAttrs
+    head
+    licenses
+    maintainers
+    optional
+    optionalAttrs
+    optionals
+    optionalString
+    pred
+    recurseIntoAttrs
+    splitList
+    switch
+    versionAtLeast
+    ;
+
   repo  = "metacoq";
   owner = "MetaCoq";
-  defaultVersion = with versions; switch coq.coq-version [
+  defaultVersion = switch coq.coq-version [
       { case = "8.11"; out = "1.0-beta2-8.11"; }
       { case = "8.12"; out = "1.0-beta2-8.12"; }
       # Do not provide 8.13 because it does not compile with equations 1.3 provided by default (only 1.2.3)
@@ -39,7 +56,7 @@ let
   template-coq = metacoq_ "template-coq";
 
   metacoq_ = package: let
-      metacoq-deps = lib.optionals (package != "single") (map metacoq_ (head (splitList (lib.pred.equal package) packages)));
+      metacoq-deps = optionals (package != "single") (map metacoq_ (head (splitList (pred.equal package) packages)));
       pkgpath = if package == "single" then "./" else "./${package}";
       pname = if package == "all" then "metacoq" else "metacoq-${package}";
       pkgallMake = ''

--- a/pkgs/development/embedded/fpga/tinyprog/default.nix
+++ b/pkgs/development/embedded/fpga/tinyprog/default.nix
@@ -3,10 +3,27 @@
 , fetchFromGitHub
 }:
 
-with python3Packages; buildPythonApplication rec {
+let
+  inherit (lib) licenses maintainers substring;
+
+  inherit (python3Packages)
+    buildPythonApplication
+    intelhex
+    jsonmerge
+    packaging
+    pyserial
+    pyusb
+    setuptools
+    setuptools-scm
+    six
+    tqdm
+    ;
+in
+
+buildPythonApplication rec {
   pname = "tinyprog";
   # `python setup.py --version` from repo checkout
-  version = "1.0.24.dev114+g${lib.substring 0 7 src.rev}";
+  version = "1.0.24.dev114+g${substring 0 7 src.rev}";
 
   src = fetchFromGitHub {
     owner = "tinyfpga";
@@ -30,7 +47,7 @@ with python3Packages; buildPythonApplication rec {
 
   nativeBuildInputs = [ setuptools-scm ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/tinyfpga/TinyFPGA-Bootloader/tree/master/programmer";
     description = "Programmer for FPGA boards using the TinyFPGA USB Bootloader";
     mainProgram = "tinyprog";

--- a/pkgs/development/embedded/platformio/core.nix
+++ b/pkgs/development/embedded/platformio/core.nix
@@ -8,8 +8,38 @@
 , substituteAll
 }:
 
+let
+  inherit (lib) licenses maintainers optionals;
 
-with python3Packages; buildPythonApplication rec {
+  inherit (python3Packages)
+    aiofiles
+    ajsonrpc
+    bottle
+    buildPythonApplication
+    chardet
+    click
+    click-completion
+    colorama
+    jsondiff
+    lockfile
+    marshmallow
+    pyelftools
+    pyserial
+    pytestCheckHook
+    python
+    pythonRelaxDepsHook
+    requests
+    semantic-version
+    setuptools
+    starlette
+    stdenv
+    tabulate
+    uvicorn
+    wsproto
+    zeroconf
+    ;
+in
+buildPythonApplication rec {
   pname = "platformio";
   version = "6.1.11";
   pyproject = true;
@@ -27,7 +57,7 @@ with python3Packages; buildPythonApplication rec {
   patches = [
     (substituteAll {
       src = ./interpreter.patch;
-      interpreter = (python3Packages.python.withPackages (_: propagatedBuildInputs)).interpreter;
+      interpreter = (python.withPackages (_: propagatedBuildInputs)).interpreter;
     })
     (substituteAll {
       src = ./use-local-spdx-license-list.patch;
@@ -77,7 +107,7 @@ with python3Packages; buildPythonApplication rec {
     uvicorn
     wsproto
     zeroconf
-  ] ++ lib.optionals (stdenv.isDarwin && stdenv.isAarch64) [
+  ] ++ optionals (stdenv.isDarwin && stdenv.isAarch64) [
     chardet
   ];
 
@@ -194,10 +224,10 @@ with python3Packages; buildPythonApplication rec {
   ]);
 
   passthru = {
-    python = python3Packages.python;
+    inherit python;
   };
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/platformio/platformio-core/releases/tag/v${version}";
     description = "An open source ecosystem for IoT development";
     downloadPage = "https://github.com/platformio/platformio-core";

--- a/pkgs/development/haskell-modules/configuration-arm.nix
+++ b/pkgs/development/haskell-modules/configuration-arm.nix
@@ -22,10 +22,16 @@
 { pkgs, haskellLib }:
 
 let
-  inherit (pkgs) lib;
-in
+  inherit (pkgs.lib) groupBy optionalAttrs;
 
-with haskellLib;
+  inherit (haskellLib)
+    doDistribute
+    dontCheck
+    dontHaddock
+    overrideCabal
+    triggerRebuild
+    ;
+in
 
 self: super: {
   # COMMON ARM OVERRIDES
@@ -43,7 +49,7 @@ self: super: {
     librarySystemDepends = librarySystemDepends ++ [pkgs.wiringpi];
   }) super.wiringPi;
 
-} // lib.optionalAttrs pkgs.stdenv.hostPlatform.isAarch64 {
+} // optionalAttrs pkgs.stdenv.hostPlatform.isAarch64 {
   # AARCH64-SPECIFIC OVERRIDES
 
   # Corrupted store path https://github.com/NixOS/nixpkgs/pull/272097#issuecomment-1848414265
@@ -121,7 +127,7 @@ self: super: {
   hls-rename-plugin = dontCheck super.hls-rename-plugin;
   hls-fourmolu-plugin = dontCheck super.hls-fourmolu-plugin;
   hls-floskell-plugin = dontCheck super.hls-floskell-plugin;
-} // lib.optionalAttrs pkgs.stdenv.hostPlatform.isAarch32 {
+} // optionalAttrs pkgs.stdenv.hostPlatform.isAarch32 {
   # AARCH32-SPECIFIC OVERRIDES
 
   # KAT/ECB/D2 test segfaults on armv7l

--- a/pkgs/development/haskell-modules/configuration-darwin.nix
+++ b/pkgs/development/haskell-modules/configuration-darwin.nix
@@ -3,10 +3,24 @@
 { pkgs, haskellLib }:
 
 let
-  inherit (pkgs) lib darwin;
-in
+  inherit (pkgs) darwin;
 
-with haskellLib;
+  inherit (pkgs.lib) optionalAttrs;
+
+  inherit (haskellLib)
+    addBuildDepend
+    addExtraLibraries
+    addExtraLibrary
+    addPkgconfigDepends
+    addTestToolDepends
+    appendConfigureFlag
+    appendPatch
+    disableCabalFlag
+    doCheck
+    dontCheck
+    overrideCabal
+    ;
+in
 
 self: super: ({
 
@@ -94,7 +108,7 @@ self: super: ({
   # I think we can add a propagatedImpureHost dep here, but I’m hoping to
   # get a proper fix available soonish.
   x509-system = overrideCabal (drv:
-    lib.optionalAttrs (!pkgs.stdenv.cc.nativeLibc) {
+    optionalAttrs (!pkgs.stdenv.cc.nativeLibc) {
       postPatch = ''
         substituteInPlace System/X509/MacOS.hs --replace security /usr/bin/security
       '' + (drv.postPatch or "");
@@ -317,7 +331,7 @@ self: super: ({
     stripLen = 1;
   }) super.inline-c-cpp;
 
-} // lib.optionalAttrs pkgs.stdenv.isAarch64 {  # aarch64-darwin
+} // optionalAttrs pkgs.stdenv.isAarch64 {  # aarch64-darwin
 
   # https://github.com/fpco/unliftio/issues/87
   unliftio = dontCheck super.unliftio;
@@ -347,7 +361,7 @@ self: super: ({
   # https://github.com/NixOS/nixpkgs/issues/149692
   Agda = disableCabalFlag "optimise-heavily" super.Agda;
 
-} // lib.optionalAttrs pkgs.stdenv.isx86_64 {  # x86_64-darwin
+} // optionalAttrs pkgs.stdenv.isx86_64 {  # x86_64-darwin
 
   # tests appear to be failing to link or something:
   # https://hydra.nixos.org/build/174540882/nixlog/9

--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -1,10 +1,22 @@
 { pkgs, haskellLib }:
 
-with haskellLib;
-
 let
   inherit (pkgs.stdenv.hostPlatform) isDarwin;
-  inherit (pkgs) lib;
+
+  inherit (pkgs.lib) dontRecurseIntoAttrs mapAttrs;
+
+  inherit (haskellLib)
+    addBuildDepend
+    addBuildDepends
+    disableOptimization
+    doDistribute
+    doJailbreak
+    dontCheck
+    generateOptparseApplicativeCompletions
+    markUnbroken
+    overrideCabal
+    unmarkBroken
+    ;
 in
 
 self: super: {
@@ -12,7 +24,7 @@ self: super: {
   # ghcjs does not use `llvmPackages` and exposes `null` attribute.
   llvmPackages =
     if self.ghc.llvmPackages != null
-    then pkgs.lib.dontRecurseIntoAttrs self.ghc.llvmPackages
+    then dontRecurseIntoAttrs self.ghc.llvmPackages
     else null;
 
   # Disable GHC 8.10.x core libraries.
@@ -164,7 +176,7 @@ self: super: {
 
   # Packages which need compat library for GHC < 9.6
   inherit
-    (lib.mapAttrs
+    (mapAttrs
       (_: addBuildDepends [ self.foldable1-classes-compat ])
       super)
     indexed-traversable

--- a/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
@@ -1,9 +1,16 @@
 { pkgs, haskellLib }:
 
-with haskellLib;
-
 let
   inherit (pkgs.stdenv.hostPlatform) isDarwin;
+
+  inherit (haskellLib)
+    addBuildDepend
+    disableOptimization
+    doDistribute
+    doJailbreak
+    dontCheck
+    markUnbroken
+    ;
 in
 
 self: super: {

--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -1,15 +1,25 @@
 { pkgs, haskellLib }:
 
-with haskellLib;
-
 let
   inherit (pkgs.stdenv.hostPlatform) isDarwin;
-  inherit (pkgs) lib;
+
+  inherit (pkgs.lib) dontRecurseIntoAttrs mapAttrs;
+
+  inherit (haskellLib)
+    addBuildDepend
+    addBuildDepends
+    appendConfigureFlags
+    doDistribute
+    doJailbreak
+    dontCheck
+    overrideCabal
+    unmarkBroken
+    ;
 in
 
 self: super: {
 
-  llvmPackages = pkgs.lib.dontRecurseIntoAttrs self.ghc.llvmPackages;
+  llvmPackages = dontRecurseIntoAttrs self.ghc.llvmPackages;
 
   # Disable GHC 9.0.x core libraries.
   array = null;
@@ -139,7 +149,7 @@ self: super: {
 
   # Packages which need compat library for GHC < 9.6
   inherit
-    (lib.mapAttrs
+    (mapAttrs
       (_: addBuildDepends [ self.foldable1-classes-compat ])
       super)
     indexed-traversable

--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -1,15 +1,27 @@
 { pkgs, haskellLib }:
 
-with haskellLib;
-
 let
   inherit (pkgs.stdenv.hostPlatform) isDarwin;
-  inherit (pkgs) lib;
+
+  inherit (pkgs.lib) dontRecurseIntoAttrs mapAttrs pipe;
+
+  inherit (haskellLib)
+    addBuildDepends
+    appendConfigureFlags
+    disableCabalFlag
+    doDistribute
+    doJailbreak
+    dontCheck
+    dontDistribute
+    enableCabalFlag
+    markBroken
+    unmarkBroken
+    ;
 in
 
 self: super: {
 
-  llvmPackages = pkgs.lib.dontRecurseIntoAttrs self.ghc.llvmPackages;
+  llvmPackages = dontRecurseIntoAttrs self.ghc.llvmPackages;
 
   # Disable GHC 9.2.x core libraries.
   array = null;
@@ -75,7 +87,7 @@ self: super: {
 
   stylish-haskell = doJailbreak super.stylish-haskell_0_14_4_0;
 
-  haskell-language-server = lib.pipe (super.haskell-language-server.override {
+  haskell-language-server = pipe (super.haskell-language-server.override {
     hls-ormolu-plugin = null;
     hls-stylish-haskell-plugin = null;
     hls-fourmolu-plugin = null;
@@ -138,7 +150,7 @@ self: super: {
 
   # Packages which need compat library for GHC < 9.6
   inherit
-    (lib.mapAttrs
+    (mapAttrs
       (_: addBuildDepends [ self.foldable1-classes-compat ])
       super)
     indexed-traversable

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -1,14 +1,24 @@
 { pkgs, haskellLib }:
 
-with haskellLib;
-
 let
   inherit (pkgs.stdenv.hostPlatform) isDarwin;
+
+  inherit (pkgs.lib) dontRecurseIntoAttrs;
+
+  inherit (haskellLib)
+    appendConfigureFlag
+    appendPatch
+    doDistribute
+    doJailbreak
+    dontCheck
+    overrideCabal
+    unmarkBroken
+    ;
 in
 
 self: super: {
 
-  llvmPackages = pkgs.lib.dontRecurseIntoAttrs self.ghc.llvmPackages;
+  llvmPackages = dontRecurseIntoAttrs self.ghc.llvmPackages;
 
   # Disable GHC core libraries.
   array = null;

--- a/pkgs/development/haskell-modules/configuration-ghcjs.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs.nix
@@ -5,11 +5,19 @@
 { pkgs, haskellLib }:
 
 let
-  removeLibraryHaskellDepends = pnames: depends:
-    builtins.filter (e: !(builtins.elem (e.pname or "") pnames)) depends;
-in
+  inherit (pkgs.lib) elem filter warn;
 
-with haskellLib;
+  inherit (haskellLib)
+    appendPatch
+    doJailbreak
+    dontCheck
+    overrideCabal
+    ;
+
+  removeLibraryHaskellDepends = pnames: depends:
+    filter (e: !(elem (e.pname or "") pnames)) depends;
+
+in
 
 self: super:
 
@@ -41,7 +49,7 @@ self: super:
   text-short = dontCheck super.text-short;
 
   # doctest doesn't work on ghcjs, but sometimes dontCheck doesn't seem to get rid of the dependency
-  doctest = pkgs.lib.warn "ignoring dependency on doctest" null;
+  doctest = warn "ignoring dependency on doctest" null;
 
   ghcjs-dom = overrideCabal (drv: {
     libraryHaskellDepends = with self; [

--- a/pkgs/development/haskell-modules/configuration-tensorflow.nix
+++ b/pkgs/development/haskell-modules/configuration-tensorflow.nix
@@ -1,9 +1,8 @@
 { pkgs, haskellLib }:
 
-with haskellLib;
-
-self: super:
 let
+  inherit (haskellLib) doJailbreak overrideCabal;
+
   # This contains updates to the dependencies, without which it would
   # be even more work to get it to build.
   # As of 2020-04, there's no new release in sight, which is why we're
@@ -20,7 +19,8 @@ let
     (overrideCabal (drv: { src = tensorflow-haskell; }) drv)
       .overrideAttrs (_oldAttrs: { sourceRoot = "${tensorflow-haskell.name}/${dir}"; });
 in
-{
+
+self: super: {
   tensorflow-proto = doJailbreak (setTensorflowSourceRoot "tensorflow-proto" super.tensorflow-proto);
 
   tensorflow = overrideCabal

--- a/pkgs/development/interpreters/eff/default.nix
+++ b/pkgs/development/interpreters/eff/default.nix
@@ -1,6 +1,10 @@
 { lib, fetchFromGitHub, ocamlPackages }:
 
-with ocamlPackages; buildDunePackage rec {
+let
+  inherit (ocamlPackages) buildDunePackage js_of_ocaml menhir;
+in
+
+buildDunePackage rec {
   pname = "eff";
   version = "5.1";
 

--- a/pkgs/development/julia-modules/extra-python-packages.nix
+++ b/pkgs/development/julia-modules/extra-python-packages.nix
@@ -4,9 +4,14 @@
 
 # This file contains an extra mapping from Julia packages to the Python packages they depend on.
 
-with lib;
+let
+  inherit (lib)
+    concatMap
+    filter
+    getAttr
+    hasAttr
+    ;
 
-rec {
   packageMapping = {
     ExcelFiles = ["xlrd"];
     PyPlot = ["matplotlib"];
@@ -19,4 +24,7 @@ rec {
   in
     filter (x: hasAttr x python3.pkgs) allCandidates
   ) names;
+in
+{
+  inherit packageMapping getExtraPythonPackages;
 }

--- a/pkgs/development/lisp-modules-new-obsolete/ql.nix
+++ b/pkgs/development/lisp-modules-new-obsolete/ql.nix
@@ -1,11 +1,63 @@
-{ pkgs, build-asdf-system, fixup ? pkgs.lib.id, ... }:
-
-with pkgs;
-with lib;
-with lib.lists;
-with lib.strings;
+{ pkgs, build-asdf-system, fixup ? pkgs.id, ... }:
 
 let
+  inherit (pkgs)
+    allegro5
+    assimp
+    cairo
+    cl
+    fetchzip
+    freeglut
+    freeimage
+    freetds
+    freetype
+    gdk-pixbuf
+    glfw
+    glib
+    glucose
+    gobject-introspection
+    gsl
+    gtk2-x11
+    gtk3
+    hdf5
+    libdevil
+    libev
+    libffi
+    libfixposix
+    libGL
+    libGLU
+    libpng
+    librsvg
+    libssh2
+    libuv
+    libxml2
+    libyaml
+    mariadb
+    minisat
+    ode
+    openblas
+    openssl_1_1
+    pango
+    patch
+    postgresql
+    rabbitmq-c
+    rdkafka
+    readline
+    runCommand
+    SDL
+    SDL2
+    sqlite
+    webkitgtk
+    which
+    zeromq
+    ;
+
+  inherit (pkgs.lib)
+    hasAttr
+    mapAttrs
+    optionalAttrs
+    pathExists
+    ;
 
   # FIXME: automatically add nativeLibs based on conditions signalled
 
@@ -19,8 +71,8 @@ let
       nativeLibs = [ openssl_1_1 ];
     };
     "cl-ana.hdf-cffi" = pkg: {
-      nativeBuildInputs = [ pkgs.hdf5 ];
-      nativeLibs = [ pkgs.hdf5 ];
+      nativeBuildInputs = [ hdf5 ];
+      nativeLibs = [ hdf5 ];
       NIX_LDFLAGS = [ "-lhdf5" ];
     };
     cl-async-ssl = pkg: {
@@ -48,8 +100,8 @@ let
       nativeLibs = [ gtk2-x11 ];
     };
     cl-devil = pkg: {
-      nativeBuildInputs = [ pkgs.libdevil ];
-      nativeLibs = [ pkgs.libdevil ];
+      nativeBuildInputs = [ libdevil ];
+      nativeLibs = [ libdevil ];
     };
     cl-freeimage = pkg: {
       nativeLibs = [ freeimage ];
@@ -96,10 +148,10 @@ let
       nativeLibs = [ libuv ];
     };
     cl-libxml2 = pkg: {
-      nativeLibs = [ pkgs.libxml2 ];
+      nativeLibs = [ libxml2 ];
     };
     cl-libyaml = pkg: {
-      nativeLibs = [ pkgs.libyaml ];
+      nativeLibs = [ libyaml ];
     };
     cl-mysql = pkg: {
       nativeLibs = [ mariadb.client ];
@@ -129,18 +181,18 @@ let
       nativeLibs = [ rdkafka ];
     };
     cl-readline = pkg: {
-      nativeLibs = [ pkgs.readline ];
+      nativeLibs = [ readline ];
     };
     cl-rsvg2 = pkg: {
       nativeLibs = [ librsvg ];
     };
     "cl-sat.glucose" = pkg: {
-      propagatedBuildInputs = [ pkgs.glucose ];
+      propagatedBuildInputs = [ glucose ];
       patches = [ ./patches/cl-sat.glucose-binary-from-PATH-if-present.patch ];
 
     };
     "cl-sat.minisat" = pkg: {
-      propagatedBuildInputs = [ pkgs.minisat ];
+      propagatedBuildInputs = [ minisat ];
     };
     cl-webkit2 = pkg: {
       nativeLibs = [ webkitgtk ];
@@ -159,8 +211,8 @@ let
       nativeLibs = [ mariadb.client ];
     };
     gsll = pkg: {
-      nativeBuildInputs = [ pkgs.gsl ];
-      nativeLibs = [ pkgs.gsl ];
+      nativeBuildInputs = [ gsl ];
+      nativeLibs = [ gsl ];
     };
     iolib = pkg: {
       nativeBuildInputs = [ libfixposix ];
@@ -183,24 +235,24 @@ let
       LD_LIBRARY_PATH = "${pkg}/posix/";
     };
     png = pkg: {
-      nativeBuildInputs = [ pkgs.libpng ];
-      nativeLibs = [ pkgs.libpng ];
+      nativeBuildInputs = [ libpng ];
+      nativeLibs = [ libpng ];
     };
     pzmq = pkg: {
-      nativeBuildInputs = [ pkgs.zeromq ];
-      nativeLibs = [ pkgs.zeromq ];
+      nativeBuildInputs = [ zeromq ];
+      nativeLibs = [ zeromq ];
     };
     pzmq-compat = pkg: {
-      nativeBuildInputs = [ pkgs.zeromq ];
-      nativeLibs = [ pkgs.zeromq ];
+      nativeBuildInputs = [ zeromq ];
+      nativeLibs = [ zeromq ];
     };
     pzmq-examples = pkg: {
-      nativeBuildInputs = [ pkgs.zeromq ];
-      nativeLibs = [ pkgs.zeromq ];
+      nativeBuildInputs = [ zeromq ];
+      nativeLibs = [ zeromq ];
     };
     pzmq-test = pkg: {
-      nativeBuildInputs = [ pkgs.zeromq ];
-      nativeLibs = [ pkgs.zeromq ];
+      nativeBuildInputs = [ zeromq ];
+      nativeLibs = [ zeromq ];
     };
     sdl2 = pkg: {
       nativeLibs = [ SDL2 ];
@@ -209,19 +261,19 @@ let
       nativeLibs = [ sqlite ];
     };
     trivial-package-manager = pkg: {
-      propagatedBuildInputs = [ pkgs.which ];
+      propagatedBuildInputs = [ which ];
     };
     trivial-ssh-libssh2 = pkg: {
       nativeLibs = [ libssh2 ];
     };
     zmq = pkg: {
-      nativeBuildInputs = [ pkgs.zeromq ];
-      nativeLibs = [ pkgs.zeromq ];
+      nativeBuildInputs = [ zeromq ];
+      nativeLibs = [ zeromq ];
     };
   };
 
   qlpkgs =
-    lib.optionalAttrs (builtins.pathExists ./imported.nix)
+    optionalAttrs (pathExists ./imported.nix)
       (import ./imported.nix { inherit (pkgs) runCommand fetchzip; pkgs = builtQlpkgs; });
 
   builtQlpkgs = mapAttrs (n: v: build v) qlpkgs;

--- a/pkgs/development/lisp-modules-obsolete/openssl-lib-marked.nix
+++ b/pkgs/development/lisp-modules-obsolete/openssl-lib-marked.nix
@@ -1,12 +1,19 @@
-with import ../../../default.nix {};
+
+let
+  pkgs = import ../../../default.nix {};
+
+  inherit (pkgs) openssl runCommand;
+  inherit (pkgs.lib) getLib getVersion;
+in
+
 runCommand "openssl-lib-marked" {} ''
   mkdir -p "$out/lib"
   for lib in ssl crypto; do
-    version="${lib.getVersion openssl}"
-    ln -s "${lib.getLib openssl}/lib/lib$lib.so" "$out/lib/lib$lib.so.$version"
+    version="${getVersion openssl}"
+    ln -s "${getLib openssl}/lib/lib$lib.so" "$out/lib/lib$lib.so.$version"
     version="$(echo "$version" | sed -re 's/[a-z]+$//')"
     while test -n "$version"; do
-      ln -sfT "${lib.getLib openssl}/lib/lib$lib.so" "$out/lib/lib$lib.so.$version"
+      ln -sfT "${getLib openssl}/lib/lib$lib.so" "$out/lib/lib$lib.so.$version"
       nextversion="''${version%.*}"
       if test "$version" = "$nextversion"; then
         version=

--- a/pkgs/development/lua-modules/aliases.nix
+++ b/pkgs/development/lua-modules/aliases.nix
@@ -7,31 +7,31 @@ lib: self: super:
 ### Use `./remove-attr.py [attrname]` in this directory to remove your alias
 ### from the `luaPackages` set without regenerating the entire file.
 
-with self;
-
 let
+  inherit (lib) dontDistribute hasAttr isDerivation mapAttrs;
+
   # Removing recurseForDerivation prevents derivations of aliased attribute
   # set to appear while listing all the packages available.
-  removeRecurseForDerivations = alias: with lib;
+  removeRecurseForDerivations = alias:
     if alias.recurseForDerivations or false
     then removeAttrs alias ["recurseForDerivations"]
     else alias;
 
   # Disabling distribution prevents top-level aliases for non-recursed package
   # sets from building on Hydra.
-  removeDistribute = alias: with lib;
+  removeDistribute = alias:
     if isDerivation alias then
       dontDistribute alias
     else alias;
 
   # Make sure that we are not shadowing something from node-packages.nix.
   checkInPkgs = n: alias:
-    if builtins.hasAttr n super
+    if hasAttr n super
     then throw "Alias ${n} is still in generated.nix"
     else alias;
 
   mapAliases = aliases:
-    lib.mapAttrs (n: alias:
+    mapAttrs (n: alias:
       removeDistribute
         (removeRecurseForDerivations
           (checkInPkgs n alias)))

--- a/pkgs/development/node-packages/aliases.nix
+++ b/pkgs/development/node-packages/aliases.nix
@@ -6,31 +6,31 @@ pkgs: lib: self: super:
 ### Use `./remove-attr.py [attrname]` in this directory to remove your alias
 ### from the `nodePackages` set without regenerating the entire file.
 
-with self;
-
 let
+  inherit (lib) dontDistribute hasAttr isDerivation mapAttrs;
+
   # Removing recurseForDerivation prevents derivations of aliased attribute
   # set to appear while listing all the packages available.
-  removeRecurseForDerivations = alias: with lib;
+  removeRecurseForDerivations = alias:
     if alias.recurseForDerivations or false
     then removeAttrs alias ["recurseForDerivations"]
     else alias;
 
   # Disabling distribution prevents top-level aliases for non-recursed package
   # sets from building on Hydra.
-  removeDistribute = alias: with lib;
+  removeDistribute = alias:
     if isDerivation alias then
       dontDistribute alias
     else alias;
 
   # Make sure that we are not shadowing something from node-packages.nix.
   checkInPkgs = n: alias:
-    if builtins.hasAttr n super
+    if hasAttr n super
     then throw "Alias ${n} is still in node-packages.nix"
     else alias;
 
   mapAliases = aliases:
-    lib.mapAttrs (n: alias:
+    mapAttrs (n: alias:
       removeDistribute
         (removeRecurseForDerivations
           (checkInPkgs n alias)))
@@ -99,7 +99,7 @@ mapAliases {
   inherit (pkgs) jake; # added 2023-08-19
   inherit (pkgs) javascript-typescript-langserver; # added 2023-08-19
   karma = pkgs.karma-runner; # added 2023-07-29
-  leetcode-cli = vsc-leetcode-cli; # added 2023-08-31
+  leetcode-cli = self.vsc-leetcode-cli; # added 2023-08-31
   manta = pkgs.node-manta; # Added 2023-05-06
   markdownlint-cli = pkgs.markdownlint-cli; # added 2023-07-29
   inherit (pkgs) markdownlint-cli2; # added 2023-08-22
@@ -111,7 +111,7 @@ mapAliases {
   node-inspector = throw "node-inspector was removed because it was broken"; # added 2023-08-21
   inherit (pkgs) npm-check-updates; # added 2023-08-22
   ocaml-language-server = throw "ocaml-language-server was removed because it was abandoned upstream"; # added 2023-09-04
-  parcel-bundler = parcel; # added 2023-09-04
+  parcel-bundler = self.parcel; # added 2023-09-04
   pkg = pkgs.vercel-pkg; # added 2023-10-04
   inherit (pkgs) pm2; # added 2024-01-22
   prettier_d_slim = pkgs.prettier-d-slim; # added 2023-09-14

--- a/pkgs/development/python-modules/asn1crypto/default.nix
+++ b/pkgs/development/python-modules/asn1crypto/default.nix
@@ -13,8 +13,8 @@
 # Switch version based on python version, as the situation isn't easy:
 #   https://github.com/wbond/asn1crypto/issues/269
 #   https://github.com/MatthiasValvekens/certomancer/issues/12
-with (
-  if lib.versionOlder python.version "3.12" then rec {
+let
+  provenance = if lib.versionOlder python.version "3.12" then rec {
     version = "1.5.1";
     rev = version;
     hash = "sha256-M8vASxhaJPgkiTrAckxz7gk/QHkrFlNz7fFbnLEBT+M=";
@@ -22,19 +22,19 @@ with (
     version = "1.5.1-unstable-2023-11-03";
     rev = "b763a757bb2bef2ab63620611ddd8006d5e9e4a2";
     hash = "sha256-11WajEDtisiJsKQjZMSd5sDog3DuuBzf1PcgSY+uuXY=";
-  }
-);
+  };
+in
 
 buildPythonPackage rec {
   pname = "asn1crypto";
   pyproject = true;
-  inherit version;
+  inherit (provenance) version;
 
   # Pulling from Github to run tests
   src = fetchFromGitHub {
     owner = "wbond";
     repo = "asn1crypto";
-    inherit rev hash;
+    inherit (provenance) rev hash;
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/pillow/generic.nix
+++ b/pkgs/development/python-modules/pillow/generic.nix
@@ -5,10 +5,35 @@
 , patches ? []
 , meta
 , passthru ? {}
+, buildPythonPackage
+, format
+, lib
+, stdenv
+, olefile
+, defusedxml
+, pytestCheckHook
+, numpy
+, setuptools
+, freetype
+, libjpeg
+, openjpeg
+, libimagequant
+, zlib
+, libtiff
+, libwebp
+, libxcrypt
+, tcl
+, lcms2
+, libxcb
+, isPyPy
+, tk
+, libX11
 , ...
-}@args:
+}:
 
-with args;
+let
+  inherit (lib) optionals optionalString versionAtLeast;
+in
 
 buildPythonPackage rec {
   inherit pname version format src meta passthru patches;
@@ -27,7 +52,7 @@ buildPythonPackage rec {
     "test_roundtrip"
     "test_basic"
     "test_custom_metadata"
-  ] ++ lib.optionals stdenv.isDarwin [
+  ] ++ optionals stdenv.isDarwin [
     # Disable darwin tests which require executables: `iconutil` and `screencapture`
     "test_grab"
     "test_grabclipboard"
@@ -35,15 +60,15 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [ olefile ]
-    ++ lib.optionals (lib.versionAtLeast version "8.2.0") [ defusedxml ];
+    ++ optionals (versionAtLeast version "8.2.0") [ defusedxml ];
 
   nativeCheckInputs = [ pytestCheckHook numpy ];
 
   nativeBuildInputs = [ setuptools ];
 
   buildInputs = [ freetype libjpeg openjpeg libimagequant zlib libtiff libwebp libxcrypt tcl lcms2 ]
-    ++ lib.optionals (lib.versionAtLeast version "7.1.0") [ libxcb ]
-    ++ lib.optionals (isPyPy) [ tk libX11 ];
+    ++ optionals (versionAtLeast version "7.1.0") [ libxcb ]
+    ++ optionals (isPyPy) [ tk libX11 ];
 
   # NOTE: we use LCMS_ROOT as WEBP root since there is not other setting for webp.
   # NOTE: The Pillow install script will, by default, add paths like /usr/lib
@@ -70,7 +95,7 @@ buildPythonPackage rec {
             s|self\.disable_platform_guessing = None|self.disable_platform_guessing = True|g ;'
     export LDFLAGS="$LDFLAGS -L${libwebp}/lib"
     export CFLAGS="$CFLAGS -I${libwebp}/include"
-  '' + lib.optionalString (lib.versionAtLeast version "7.1.0") ''
+  '' + optionalString (versionAtLeast version "7.1.0") ''
     export LDFLAGS="$LDFLAGS -L${libxcb}/lib"
     export CFLAGS="$CFLAGS -I${libxcb.dev}/include"
   '';

--- a/pkgs/development/python-modules/tasklib/default.nix
+++ b/pkgs/development/python-modules/tasklib/default.nix
@@ -5,13 +5,22 @@
 , writeShellScriptBin
 }:
 
-with pythonPackages;
-
 let
+  inherit (lib) licenses maintainers platforms;
 
-wsl_stub = writeShellScriptBin "wsl" "true";
+  inherit (pythonPackages)
+    buildPythonPackage
+    pytz
+    setuptools
+    six
+    tzlocal
+    ;
 
-in buildPythonPackage rec {
+  wsl_stub = writeShellScriptBin "wsl" "true";
+
+in
+
+buildPythonPackage rec {
   pname = "tasklib";
   version = "2.5.1";
   format = "setuptools";
@@ -32,7 +41,7 @@ in buildPythonPackage rec {
     wsl_stub
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/robgolding/tasklib";
     description = "Library for interacting with taskwarrior databases";
     changelog = "https://github.com/GothenburgBitFactory/tasklib/releases/tag/${version}";

--- a/pkgs/development/skaware-packages/execline/default.nix
+++ b/pkgs/development/skaware-packages/execline/default.nix
@@ -1,7 +1,13 @@
 { fetchFromGitHub, skawarePackages }:
 
-with skawarePackages;
 let
+  inherit (skawarePackages)
+    buildPackage
+    execline
+    execline-man-pages
+    skalibs
+    ;
+
   version = "2.9.4.0";
 
   # Maintainer of manpages uses following versioning scheme: for every

--- a/pkgs/development/skaware-packages/mdevd/default.nix
+++ b/pkgs/development/skaware-packages/mdevd/default.nix
@@ -1,6 +1,9 @@
 { lib, skawarePackages }:
 
-with skawarePackages;
+let
+  inherit (lib) platforms;
+  inherit (skawarePackages) buildPackage mdevd skalibs;
+in
 
 buildPackage {
   pname = "mdevd";
@@ -8,7 +11,7 @@ buildPackage {
   sha256 = "9uzw73zUjQTvx1rLLa2WfYULyIFb2wCY8cnvBDOU1DA=";
 
   description = "mdev-compatible Linux hotplug manager daemon";
-  platforms = lib.platforms.linux;
+  platforms = platforms.linux;
 
   outputs = [ "bin" "out" "dev" "doc" ];
 

--- a/pkgs/development/skaware-packages/nsss/default.nix
+++ b/pkgs/development/skaware-packages/nsss/default.nix
@@ -1,6 +1,8 @@
 { skawarePackages }:
 
-with skawarePackages;
+let
+  inherit (skawarePackages) buildPackage nsss skalibs;
+in
 
 buildPackage {
   pname = "nsss";

--- a/pkgs/development/skaware-packages/s6-dns/default.nix
+++ b/pkgs/development/skaware-packages/s6-dns/default.nix
@@ -1,6 +1,8 @@
 { skawarePackages }:
 
-with skawarePackages;
+let
+  inherit (skawarePackages) buildPackage s6-dns skalibs;
+in
 
 buildPackage {
   pname = "s6-dns";

--- a/pkgs/development/skaware-packages/s6-linux-init/default.nix
+++ b/pkgs/development/skaware-packages/s6-linux-init/default.nix
@@ -1,6 +1,16 @@
 { lib, skawarePackages }:
 
-with skawarePackages;
+let
+  inherit (lib) platforms;
+
+  inherit (skawarePackages)
+    buildPackage
+    execline
+    s6
+    s6-linux-init
+    skalibs
+    ;
+in
 
 buildPackage {
   pname = "s6-linux-init";
@@ -8,7 +18,7 @@ buildPackage {
   sha256 = "sha256-Ea4I0KZiELXla2uu4Pa5sbafvtsF/aEoWxFaMcpGx38=";
 
   description = "A set of minimalistic tools used to create a s6-based init system, including a /sbin/init binary, on a Linux kernel";
-  platforms = lib.platforms.linux;
+  platforms = platforms.linux;
 
   outputs = [ "bin" "dev" "doc" "out" ];
 

--- a/pkgs/development/skaware-packages/s6-linux-utils/default.nix
+++ b/pkgs/development/skaware-packages/s6-linux-utils/default.nix
@@ -1,6 +1,14 @@
 { lib, skawarePackages }:
 
-with skawarePackages;
+let
+  inherit (lib) platforms;
+  inherit (skawarePackages)
+    buildPackage
+    s6
+    s6-linux-utils
+    skalibs
+    ;
+in
 
 buildPackage {
   pname = "s6-linux-utils";
@@ -8,7 +16,7 @@ buildPackage {
   sha256 = "j5RGM8qH09I+DwPJw4PRUC1QjJusFtOMP79yOl6rK7c=";
 
   description = "A set of minimalistic Linux-specific system utilities";
-  platforms = lib.platforms.linux;
+  platforms = platforms.linux;
 
   outputs = [ "bin" "dev" "doc" "out" ];
 

--- a/pkgs/development/skaware-packages/s6-networking/default.nix
+++ b/pkgs/development/skaware-packages/s6-networking/default.nix
@@ -2,11 +2,21 @@
 
 # Whether to build the TLS/SSL tools and what library to use
 # acceptable values: "bearssl", "libressl", false
-, sslSupport ? "bearssl" , libressl, bearssl
+, sslSupport ? "bearssl", libressl, bearssl
 }:
 
-with skawarePackages;
 let
+  inherit (lib) getDev getLib optionals;
+
+  inherit (skawarePackages)
+    buildPackage
+    execline
+    s6
+    s6-dns
+    s6-networking
+    skalibs
+    ;
+
   sslSupportEnabled = sslSupport != false;
   sslLibs = {
     libressl = libressl;
@@ -14,8 +24,8 @@ let
   };
 
 in
-assert sslSupportEnabled -> sslLibs ? ${sslSupport};
 
+assert sslSupportEnabled -> sslLibs ? ${sslSupport};
 
 buildPackage {
   pname = "s6-networking";
@@ -47,11 +57,11 @@ buildPackage {
     "--with-dynlib=${s6.out}/lib"
     "--with-dynlib=${s6-dns.lib}/lib"
   ]
-  ++ (lib.optionals sslSupportEnabled [
+  ++ (optionals sslSupportEnabled [
        "--enable-ssl=${sslSupport}"
-       "--with-include=${lib.getDev sslLibs.${sslSupport}}/include"
-       "--with-lib=${lib.getLib sslLibs.${sslSupport}}/lib"
-       "--with-dynlib=${lib.getLib sslLibs.${sslSupport}}/lib"
+       "--with-include=${getDev sslLibs.${sslSupport}}/include"
+       "--with-lib=${getLib sslLibs.${sslSupport}}/lib"
+       "--with-dynlib=${getLib sslLibs.${sslSupport}}/lib"
      ]);
 
   postInstall = ''

--- a/pkgs/development/skaware-packages/s6-portable-utils/default.nix
+++ b/pkgs/development/skaware-packages/s6-portable-utils/default.nix
@@ -1,6 +1,13 @@
 { skawarePackages }:
 
-with skawarePackages;
+let
+  inherit (skawarePackages)
+    buildPackage
+    s6
+    s6-portable-utils
+    skalibs
+    ;
+in
 
 buildPackage {
   pname = "s6-portable-utils";

--- a/pkgs/development/skaware-packages/s6-rc/default.nix
+++ b/pkgs/development/skaware-packages/s6-rc/default.nix
@@ -1,6 +1,16 @@
 { lib, stdenv, skawarePackages, targetPackages }:
 
-with skawarePackages;
+let
+  inherit (lib) optionalString platforms;
+
+  inherit (skawarePackages)
+    buildPackage
+    execline
+    s6
+    s6-rc
+    skalibs
+    ;
+in
 
 buildPackage {
   pname = "s6-rc";
@@ -8,7 +18,7 @@ buildPackage {
   sha256 = "AL36WW+nFhUS6XLskoKiq9j9DjHwkXe616K8PY8oOYI=";
 
   description = "A service manager for s6-based systems";
-  platforms = lib.platforms.unix;
+  platforms = platforms.unix;
 
   outputs = [ "bin" "lib" "dev" "doc" "out" ];
 
@@ -42,7 +52,7 @@ buildPackage {
   # only time hostPlatform != targetPlatform.  When that happens we
   # modify s6-rc-compile to use the configuration headers for the
   # system we're cross-compiling for.
-  postConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) ''
+  postConfigure = optionalString (stdenv.hostPlatform != stdenv.targetPlatform) ''
     substituteInPlace src/s6-rc/s6-rc-compile.c \
         --replace '<execline/config.h>' '"${targetPackages.execline.dev}/include/execline/config.h"' \
         --replace '<s6/config.h>' '"${targetPackages.s6.dev}/include/s6/config.h"' \

--- a/pkgs/development/skaware-packages/s6/default.nix
+++ b/pkgs/development/skaware-packages/s6/default.nix
@@ -1,6 +1,13 @@
 { skawarePackages }:
 
-with skawarePackages;
+let
+  inherit (skawarePackages)
+    buildPackage
+    execline
+    s6
+    skalibs
+    ;
+in
 
 buildPackage {
   pname = "s6";

--- a/pkgs/development/skaware-packages/sdnotify-wrapper/default.nix
+++ b/pkgs/development/skaware-packages/sdnotify-wrapper/default.nix
@@ -1,8 +1,10 @@
 { stdenv, lib, runCommandCC, skawarePackages }:
 
-with skawarePackages;
-
 let
+  inherit (lib) licenses maintainers platforms;
+
+  inherit (skawarePackages) sdnotify-wrapper skalibs;
+
   # From https://skarnet.org/software/misc/sdnotify-wrapper.c,
   # which is unversioned.
   src = ./sdnotify-wrapper.c;
@@ -15,9 +17,9 @@ in runCommandCC "sdnotify-wrapper" {
      homepage = "https://skarnet.org/software/misc/sdnotify-wrapper.c";
      description = "Use systemd sd_notify without having to link against libsystemd";
      mainProgram = "sdnotify-wrapper";
-     platforms = lib.platforms.linux;
-     license = lib.licenses.isc;
-     maintainers = with lib.maintainers; [ Profpatsch ];
+     platforms = platforms.linux;
+     license = licenses.isc;
+     maintainers = with maintainers; [ Profpatsch ];
    };
 
 } ''

--- a/pkgs/development/skaware-packages/skalibs/default.nix
+++ b/pkgs/development/skaware-packages/skalibs/default.nix
@@ -4,7 +4,10 @@
 , pkgs
 }:
 
-with skawarePackages;
+let
+  inherit (lib) optionals;
+  inherit (skawarePackages) buildPackage skalibs;
+in
 
 buildPackage {
   pname = "skalibs";
@@ -26,7 +29,7 @@ buildPackage {
     # It would be set when PATH is empty. This hurts hermeticity.
     "--with-default-path="
 
-  ] ++ lib.optionals (stdenv.buildPlatform.config != stdenv.hostPlatform.config) [
+  ] ++ optionals (stdenv.buildPlatform.config != stdenv.hostPlatform.config) [
     # ./configure: sysdep posixspawnearlyreturn cannot be autodetected
     # when cross-compiling. Please manually provide a value with the
     # --with-sysdep-posixspawnearlyreturn=yes|no|... option.

--- a/pkgs/development/skaware-packages/tipidee/default.nix
+++ b/pkgs/development/skaware-packages/tipidee/default.nix
@@ -1,6 +1,8 @@
 { skawarePackages }:
 
-with skawarePackages;
+let
+  inherit (skawarePackages) buildPackage skalibs tipidee;
+in
 
 buildPackage {
   pname = "tipidee";

--- a/pkgs/development/skaware-packages/utmps/default.nix
+++ b/pkgs/development/skaware-packages/utmps/default.nix
@@ -1,6 +1,13 @@
 { skawarePackages }:
 
-with skawarePackages;
+let
+  inherit (skawarePackages)
+    buildPackage
+    execline
+    skalibs
+    utmps
+    ;
+in
 
 buildPackage {
   pname = "utmps";

--- a/pkgs/development/tools/agda-pkg/default.nix
+++ b/pkgs/development/tools/agda-pkg/default.nix
@@ -3,7 +3,26 @@
 , fetchPypi
 }:
 
-with python3Packages;
+let
+  inherit (lib) licenses maintainers;
+
+  inherit (python3Packages)
+    buildPythonApplication
+    click
+    click-log
+    distlib
+    gitpython
+    humanize
+    jinja2
+    natsort
+    pony
+    ponywhoosh
+    pythonOlder
+    pyyaml
+    requests
+    whoosh
+    ;
+in
 
 buildPythonApplication rec {
   pname = "agda-pkg";
@@ -38,7 +57,7 @@ buildPythonApplication rec {
     ponywhoosh
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://agda.github.io/agda-pkg/";
     description = "Package manager for Agda";
     license = licenses.mit;

--- a/pkgs/development/tools/analysis/uefi-firmware-parser/default.nix
+++ b/pkgs/development/tools/analysis/uefi-firmware-parser/default.nix
@@ -1,6 +1,9 @@
 { lib, python3, fetchFromGitHub }:
 
-with python3.pkgs;
+let
+  inherit (lib) licenses maintainers platforms;
+  inherit (python3.pkgs) buildPythonApplication;
+in
 
 buildPythonApplication rec {
   pname = "uefi-firmware-parser";
@@ -14,7 +17,7 @@ buildPythonApplication rec {
     sha256 = "1yn9vi91j1yxkn0icdnjhgl0qrqqkzyhccj39af4f19q1gdw995l";
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/theopolis/uefi-firmware-parser/";
     description = "Parse BIOS/Intel ME/UEFI firmware related structures: Volumes, FileSystems, Files, etc";
     mainProgram = "uefi-firmware-parser";

--- a/pkgs/development/tools/check-jsonschema/default.nix
+++ b/pkgs/development/tools/check-jsonschema/default.nix
@@ -1,6 +1,22 @@
 { lib, fetchFromGitHub, python3 }:
 
-with python3.pkgs;
+let
+  inherit (lib) licenses maintainers;
+
+  inherit (python3.pkgs)
+    buildPythonApplication
+    click
+    jsonschema
+    pytestCheckHook
+    pytest-xdist
+    pythonOlder
+    regress
+    requests
+    responses
+    ruamel-yaml
+    setuptools
+    ;
+in
 
 buildPythonApplication rec {
   pname = "check-jsonschema";
@@ -39,7 +55,7 @@ buildPythonApplication rec {
     "test_schemaloader_yaml_data"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "A jsonschema CLI and pre-commit hook";
     mainProgram = "check-jsonschema";
     homepage = "https://github.com/python-jsonschema/check-jsonschema";

--- a/pkgs/development/tools/clpm/default.nix
+++ b/pkgs/development/tools/clpm/default.nix
@@ -9,12 +9,11 @@
 # Broken on newer versions:
 # "https://gitlab.common-lisp.net/clpm/clpm/-/issues/51". Once that bug is
 # fixed, remove this, and all 2.1.9 references from the SBCL build file.
-with rec {
+let
   sbcl_2_1_9 = sbcl.override (_: {
     version = "2.1.9";
   });
-};
-
+in
 
 stdenv.mkDerivation rec {
   pname = "clpm";

--- a/pkgs/development/tools/cppclean/default.nix
+++ b/pkgs/development/tools/cppclean/default.nix
@@ -1,6 +1,9 @@
 { lib, fetchFromGitHub, python3Packages }:
 
-with python3Packages;
+let
+  inherit (lib) licenses maintainers platforms;
+  inherit (python3Packages) buildPythonApplication;
+in
 
 buildPythonApplication rec {
   pname = "cppclean";
@@ -21,7 +24,7 @@ buildPythonApplication rec {
     ./test.bash
     '';
 
-  meta = with lib; {
+  meta = {
     description = "Finds problems in C++ source that slow development of large code bases";
     mainProgram = "cppclean";
     homepage    = "https://github.com/myint/cppclean";

--- a/pkgs/development/tools/google-app-engine-go-sdk/default.nix
+++ b/pkgs/development/tools/google-app-engine-go-sdk/default.nix
@@ -1,6 +1,10 @@
 { lib, stdenv, fetchzip, python3Packages, makeWrapper }:
 
-with python3Packages;
+let
+  inherit (lib) licenses maintainers platforms sourceTypes;
+
+  inherit (python3Packages) cffi cryptography pyopenssl python;
+in
 
 stdenv.mkDerivation rec {
   pname = "google-app-engine-go-sdk";
@@ -32,7 +36,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Google App Engine SDK for Go";
     version = version;
     homepage = "https://cloud.google.com/appengine/docs/go/";

--- a/pkgs/development/tools/headache/default.nix
+++ b/pkgs/development/tools/headache/default.nix
@@ -1,6 +1,9 @@
 { lib, fetchFromGitHub, nix-update-script, ocamlPackages }:
 
-with ocamlPackages;
+let
+  inherit (lib) licenses maintainers;
+  inherit (ocamlPackages) buildDunePackage camomile;
+in
 
 buildDunePackage rec {
   pname = "headache";
@@ -19,7 +22,7 @@ buildDunePackage rec {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/frama-c/${pname}";
     description = "Lightweight tool for managing headers in source code files";
     mainProgram = "headache";

--- a/pkgs/development/tools/mbed-cli/default.nix
+++ b/pkgs/development/tools/mbed-cli/default.nix
@@ -1,6 +1,9 @@
 { lib, python3Packages, fetchPypi, git, mercurial }:
 
-with python3Packages;
+let
+  inherit (lib) licenses maintainers;
+  inherit (python3Packages) buildPythonApplication pytest;
+in
 
 buildPythonApplication rec {
   pname = "mbed-cli";
@@ -24,11 +27,10 @@ buildPythonApplication rec {
     pytest test
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/ARMmbed/mbed-cli";
     description = "Arm Mbed Command Line Interface";
     license = licenses.asl20;
     maintainers = with maintainers; [ ];
   };
 }
-

--- a/pkgs/development/tools/misc/ctags/wrapped.nix
+++ b/pkgs/development/tools/misc/ctags/wrapped.nix
@@ -1,6 +1,13 @@
 { pkgs, ctags }:
 
-with pkgs.lib;
+let
+  inherit (pkgs.lib)
+    concatLists
+    concatStringsSep
+    escapeShellArg
+    makeOverridable
+    ;
+in
 
 # define some ctags wrappers adding support for some not that common languages
 # customization:

--- a/pkgs/development/tools/misc/nrfutil/default.nix
+++ b/pkgs/development/tools/misc/nrfutil/default.nix
@@ -1,10 +1,29 @@
 { lib
-, stdenv
 , fetchFromGitHub
 , python3
 }:
 
-with python3.pkgs;
+let
+  inherit (lib) licenses maintainers platforms;
+
+  inherit (python3.pkgs)
+    behave
+    buildPythonApplication
+    click
+    crcmod
+    ecdsa
+    intelhex
+    libusb1
+    nose
+    pc-ble-driver-py
+    piccata
+    protobuf
+    pyserial
+    pyspinel
+    pyyaml
+    tqdm
+    ;
+in
 
 buildPythonApplication rec {
   pname = "nrfutil";
@@ -45,7 +64,7 @@ buildPythonApplication rec {
       --replace "protobuf >=3.17.3, < 4.0.0" "protobuf"
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Device Firmware Update tool for nRF chips";
     homepage = "https://github.com/NordicSemiconductor/pc-nrfutil";
     license = licenses.unfreeRedistributable;

--- a/pkgs/development/tools/ocaml/ocaml-top/default.nix
+++ b/pkgs/development/tools/ocaml/ocaml-top/default.nix
@@ -1,6 +1,11 @@
 { lib, fetchFromGitHub, ocamlPackages }:
 
-with ocamlPackages; buildDunePackage rec {
+let
+  inherit (lib) licenses maintainers;
+  inherit (ocamlPackages) buildDunePackage lablgtk3-sourceview3 ocp-index;
+in
+
+buildDunePackage rec {
   pname = "ocaml-top";
   version = "1.2.0";
 
@@ -15,9 +20,9 @@ with ocamlPackages; buildDunePackage rec {
 
   meta = {
     homepage = "https://www.typerex.org/ocaml-top.html";
-    license = lib.licenses.gpl3;
+    license = licenses.gpl3;
     description = "A simple cross-platform OCaml code editor built for top-level evaluation";
     mainProgram = "ocaml-top";
-    maintainers = with lib.maintainers; [ vbgl ];
+    maintainers = with maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/tools/ocaml/opam-publish/default.nix
+++ b/pkgs/development/tools/ocaml/opam-publish/default.nix
@@ -1,6 +1,19 @@
 { lib, fetchFromGitHub, ocamlPackages }:
 
-with ocamlPackages;
+let
+  inherit (lib) licenses maintainers;
+
+  inherit (ocamlPackages)
+    buildDunePackage
+    cmdliner
+    github
+    github-unix
+    lwt_ssl
+    opam-core
+    opam-format
+    opam-state
+    ;
+in
 
 buildDunePackage rec {
   pname = "opam-publish";
@@ -25,7 +38,7 @@ buildDunePackage rec {
     github-unix
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/ocaml-opam/${pname}";
     description = "A tool to ease contributions to opam repositories";
     mainProgram = "opam-publish";

--- a/pkgs/development/tools/pew/default.nix
+++ b/pkgs/development/tools/pew/default.nix
@@ -1,6 +1,13 @@
-{ lib, python3, fetchPypi }:
+{ lib, python3Packages, fetchPypi }:
 
-with python3.pkgs;
+let
+  inherit (python3Packages)
+    buildPythonApplication
+    setuptools
+    virtualenv
+    virtualenv-clone
+    ;
+in
 
 buildPythonApplication rec {
   pname = "pew";

--- a/pkgs/development/tools/pipenv/default.nix
+++ b/pkgs/development/tools/pipenv/default.nix
@@ -5,9 +5,23 @@
 , installShellFiles
 }:
 
-with python3.pkgs;
-
 let
+  inherit (lib)
+    licenses
+    maintainers
+    optionals
+    platforms
+    ;
+
+  # This file is a bit special due to runtimeDeps below.
+  inherit (python3.pkgs)
+    buildPythonApplication
+    mock
+    pytestCheckHook
+    pytest-xdist
+    pytz
+    requests
+    ;
 
   runtimeDeps = ps: with ps; [
     certifi
@@ -16,7 +30,7 @@ let
     virtualenv
     virtualenv-clone
   ]
-  ++ lib.optionals stdenv.hostPlatform.isAndroid [
+  ++ optionals stdenv.hostPlatform.isAndroid [
     pyjnius
   ];
 
@@ -36,7 +50,7 @@ in buildPythonApplication rec {
 
   env.LC_ALL = "en_US.UTF-8";
 
-  nativeBuildInputs = [
+  nativeBuildInputs = with python3.pkgs; [
     installShellFiles
     setuptools
     wheel
@@ -81,7 +95,7 @@ in buildPythonApplication rec {
       --fish <(_PIPENV_COMPLETE=fish_source $out/bin/pipenv)
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Python Development Workflow for Humans";
     license = licenses.mit;
     platforms = platforms.all;

--- a/pkgs/development/tools/pylint-exit/default.nix
+++ b/pkgs/development/tools/pylint-exit/default.nix
@@ -1,6 +1,10 @@
 { lib, fetchFromGitHub, python3Packages }:
 
-with python3Packages; buildPythonApplication rec {
+let
+  inherit (python3Packages) buildPythonApplication m2r python;
+in
+
+buildPythonApplication rec {
   pname = "pylint-exit";
   version = "1.2.0";
 

--- a/pkgs/development/tools/rdbtools/default.nix
+++ b/pkgs/development/tools/rdbtools/default.nix
@@ -1,6 +1,9 @@
 { lib, python, fetchPypi }:
 
-with python.pkgs;
+let
+  inherit (lib) licenses maintainers;
+  inherit (python.pkgs) buildPythonApplication python-lzf redis;
+in
 
 buildPythonApplication rec {
   pname = "rdbtools";
@@ -16,7 +19,7 @@ buildPythonApplication rec {
   # No tests in published package
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Parse Redis dump.rdb files, Analyze Memory, and Export Data to JSON";
     homepage = "https://github.com/sripathikrishnan/redis-rdb-tools";
     license = licenses.mit;

--- a/pkgs/development/tools/reno/default.nix
+++ b/pkgs/development/tools/reno/default.nix
@@ -5,7 +5,25 @@
 , fetchPypi
 }:
 
-with python3Packages; buildPythonApplication rec {
+let
+  inherit (lib) licenses maintainers;
+
+  inherit (python3Packages)
+    buildPythonApplication
+    docutils
+    dulwich
+    fixtures
+    pbr
+    pytestCheckHook
+    pyyaml
+    setuptools
+    sphinx
+    testscenarios
+    testtools
+    ;
+in
+
+buildPythonApplication rec {
   pname = "reno";
   version = "3.1.0";
 
@@ -50,7 +68,7 @@ with python3Packages; buildPythonApplication rec {
     $out/bin/reno -h
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Release Notes Manager";
     mainProgram = "reno";
     homepage = "https://docs.openstack.org/reno/latest";

--- a/pkgs/development/tools/skjold/default.nix
+++ b/pkgs/development/tools/skjold/default.nix
@@ -4,6 +4,8 @@
 }:
 
 let
+  inherit (lib) licenses maintainers;
+
   py = python3.override {
     packageOverrides = self: super: {
       packaging = super.packaging.overridePythonAttrs (oldAttrs: rec {
@@ -17,8 +19,19 @@ let
       });
     };
   };
+
+  inherit (py.pkgs)
+    buildPythonApplication
+    click
+    packaging
+    poetry-core
+    pytestCheckHook
+    pytest-mock
+    pytest-watch
+    pyyaml
+    toml
+    ;
 in
-with py.pkgs;
 
 buildPythonApplication rec {
   pname = "skjold";
@@ -32,18 +45,18 @@ buildPythonApplication rec {
     hash = "sha256-rsdstzNZvokYfTjEyPrWR+0SJpf9wL0HAesq8+A+tPY=";
   };
 
-  nativeBuildInputs = with py.pkgs; [
+  nativeBuildInputs = [
     poetry-core
   ];
 
-  propagatedBuildInputs = with py.pkgs; [
+  propagatedBuildInputs = [
     click
     packaging
     pyyaml
     toml
   ];
 
-  nativeCheckInputs = with py.pkgs; [
+  nativeCheckInputs = [
     pytest-mock
     pytest-watch
     pytestCheckHook
@@ -71,7 +84,7 @@ buildPythonApplication rec {
     "skjold"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Tool to Python dependencies against security advisory databases";
     homepage = "https://github.com/twu/skjold";
     changelog = "https://github.com/twu/skjold/releases/tag/v${version}";

--- a/pkgs/development/tools/swiftpm2nix/support.nix
+++ b/pkgs/development/tools/swiftpm2nix/support.nix
@@ -1,6 +1,14 @@
 { lib, fetchgit, formats }:
-with lib;
+
 let
+  inherit (lib)
+    concatStrings
+    importJSON
+    listToAttrs
+    mapAttrsToList
+    nameValuePair
+    ;
+
   json = formats.json { };
 in rec {
 
@@ -19,7 +27,7 @@ in rec {
   # Make packaging helpers from swiftpm2nix generated output.
   helpers = generated: let
     inherit (import generated) workspaceStateFile hashes;
-    workspaceState = lib.importJSON workspaceStateFile;
+    workspaceState = importJSON workspaceStateFile;
     pinFile = mkPinFile workspaceState;
   in rec {
 

--- a/pkgs/development/tools/vcstool/default.nix
+++ b/pkgs/development/tools/vcstool/default.nix
@@ -1,7 +1,10 @@
 { lib, python3Packages, fetchPypi
 , git, breezy, subversion }:
 
-with python3Packages;
+let
+  inherit (lib) licenses maintainers makeBinPath;
+  inherit (python3Packages) buildPythonApplication pyyaml setuptools;
+in
 
 buildPythonApplication rec {
   pname = "vcstool";
@@ -14,11 +17,11 @@ buildPythonApplication rec {
 
   propagatedBuildInputs = [ pyyaml setuptools ];
 
-  makeWrapperArgs = ["--prefix" "PATH" ":" (lib.makeBinPath [ git breezy subversion ])];
+  makeWrapperArgs = ["--prefix" "PATH" ":" (makeBinPath [ git breezy subversion ])];
 
   doCheck = false; # requires network
 
-  meta = with lib; {
+  meta = {
     description = "Provides a command line tool to invoke vcs commands on multiple repositories";
     homepage = "https://github.com/dirk-thomas/vcstool";
     license = licenses.asl20;

--- a/pkgs/development/tools/vim-vint/default.nix
+++ b/pkgs/development/tools/vim-vint/default.nix
@@ -1,6 +1,20 @@
 { lib, python3Packages, fetchPypi }:
 
-with python3Packages;
+let
+  inherit (lib) licenses maintainers platforms;
+
+  inherit (python3Packages)
+    ansicolor
+    buildPythonApplication
+    chardet
+    mock
+    pytest
+    pytest-cov
+    pythonAtLeast
+    pyyaml
+    setuptools
+    ;
+in
 
 buildPythonApplication rec {
   pname = "vim-vint";
@@ -23,7 +37,7 @@ buildPythonApplication rec {
     sed -i 's/mock == 1.0.1/mock/g' setup.py
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Fast and Highly Extensible Vim script Language Lint implemented by Python";
     homepage = "https://github.com/Kuniwak/vint";
     license = licenses.mit;


### PR DESCRIPTION
## Description of changes

Using `with` at a top-level scope is [an anti-pattern](https://nix.dev/guides/best-practices#with-scopes). The tracking issue is #208242. This is a pure refactor: there is no functional change contained in this PR, though spot the bug fix where `libiconv` wasn't injected!

I used the refactor strategy that looks for the uses of names [coming from `lib`, `pkgs`, `python3Packages`, and more](https://gist.github.com/philiptaron/04326000d5ff20cb72c2805efd09701c). 

Following advice, I also preferred to inherit names from `lib` instead of `builtins` where there was a choice. I also preferred to inherit from `lib` in one place, rather than to have a mixture of `lib.thing` and `inherit (lib) thing`.

There are no rebuilds when I run `nixpkgs-review rev HEAD`, so I've targeted master with this PR.

See also:
- https://github.com/NixOS/nixpkgs/pull/295975

Remaining top-level `with` expressions in `pkgs/development`:

```
$ rg '^with' -tnix --sort=path pkgs/development/
pkgs/development/lisp-modules-new-obsolete/shell.nix
1:with import ../../../default.nix {};

pkgs/development/lisp-modules-obsolete/shell.nix
1:with import ../../../default.nix {};

pkgs/development/lua-modules/overrides.nix
59:with prev;

pkgs/development/ocaml-modules/janestreet/0.12.nix
5:with self;

pkgs/development/ocaml-modules/janestreet/0.14.nix
8:with self;

pkgs/development/ocaml-modules/janestreet/0.15.nix
11:with self;

pkgs/development/ocaml-modules/janestreet/0.16.nix
11:with self;

pkgs/development/ocaml-modules/janestreet/default.nix
5:with self;

pkgs/development/ocaml-modules/janestreet/old.nix
27:with self;

pkgs/development/r-modules/generate-shell.nix
1:with import ../../.. {};

pkgs/development/ruby-modules/testing/tap-support.nix
1:with builtins;

pkgs/development/ruby-modules/testing/testing.nix
1:with builtins;

pkgs/development/tools/misc/travis/shell.nix
3:with import <nixpkgs> {};
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).