### PR TITLE
sketchybar-app-font: 2.0.12 -> 2.0.16, add meta.passthru.updateScript and include additional artifacts

### DIFF
--- a/pkgs/data/fonts/sketchybar-app-font/default.nix
+++ b/pkgs/data/fonts/sketchybar-app-font/default.nix
@@ -4,64 +4,88 @@ in
 { lib
 , stdenvNoCC
 , fetchurl
+, common-updater-scripts
+, curl
+, jq
+, writeShellScript
 , artifactList ? artifacts
 }:
-let
-  pname = "sketchybar-app-font";
-  version = "2.0.15";
-
-  selectedSources = map (themeName: builtins.getAttr themeName sources) artifactList;
-  sources = {
-    font = fetchurl {
-      url = "https://github.com/kvndrsslr/sketchybar-app-font/releases/download/v${version}/sketchybar-app-font.ttf";
-      hash = "sha256-s1mnoHEozmDNsW0P4z97fupAVElxikia0TYLVHJPAM4=";
-    };
-    lua = fetchurl {
-      url = "https://github.com/kvndrsslr/sketchybar-app-font/releases/download/v${version}/icon_map.lua";
-      hash = "sha256-YLr7dlKliKLUEK18uG4ouXfLqodVpcDQzfu+H1+oe/w=";
-    };
-    shell = fetchurl {
-      url = "https://github.com/kvndrsslr/sketchybar-app-font/releases/download/v${version}/icon_map.sh";
-      hash = "sha256-ZT/k6Vk/nO6mq1yplXaWyz9HxqwEiVWba+rk+pIRZq4=";
-    };
-  };
-in
-lib.checkListOfEnum "${pname}: artifacts" artifacts artifactList
+lib.checkListOfEnum "sketchybar-app-font: artifacts" artifacts artifactList
   stdenvNoCC.mkDerivation
