### PR TITLE
python311Packages.symspellpy: init at 6.7.6

### DIFF
--- a/pkgs/development/python-modules/symspellpy/default.nix
+++ b/pkgs/development/python-modules/symspellpy/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "symspellpy";
-  version = "6.7.6";
+  version = "6.7.7";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -37,7 +37,7 @@ buildPythonPackage rec {
     owner = "mammothb";
     repo = "symspellpy";
     rev = "refs/tags/v${version}";
-    hash = "sha256-mxBURUAT5Jf3+c3D0h3B7gvH1srrfjwGgKkPUBTRVOU=";
+    hash = "sha256-D8xdMCy4fSff3nuS2sD2QHWk0869AlFDE+lFRvayYDQ=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/symspellpy/default.nix
+++ b/pkgs/development/python-modules/symspellpy/default.nix
@@ -1,0 +1,70 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, fetchpatch
+
+, pythonOlder
+
+, pytestCheckHook
+
+, setuptools
+
+  # for testing
+, numpy
+, importlib-resources
+
+  # requirements
+, editdistpy
+}:
+
+buildPythonPackage rec {
+  pname = "symspellpy";
+  version = "6.7.6";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  patches = [
+    # patch for fix tests
+    (fetchpatch {
+      name = "fix-pkg-resources-deprecation-warning.patch";
+      url = "https://patch-diff.githubusercontent.com/raw/mammothb/symspellpy/pull/150.patch";
+      hash = "sha256-mdUJMrcPv5zczIRP+8u5vicz2IE1AUN3YP0+zg3jqZg=";
+    })
+  ];
+
+  src = fetchFromGitHub {
+    owner = "mammothb";
+    repo = "symspellpy";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-mxBURUAT5Jf3+c3D0h3B7gvH1srrfjwGgKkPUBTRVOU=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    editdistpy
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    numpy
+    importlib-resources
+  ];
+
+  pythonImportsCheck = [
+    "symspellpy"
+    "symspellpy.symspellpy"
+  ];
+
+  meta = with lib;
+    {
+      description = "Python port of SymSpell v6.7.1, which provides much higher speed and lower memory consumption";
+      homepage = "https://github.com/mammothb/symspellpy";
+      changelog = "https://github.com/mammothb/symspellpy/releases/tag/v${version}";
+      license = licenses.mit;
+      maintainers = with maintainers; [ vizid ];
+    };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14382,6 +14382,8 @@ self: super: with self; {
 
   sympy = callPackage ../development/python-modules/sympy { };
 
+  symspellpy = callPackage ../development/python-modules/symspellpy { };
+
   syncedlyrics = callPackage ../development/python-modules/syncedlyrics { };
 
   syncer = callPackage ../development/python-modules/syncer { };


### PR DESCRIPTION
## Description of changes
https://github.com/mammothb/symspellpy
Python port of SymSpell: 1 million times faster spelling correction & fuzzy search through Symmetric Delete spelling correction algorithm

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
