### PR TITLE
systemd: add a name option to all systemd units

### DIFF
--- a/nixos/lib/systemd-lib.nix
+++ b/nixos/lib/systemd-lib.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs }:
+{ config, lib, pkgs, utils }:
 
 let
   inherit (lib)
@@ -381,8 +381,41 @@ in rec {
     };
   };
 
-  serviceConfig = { config, ... }: {
-    config.environment.PATH = mkIf (config.path != []) "${makeBinPath config.path}:${makeSearchPathOutput "bin" "sbin" config.path}";
+  serviceConfig = { name, config, ... }: {
+    config = {
+      name = "${name}.service";
+      environment.PATH = mkIf (config.path != []) "${makeBinPath config.path}:${makeSearchPathOutput "bin" "sbin" config.path}";
+    };
+  };
+
+  pathConfig = { name, config, ... }: {
+    config = {
+      name = "${name}.path";
+    };
+  };
+
+  socketConfig = { name, config, ... }: {
+    config = {
+      name = "${name}.socket";
+    };
+  };
+
+  sliceConfig = { name, config, ... }: {
+    config = {
+      name = "${name}.slice";
+    };
+  };
+
+  targetConfig = { name, config, ... }: {
+    config = {
+      name = "${name}.target";
+    };
+  };
+
+  timerConfig = { name, config, ... }: {
+    config = {
+      name = "${name}.timer";
+    };
   };
 
   stage2ServiceConfig = {
@@ -401,6 +434,7 @@ in rec {
 
   mountConfig = { config, ... }: {
     config = {
+      name = "${utils.escapeSystemdPath config.where}.mount";
       mountConfig =
         { What = config.what;
           Where = config.where;
@@ -414,6 +448,7 @@ in rec {
 
   automountConfig = { config, ... }: {
     config = {
+      name = "${utils.escapeSystemdPath config.where}.automount";
       automountConfig =
         { Where = config.where;
         };
@@ -429,8 +464,8 @@ in rec {
       WantedBy=${concatStringsSep " " def.wantedBy}
     '';
 
-  targetToUnit = name: def:
-    { inherit (def) aliases wantedBy requiredBy upheldBy enable overrideStrategy;
+  targetToUnit = def:
+    { inherit (def) name aliases wantedBy requiredBy upheldBy enable overrideStrategy;
       text =
         ''
           [Unit]
@@ -438,8 +473,8 @@ in rec {
         '';
     };
 
-  serviceToUnit = name: def:
-    { inherit (def) aliases wantedBy requiredBy upheldBy enable overrideStrategy;
+  serviceToUnit = def:
+    { inherit (def) name aliases wantedBy requiredBy upheldBy enable overrideStrategy;
       text = commonUnitText def (''
         [Service]
       '' + (let env = cfg.globalEnvironment // def.environment;
@@ -448,7 +483,7 @@ in rec {
             "Environment=${toJSON "${n}=${env.${n}}"}\n";
           # systemd max line length is now 1MiB
           # https://github.com/systemd/systemd/commit/e6dde451a51dc5aaa7f4d98d39b8fe735f73d2af
-          in if stringLength s >= 1048576 then throw "The value of the environment variable ‘${n}’ in systemd service ‘${name}.service’ is too long." else s) (attrNames env))
+          in if stringLength s >= 1048576 then throw "The value of the environment variable ‘${n}’ in systemd service ‘${def.name}.service’ is too long." else s) (attrNames env))
       + (if def ? reloadIfChanged && def.reloadIfChanged then ''
         X-ReloadIfChanged=true
       '' else if (def ? restartIfChanged && !def.restartIfChanged) then ''
@@ -459,8 +494,8 @@ in rec {
       '' + attrsToSection def.serviceConfig);
     };
 
-  socketToUnit = name: def:
-    { inherit (def) aliases wantedBy requiredBy upheldBy enable overrideStrategy;
+  socketToUnit = def:
+    { inherit (def) name aliases wantedBy requiredBy upheldBy enable overrideStrategy;
       text = commonUnitText def ''
         [Socket]
         ${attrsToSection def.socketConfig}
@@ -469,40 +504,40 @@ in rec {
       '';
     };
 
-  timerToUnit = name: def:
-    { inherit (def) aliases wantedBy requiredBy upheldBy enable overrideStrategy;
+  timerToUnit = def:
+    { inherit (def) name aliases wantedBy requiredBy upheldBy enable overrideStrategy;
       text = commonUnitText def ''
         [Timer]
         ${attrsToSection def.timerConfig}
       '';
     };
 
-  pathToUnit = name: def:
-    { inherit (def) aliases wantedBy requiredBy upheldBy enable overrideStrategy;
+  pathToUnit = def:
+    { inherit (def) name aliases wantedBy requiredBy upheldBy enable overrideStrategy;
       text = commonUnitText def ''
         [Path]
         ${attrsToSection def.pathConfig}
       '';
     };
 
-  mountToUnit = name: def:
-    { inherit (def) aliases wantedBy requiredBy upheldBy enable overrideStrategy;
+  mountToUnit = def:
+    { inherit (def) name aliases wantedBy requiredBy upheldBy enable overrideStrategy;
       text = commonUnitText def ''
         [Mount]
         ${attrsToSection def.mountConfig}
       '';
     };
 
-  automountToUnit = name: def:
-    { inherit (def) aliases wantedBy requiredBy upheldBy enable overrideStrategy;
+  automountToUnit = def:
+    { inherit (def) name aliases wantedBy requiredBy upheldBy enable overrideStrategy;
       text = commonUnitText def ''
         [Automount]
         ${attrsToSection def.automountConfig}
       '';
     };
 
-  sliceToUnit = name: def:
-    { inherit (def) aliases wantedBy requiredBy upheldBy enable overrideStrategy;
+  sliceToUnit = def:
+    { inherit (def) name aliases wantedBy requiredBy upheldBy enable overrideStrategy;
       text = commonUnitText def ''
         [Slice]
         ${attrsToSection def.sliceConfig}

--- a/nixos/lib/systemd-types.nix
+++ b/nixos/lib/systemd-types.nix
@@ -5,8 +5,13 @@ let
     automountConfig
     makeUnit
     mountConfig
+    pathConfig
+    sliceConfig
+    socketConfig
     stage1ServiceConfig
     stage2ServiceConfig
+    targetConfig
+    timerConfig
     unitConfig
     ;
 
@@ -48,29 +53,32 @@ let
     ;
 in
 
-rec {
+{
   units = attrsOf (submodule ({ name, config, ... }: {
     options = concreteUnitOptions;
-    config = { unit = mkDefault (makeUnit name config); };
+    config = {
+      name = mkDefault name;
+      unit = mkDefault (makeUnit name config);
+    };
   }));
 
   services = attrsOf (submodule [ stage2ServiceOptions unitConfig stage2ServiceConfig ]);
   initrdServices = attrsOf (submodule [ stage1ServiceOptions unitConfig stage1ServiceConfig ]);
 
-  targets = attrsOf (submodule [ stage2CommonUnitOptions unitConfig ]);
-  initrdTargets = attrsOf (submodule [ stage1CommonUnitOptions unitConfig ]);
+  targets = attrsOf (submodule [ stage2CommonUnitOptions unitConfig targetConfig ]);
+  initrdTargets = attrsOf (submodule [ stage1CommonUnitOptions unitConfig targetConfig ]);
 
-  sockets = attrsOf (submodule [ stage2SocketOptions unitConfig ]);
-  initrdSockets = attrsOf (submodule [ stage1SocketOptions unitConfig ]);
+  sockets = attrsOf (submodule [ stage2SocketOptions unitConfig socketConfig]);
+  initrdSockets = attrsOf (submodule [ stage1SocketOptions unitConfig socketConfig ]);
 
-  timers = attrsOf (submodule [ stage2TimerOptions unitConfig ]);
-  initrdTimers = attrsOf (submodule [ stage1TimerOptions unitConfig ]);
+  timers = attrsOf (submodule [ stage2TimerOptions unitConfig timerConfig ]);
+  initrdTimers = attrsOf (submodule [ stage1TimerOptions unitConfig timerConfig ]);
 
-  paths = attrsOf (submodule [ stage2PathOptions unitConfig ]);
-  initrdPaths = attrsOf (submodule [ stage1PathOptions unitConfig ]);
+  paths = attrsOf (submodule [ stage2PathOptions unitConfig pathConfig ]);
+  initrdPaths = attrsOf (submodule [ stage1PathOptions unitConfig pathConfig ]);
 
-  slices = attrsOf (submodule [ stage2SliceOptions unitConfig ]);
-  initrdSlices = attrsOf (submodule [ stage1SliceOptions unitConfig ]);
+  slices = attrsOf (submodule [ stage2SliceOptions unitConfig sliceConfig ]);
+  initrdSlices = attrsOf (submodule [ stage1SliceOptions unitConfig sliceConfig ]);
 
   mounts = listOf (submodule [ stage2MountOptions unitConfig mountConfig ]);
   initrdMounts = listOf (submodule [ stage1MountOptions unitConfig mountConfig ]);

--- a/nixos/lib/systemd-unit-options.nix
+++ b/nixos/lib/systemd-unit-options.nix
@@ -65,6 +65,14 @@ in rec {
       '';
     };
 
+    name = lib.mkOption {
+      type = lib.types.str;
+      description = ''
+        The name of this systemd unit, including its extension.
+        This can be used to refer to this unit from other systemd units.
+      '';
+    };
+
     overrideStrategy = mkOption {
       default = "asDropinIfExists";
       type = types.enum [ "asDropinIfExists" "asDropin" ];

--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -35,7 +35,8 @@ let
   inherit (lib.strings) toJSON normalizePath escapeC;
 in
 
-rec {
+let
+utils = rec {
 
   # Copy configuration files to avoid having the entire sources in the system closure
   copyFile = filePath: pkgs.runCommand (builtins.unsafeDiscardStringContext (baseNameOf filePath)) {} ''
@@ -262,11 +263,12 @@ rec {
       filter (x: !(elem (getName x) namesToRemove)) packages;
 
   systemdUtils = {
-    lib = import ./systemd-lib.nix { inherit lib config pkgs; };
+    lib = import ./systemd-lib.nix { inherit lib config pkgs utils; };
     unitOptions = import ./systemd-unit-options.nix { inherit lib systemdUtils; };
     types = import ./systemd-types.nix { inherit lib systemdUtils pkgs; };
     network = {
       units = import ./systemd-network-units.nix { inherit lib systemdUtils; };
     };
   };
-}
+};
+in utils

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -595,18 +595,17 @@ in
     };
 
     systemd.units =
-         mapAttrs' (n: v: nameValuePair "${n}.path"    (pathToUnit    n v)) cfg.paths
-      // mapAttrs' (n: v: nameValuePair "${n}.service" (serviceToUnit n v)) cfg.services
-      // mapAttrs' (n: v: nameValuePair "${n}.slice"   (sliceToUnit   n v)) cfg.slices
-      // mapAttrs' (n: v: nameValuePair "${n}.socket"  (socketToUnit  n v)) cfg.sockets
-      // mapAttrs' (n: v: nameValuePair "${n}.target"  (targetToUnit  n v)) cfg.targets
-      // mapAttrs' (n: v: nameValuePair "${n}.timer"   (timerToUnit   n v)) cfg.timers
-      // listToAttrs (map
-                   (v: let n = escapeSystemdPath v.where;
-                       in nameValuePair "${n}.mount" (mountToUnit n v)) cfg.mounts)
-      // listToAttrs (map
-                   (v: let n = escapeSystemdPath v.where;
-                       in nameValuePair "${n}.automount" (automountToUnit n v)) cfg.automounts);
+      let
+        withName = cfgToUnit: cfg: lib.nameValuePair cfg.name (cfgToUnit cfg);
+      in
+         mapAttrs' (_: withName pathToUnit) cfg.paths
+      // mapAttrs' (_: withName serviceToUnit) cfg.services
+      // mapAttrs' (_: withName sliceToUnit) cfg.slices
+      // mapAttrs' (_: withName socketToUnit) cfg.sockets
+      // mapAttrs' (_: withName targetToUnit) cfg.targets
+      // mapAttrs' (_: withName timerToUnit) cfg.timers
+      // listToAttrs (map (withName mountToUnit) cfg.mounts)
+      // listToAttrs (map (withName automountToUnit) cfg.automounts);
 
       # Environment of PID 1
       systemd.managerEnvironment = {

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -490,18 +490,18 @@ in {
 
       targets.initrd.aliases = ["default.target"];
       units =
-           mapAttrs' (n: v: nameValuePair "${n}.path"    (pathToUnit    n v)) cfg.paths
-        // mapAttrs' (n: v: nameValuePair "${n}.service" (serviceToUnit n v)) cfg.services
-        // mapAttrs' (n: v: nameValuePair "${n}.slice"   (sliceToUnit   n v)) cfg.slices
-        // mapAttrs' (n: v: nameValuePair "${n}.socket"  (socketToUnit  n v)) cfg.sockets
-        // mapAttrs' (n: v: nameValuePair "${n}.target"  (targetToUnit  n v)) cfg.targets
-        // mapAttrs' (n: v: nameValuePair "${n}.timer"   (timerToUnit   n v)) cfg.timers
+           mapAttrs' (n: v: nameValuePair "${n}.path"    (pathToUnit    v)) cfg.paths
+        // mapAttrs' (n: v: nameValuePair "${n}.service" (serviceToUnit v)) cfg.services
+        // mapAttrs' (n: v: nameValuePair "${n}.slice"   (sliceToUnit   v)) cfg.slices
+        // mapAttrs' (n: v: nameValuePair "${n}.socket"  (socketToUnit  v)) cfg.sockets
+        // mapAttrs' (n: v: nameValuePair "${n}.target"  (targetToUnit  v)) cfg.targets
+        // mapAttrs' (n: v: nameValuePair "${n}.timer"   (timerToUnit   v)) cfg.timers
         // listToAttrs (map
                      (v: let n = escapeSystemdPath v.where;
-                         in nameValuePair "${n}.mount" (mountToUnit n v)) cfg.mounts)
+                         in nameValuePair "${n}.mount" (mountToUnit v)) cfg.mounts)
         // listToAttrs (map
                      (v: let n = escapeSystemdPath v.where;
-                         in nameValuePair "${n}.automount" (automountToUnit n v)) cfg.automounts);
+                         in nameValuePair "${n}.automount" (automountToUnit v)) cfg.automounts);
 
       # make sure all the /dev nodes are set up
       services.systemd-tmpfiles-setup-dev.wantedBy = ["sysinit.target"];

--- a/nixos/modules/system/boot/systemd/user.nix
+++ b/nixos/modules/system/boot/systemd/user.nix
@@ -175,12 +175,12 @@ in {
     };
 
     systemd.user.units =
-         mapAttrs' (n: v: nameValuePair "${n}.path"    (pathToUnit    n v)) cfg.paths
-      // mapAttrs' (n: v: nameValuePair "${n}.service" (serviceToUnit n v)) cfg.services
-      // mapAttrs' (n: v: nameValuePair "${n}.slice"   (sliceToUnit   n v)) cfg.slices
-      // mapAttrs' (n: v: nameValuePair "${n}.socket"  (socketToUnit  n v)) cfg.sockets
-      // mapAttrs' (n: v: nameValuePair "${n}.target"  (targetToUnit  n v)) cfg.targets
-      // mapAttrs' (n: v: nameValuePair "${n}.timer"   (timerToUnit   n v)) cfg.timers;
+         mapAttrs' (n: v: nameValuePair "${n}.path"    (pathToUnit    v)) cfg.paths
+      // mapAttrs' (n: v: nameValuePair "${n}.service" (serviceToUnit v)) cfg.services
+      // mapAttrs' (n: v: nameValuePair "${n}.slice"   (sliceToUnit   v)) cfg.slices
+      // mapAttrs' (n: v: nameValuePair "${n}.socket"  (socketToUnit  v)) cfg.sockets
+      // mapAttrs' (n: v: nameValuePair "${n}.target"  (targetToUnit  v)) cfg.targets
+      // mapAttrs' (n: v: nameValuePair "${n}.timer"   (timerToUnit   v)) cfg.timers;
 
     # Generate timer units for all services that have a ‘startAt’ value.
     systemd.user.timers =

--- a/nixos/tests/systemd.nix
+++ b/nixos/tests/systemd.nix
@@ -1,7 +1,7 @@
 import ./make-test-python.nix ({ pkgs, ... }: {
   name = "systemd";
 
-  nodes.machine = { lib, ... }: {
+  nodes.machine = { config, lib, ... }: {
     imports = [ common/user-account.nix common/x11.nix ];
 
     virtualisation.emptyDiskImages = [ 512 512 ];
@@ -38,9 +38,18 @@ import ./make-test-python.nix ({ pkgs, ... }: {
       script = "true";
     };
 
+    systemd.services.testDependency1 = {
+      description = "Test Dependency 1";
+      wantedBy = [ config.systemd.services."testservice1".name ];
+      serviceConfig.Type = "oneshot";
+      script = ''
+        true
+      '';
+    };
+
     systemd.services.testservice1 = {
       description = "Test Service 1";
-      wantedBy = [ "multi-user.target" ];
+      wantedBy = [ config.systemd.targets.multi-user.name ];
       serviceConfig.Type = "oneshot";
       script = ''
         if [ "$XXX_SYSTEM" = foo ]; then


### PR DESCRIPTION
## Description of changes

This allows us to set things like dependencies in a way that we can catch typos at eval time.
So instead of
```nix
systemd.services.foo.wants = [ "bar.service" ];
```
we can write
```nix
systemd.services.foo.wants = [ config.systemd.services.bar.name ];
```
which will throw an error if no such service has been defined.

Not all cases can be done like this (eg template services), but in a lot of cases this will allow to avoid typos.

There is a matching option on the unit option (`systemd.units."foo.service".name`) as well.

I updated one test to use this new syntax to both test it and show how it can work.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
