### PR TITLE
python3Packages.simplicial: init at 1.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2453,6 +2453,12 @@
     github = "benwis";
     githubId = 6953353;
   };
+  berber = {
+    name = "Berthold Blatt Lorke";
+    email = "berber@zmberber.com";
+    github = "zmberber";
+    githubId = 29400525;
+  };
   berberman = {
     email = "berberman@yandex.com";
     matrix = "@berberman:mozilla.org";

--- a/pkgs/development/python-modules/simplicial/default.nix
+++ b/pkgs/development/python-modules/simplicial/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+, wheel
+, matplotlib
+, numpy
+, pytestCheckHook
+}:
+
+buildPythonPackage rec {
+  pname = "simplicial";
+  version = "1.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "simoninireland";
+    repo = "simplicial";
+    rev = "v${version}";
+    hash = "sha256-o9YoswTthqW+xMrIrSMscRPnqz9A0EGQMXlbuIZ0OWE=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+    pytestCheckHook
+  ];
+
+  propagatedBuildInputs = [
+    matplotlib
+    numpy
+  ];
+
+  pythonImportsCheck = [ "simplicial" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/simoninireland/simplicial/blob/v${version}/HISTORY";
+    description = "Simplicial topology in Python";
+    homepage = "https://github.com/simoninireland/simplicial";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ berber ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13634,6 +13634,8 @@ self: super: with self; {
 
   simple-websocket-server = callPackage ../development/python-modules/simple-websocket-server { };
 
+  simplicial = callPackage ../development/python-modules/simplicial { };
+
   simplisafe-python = callPackage ../development/python-modules/simplisafe-python { };
 
   simpful = callPackage ../development/python-modules/simpful { };


### PR DESCRIPTION
## Description of changes

- New Maintainer:  `berber`
- New Python package [`simplicial`](https://pypi.org/project/simplicial/)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
