### PR TITLE
mozjpeg-lossless-optimization: init at 1.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14291,6 +14291,12 @@
     github = "Noodlesalat";
     githubId = 12748782;
   };
+  nueidris = {
+    email = "filipessantos@academico.ufs.br";
+    name = "Filipe da Silva Santos";
+    github = "nueidris";
+    githubId = 70187554;
+  };
   nukaduka = {
     email = "ksgokte@gmail.com";
     github = "NukaDuka";

--- a/pkgs/development/python-modules/mozjpeg-lossless-optimization/default.nix
+++ b/pkgs/development/python-modules/mozjpeg-lossless-optimization/default.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildPythonPackage
+, cffi
+, cmake
+, fetchPypi
+, nasm
+, pythonOlder
+}:
+
+buildPythonPackage rec {
+  pname = "mozjpeg-lossless-optimization";
+  version = "1.1.3";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "725d98772e943fca18b0801cb94e645c477ff52e56ad0b27bddb76ddf091ca3e";
+  };
+
+  dependencies = [ cffi ];
+  nativeBuildInputs = [ cmake nasm ];
+  dontUseCmakeConfigure = true;
+
+  pythonImportsCheck = [ "mozjpeg_lossless_optimization" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/wanadev/${pname}/releases/tag/v${version}";
+    description = "Python library to optimize JPEGs losslessly using MozJPEG";
+    homepage = "https://github.com/wanadev/${pname}";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ nueidris ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7487,6 +7487,8 @@ self: super: with self; {
 
   mox3 = callPackage ../development/python-modules/mox3 { };
 
+  mozjpeg-lossless-optimization = callPackage ../development/python-modules/mozjpeg-lossless-optimization { };
+
   mpd2 = callPackage ../development/python-modules/mpd2 { };
 
   mpi4py = callPackage ../development/python-modules/mpi4py { };


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[mozjpeg-lossless-optimization](https://github.com/wanadev/mozjpeg-lossless-optimization) is a Python library for image optimization.

Needed to update [kcc](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/graphics/kcc/default.nix).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
