### PR TITLE
dmenu, slstatus, st, dwm, slock: add updateScript

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15973,6 +15973,12 @@
     githubId = 39039420;
     name = "Quinn Dougherty";
   };
+  qusic = {
+    email = "qusicx@gmail.com";
+    github = "Qusic";
+    githubId = 2141853;
+    name = "Bang Lee";
+  };
   qyliss = {
     email = "hi@alyssa.is";
     github = "alyssais";

--- a/pkgs/applications/misc/dmenu/default.nix
+++ b/pkgs/applications/misc/dmenu/default.nix
@@ -1,4 +1,7 @@
-{ lib, stdenv, fetchurl, libX11, libXinerama, libXft, zlib, patches ? null }:
+{ lib, stdenv, fetchurl, libX11, libXinerama, libXft, zlib, patches ? null
+# update script dependencies
+, writeScript, common-updater-scripts, coreutils, git
+}:
 
 stdenv.mkDerivation rec {
   pname = "dmenu";
@@ -23,6 +26,12 @@ stdenv.mkDerivation rec {
   '';
 
   makeFlags = [ "CC:=$(CC)" ];
+
+  passthru.updateScript = writeScript "update-dmenu" ''
+    PATH=${lib.makeBinPath [ common-updater-scripts coreutils git ]}
+    version=$(git ls-remote --exit-code --refs --tags --sort=version:refname git://git.suckless.org/dmenu | tail -n1 | cut -d/ -f3)
+    update-source-version dmenu "$version"
+  '';
 
   meta = with lib; {
     description = "A generic, highly customizable, and efficient menu for the X Window System";

--- a/pkgs/applications/misc/slstatus/default.nix
+++ b/pkgs/applications/misc/slstatus/default.nix
@@ -8,6 +8,11 @@
 , libXdmcp
 , conf ? null
 , patches ? [ ]
+# update script dependencies
+, writeScript
+, common-updater-scripts
+, coreutils
+, git
 }:
 
 stdenv.mkDerivation rec {
@@ -35,6 +40,12 @@ stdenv.mkDerivation rec {
   buildInputs = [ libX11 libXau libXdmcp ];
 
   installFlags = [ "PREFIX=$(out)" ];
+
+  passthru.updateScript = writeScript "update-slstatus" ''
+    PATH=${lib.makeBinPath [ common-updater-scripts coreutils git ]}
+    version=$(git ls-remote --exit-code --refs --tags --sort=version:refname git://git.suckless.org/slstatus | tail -n1 | cut -d/ -f3)
+    update-source-version slstatus "$version"
+  '';
 
   meta = with lib; {
     homepage = "https://tools.suckless.org/slstatus/";

--- a/pkgs/applications/window-managers/dwm/default.nix
+++ b/pkgs/applications/window-managers/dwm/default.nix
@@ -1,4 +1,7 @@
-{ lib, stdenv, fetchurl, libX11, libXinerama, libXft, writeText, patches ? [ ], conf ? null}:
+{ lib, stdenv, fetchurl, libX11, libXinerama, libXft, writeText, patches ? [ ], conf ? null
+# update script dependencies
+, writeScript, common-updater-scripts, coreutils, git
+}:
 
 stdenv.mkDerivation rec {
   pname = "dwm";
@@ -28,6 +31,12 @@ stdenv.mkDerivation rec {
     lib.optionalString (conf != null) "cp ${configFile} config.def.h";
 
   makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
+
+  passthru.updateScript = writeScript "update-dwm" ''
+    PATH=${lib.makeBinPath [ common-updater-scripts coreutils git ]}
+    version=$(git ls-remote --exit-code --refs --tags --sort=version:refname git://git.suckless.org/dwm | tail -n1 | cut -d/ -f3)
+    update-source-version dwm "$version"
+  '';
 
   meta = with lib; {
     homepage = "https://dwm.suckless.org/";

--- a/pkgs/misc/screensavers/slock/default.nix
+++ b/pkgs/misc/screensavers/slock/default.nix
@@ -2,7 +2,10 @@
 , xorgproto, libX11, libXext, libXrandr, libxcrypt
 # default header can be obtained from
 # https://git.suckless.org/slock/tree/config.def.h
-, conf ? null }:
+, conf ? null
+# update script dependencies
+, writeScript, common-updater-scripts, coreutils, git
+}:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "slock";
@@ -24,6 +27,12 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   makeFlags = [ "CC:=$(CC)" ];
+
+  passthru.updateScript = writeScript "update-slock" ''
+    PATH=${lib.makeBinPath [ common-updater-scripts coreutils git ]}
+    version=$(git ls-remote --exit-code --refs --tags --sort=version:refname git://git.suckless.org/slock | tail -n1 | cut -d/ -f3)
+    update-source-version slock "$version"
+  '';
 
   meta = with lib; {
     homepage = "https://tools.suckless.org/slock";


### PR DESCRIPTION
## Description of changes

* Add updateScript for a few suckless packages
* Add myself to and remove inactive @andsild from `st` package maintainers, as [pointed out](https://github.com/NixOS/nixpkgs/pull/297472#issuecomment-2009838025) by @AndersonTorres

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
