### PR TITLE
sold: init at 0-unstable-2024-02-22

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5612,6 +5612,16 @@
     githubId = 5737945;
     name = "Elia Argentieri";
   };
+  elise = {
+      name = "Elise Amber Katze";
+      email = "nix@katze.sh";
+      matrix = "@elise:katze.sh";
+      github = "EliseZeroTwo";
+      githubId = 42453798;
+      keys = [{
+        fingerprint = "2E09 8C8A BC51 9D6A E4B1  BB1E FA8F 56FF FE6E 8B3E";
+      }];
+    };
   elisesouche = {
     email = "elise@souche.one";
     github = "elisesouche";

--- a/pkgs/by-name/so/sold/package.nix
+++ b/pkgs/by-name/so/sold/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  openssl,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sold";
+  version = "0-unstable-2024-02-22";
+
+  src = fetchFromGitHub {
+    owner = "bluewhalesystems";
+    repo = pname;
+    rev = "a52e8b37661562c866a579ab1164f94694f479a5";
+    sha256 = "0iyrgz0ay2453rqrlvxsrla0998l8yq6q3xyqqw5icfvh05ld8i8";
+  };
+
+  buildInputs = [ openssl ];
+  nativeBuildInputs = [ cmake ];
+  enableParallelBuilding = true;
+
+  meta = {
+    description = "A fork of mold, a faster drop-in replacement for existing Unix linkers, with support for iOS and MacOS";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/bluewhalesystems/sold";
+    maintainers = with lib.maintainers; [ elise ];
+    platforms = lib.platforms.all;
+    mainProgram = "ld64.sold";
+  };
+}


### PR DESCRIPTION
## Description of changes

Adding a package for sold, a fork of mold that supports linking for iOS & MacOS platforms.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
