### PR TITLE
xca: 2.4.0 -> 2.6.0

### DIFF
--- a/pkgs/applications/misc/xca/default.nix
+++ b/pkgs/applications/misc/xca/default.nix
@@ -1,26 +1,35 @@
-{ stdenv, mkDerivation, lib, fetchFromGitHub, fetchpatch, autoreconfHook, pkg-config
-, libtool, openssl, qtbase, qttools, sphinx }:
+{ stdenv
+, lib
+, fetchFromGitHub
+, wrapQtAppsHook
+, cmake
+, pkg-config
+, openssl
+, qtbase
+, qttools
+, sphinx
+}:
 
-mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "xca";
-  version = "2.4.0";
+  version = "2.6.0";
 
   src = fetchFromGitHub {
-    owner  = "chris2511";
-    repo   = "xca";
-    rev    = "RELEASE.${version}";
-    sha256 = "04z0mmjsry72nvib4icmwh1717y4q9pf2gr68ljrzln4vv4ckpwk";
+    owner = "chris2511";
+    repo = "xca";
+    rev = "RELEASE.${finalAttrs.version}";
+    hash = "sha256-E0Ap+JDK/oYTG+uaRHsdOxyLIywlYJ01T4ANQhNH220=";
   };
 
-  # Adaptions to stay OpenSSL 3.0 compatible
-  patches = [ (fetchpatch {
-    url = "https://github.com/chris2511/xca/commit/f5ac099e948ea354deac75ff9fa09d51453476e1.patch";
-    hash = "sha256-4rRO2y9hZq879HTsgBgbXGRYEcgfG4niJKyK3l3PMZ8=";
-  }) ];
+  buildInputs = [ openssl qtbase ];
 
-  buildInputs = [ libtool openssl qtbase ];
-
-  nativeBuildInputs = [ autoreconfHook pkg-config qttools sphinx ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qttools
+    sphinx
+    wrapQtAppsHook
+  ];
 
   # Needed for qcollectiongenerator (see https://github.com/NixOS/nixpkgs/pull/92710)
   QT_PLUGIN_PATH = "${qtbase}/${qtbase.qtPluginPrefix}";
@@ -28,12 +37,11 @@ mkDerivation rec {
   enableParallelBuilding = true;
 
   meta = with lib; {
-    broken = stdenv.isDarwin;
     description = "An x509 certificate generation tool, handling RSA, DSA and EC keys, certificate signing requests (PKCS#10) and CRLs";
     mainProgram = "xca";
-    homepage    = "https://hohnstaedt.de/xca/";
-    license     = licenses.bsd3;
+    homepage = "https://hohnstaedt.de/xca/";
+    license = licenses.bsd3;
     maintainers = with maintainers; [ offline peterhoeg ];
-    platforms   = platforms.all;
+    inherit (qtbase.meta) platforms;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -36059,7 +36059,7 @@ with pkgs;
 
   kodi-cli = callPackage ../tools/misc/kodi-cli { };
 
-  xca = libsForQt5.callPackage ../applications/misc/xca { };
+  xca = qt6Packages.callPackage ../applications/misc/xca { };
 
   xcalib = callPackage ../tools/X11/xcalib { };
 


### PR DESCRIPTION
## Description of changes

Bump and build with qt6 instead of qt5. Also does autotools -> cmake.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
