### PR TITLE
kpt: updated version from 0.39.3 to 1.0.0-beta.49

### DIFF
--- a/pkgs/applications/networking/cluster/kpt/default.nix
+++ b/pkgs/applications/networking/cluster/kpt/default.nix
@@ -2,16 +2,16 @@
 
 buildGoModule rec {
   pname = "kpt";
-  version = "0.39.3";
+  version = "1.0.0-beta.49";
 
   src = fetchFromGitHub {
-    owner = "GoogleContainerTools";
+    owner = "kptdev";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-vidrKfmP0Lw6EYYufLDxh3ROOJ3hPIusDTI/Hr73NYM=";
+    hash = "sha256-whqA1ACN7vXSDWVi55/fJKnuBrDCIdOpyDS8KNrhZq0=";
   };
 
-  vendorHash = "sha256-CoXlUX9hkP8gijA/vg19AS9030w95A2oKGD1wjzO8ak=";
+  vendorHash = "sha256-NQ/JqXokNmr8GlIhqTJb0JFyU2mAEXO+2y5vI79TuX4=";
 
   subPackages = [ "." ];
 
@@ -23,6 +23,5 @@ buildGoModule rec {
     homepage = "https://googlecontainertools.github.io/kpt/";
     license = licenses.asl20;
     maintainers = with maintainers; [ mikefaille ];
-    broken = stdenv.isDarwin;
   };
 }


### PR DESCRIPTION
## Description of changes
Updated kpt version from 0.39.3 to 1.0.0-beta.49. Also updated owner repository and hashes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
