### PR TITLE
Draft/Dev: protonmail-desktop - electron-forge based source-build

### DIFF
--- a/pkgs/by-name/pr/protonmail-desktop/forge.config.ts
+++ b/pkgs/by-name/pr/protonmail-desktop/forge.config.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 require("dotenv").config();
 
 import { AutoUnpackNativesPlugin } from "@electron-forge/plugin-auto-unpack-natives";
@@ -9,6 +10,7 @@ import { getAppTransportSecuity, getExtraResource, getIco, getIcon, getName, isB
 import { FuseV1Options, FuseVersion } from "@electron/fuses";
 import { mainConfig } from "./webpack.main.config";
 import { rendererConfig } from "./webpack.renderer.config";
+import pkg from "./package.json";
 
 let currentArch = "";
 const config: ForgeConfig = {
@@ -22,12 +24,14 @@ const config: ForgeConfig = {
         },
     },
     packagerConfig: {
-        electronZipDir: "@ELECTRON_ZIP@",
+        electronZipDir: process.env.electron_zip_dir,
         icon: `${__dirname}/assets/icons/${getIcon()}`,
         asar: true,
         name: getName(),
         executableName: getName(),
         extraResource: getExtraResource(),
+        appVersion: pkg.version,
+        appCopyright: pkg.config.copyright,
         // Required for macOS mailto protocol
         protocols: [
             {
@@ -37,7 +41,7 @@ const config: ForgeConfig = {
         ],
         // Change category type of the application on macOS
         appCategoryType: "public.app-category.productivity",
-        appBundleId: "ch.protonmail.desktop",
+        appBundleId: pkg.config.appBundleId,
         osxSign: {},
         osxNotarize: {
             appleId: process.env.APPLE_ID!,
@@ -92,8 +96,8 @@ const config: ForgeConfig = {
                 options: {
                     bin: getName(),
                     icon: `${__dirname}/assets/linux/${getIcon()}.svg`,
-                    homepage: "https://proton.me/",
-                    categories: ["Utility"],
+                    homepage: pkg.author.url,
+                    categories: ["Network", "Email"],
                     mimeType: ["x-scheme-handler/mailto"],
                 },
             },
@@ -104,9 +108,9 @@ const config: ForgeConfig = {
                 options: {
                     bin: getName(),
                     icon: `${__dirname}/assets/linux/${getIcon()}.svg`,
-                    maintainer: "Proton",
-                    homepage: "https://proton.me/",
-                    categories: ["Utility"],
+                    maintainer: pkg.author.name,
+                    homepage: pkg.author.url,
+                    categories: ["Network", "Email"],
                     mimeType: ["x-scheme-handler/mailto"],
                 },
             },
@@ -123,8 +127,8 @@ const config: ForgeConfig = {
             config: {
                 prerelase: isBetaRelease,
                 repository: {
-                    owner: "ProtonMail",
-                    name: "inbox-desktop",
+                    owner: pkg.config.githubUser,
+                    name: pkg.config.githubRepo,
                 },
             },
         },

--- a/pkgs/by-name/pr/protonmail-desktop/forge.config.ts
+++ b/pkgs/by-name/pr/protonmail-desktop/forge.config.ts
@@ -1,0 +1,166 @@
+require("dotenv").config();
+
+import { AutoUnpackNativesPlugin } from "@electron-forge/plugin-auto-unpack-natives";
+import { FusesPlugin } from "@electron-forge/plugin-fuses";
+import { WebpackPlugin } from "@electron-forge/plugin-webpack";
+import type { ForgeConfig } from "@electron-forge/shared-types";
+import { getAppTransportSecuity, getExtraResource, getIco, getIcon, getName, isBetaRelease } from "./src/utils/config";
+
+import { FuseV1Options, FuseVersion } from "@electron/fuses";
+import { mainConfig } from "./webpack.main.config";
+import { rendererConfig } from "./webpack.renderer.config";
+
+let currentArch = "";
+const config: ForgeConfig = {
+    hooks: {
+        generateAssets: async (_x, _y, arch) => {
+            if (arch === "all") {
+                currentArch = "universal";
+                return;
+            }
+            currentArch = arch;
+        },
+    },
+    packagerConfig: {
+        electronZipDir: "@ELECTRON_ZIP@",
+        icon: `${__dirname}/assets/icons/${getIcon()}`,
+        asar: true,
+        name: getName(),
+        executableName: getName(),
+        extraResource: getExtraResource(),
+        // Required for macOS mailto protocol
+        protocols: [
+            {
+                name: "mailto",
+                schemes: ["mailto"],
+            },
+        ],
+        // Change category type of the application on macOS
+        appCategoryType: "public.app-category.productivity",
+        appBundleId: "ch.protonmail.desktop",
+        osxSign: {},
+        osxNotarize: {
+            appleId: process.env.APPLE_ID!,
+            appleIdPassword: process.env.APPLE_PASSWORD!,
+            teamId: process.env.APPLE_TEAM_ID!,
+        },
+        extendInfo: {
+            ...getAppTransportSecuity(),
+        },
+    },
+    rebuildConfig: {},
+    makers: [
+        {
+            name: "@electron-forge/maker-squirrel",
+            config: {
+                name: "proton_mail", // Avoids clash with ProtonMail folder used by Bridge in appData
+                iconUrl: `${__dirname}/assets/icons/${getIco()}`,
+                setupIcon: `${__dirname}/assets/icons/${getIco()}`,
+                loadingGif: `${__dirname}/assets/windows/install-spinner.gif`,
+                signWithParams: `/a /d "Proton Mail Desktop" /t "http://timestamp.sectigo.com" /fd SHA256`,
+            },
+        },
+        {
+            name: "@electron-forge/maker-dmg",
+            config: {
+                background: `${__dirname}/assets/macos/background.png`,
+                icon: `${__dirname}/assets/macos/volume.icns`,
+                contents: () => {
+                    return [
+                        {
+                            x: 229,
+                            y: 250,
+                            type: "file",
+                            path: `${process.cwd()}/out/${getName()}-darwin-${currentArch}/${getName()}.app`,
+                        },
+                        { x: 429, y: 250, type: "link", path: "/Applications" },
+                    ];
+                },
+                additionalDMGOptions: {
+                    window: {
+                        size: {
+                            width: 658,
+                            height: 490,
+                        },
+                    },
+                },
+            },
+        },
+        {
+            name: "@electron-forge/maker-rpm",
+            config: {
+                options: {
+                    bin: getName(),
+                    icon: `${__dirname}/assets/linux/${getIcon()}.svg`,
+                    homepage: "https://proton.me/",
+                    categories: ["Utility"],
+                    mimeType: ["x-scheme-handler/mailto"],
+                },
+            },
+        },
+        {
+            name: "@electron-forge/maker-deb",
+            config: {
+                options: {
+                    bin: getName(),
+                    icon: `${__dirname}/assets/linux/${getIcon()}.svg`,
+                    maintainer: "Proton",
+                    homepage: "https://proton.me/",
+                    categories: ["Utility"],
+                    mimeType: ["x-scheme-handler/mailto"],
+                },
+            },
+        },
+        {
+            name: "@electron-forge/maker-zip",
+            platforms: ["win32", "darwin", "linux"],
+            config: {},
+        },
+    ],
+    publishers: [
+        {
+            name: "@electron-forge/publisher-github",
+            config: {
+                prerelase: isBetaRelease,
+                repository: {
+                    owner: "ProtonMail",
+                    name: "inbox-desktop",
+                },
+            },
+        },
+    ],
+    plugins: [
+        new AutoUnpackNativesPlugin({}),
+        new WebpackPlugin({
+            mainConfig,
+            renderer: {
+                config: rendererConfig,
+                entryPoints: [
+                    {
+                        html: "./src/index.html",
+                        js: "./src/renderer.ts",
+                        name: "main_window",
+                        preload: {
+                            js: "./src/preload.ts",
+                        },
+                    },
+                ],
+            },
+        }),
+        new FusesPlugin({
+            version: FuseVersion.V1,
+            // Disables ELECTRON_RUN_AS_NODE
+            [FuseV1Options.RunAsNode]: false,
+            // Disables the NODE_OPTIONS environment variable
+            [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
+            // Disables the --inspect and --inspect-brk family of CLI options
+            [FuseV1Options.EnableNodeCliInspectArguments]: false,
+            // Enables validation of the app.asar archive on macOS
+            [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true,
+            // Enforces that Electron will only load your app from "app.asar" instead of its normal search paths
+            [FuseV1Options.OnlyLoadAppFromAsar]: true,
+        }),
+    ],
+};
+
+export default config;


### PR DESCRIPTION
## Description of changes

```
proton-mail> [STARTED] Preparing to package application
proton-mail>   electron-forge:project-resolver searching for project in: /build/pmd-source-1.0.2/deps/proton-mail +0ms
proton-mail>   electron-forge:project-resolver package.json with forge dependency found in /build/pmd-source-1.0.2/deps/proton-mail/package.json +1ms
proton-mail> Failed to load: /build/pmd-source-1.0.2/deps/proton-mail/forge.config.ts
proton-mail> [FAILED] Electron failed to install correctly, please delete node_modules/electron and try installing again
proton-mail>
proton-mail> An unhandled rejection has occurred inside Forge:
proton-mail> Error: Electron failed to install correctly, please delete node_modules/electron and try installing again
proton-mail> at getElectronPath (/build/pmd-source-1.0.2/node_modules/electron/index.js:17:11)
proton-mail>     at Object.<anonymous> (/build/pmd-source-1.0.2/node_modules/electron/index.js:21:18)
proton-mail>     at Module._compile (node:internal/modules/cjs/loader:1369:14)
proton-mail>     at Module._extensions..js (node:internal/modules/cjs/loader:1427:10)
proton-mail>     at Object.require.extensions.<computed> [as .js] (/nix/store/p5m37ass6r1ra9qbvx6i12mr5hgv4qqj-proton-mail-modules-1.0.2/deps/proton-mail/node_modules/ts-node/src/index.ts:1608:43)
proton-mail>     at Module.load (node:internal/modules/cjs/loader:1206:32)
proton-mail>     at Function.Module._load (node:internal/modules/cjs/loader:1022:12)
proton-mail>     at Module.require (node:internal/modules/cjs/loader:1231:19)
proton-mail>     at require (node:internal/modules/helpers:179:18)
proton-mail>     at Object.<anonymous> (/build/pmd-source-1.0.2/deps/proton-mail/src/utils/config.ts:1:1)
proton-mail>     at Module._compile (node:internal/modules/cjs/loader:1369:14)
proton-mail>     at Module.m._compile (/nix/store/p5m37ass6r1ra9qbvx6i12mr5hgv4qqj-proton-mail-modules-1.0.2/deps/proton-mail/node_modules/ts-node/src/index.ts:1618:23)
proton-mail>     at Module._extensions..js (node:internal/modules/cjs/loader:1427:10)
proton-mail>     at Object.require.extensions.<computed> [as .ts] (/nix/store/p5m37ass6r1ra9qbvx6i12mr5hgv4qqj-proton-mail-modules-1.0.2/deps/proton-mail/node_modules/ts-node/src/index.ts:1621:12)
proton-mail>     at Module.load (node:internal/modules/cjs/loader:1206:32)
proton-mail>     at Function.Module._load (node:internal/modules/cjs/loader:1022:12)
proton-mail> error Command failed with exit code 1.
proton-mail> info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error: builder for '/nix/store/cs924hq91d8nfa4fpxjygc8digxdnxf6-proton-mail-1.0.2.drv' failed with exit code 1;
       last 10 log lines:
       >     at require (node:internal/modules/helpers:179:18)
       >     at Object.<anonymous> (/build/pmd-source-1.0.2/deps/proton-mail/src/utils/config.ts:1:1)
       >     at Module._compile (node:internal/modules/cjs/loader:1369:14)
       >     at Module.m._compile (/nix/store/p5m37ass6r1ra9qbvx6i12mr5hgv4qqj-proton-mail-modules-1.0.2/deps/proton-mail/node_modules/ts-node/src/index.ts:1618:23)
       >     at Module._extensions..js (node:internal/modules/cjs/loader:1427:10)
       >     at Object.require.extensions.<computed> [as .ts] (/nix/store/p5m37ass6r1ra9qbvx6i12mr5hgv4qqj-proton-mail-modules-1.0.2/deps/proton-mail/node_modules/ts-node/src/index.ts:1621:12)
       >     at Module.load (node:internal/modules/cjs/loader:1206:32)
       >     at Function.Module._load (node:internal/modules/cjs/loader:1022:12)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
