### PR TITLE
ocamlPackages.irmin: 3.5.1 → 3.7.2

### DIFF
--- a/pkgs/development/ocaml-modules/irmin/chunk.nix
+++ b/pkgs/development/ocaml-modules/irmin/chunk.nix
@@ -4,7 +4,6 @@ buildDunePackage rec {
 
   pname = "irmin-chunk";
   inherit (irmin) version src strictDeps;
-  duneVersion = "3";
 
   propagatedBuildInputs = [ irmin fmt logs lwt ];
 

--- a/pkgs/development/ocaml-modules/irmin/containers.nix
+++ b/pkgs/development/ocaml-modules/irmin/containers.nix
@@ -7,7 +7,6 @@ buildDunePackage {
   pname = "irmin-containers";
 
   inherit (ppx_irmin) src version strictDeps;
-  duneVersion = "3";
 
   nativeBuildInputs = [
     ppx_irmin

--- a/pkgs/development/ocaml-modules/irmin/default.nix
+++ b/pkgs/development/ocaml-modules/irmin/default.nix
@@ -10,7 +10,6 @@ buildDunePackage {
   inherit (ppx_irmin) src version strictDeps;
 
   minimalOCamlVersion = "4.10";
-  duneVersion = "3";
 
   propagatedBuildInputs = [
     astring

--- a/pkgs/development/ocaml-modules/irmin/fs.nix
+++ b/pkgs/development/ocaml-modules/irmin/fs.nix
@@ -7,7 +7,6 @@ buildDunePackage rec {
   pname = "irmin-fs";
 
   inherit (irmin) version src strictDeps;
-  duneVersion = "3";
 
   propagatedBuildInputs = [ irmin astring logs lwt ];
 

--- a/pkgs/development/ocaml-modules/irmin/git.nix
+++ b/pkgs/development/ocaml-modules/irmin/git.nix
@@ -10,7 +10,6 @@ buildDunePackage {
   pname = "irmin-git";
 
   inherit (irmin) version src strictDeps;
-  duneVersion = "3";
 
   propagatedBuildInputs = [
     git

--- a/pkgs/development/ocaml-modules/irmin/graphql.nix
+++ b/pkgs/development/ocaml-modules/irmin/graphql.nix
@@ -7,7 +7,6 @@ buildDunePackage rec {
   pname = "irmin-graphql";
 
   inherit (irmin) version src;
-  duneVersion = "3";
 
   propagatedBuildInputs = [ cohttp-lwt cohttp-lwt-unix graphql-cohttp graphql-lwt irmin git-unix ];
 

--- a/pkgs/development/ocaml-modules/irmin/http.nix
+++ b/pkgs/development/ocaml-modules/irmin/http.nix
@@ -9,8 +9,6 @@ buildDunePackage rec {
   pname = "irmin-http";
 
   inherit (irmin) version src strictDeps;
-  duneVersion = "3";
-
 
   propagatedBuildInputs = [ astring cohttp-lwt cohttp-lwt-unix fmt jsonm logs lwt uri irmin webmachine ];
 
@@ -25,5 +23,3 @@ buildDunePackage rec {
   };
 
 }
-
-

--- a/pkgs/development/ocaml-modules/irmin/mirage-git.nix
+++ b/pkgs/development/ocaml-modules/irmin/mirage-git.nix
@@ -7,7 +7,6 @@ buildDunePackage {
   pname = "irmin-mirage-git";
 
   inherit (irmin-mirage) version src strictDeps;
-  duneVersion = "3";
 
   propagatedBuildInputs = [
     irmin-mirage

--- a/pkgs/development/ocaml-modules/irmin/mirage-graphql.nix
+++ b/pkgs/development/ocaml-modules/irmin/mirage-graphql.nix
@@ -6,7 +6,6 @@ buildDunePackage {
   pname = "irmin-mirage-graphql";
 
   inherit (irmin-mirage) version src strictDeps;
-  duneVersion = "3";
 
   propagatedBuildInputs = [
     irmin-mirage

--- a/pkgs/development/ocaml-modules/irmin/mirage.nix
+++ b/pkgs/development/ocaml-modules/irmin/mirage.nix
@@ -4,7 +4,6 @@ buildDunePackage {
   pname = "irmin-mirage";
 
   inherit (irmin) version src strictDeps;
-  duneVersion = "3";
 
   propagatedBuildInputs = [
     irmin fmt ptime mirage-clock

--- a/pkgs/development/ocaml-modules/irmin/pack.nix
+++ b/pkgs/development/ocaml-modules/irmin/pack.nix
@@ -4,8 +4,7 @@
 }:
 
 buildDunePackage rec {
-  minimalOCamlVersion = "4.10";
-  duneVersion = "3";
+  minimalOCamlVersion = "4.12";
 
   pname = "irmin-pack";
 

--- a/pkgs/development/ocaml-modules/irmin/ppx.nix
+++ b/pkgs/development/ocaml-modules/irmin/ppx.nix
@@ -2,15 +2,14 @@
 
 buildDunePackage rec {
   pname = "ppx_irmin";
-  version = "3.5.1";
+  version = "3.7.2";
 
   src = fetchurl {
     url = "https://github.com/mirage/irmin/releases/download/${version}/irmin-${version}.tbz";
-    hash = "sha256-zXiKjT9KPdGNwWChU9SuyR6vaw+0GtQUZNJsecMEqY4=";
+    hash = "sha256-aqW6TGoCM3R9S9OrOW8rOjO7gPnY7UoXjIOgNQM8DlI=";
   };
 
   minimalOCamlVersion = "4.10";
-  duneVersion = "3";
 
   propagatedBuildInputs = [
     ppx_repr

--- a/pkgs/development/ocaml-modules/irmin/test.nix
+++ b/pkgs/development/ocaml-modules/irmin/test.nix
@@ -8,7 +8,6 @@ buildDunePackage {
   pname = "irmin-test";
 
   inherit (irmin) version src strictDeps;
-  duneVersion = "3";
 
   nativeBuildInputs = [ ppx_irmin ];
 

--- a/pkgs/development/ocaml-modules/irmin/tezos.nix
+++ b/pkgs/development/ocaml-modules/irmin/tezos.nix
@@ -7,7 +7,6 @@ buildDunePackage rec {
   pname = "irmin-tezos";
 
   inherit (irmin) version src strictDeps;
-  duneVersion = "3";
 
   propagatedBuildInputs = [
     irmin


### PR DESCRIPTION
## Description of changes

https://raw.githubusercontent.com/mirage/irmin/3.7.2/CHANGES.md

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
