### PR TITLE
openfga: init at 1.5.1, openfga-cli: init at 0.3.0

### DIFF
--- a/pkgs/by-name/op/openfga-cli/package.nix
+++ b/pkgs/by-name/op/openfga-cli/package.nix
@@ -1,0 +1,57 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+, testers
+, openfga-cli
+}:
+
+buildGoModule rec {
+  pname = "openfga-cli";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "openfga";
+    repo = "cli";
+    rev = "v${version}";
+    hash = "sha256-bRDaUPWzCGRV824ncx6G/+kx66XRcLiui6h22qWDEYk=";
+  };
+
+  vendorHash = "sha256-WCFNO1mign4u0dnvGs7qQcXUFB29zC6bjRiPVXNC30M=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/openfga/cli/internal/build.Version=${version}"
+    "-X=github.com/openfga/cli/internal/build.Commit=${src.rev}"
+    "-X=github.com/openfga/cli/internal/build.Date="
+  ];
+
+  subPackages = [ "cmd/fga" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installShellCompletion --cmd fga \
+      --bash <($out/bin/fga completion bash) \
+      --fish <($out/bin/fga completion fish) \
+      --zsh <($out/bin/fga completion zsh)
+  '';
+
+  passthru.tests = {
+    version = testers.testVersion {
+      package = openfga-cli;
+      version = src.rev;
+      command = "fga version";
+    };
+  };
+
+  meta = with lib; {
+    description = "A cross-platform CLI to interact with an OpenFGA server";
+    homepage = "https://github.com/openfga/cli";
+    changelog = "https://github.com/openfga/cli/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ gaelreyrol ];
+    mainProgram = "fga";
+  };
+}

--- a/pkgs/by-name/op/openfga/package.nix
+++ b/pkgs/by-name/op/openfga/package.nix
@@ -1,0 +1,59 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, installShellFiles
+, testers
+, openfga
+}:
+
+buildGoModule rec {
+  pname = "openfga";
+  version = "1.5.1";
+
+  src = fetchFromGitHub {
+    owner = "openfga";
+    repo = "openfga";
+    rev = "v${version}";
+    hash = "sha256-R/KW3TeVhQtlg16ShCsQhXXnzlFA2PoLbFIRQWWmkFM=";
+  };
+
+  vendorHash = "sha256-9stk91Ga5hTKXvLxBmmBf5ShtEEXxO+ZEAt8Nb5YPcA=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/openfga/openfga/internal/build.Version=v${version}"
+    "-X=github.com/openfga/openfga/internal/build.Commit=${src.rev}"
+    "-X=github.com/openfga/openfga/internal/build.Date="
+    "-X=github.com/openfga/openfga/internal/build.ProjectName=${pname}"
+  ];
+
+
+  subPackages = [ "cmd/openfga" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = ''
+    installShellCompletion --cmd openfga \
+      --bash <($out/bin/openfga completion bash) \
+      --fish <($out/bin/openfga completion fish) \
+      --zsh <($out/bin/openfga completion zsh)
+  '';
+
+  passthru.tests = {
+    version = testers.testVersion {
+      package = openfga;
+      version = src.rev;
+      command = "openfga version";
+    };
+  };
+
+  meta = with lib; {
+    description = "A high performance and flexible authorization/permission engine built for developers and inspired by Google Zanzibar";
+    homepage = "https://github.com/openfga/openfga";
+    changelog = "https://github.com/openfga/openfga/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ gaelreyrol ];
+    mainProgram = "openfga";
+  };
+}


### PR DESCRIPTION
## Description of changes

This PR adds two new packages:
- openfga: https://github.com/openfga/openfga
- openfga-cli: https://github.com/openfga/cli

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
