### PR TITLE
haskell.compiler.{ghc98*,ghcHEAD}: bootstrap using source built 9.6

### DIFF
--- a/pkgs/development/compilers/ghc/9.6.3-binary.nix
+++ b/pkgs/development/compilers/ghc/9.6.3-binary.nix
@@ -403,5 +403,8 @@ stdenv.mkDerivation rec {
     # `pkgsMusl`.
     platforms = builtins.attrNames ghcBinDists.${distSetName};
     maintainers = lib.teams.haskell.members;
+    # packages involving hsc2hs (clock) produce libraries our
+    # ld can't link against
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -298,6 +298,13 @@ in {
           packages.ghc963
         else if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
           packages.ghc963
+        else if stdenv.hostPlatform.isDarwin then
+          # it seems like the GHC 9.6.* bindists are built with a different
+          # toolchain than we are using (which I'm guessing from the fact
+          # that 9.6.4 bindists pass linker flags our ld doesn't support).
+          # With both 9.6.3 and 9.6.4 binary it is impossible to link against
+          # the clock package (probably a hsc2hs problem).
+          packages.ghc963
         else
           packages.ghc963Binary;
       inherit (buildPackages.python3Packages) sphinx;
@@ -315,6 +322,13 @@ in {
         if stdenv.hostPlatform.isAarch32 then
           packages.ghc963
         else if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
+          packages.ghc963
+        else if stdenv.hostPlatform.isDarwin then
+          # it seems like the GHC 9.6.* bindists are built with a different
+          # toolchain than we are using (which I'm guessing from the fact
+          # that 9.6.4 bindists pass linker flags our ld doesn't support).
+          # With both 9.6.3 and 9.6.4 binary it is impossible to link against
+          # the clock package (probably a hsc2hs problem).
           packages.ghc963
         else
           packages.ghc963Binary;
@@ -334,6 +348,13 @@ in {
         if stdenv.hostPlatform.isAarch32 then
           packages.ghc963
         else if stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian then
+          packages.ghc963
+        else if stdenv.hostPlatform.isDarwin then
+          # it seems like the GHC 9.6.* bindists are built with a different
+          # toolchain than we are using (which I'm guessing from the fact
+          # that 9.6.4 bindists pass linker flags our ld doesn't support).
+          # With both 9.6.3 and 9.6.4 binary it is impossible to link against
+          # the clock package (probably a hsc2hs problem).
           packages.ghc963
         else
           packages.ghc963Binary;


### PR DESCRIPTION
Unfortunately, we are running into trouble linking dependencies of hadrian against the libraries of the clock package with 9.6.3 and 9.6.4 _bindists_. My current suspiscion is that this is caused by some kind of discrepancy between the toolchain used by GHC upstream and us that persists from the configure step used when building the bindist. The problem seems to be somewhat localized to hsc2hs (hence clock is an issue), with GHC 9.6.4 bindists even passing a flag to ld that is not supported by our version of cctools.

The problem is not fully diagnosed, so take the speculation above with a grain of salt.

As a workaround, we can use the source built GHC 9.6 which is, of course, configured with our toolchain in the environment.

Fast track into master.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
