### PR TITLE
jetbrains: fix JRE configuration for devcontainer development

### DIFF
--- a/pkgs/applications/editors/jetbrains/bin/linux.nix
+++ b/pkgs/applications/editors/jetbrains/bin/linux.nix
@@ -102,6 +102,9 @@ with stdenv; lib.makeOverridable mkDerivation (rec {
     jdk=${jdk.home}
     item=${desktopItem}
 
+    # Jetbrains Remote Client is downloaded at invocation time and is unaware of Nix environment.
+    # Most downloads (after 2024.03.20) use JETBRAINS_CLIENT_JDK instead of JETBRAINSCLIENT_JDK,
+    # export both variants to be on safe side.
     wrapProgram  "$out/$pname/bin/${loName}.sh" \
       --prefix PATH : "${lib.makeBinPath [ jdk coreutils gnugrep which git ]}" \
       --suffix PATH : "${lib.makeBinPath [ python3 ]}" \
@@ -111,6 +114,7 @@ with stdenv; lib.makeOverridable mkDerivation (rec {
       --set-default ANDROID_JAVA_HOME "$jdk" \
       --set-default JAVA_HOME "$jdk" \
       --set-default JETBRAINSCLIENT_JDK "$jdk" \
+      --set-default JETBRAINS_CLIENT_JDK "$jdk" \
       --set-default ${hiName}_JDK "$jdk" \
       --set-default ${hiName}_VM_OPTIONS ${vmoptsFile}
 


### PR DESCRIPTION
## Description of changes
Jetbrains IDEs download the remote client GUI on each invocation. This client is not patched for Nix and includes its own JDK.  JDK selection can be overridden through environment variable (to a Nix patched version).

Previously this was done with `JETBRAINSCLIENT_JDK`, now it should be done with `JETBRAINS_CLIENT_JDK`.

See previous PR #195132.

Without this change when trying to start a devcontainer session with either IntelliJ Ultimate or Jetbrains Gateway fails due to attempting to invoke the internally bundled JRE.

## Things done

Set `JETBRAINS_CLIENT_JDK` in addition to `JETBRAINSCLIENT_JDK` to preserve inconsistent behaviour of downloaded clients.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

Manually tested with the following environment:

```
nix-shell -I nixpkgs=$NIXPKGS -p jetbrains.gateway -p jetbrains.idea-ultimate 
```

Checked that IntelliJ Ultimate and Jetbrains Gateway is able to start a devcontainer for the Jetbrains sample project and author's own Go based projects.

Using following script to check environment variables were set as expected:
```
cat /proc/$(pgrep -f JetBrainsClient)/environ | xargs -0 -n1 echo | grep  JDK
JDK_HOME=/nix/store/a9hjq76qi7acm4pfi928ih7z70d5bndj-jetbrains-jdk-jcef-17.0.8-b1000.8/lib/openjdk
IDEA_JDK=/nix/store/a9hjq76qi7acm4pfi928ih7z70d5bndj-jetbrains-jdk-jcef-17.0.8-b1000.8/lib/openjdk
JETBRAINSCLIENT_JDK=/nix/store/a9hjq76qi7acm4pfi928ih7z70d5bndj-jetbrains-jdk-jcef-17.0.8-b1000.8/lib/openjdk
JETBRAINS_CLIENT_JDK=/nix/store/a9hjq76qi7acm4pfi928ih7z70d5bndj-jetbrains-jdk-jcef-17.0.8-b1000.8/lib/openjdk
```
