### PR TITLE
zenergy: init at 0-unstable-2024-10-10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23179,6 +23179,17 @@
     githubId = 36118348;
     keys = [ { fingerprint = "69C9 876B 5797 1B2E 11C5  7C39 80A1 F76F C9F9 54AE"; } ];
   };
+  wizardlink = {
+    name = "wizardlink";
+    email = "contact@thewizard.link";
+    github = "wizardlink";
+    githubId = 26727907;
+    keys = [
+      {
+        fingerprint = "A1D3 A2B4 E14B D7C0 445B  B749 A576 7B54 367C FBDF";
+      }
+    ];
+  };
   wizeman = {
     email = "rcorreia@wizy.org";
     github = "wizeman";

--- a/pkgs/os-specific/linux/zenergy/default.nix
+++ b/pkgs/os-specific/linux/zenergy/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  kernel,
+  kmod,
+}:
+
+let
+  kernelDirectory = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+in
+stdenv.mkDerivation {
+  pname = "zenergy";
+  version = "0-unstable-2024-10-10";
+
+  src = fetchFromGitHub {
+    owner = "BoukeHaarsma23";
+    repo = "zenergy";
+    rev = "7c4e83d5e2f887f4c31edaf92e5f94e9448e9764";
+    hash = "sha256-5fYelEr4IYnuXrly15IcyicFrF0tYjs7OBqIhUYQXZ0=";
+  };
+
+  nativeBuildInputs = [ kmod ] ++ kernel.moduleBuildDependencies;
+
+  hardeningDisable = [
+    "format"
+    "pic"
+  ];
+
+  makeFlags = kernel.makeFlags ++ [ "KDIR=${kernelDirectory}" ];
+
+  installTargets = [ "modules_install" ];
+
+  preBuild = ''
+    substituteInPlace Makefile --replace-fail "PWD modules_install" "PWD INSTALL_MOD_PATH=$out modules_install"
+  '';
+
+  meta = with lib; {
+    description = "Based on AMD_ENERGY driver, but with some jiffies added so non-root users can read it safely.";
+    homepage = "https://github.com/BoukeHaarsma23/zenergy";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ wizardlink ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -407,6 +407,8 @@ in {
 
     new-lg4ff = callPackage ../os-specific/linux/new-lg4ff { };
 
+    zenergy = callPackage ../os-specific/linux/zenergy { };
+
     nvidiabl = callPackage ../os-specific/linux/nvidiabl { };
 
     nvidiaPackages = dontRecurseIntoAttrs (lib.makeExtensible (_: callPackage ../os-specific/linux/nvidia-x11 { }));


### PR DESCRIPTION
## Description of changes

Adds a new kernel module, [`zenergy`](https://github.com/BoukeHaarsma23/zenergy), this is necessary for accessing CPU power draw data without root permission, specifically [MangoHud](https://github.com/flightlessmango/MangoHud) requires it to be able to show the user their CPU power draw.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
