### PR TITLE
google-cloud-sdk: reduce closure size when using extra components

### DIFF
--- a/pkgs/tools/admin/google-cloud-sdk/withExtraComponents.nix
+++ b/pkgs/tools/admin/google-cloud-sdk/withExtraComponents.nix
@@ -1,4 +1,4 @@
-{ lib, google-cloud-sdk, runCommand, components }:
+{ lib, google-cloud-sdk, symlinkJoin, components }:
 
 comps_:
 
@@ -19,44 +19,46 @@ let
   defaultComponents = with components; [ alpha beta ];
 
   comps = [ google-cloud-sdk ] ++ filterPreInstalled (findDepsRecursive (defaultComponents ++ comps_));
-in
-# Components are installed by copying the `google-cloud-sdk` package, along
-# with each component, over to a new location, and then patching that location
-# with `sed` to ensure the proper paths are used.
-# For some reason, this does not work properly with a `symlinkJoin`: the
-# `gcloud` binary doesn't seem able to find the installed components.
-runCommand "google-cloud-sdk-${google-cloud-sdk.version}"
-{
-  inherit (google-cloud-sdk) meta;
-  inherit comps;
-  passAsFile = [ "comps" ];
 
-  doInstallCheck = true;
-  disallowedRequisites = [ google-cloud-sdk ];
-  installCheckPhase =
+  installCheck =
     let
-      compNames = builtins.map (drv: drv.name) comps_;
+      compNames = builtins.map lib.getName comps_;
     in
     ''
-      $out/bin/gcloud components list > component_list.txt
+      $out/bin/gcloud components list --only-local-state --format 'value(id)' > component_list.txt
       for comp in ${builtins.toString compNames}; do
-        if [ ! grep ... component_list.txt | grep "Not Installed" ]; then
+        snapshot_file="$out/google-cloud-sdk/.install/$comp.snapshot.json"
+
+        if ! [ -f "$snapshot_file"  ]; then
+          echo "Failed to install component '$comp'"
+          exit 1
+        fi
+
+        if grep --quiet '"is_hidden":true' "$snapshot_file"; then
+          continue
+        fi
+
+        if ! grep --quiet "^$comp$" component_list.txt; then
           echo "Failed to install component '$comp'"
           exit 1
         fi
       done
     '';
+in
+# The `gcloud` entrypoint script has some custom logic to determine the "real" cloud sdk
+# root. In order to not trip up this logic and still have the symlink joined root we copy
+# over this file. Since this file also has a Python wrapper, we need to copy that as well.
+symlinkJoin {
+  name = "google-cloud-sdk-${google-cloud-sdk.version}";
+  inherit (google-cloud-sdk) meta;
+
+  paths = [
+    google-cloud-sdk
+  ] ++ comps;
+
+  postBuild = ''
+    sed -i ';' $out/google-cloud-sdk/bin/.gcloud-wrapped
+    sed -i -e "s#${google-cloud-sdk}#$out#" "$out/google-cloud-sdk/bin/gcloud"
+    ${installCheck}
+  '';
 }
-  ''
-    mkdir -p $out
-
-    # Install each component
-    for comp in $(cat $compsPath); do
-      echo "installing component $comp"
-      cp -dRf $comp/. $out
-      find $out -type d -exec chmod 744 {} +
-    done
-
-    # Replace references to the original google-cloud-sdk with this one
-    find $out/google-cloud-sdk -type f -exec sed -i -e "s#${google-cloud-sdk}#$out#" {} \;
-  ''


### PR DESCRIPTION
## Description of changes

Previous implementation copied over all the components in order to retain the component detection. After some investigation I discovered that the cause of this was the entrypoint which had some logic to grab the cloud sdk root from the realpath of that script.

In order to solve this I copy over this file as well as it's Python wrapper (since this has the explicit path to this script).

I could also not get the install check script to work as it tried to reach the Internet, so I added the flag `--only-local-state`, which in turn changed the output format, so I could not rely on the previous plugin installed detection.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