-{
-  inherit pname version;
+  (finalAttrs:
+  let
+    selectedSources = map (artifact: builtins.getAttr artifact finalAttrs.passthru.sources) artifactList;
+  in
+  {
+    pname = "sketchybar-app-font";
+    version = "2.0.15";
 
-  srcs = selectedSources;
+    srcs = selectedSources;
 
-  unpackPhase = ''
-    for s in $selectedSources; do
-      b=$(basename $s)
-      cp $s ''${b#*-}
-    done
-  '';
+    unpackPhase = ''
+      runHook preUnpack
 
-  installPhase = ''
-    runHook preInstall
+      for s in $selectedSources; do
+        b=$(basename $s)
+        cp $s ''${b#*-}
+      done
 
-  '' + lib.optionalString (lib.elem "font" artifactList) ''
-    install -Dm644 ${sources.font} "$out/share/fonts/truetype/sketchybar-app-font.ttf"
-
-  '' + lib.optionalString (lib.elem "shell" artifactList) ''
-    install -Dm755 ${sources.shell} "$out/bin/icon_map.sh"
-
-  '' + lib.optionalString (lib.elem "lua" artifactList) ''
-    install -Dm644 ${sources.lua} "$out/lib/${pname}/icon_map.lua"
-
-    runHook postInstall
-  '';
-
-  meta = {
-    description = "A ligature-based symbol font and a mapping function for sketchybar";
-    longDescription = ''
-      A ligature-based symbol font and a mapping function for sketchybar, inspired by simple-bar's usage of community-contributed minimalistic app icons.
+      runHook postUnpack
     '';
-    homepage = "https://github.com/kvndrsslr/sketchybar-app-font";
-    license = lib.licenses.cc0;
-    maintainers = with lib.maintainers; [ khaneliman ];
-  };
-}
+
+    installPhase = ''
+      runHook preInstall
+
+    '' + lib.optionalString (lib.elem "font" artifactList) ''
+      install -Dm644 ${finalAttrs.passthru.sources.font} "$out/share/fonts/truetype/sketchybar-app-font.ttf"
+
+    '' + lib.optionalString (lib.elem "shell" artifactList) ''
+      install -Dm755 ${finalAttrs.passthru.sources.shell} "$out/bin/icon_map.sh"
+
+    '' + lib.optionalString (lib.elem "lua" artifactList) ''
+      install -Dm644 ${finalAttrs.passthru.sources.lua} "$out/lib/sketchybar-app-font/icon_map.lua"
+
+      runHook postInstall
+    '';
+
+    passthru = {
+      sources = {
+        font = fetchurl {
+          url = "https://github.com/kvndrsslr/sketchybar-app-font/releases/download/v${finalAttrs.version}/sketchybar-app-font.ttf";
+          hash = "sha256-s1mnoHEozmDNsW0P4z97fupAVElxikia0TYLVHJPAM4=";
+        };
+        lua = fetchurl {
+          url = "https://github.com/kvndrsslr/sketchybar-app-font/releases/download/v${finalAttrs.version}/icon_map.lua";
+          hash = "sha256-YLr7dlKliKLUEK18uG4ouXfLqodVpcDQzfu+H1+oe/w=";
+        };
+        shell = fetchurl {
+          url = "https://github.com/kvndrsslr/sketchybar-app-font/releases/download/v${finalAttrs.version}/icon_map.sh";
+          hash = "sha256-ZT/k6Vk/nO6mq1yplXaWyz9HxqwEiVWba+rk+pIRZq4=";
+        };
+      };
+
+      updateScript = writeShellScript "update-sketchybar-app-font" ''
+        set -o errexit
+        export PATH="${lib.makeBinPath [ curl jq common-updater-scripts ]}"
+        NEW_VERSION=$(curl --silent https://api.github.com/repos/kvndrsslr/sketchybar-app-font/releases/latest | jq '.tag_name | ltrimstr("v")' --raw-output)
+        if [[ "${finalAttrs.version}" = "$NEW_VERSION" ]]; then
+            echo "The new version same as the old version."
+            exit 0
+        fi
+        for artifact in ${lib.escapeShellArgs (lib.mapAttrsToList(a: _: a) finalAttrs.passthru.sources)}; do
+          update-source-version "sketchybar-app-font" "0" "${lib.fakeHash}" --source-key="sources.$artifact"
+          update-source-version "sketchybar-app-font" "$NEW_VERSION" --source-key="sources.$artifact"
+        done
+      '';
+    };
+
+    meta = {
+      description = "A ligature-based symbol font and a mapping function for sketchybar";
+      longDescription = ''
+        A ligature-based symbol font and a mapping function for sketchybar, inspired by simple-bar's usage of community-contributed minimalistic app icons.
+      '';
+      homepage = "https://github.com/kvndrsslr/sketchybar-app-font";
+      license = lib.licenses.cc0;
+      maintainers = with lib.maintainers; [ khaneliman ];
+    };
+  })

--- a/pkgs/data/fonts/sketchybar-app-font/default.nix
+++ b/pkgs/data/fonts/sketchybar-app-font/default.nix
@@ -8,13 +8,13 @@ in
 }:
 let
   pname = "sketchybar-app-font";
-  version = "2.0.14";
+  version = "2.0.15";
 
   selectedSources = map (themeName: builtins.getAttr themeName sources) artifactList;
   sources = {
     font = fetchurl {
       url = "https://github.com/kvndrsslr/sketchybar-app-font/releases/download/v${version}/sketchybar-app-font.ttf";
-      hash = "sha256-lGzNLBtM+1Cl9tTB4yKkc46ZqDjyt8J0EPNTM/eAziY=";
+      hash = "sha256-s1mnoHEozmDNsW0P4z97fupAVElxikia0TYLVHJPAM4=";
     };
     lua = fetchurl {
       url = "https://github.com/kvndrsslr/sketchybar-app-font/releases/download/v${version}/icon_map.lua";

--- a/pkgs/data/fonts/sketchybar-app-font/default.nix
+++ b/pkgs/data/fonts/sketchybar-app-font/default.nix
@@ -18,7 +18,7 @@ lib.checkListOfEnum "sketchybar-app-font: artifacts" artifacts artifactList
   in
   {
     pname = "sketchybar-app-font";
-    version = "2.0.15";
+    version = "2.0.16";
 
     srcs = selectedSources;
 
@@ -52,15 +52,15 @@ lib.checkListOfEnum "sketchybar-app-font: artifacts" artifacts artifactList
       sources = {
         font = fetchurl {
           url = "https://github.com/kvndrsslr/sketchybar-app-font/releases/download/v${finalAttrs.version}/sketchybar-app-font.ttf";
-          hash = "sha256-s1mnoHEozmDNsW0P4z97fupAVElxikia0TYLVHJPAM4=";
+          hash = "sha256-mZ3LmkL54NNQzXuCyWVNlAIod3T5/aGKvnLZjZ/GYdw=";
         };
         lua = fetchurl {
           url = "https://github.com/kvndrsslr/sketchybar-app-font/releases/download/v${finalAttrs.version}/icon_map.lua";
-          hash = "sha256-YLr7dlKliKLUEK18uG4ouXfLqodVpcDQzfu+H1+oe/w=";
+          hash = "sha256-8daDECZ8hsoyh4Rp3xbkYgPSamCylrzf8zzyu/iwZEc=";
         };
         shell = fetchurl {
           url = "https://github.com/kvndrsslr/sketchybar-app-font/releases/download/v${finalAttrs.version}/icon_map.sh";
-          hash = "sha256-ZT/k6Vk/nO6mq1yplXaWyz9HxqwEiVWba+rk+pIRZq4=";
+          hash = "sha256-h0rGkzy1smDL2guvvgeUVUD0q4n9LDKDLQJahbWHgWA=";
         };
       };
 


### PR DESCRIPTION
Also added icon_map.sh and icon_map.lua artifacts

## Description of changes
https://github.com/kvndrsslr/sketchybar-app-font/releases/tag/v2.0.13
https://github.com/kvndrsslr/sketchybar-app-font/releases/tag/v2.0.14
https://github.com/kvndrsslr/sketchybar-app-font/releases/tag/v2.0.15
https://github.com/kvndrsslr/sketchybar-app-font/releases/tag/v2.0.16
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
