### PR TITLE
mpvScripts.modernx: init at 0.2.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11520,6 +11520,12 @@
       fingerprint = "66D1 3048 2B5F 2069 81A6  6B83 6F98 7CCF 224D 20B9";
     }];
   };
+  luftmensch-luftmensch = {
+    email = "valentinobocchetti59@gmail.com";
+    name = "Valentino Bocchetti";
+    github = "luftmensch-luftmensch";
+    githubId = 65391343;
+  };
   lugarun = {
     email = "lfschmidt.me@gmail.com";
     github = "lugarun";

--- a/pkgs/applications/video/mpv/scripts/default.nix
+++ b/pkgs/applications/video/mpv/scripts/default.nix
@@ -68,6 +68,7 @@ let
     convert = callPackage ./convert.nix { };
     cutter = callPackage ./cutter.nix { };
     inhibit-gnome = callPackage ./inhibit-gnome.nix { };
+    modernx = callPackage ./modernx.nix { };
     mpris = callPackage ./mpris.nix { };
     mpv-cheatsheet = callPackage ./mpv-cheatsheet.nix { };
     mpv-playlistmanager = callPackage ./mpv-playlistmanager.nix { };

--- a/pkgs/applications/video/mpv/scripts/modernx.nix
+++ b/pkgs/applications/video/mpv/scripts/modernx.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  fetchFromGitHub,
+  makeFontsConf,
+  buildLua,
+}:
+buildLua (finalAttrs: {
+  pname = "modernx";
+  version = "0.2.8";
+
+  src = fetchFromGitHub {
+    owner = "zydezu";
+    repo = "ModernX";
+    rev = finalAttrs.version;
+    sha256 = "sha256-rruscDutFyQCl5sTtQfmtYPcXKWU51/QFbghSOyMC9o=";
+  };
+
+  # the script uses custom "texture" fonts as the background for ui elements.
+  # In order for mpv to find them, we need to adjust the fontconfig search path.
+  postInstall = "cp -r *.ttf $out/share";
+  passthru.extraWrapperArgs = [
+    "--set"
+    "FONTCONFIG_FILE"
+    (toString (makeFontsConf {
+      fontDirectories = ["${finalAttrs.finalPackage}/share/fonts"];
+    }))
+  ];
+
+  meta = with lib; {
+    description = "Fork of modernX (a replacement for MPV that retains the functionality of the default OSC), adding additional features.";
+    homepage = "https://github.com/zydezu/ModernX";
+    license = licenses.unlicense;
+    maintainers = with lib.maintainers; [luftmensch-luftmensch];
+  };
+})


### PR DESCRIPTION
## Description of changes
Feature-rich modern UI for [MPV player](https://mpv.io/).
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

The script can be tested with:
```
# At the root of the project
nix-build -A mpvScripts.modernx

mpv --load-scripts --script=./result/share/mpv/scripts/modernx.lua /path/to/file_video
```

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
