### PR TITLE
payme: fix version number string

### DIFF
--- a/pkgs/by-name/pa/payme/package.nix
+++ b/pkgs/by-name/pa/payme/package.nix
@@ -13,6 +13,13 @@ buildGoModule rec {
 
   vendorHash = null;
 
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.gitRefName=v${version}"
+    "-X main.gitCommit=416d53e3f518898a0411889a5af08e8d9858e70e"
+  ];
+
   meta = {
     description = "QR code generator (ASCII & PNG) for SEPA payments";
     mainProgram = "payme";

--- a/pkgs/by-name/pa/payme/package.nix
+++ b/pkgs/by-name/pa/payme/package.nix
@@ -3,13 +3,18 @@
 buildGoModule rec {
   pname = "payme";
   version = "1.2.0";
-  commit = "416d53e3f518898a0411889a5af08e8d9858e70e";
 
   src = fetchFromGitHub {
     owner = "jovandeginste";
     repo = "payme";
     rev = "v${version}";
-    hash = "sha256-WE/sAs0VSeb5UKkUy1iyjyXtgDmlQhdZkw8HMMSbQiE=";
+    hash = "sha256-2gZgmYgLaJQRQ+3VOUDnMm5QBjfKyxyutVf9NrbGO3g=";
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse HEAD > $out/COMMIT
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
   };
 
   vendorHash = null;
@@ -18,8 +23,11 @@ buildGoModule rec {
     "-s"
     "-w"
     "-X main.gitRefName=${src.rev}"
-    "-X main.gitCommit=${commit}"
   ];
+
+  preBuild = ''
+    ldflags+=" -X main.gitCommit=$(cat COMMIT)"
+  '';
 
   meta = {
     description = "QR code generator (ASCII & PNG) for SEPA payments";

--- a/pkgs/by-name/pa/payme/package.nix
+++ b/pkgs/by-name/pa/payme/package.nix
@@ -3,6 +3,7 @@
 buildGoModule rec {
   pname = "payme";
   version = "1.2.0";
+  commit = "416d53e3f518898a0411889a5af08e8d9858e70e";
 
   src = fetchFromGitHub {
     owner = "jovandeginste";
@@ -16,8 +17,8 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X main.gitRefName=v${version}"
-    "-X main.gitCommit=416d53e3f518898a0411889a5af08e8d9858e70e"
+    "-X main.gitRefName=${src.rev}"
+    "-X main.gitCommit=${commit}"
   ];
 
   meta = {


### PR DESCRIPTION
## Description of changes

The current payme version in nixpkgs unstable does not show the correct version string for the application, notice the "local" in the version number:

```
$ payme --version
payme version local (local), built at 2024-03-14T11:42:21+01:00
```

This pull request corrects to version string as requested by the application developer:

```
$ payme --version
payme version v1.2.0 (416d53e3f518898a0411889a5af08e8d9858e70e), built at 2024-03-20T15:29:31+01:00
```

Background discussion can be found in the [payme repo issue](https://github.com/jovandeginste/payme/issues/4).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
