### PR TITLE
nixos/budgie: Use gnome-terminal by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -331,6 +331,8 @@ The pre-existing [services.ankisyncd](#opt-services.ankisyncd.enable) has been m
   - Similarly, please use `services.xserver.desktopManager.mate.extraCajaExtensions` option for installing Caja extensions.
   - To use the Wayland session, enable `services.xserver.desktopManager.mate.enableWaylandSession`. This is opt-in for now as it is in early stage and introduces a new set of Wayfire closure. Due to [known issues with LightDM](https://github.com/canonical/lightdm/issues/63), we suggest using SDDM for display manager.
 
+- The Budgie module installs gnome-terminal by default (instead of mate-terminal).
+
 - New `boot.loader.systemd-boot.xbootldrMountPoint` allows setting up a separate [XBOOTLDR partition](https://uapi-group.org/specifications/specs/boot_loader_specification/) to store boot files. Useful on systems with a small EFI System partition that cannot be easily repartitioned.
 
 - `boot.loader.systemd-boot` will now verify that `efiSysMountPoint` (and `xbootldrMountPoint` if configured) are mounted partitions.

--- a/nixos/modules/services/x11/desktop-managers/budgie.nix
+++ b/nixos/modules/services/x11/desktop-managers/budgie.nix
@@ -144,7 +144,6 @@ in {
           mate.atril
           mate.engrampa
           mate.mate-calc
-          mate.mate-terminal
           mate.mate-system-monitor
           vlc
 
@@ -157,6 +156,9 @@ in {
           nixos-gsettings-overrides
         ] config.environment.budgie.excludePackages)
       ++ cfg.sessionPath;
+
+    # Both budgie-desktop-view and nemo defaults to this emulator.
+    programs.gnome-terminal.enable = mkDefault true;
 
     # Fonts.
     fonts.packages = [

--- a/nixos/tests/budgie.nix
+++ b/nixos/tests/budgie.nix
@@ -82,9 +82,9 @@ import ./make-test-python.nix ({ pkgs, lib, ... }: {
           machine.wait_until_succeeds("${su "budgie-screensaver-command -q"} | grep 'The screensaver is inactive'")
           machine.sleep(2)
 
-      with subtest("Open MATE terminal"):
-          machine.succeed("${su "mate-terminal >&2 &"}")
-          machine.wait_for_window("Terminal")
+      with subtest("Open GNOME terminal"):
+          machine.succeed("${su "gnome-terminal"}")
+          machine.wait_for_window("${user.name}@machine: ~")
 
       with subtest("Check if Budgie has ever coredumped"):
           machine.fail("coredumpctl --json=short | grep budgie")

--- a/pkgs/desktops/budgie/budgie-gsettings-overrides/default.nix
+++ b/pkgs/desktops/budgie/budgie-gsettings-overrides/default.nix
@@ -5,7 +5,6 @@
 , glib
 , gsettings-desktop-schemas
 , gnome
-, mate
 , nixos-artwork
 , nixos-background-light ? nixos-artwork.wallpapers.nineish
 , nixos-background-dark ? nixos-artwork.wallpapers.nineish-dark-gray
@@ -54,7 +53,6 @@ let
     [org.buddiesofbudgie.budgie-desktop-view:Budgie]
     show=true
     show-active-mounts=true
-    terminal="${mate.mate-terminal}/bin/mate-terminal"
 
     ${extraGSettingsOverrides}
   '';


### PR DESCRIPTION
- Both [budgie-desktop-view](https://github.com/BuddiesOfBudgie/budgie-desktop-view/blob/v1.3/data/org.buddiesofbudgie.budgie-desktop-view.gschema.xml#L60) and nemo ([cinnamon-desktop](https://github.com/linuxmint/cinnamon-desktop/blob/6.0.0/schemas/org.cinnamon.desktop.default-applications.gschema.xml.in#L46)) defaults to gnome-terminal, there are no clear reason why we don't use the defaults here. The cinnamon-desktop `org.cinnamon.desktop.default-applications.terminal` schema is [used in nemo](https://github.com/linuxmint/nemo/blob/6.0.0/src/nemo-view.c#L7193) for default emulator, since we use nemo by default this fixes nemo open in terminal entry without introducing another override.
- There are theming issues with Qogir when opening right-click menu in a second tab.
- Transparency is broken when hovering on other windows, showing only the wallpaper.

This also ensures a stable default for budgie-desktop-view, by using only the executable name and not a nix store path.

This is part one fix of #297570. (If staying on mate-terminal is still preferred, I can just update this PR to override `org.cinnamon.desktop.default-applications.terminal` instead).




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
