### PR TITLE
Add i3ipc-gjs

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18642,6 +18642,11 @@
     githubId = 3889585;
     name = "Cheng Shao";
   };
+  tesnos6921 = {
+    github = "tesnos6921";
+    githubId = 7860497;
+    name = "tesnos6921";
+  };
   tesq0 = {
     email = "mikolaj.galkowski@gmail.com";
     github = "tesq0";

--- a/pkgs/by-name/i3/i3ipc-gjs/package.nix
+++ b/pkgs/by-name/i3/i3ipc-gjs/package.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, autoreconfHook
+, gjs
+, i3ipc-glib
+, pkg-config
+, which
+}:
+stdenv.mkDerivation rec {
+  pname = "i3ipc-gjs";
+  version = "0.1.2";
+
+  meta = with lib; {
+    description = "An improved JavaScript library to control i3wm";
+    homepage = "https://github.com/acrisci/i3ipc-gjs";
+    maintainers = with maintainers; [tesnos6921];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    gjs
+    pkg-config
+    which
+  ];
+
+  buildInputs = [
+    gjs
+    i3ipc-glib
+  ];
+
+  src = fetchFromGitHub {
+    owner = "acrisci";
+    repo = "i3ipc-gjs";
+    rev = "v${version}";
+    sha256 = "sha256-x5XMS3md3V2ytBgtQ6pXRynNF6PqL+GjQwPJYUl54UY=";
+  };
+
+  configureFlags = [
+    (lib.withFeatureAs true "gjs-overrides-dir" "$(out)/usr/share/gjs-1.0/overrides")
+  ];
+}


### PR DESCRIPTION
## Description of changes

Initialize [i3ipc-gjs](https://github.com/acrisci/i3ipc-gjs/), "an improved JavaScript library to control i3wm", at v0.1.2.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
