### PR TITLE
home-assistant-custom-components.frigate: init at 5.1.0

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -12,6 +12,8 @@
 
   epex_spot = callPackage ./epex_spot {};
 
+  frigate = callPackage ./frigate {};
+
   govee-lan = callPackage ./govee-lan {};
 
   gpio = callPackage ./gpio {};

--- a/pkgs/servers/home-assistant/custom-components/frigate/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/frigate/default.nix
@@ -1,0 +1,32 @@
+{ lib
+, fetchFromGitHub
+, buildHomeAssistantComponent
+, pytz
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "presto8";
+  domain = "frigate";
+  version = "5.1.0";
+
+  src = fetchFromGitHub {
+    owner = "blakeblackshear";
+    repo = "frigate-hass-integration";
+    rev = "v${version}";
+    hash = "sha256-6W9U0Q0wW36RsErvtFQo1sc1AF7js6MMHxgMQcDFexw=";
+  };
+
+  propagatedBuildInputs = [
+    pytz
+  ];
+
+  dontBuild = true;
+
+  meta = with lib; {
+    description = "Provides Home Assistant integration to interface with a separately running Frigate service";
+    homepage = "https://github.com/blakeblackshear/frigate-hass-integration";
+    changelog = "https://github.com/blakeblackshear/frigate-hass-integration/releases/tag/v${version}";
+    maintainers = with maintainers; [ presto8 ];
+    license = licenses.mit;
+  };
+}


### PR DESCRIPTION
Package frigate-hass-integration. Tested with services.frigate and services.go2rtc on HA 2024.3.1. Verified that live camera feed appears in Home Assistant. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
