### PR TITLE
python3Packages.torch: allow lazy loading libnvrtc

### DIFF
--- a/pkgs/development/cuda-modules/saxpy/default.nix
+++ b/pkgs/development/cuda-modules/saxpy/default.nix
@@ -56,6 +56,5 @@ backendStdenv.mkDerivation {
     license = lib.licenses.mit;
     maintainers = lib.teams.cuda.members;
     platforms = lib.platforms.unix;
-    badPlatforms = lib.optionals flags.isJetsonBuild platforms;
   };
 }

--- a/pkgs/development/cuda-modules/setup-hooks/auto-add-driver-runpath-hook.sh
+++ b/pkgs/development/cuda-modules/setup-hooks/auto-add-driver-runpath-hook.sh
@@ -1,8 +1,11 @@
 # shellcheck shell=bash
-# Run addDriverRunpath on all dynamically linked ELF files
-echo "Sourcing auto-add-driver-runpath-hook"
+# Equivalent to running addDriverRunpath on all dynamically linked ELF files
+
+[[ -n ${autoAddDriverRunpath_Once-} ]] && return
+declare -g autoAddDriverRunpath_Once=1
+
+echo "Sourcing auto-add-driver-runpath-hook.sh"
 
 if [ -z "${dontUseAutoAddDriverRunpath-}" ]; then
-  echo "Using autoAddDriverRunpath"
-  postFixupHooks+=("autoFixElfFiles addDriverRunpath")
+  elfPrependRunpaths+=( "@driverLink@/lib" )
 fi

