### PR TITLE
electrum: update.nix - download files to temp folder and allow update for tests hash

### DIFF
--- a/pkgs/applications/misc/electrum/default.nix
+++ b/pkgs/applications/misc/electrum/default.nix
@@ -42,16 +42,12 @@ let
     else "libzbar${stdenv.hostPlatform.extensions.sharedLibrary}";
 
   # Not provided in official source releases, which are what upstream signs.
+  githash = "sha256-baMCeJlsC1C9S2lSolKk3oOFTGNRffTUO3yLluXrp+c=";
   tests = fetchFromGitHub {
     owner = "spesmilo";
     repo = "electrum";
     rev = version;
-    sha256 = "sha256-fDu2PlEQOF7ftlS6dYw15S2XiAx+D/bng4zC9ELj6uk=";
-
-    postFetch = ''
-      mv $out ./all
-      mv ./all/tests $out
-    '';
+    hash = githash;
   };
 
 in
@@ -62,12 +58,12 @@ python.pkgs.buildPythonApplication {
 
   src = fetchurl {
     url = "https://download.electrum.org/${version}/Electrum-${version}.tar.gz";
-    sha256 = "sha256-lDuwXhOjcbCx8x/oIoigrklDwCbhn1trf5lDf/X/1Qc=";
+    hash = "sha256-lDuwXhOjcbCx8x/oIoigrklDwCbhn1trf5lDf/X/1Qc=";
   };
 
   postUnpack = ''
     # can't symlink, tests get confused
-    cp -ar ${tests} $sourceRoot/tests
+    cp -ar "${tests}/tests" $sourceRoot/tests
   '';
 
   nativeBuildInputs = lib.optionals enableQt [ wrapQtAppsHook ];

--- a/pkgs/applications/misc/electrum/update.nix
+++ b/pkgs/applications/misc/electrum/update.nix
@@ -47,6 +47,11 @@ export PATH=${lib.makeBinPath [
   nix
 ]}
 
+# Download files to a temp directory
+tmpdir=$(mktemp -d --tmpdir electrum-update-XXXX)
+pushd "$tmpdir"
+trap 'rm -r -- "$tmpdir"' EXIT
+
 version=$(curl -L --list-only -- '${downloadPageUrl}' \
     | grep -Po '<a href="\K([[:digit:]]+\.?)+' \
     | sort -Vu \
@@ -69,5 +74,6 @@ gpg --batch --verify "$sigFile" "$srcFile"
 
 sha256=$(nix-prefetch-url --type sha256 "file://$PWD/$srcFile")
 
+popd
 update-source-version electrum "$version" "$sha256"
 ''


### PR DESCRIPTION
## Description of changes

1. `update.nix` for `electrum` currently downloads files to the nixpkgs git directory, which have to be manually removed before committing. The first commit changes this by downloading to a temp folder instead.

2. `update.nix` currently only updates the hash for the `Electrum-${version}.tar.gz` downloaded from `electrum.org` and not the github hash needed for tests. The 2nd commit adds a few lines to the `update.nix` script to do this automatically. To make this easier I created a new variable in `default.nix` called `githash` to contain the hash for the git repo. 
In `default.nix` I had to remove the `postFetch` lines from `tests` which were meant to delete everything from the git download except the `tests` folder. This is because these lines change the hash value nix computes, so there is no easy way of pre-computing the hash programatically in the update script. To compensate for this I changed the line ` cp -ar "${tests}" $sourceRoot/tests` to  `cp -ar "${tests}/tests" $sourceRoot/tests`.

### To test changes
To test the `update.nix` script revert `...electrum/default.nix` to version `4.5.3` by manually changing the following lines:

```
16: version = "4.5.3";
45: githash = "sha256-+iVqp7tOdIoVVKDEQoU4/YWTOGX/72fD5e1OCWd7DH0=";
61: hash = "sha256-kej0msc7SB+51ad5xZrT8MMEY5rfYOGqum6RO1gBH5s=";
```
Then run `nix-update -u electrum` in the root of your nixpkgs git folder. If all is well it should return the message `No changes detected, skipping remaining steps` since our "update" just reverts the file to it's prior commit state (4.5.4). Obviously in an actual update this message wouldn't be displayed. Also there should be no files downloaded to the nixpkgs git folder.


Finally test that the updated file actually builds with `nix-build -A electrum`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
