### PR TITLE
ahk_x11: init at 1.0.4

### DIFF
--- a/pkgs/by-name/ah/ahk_x11/adjust.patch
+++ b/pkgs/by-name/ah/ahk_x11/adjust.patch
@@ -1,0 +1,58 @@
+diff --git a/Makefile b/Makefile
+index 8b54a8b..6522293 100644
+--- a/Makefile
++++ b/Makefile
+@@ -60,7 +60,6 @@ xdotool/libxdo.a: xdotool/.git
+ 	$(MAKE) -C xdotool libxdo.a
+ 
+ lib/configured:
+-	shards install --frozen
+ 	./bin/gi-crystal
+ # TODO: can be fixed in application code?
+ 	sed -i -E 's/private getter xdo_p/getter xdo_p/' lib/x_do/src/x_do.cr
+@@ -71,7 +70,7 @@ lib/configured:
+ test-appimage: ahk_x11.AppImage
+ 	./ahk_x11.AppImage tests.ahk
+ test-dev: bin/ahk_x11
+-	./bin/ahk_x11 tests.ahk
++	XDG_CACHE_HOME=${TMPDIR} HOME=${TMPDIR} xvfb-run --auto-display openbox --startup "./bin/ahk_x11 tests.ahk"
+ 
+ clean:
+ 	rm -rf ahk_x11.AppImage bin/ahk_x11 bin/ahk_x11.dev linuxdeploy-plugin-gtk.sh linuxdeploy-x86_64.AppImage lib
+diff --git a/src/ahk_x11.cr b/src/ahk_x11.cr
+index 16777d8..b4d96e1 100644
+--- a/src/ahk_x11.cr
++++ b/src/ahk_x11.cr
+@@ -67,14 +67,12 @@ version = {{ read_file("./shard.yml").split("\n")[1][9..] }}
+ lines = Compiler.new.extract.try &.split('\n')
+ is_compiled = !! lines
+ if ! lines
+-	# Only needed for installer script, this can't (yet) really be part of ahk code. TODO: rm on exit
+-	File.write("/tmp/tmp_ahk_x11_logo.png", logo_blob)
+ 	if ARGV[0]?
+ 		if ARGV[0] == "-v" || ARGV[0] == "--version"
+ 			puts "AHK_X11 version: #{version}\nTargets to partially implement Classic Windows AutoHotkey specification: v1.0.24 (2004). AutoHotkey is a scripting language."
+ 			::exit
+ 		elsif ARGV[0] == "-h" || ARGV[0] == "--help"
+-			puts "AHK_X11 is a Linux implementation for AutoHotkey classic version 1.0.24 (2004). Internal version: #{version}. Full up to date documentation can be found at https://phil294.github.io/AHK_X11/.\n\nPossible methods of invocation:\n\nahk_x11.AppImage \"path to script.ahk\"\nahk_x11.AppImage <<< $'MsgBox, 1\\nMsgBox, 2'\nahk_x11.AppImage --repl\nahk_x11.AppImage --windowspy\nahk_x11.AppImage --compile \"path to script.ahk\" \"optional: output executable file path\"\n\nAlternatively, just run the program without arguments to open the graphical installer. Once installed, you should be able to run and/or compile any .ahk file in your file manager by selecting it from the right click context menu."
++			puts "AHK_X11 is a Linux implementation for AutoHotkey classic version 1.0.24 (2004). Internal version: #{version}. Full up to date documentation can be found at https://phil294.github.io/AHK_X11/.\n\nPossible methods of invocation:\n\nahk_x11 \"path to script.ahk\"\nahk_x11 <<< $'MsgBox, 1\\nMsgBox, 2'\nahk_x11 --repl\nahk_x11 --windowspy\nahk_x11 --compile \"path to script.ahk\" \"optional: output executable file path\"\n\nAlternatively, you should be able to run and/or compile any .ahk file in your file manager by selecting it from the right click context menu."
+ 			::exit
+ 		elsif ARGV[0] == "--repl"
+ 			lines = ["#Persistent"]
+@@ -101,7 +99,8 @@ if ! lines
+ 		if stdin
+ 			lines = stdin.split('\n')
+ 		else
+-			lines = {{ read_file("./src/installer.ahk").split("\n") }}
++			puts "Use -h for help."
++			::exit 1
+ 		end
+ 	end
+ end
+@@ -120,4 +119,4 @@ rescue e : Run::RuntimeException
+ 	build_error e
+ end
+ 
+-sleep # exiting is completely handled in runner
+\ No newline at end of file
++sleep # exiting is completely handled in runner

