### PR TITLE
[23.11] wolfssl: add patches for CVE-2024-0901 & CVE-2024-1545

### DIFF
--- a/pkgs/development/libraries/wolfssl/default.nix
+++ b/pkgs/development/libraries/wolfssl/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , Security
 , autoreconfHook
 , util-linux
@@ -22,6 +23,27 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "refs/tags/v${finalAttrs.version}-stable";
     hash = "sha256-HXl8GgngC1J8Dlt7fXBrVRa+IV7thVr+MIpeuf3Khcg=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "CVE-2024-0901.patch";
+      url = "https://github.com/wolfSSL/wolfssl/commit/9db20774d8abe0725734d48090bd4f650a477b8a.patch";
+      hash = "sha256-tO0fVBtEuvoJLUgDwjz3otk4yj1txASXEt0c0Rf9g3Q=";
+    })
+    # simply adds an optional rowhammer-resistant mode for RSA decryption,
+    # *not enabled by default*
+    (fetchpatch {
+      name = "CVE-2024-1545.patch";
+      url = "https://github.com/wolfSSL/wolfssl/commit/de4a6f9e00f6fbcaa7e20ed7bd89b5d50179e634.patch";
+      hash = "sha256-6DctT4GSBDqVeON9QsTsxVXTLD20zE64uUxGTZZFl5M=";
+    })
+    # CVE-2024-1545, but for eddsa
+    (fetchpatch {
+      name = "eddsa-check-priv.patch";
+      url = "https://github.com/wolfSSL/wolfssl/commit/c8d0bb0bd8fcd3dd177ec04e9a659a006df51b73.patch";
+      hash = "sha256-YlGBilR1pgH7BVuvL/liwOtgx/f+1troyV9Rl6Ftkr4=";
+    })
+  ];
 
   postPatch = ''
     patchShebangs ./scripts


### PR DESCRIPTION
## Description of changes
Counter-proposal to #298136

The three security issues mentioned in 5.7.0's release notes, CVE-2024-0901 is significant, CVE-2024-1545 (+ its eddsa variant) have admittedly limited value in patching because the added mitigation is disabled by default (as in 5.7.0).

Also built `pkgsStatic`, `pkgsCross.aarch64-multiplatform` & `pkgsi686Linux` variants.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
