### PR TITLE
androguard: 4.1.0 -> 3.4.0a1, fix build

### DIFF
--- a/pkgs/development/python-modules/androguard/default.nix
+++ b/pkgs/development/python-modules/androguard/default.nix
@@ -31,14 +31,14 @@
 
 buildPythonPackage rec {
   pname = "androguard";
-  version = "4.1.0";
+  version = "3.4.0a1";
   format = "setuptools";
 
   src = fetchFromGitHub {
     repo = pname;
     owner = pname;
-    rev = "refs/tags/v${version}";
-    sha256 = "sha256-NJYiuAr/rfR24pAhQDysGWXH2bBuvTrJI1jkmrJS8+c=";
+    rev = "v${version}";
+    sha256 = "1aparxiq11y0hbvkayp92w684nyxyyx7mi0n1x6x51g5z6c58vmy";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Description of changes

This reverts 76b11df7f5778c37cf76998b4ebd706fb22c2d8f and enables both this package and diffoscope to build.

I tried to fail forward and ran into some hurdles. WIP commit is here: https://github.com/philiptaron/nixpkgs/commit/16a08ea2c8a585beaf23c865fa1a0821a7f0c3d2

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>14 packages built:</summary>
  <ul>
    <li>androguard (python311Packages.androguard)</li>
    <li>androguard.dist (python311Packages.androguard.dist)</li>
    <li>apkleaks</li>
    <li>apkleaks.dist</li>
    <li>diffoscope</li>
    <li>diffoscope.dist</li>
    <li>diffoscope.man</li>
    <li>fdroidserver</li>
    <li>fdroidserver.dist</li>
    <li>jadx</li>
    <li>python312Packages.androguard</li>
    <li>python312Packages.androguard.dist</li>
    <li>quark-engine</li>
    <li>quark-engine.dist</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).