### PR TITLE
nixos/prometheus: abbility to add downstream exporters

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -971,6 +971,9 @@
   "module-services-prometheus-exporters-update-exporter-module": [
     "index.html#module-services-prometheus-exporters-update-exporter-module"
   ],
+  "module-services-prometheus-exporters-downstream-exporter": [
+    "index.html#module-services-prometheus-exporters-downstream-exporter"
+  ],
   "module-services-parsedmarc": [
     "index.html#module-services-parsedmarc"
   ],

--- a/nixos/modules/services/monitoring/prometheus/exporters.md
+++ b/nixos/modules/services/monitoring/prometheus/exporters.md
@@ -178,3 +178,20 @@ in
   ];
 }
 ```
+
+## Adding a downstream exporter {#module-services-prometheus-exporters-downstream-exporter}
+
+First create the exporter file, `EXPORTER-exporter.nix` as you would with an upstream exporter
+
+Then create a module that imports the exporter
+
+```nix
+{ modulesPath, ... }: {
+  imports = [
+    (import "${modulesPath}/services/monitoring/prometheus/mk-downstream-exporter.nix" {
+      name = "EXPORTER";
+      file = ./EXPORTER-exporter.nix;
+    })
+  ];
+}
+```

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -7,6 +7,8 @@
   ...
 }:
 
+with (import ./mk-exporter.nix config.networking.nftables.enable lib pkgs);
+
 let
   inherit (lib)
     concatStrings
@@ -187,110 +189,6 @@ let
       }
     );
 
-  mkExporterOpts = (
-    { name, port }:
-    {
-      enable = mkEnableOption "the prometheus ${name} exporter";
-      port = mkOption {
-        type = types.port;
-        default = port;
-        description = ''
-          Port to listen on.
-        '';
-      };
-      listenAddress = mkOption {
-        type = types.str;
-        default = "0.0.0.0";
-        description = ''
-          Address to listen on.
-        '';
-      };
-      extraFlags = mkOption {
-        type = types.listOf types.str;
-        default = [ ];
-        description = ''
-          Extra commandline options to pass to the ${name} exporter.
-        '';
-      };
-      openFirewall = mkOption {
-        type = types.bool;
-        default = false;
-        description = ''
-          Open port in firewall for incoming connections.
-        '';
-      };
-      firewallFilter = mkOption {
-        type = types.nullOr types.str;
-        default = null;
-        example = literalExpression ''
-          "-i eth0 -p tcp -m tcp --dport ${toString port}"
-        '';
-        description = ''
-          Specify a filter for iptables to use when
-          {option}`services.prometheus.exporters.${name}.openFirewall`
-          is true. It is used as `ip46tables -I nixos-fw firewallFilter -j nixos-fw-accept`.
-        '';
-      };
-      firewallRules = mkOption {
-        type = types.nullOr types.lines;
-        default = null;
-        example = literalExpression ''
-          iifname "eth0" tcp dport ${toString port} counter accept
-        '';
-        description = ''
-          Specify rules for nftables to add to the input chain
-          when {option}`services.prometheus.exporters.${name}.openFirewall` is true.
-        '';
-      };
-      user = mkOption {
-        type = types.str;
-        default = "${name}-exporter";
-        description = ''
-          User name under which the ${name} exporter shall be run.
-        '';
-      };
-      group = mkOption {
-        type = types.str;
-        default = "${name}-exporter";
-        description = ''
-          Group under which the ${name} exporter shall be run.
-        '';
-      };
-    }
-  );
-
-  mkSubModule =
-    {
-      name,
-      port,
-      extraOpts,
-      imports,
-    }:
-    {
-      ${name} = mkOption {
-        type = types.submodule [
-          {
-            inherit imports;
-            options = (
-              mkExporterOpts {
-                inherit name port;
-              }
-              // extraOpts
-            );
-          }
-          (
-            { config, ... }:
-            mkIf config.openFirewall {
-              firewallFilter = mkDefault "-p tcp -m tcp --dport ${toString config.port}";
-              firewallRules = mkDefault ''tcp dport ${toString config.port} accept comment "${name}-exporter"'';
-            }
-          )
-        ];
-        internal = true;
-        default = { };
-      };
-    };
-
   mkSubModules = (
     foldl' (a: b: a // b) { } (
       mapAttrsToList (
@@ -304,82 +202,6 @@ let
       ) exporterOpts
     )
   );
-
-  mkExporterConf =
-    {
-      name,
-      conf,
-      serviceOpts,
-    }:
-    let
-      enableDynamicUser = serviceOpts.serviceConfig.DynamicUser or true;
-      nftables = config.networking.nftables.enable;
-    in
-    mkIf conf.enable {
-      warnings = conf.warnings or [ ];
-      assertions = conf.assertions or [ ];
-      users.users."${name}-exporter" = (
-        mkIf (conf.user == "${name}-exporter" && !enableDynamicUser) {
-          description = "Prometheus ${name} exporter service user";
-          isSystemUser = true;
-          inherit (conf) group;
-        }
-      );
-      users.groups = mkMerge [
-        (mkIf (conf.group == "${name}-exporter" && !enableDynamicUser) {
-          "${name}-exporter" = { };
-        })
-        (mkIf (name == "smartctl") {
-          "smartctl-exporter-access" = { };
-        })
-      ];
-      services.udev.extraRules = mkIf (name == "smartctl") ''
-        ACTION=="add", SUBSYSTEM=="nvme", KERNEL=="nvme[0-9]*", RUN+="${pkgs.acl}/bin/setfacl -m g:smartctl-exporter-access:rw /dev/$kernel"
-      '';
-      networking.firewall.extraCommands = mkIf (conf.openFirewall && !nftables) (concatStrings [
-        "ip46tables -A nixos-fw ${conf.firewallFilter} "
-        "-m comment --comment ${name}-exporter -j nixos-fw-accept"
-      ]);
-      networking.firewall.extraInputRules = mkIf (conf.openFirewall && nftables) conf.firewallRules;
-      systemd.services."prometheus-${name}-exporter" = mkMerge ([
-        {
-          wantedBy = [ "multi-user.target" ];
-          after = [ "network.target" ];
-          serviceConfig.Restart = mkDefault "always";
-          serviceConfig.PrivateTmp = mkDefault true;
-          serviceConfig.WorkingDirectory = mkDefault /tmp;
-          serviceConfig.DynamicUser = mkDefault enableDynamicUser;
-          serviceConfig.User = mkDefault conf.user;
-          serviceConfig.Group = conf.group;
-          # Hardening
-          serviceConfig.CapabilityBoundingSet = mkDefault [ "" ];
-          serviceConfig.DeviceAllow = [ "" ];
-          serviceConfig.LockPersonality = true;
-          serviceConfig.MemoryDenyWriteExecute = true;
-          serviceConfig.NoNewPrivileges = true;
-          serviceConfig.PrivateDevices = mkDefault true;
-          serviceConfig.ProtectClock = mkDefault true;
-          serviceConfig.ProtectControlGroups = true;
-          serviceConfig.ProtectHome = true;
-          serviceConfig.ProtectHostname = true;
-          serviceConfig.ProtectKernelLogs = true;
-          serviceConfig.ProtectKernelModules = true;
-          serviceConfig.ProtectKernelTunables = true;
-          serviceConfig.ProtectSystem = mkDefault "strict";
-          serviceConfig.RemoveIPC = true;
-          serviceConfig.RestrictAddressFamilies = [
-            "AF_INET"
-            "AF_INET6"
-          ];
-          serviceConfig.RestrictNamespaces = true;
-          serviceConfig.RestrictRealtime = true;
-          serviceConfig.RestrictSUIDSGID = true;
-          serviceConfig.SystemCallArchitectures = "native";
-          serviceConfig.UMask = "0077";
-        }
-        serviceOpts
-      ]);
-    };
 in
 {
 

--- a/nixos/modules/services/monitoring/prometheus/mk-downstream-exporter.nix
+++ b/nixos/modules/services/monitoring/prometheus/mk-downstream-exporter.nix
@@ -1,0 +1,16 @@
+{ name, file }:
+{
+  config,
+  pkgs,
+  lib,
+  options,
+  utils,
+  ...
+}@args:
+
+with (import ./mk-exporter.nix config.networking.nftables.enable lib pkgs);
+
+{
+  options.services.prometheus.exporters = mkDownstreamOptions name (import file args);
+  config = mkDownstreamConfig name (import file args) config.services.prometheus.exporters.${name};
+}

--- a/nixos/modules/services/monitoring/prometheus/mk-exporter.nix
+++ b/nixos/modules/services/monitoring/prometheus/mk-exporter.nix
@@ -1,0 +1,229 @@
+nftables: lib: pkgs:
+
+let
+  inherit (lib)
+    concatStrings
+    foldl
+    foldl'
+    genAttrs
+    literalExpression
+    maintainers
+    mapAttrs
+    mapAttrsToList
+    mkDefault
+    mkEnableOption
+    mkIf
+    mkMerge
+    mkOption
+    optional
+    types
+    mkOptionDefault
+    flip
+    attrNames
+    xor
+    ;
+
+  mkExporterOpts = (
+    { name, port }:
+    {
+      enable = mkEnableOption "the prometheus ${name} exporter";
+      port = mkOption {
+        type = types.port;
+        default = port;
+        description = ''
+          Port to listen on.
+        '';
+      };
+      listenAddress = mkOption {
+        type = types.str;
+        default = "0.0.0.0";
+        description = ''
+          Address to listen on.
+        '';
+      };
+      extraFlags = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = ''
+          Extra commandline options to pass to the ${name} exporter.
+        '';
+      };
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Open port in firewall for incoming connections.
+        '';
+      };
+      firewallFilter = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = literalExpression ''
+          "-i eth0 -p tcp -m tcp --dport ${toString port}"
+        '';
+        description = ''
+          Specify a filter for iptables to use when
+          {option}`services.prometheus.exporters.${name}.openFirewall`
+          is true. It is used as `ip46tables -I nixos-fw firewallFilter -j nixos-fw-accept`.
+        '';
+      };
+      firewallRules = mkOption {
+        type = types.nullOr types.lines;
+        default = null;
+        example = literalExpression ''
+          iifname "eth0" tcp dport ${toString port} counter accept
+        '';
+        description = ''
+          Specify rules for nftables to add to the input chain
+          when {option}`services.prometheus.exporters.${name}.openFirewall` is true.
+        '';
+      };
+      user = mkOption {
+        type = types.str;
+        default = "${name}-exporter";
+        description = ''
+          User name under which the ${name} exporter shall be run.
+        '';
+      };
+      group = mkOption {
+        type = types.str;
+        default = "${name}-exporter";
+        description = ''
+          Group under which the ${name} exporter shall be run.
+        '';
+      };
+    }
+  );
+
+  mkSubModule =
+    {
+      name,
+      port,
+      extraOpts,
+      imports,
+    }:
+    {
+      ${name} = mkOption {
+        type = types.submodule [
+          {
+            inherit imports;
+            options = (
+              mkExporterOpts {
+                inherit name port;
+              }
+              // extraOpts
+            );
+          }
+          (
+            { config, ... }:
+            mkIf config.openFirewall {
+              firewallFilter = mkDefault "-p tcp -m tcp --dport ${toString config.port}";
+              firewallRules = mkDefault ''tcp dport ${toString config.port} accept comment "${name}-exporter"'';
+            }
+          )
+        ];
+        internal = true;
+        default = { };
+      };
+    };
+
+  mkExporterConf =
+    {
+      name,
+      conf,
+      serviceOpts,
+    }:
+    let
+      enableDynamicUser = serviceOpts.serviceConfig.DynamicUser or true;
+    in
+    mkIf conf.enable {
+      warnings = conf.warnings or [ ];
+      assertions = conf.assertions or [ ];
+      users.users."${name}-exporter" = (
+        mkIf (conf.user == "${name}-exporter" && !enableDynamicUser) {
+          description = "Prometheus ${name} exporter service user";
+          isSystemUser = true;
+          inherit (conf) group;
+        }
+      );
+      users.groups = mkMerge [
+        (mkIf (conf.group == "${name}-exporter" && !enableDynamicUser) {
+          "${name}-exporter" = { };
+        })
+        (mkIf (name == "smartctl") {
+          "smartctl-exporter-access" = { };
+        })
+      ];
+      services.udev.extraRules = mkIf (name == "smartctl") ''
+        ACTION=="add", SUBSYSTEM=="nvme", KERNEL=="nvme[0-9]*", RUN+="${pkgs.acl}/bin/setfacl -m g:smartctl-exporter-access:rw /dev/$kernel"
+      '';
+      networking.firewall.extraCommands = mkIf (conf.openFirewall && !nftables) (concatStrings [
+        "ip46tables -A nixos-fw ${conf.firewallFilter} "
+        "-m comment --comment ${name}-exporter -j nixos-fw-accept"
+      ]);
+      networking.firewall.extraInputRules = mkIf (conf.openFirewall && nftables) conf.firewallRules;
+      systemd.services."prometheus-${name}-exporter" = mkMerge ([
+        {
+          wantedBy = [ "multi-user.target" ];
+          after = [ "network.target" ];
+          serviceConfig.Restart = mkDefault "always";
+          serviceConfig.PrivateTmp = mkDefault true;
+          serviceConfig.WorkingDirectory = mkDefault /tmp;
+          serviceConfig.DynamicUser = mkDefault enableDynamicUser;
+          serviceConfig.User = mkDefault conf.user;
+          serviceConfig.Group = conf.group;
+          # Hardening
+          serviceConfig.CapabilityBoundingSet = mkDefault [ "" ];
+          serviceConfig.DeviceAllow = [ "" ];
+          serviceConfig.LockPersonality = true;
+          serviceConfig.MemoryDenyWriteExecute = true;
+          serviceConfig.NoNewPrivileges = true;
+          serviceConfig.PrivateDevices = mkDefault true;
+          serviceConfig.ProtectClock = mkDefault true;
+          serviceConfig.ProtectControlGroups = true;
+          serviceConfig.ProtectHome = true;
+          serviceConfig.ProtectHostname = true;
+          serviceConfig.ProtectKernelLogs = true;
+          serviceConfig.ProtectKernelModules = true;
+          serviceConfig.ProtectKernelTunables = true;
+          serviceConfig.ProtectSystem = mkDefault "strict";
+          serviceConfig.RemoveIPC = true;
+          serviceConfig.RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+          ];
+          serviceConfig.RestrictNamespaces = true;
+          serviceConfig.RestrictRealtime = true;
+          serviceConfig.RestrictSUIDSGID = true;
+          serviceConfig.SystemCallArchitectures = "native";
+          serviceConfig.UMask = "0077";
+        }
+        serviceOpts
+      ]);
+    };
+
+  mkDownstreamOptions =
+    name: opts:
+    mkSubModule {
+      inherit name;
+      inherit (opts) port;
+      extraOpts = opts.extraOpts or { };
+      imports = opts.imports or [ ];
+    };
+
+  mkDownstreamConfig =
+    name: opts: cfg:
+    mkExporterConf {
+      inherit name;
+      inherit (opts) serviceOpts;
+      conf = cfg;
+    };
+in
+{
+  inherit
+    mkExporterConf
+    mkSubModule
+    mkDownstreamOptions
+    mkDownstreamConfig
+    ;
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds the abbility to add downstream exporters while profiting from upstream's exporter config generator

Documentation of the new method: https://github.com/mgit-at/nixpkgs/blob/downstream-exporter/nixos/modules/services/monitoring/prometheus/exporters.md#adding-a-downstream-exporter-module-services-prometheus-exporters-downstream-exporter

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
