### PR TITLE
cbtemulator: init at 1.22.0

### DIFF
--- a/pkgs/by-name/cb/cbtemulator/package.nix
+++ b/pkgs/by-name/cb/cbtemulator/package.nix
@@ -1,0 +1,67 @@
+{ lib
+, stdenv
+, buildGoModule
+, fetchFromGitHub
+, runCommand
+, cbtemulator
+, google-cloud-bigtable-tool
+}:
+
+buildGoModule rec {
+  pname = "cbtemulator";
+  version = "1.22.0";
+
+  # There's a go.{mod,sum} in the root and in the "bigtable" subdir.
+  # We only ever use things in that subdir.
+  src = (fetchFromGitHub {
+    owner = "googleapis";
+    repo = "google-cloud-go";
+    rev = "bigtable/v${version}";
+    hash = "sha256-eOi4QFthnmZb5ry/5L7wzr4Fy1pF/H07BzxOnXtmSu4=";
+  }) + "/bigtable";
+
+  vendorHash = "sha256-7M7YZfl0usjN9hLGozqJV2bGh+M1ec4PZRGYUhEckpY=";
+  subPackages = [ "cmd/emulator" ];
+
+  postInstall = ''
+    mv $out/bin/emulator $out/bin/cbtemulator
+  '';
+
+  passthru = {
+    # Sets up a table and family, then inserts, and ensures it gets back the value.
+    tests.smoketest = runCommand "cbtemulator-smoketest"
+      {
+        nativeBuildInputs = [ google-cloud-bigtable-tool ];
+      } ''
+      # Start the emulator
+      ${lib.getExe cbtemulator} &
+      EMULATOR_PID=$!
+
+      cleanup() {
+        kill $EMULATOR_PID
+      }
+
+      trap cleanup EXIT
+
+      export BIGTABLE_EMULATOR_HOST=localhost:9000
+
+      cbt -instance instance-1 -project project-1 createtable table-1
+      cbt -instance instance-1 -project project-1 createfamily table-1 cf1
+      cbt -instance instance-1 -project project-1 ls table-1
+      cbt -instance instance-1 -project project-1 set table-1 key1 cf1:c1=value1
+
+      cbt -instance instance-1 -project project-1 read table-1 | grep -q value1
+
+      touch $out;
+    '';
+  };
+
+  meta = with lib; {
+    description = "In-memory Google Cloud Bigtable server";
+    homepage = "https://github.com/googleapis/google-cloud-go/blob/bigtable/v1.22.0/bigtable/cmd/emulator/cbtemulator.go";
+    license = licenses.asl20;
+    maintainers = [ maintainers.flokli ];
+    mainProgram = "cbtemulator";
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
This packages cbtemulator, an in-memory emulator for Google Bigtable.

I added a small smoketest, setting up tables, inserting a value, and asserting we get it back.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
