### PR TITLE
python312Packages.gurobipy: 7.5.2 -> 11.0.1 (darwin)

### DIFF
--- a/pkgs/development/python-modules/gurobipy/darwin.nix
+++ b/pkgs/development/python-modules/gurobipy/darwin.nix
@@ -1,33 +1,49 @@
-{ fetchurl, python, xar, cpio, cctools, insert_dylib }:
-assert python.pkgs.isPy27 && python.ucsEncoding == 2;
-python.pkgs.buildPythonPackage
-  { pname = "gurobipy";
-    version = "7.5.2";
-    src = fetchurl
-      { url = "http://packages.gurobi.com/7.5/gurobi7.5.2_mac64.pkg";
-        sha256 = "10zgn8741x48xjdiknj59x66mwj1azhihi1j5a1ajxi2n5fsak2h";
-      };
-    buildInputs = [ xar cpio cctools insert_dylib ];
-    unpackPhase =
-      ''
-        xar -xf $src
-        zcat gurobi*mac64tar.pkg/Payload | cpio -i
-        tar xf gurobi*_mac64.tar.gz
-        sourceRoot=$(echo gurobi*/*64)
-        runHook postUnpack
-      '';
-    patches = [ ./no-clever-setup.patch ];
-    postInstall = "mv lib/lib*.so $out/lib";
-    postFixup =
-      ''
-        install_name_tool -change \
-          /System/Library/Frameworks/Python.framework/Versions/2.7/Python \
-          ${python}/lib/libpython2.7.dylib \
-          $out/lib/python2.7/site-packages/gurobipy/gurobipy.so
-        install_name_tool -change /Library/gurobi752/mac64/lib/libgurobi75.so \
-          $out/lib/libgurobi75.so \
-          $out/lib/python2.7/site-packages/gurobipy/gurobipy.so
-        insert_dylib --inplace $out/lib/libaes75.so \
-          $out/lib/python2.7/site-packages/gurobipy/gurobipy.so
-      '';
-  }
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  python,
+  fetchPypi,
+}:
+
+let
+  format = "wheel";
+  pyShortVersion = "cp" + builtins.replaceStrings [ "." ] [ "" ] python.pythonVersion;
+  platforms = rec {
+    aarch64-darwin = "macosx_10_9_universal2";
+    x86_64-darwin = aarch64-darwin;
+  };
+  platform = platforms.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
+  hashes = rec {
+    cp311-aarch64-darwin = "sha256-pMwq4TXvr0mrKxZppeW2MQE/KrplWWFGmjKRLKwbHCI=";
+    cp311-x86_64-darwin = cp311-aarch64-darwin;
+    cp312-aarch64-darwin = "sha256-5+1QxYOhjbs01S3gqhkQ9Bx/0/NhbXEi710BGpiC5kM=";
+    cp312-x86_64-darwin = cp312-aarch64-darwin;
+  };
+  hash =
+    hashes."${pyShortVersion}-${stdenv.system}"
+      or (throw "Unsupported Python version: ${python.pythonVersion}");
+in
+buildPythonPackage rec {
+  pname = "gurobipy";
+  version = "11.0.1";
+  inherit format;
+
+  src = fetchPypi {
+    inherit pname version;
+    python = pyShortVersion;
+    abi = pyShortVersion;
+    dist = pyShortVersion;
+    inherit format platform hash;
+  };
+
+  pythonImportsCheck = [ "gurobipy" ];
+
+  meta = {
+    description = "Python interface to Gurobi";
+    homepage = "https://www.gurobi.com";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ wegank ];
+    platforms = builtins.attrNames platforms;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5098,10 +5098,8 @@ self: super: with self; {
 
   guppy3 = callPackage ../development/python-modules/guppy3 { };
 
-  gurobipy = if stdenv.hostPlatform.system == "x86_64-darwin" then
-    callPackage ../development/python-modules/gurobipy/darwin.nix {
-      inherit (pkgs.darwin) cctools insert_dylib;
-    }
+  gurobipy = if stdenv.hostPlatform.isDarwin then
+    callPackage ../development/python-modules/gurobipy/darwin.nix { }
   else if stdenv.hostPlatform.system == "x86_64-linux" then
     callPackage ../development/python-modules/gurobipy/linux.nix { }
   else


### PR DESCRIPTION
## Description of changes

This PR unbreaks `gurobipy` on darwin by a total rewrite, bumping it to 11.0.1. This is safe since `gurobi` in Nixpkgs only supports x86_64-linux. Tested with modeling examples.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
