### PR TITLE
nixos/tests/ustreamer: init

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -963,6 +963,7 @@ in {
   user-activation-scripts = handleTest ./user-activation-scripts.nix {};
   user-expiry = runTest ./user-expiry.nix;
   user-home-mode = handleTest ./user-home-mode.nix {};
+  ustreamer = handleTest ./ustreamer.nix {};
   uwsgi = handleTest ./uwsgi.nix {};
   v2ray = handleTest ./v2ray.nix {};
   varnish60 = handleTest ./varnish.nix { package = pkgs.varnish60; };

--- a/nixos/tests/ustreamer.nix
+++ b/nixos/tests/ustreamer.nix
@@ -1,0 +1,75 @@
+import ./make-test-python.nix ({ pkgs, ... }: {
+  name = "ustreamer-vmtest";
+  nodes = {
+    client = {...}: {
+      environment.systemPackages = [ pkgs.curl ];
+    };
+    camera = {config, ...}: let
+      configFile = pkgs.writeText "akvcam-configFile" ''
+        [Cameras]
+        cameras/size = 2
+
+        cameras/1/type = output
+        cameras/1/mode = mmap, userptr, rw
+        cameras/1/description = Virtual Camera (output device)
+        cameras/1/formats = 2
+        cameras/1/videonr = 7
+
+        cameras/2/type = capture
+        cameras/2/mode = mmap, rw
+        cameras/2/description = Virtual Camera
+        cameras/2/formats = 1, 2
+        cameras/2/videonr = 9
+
+        [Connections]
+        connections/size = 1
+        connections/1/connection = 1:2
+
+        [Formats]
+        formats/size = 2
+
+        formats/1/format = YUY2
+        formats/1/width = 640
+        formats/1/height = 480
+        formats/1/fps = 30
+
+        formats/2/format = RGB24, YUY2
+        formats/2/width = 640
+        formats/2/height = 480
+        formats/2/fps = 20/1, 15/2
+      '';
+    in {
+      environment.systemPackages = [ pkgs.ustreamer ];
+      networking.firewall.enable = false;
+      systemd.services.ustreamer = {
+        description = "ustreamer service";
+        wantedBy = ["multi-user.target"];
+        serviceConfig = {
+          DynamicUser = true;
+          ExecStart = "${pkgs.ustreamer}/bin/ustreamer --host=0.0.0.0 --port 8000 --device /dev/video9 --device-timeout=8";
+          PrivateTmp = true;
+          BindReadOnlyPaths = "/dev/video9";
+          SupplementaryGroups = [
+            "video"
+          ];
+          Restart = "always";
+        };
+      };
+      boot.extraModulePackages = [config.boot.kernelPackages.akvcam];
+      boot.kernelModules = ["akvcam"];
+      boot.extraModprobeConfig = ''
+        options akvcam config_file=${configFile}
+      '';
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    camera.wait_for_unit("ustreamer.service")
+    camera.wait_for_open_port(8000)
+
+    client.wait_for_unit("multi-user.target")
+    client.succeed("curl http://camera:8000")
+  '';
+})

--- a/pkgs/os-specific/linux/akvcam/default.nix
+++ b/pkgs/os-specific/linux/akvcam/default.nix
@@ -29,6 +29,5 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ freezeboy ];
     platforms = platforms.linux;
     license = licenses.gpl2Only;
-    broken = kernel.kernelAtLeast "5.18";
   };
 }


### PR DESCRIPTION
## Description of changes

Initialises a VM Test for Ustreamer, and updates the ustreamer package in Nixpkgs. This is a port of the VM Test defined in https://github.com/pikvm/ustreamer/pull/136 since upstream do not want a Nix flake as their build system. I also intend to nixify more pikvm related software in the future.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
