### PR TITLE
darwin.binutils: properly handle cctools-llvm

### DIFF
--- a/pkgs/os-specific/darwin/binutils/default.nix
+++ b/pkgs/os-specific/darwin/binutils/default.nix
@@ -11,6 +11,7 @@ let
     "ld" "strip" "otool" "lipo" "nm" "strings" "size"
     "codesign_allocate"
   ];
+  isCCToolsLLVM = lib.getName cctools == "cctools-llvm";
 in
 
 # TODO: loop over targetPrefixed binaries too
@@ -33,7 +34,7 @@ stdenv.mkDerivation {
     # - strip: the binutils one seems to break mach-o files
     # - lipo: gcc build assumes it exists
     # - nm: the gnu one doesn't understand many new load commands
-    for i in ${lib.concatStringsSep " " (builtins.map (e: targetPrefix + e) cmds)}; do
+    for i in ${lib.concatStringsSep " " (map (e: targetPrefix + e) cmds)}; do
       ln -sf "${cctools}/bin/$i" "$out/bin/$i"
     done
 
@@ -41,51 +42,59 @@ stdenv.mkDerivation {
 
     ln -s ${binutils-unwrapped.out}/share $out/share
 
-    ln -s ${cctools}/libexec $out/libexec
-
     mkdir -p "$man"/share/man/man{1,5}
-    for i in ${builtins.concatStringsSep " " cmds}; do
+    for i in ${lib.concatStringsSep " " cmds}; do
       for path in "${cctools.man}"/share/man/man?/$i.*; do
         dest_path="$man''${path#${cctools.man}}"
         ln -sv "$path" "$dest_path"
       done
     done
   ''
-  # On aarch64-darwin we must use clang, because "as" from cctools just doesn't
-  # handle the arch. Proxying calls to clang produces quite a bit of warnings,
-  # and using clang directly here is a better option than relying on cctools.
-  # On x86_64-darwin the Clang version is too old to support this mode.
-  + lib.optionalString stdenv.isAarch64 ''
-    rm $out/bin/${targetPrefix}as
-    makeWrapper "${clang-unwrapped}/bin/clang" "$out/bin/${targetPrefix}as" \
-      --add-flags "-x assembler -integrated-as -c"
-  ''
-  # x86-64 Darwin gnat-bootstrap emits assembly
-  # with MOVQ as the mnemonic for quadword interunit moves
-  # such as `movq %rbp, %xmm0`.
-  # The clang integrated assembler recognises this as valid,
-  # but unfortunately the cctools-port GNU assembler does not;
-  # it instead uses MOVD as the mnemonic.
-  # The assembly that a GCC build emits is determined at build time
-  # and cannot be changed afterwards.
-  #
-  # To build GNAT on x86-64 Darwin, therefore,
-  # we need both the clang _and_ the cctools-port assemblers to be available:
-  # the former to build at least the stage1 compiler,
-  # and the latter at least to be detectable
-  # as the target for the final compiler.
-  #
-  # We choose to match the Aarch64 case above,
-  # wrapping the clang integrated assembler as `as`.
-  # It then seems sensible to wrap the cctools GNU assembler as `gas`.
-  #
-  + lib.optionalString (stdenv.isx86_64 && dualAs) ''
-    mv $out/bin/${targetPrefix}as $out/bin/${targetPrefix}gas
-    makeWrapper "${clang-unwrapped}/bin/clang" "$out/bin/${targetPrefix}as" \
-      --add-flags "-x assembler -integrated-as -c"
-  '';
+  + lib.optionalString (!isCCToolsLLVM) (
+    # cctools-port has a `libexec` folder for `as`, but cctools-llvm uses the clang
+    # assembler on both platforms. Only link it when cctools is cctools-port.
+    ''
+      ln -s ${cctools}/libexec $out/libexec
+    ''
+    # cctools-llvm uses the LLVM assembler on both architectures, so use the assembler
+    # from that instead of relinking it.
+    #
+    # On aarch64-darwin we must use clang, because "as" from cctools just doesn't
+    # handle the arch. Proxying calls to clang produces quite a bit of warnings,
+    # and using clang directly here is a better option than relying on cctools.
+    # On x86_64-darwin the Clang version is too old to support this mode.
+    + lib.optionalString stdenv.isAarch64 ''
+      rm $out/bin/${targetPrefix}as
+      makeWrapper "${clang-unwrapped}/bin/clang" "$out/bin/${targetPrefix}as" \
+        --add-flags "-x assembler -integrated-as -c"
+    ''
+    # x86-64 Darwin gnat-bootstrap emits assembly
+    # with MOVQ as the mnemonic for quadword interunit moves
+    # such as `movq %rbp, %xmm0`.
+    # The clang integrated assembler recognises this as valid,
+    # but unfortunately the cctools-port GNU assembler does not;
+    # it instead uses MOVD as the mnemonic.
+    # The assembly that a GCC build emits is determined at build time
+    # and cannot be changed afterwards.
+    #
+    # To build GNAT on x86-64 Darwin, therefore,
+    # we need both the clang _and_ the cctools-port assemblers to be available:
+    # the former to build at least the stage1 compiler,
+    # and the latter at least to be detectable
+    # as the target for the final compiler.
+    #
+    # We choose to match the Aarch64 case above,
+    # wrapping the clang integrated assembler as `as`.
+    # It then seems sensible to wrap the cctools GNU assembler as `gas`.
+    #
+    + lib.optionalString (stdenv.isx86_64 && dualAs) ''
+      mv $out/bin/${targetPrefix}as $out/bin/${targetPrefix}gas
+      makeWrapper "${clang-unwrapped}/bin/clang" "$out/bin/${targetPrefix}as" \
+        --add-flags "-x assembler -integrated-as -c"
+    ''
+  );
 
-  nativeBuildInputs = lib.optionals (stdenv.isAarch64 || dualAs) [ makeWrapper ];
+  nativeBuildInputs = lib.optionals (!isCCToolsLLVM && (stdenv.isAarch64 || dualAs)) [ makeWrapper ];
 
   passthru = {
     inherit targetPrefix;


### PR DESCRIPTION
## Description of changes

- Only link `libexec` when using cctools-port. cctools-llvm does not have a `libexec` folder;
- Use `as` provided by cctools-llvm, which is already using the clang-integrated assembler on both platforms; and
- Clean up inconsistent use of `builtins`.

This was reported on Matrix. `libexec` is a dangling symlink, which prevents binutils from being added to `home.packages` after upgrading to 23.11 with the following error:

```
darwin-rebuild --flake ~/path-to-flake/ build
building the system configuration...
error: builder for '/nix/store/77pb55j08rfh3lbxxx5v1q7nyih900d3-home-manager-path.drv' failed with exit code 2;
       last 1 log lines:
       > error: not a directory: `/nix/store/8kkn9qqg1mnny41cc8i33ws9ilmxyww1-cctools-binutils-darwin-16.0.6-973.0.1/libexec'
       For full logs, run 'nix log /nix/store/77pb55j08rfh3lbxxx5v1q7nyih900d3-home-manager-path.drv'.
error: 1 dependencies of derivation '/nix/store/cg4axwsiaygf47xa472h50nrp3nl9fm4-home-manager-generation.drv' failed to build
error: 1 dependencies of derivation '/nix/store/pghcqfradm590s6yvri7n8p1iykal267-user-environment.drv' failed to build
error: 1 dependencies of derivation '/nix/store/9dnqxmm927zl3mzcfd2a15cmx9wxn6bz-activation-brendan.drv' failed to build
error: 1 dependencies of derivation '/nix/store/30rpflszvj9js6v6isnfxjr9asg39f5l-darwin-system-23.11.20240317.614b461+darwin4.bcc8afd.drv' failed to build
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
