### PR TITLE
scaphandre: 0.5.0 -> 1.0.0

### DIFF
--- a/pkgs/servers/scaphandre/cargo-version.patch
+++ b/pkgs/servers/scaphandre/cargo-version.patch
@@ -1,0 +1,25 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 94da456..b959d0c 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1486,7 +1486,7 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+ 
+ [[package]]
+ name = "scaphandre"
+-version = "0.5.0"
++version = "1.0.0"
+ dependencies = [
+  "chrono",
+  "clap",
+diff --git a/Cargo.toml b/Cargo.toml
+index 2074d40..76161b1 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -1,6 +1,6 @@
+ [package]
+ name = "scaphandre"
+-version = "0.5.0"
++version = "1.0.0"
+ authors = ["Benoit Petit <bpetit@hubblo.org>"]
+ edition = "2021"
+ license = "Apache-2.0"

--- a/pkgs/servers/scaphandre/default.nix
+++ b/pkgs/servers/scaphandre/default.nix
@@ -13,16 +13,18 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "scaphandre";
-  version = "0.5.0";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "hubblo-org";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-cXwgPYTgom4KrL/PH53Fk6ChtALuMYyJ/oTrUKHCrzE=";
+    hash = "sha256-Y3TZJJ6ypZGGIEApDqiID7xWOSFTVjNQeDSomR3v5gY=";
   };
 
-  cargoSha256 = "sha256-Vdkq9ShbHWepvIgHPjhKY+LmhjS+Pl84QelgEpen7Qs=";
+  cargoPatches = [ ./cargo-version.patch ];
+
+  cargoHash = "sha256-E8xNv6Krq60cKIpuS2wMzLe+d2oo0YW9smViyP29y7k=";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ];
@@ -31,7 +33,7 @@ rustPlatform.buildRustPackage rec {
     runHook preCheck
 
     # Work around to pass test due to non existing path
-    # https://github.com/hubblo-org/scaphandre/blob/v0.5.0/src/sensors/powercap_rapl.rs#L29
+    # https://github.com/hubblo-org/scaphandre/blob/v1.0.0/src/sensors/powercap_rapl.rs#L34
     export SCAPHANDRE_POWERCAP_PATH="$(mktemp -d)/scaphandre"
 
     mkdir -p "$SCAPHANDRE_POWERCAP_PATH"


### PR DESCRIPTION
## Description of changes

This PR updates Scaphandre to its latest version: https://github.com/hubblo-org/scaphandre/releases/tag/v1.0.0

## Things done

- Cargo.toml & Cargo.lock update due to wrong version.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
