### PR TITLE
limine: init at 7.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -203,6 +203,12 @@
       fingerprint = "D292 365E 3C46 A5AA 75EE  B30B 78DB 7EDE 3540 794B";
     }];
   };
+  _48cf = {
+    name = "czapek";
+    email = "czapek1337@gmail.com";
+    github = "48cf";
+    githubId = 32851089;
+  };
   _6543 = {
     email = "6543@obermui.de";
     github = "6543";

--- a/pkgs/by-name/li/limine/package.nix
+++ b/pkgs/by-name/li/limine/package.nix
@@ -53,6 +53,7 @@ stdenv.mkDerivation {
     # necessarily the platforms for that bootable images can be created.
     platforms = platforms.unix;
     maintainers = [
+      maintainers._48cf
       maintainers.phip1611
     ];
   };

--- a/pkgs/by-name/li/limine/package.nix
+++ b/pkgs/by-name/li/limine/package.nix
@@ -48,7 +48,13 @@ stdenv.mkDerivation {
     homepage = "https://limine-bootloader.org/";
     description = "Limine Bootloader";
     # Caution. Some submodules have different licenses.
-    license = licenses.bsd2;
+    license = [
+      licenses.bsd2 # limine, flanterm
+      licenses.bsd0 # freestanding-toolchain, freestanding-headers
+      licenses.asl20 # cc-runtime
+      licenses.mit # limine-efi, stb
+      licenses.zlib # tinf
+    ];
     # The platforms on that the Liminine binary and helper tools can run, not
     # necessarily the platforms for that bootable images can be created.
     platforms = platforms.unix;

--- a/pkgs/by-name/li/limine/package.nix
+++ b/pkgs/by-name/li/limine/package.nix
@@ -1,0 +1,59 @@
+# Builds limine with all available features.
+
+{
+  # Helpers
+  stdenv
+, fetchurl
+, lib
+, # Dependencies
+  llvmPackages
+, mtools
+, nasm
+}:
+
+let
+  version = "7.3.0";
+in
+# The output of the derivation is a tool to create bootable images using Limine
+# as bootloader for various platforms and corresponding binary and helper files.
+stdenv.mkDerivation {
+  inherit version;
+  pname = "limine";
+  # We don't use the Git source but the release tarball, as the source has a
+  # `./bootstrap` script performing network access to download resources.
+  # Packaging that in Nix is very cumbersome.
+  src = fetchurl {
+    url = "https://github.com/limine-bootloader/limine/releases/download/v${version}/limine-${version}.tar.gz";
+    sha256 = "sha256-iPi6u3iZOJfVRERrJVgH6q16aANnSGgBL5AtNuANrao=";
+  };
+
+  nativeBuildInputs = [
+    llvmPackages.bintools
+    # gcc is used for the host tool, while clang is used for the bootloader.
+    llvmPackages.clang
+    llvmPackages.lld
+    mtools
+    nasm
+  ];
+
+  configureFlags = [
+    "--enable-all"
+  ];
+
+  installFlags = [ "destdir=$out" "manprefix=/share" ];
+
+  outputs = [ "out" "doc" "dev" "man" ];
+
+  meta = with lib; {
+    homepage = "https://limine-bootloader.org/";
+    description = "Limine Bootloader";
+    # Caution. Some submodules have different licenses.
+    license = licenses.bsd2;
+    # The platforms on that the Liminine binary and helper tools can run, not
+    # necessarily the platforms for that bootable images can be created.
+    platforms = platforms.unix;
+    maintainers = [
+      maintainers.phip1611
+    ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This inits the Limine bootloader. Unlike https://github.com/NixOS/nixpkgs/pull/194841, this only inits the package for now. The package itself is very useful already, for example for OS developers that want to boot their kernel using Limine. (Similar to using `grub-mkstandalone` or `grub-mkrescue`)

Adding `boot.loader.limine.enable` as NixOS option will be a follow-up.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
