### PR TITLE
slimserver: 8.4.0 -> 8.5.0

### DIFF
--- a/pkgs/by-name/sl/slimserver/package.nix
+++ b/pkgs/by-name/sl/slimserver/package.nix
@@ -6,7 +6,7 @@
 , makeWrapper
 , monkeysAudio
 , nixosTests
-, perl538Packages
+, perlPackages
 , sox
 , stdenv
 , wavpack
@@ -15,8 +15,6 @@
 }:
 
 let
-  perlPackages = perl538Packages;
-
   binPath = lib.makeBinPath ([ lame flac faad2 sox wavpack ] ++ (lib.optional stdenv.isLinux monkeysAudio));
   libPath = lib.makeLibraryPath [ zlib stdenv.cc.cc.lib ];
 in
@@ -144,8 +142,12 @@ perlPackages.buildPerlPackage rec {
 
   outputs = [ "out" ];
 
-  passthru.tests = {
-    inherit (nixosTests) slimserver;
+  passthru = {
+    tests = {
+      inherit (nixosTests) slimserver;
+    };
+
+    updateScript = ./update.nu;
   };
 
   meta = with lib; {

--- a/pkgs/by-name/sl/slimserver/package.nix
+++ b/pkgs/by-name/sl/slimserver/package.nix
@@ -20,13 +20,13 @@ let
 in
 perlPackages.buildPerlPackage rec {
   pname = "slimserver";
-  version = "8.4.0";
+  version = "8.5.0";
 
   src = fetchFromGitHub {
     owner = "Logitech";
     repo = "slimserver";
     rev = version;
-    hash = "sha256-92mKchgAWRIrNOeK/zXUYRqIAk6THdtz1zQe3fg2kE0=";
+    hash = "sha256-yDJVqZ0+qVm4r/wmQK/hf9uRJaN56WQMO28RE59mNNI=";
   };
 
   nativeBuildInputs = [ makeWrapper ];

--- a/pkgs/by-name/sl/slimserver/package.nix
+++ b/pkgs/by-name/sl/slimserver/package.nix
@@ -23,7 +23,7 @@ perlPackages.buildPerlPackage rec {
   version = "8.5.0";
 
   src = fetchFromGitHub {
-    owner = "Logitech";
+    owner = "LMS-Community";
     repo = "slimserver";
     rev = version;
     hash = "sha256-yDJVqZ0+qVm4r/wmQK/hf9uRJaN56WQMO28RE59mNNI=";
@@ -56,7 +56,7 @@ perlPackages.buildPerlPackage rec {
     DataURIEncode
     DBDSQLite
     DBI
-    # DBIxClass # https://github.com/Logitech/slimserver/issues/138
+    # DBIxClass # https://github.com/LMS-Community/slimserver/issues/138
     DigestSHA1
     EncodeDetect
     EV
@@ -151,11 +151,11 @@ perlPackages.buildPerlPackage rec {
   };
 
   meta = with lib; {
-    homepage = "https://github.com/Logitech/slimserver";
-    changelog = "https://github.com/Logitech/slimserver/blob/${version}/Changelog${lib.versions.major version}.html";
+    homepage = "https://github.com/LMS-Community/slimserver";
+    changelog = "https://github.com/LMS-Community/slimserver/blob/${version}/Changelog${lib.versions.major version}.html";
     description = "Server for Logitech Squeezebox players. This server is also called Logitech Media Server";
     # the firmware is not under a free license, so we do not include firmware in the default package
-    # https://github.com/Logitech/slimserver/blob/public/8.3/License.txt
+    # https://github.com/LMS-Community/slimserver/blob/public/8.3/License.txt
     license = if enableUnfreeFirmware then licenses.unfree else licenses.gpl2Only;
     mainProgram = "slimserver";
     maintainers = with maintainers; [ adamcstephens jecaro ];

--- a/pkgs/by-name/sl/slimserver/update.nu
+++ b/pkgs/by-name/sl/slimserver/update.nu
@@ -1,0 +1,14 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i nu -p nushell common-updater-scripts
+
+# get latest tag, but drop versions 10.0 tags since they are 10+ years old
+let latest_tag = list-git-tags --url=https://github.com/logitech/slimserver | lines | find --invert 10.0 | sort --natural | last
+
+let current_version = nix eval --raw -f default.nix slimserver | str trim
+
+if $latest_tag != $current_version {
+  update-source-version slimserver $latest_tag $"--file=(pwd)/pkgs/by-name/sl/slimserver/package.nix"
+  {before: $current_version, after: $latest_tag}
+} else {
+  "No new version"
+}

--- a/pkgs/by-name/sl/slimserver/update.nu
+++ b/pkgs/by-name/sl/slimserver/update.nu
@@ -2,7 +2,7 @@
 #!nix-shell -i nu -p nushell common-updater-scripts
 
 # get latest tag, but drop versions 10.0 tags since they are 10+ years old
-let latest_tag = list-git-tags --url=https://github.com/logitech/slimserver | lines | find --invert 10.0 | sort --natural | last
+let latest_tag = list-git-tags --url=https://github.com/LMS-Community/slimserver | lines | find --invert 10.0 | sort --natural | last
 
 let current_version = nix eval --raw -f default.nix slimserver | str trim
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -26953,8 +26953,6 @@ with pkgs;
 
   sipwitch = callPackage ../servers/sip/sipwitch { };
 
-  slimserver = callPackage ../servers/slimserver { };
-
   smcroute = callPackage ../servers/smcroute { };
 
   snipe-it = callPackage ../by-name/sn/snipe-it/package.nix {


### PR DESCRIPTION
## Description of changes

- slimserver: add updatescript, move to by-name
- slimserver: 8.4.0 -> 8.5.0
- slimserver: Logitech -> LMS-Community

https://github.com/LMS-Community/slimserver/compare/8.4.0...8.5.0

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
