### PR TITLE
opensta: Add new package

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15632,6 +15632,12 @@
     githubId = 146413;
     name = "Tobias Poschwatta";
   };
+  povik = {
+    email = "povik+nix@cutebit.org";
+    github = "povik";
+    githubId = 382160;
+    name = "Martin Povišer";
+  };
   poweredbypie = {
     name = "poweredbypie";
     github = "poweredbypie";

--- a/pkgs/by-name/op/opensta/package.nix
+++ b/pkgs/by-name/op/opensta/package.nix
@@ -1,0 +1,68 @@
+{ lib
+, stdenv
+, cmake
+, flex
+, bison
+, swig4
+, fetchFromGitHub
+, fetchurl
+, tcl
+, tclreadline
+, zlib
+}:
+
+let
+  cudd = stdenv.mkDerivation rec {
+    pname = "cudd";
+    version = "3.0.0";
+
+    src = fetchurl {
+      url = "https://github.com/davidkebo/cudd/raw/main/cudd_versions/cudd-${version}.tar.gz";
+      hash = "sha256-uOlmtFYslqA+f76iOXKVh9ezldU8rcw5pyA7Sc9+62k=";
+    };
+
+    meta = with lib; {
+      description = "Package for manipulation of binary and other kinds of decision diagrams";
+      homepage = "https://davidkebo.com/cudd/";
+      license = licenses.bsd3;
+    };
+  };
+in stdenv.mkDerivation rec {
+  pname = "opensta";
+  version = "0-unstable-2024-03-21";
+
+  src = fetchFromGitHub {
+    owner = "parallaxsw";
+    repo = "OpenSTA";
+    rev = "8bf51ab7ee5c544d4f12d33f8f26c09a70914dfa";
+    hash = "sha256-As2jbIS04p5FsSCNtuQFuTLY3+nAAPMZsYjJnPQAcCU=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    flex
+    bison
+    swig4
+  ];
+
+  buildInputs = [
+    tcl
+    tclreadline
+    zlib
+    cudd
+  ];
+
+  cmakeFlags = [
+    "-DTCL_LIB_PATHS=${tcl}"
+    "-DUSE_TCL_READLINE=ON"
+    "-DUSE_CUDD=ON"
+    "-DCUDD_DIR=${cudd}"
+  ];
+
+  meta = with lib; {
+    description = "OpenSTA - Parallax Static Timing Analyzer";
+    homepage = "https://github.com/parallaxsw/OpenSTA";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.povik ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This adds [OpenSTA](https://github.com/parallaxsw/OpenSTA), a Static Timing Analyzer for usage in digital circuit design.  It's a tool that's relied on by [the OpenROAD project](https://github.com/The-OpenROAD-Project), though they package their own embedded version (there's an `openroad` derivation already).

This new derivation builds from the upstream of the OpenSTA project, for standalone use of the tool, and it also builds on other platforms than Linux. There's another, seemingly more popular [project called OpenSTA](https://en.wikipedia.org/wiki/OpenSTA), hence why the derivation is called `opensta-eda`.

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
