### PR TITLE
ghc98x: use ghc964 to bootstrap on Darwin

### DIFF
--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -298,6 +298,9 @@ in {
           packages.ghc963
         else if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
           packages.ghc963
+        # ghc963Binary.shake broken on MacOS
+        else if stdenv.hostPlatform.isDarwin then
+          packages.ghc964
         else
           packages.ghc963Binary;
       inherit (buildPackages.python3Packages) sphinx;
@@ -316,6 +319,9 @@ in {
           packages.ghc963
         else if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
           packages.ghc963
+        # ghc963Binary.shake broken on MacOS
+        else if stdenv.hostPlatform.isDarwin then
+          packages.ghc964
         else
           packages.ghc963Binary;
       inherit (buildPackages.python3Packages) sphinx;


### PR DESCRIPTION
`haskell.packages.ghc963Binary.shake` fails to build with this (extremely confusing) linker error on Darwin:

```
[72 of 72] Linking dist/build/shake/shake
ld: warning: ignoring file /nix/store/9x5cwd0bhsyi79kr7aaygyxkbkymrmxi-clock-0.8.4/lib/ghc-9.6.3/lib/aarch64-osx-ghc-9.6.3/clock-0.8.4-Bnns7LmnhG01nLONJf4lGG/libHSclock-0.8.4-Bnns7LmnhG01nLONJf4lGG.a, building for macOS-arm64 but attempting to link with file built for macOS-arm64
Undefined symbols for architecture arm64:
  "_hashablezm1zi4zi3zi0zmA9LFXpiwTxs1MJiRE3ofES_DataziHashableziLowLevel_hashInt_closure", referenced from:
      _hashablezm1zi4zi3zi0zmA9LFXpiwTxs1MJiRE3ofES_DataziHashableziClass_zdfHashableInt_closure in libHShashable-1.4.3.0-A9LFXpiwTxs1MJiRE3ofES.a(Class.o)
  "_clockzm0zi8zi4zmBnns7LmnhG01nLONJf4lGG_SystemziClock_getTime1_closure", referenced from:
      _LufAk_srt in libHSextra-1.7.14-C0NyHfWRM5MFtpHgm996cH.a(Extra.o)
  "_hashablezm1zi4zi3zi0zmA9LFXpiwTxs1MJiRE3ofES_DataziHashableziLowLevel_hashWord64_closure", referenced from:
      _hashablezm1zi4zi3zi0zmA9LFXpiwTxs1MJiRE3ofES_DataziHashableziClass_zdfHashableWord64_closure in libHShashable-1.4.3.0-A9LFXpiwTxs1MJiRE3ofES.a(Class.o)
  "_clockzm0zi8zi4zmBnns7LmnhG01nLONJf4lGG_SystemziClock_zdwtoNanoSecs_closure", referenced from:
      _LufAf_srt in libHSextra-1.7.14-C0NyHfWRM5MFtpHgm996cH.a(Extra.o)
  "_clockzm0zi8zi4zmBnns7LmnhG01nLONJf4lGG_SystemziClock_Monotonic_closure", referenced from:
      _Lsfp9_info in libHSextra-1.7.14-C0NyHfWRM5MFtpHgm996cH.a(Extra.o)
      _extrazm1zi7zi14zmC0NyHfWRM5MFtpHgm996cH_SystemziTimeziExtra_duration1_info in libHSextra-1.7.14-C0NyHfWRM5MFtpHgm996cH.a(Extra.o)
  "_clockzm0zi8zi4zmBnns7LmnhG01nLONJf4lGG_SystemziClock_getTime1_info", referenced from:
      _Lsfp9_info in libHSextra-1.7.14-C0NyHfWRM5MFtpHgm996cH.a(Extra.o)
      _extrazm1zi7zi14zmC0NyHfWRM5MFtpHgm996cH_SystemziTimeziExtra_duration1_info in libHSextra-1.7.14-C0NyHfWRM5MFtpHgm996cH.a(Extra.o)
  "_clockzm0zi8zi4zmBnns7LmnhG01nLONJf4lGG_SystemziClock_zdwtoNanoSecs_info", referenced from:
      _LcfzD_info in libHSextra-1.7.14-C0NyHfWRM5MFtpHgm996cH.a(Extra.o)
  "_clockzm0zi8zi4zmBnns7LmnhG01nLONJf4lGG_SystemziClock_zdwnormalizze_info", referenced from:
      _Lcfzs_info in libHSextra-1.7.14-C0NyHfWRM5MFtpHgm996cH.a(Extra.o)
  "_ghczuwrapperZC0ZChashablezm1zi4zi3zi0zmA9LFXpiwTxs1MJiRE3ofESZCDataziHashableziLowLevelZChashablezufnvzuhashzuoffset", referenced from:
      _Lccgd_info in libHShashable-1.4.3.0-A9LFXpiwTxs1MJiRE3ofES.a(Class.o)
      _LcdAH_info in libHShashable-1.4.3.0-A9LFXpiwTxs1MJiRE3ofES.a(Class.o)
      _LcgYU_info in libHShashable-1.4.3.0-A9LFXpiwTxs1MJiRE3ofES.a(Class.o)
      _Lch0Y_info in libHShashable-1.4.3.0-A9LFXpiwTxs1MJiRE3ofES.a(Class.o)
      _Lchlx_info in libHShashable-1.4.3.0-A9LFXpiwTxs1MJiRE3ofES.a(Class.o)
      _Lchnw_info in libHShashable-1.4.3.0-A9LFXpiwTxs1MJiRE3ofES.a(Class.o)
      _Lchpu_info in libHShashable-1.4.3.0-A9LFXpiwTxs1MJiRE3ofES.a(Class.o)
      ...
  "_hashablezm1zi4zi3zi0zmA9LFXpiwTxs1MJiRE3ofES_DataziHashableziLowLevel_hashInt64_closure", referenced from:
      _hashablezm1zi4zi3zi0zmA9LFXpiwTxs1MJiRE3ofES_DataziHashableziClass_zdfHashableInt64_closure in libHShashable-1.4.3.0-A9LFXpiwTxs1MJiRE3ofES.a(Class.o)
  "_clockzm0zi8zi4zmBnns7LmnhG01nLONJf4lGG_SystemziClock_zdwnormalizze_closure", referenced from:
      _LufAg_srt in libHSextra-1.7.14-C0NyHfWRM5MFtpHgm996cH.a(Extra.o)
  "_ghczuwrapperZC1ZChashablezm1zi4zi3zi0zmA9LFXpiwTxs1MJiRE3ofESZCDataziHashableziLowLevelZChashablezufnvzuhash", referenced from:
      _LcVe7_info in FileInfo.o
      _Ls1edD_info in Cloud.o
      _Ls2zGO_info in Files.o
      _Ls2xXm_info in Derived.o
      _Lsa90_info in libHShashable-1.4.3.0-A9LFXpiwTxs1MJiRE3ofES.a(Class.o)
      _LcdzG_info in libHShashable-1.4.3.0-A9LFXpiwTxs1MJiRE3ofES.a(Class.o)
      _Lsb7C_info in libHShashable-1.4.3.0-A9LFXpiwTxs1MJiRE3ofES.a(Class.o)
      ...
ld: symbol(s) not found for architecture arm64
clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
ghc-9.6.3: `clang' failed in phase `Linker'. (Exit code: 1)
```

This prevents us from building GHC 9.8.x on Darwin. `haskell.packages.ghc963.shake` has no such issue.