### PR TITLE
treewide: use stripJavaArchivesHook in trivial cases

### DIFF
--- a/pkgs/applications/graphics/processing/default.nix
+++ b/pkgs/applications/graphics/processing/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchurl, ant, unzip, makeWrapper, jdk, jogl, rsync, ffmpeg, batik, wrapGAppsHook, libGL }:
+{ lib, stdenv, fetchFromGitHub, fetchurl, ant, unzip, makeWrapper, jdk, jogl, rsync, ffmpeg, batik, stripJavaArchivesHook, wrapGAppsHook, libGL }:
 let
   buildNumber = "1293";
   vaqua = fetchurl {
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-SzQemZ6iZ9o89/doV8YMv7DmyPSDyckJl3oyxJyfrm0=";
   };
 
-  nativeBuildInputs = [ ant unzip makeWrapper wrapGAppsHook ];
+  nativeBuildInputs = [ ant unzip makeWrapper stripJavaArchivesHook wrapGAppsHook ];
   buildInputs = [ jdk jogl ant rsync ffmpeg batik ];
 
   dontWrapGApps = true;

--- a/pkgs/applications/misc/sweethome3d/default.nix
+++ b/pkgs/applications/misc/sweethome3d/default.nix
@@ -6,6 +6,7 @@
 , makeDesktopItem
 , jdk
 , ant
+, stripJavaArchivesHook
 , gtk3
 , gsettings-desktop-schemas
 , p7zip
@@ -51,7 +52,7 @@ let
       find . -name '*.so' | xargs strings | { grep '/nix/store' || :; } >> ./.jar-paths
     '';
 
-    nativeBuildInputs = [ makeWrapper autoPatchelfHook ];
+    nativeBuildInputs = [ makeWrapper autoPatchelfHook stripJavaArchivesHook ];
     buildInputs = [ ant jdk p7zip gtk3 gsettings-desktop-schemas libXxf86vm ];
 
     # upstream targets Java 7 by default

--- a/pkgs/applications/misc/sweethome3d/editors.nix
+++ b/pkgs/applications/misc/sweethome3d/editors.nix
@@ -5,6 +5,7 @@
 , makeDesktopItem
 , jdk
 , ant
+, stripJavaArchivesHook
 , gtk3
 , gsettings-desktop-schemas
 , sweethome3dApp
@@ -33,7 +34,7 @@ let
       categories = [ "Graphics" "2DGraphics" "3DGraphics" ];
     };
 
-    nativeBuildInputs = [ makeWrapper ];
+    nativeBuildInputs = [ makeWrapper stripJavaArchivesHook ];
     buildInputs = [ ant jdk gtk3 gsettings-desktop-schemas ];
 
     # upstream targets Java 7 by default

--- a/pkgs/by-name/op/openrocket/package.nix
+++ b/pkgs/by-name/op/openrocket/package.nix
@@ -4,6 +4,7 @@
 , ant
 , jdk17
 , makeWrapper
+, stripJavaArchivesHook
 }:
 
 let
@@ -25,6 +26,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     ant
     jdk
     makeWrapper
+    stripJavaArchivesHook
   ];
 
   buildPhase = ''

--- a/pkgs/development/embedded/arduino/arduino-core/default.nix
+++ b/pkgs/development/embedded/arduino/arduino-core/default.nix
@@ -4,6 +4,7 @@
 , fetchurl
 , jdk
 , ant
+, stripJavaArchivesHook
 , libusb-compat-0_1
 , libusb1
 , unzip
@@ -112,7 +113,7 @@ stdenv.mkDerivation rec {
   # the glib setup hook will populate GSETTINGS_SCHEMAS_PATH,
   # wrapGAppHooks (among other things) adds it to XDG_DATA_DIRS
   # so 'save as...' works:
-  nativeBuildInputs = [ glib wrapGAppsHook unzip ];
+  nativeBuildInputs = [ glib stripJavaArchivesHook wrapGAppsHook unzip ];
   buildInputs = [
     jdk
     ant

--- a/pkgs/tools/filesystems/xtreemfs/default.nix
+++ b/pkgs/tools/filesystems/xtreemfs/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , fetchpatch
 , makeWrapper
+, stripJavaArchivesHook
 , ant
 , attr
 , boost
@@ -28,7 +29,7 @@ stdenv.mkDerivation {
     sha256 = "1hjmd32pla27zf98ghzz6r5ml8ry86m9dsryv1z01kxv5l95b3m0";
   };
 
-  nativeBuildInputs = [ makeWrapper python3 ];
+  nativeBuildInputs = [ makeWrapper python3 stripJavaArchivesHook ];
   buildInputs = [ which attr ];
 
   patches = [


### PR DESCRIPTION
## Description of changes

Tracking issue: https://github.com/NixOS/nixpkgs/issues/278518

In this PR I tried to find as many java-based packages as possible, which weren't deterministic and added `stripJavaArchivesHook` to them.
I'll only do this to packages for which I am not planning to create separate cleanup PR. (Either because it's already clean or because it's too much of a mess)

I'll try to add more packages in the following days

Should I squash the commits?

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