--- a/pkgs/by-name/ah/ahk_x11/package.nix
+++ b/pkgs/by-name/ah/ahk_x11/package.nix
@@ -1,0 +1,112 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  crystal,
+  copyDesktopItems,
+  linkFarm,
+  fetchgit,
+
+  gtk3,
+  libxkbcommon,
+  xorg,
+  libnotify,
+  gobject-introspection, # needed to build gi-crystal
+  openbox,
+  xvfb-run,
+  xdotool,
+
+  buildDevTarget ? false, # the dev version prints debug info
+}:
+
+# NOTICE: AHK_X11 from this package does not support compiling scripts into portable executables.
+let
+  pname = "ahk_x11";
+  version = "1.0.4";
+
+  inherit (xorg)
+    libXinerama
+    libXtst
+    libXext
+    libXi
+    ;
+
+in
+crystal.buildCrystalPackage {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "phil294";
+    repo = "AHK_X11";
+    rev = version;
+    hash = "sha256-Kxe0tLbER1XFnnfUUIiy9CgCgz2qK21AIk4DfHymKlI=";
+    fetchSubmodules = true;
+  };
+
+  # Fix build problems and the following UX problem:
+  # Without this patch, the binary launches a graphical installer GUI that is useless with system-wide installation.
+  # With this patch, it prompts to use -h for help.
+  patches = [ ./adjust.patch ];
+
+  shardsFile = ./shards.nix;
+  copyShardDeps = true;
+
+  preBuild = ''
+    mkdir bin
+    cd lib/gi-crystal
+    shards build -Dpreview_mt --release --no-debug
+    cd ../..
+    cp lib/gi-crystal/bin/gi-crystal bin
+  '';
+
+  postBuild = lib.optionalString buildDevTarget ''
+    mv bin/ahk_x11.dev bin/ahk_x11
+  '';
+
+  preInstall = ''
+    mkdir -p $out/bin
+  '';
+
+  postInstall = ''
+    install -Dm644 -t $out/share/licenses/ahk_x11/ LICENSE
+    install -Dm644 -t $out/share/pixmaps/ assets/ahk_x11.png
+    install -Dm644 -t $out/share/applications/ assets/*.desktop
+    install -Dm644 assets/ahk_x11-mime.xml $out/share/mime/packages/ahk_x11.xml
+  '';
+
+  buildInputs = [
+    gtk3
+    libxkbcommon
+    libXinerama
+    libXtst
+    libXext
+    libXi
+    libnotify
+  ];
+  nativeBuildInputs = [
+    copyDesktopItems
+    gobject-introspection
+  ];
+  nativeCheckInputs = [
+    xvfb-run
+    openbox
+    xdotool
+  ];
+
+  buildTargets = if buildDevTarget then "bin/ahk_x11.dev" else "bin/ahk_x11";
+  checkTarget = "test-dev";
+
+  # The tests fail with AtSpi failure. This means it lacks assistive technologies:
+  # https://github.com/phil294/AHK_X11?tab=readme-ov-file#accessibility
+  # I don't know how to fix it for xvfb and openbox.
+  doCheck = false;
+
+  meta = {
+    description = "AutoHotkey for X11";
+    homepage = "https://phil294.github.io/AHK_X11";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+    platforms = lib.platforms.linux;
+    mainProgram = "ahk_x11";
+  };
+}

--- a/pkgs/by-name/ah/ahk_x11/shards.nix
+++ b/pkgs/by-name/ah/ahk_x11/shards.nix
@@ -1,0 +1,62 @@
+{
+  atspi = {
+    url = "https://github.com/phil294/atspi.cr.git";
+    rev = "7aec8d3604313da415e54e654c1dc6b33ae05d8d";
+    sha256 = "1r6k9f00a2y406hqsgq0r58zlfmg3xbzqjmfh93nwqs4m6h0shml";
+  };
+  cron_parser = {
+    url = "https://github.com/kostya/cron_parser.git";
+    rev = "v0.4.0";
+    sha256 = "17fgg2nvyx99v05l10h6cnxfr7swz8yaxhmnk4l47kg2spi8w90a";
+  };
+  future = {
+    url = "https://github.com/crystal-community/future.cr.git";
+    rev = "v1.0.0";
+    sha256 = "1mji2djkrf4vxgs432kgkzxx54ybzk636789k2vsws3sf14l74i8";
+  };
+  gi-crystal = {
+    url = "https://github.com/hugopl/gi-crystal.git";
+    rev = "v0.22.1";
+    sha256 = "1bwsr5i6cmvnc72qdnmq4v6grif1hahrc7s6js2ivdrfix72flyg";
+  };
+  gtk3 = {
+    url = "https://github.com/phil294/gtk3.cr.git";
+    rev = "3105fc24ef5e841791f8c30002db998b9c20a677";
+    sha256 = "16sjiyyfprnfmqw8pf58d12sv2x8rnv7kb72k5rmvd67sr6gv8pq";
+  };
+  harfbuzz = {
+    url = "https://github.com/hugopl/harfbuzz.cr.git";
+    rev = "v0.2.0";
+    sha256 = "06wgqxwyib5416yp53j2iwcbr3bl4jjxb1flm7z103l365par694";
+  };
+  notify = {
+    url = "https://github.com/phil294/notify.cr.git";
+    rev = "0c9880e6169e09f0db1cb40432e0b76651d15ad3";
+    sha256 = "1waasvhx4n817d8gqk3fza4ac4a9d71f80cfii5dbh2aqzhqf070";
+  };
+  pango = {
+    url = "https://github.com/hugopl/pango.cr.git";
+    rev = "v0.3.1";
+    sha256 = "0xlf127flimnll875mcq92q7xsi975rrgdpcpmnrwllhdhfx9qmv";
+  };
+  tasker = {
+    url = "https://github.com/spider-gazelle/tasker.git";
+    rev = "v2.1.4";
+    sha256 = "0254sl279nrw5nz43dz5gm89ah1zrw5bvxfma81navpx5gfg9pyb";
+  };
+  x11 = {
+    url = "https://github.com/phil294/x11-cr.git";
+    rev = "5a937d647d8eac29106602fcdeb161a78eb3d59d";
+    sha256 = "11rflkxrg1dl5c80llwan4qs47ir7w7lgqdmhy2z907kxbrfkznr";
+  };
+  x_do = {
+    url = "https://github.com/phil294/x_do.cr.git";
+    rev = "94f755a4f18a9a9820e9738b371cbe6b49731926";
+    sha256 = "099mrhyb8kly6isk7xr1mzxbxfm4xizmyyw2ylmlx4ywynz9iyl6";
+  };
+  xtst = {
+    url = "https://github.com/phil294/xtst-cr.git";
+    rev = "f731b708e1789d039258ecd62f7b0d1107a00b78";
+    sha256 = "1vhzn1ck7ifkvhw5f9kpljsa278va039wa6f3hhd8w6gr2zqvzk8";
+  };
+}


### PR DESCRIPTION
## Description of changes

Adds package [AHK_X11](https://github.com/phil294/AHK_X11), an [AutoHotkey](https://www.autohotkey.com) implementation for Linux.

Closes #279323. ~~Closes #297972 (this PR contains the commit in that PR)~~ (already merged). CC @AndersonTorres.

~~It reports command not found for `file` command if your PATH does not contain that command. This error does not affect normal usage. I could have fixed by adding `file` as a dependency, but this is actually a non-fatal upstream bug (phil294/AHK_X11#75), so I left it like this~~ (Fixed in upstream).

AHK_X11 from this package does not have functionality of compiling scripts into portable executable. The implementation of that compilation feature is simply to concatenate the binary and the script to form an executable file, but executable files in NixOS are not executable in other systems. I was thinking packaging a `ahk_x11-bin` package for that demand, but I didn't do that because the executable cannot run in the environment where it was built (even with `steam-run` due to the requirement of `libnotify`).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
