### PR TITLE
i3lock-fancy: unstable-2018-11-25 -> unstable-2023-04-28

### DIFF
--- a/pkgs/applications/window-managers/i3/lock-fancy.nix
+++ b/pkgs/applications/window-managers/i3/lock-fancy.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation {
   meta = with lib; {
     description = "i3lock is a bash script that takes a screenshot of the desktop, blurs the background and adds a lock icon and text";
     homepage = "https://github.com/meskarune/i3lock-fancy";
-    maintainers = [ ];
+    maintainers = [ maintainers.reedrw ];
     mainProgram = "i3lock-fancy";
     license = licenses.mit;
     platforms = platforms.linux;

--- a/pkgs/applications/window-managers/i3/lock-fancy.nix
+++ b/pkgs/applications/window-managers/i3/lock-fancy.nix
@@ -1,54 +1,67 @@
-{ lib
-, stdenv
+{ coreutils
 , fetchFromGitHub
-, coreutils
-, scrot
-, imagemagick
-, gawk
-, i3lock-color
-, getopt
 , fontconfig
+, gawk
+, getopt
+, i3lock-color
+, imagemagick
+, installShellFiles
+, lib
+, makeWrapper
+, scrot
+, stdenv
+
+, screenshotCommand ? ""
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "i3lock-fancy";
-  version = "unstable-2018-11-25";
+  version = "unstable-2023-04-28";
 
   src = fetchFromGitHub {
     owner = "meskarune";
     repo = "i3lock-fancy";
-    rev = "7accfb2aa2f918d1a3ab975b860df1693d20a81a";
-    sha256 = "00lqsvz1knb8iqy8lnkn3sf4c2c4nzb0smky63qf48m8za5aw9b1";
+    rev = "55f5c30071403faf5ae4363a54b6d1f63876d5ce";
+    hash = "sha256-ISymKlxLE4/ChDiyjnavFx4T5hEVI62cCxYLWrWiHrg=";
   };
+
+  nativeBuildInputs = [
+    makeWrapper
+    installShellFiles
+  ];
 
   postPatch = ''
     sed -i i3lock-fancy \
-      -e "s|mktemp|${coreutils}/bin/mktemp|" \
-      -e "s|'rm -f |'${coreutils}/bin/rm -f |" \
-      -e "s|scrot -z |${scrot}/bin/scrot -z |" \
-      -e "s|convert |${imagemagick.out}/bin/convert |" \
-      -e "s|awk -F|${gawk}/bin/awk -F|" \
-      -e "s| awk | ${gawk}/bin/awk |" \
-      -e "s|i3lock -i |${i3lock-color}/bin/i3lock-color -i |" \
       -e 's|icon="/usr/share/i3lock-fancy/icons/lockdark.png"|icon="'$out'/share/i3lock-fancy/icons/lockdark.png"|' \
-      -e 's|icon="/usr/share/i3lock-fancy/icons/lock.png"|icon="'$out'/share/i3lock-fancy/icons/lock.png"|' \
-      -e "s|getopt |${getopt}/bin/getopt |" \
-      -e "s|fc-match |${fontconfig.bin}/bin/fc-match |" \
-      -e "s|shot=(import -window root)|shot=(${scrot}/bin/scrot -z -o)|"
+      -e 's|icon="/usr/share/i3lock-fancy/icons/lock.png"|icon="'$out'/share/i3lock-fancy/icons/lock.png"|'
     rm Makefile
+  '' + lib.optionalString (screenshotCommand != "") ''
+    sed -i i3lock-fancy \
+      -e "s|shot=(import -silent -window root)|shot=(${screenshotCommand})|";
   '';
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin $out/share/i3lock-fancy/icons
     cp i3lock-fancy $out/bin/i3lock-fancy
     ln -s $out/bin/i3lock-fancy $out/bin/i3lock
     cp icons/lock*.png $out/share/i3lock-fancy/icons
+    installManPage doc/i3lock-fancy.1
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/i3lock-fancy \
+      --prefix PATH : ${lib.makeBinPath [ coreutils fontconfig gawk getopt i3lock-color imagemagick scrot ]}
   '';
 
   meta = with lib; {
     description = "i3lock is a bash script that takes a screenshot of the desktop, blurs the background and adds a lock icon and text";
     homepage = "https://github.com/meskarune/i3lock-fancy";
-    maintainers = with maintainers; [ ];
+    maintainers = [ ];
+    mainProgram = "i3lock-fancy";
     license = licenses.mit;
     platforms = platforms.linux;
   };


### PR DESCRIPTION
## Description of changes

Updated package to latest commit, added `meta.mainProgram` attribute, clean things up

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
