### PR TITLE
python311Packages.slicer: 0.0.7 -> 0.0.8

### DIFF
--- a/pkgs/development/python-modules/slicer/default.nix
+++ b/pkgs/development/python-modules/slicer/default.nix
@@ -1,63 +1,40 @@
 { lib
 , buildPythonPackage
-, dos2unix
-, fetchpatch
 , fetchPypi
 , pytestCheckHook
 , pythonOlder
 , pandas
 , torch
 , scipy
+, setuptools
 }:
 
 buildPythonPackage rec {
   pname = "slicer";
-  version = "0.0.7";
-  format = "setuptools";
+  version = "0.0.8";
+  pyproject = true;
+
   disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-9dX3tF+Y0VW5wLplVPqXcMaybVeTo+d6EDD7VpEOvuw=";
+    hash = "sha256-LnVTr3PwwMLTVfSvzD7Pl8byFW/PRZOVXD9Wz2xNbrc=";
   };
 
-  prePatch = ''
-    dos2unix slicer/*
-  '';
-
-  patches = [
-    # these patches add support for numpy>=1.24
-    (fetchpatch {
-      url = "https://github.com/interpretml/slicer/commit/028e09e639c4a3c99abe1d537cce30af2eebb081.patch";
-      hash = "sha256-jh/cbz7cx2ks6jMNh1gI1n5RS/OHBtSIDZRxUGyrl/I=";
-    })
-    (fetchpatch {
-      url = "https://github.com/interpretml/slicer/commit/d4bb09f136d7e1f64711633c16a37e7bee738696.patch";
-      hash = "sha256-9rh99s4JWF4iKClZ19jvqSeRulL32xB5Use8PGkh/SA=";
-    })
-    (fetchpatch {
-      url = "https://github.com/interpretml/slicer/commit/74b3683a5a7bd982f9eaaf8d8d665dfdaf2c6604.patch";
-      hash = "sha256-R3zsC3udYPFUT93eRhb6wyc9S5n2wceiOunWJ8K+648=";
-    })
+  build-system = [
+    setuptools
   ];
 
-  nativeBuildInputs = [
-    dos2unix
+  pythonImportsCheck = [
+    "slicer"
   ];
 
   nativeCheckInputs = [ pytestCheckHook pandas torch scipy ];
-
-  disabledTests = [
-    # IndexError: too many indices for array
-    "test_slicer_sparse"
-    "test_operations_2d"
-  ];
 
   meta = with lib; {
     description = "Wraps tensor-like objects and provides a uniform slicing interface via __getitem__";
     homepage = "https://github.com/interpretml/slicer";
     license = licenses.mit;
     maintainers = with maintainers; [ evax ];
-    platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
Diff: https://github.com/interpretml/slicer/compare/v0.0.7...v0.0.8

Changelog: https://github.com/interpretml/slicer/releases/tag/v0.0.8

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
