### PR TITLE
tor-browser: 13.0.11 -> 13.0.12, mullvad-browser: 13.0.10 -> 13.0.12

### DIFF
--- a/pkgs/applications/networking/browsers/mullvad-browser/default.nix
+++ b/pkgs/applications/networking/browsers/mullvad-browser/default.nix
@@ -90,7 +90,7 @@ let
       ++ lib.optionals mediaSupport [ ffmpeg ]
   );
 
-  version = "13.0.10";
+  version = "13.0.12";
 
   sources = {
     x86_64-linux = fetchurl {
@@ -102,7 +102,7 @@ let
         "https://tor.eff.org/dist/mullvadbrowser/${version}/mullvad-browser-linux-x86_64-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/mullvadbrowser/${version}/mullvad-browser-linux-x86_64-${version}.tar.xz"
       ];
-      hash = "sha256-+8b3K3XLSPlndR12KNUH0lsPquhTupxQrLBuSEGac7Y=";
+      hash = "sha256-qqz3tdic2muBQI6JXc0/uxBeenWFYHN43K7qJee9q78=";
     };
   };
 

--- a/pkgs/applications/networking/browsers/tor-browser/default.nix
+++ b/pkgs/applications/networking/browsers/tor-browser/default.nix
@@ -101,7 +101,7 @@ lib.warnIf (useHardenedMalloc != null)
       ++ lib.optionals mediaSupport [ ffmpeg ]
   );
 
-  version = "13.0.11";
+  version = "13.0.12";
 
   sources = {
     x86_64-linux = fetchurl {
@@ -111,7 +111,7 @@ lib.warnIf (useHardenedMalloc != null)
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux-x86_64-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux-x86_64-${version}.tar.xz"
       ];
-      hash = "sha256-a8BAesBp85oaHJrkQYcYufH9cy7OrFrfnljZZrFPlGE=";
+      hash = "sha256-2AzcDYngLr+J+s12tAMdB9SjDzOWPnQY9WL7/3+N0FA=";
     };
 
     i686-linux = fetchurl {
@@ -121,7 +121,7 @@ lib.warnIf (useHardenedMalloc != null)
         "https://tor.eff.org/dist/torbrowser/${version}/tor-browser-linux-i686-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/torbrowser/${version}/tor-browser-linux-i686-${version}.tar.xz"
       ];
-      hash = "sha256-cyZnLcJmXNjBJhBLwBoW09K6dsT6Og+h0ufc4/6zxac=";
+      hash = "sha256-ect++2xZe00Hlikz6eMNMiiHnVoETSvjD0Cf1oBgj9E=";
     };
   };
 


### PR DESCRIPTION
## Description of changes

https://blog.torproject.org/new-release-tor-browser-13012/
https://github.com/mullvad/mullvad-browser/releases/tag/13.0.12

> This version includes important [security updates](https://www.mozilla.org/en-US/security/advisories/mfsa2024-13/) to Firefox.

> **Removal of automatic .onion site prioritization**
>
> The Tor Project has recently been notified of a potential fingerprinting vulnerability with automatic Onion-Location redirects. In an abundance of caution, we have removed the 'prioritize .onion sites when known' option from Tor Browser. We are looking further into this issue and will provide timely updates as more research and additional recommendations become available.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
