### PR TITLE
vendor-reset: apply patch to fix build for linux 6.8

### DIFF
--- a/pkgs/os-specific/linux/vendor-reset/default.nix
+++ b/pkgs/os-specific/linux/vendor-reset/default.nix
@@ -18,6 +18,9 @@ stdenv.mkDerivation rec {
       url = "https://github.com/gnif/vendor-reset/commit/5bbffcd6fee5348e8808bdbfcb5b21d455b02f55.patch";
       sha256 = "sha256-L1QxVpcZAVYiaMFCBfL2EJgeMyOR8sDa1UqF1QB3bns=";
     })
+    # Fix build with Linux 6.8+
+    # https://github.com/gnif/vendor-reset/pull/77
+    ./linux68.patch
   ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;

--- a/pkgs/os-specific/linux/vendor-reset/linux68.patch
+++ b/pkgs/os-specific/linux/vendor-reset/linux68.patch
@@ -1,0 +1,41 @@
+From cc6bf3085ad43f9bbad6ef4e12a2437376d7d5c1 Mon Sep 17 00:00:00 2001
+From: Sakari <20642596+sakarie9@users.noreply.github.com>
+Date: Thu, 14 Mar 2024 10:59:15 +0800
+Subject: [PATCH] Fix build on kernel 6.8+
+
+---
+ src/amd/amdgpu/atom.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/amd/amdgpu/atom.c b/src/amd/amdgpu/atom.c
+index 9a04857..333961f 100644
+--- a/src/amd/amdgpu/atom.c
++++ b/src/amd/amdgpu/atom.c
+@@ -28,6 +28,7 @@
+ #include <linux/sched.h>
+ #include <linux/slab.h>
+ #include <linux/delay.h>
++#include <linux/version.h>
+ #include <asm/unaligned.h>
+ 
+ //#include <drm/drm_util.h>
+@@ -39,6 +40,10 @@
+ #include "atom-names.h"
+ #include "atom-bits.h"
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0)
++#define strscpy strlcpy
++#endif
++
+ #define ATOM_COND_ABOVE 0
+ #define ATOM_COND_ABOVEOREQUAL 1
+ #define ATOM_COND_ALWAYS 2
+@@ -1424,7 +1429,7 @@ struct atom_context *amdgpu_atom_parse(struct card_info *card, void *bios)
+ 	if (*str != '\0')
+ 	{
+ 		pr_info("ATOM BIOS: %s\n", str);
+-		strlcpy(ctx->vbios_version, str, sizeof(ctx->vbios_version));
++		strscpy(ctx->vbios_version, str, sizeof(ctx->vbios_version));
+ 	}
+ 
+ 	return ctx;


### PR DESCRIPTION
## Description of changes

The build of the vendor-reset kernel module is currently failing for Linux 6.8. This patch fixes the build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
