### PR TITLE
nssmdns: Fix configuration location

### DIFF
--- a/pkgs/tools/networking/nss-mdns/default.nix
+++ b/pkgs/tools/networking/nss-mdns/default.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec {
     "--enable-avahi"
     # Connect to the daemon at `/var/run/avahi-daemon/socket'.
     "--localstatedir=/var"
+    # Read configuration at `/etc/mdns.allow`, not `$out/etc/mdns.allow`.
+    "--sysconfdir=/etc"
   ];
 
   meta = {

--- a/pkgs/tools/networking/nss-mdns/default.nix
+++ b/pkgs/tools/networking/nss-mdns/default.nix
@@ -5,7 +5,7 @@ stdenv.mkDerivation rec {
   version = "0.15.1";
 
   src = fetchFromGitHub {
-    owner = "lathiat";
+    owner = "avahi";
     repo = "nss-mdns";
     rev = "v${version}";
     hash = "sha256-iRaf9/gu9VkGi1VbGpxvC5q+0M8ivezCz/oAKEg5V1M=";
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
       resolution by common Unix/Linux programs in the ad-hoc mDNS
       domain `.local'.
     '';
-    homepage = "http://0pointer.de/lennart/projects/nss-mdns/";
+    homepage = "https://github.com/avahi/nss-mdns/";
     license = lib.licenses.lgpl2Plus;
     # Supports both the GNU and FreeBSD NSS.
     platforms = lib.platforms.gnu ++ lib.platforms.linux ++ lib.platforms.freebsd;


### PR DESCRIPTION
Nssmdns reads the `mdns.allow` configuration file if it is present. By default it expects the file at `${sysconfdir}/mdns.allow`, sysconfdir defaults to `${prefix}/etc` and ends up being a path inside the package's directory in the store.

This makes it impossible to configure nssmdns through this file. The `bootstrap.sh` script included in the sources passes the same `--sysconfdir=/etc` as suggested here.

Maybe we should run the script instead? It runs autoreconf so we might be able to drop the autoreconfHook.

An alternative would be to set `MDNS_ALLOW_FILE`, but sysconfdir is only used for this file so I suggest leaving this as a simple way for users of the package to override the location of the file.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
