### PR TITLE
python3Packages.dbf: fix build on Darwin

### DIFF
--- a/pkgs/development/python-modules/dbf/darwin.patch
+++ b/pkgs/development/python-modules/dbf/darwin.patch
@@ -1,0 +1,12 @@
+diff --git a/dbf/test.py b/dbf/test.py
+index 117f611..34a9507 100755
+--- a/dbf/test.py
++++ b/dbf/test.py
+@@ -4814,6 +4814,7 @@ def test_index_search(self):
+         self.assertEqual(sorted.index_search('jul', partial=True), 9)
+         self.assertTrue(sorted.index_search('jul', partial=True))
+ 
++    @unittest.skipIf(sys.platform == 'darwin', 'fails on case-insensitive filesystems')
+     def test_mismatched_extensions(self):
+         old_memo_name = self.dbf_table._meta.memoname
+         new_memo_name = old_memo_name[:-3] + 'Dbt'

--- a/pkgs/development/python-modules/dbf/default.nix
+++ b/pkgs/development/python-modules/dbf/default.nix
@@ -22,7 +22,9 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ aenum ];
 
   checkPhase = ''
+    runHook preCheck
     ${python.interpreter} -m dbf.test
+    runHook postCheck
   '';
 
   pythonImportsCheck = [ "dbf" ];

--- a/pkgs/development/python-modules/dbf/default.nix
+++ b/pkgs/development/python-modules/dbf/default.nix
@@ -19,6 +19,9 @@ buildPythonPackage rec {
     hash = "sha256-MFEi1U0RNvrfDtV4HpvPgKTCibAh76z7Gnmj32IubYw=";
   };
 
+  # Workaround for https://github.com/ethanfurman/dbf/issues/48
+  patches = lib.optional python.stdenv.isDarwin ./darwin.patch;
+
   propagatedBuildInputs = [ aenum ];
 
   checkPhase = ''


### PR DESCRIPTION
Skip test that fails on case-insensitive filesystems.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
