### PR TITLE
jupyter related packages updates 2024-03-22

### DIFF
--- a/pkgs/development/python-modules/comm/default.nix
+++ b/pkgs/development/python-modules/comm/default.nix
@@ -8,7 +8,7 @@
 
 let
   pname = "comm";
-  version = "0.2.1";
+  version = "0.2.2";
 in
 buildPythonPackage {
   inherit pname version;
@@ -18,7 +18,7 @@ buildPythonPackage {
     owner = "ipython";
     repo = "comm";
     rev = "refs/tags/v${version}";
-    hash = "sha256-iyO3q9E2lYU1rMYTnsa+ZJYh+Hq72LEvE9ynebFIBUk=";
+    hash = "sha256-51HSSULhbKb1NdLJ//b3Vh6sOLWp0B4KW469htpduqM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/hatch-jupyter-builder/default.nix
+++ b/pkgs/development/python-modules/hatch-jupyter-builder/default.nix
@@ -6,29 +6,35 @@
 , pytestCheckHook
 , tomli
 , twine
+, pythonOlder
 }:
 
 buildPythonPackage rec {
   pname = "hatch-jupyter-builder";
-  version = "0.8.3";
-  format = "pyproject";
+  version = "0.9.1";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jupyterlab";
     repo = "hatch-jupyter-builder";
     rev = "refs/tags/v${version}";
-    hash = "sha256-UywhFJ8d1+lSFOF5ECsknDeQuO7ppckdy5IqAT14ius=";
+    hash = "sha256-QDWHVdjtexUNGRL+dVehdBwahSW2HmNkZKkQyuOghyI=";
   };
 
-  nativeBuildInputs = [
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
     hatchling
   ];
 
   nativeCheckInputs = [
     pytest-mock
     pytestCheckHook
-    tomli
     twine
+  ] ++ lib.optionals (pythonOlder "3.11") [
+    tomli
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/ipyvuetify/default.nix
+++ b/pkgs/development/python-modules/ipyvuetify/default.nix
@@ -11,13 +11,13 @@
 
 buildPythonPackage rec {
   pname = "ipyvuetify";
-  version = "1.9.1";
+  version = "1.9.2";
   pyproject = true;
 
   # GitHub version tries to run npm (Node JS)
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-MAqO6wREtnaVCgG88UXYsKlLpkizbtPqmeQ9u3UVnU0=";
+    hash = "sha256-kAcL/PR3jThbmfDKMBQRPbcDyZ7GrRwuzDLWE8bC1M4=";
   };
 
   # drop pynpm which tries to install node_modules

--- a/pkgs/development/python-modules/jupyter-client/default.nix
+++ b/pkgs/development/python-modules/jupyter-client/default.nix
@@ -13,13 +13,13 @@
 
 buildPythonPackage rec {
   pname = "jupyter-client";
-  version = "8.6.0";
+  version = "8.6.1";
   pyproject = true;
 
   src = fetchPypi {
     pname = "jupyter_client";
     inherit version;
-    hash = "sha256-BkIkS7g7R2SuYNB+AQ4V8OLSdexOkYqPe4D7vvPKYMc=";
+    hash = "sha256-6EJRXiurjhkYbYn9/qer0V453VgflOOZ8A4q9aFlLT8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/jupyter-collaboration/default.nix
+++ b/pkgs/development/python-modules/jupyter-collaboration/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "jupyter-collaboration";
-  version = "2.0.4";
+  version = "2.0.5";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -27,21 +27,21 @@ buildPythonPackage rec {
   src = fetchPypi {
     pname = "jupyter_collaboration";
     inherit version;
-    hash = "sha256-3N3w6JJ0SHa1EYBED/aU1g0IX9nDHf4iseGPwEK1zpw=";
+    hash = "sha256-aQYZGiya7E3blwVkWx6w2Hb2M0v/z9dOMU72EGW4aCg=";
   };
 
   postPatch = ''
     sed -i "/^timeout/d" pyproject.toml
   '';
 
-  nativeBuildInputs = [
+  build-system = [
     hatch-jupyter-builder
     hatch-nodejs-version
     hatchling
     jupyterlab
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     jsonschema
     jupyter-events
     jupyter-server
@@ -60,13 +60,14 @@ buildPythonPackage rec {
     "jupyter_collaboration"
   ];
 
-  pytestFlagsArray = [
-    "-W" "ignore::DeprecationWarning"
-  ];
-
   preCheck = ''
     export HOME=$TEMP
   '';
+
+  disabledTests = [
+    # ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
+    "test_dirty"
+  ];
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/development/python-modules/jupyter-core/default.nix
+++ b/pkgs/development/python-modules/jupyter-core/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "jupyter-core";
-  version = "5.7.1";
+  version = "5.7.2";
   disabled = pythonOlder "3.7";
 
   pyproject = true;
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "jupyter";
     repo = "jupyter_core";
     rev = "refs/tags/v${version}";
-    hash = "sha256-Uh7slD8mQg2R++wltXrYiPSJnmM5w9tej8GN/0GMBmA=";
+    hash = "sha256-qu25ryZreRPHoubFJTFusGdkTPHbl/yl94g+XU5A5Mc=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/jupyter-events/default.nix
+++ b/pkgs/development/python-modules/jupyter-events/default.nix
@@ -25,7 +25,7 @@
 
 buildPythonPackage rec {
   pname = "jupyter-events";
-  version = "0.9.0";
+  version = "0.10.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -34,7 +34,7 @@ buildPythonPackage rec {
     owner = "jupyter";
     repo = "jupyter_events";
     rev = "refs/tags/v${version}";
-    hash = "sha256-LDj6dTtq3npJxLKBQEEwGQFeDPvWF2adHeJhOai2MRU=";
+    hash = "sha256-8aps8aNgXw+XbDgtCvWw+Ij1Cm1N0G+wcL35ySkofOk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/jupyter-server-terminals/default.nix
+++ b/pkgs/development/python-modules/jupyter-server-terminals/default.nix
@@ -16,14 +16,14 @@
 
 let self = buildPythonPackage rec {
   pname = "jupyter-server-terminals";
-  version = "0.5.2";
+  version = "0.5.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jupyter-server";
     repo = "jupyter_server_terminals";
     rev = "refs/tags/v${version}";
-    hash = "sha256-e4PtrK2DCJAK+LYmGguwU5hmxdqP5Dws1dPoPOv/WrM=";
+    hash = "sha256-af7jBscGkbekXgfDxwAfrJSY1uEuIGfzzSsjaPdlYcY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/jupyterhub/default.nix
+++ b/pkgs/development/python-modules/jupyterhub/default.nix
@@ -72,14 +72,14 @@ in
 
 buildPythonPackage rec {
   pname = "jupyterhub";
-  version = "4.0.2";
+  version = "4.1.0";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-1ORQ7tjZDfvPDsoI8A8gk6C8503FH3z8C3BX9gI0Gh0=";
+    hash = "sha256-sKpNnbmpg5gWgLyoZ+15FSV4/oPJqDJ3TuE5Bbe3V0w=";
   };
 
   # Most of this only applies when building from source (e.g. js/css assets are

--- a/pkgs/development/python-modules/jupyterlab/default.nix
+++ b/pkgs/development/python-modules/jupyterlab/default.nix
@@ -20,14 +20,14 @@
 
 buildPythonPackage rec {
   pname = "jupyterlab";
-  version = "4.1.4";
+  version = "4.1.5";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-4DyCwSStigiS5Ji53eecUIaLLCZ4Gayj9VzkfFfr6x0=";
+    hash = "sha256-ya11KQyxC/r/NiS/P7uFIxm0zOTEVmE/jruqmNA1JNs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/nbclient/default.nix
+++ b/pkgs/development/python-modules/nbclient/default.nix
@@ -19,7 +19,7 @@
 
 let nbclient = buildPythonPackage rec {
   pname = "nbclient";
-  version = "0.9.0";
+  version = "0.10.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.7";
@@ -28,7 +28,7 @@ let nbclient = buildPythonPackage rec {
     owner = "jupyter";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-m0Tke/JlTeKE3PJZ1rBejra/HPEXCSS0ur/cPiSBJZw=";
+    hash = "sha256-8OLkpwX4Gpam9VSFUtNS41Ypxe4+2yN3ng6iVY9DSqY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/nbformat/default.nix
+++ b/pkgs/development/python-modules/nbformat/default.nix
@@ -15,13 +15,13 @@
 
 buildPythonPackage rec {
   pname = "nbformat";
-  version = "5.9.2";
+  version = "5.10.3";
   format = "pyproject";
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-X5i1uhmX3/F1534MF9XBCpbq7Sy9HeNTPR/DXV4REZI=";
+    hash = "sha256-YO1ekQ73xiZLh9ZE8naxtJ4kARkw3u9UYFGI3eshFoU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/notebook/default.nix
+++ b/pkgs/development/python-modules/notebook/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "notebook";
-  version = "7.1.1";
+  version = "7.1.2";
   disabled = pythonOlder "3.8";
 
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-gY50IPoh9ALnJq+58C3388EPKUwC44PtGYUoZsMWEIs=";
+    hash = "sha256-78LIAEOQng+qF/zp6bN8BZwDrw7Jmk1NuEyyHZ0uk2o=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/oauthenticator/default.nix
+++ b/pkgs/development/python-modules/oauthenticator/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "oauthenticator";
-  version = "16.2.1";
+  version = "16.3.0";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-qJrreq2GhJxrX9keZOYVzjihs0RCymad+MGErW5ecPc=";
+    hash = "sha256-QMddGJUfafXoBxMCjlx1lH45a4Bab3AP4j8Px7JxYaQ=";
   };
 
   postPatch = ''
@@ -36,12 +36,10 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     jupyterhub
+    pyjwt
   ];
 
   passthru.optional-dependencies = {
-    azuread = [
-      pyjwt
-    ];
     googlegroups = [
       google-api-python-client
       google-auth-oauthlib

--- a/pkgs/development/python-modules/pytest-jupyter/default.nix
+++ b/pkgs/development/python-modules/pytest-jupyter/default.nix
@@ -22,14 +22,14 @@
 
 let self = buildPythonPackage rec {
   pname = "pytest-jupyter";
-  version = "0.9.0";
+  version = "0.9.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jupyter-server";
     repo = "pytest-jupyter";
     rev = "refs/tags/v${version}";
-    hash = "sha256-8pQNtzMylW9b3vk0kp7NcJnXAJKYeoFsHy/lyQFCNzc=";
+    hash = "sha256-+NtLyTpMpJ+asbiQZNLFs1qLr00UlEOlbxortQ1B4so=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

Update jupyter-related packages at once to avoid building hundreds of packages over and over again.

This PR is based on the commits generated by the following command.

```
nix search nixpkgs#python311Packages 'ipython|jupyter|notebook' --json | jq -r 'keys | .[]' | cut -d . -f 3,4 | xargs -n 1 nix-update --commit
```

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
