### PR TITLE
qemu: 8.2.4 -> 9.0.0

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -55,11 +55,11 @@ stdenv.mkDerivation (finalAttrs: {
     + lib.optionalString hostCpuOnly "-host-cpu-only"
     + lib.optionalString nixosTestRunner "-for-vm-tests"
     + lib.optionalString toolsOnly "-utils";
-  version = "8.2.4";
+  version = "9.0.0";
 
   src = fetchurl {
     url = "https://download.qemu.org/qemu-${finalAttrs.version}.tar.xz";
-    hash = "sha256-7PVTf+q5JkG5nXSC9VHyGV06W9NKzvnVK/v/NTpgc5c=";
+    hash = "sha256-MnCKxmww2MiSYz6paMdxwcdtWX1w3erSGg0izPOG2mk=";
   };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ]
@@ -124,11 +124,9 @@ stdenv.mkDerivation (finalAttrs: {
     # Cocoa clipboard support only works on macOS 10.14+
     ./revert-ui-cocoa-add-clipboard-support.patch
     # Standard about panel requires AppKit and macOS 10.13+
-    (fetchpatch {
-      url = "https://gitlab.com/qemu-project/qemu/-/commit/99eb313ddbbcf73c1adcdadceba1423b691c6d05.diff";
-      sha256 = "sha256-gTRf9XENAfbFB3asYCXnw4OV4Af6VE1W56K2xpYDhgM=";
-      revert = true;
-    })
+    ./revert-ui-cocoa-use-the-standard-about-panel.patch
+    # Safe area insets require macOS 11+
+    ./remove-ui-cocoa-use-safe-area-insets.patch
     # Workaround for upstream issue with nested virtualisation: https://gitlab.com/qemu-project/qemu/-/issues/1008
     (fetchpatch {
       url = "https://gitlab.com/qemu-project/qemu/-/commit/3e4546d5bd38a1e98d4bd2de48631abf0398a3a2.diff";
@@ -239,6 +237,10 @@ stdenv.mkDerivation (finalAttrs: {
     # get-fsinfo attempts to access block devices, disallowed by sandbox
     sed -i -e '/\/qga\/get-fsinfo/d' -e '/\/qga\/blacklist/d' \
       ../tests/unit/test-qga.c
+
+    # xattrs are not allowed in the sandbox
+    substituteInPlace ../tests/qtest/virtio-9p-test.c \
+      --replace-fail mapped-xattr mapped-file
   '' + lib.optionalString stdenv.isDarwin ''
     # skip test that stalls on darwin, perhaps due to subtle differences
     # in fifo behaviour

--- a/pkgs/applications/virtualization/qemu/remove-ui-cocoa-use-safe-area-insets.patch
+++ b/pkgs/applications/virtualization/qemu/remove-ui-cocoa-use-safe-area-insets.patch
@@ -1,0 +1,14 @@
+diff --git a/ui/cocoa.m b/ui/cocoa.m
+index 25e0db9dd0..7ce889d798 100644
+--- a/ui/cocoa.m
++++ b/ui/cocoa.m
+@@ -539,9 +539,6 @@ - (NSSize)fixAspectRatio:(NSSize)max
+ - (NSSize) screenSafeAreaSize
+ {
+     NSSize size = [[[self window] screen] frame].size;
+-    NSEdgeInsets insets = [[[self window] screen] safeAreaInsets];
+-    size.width -= insets.left + insets.right;
+-    size.height -= insets.top + insets.bottom;
+     return size;
+ }
+ 

--- a/pkgs/applications/virtualization/qemu/revert-ui-cocoa-add-clipboard-support.patch
+++ b/pkgs/applications/virtualization/qemu/revert-ui-cocoa-add-clipboard-support.patch
@@ -47,7 +47,7 @@ index 660d3e0935..0e6760c360 100644
 -static QemuClipboardInfo *cbinfo;
 -static QemuEvent cbevent;
 -
- // Utility functions to run specified code block with iothread lock held
+ // Utility functions to run specified code block with the BQL held
  typedef void (^CodeBlock)(void);
  typedef bool (^BoolCodeBlock)(void);
 @@ -1799,107 +1794,6 @@ static void addRemovableDevicesMenuItems(void)
@@ -65,7 +65,7 @@ index 660d3e0935..0e6760c360 100644
 -        return;
 -    }
 -
--    with_iothread_lock(^{
+-    with_bql(^{
 -        QemuClipboardInfo *info = qemu_clipboard_info_ref(cbinfo);
 -        qemu_event_reset(&cbevent);
 -        qemu_clipboard_request(info, QEMU_CLIPBOARD_TYPE_TEXT);
@@ -73,9 +73,9 @@ index 660d3e0935..0e6760c360 100644
 -        while (info == cbinfo &&
 -               info->types[QEMU_CLIPBOARD_TYPE_TEXT].available &&
 -               info->types[QEMU_CLIPBOARD_TYPE_TEXT].data == NULL) {
--            qemu_mutex_unlock_iothread();
+-            bql_unlock();
 -            qemu_event_wait(&cbevent);
--            qemu_mutex_lock_iothread();
+-            bql_lock();
 -        }
 -
 -        if (info == cbinfo) {
@@ -186,9 +186,9 @@ index 660d3e0935..0e6760c360 100644
  }
  
 @@ -2071,12 +1952,6 @@ static void cocoa_display_init(DisplayState *ds, DisplayOptions *opts)
- 
      // register vga output callbacks
      register_displaychangelistener(&dcl);
+     [cocoaView updateUIInfo];
 -
 -    qemu_event_init(&cbevent, false);
 -    cbowner = [[QemuCocoaPasteboardTypeOwner alloc] init];

--- a/pkgs/applications/virtualization/qemu/revert-ui-cocoa-use-the-standard-about-panel.patch
+++ b/pkgs/applications/virtualization/qemu/revert-ui-cocoa-use-the-standard-about-panel.patch
@@ -1,0 +1,145 @@
+diff --git a/ui/cocoa.m b/ui/cocoa.m
+index 25e0db9dd0..4af0712036 100644
+--- a/ui/cocoa.m
++++ b/ui/cocoa.m
+@@ -93,6 +93,7 @@ static void cocoa_switch(DisplayChangeListener *dcl,
+ 
+ static void cocoa_refresh(DisplayChangeListener *dcl);
+ 
++static NSWindow *about_window;
+ static const DisplayChangeListenerOps dcl_ops = {
+     .dpy_name          = "cocoa",
+     .dpy_gfx_update = cocoa_update,
+@@ -1180,6 +1181,7 @@ - (void)changeDeviceMedia:(id)sender;
+ - (BOOL)verifyQuit;
+ - (void)openDocumentation:(NSString *)filename;
+ - (IBAction) do_about_menu_item: (id) sender;
++- (void)make_about_window;
+ - (void)adjustSpeed:(id)sender;
+ @end
+ 
+@@ -1227,6 +1229,8 @@ - (id) init
+         [pauseLabel setFont: [NSFont fontWithName: @"Helvetica" size: 90]];
+         [pauseLabel setTextColor: [NSColor blackColor]];
+         [pauseLabel sizeToFit];
++
++        [self make_about_window];
+     }
+     return self;
+ }
+@@ -1549,29 +1553,92 @@ - (BOOL)verifyQuit
+ /* The action method for the About menu item */
+ - (IBAction) do_about_menu_item: (id) sender
+ {
+-    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+-    char *icon_path_c = get_relocated_path(CONFIG_QEMU_ICONDIR "/hicolor/512x512/apps/qemu.png");
+-    NSString *icon_path = [NSString stringWithUTF8String:icon_path_c];
+-    g_free(icon_path_c);
+-    NSImage *icon = [[NSImage alloc] initWithContentsOfFile:icon_path];
+-    NSString *version = @"QEMU emulator version " QEMU_FULL_VERSION;
+-    NSString *copyright = @QEMU_COPYRIGHT;
+-    NSDictionary *options;
+-    if (icon) {
+-        options = @{
+-            NSAboutPanelOptionApplicationIcon : icon,
+-            NSAboutPanelOptionApplicationVersion : version,
+-            @"Copyright" : copyright,
+-        };
+-        [icon release];
+-    } else {
+-        options = @{
+-            NSAboutPanelOptionApplicationVersion : version,
+-            @"Copyright" : copyright,
+-        };
+-    }
+-    [NSApp orderFrontStandardAboutPanelWithOptions:options];
+-    [pool release];
++    [about_window makeKeyAndOrderFront: nil];
++}
++
++/* Create and display the about dialog */
++- (void)make_about_window
++{
++    /* Make the window */
++    int x = 0, y = 0, about_width = 400, about_height = 200;
++    NSRect window_rect = NSMakeRect(x, y, about_width, about_height);
++    about_window = [[NSWindow alloc] initWithContentRect:window_rect
++                    styleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskClosable |
++                    NSWindowStyleMaskMiniaturizable
++                    backing:NSBackingStoreBuffered
++                    defer:NO];
++    [about_window setTitle: @"About"];
++    [about_window setReleasedWhenClosed: NO];
++    [about_window center];
++    NSView *superView = [about_window contentView];
++
++    /* Create the dimensions of the picture */
++    int picture_width = 80, picture_height = 80;
++    x = (about_width - picture_width)/2;
++    y = about_height - picture_height - 10;
++    NSRect picture_rect = NSMakeRect(x, y, picture_width, picture_height);
++
++    /* Make the picture of QEMU */
++    NSImageView *picture_view = [[NSImageView alloc] initWithFrame:
++                                                     picture_rect];
++    char *qemu_image_path_c = get_relocated_path(CONFIG_QEMU_ICONDIR "/hicolor/512x512/apps/qemu.png");
++    NSString *qemu_image_path = [NSString stringWithUTF8String:qemu_image_path_c];
++    g_free(qemu_image_path_c);
++    NSImage *qemu_image = [[NSImage alloc] initWithContentsOfFile:qemu_image_path];
++    [picture_view setImage: qemu_image];
++    [picture_view setImageScaling: NSImageScaleProportionallyUpOrDown];
++    [superView addSubview: picture_view];
++
++    /* Make the name label */
++    NSBundle *bundle = [NSBundle mainBundle];
++    if (bundle) {
++        x = 0;
++        y = y - 25;
++        int name_width = about_width, name_height = 20;
++        NSRect name_rect = NSMakeRect(x, y, name_width, name_height);
++        NSTextField *name_label = [[NSTextField alloc] initWithFrame: name_rect];
++        [name_label setEditable: NO];
++        [name_label setBezeled: NO];
++        [name_label setDrawsBackground: NO];
++        [name_label setAlignment: NSTextAlignmentCenter];
++        NSString *qemu_name = [[bundle executablePath] lastPathComponent];
++        [name_label setStringValue: qemu_name];
++        [superView addSubview: name_label];
++    }
++
++    /* Set the version label's attributes */
++    x = 0;
++    y = 50;
++    int version_width = about_width, version_height = 20;
++    NSRect version_rect = NSMakeRect(x, y, version_width, version_height);
++    NSTextField *version_label = [[NSTextField alloc] initWithFrame:
++                                                      version_rect];
++    [version_label setEditable: NO];
++    [version_label setBezeled: NO];
++    [version_label setAlignment: NSTextAlignmentCenter];
++    [version_label setDrawsBackground: NO];
++
++    /* Create the version string*/
++    NSString *version_string;
++    version_string = [[NSString alloc] initWithFormat:
++    @"QEMU emulator version %s", QEMU_FULL_VERSION];
++    [version_label setStringValue: version_string];
++    [superView addSubview: version_label];
++
++    /* Make copyright label */
++    x = 0;
++    y = 35;
++    int copyright_width = about_width, copyright_height = 20;
++    NSRect copyright_rect = NSMakeRect(x, y, copyright_width, copyright_height);
++    NSTextField *copyright_label = [[NSTextField alloc] initWithFrame:
++                                                        copyright_rect];
++    [copyright_label setEditable: NO];
++    [copyright_label setBezeled: NO];
++    [copyright_label setDrawsBackground: NO];
++    [copyright_label setAlignment: NSTextAlignmentCenter];
++    [copyright_label setStringValue: [NSString stringWithFormat: @"%s",
++                                     QEMU_COPYRIGHT]];
++    [superView addSubview: copyright_label];
+ }
+ 
+ /* Used by the Speed menu items */


### PR DESCRIPTION
## Description of changes

- [ChangeLog](https://wiki.qemu.org/ChangeLog/9.0)
- [Planning](https://wiki.qemu.org/Planning/9.0) (ETA: 2024-04-16)

The Darwin patches have stopped applying again. (cc @willcohen)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
