### PR TITLE
cc-wrapper: Workaround gnuabielfv{1,2} support deficiency on Clang

### DIFF
--- a/pkgs/build-support/cc-wrapper/add-clang-cc-cflags-before.sh
+++ b/pkgs/build-support/cc-wrapper/add-clang-cc-cflags-before.sh
@@ -30,4 +30,8 @@ if $targetPassed && [[ "$targetValue" != "@defaultTarget@" ]] && (( "${NIX_CC_WR
     echo "Warning: supplying the --target $targetValue != @defaultTarget@ argument to a nix-wrapped compiler may not work correctly - cc-wrapper is currently not designed with multi-target compilers in mind. You may want to use an un-wrapped compiler instead." >&2
 elif [[ $0 != *cpp ]]; then
     extraBefore+=(-target @defaultTarget@ @machineFlags@)
+
+    if [[ "@explicitAbiValue@" != "" ]]; then
+        extraBefore+=(-mabi=@explicitAbiValue@)
+    fi
 fi

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -94,12 +94,14 @@ let
     getLib
     getName
     getVersion
+    hasPrefix
     mapAttrsToList
     optional
     optionalAttrs
     optionals
     optionalString
     removePrefix
+    removeSuffix
     replaceStrings
     toList
     versionAtLeast
@@ -900,12 +902,24 @@ stdenvNoCC.mkDerivation {
     ## General Clang support
     ## Needs to go after ^ because the for loop eats \n and makes this file an invalid script
     ##
-    + optionalString isClang ''
-      # Escape twice: once for this script, once for the one it gets substituted into.
-      export machineFlags=${escapeShellArg (escapeShellArgs machineFlags)}
-      export defaultTarget=${targetPlatform.config}
-      substituteAll ${./add-clang-cc-cflags-before.sh} $out/nix-support/add-local-cc-cflags-before.sh
-    ''
+    + optionalString isClang (
+      let
+        hasUnsupportedGnuSuffix = hasPrefix "gnuabielfv" targetPlatform.parsed.abi.name;
+        clangCompatibleConfig =
+          if hasUnsupportedGnuSuffix then
+            removeSuffix (removePrefix "gnu" targetPlatform.parsed.abi.name) targetPlatform.config
+          else
+            targetPlatform.config;
+        explicitAbiValue = if hasUnsupportedGnuSuffix then targetPlatform.parsed.abi.abi else "";
+      in
+      ''
+        # Escape twice: once for this script, once for the one it gets substituted into.
+        export machineFlags=${escapeShellArg (escapeShellArgs machineFlags)}
+        export defaultTarget=${clangCompatibleConfig}
+        export explicitAbiValue=${explicitAbiValue}
+        substituteAll ${./add-clang-cc-cflags-before.sh} $out/nix-support/add-local-cc-cflags-before.sh
+      ''
+    )
 
     ##
     ## Extra custom steps


### PR DESCRIPTION
## Description of changes

Clang doesn't parse the "gnuabielfv{1,2}" part of the triplet as anything beyond "gnu", so desired ABI gets ignored.

Work around this by explicitly setting the ABI.

---

Follow-up to #307819 which fixes building LLVM on powerpc64, this gets `llvmPackages*.stdenv` working.

- I haven't checked how this may affect musl, and
- I'm not sure if checking for non-"gnu" has any point beyond signaling intention, because we assert on `powerpc64{,le}-unknown-linux-gnu` due to this exact ABI ambiguity. Maybe checking for non-"musl" would be better, since that only supports ELFv2?

Staging just so cc-wrapper stuff that might get sent there doesn't encounter any merge conflicts.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] powerpc64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
