### PR TITLE
doc: improve fetchers overview, deduplicate readme content, follow doc conventions

### DIFF
--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -3,12 +3,8 @@
 Building software with Nix often requires downloading source code and other files from the internet.
 To do this, we use functions that we call _fetchers_ to obtain remote sources via various protocols and services.
 
-Nix provides built-in fetchers such as [`builtins.fetchTarball`](https://nixos.org/manual/nix/stable/language/builtins.html#builtins-fetchTarball) to accomplish this, but they behave in ways that complicate the task of evaluating code in Nixpkgs.
-Nixpkgs provides its own fetchers, which work differently and reduce the time needed to evaluate code in Nixpkgs, as well as allow [Hydra](https://nixos.org/hydra) to retain and re-distribute sources used by Nixpkgs in the [public binary cache](https://cache.nixos.org).
-
-Since the Nixpkgs fetchers work better with Nixpkgs, the Nix built-in fetchers are not allowed in Nixpkgs code.
-
-The differences are explained in this list:
+Nix provides built-in fetchers such as [`builtins.fetchTarball`](https://nixos.org/manual/nix/stable/language/builtins.html#builtins-fetchTarball) to accomplish this.
+Nixpkgs provides its own fetchers, which work differenty:
 
 - A built-in fetcher will download and cache files at evaluation time and produce a [store path](https://nixos.org/manual/nix/stable/glossary#gloss-store-path).
   A Nixpkgs fetcher will create a ([fixed-output](https://nixos.org/manual/nix/stable/glossary#gloss-fixed-output-derivation)) [derivation](https://nixos.org/manual/nix/stable/glossary#gloss-derivation), and files are downloaded at build time.
@@ -16,6 +12,10 @@ The differences are explained in this list:
   Nixpkgs fetchers only re-download if the specified hash changes or the store object is not available.
 - Built-in fetchers do not use [substituters](https://nixos.org/manual/nix/stable/command-ref/conf-file#conf-substituters).
   Derivations produced by Nixpkgs fetchers will use any configured binary cache transparently.
+
+This significantly reduces the time needed to evaluate code in Nixpkgs, as well as allow [Hydra](https://nixos.org/hydra) to retain and re-distribute sources used by Nixpkgs in the [public binary cache](https://cache.nixos.org).
+
+For these reasons, the Nix built-in fetchers are not allowed in Nixpkgs code.
 
 The following table summarizes the differences:
 

--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -14,7 +14,6 @@ Nixpkgs provides its own fetchers, which work differently:
   Derivations produced by Nixpkgs fetchers will use any configured binary cache transparently.
 
 This significantly reduces the time needed to evaluate code in Nixpkgs, and allows [Hydra](https://nixos.org/hydra) to retain and re-distribute sources used by Nixpkgs in the [public binary cache](https://cache.nixos.org).
-
 For these reasons, the Nix built-in fetchers are not allowed in Nixpkgs code.
 
 The following table summarises the differences:

--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -17,7 +17,7 @@ This significantly reduces the time needed to evaluate code in Nixpkgs, and allo
 
 For these reasons, the Nix built-in fetchers are not allowed in Nixpkgs code.
 
-The following table summarizes the differences:
+The following table summarises the differences:
 
 | Fetchers | Download | Output | Cache | Re-download when |
 |-|-|-|-|-|

--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -1,10 +1,10 @@
 # Fetchers {#chap-pkgs-fetchers}
 
 Building software with Nix often requires downloading source code and other files from the internet.
-To do this, we use functions that we call _fetchers_ to obtain remote sources via various protocols and services.
+To this end, we use functions that we call _fetchers_, which obtain remote sources via various protocols and services.
 
-Nix provides built-in fetchers such as [`builtins.fetchTarball`](https://nixos.org/manual/nix/stable/language/builtins.html#builtins-fetchTarball) to accomplish this.
-Nixpkgs provides its own fetchers, which work differenty:
+Nix provides built-in fetchers such as [`builtins.fetchTarball`](https://nixos.org/manual/nix/stable/language/builtins.html#builtins-fetchTarball).
+Nixpkgs provides its own fetchers, which work differently:
 
 - A built-in fetcher will download and cache files at evaluation time and produce a [store path](https://nixos.org/manual/nix/stable/glossary#gloss-store-path).
   A Nixpkgs fetcher will create a ([fixed-output](https://nixos.org/manual/nix/stable/glossary#gloss-fixed-output-derivation)) [derivation](https://nixos.org/manual/nix/stable/glossary#gloss-derivation), and files are downloaded at build time.
@@ -13,7 +13,7 @@ Nixpkgs provides its own fetchers, which work differenty:
 - Built-in fetchers do not use [substituters](https://nixos.org/manual/nix/stable/command-ref/conf-file#conf-substituters).
   Derivations produced by Nixpkgs fetchers will use any configured binary cache transparently.
 
-This significantly reduces the time needed to evaluate code in Nixpkgs, as well as allow [Hydra](https://nixos.org/hydra) to retain and re-distribute sources used by Nixpkgs in the [public binary cache](https://cache.nixos.org).
+This significantly reduces the time needed to evaluate code in Nixpkgs, and allows [Hydra](https://nixos.org/hydra) to retain and re-distribute sources used by Nixpkgs in the [public binary cache](https://cache.nixos.org).
 
 For these reasons, the Nix built-in fetchers are not allowed in Nixpkgs code.
 

--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -13,8 +13,8 @@ Nixpkgs provides its own fetchers, which work differently:
 - Built-in fetchers do not use [substituters](https://nixos.org/manual/nix/stable/command-ref/conf-file#conf-substituters).
   Derivations produced by Nixpkgs fetchers will use any configured binary cache transparently.
 
-This significantly reduces the time needed to evaluate code in Nixpkgs, and allows [Hydra](https://nixos.org/hydra) to retain and re-distribute sources used by Nixpkgs in the [public binary cache](https://cache.nixos.org).
-For these reasons, the Nix built-in fetchers are not allowed in Nixpkgs code.
+This significantly reduces the time needed to evaluate Nixpkgs, and allows [Hydra](https://nixos.org/hydra) to retain and re-distribute sources used by Nixpkgs in the [public binary cache](https://cache.nixos.org).
+For these reasons, Nix's built-in fetchers are not allowed in Nixpkgs.
 
 The following table summarises the differences:
 
@@ -86,7 +86,7 @@ Unless you understand how the fetcher you're using calculates the hash from the 
    - `lib.fakeSha256`
    - `lib.fakeSha512`
 
-   Once you attempt to build, error messages with the calculated hashes will show up, which you then replace in the recipe.
+   Attempt to build, extract the calculated hashes from error messages, and put them into the recipe.
 
    :::{.warning}
    You must use one of these four fake hashes and not some arbitrarily-chosen hash.
@@ -118,7 +118,7 @@ fetchurl {
 ```
 
 **This will produce the same output as before!**
-To determine the new hash, set it to an empty value (it's a fake hash, hence the name of the method):
+Set the hash to an empty string:
 
 ```nix
 { fetchurl }:

--- a/doc/manpage-urls.json
+++ b/doc/manpage-urls.json
@@ -320,5 +320,7 @@
   "login.defs(5)": "https://man.archlinux.org/man/login.defs.5",
   "unshare(1)": "https://man.archlinux.org/man/unshare.1.en",
   "nix-shell(1)": "https://nixos.org/manual/nix/stable/command-ref/nix-shell.html",
-  "mksquashfs(1)": "https://man.archlinux.org/man/extra/squashfs-tools/mksquashfs.1.en"
+  "mksquashfs(1)": "https://man.archlinux.org/man/extra/squashfs-tools/mksquashfs.1.en",
+  "curl(1)": "https://curl.se/docs/manpage.html",
+  "netrc(5)": "https://man.cx/netrc"
 }

--- a/pkgs/README.md
+++ b/pkgs/README.md
@@ -397,7 +397,7 @@ All versions of a package _must_ be included in `all-packages.nix` to make sure 
 
 See the Nixpkgs manual for more details on [standard meta-attributes](https://nixos.org/nixpkgs/manual/#sec-standard-meta-attributes).
 
-### Import From Derivation
+## Import From Derivation
 
 [Import From Derivation](https://nixos.org/manual/nix/unstable/language/import-from-derivation) (IFD) is disallowed in Nixpkgs for performance reasons:
 [Hydra](https://github.com/NixOS/hydra) evaluates the entire package set, and sequential builds during evaluation would increase evaluation times to become impractical.
@@ -406,13 +406,12 @@ Import From Derivation can be worked around in some cases by committing generate
 
 ## Sources
 
-### Fetching Sources
+Always fetch source files using [Nixpkgs fetchers](https://nixos.org/manual/nixpkgs/unstable/#chap-pkgs-fetchers).
+Use reproducible sources with a high degree of availability.
+Currently only [`fetchurl`](https://nixos.org/manual/nixpkgs/unstable/#fetchurl) has mirroring support.
+Prefer protocols that support proxies.
 
-There are multiple ways to fetch a package source in nixpkgs. The general guideline is that you should package reproducible sources with a high degree of availability. Right now there is only one fetcher which has mirroring support and that is `fetchurl`. Note that you should also prefer protocols which have a corresponding proxy environment variable.
-
-You can find many source fetch helpers in `pkgs/build-support/fetch*`.
-
-In the file `pkgs/top-level/all-packages.nix` you can find fetch helpers, these have names on the form `fetchFrom*`. The intention of these are to provide snapshot fetches but using the same api as some of the version controlled fetchers from `pkgs/build-support/`. As an example going from bad to good:
+Examples going from bad to best practices:
 
 - Bad: Uses `git://` which won't be proxied.
 
@@ -438,7 +437,7 @@ In the file `pkgs/top-level/all-packages.nix` you can find fetch helpers, these 
   }
   ```
 
-- Best: Fetches a snapshot archive and you get the rev you want.
+- Best: Fetches a snapshot archive for the given revision.
 
   ```nix
   {
@@ -451,63 +450,14 @@ In the file `pkgs/top-level/all-packages.nix` you can find fetch helpers, these 
   }
   ```
 
-When fetching from GitHub, commits must always be referenced by their full commit hash. This is because GitHub shares commit hashes among all forks and returns `404 Not Found` when a short commit hash is ambiguous. It already happens for some short, 6-character commit hashes in `nixpkgs`.
-It is a practical vector for a denial-of-service attack by pushing large amounts of auto generated commits into forks and was already [demonstrated against GitHub Actions Beta](https://blog.teddykatz.com/2019/11/12/github-actions-dos.html).
+> [!Note]
+> When fetching from GitHub, always reference revisions by their full commit hash.
+> GitHub shares commit hashes among all forks and returns `404 Not Found` when a short commit hash is ambiguous.
+> It already happened in Nixpkgs for short, 6-character commit hashes.
+>
+> Pushing large amounts of auto generated commits into forks is a practical vector for a denial-of-service attack, and was already [demonstrated against GitHub Actions Beta](https://blog.teddykatz.com/2019/11/12/github-actions-dos.html).
 
-Find the value to put as `hash` by running `nix-shell -p nix-prefetch-github --run "nix-prefetch-github --rev 1f795f9f44607cc5bec70d1300150bfefcef2aae NixOS nix"`.
-
-#### Obtaining source hash
-
-Preferred source hash type is sha256. There are several ways to get it.
-
-1. Prefetch URL (with `nix-prefetch-XXX URL`, where `XXX` is one of `url`, `git`, `hg`, `cvs`, `bzr`, `svn`). Hash is printed to stdout.
-
-2. Prefetch by package source (with `nix-prefetch-url '<nixpkgs>' -A PACKAGE.src`, where `PACKAGE` is package attribute name). Hash is printed to stdout.
-
-    This works well when you've upgraded existing package version and want to find out new hash, but is useless if package can't be accessed by attribute or package has multiple sources (`.srcs`, architecture-dependent sources, etc).
-
-3. Upstream provided hash: use it when upstream provides `sha256` or `sha512` (when upstream provides `md5`, don't use it, compute `sha256` instead).
-
-    A little nuance is that `nix-prefetch-*` tools produce hash encoded with `base32`, but upstream usually provides hexadecimal (`base16`) encoding. Fetchers understand both formats. Nixpkgs does not standardize on any one format.
-
-    You can convert between formats with nix-hash, for example:
-
-    ```ShellSession
-    $ nix-hash --type sha256 --to-base32 HASH
-    ```
-
-4. Extracting hash from local source tarball can be done with `sha256sum`. Use `nix-prefetch-url file:///path/to/tarball` if you want base32 hash.
-
-5. Fake hash: set the hash to one of
-
-   - `""`
-   - `lib.fakeHash`
-   - `lib.fakeSha256`
-   - `lib.fakeSha512`
-
-   in the package expression, attempt build and extract correct hash from error messages.
-
-   > [!Warning]
-   > You must use one of these four fake hashes and not some arbitrarily-chosen hash.
-   > See [here][secure-hashes]
-
-   This is last resort method when reconstructing source URL is non-trivial and `nix-prefetch-url -A` isn’t applicable (for example, [one of `kodi` dependencies](https://github.com/NixOS/nixpkgs/blob/d2ab091dd308b99e4912b805a5eb088dd536adb9/pkgs/applications/video/kodi/default.nix#L73)). The easiest way then would be replace hash with a fake one and rebuild. Nix build will fail and error message will contain desired hash.
-
-
-#### Obtaining hashes securely
-[secure-hashes]: #obtaining-hashes-securely
-
-Let's say Man-in-the-Middle (MITM) sits close to your network. Then instead of fetching source you can fetch malware, and instead of source hash you get hash of malware. Here are security considerations for this scenario:
-
-- `http://` URLs are not secure to prefetch hash from;
-
-- hashes from upstream (in method 3) should be obtained via secure protocol;
-
-- `https://` URLs are secure in methods 1, 2, 3;
-
-- `https://` URLs are secure in method 5 *only if* you use one of the listed fake hashes. If you use any other hash, `fetchurl` will pass `--insecure` to `curl` and may then degrade to HTTP in case of TLS certificate expiration.
-
-### Patches
+## Patches
 
 Patches available online should be retrieved using `fetchpatch`.
 

--- a/pkgs/README.md
+++ b/pkgs/README.md
@@ -94,11 +94,7 @@ Now that this is out of the way. To add a package to Nixpkgs:
 
    - All other [`meta`](https://nixos.org/manual/nixpkgs/stable/#chap-meta) attributes are optional, but it’s still a good idea to provide at least the `description`, `homepage` and [`license`](https://nixos.org/manual/nixpkgs/stable/#sec-meta-license).
 
-   - You can use `nix-prefetch-url url` to get the SHA-256 hash of source distributions. There are similar commands as `nix-prefetch-git` and `nix-prefetch-hg` available in `nix-prefetch-scripts` package.
-
-   - A list of schemes for `mirror://` URLs can be found in [`pkgs/build-support/fetchurl/mirrors.nix`](build-support/fetchurl/mirrors.nix).
-
-   The exact syntax and semantics of the Nix expression language, including the built-in function, are [described in the Nix manual](https://nixos.org/manual/nix/stable/language/).
+   - The exact syntax and semantics of the Nix expression language, including the built-in functions, are [Nix language reference](https://nixos.org/manual/nix/stable/language/).
 
 5. To test whether the package builds, run the following command from the root of the nixpkgs source tree:
 
@@ -408,8 +404,12 @@ Import From Derivation can be worked around in some cases by committing generate
 
 Always fetch source files using [Nixpkgs fetchers](https://nixos.org/manual/nixpkgs/unstable/#chap-pkgs-fetchers).
 Use reproducible sources with a high degree of availability.
-Currently only [`fetchurl`](https://nixos.org/manual/nixpkgs/unstable/#fetchurl) has mirroring support.
 Prefer protocols that support proxies.
+
+Currently only [`fetchurl`](https://nixos.org/manual/nixpkgs/unstable/#fetchurl) has mirroring support.
+A list of schemes for `mirror://` URLs can be found in [`pkgs/build-support/fetchurl/mirrors.nix`](build-support/fetchurl/mirrors.nix).
+
+The preferred source hash type is `sha256`.
 
 Examples going from bad to best practices:
 

--- a/pkgs/README.md
+++ b/pkgs/README.md
@@ -406,8 +406,8 @@ Always fetch source files using [Nixpkgs fetchers](https://nixos.org/manual/nixp
 Use reproducible sources with a high degree of availability.
 Prefer protocols that support proxies.
 
-Currently only [`fetchurl`](https://nixos.org/manual/nixpkgs/unstable/#fetchurl) has mirroring support.
-A list of schemes for `mirror://` URLs can be found in [`pkgs/build-support/fetchurl/mirrors.nix`](build-support/fetchurl/mirrors.nix).
+A list of schemes for `mirror://` URLs can be found in [`pkgs/build-support/fetchurl/mirrors.nix`](build-support/fetchurl/mirrors.nix), and is supported by [`fetchurl`](https://nixos.org/manual/nixpkgs/unstable/#fetchurl).
+Other fetchers which end up relying on `fetchurl` may also support mirroring.
 
 The preferred source hash type is `sha256`.
 


### PR DESCRIPTION
## Description of changes

This PR starts my work to update and improve the chapter on fetchers in the Nixpkgs manual. It adds more explanations on the overview of the chapter, moves content from the contributor README into the manual, and deduplicates information.

**NOTE:** this PR started as a change of the fetchers overview AND updating the documentation for `fetchurl`. After a lot of reviewing, we decided to split this PR into two. The PR concerns the description above. The second PR is #300429 and concerns only with updating the documentation for `fetchurl`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
