### PR TITLE
nixos/podgrab: add user/group/dataDirectory options

### DIFF
--- a/nixos/modules/services/misc/podgrab.nix
+++ b/nixos/modules/services/misc/podgrab.nix
@@ -1,6 +1,8 @@
 { config, lib, pkgs, ... }:
 let
   cfg = config.services.podgrab;
+
+  stateDir = "/var/lib/podgrab";
 in
 {
   options.services.podgrab = with lib; {
@@ -23,6 +25,13 @@ in
       description = lib.mdDoc "The port on which Podgrab will listen for incoming HTTP traffic.";
     };
 
+    dataDirectory = mkOption {
+      type = types.path;
+      default = "${stateDir}/data";
+      example = "/mnt/podcasts";
+      description = "Directory to store downloads.";
+    };
+
     user = mkOption {
       type = types.str;
       default = "podgrab";
@@ -37,12 +46,16 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    systemd.tmpfiles.settings."10-pyload" = {
+      ${cfg.dataDirectory}.d = { inherit (cfg) user group; };
+    };
+
     systemd.services.podgrab = {
       description = "Podgrab podcast manager";
       wantedBy = [ "multi-user.target" ];
       environment = {
-        CONFIG = "/var/lib/podgrab/config";
-        DATA = "/var/lib/podgrab/data";
+        CONFIG = "${stateDir}/config";
+        DATA = cfg.dataDirectory;
         GIN_MODE = "release";
         PORT = toString cfg.port;
       };
@@ -54,7 +67,7 @@ in
         ];
         ExecStart = "${pkgs.podgrab}/bin/podgrab";
         WorkingDirectory = "${pkgs.podgrab}/share";
-        StateDirectory = [ "podgrab/config" "podgrab/data" ];
+        StateDirectory = [ "podgrab/config" ];
       };
     };
 

--- a/nixos/modules/services/misc/podgrab.nix
+++ b/nixos/modules/services/misc/podgrab.nix
@@ -22,6 +22,18 @@ in
       example = 4242;
       description = lib.mdDoc "The port on which Podgrab will listen for incoming HTTP traffic.";
     };
+
+    user = mkOption {
+      type = types.str;
+      default = "podgrab";
+      description = "User under which Podgrab runs, and which owns the download directory.";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "podgrab";
+      description = "Group under which Podgrab runs, and which owns the download directory.";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -35,7 +47,8 @@ in
         PORT = toString cfg.port;
       };
       serviceConfig = {
-        DynamicUser = true;
+        User = cfg.user;
+        Group = cfg.group;
         EnvironmentFile = lib.optionals (cfg.passwordFile != null) [
           cfg.passwordFile
         ];
@@ -44,6 +57,13 @@ in
         StateDirectory = [ "podgrab/config" "podgrab/data" ];
       };
     };
+
+    users.users.podgrab = lib.mkIf (cfg.user == "podgrab") {
+      isSystemUser = true;
+      group = cfg.group;
+    };
+
+    users.groups.podgrab = lib.mkIf (cfg.group == "podgrab") { };
   };
 
   meta.maintainers = with lib.maintainers; [ ambroisie ];


### PR DESCRIPTION
## Description of changes

I want to use it in conjunction with Audiobookshelf, having control over the user/group makes it easier.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
