### PR TITLE
[Backport release-23.11] python3Packages.pyinfra: 2.8 -> 2.9.2

### DIFF
--- a/pkgs/development/python-modules/pyinfra/default.nix
+++ b/pkgs/development/python-modules/pyinfra/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "pyinfra";
-  version = "2.8";
+  version = "2.9.2";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
@@ -28,17 +28,8 @@ buildPythonPackage rec {
     owner = "Fizzadar";
     repo = pname;
     rev = "refs/tags/v${version}";
-    hash = "sha256-BYd2UYQJD/HsmpnlQjZvjfg17ShPuA3j4rtv6fTQK/A=";
+    hash = "sha256-lzbFwAg1aLCfBnSnqq4oVteArpkRBa7hU8V3vB5ODa8=";
   };
-
-  patches = [
-    # https://github.com/Fizzadar/pyinfra/pull/1018
-    (fetchpatch {
-      name = "bump-paramiko-major-version.patch";
-      url = "https://github.com/Fizzadar/pyinfra/commit/62a8f081279779c4f1eed246139f615cf5fed642.patch";
-      hash = "sha256-aT9SeSqXOD76LFzf6R/MWTtavcW6fZT7chkVg9aXiBg=";
-    })
-  ];
 
   propagatedBuildInputs = [
     click


### PR DESCRIPTION
https://github.com/Fizzadar/pyinfra/blob/v2.9.2/CHANGELOG.md

(cherry picked from commit e22264f8f5dd4c0f5f8b6957bac87f810a9fb47f and eebd1d6c0bcfcd147c3508255e987febbaff7218)

## Description of changes

These landed into master as part of #294305 so it is rather difficult to use the standard backporting machinery. On the other hand, the version update of pyinfra solves some annoying bugs and deserves to be backported.