### PR TITLE
dt-schema: 2023.04 -> 2024.02

### DIFF
--- a/pkgs/development/python-modules/dtschema/default.nix
+++ b/pkgs/development/python-modules/dtschema/default.nix
@@ -12,8 +12,8 @@
 
 buildPythonPackage rec {
   pname = "dtschema";
-  version = "2023.04";
-  format = "setuptools";
+  version = "2024.02";
+  format = "pyproject";
 
   disabled = pythonOlder "3.7";
 
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "devicetree-org";
     repo = "dt-schema";
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-w9TsRdiDTdExft7rdb2hYcvxP6hxOFZKI3hITiNSwgw=";
+    sha256 = "sha256-UJU8b9BzuuUSHRjnA6hOd1bMPNOlk4LNtrQV5aZmGhI=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/dtschema/fix_libfdt_name.patch
+++ b/pkgs/development/python-modules/dtschema/fix_libfdt_name.patch
@@ -1,13 +1,13 @@
-diff --git a/setup.py b/setup.py
-index 62db8af..4a980c1 100755
---- a/setup.py
-+++ b/setup.py
-@@ -52,7 +52,7 @@ setuptools.setup(
-         'ruamel.yaml>0.15.69',
-         'jsonschema>=4.1.2',
-         'rfc3987',
--        'pylibfdt',
-+        'libfdt',
-     ],
+diff --git a/pyproject.toml b/pyproject.toml
+index 2192a68..6a7ba95 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -27,7 +27,7 @@ dependencies = [
+     "ruamel.yaml>0.15.69",
+     "jsonschema>=4.1.2,<4.18",
+     "rfc3987",
+-    "pylibfdt",
++    "libfdt",
+ ]
  
-     classifiers=[
+ [project.scripts]


### PR DESCRIPTION
## Description of changes

Bump `dt-schema` to `v2024.02` since at-least Linux 6.7 requires it for `make (dt_binding_check|dtbs_check)`. Verified the functionality by building and modifying PATH like so: `export PATH="$(readlink ~/my-git-repos/pratham/nixpkgs/result)/bin:$PATH` and doing a `make -j1 dt_binding_check`.

**Update**: I get a RecursionError. Not sure if this is because of an upstream issue or something else. I couldn't perform any checks, it would fail because the version being older so no data from any "previous runs".

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

cc: @sorki 
