### PR TITLE
rtl8814au: unstable-2023-03-21 -> unstable-2024-03-19

### DIFF
--- a/pkgs/os-specific/linux/rtl8814au/default.nix
+++ b/pkgs/os-specific/linux/rtl8814au/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "rtl8814au";
-  version = "${kernel.version}-unstable-2023-03-21";
+  version = "${kernel.version}-unstable-2024-03-19";
 
   src = fetchFromGitHub {
     owner = "morrownr";
     repo = "8814au";
-    rev = "6f80699e68fd2a9f2bba3f1a56ca06d1b7992bd8";
-    hash = "sha256-7dv+8vNI1OLLA4SdZQPL87pTS9HR6mGijzWo9WL7vc0=";
+    rev = "d7945c1e0244c83cbbad4da331648246f12eaee9";
+    hash = "sha256-idjHlvyFpQgLGfNAPpZKRnLdXnAogUW3qGHC1WzGVmA=";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;


### PR DESCRIPTION
## Description of changes

Add support for kernel 6.8.

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)

<details>
  <summary>2 packages failed to build:</summary>
  <ul>
    <li>linuxKernel.packages.linux_4_19_hardened.rtl8814au</li>
    <li>linuxKernel.packages.linux_5_4_hardened.rtl8814au</li>
  </ul>
</details>
<details>
  <summary>19 packages built:</summary>
  <ul>
    <li>linuxKernel.packages.linux_4_19.rtl8814au</li>
    <li>linuxKernel.packages.linux_5_10.rtl8814au</li>
    <li>linuxKernel.packages.linux_5_10_hardened.rtl8814au</li>
    <li>linuxKernel.packages.linux_5_15.rtl8814au</li>
    <li>linuxKernel.packages.linux_5_15_hardened.rtl8814au</li>
    <li>linuxKernel.packages.linux_5_4.rtl8814au</li>
    <li>linuxKernel.packages.linux_6_1.rtl8814au</li>
    <li>linuxKernel.packages.linux_6_1_hardened.rtl8814au</li>
    <li>linuxKernel.packages.linux_6_6.rtl8814au</li>
    <li>linuxKernel.packages.linux_hardened.rtl8814au (linuxKernel.packages.linux_6_6_hardened.rtl8814au)</li>
    <li>linuxKernel.packages.linux_6_7.rtl8814au</li>
    <li>linuxKernel.packages.linux_6_7_hardened.rtl8814au</li>
    <li>linuxKernel.packages.linux_6_8.rtl8814au</li>
    <li>linuxKernel.packages.linux_latest_libre.rtl8814au</li>
    <li>linuxKernel.packages.linux_libre.rtl8814au</li>
    <li>linuxKernel.packages.linux_lqx.rtl8814au</li>
    <li>linuxKernel.packages.linux_xanmod.rtl8814au</li>
    <li>linuxKernel.packages.linux_xanmod_latest.rtl8814au (linuxKernel.packages.linux_xanmod_stable.rtl8814au)</li>
    <li>linuxKernel.packages.linux_zen.rtl8814au</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
