### PR TITLE
doc: migrate lib.cli to use doc-comments

### DIFF
--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -1,43 +1,64 @@
 { lib }:
 
 rec {
-  /* Automatically convert an attribute set to command-line options.
+  /**
+    Automatically convert an attribute set to command-line options.
 
-     This helps protect against malformed command lines and also to reduce
-     boilerplate related to command-line construction for simple use cases.
+    This helps protect against malformed command lines and also to reduce
+    boilerplate related to command-line construction for simple use cases.
 
-     `toGNUCommandLine` returns a list of nix strings.
-     `toGNUCommandLineShell` returns an escaped shell string.
+    `toGNUCommandLine` returns a list of nix strings.
 
-     Example:
-       cli.toGNUCommandLine {} {
-         data = builtins.toJSON { id = 0; };
-         X = "PUT";
-         retry = 3;
-         retry-delay = null;
-         url = [ "https://example.com/foo" "https://example.com/bar" ];
-         silent = false;
-         verbose = true;
-       }
-       => [
-         "-X" "PUT"
-         "--data" "{\"id\":0}"
-         "--retry" "3"
-         "--url" "https://example.com/foo"
-         "--url" "https://example.com/bar"
-         "--verbose"
-       ]
+    `toGNUCommandLineShell` returns an escaped shell string.
 
-       cli.toGNUCommandLineShell {} {
-         data = builtins.toJSON { id = 0; };
-         X = "PUT";
-         retry = 3;
-         retry-delay = null;
-         url = [ "https://example.com/foo" "https://example.com/bar" ];
-         silent = false;
-         verbose = true;
-       }
-       => "'-X' 'PUT' '--data' '{\"id\":0}' '--retry' '3' '--url' 'https://example.com/foo' '--url' 'https://example.com/bar' '--verbose'";
+
+    # Inputs
+
+    `options`
+
+    : 1\. Function argument
+
+    `attrs`
+
+    : 2\. Function argument
+
+
+    # Examples
+    :::{.example}
+    ## `lib.cli.toGNUCommandLineShell` usage example
+
+    ```nix
+    cli.toGNUCommandLine {} {
+      data = builtins.toJSON { id = 0; };
+      X = "PUT";
+      retry = 3;
+      retry-delay = null;
+      url = [ "https://example.com/foo" "https://example.com/bar" ];
+      silent = false;
+      verbose = true;
+    }
+    => [
+      "-X" "PUT"
+      "--data" "{\"id\":0}"
+      "--retry" "3"
+      "--url" "https://example.com/foo"
+      "--url" "https://example.com/bar"
+      "--verbose"
+    ]
+
+    cli.toGNUCommandLineShell {} {
+      data = builtins.toJSON { id = 0; };
+      X = "PUT";
+      retry = 3;
+      retry-delay = null;
+      url = [ "https://example.com/foo" "https://example.com/bar" ];
+      silent = false;
+      verbose = true;
+    }
+    => "'-X' 'PUT' '--data' '{\"id\":0}' '--retry' '3' '--url' 'https://example.com/foo' '--url' 'https://example.com/bar' '--verbose'";
+    ```
+
+    :::
   */
   toGNUCommandLineShell =
     options: attrs: lib.escapeShellArgs (toGNUCommandLine options attrs);


### PR DESCRIPTION
## Description of changes

**Part of ongoing doc-comment migration**

cc @DanielSidhion 

- [x] Inner/outer format migrated `/* {nixdoc} */` -> `/** {commonmark} */`
- [x] Clean up function arguments. Manually remove the redundant line comments. We decided the codemod won't delete anything.
- [x] Reify examples. After the migration is done all examples should be placed at the end under an `# Examples` heading.
    - [x] Examples should be surrunded by :::{.example} such that they are properly styled.
    - [x] Make sure examples have a descriptive heading. e.g. `## lib.trivial.const usage examples`
- [x] Manual reformatting work for consistency

Please comment all other errors / mistakes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