--- a/pkgs/development/cuda-modules/setup-hooks/auto-fix-elf-files.sh
+++ b/pkgs/development/cuda-modules/setup-hooks/auto-fix-elf-files.sh
@@ -59,7 +59,7 @@ autoFixElfFiles() {
     elif elfHasDynamicSection "$f"; then
       # patchelf returns an error on statically linked ELF files, and in
       # practice fixing actions all involve patchelf
-      echo "autoFixElfFiles: using $fixAction to fix $f" >&2
+      (( "${NIX_DEBUG:-0}" >= 1 )) && echo "autoFixElfFiles: using $fixAction to fix $f" >&2
       $fixAction "$f"
     elif (( "${NIX_DEBUG:-0}" >= 1 )); then
       echo "autoFixElfFiles: skipping a statically-linked ELF file $f"

--- a/pkgs/development/cuda-modules/setup-hooks/auto-fix-elf-files.sh
+++ b/pkgs/development/cuda-modules/setup-hooks/auto-fix-elf-files.sh
@@ -2,7 +2,11 @@
 # List all dynamically linked ELF files in the outputs and apply a generic fix
 # action provided as a parameter (currently used to add the CUDA or the
 # cuda_compat driver to the runpath of binaries)
-echo "Sourcing cuda/fix-elf-files.sh"
+
+[[ -n ${autoFixElfFiles_Once-} ]] && return
+declare -g autoFixElfFiles_Once=1
+
+echo "Sourcing auto-fix-elf-files.sh"
 
 # Returns the exit code of patchelf --print-rpath.
 # A return code of 0 (success) means the ELF file has a dynamic section, while
@@ -62,3 +66,69 @@ autoFixElfFiles() {
     fi
   done
 }
+
+inputsToArray() {
+    local inputVar="$1"
+    local outputVar="$2"
+    shift 2
+
+    local -n namerefOut="$outputVar"
+
+    if [ -z "${!inputVar+1}" ] ; then
+        # Undeclared variable
+        return
+    fi
+
+    local type="$(declare -p "$inputVar")"
+    if [[ "$type" =~ "declare -a" ]]; then
+        local -n namerefIn="$inputVar"
+        namerefOut=( "${namerefIn[@]}" )
+    else
+        read -r -a namerefOut <<< "${!inputVar}"
+    fi
+}
+
+elfBuildRunpathStrings() {
+    local path
+    local -a elfAddRunpathsArray elfPrependRunpathsArray
+
+    inputsToArray elfAddRunpaths elfAddRunpathsArray
+    inputsToArray elfPrependRunpaths elfPrependRunpathsArray
+
+    for path in "${elfPrependRunpathsArray[@]}" ; do
+        elfAddRunpathsPrefix="$elfAddRunpathsPrefix:$path"
+    done
+    elfAddRunpathsPrefix="${elfAddRunpathsPrefix##:}"
+
+    for path in "${elfAddRunpathsArray[@]}" ; do
+        elfAddRunpathsSuffix="$elfAddRunpathsSuffix:$path"
+    done
+    elfAddRunpathsSuffix="${elfAddRunpathsSuffix##:}"
+}
+
+# Expects that elfAddRunpathPrefix and elfAddRunpathSuffix are set
+elfAddRunpathsAction() {
+    local origPath="$(patchelf --print-rpath "$1")"
+    local newPath
+
+    newPath="$elfAddRunpathsPrefix"
+    newPath="${newPath}${newPath:+:}${origPath}"
+    newPath="${newPath}${elfAddRunpathsSuffix:+:}${elfAddRunpathsSuffix}"
+
+    (( "${NIX_DEBUG:-0}" >= 4 )) && echo patchelf --set-rpath "$newPath" "$1" >&2
+    patchelf --set-rpath "$newPath" "$1"
+}
+
+elfAddRunpathsHook() {
+    [[ -z "${elfAddRunpaths[@]}" ]] && [[ -z "${elfPrependRunpaths[@]}" ]] && return
+
+    echo "Executing elfAddRunpaths: ${elfAddRunpaths[@]}" >&2
+    [[ -z "${elfPrependRunpaths[@]}" ]] || echo "elfPrependRunpaths: ${elfPrependRunpaths[@]}" >&2
+
+    local elfAddRunpathsPrefix
+    local elfAddRunpathsSuffix
+    elfBuildRunpathStrings
+    autoFixElfFiles elfAddRunpathsAction
+}
+
+postFixupHooks+=(elfAddRunpathsHook)

--- a/pkgs/development/cuda-modules/setup-hooks/extension.nix
+++ b/pkgs/development/cuda-modules/setup-hooks/extension.nix
@@ -54,7 +54,8 @@ final: _: {
         makeSetupHook
           {
             name = "auto-add-opengl-runpath-hook";
-            propagatedBuildInputs = [addDriverRunpath autoFixElfFiles];
+            propagatedBuildInputs = [autoFixElfFiles];
+            substitutions = { inherit (addDriverRunpath) driverLink; };
           }
           ./auto-add-driver-runpath-hook.sh
       )
@@ -71,15 +72,17 @@ final: _: {
   autoAddCudaCompatRunpath =
     final.callPackage
       (
-        {makeSetupHook, autoFixElfFiles, cuda_compat ? null }:
+        {makeSetupHook, addDriverRunpath, autoFixElfFiles, cuda_compat ? null }:
         makeSetupHook
           {
             name = "auto-add-cuda-compat-runpath-hook";
             propagatedBuildInputs = [autoFixElfFiles];
 
             substitutions = {
+              inherit (addDriverRunpath) driverLink;
+
               # Hotfix Ofborg evaluation
-              libcudaPath = if final.flags.isJetsonBuild then "${cuda_compat}/compat" else null;
+              libcudaPath = if final.flags.isJetsonBuild then "${cuda_compat}/compat" else "";
             };
 
             meta.broken = !final.flags.isJetsonBuild;

--- a/pkgs/development/python-modules/torch/bin.nix
+++ b/pkgs/development/python-modules/torch/bin.nix
@@ -88,9 +88,11 @@ in buildPythonPackage {
     rm -rf $out/bin
   '';
 
-  postFixup = lib.optionalString stdenv.isLinux ''
-    addAutoPatchelfSearchPath "$out/${python.sitePackages}/torch/lib"
-  '';
+  elfAddRunpaths = [
+    "${lib.getLib cudaPackages.cuda_nvrtc}/lib"
+    "$ORIGIN"
+  ];
+
 
   # The wheel-binary is not stripped to avoid the error of `ImportError: libtorch_cuda_cpp.so: ELF load command address/offset not properly aligned.`.
   dontStrip = true;

--- a/pkgs/development/python-modules/torch/default.nix
+++ b/pkgs/development/python-modules/torch/default.nix
@@ -337,6 +337,8 @@ in buildPythonPackage rec {
     pybind11
     pythonRelaxDepsHook
     removeReferencesTo
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
+    cudaPackages.autoFixElfFiles
   ] ++ lib.optionals cudaSupport (with cudaPackages; [
     autoAddDriverRunpath
     cuda_nvcc
@@ -487,6 +489,10 @@ in buildPythonPackage rec {
     install_name_tool -change @rpath/libtorch.dylib $lib/lib/libtorch.dylib $lib/lib/libshm.dylib
     install_name_tool -change @rpath/libc10.dylib $lib/lib/libc10.dylib $lib/lib/libshm.dylib
   '';
+
+  elfAddRunpaths = lib.optionals cudaSupport [
+    "${lib.getLib cudaPackages.cuda_nvrtc}/lib"
+  ];
 
   # Builds in 2+h with 2 cores, and ~15m with a big-parallel builder.
   requiredSystemFeatures = [ "big-parallel" ];


### PR DESCRIPTION
## Description of changes

Fixes https://github.com/NixOS/nixpkgs/issues/296179, refactors `autoAddDriverRunapth` and `autoAddCudaCompatHook`

CC @yannham 

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
