### PR TITLE
kernel/common-config: throw on duplicate configuration option definitions

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -23,7 +23,7 @@ let
 
 
   # configuration items have to be part of a subattrs
-  flattenKConf =  nested: mapAttrs (_: head) (zipAttrs (attrValues nested));
+  flattenKConf = nested: mapAttrs (name: values: if length values == 1 then head values else throw "duplicate kernel configuration option: ${name}") (zipAttrs (attrValues nested));
 
   whenPlatformHasEBPFJit =
     mkIf (stdenv.hostPlatform.isAarch32 ||
@@ -110,9 +110,6 @@ let
 
       # Enable CPU energy model for scheduling
       ENERGY_MODEL                     = whenAtLeast "5.0" yes;
-
-      # Enable scheduling stats collection
-      SCHEDSTATS                       = yes;
 
       # Enable thermal interface netlink API
       THERMAL_NETLINK                  = whenAtLeast "5.9" yes;
@@ -413,7 +410,6 @@ let
       whenHasDevicePrivate = mkIf (!stdenv.isx86_32 && versionAtLeast version "5.1");
     in {
       DRM_LEGACY = whenOlder "6.8" no;
-      DRM_SIMPLEDRM = yes;
 
       NOUVEAU_LEGACY_CTX_SUPPORT = whenBetween "5.2" "6.3" no;
 
@@ -890,7 +886,6 @@ let
       NOTIFIER_ERROR_INJECTION = option no;
       RCU_PERF_TEST            = whenOlder "5.9" no;
       RCU_SCALE_TEST           = whenAtLeast "5.10" no;
-      RCU_TORTURE_TEST         = option no;
       TEST_ASYNC_DRIVER_PROBE  = option no;
       WW_MUTEX_SELFTEST        = option no;
       XZ_DEC_TEST              = option no;
@@ -999,7 +994,6 @@ let
       # Removed on 5.17 as it was unused
       # upstream: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0a4ee518185e902758191d968600399f3bc2be31
       CLEANCACHE = whenOlder "5.17" (option yes);
-      CRASH_DUMP = option no;
 
       FSCACHE_STATS = yes;
 


### PR DESCRIPTION
Previously, when a kernel configuration option was defined multiple times (in different sections), only the first value was honored and all subsequent ones were silently ignored. Remove this footgun by throwing in this situation instead.
In addition, fix all instances where an option was in fact defined multiple times. In two cases (`RCU_TORTURE_TEST` and `CRASH_DUMP`), the value was effectively the same both times. In the other two cases (`SCHEDSTATS` and `DRM_SIMPLEDRM`) the value was in fact different; the one that was actually applied was kept here to prevent a rebuild.

Pinging @K900: `SCHEDSTATS` and `DRM_SIMPLEDRM` that were intended to be introduced in https://github.com/NixOS/nixpkgs/pull/296867/files should be revisited, retested and then probably merged along with a round of kernel updates.

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
