### PR TITLE
tpnote: 1.23.9 -> 1.23.10

### DIFF
--- a/pkgs/by-name/tp/tpnote/package.nix
+++ b/pkgs/by-name/tp/tpnote/package.nix
@@ -15,7 +15,7 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "tpnote";
-  version = "1.23.9";
+  version = "1.23.10";
 
   src = fetchFromGitHub {
     owner = "getreu";
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-HOCd5N8oS8N+9alR3cG7IEghvhvcc8A+O24L6FD1F38=";
   };
 
-  cargoHash = "sha256-T1AYiwGPolYUhJQzTyR7v5dqqNFUCSfSBzU3CithZPw=";
+  cargoHash = "sha256-hI9vzPLcMaFSQpPgIf39UsWDpdHAmQ56D8pSWZ/R1aI=";
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
## Description of changes

Security release for RUSTSEC-2024-0019, no new features

The vulnerability RUSTSEC-2024-0019 was found in one of Tp-Note's
dependencies. For those who compile Tp-Note, this is fixed by a simple
`cargo update`. Nevertheless, some distributions (e.g. NixOS), refer to
the exact versions in `Cargo.lock`, which motivates this new release.

Internal changes and refactoring:

* Build chain: migrate from Docker to Podman
* Encapsulation of the clipboard related code.