### PR TITLE
diagon: init at 1.1.158

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20245,6 +20245,12 @@
     githubId = 7420227;
     name = "Peter Tri Ho";
   };
+  petertrotman = {
+    email = "petertrotman@gmail.com";
+    github = "petertrotman";
+    githubId = 8298307;
+    name = "Peter Trotman";
+  };
   peterwilli = {
     email = "peter@codebuffet.co";
     github = "peterwilli";

--- a/pkgs/by-name/di/diagon/package.nix
+++ b/pkgs/by-name/di/diagon/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchurl,
+  boost186,
+  cmake,
+  jdk,
+}:
+
+let
+
+  antlr = fetchFromGitHub {
+    owner = "antlr";
+    repo = "antlr4";
+    rev = "4.13.2";
+    hash = "sha256-DxxRL+FQFA+x0RudIXtLhewseU50aScHKSCDX7DE9bY=";
+  };
+
+  antlr-jar = fetchurl {
+    url = "http://www.antlr.org/download/antlr-4.13.2-complete.jar";
+    hash = "sha256-6uLfoRmmQydERnKv9j6ew1ogGA3FuAkLemq4USXfTXY=";
+  };
+
+  json = fetchFromGitHub {
+    owner = "ArthurSonzogni";
+    repo = "nlohmann_json_cmake_fetchcontent";
+    rev = "v3.9.1";
+    hash = "sha256-5A18zFqbgDc99pqQUPcpwHi89WXb8YVR9VEwO18jH2I=";
+  };
+
+  kgt = fetchFromGitHub {
+    owner = "ArthurSonzogni";
+    repo = "kgt";
+    rev = "56c3f46cf286051096d9295118c048219fe0d776";
+    hash = "sha256-xH0htDZd2UihLn7PHKLjEYETzcBSeJFOMNredTqlCW8=";
+  };
+
+in
+stdenv.mkDerivation rec {
+  pname = "diagon";
+  version = "1.1.158";
+
+  src = fetchFromGitHub {
+    owner = "ArthurSonzogni";
+    repo = "Diagon";
+    rev = "v${version}";
+    hash = "sha256-Qxk3+1T0IPmvB5v3jaqvBnESpss6L8bvoW+R1l5RXdQ=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    jdk
+  ];
+
+  buildInputs = [
+    boost186
+  ];
+
+  cmakeBuildDir = "build";
+  preConfigure = ''
+    mkdir -p $cmakeBuildDir
+    ln -s ${antlr-jar} $cmakeBuildDir/antlr.jar
+  '';
+
+  cmakeFlags = [
+    "-DCMAKE_POLICY_DEFAULT_CMP0169=OLD"
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+    "-DFETCHCONTENT_SOURCE_DIR_JSON=${json}"
+    "-DFETCHCONTENT_SOURCE_DIR_ANTLR=${antlr}"
+    "-DFETCHCONTENT_SOURCE_DIR_KGT=${kgt}"
+    "-DFETCHCONTENT_FULLY_DISCONNECTED=true"
+  ];
+
+  meta = src.meta // {
+    description = "An interactive interpreter that transforms markdown-style expression into an ascii-art representation";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.petertrotman ];
+    mainProgram = "diagon";
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
Added package for diagon and myself as maintainer.

https://github.com/ArthurSonzogni/Diagon

Diagon is an interactive interpreter. It transforms markdown-style expression into an ascii-art representation.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
