### PR TITLE
pretix: compile all languages at build time

### DIFF
--- a/pkgs/by-name/pr/pretix/language-build.patch
+++ b/pkgs/by-name/pr/pretix/language-build.patch
@@ -1,0 +1,12 @@
+diff --git a/src/pretix/_build_settings.py b/src/pretix/_build_settings.py
+index d1ea73b84..9e13cdc87 100644
+--- a/src/pretix/_build_settings.py
++++ b/src/pretix/_build_settings.py
+@@ -49,6 +49,7 @@ HAS_MEMCACHED = False
+ HAS_CELERY = False
+ HAS_GEOIP = False
+ SENTRY_ENABLED = False
++LANGUAGES = ALL_LANGUAGES
+ 
+ for entry_point in entry_points(group='pretix.plugin'):
+     INSTALLED_APPS.append(entry_point.module) # noqa: F405

--- a/pkgs/by-name/pr/pretix/package.nix
+++ b/pkgs/by-name/pr/pretix/package.nix
@@ -67,6 +67,10 @@ python.pkgs.buildPythonApplication rec {
     # INSTALLED_APPS, so that their static files are collected.
     ./plugin-build.patch
 
+    # Configure django-statici18n to compile all available languages at
+    # build time.
+    ./language-build.patch
+
     (fetchpatch2 {
       # Allow customization of cache and log directory
       # https://github.com/pretix/pretix/pull/3997

--- a/pkgs/by-name/pr/pretix/package.nix
+++ b/pkgs/by-name/pr/pretix/package.nix
@@ -251,7 +251,6 @@ python.pkgs.buildPythonApplication rec {
 
   meta = with lib; {
     description = "Ticketing software that cares about your event—all the way";
-    mainProgram = "pretix-manage";
     homepage = "https://github.com/pretix/pretix";
     license = with licenses; [
       agpl3Only
@@ -265,5 +264,7 @@ python.pkgs.buildPythonApplication rec {
       asl20
     ];
     maintainers = with maintainers; [ hexa ];
+    mainProgram = "pretix-manage";
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
Pretix wants to build locales according to the user configuration, which does not exist in our case and leads to certain languages not being built.

As our packages are immutable, the user config will never be able to influence them and we therefore must enable all languages at build time.

Closes: #297708

## Description of changes

```
pretix> adding 'pretix/static.dist/jsi18n/de-informal/djangojs.9e93049fb6e3.js'
pretix> adding 'pretix/static.dist/jsi18n/de-informal/djangojs.js'
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
