### PR TITLE
stog: 0.20.0 → 1.0.0

### DIFF
--- a/pkgs/applications/misc/stog/asy.nix
+++ b/pkgs/applications/misc/stog/asy.nix
@@ -1,0 +1,14 @@
+{ buildDunePackage, stog, ocf_ppx }:
+
+buildDunePackage {
+  pname = "stog_asy";
+
+  inherit (stog) version src;
+
+  buildInputs = [ ocf_ppx ];
+  propagatedBuildInputs = [ stog ];
+
+  meta = stog.meta // {
+    description = "Stog plugin to include Asymptote results in documents";
+  };
+}

--- a/pkgs/applications/misc/stog/default.nix
+++ b/pkgs/applications/misc/stog/default.nix
@@ -1,28 +1,18 @@
-{ lib, buildDunePackage, fetchFromGitLab, fetchpatch, ocaml
+{ lib, buildDunePackage, fetchFromGitLab
 , fmt, lwt_ppx, menhir, ocf_ppx, ppx_blob, xtmpl_ppx
 , dune-build-info, dune-site, higlo, logs, lwt, ocf, ptime, uri, uutf, xtmpl
 }:
 
-if lib.versionAtLeast ocaml.version "4.13"
-then throw "stog is not available for OCaml ${ocaml.version}"
-else
-
 buildDunePackage rec {
   pname = "stog";
-  version = "0.20.0";
-  minimalOCamlVersion = "4.12";
+  version = "1.0.0";
+  minimalOCamlVersion = "4.13";
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = "zoggy";
     repo = "stog";
     rev = version;
-    sha256 = "sha256:0krj5w4y05bcfx7hk9blmap8avl31gp7yi01lpqzs6ync23mvm0x";
-  };
-
-  # Compatibility with higlo 0.9
-  patches = fetchpatch {
-    url = "https://framagit.org/zoggy/stog/-/commit/ea0546ab4cda8cc5c4c820ebaf2e3dfddc2ab101.patch";
-    hash = "sha256-86GRHF9OjfcalGfA0Om2wXH99j4THCs9a4+o5ghuiJc=";
+    hash = "sha256-hMb6D6VSq2o2NjycwxZt3mZKy1FR+3afEwbOmTc991g=";
   };
 
   nativeBuildInputs = [ menhir ];

--- a/pkgs/applications/misc/stog/markdown.nix
+++ b/pkgs/applications/misc/stog/markdown.nix
@@ -1,0 +1,15 @@
+{ buildDunePackage, stog, ocf_ppx, omd }:
+
+buildDunePackage {
+  pname = "stog_markdown";
+
+  inherit (stog) version src;
+
+  buildInputs = [ ocf_ppx ];
+  propagatedBuildInputs = [ omd stog ];
+
+  meta = stog.meta // {
+    description = "Stog plugin to use markdown syntax";
+  };
+}
+

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -34909,7 +34909,7 @@ with pkgs;
 
   stalonetray = callPackage ../applications/window-managers/stalonetray { };
 
-  inherit (ocaml-ng.ocamlPackages_4_12) stog;
+  inherit (ocaml-ng.ocamlPackages) stog;
 
   stp = callPackage ../applications/science/logic/stp { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1724,6 +1724,7 @@ let
     stdune = callPackage ../development/ocaml-modules/stdune { };
 
     stog = callPackage ../applications/misc/stog { };
+    stog_asy = callPackage ../applications/misc/stog/asy.nix { };
 
     stringext = callPackage ../development/ocaml-modules/stringext { };
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1725,6 +1725,7 @@ let
 
     stog = callPackage ../applications/misc/stog { };
     stog_asy = callPackage ../applications/misc/stog/asy.nix { };
+    stog_markdown = callPackage ../applications/misc/stog/markdown.nix { };
 
     stringext = callPackage ../development/ocaml-modules/stringext { };
 


### PR DESCRIPTION
## Description of changes

https://www.good-eris.net/stog/posts/release-1.0.0.html

cc maintainer @thufschmitt

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
