### PR TITLE
systemd: remote journal requires gnutls to accept `--trust`

### DIFF
--- a/nixos/tests/systemd-journal-gateway.nix
+++ b/nixos/tests/systemd-journal-gateway.nix
@@ -43,7 +43,8 @@ import ./make-test-python.nix ({ lib, pkgs, ... }:
 
     def copy_pem(file: str):
       machine.copy_from_host(source=f"{tmpdir}/{file}", target=f"/run/secrets/{file}")
-      machine.succeed(f"chmod 644 /run/secrets/{file}")
+      machine.succeed(f"chmod 600 /run/secrets/{file}")
+      machine.succeed(f"chown systemd-journal-gateway /run/secrets/{file}")
 
     with subtest("Copying keys and certificates"):
       machine.succeed("mkdir -p /run/secrets/{client,server}")

--- a/nixos/tests/systemd-journal-gateway.nix
+++ b/nixos/tests/systemd-journal-gateway.nix
@@ -43,8 +43,6 @@ import ./make-test-python.nix ({ lib, pkgs, ... }:
 
     def copy_pem(file: str):
       machine.copy_from_host(source=f"{tmpdir}/{file}", target=f"/run/secrets/{file}")
-      machine.succeed(f"chmod 600 /run/secrets/{file}")
-      machine.succeed(f"chown systemd-journal-gateway /run/secrets/{file}")
 
     with subtest("Copying keys and certificates"):
       machine.succeed("mkdir -p /run/secrets/{client,server}")

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -605,7 +605,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonEnable "qrencode" withQrencode)
     (lib.mesonEnable "vmspawn" withVmspawn)
     (lib.mesonEnable "xenctrl" false)
-    (lib.mesonEnable "gnutls" false)
+    (lib.mesonEnable "gnutls" withRemote)
     (lib.mesonEnable "xkbcommon" false)
     (lib.mesonEnable "man" true)
 


### PR DESCRIPTION
## Description of changes

The systemd-journal-gatewayd test fails because of this.
See https://github.com/systemd/systemd/blob/ec0bc263d7d250d4029e8ffe7e3a888c12453331/src/journal-remote/journal-gatewayd.c#L1046-L1062

An alternative would be to either introduce a new option to selectively enable gnutls for those who need it (and for our VM test), but that's also not great in terms of discoverability.

I added a second commit to use `LoadCredentials` to make the secrets available to the service instead of needing to set file system permissions to give access to the `systemd-journal-gateway` user. This might also in the future allow us to set `DynamicUser = true` for this service.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
