### PR TITLE
ada-url: init at 2.7.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6994,6 +6994,12 @@
       fingerprint = "58CE D4BE 6B10 149E DA80  A990 2F48 6356 A4CB 30F3";
     }];
   };
+  genevieve-me = {
+    name = "Genevieve Mendoza";
+    email = "me@genevievemendoza.com";
+    github = "genevieve-me";
+    githubId = 140119870;
+  };
   genofire = {
     name = "genofire";
     email = "geno+dev@fireorbit.de";

--- a/pkgs/by-name/ad/ada-url/conditional-dl.patch
+++ b/pkgs/by-name/ad/ada-url/conditional-dl.patch
@@ -1,0 +1,20 @@
+diff --git a/cmake/CPM.cmake b/cmake/CPM.cmake
+index ad6b74a8..079eed46 100644
+--- a/cmake/CPM.cmake
++++ b/cmake/CPM.cmake
+@@ -16,9 +16,11 @@ endif()
+ # Expand relative path. This is important if the provided path contains a tilde (~)
+ get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
+ 
+-file(DOWNLOAD
+-     https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+-     ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM}
+-)
++if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
++  file(DOWNLOAD
++       https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
++       ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM}
++  )
++endif()
+ 
+ include(${CPM_DOWNLOAD_LOCATION})

--- a/pkgs/by-name/ad/ada-url/package.nix
+++ b/pkgs/by-name/ad/ada-url/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  cpm-cmake,
+  simdjson,
+  cmake,
+  cxxopts,
+}:
+
+let
+  googletest = fetchFromGitHub {
+    owner = "google";
+    repo = "googletest";
+    rev = "v1.14.0";
+    hash = "sha256-t0RchAHTJbuI5YW4uyBPykTvcjy90JW9AOPNjIhwh6U=";
+  };
+  googlebenchmark = fetchFromGitHub {
+    owner = "google";
+    repo = "benchmark";
+    rev = "v1.6.0";
+    hash = "sha256-EAJk3JhLdkuGKRMtspTLejck8doWPd7Z0Lv/Mvf3KFY=";
+  };
+  pname = "ada";
+  version = "2.7.7";
+in
+stdenv.mkDerivation rec {
+  inherit pname version;
+  src = fetchFromGitHub {
+    owner = "ada-url";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-eh/tOwU+sU/8FYYuRE7DL1v1Fp6bNFWneLtGG0wsWgA=";
+  };
+
+  patches = [ ./conditional-dl.patch ];
+
+  preConfigure = ''
+    mkdir -p ${placeholder "out"}/share/cpm
+    cp ${cpm-cmake}/share/cpm/CPM.cmake ${placeholder "out"}/share/cpm/CPM_0.38.6.cmake
+  '';
+
+  cmakeFlags = [
+    "-DCPM_SOURCE_CACHE=${placeholder "out"}/share"
+    "-DFETCHCONTENT_SOURCE_DIR_SIMDJSON=${simdjson.src}"
+    "-DFETCHCONTENT_SOURCE_DIR_GTEST=${googletest}"
+    "-DFETCHCONTENT_SOURCE_DIR_BENCHMARK=${googlebenchmark}"
+    "-DBUILD_SHARED_LIBS=ON"
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ cxxopts ];
+  meta = with lib; {
+    homepage = "https://www.ada-url.com/";
+    description = "WHATWG-compliant and fast URL parser written in modern C++";
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ genevieve-me ];
+  };
+}


### PR DESCRIPTION
## Description of changes

Note: I saw the notes on making a separate commit to add oneself to maintainers. I can do that if necessary, but I wasn't sure if maintainers can be empty? I can update this commit to either add myself as a package maintainer or remove the commented line. Besides that line, this PR is ready for review.

Add Ada, "a fast and [WHATWG spec](https://url.spec.whatwg.org/#url-parsing) compliant URL parser written in C++.

Based on https://github.com/NixOS/nixpkgs/pull/227030

The patch is included since I ran into a roadblock due to how ada implemented cpm (cmake package manager). There are other packages in nixpkgs which work around it (e.g., poac) but those package upstreams gate their downloads on a conditional:

```
if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
  file(DOWNLOAD
    ...
```

I patched ada to reproduce this behavior so it can build in the sandbox.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - runs [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
