### PR TITLE
manim-slides: init at 5.1.3

### DIFF
--- a/pkgs/applications/video/manim/default.nix
+++ b/pkgs/applications/video/manim/default.nix
@@ -64,8 +64,10 @@ in python.pkgs.buildPythonApplication rec {
 
   pythonRelaxDeps = [
     "cloup"
+    "isosurfaces"
     "pillow"
     "skia-pathops"
+    "watchdog"
   ];
 
   patches = [

--- a/pkgs/applications/video/manim/failing_tests.nix
+++ b/pkgs/applications/video/manim/failing_tests.nix
@@ -64,6 +64,10 @@
   "test_PointCloudDot"
   "test_Torus"
 
+  # ???
+  "test_ImplicitFunction"
+  "test_implicit_graph"
+
   # failing with:
   # TypeError: __init__() got an unexpected keyword argument 'msg' - maybe you meant pytest.mark.skipif?
   "test_force_window_opengl_render_with_movies"

--- a/pkgs/development/python-modules/manim-slides/default.nix
+++ b/pkgs/development/python-modules/manim-slides/default.nix
@@ -1,0 +1,94 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, pythonOlder
+
+, manim
+, ffmpeg
+
+, av
+, click
+, click-default-group
+, jinja2
+, lxml
+, numpy
+, opencv4
+, pillow
+, pydantic
+, pydantic-extra-types
+, python-pptx
+, qtpy
+, requests
+, rich
+, rtoml
+, tqdm
+
+  # Optional dependencies
+, ipython
+
+  # Hooks
+, pdm-backend
+, pythonRelaxDepsHook
+
+  # As Module or application?
+, withGui ? false
+}:
+buildPythonPackage rec {
+  pname = "manim-slides";
+  format = "pyproject";
+  version = "5.1.3";
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "jeertmans";
+    repo = "manim-slides";
+    rev = "refs/tags/v${version}";
+    sha256 = "sha256-WZR95swapT2Fbu6mbuHLjMu3Okq/wKFabzN7xpZw0/g=";
+  };
+
+  nativeBuildInputs = [
+    pdm-backend
+    pythonRelaxDepsHook
+  ];
+
+  pythonRemoveDeps = [ "opencv-python" ];
+
+  pythonRelaxDeps = [
+    "rtoml"
+    "qtpy"
+  ];
+
+  propagatedBuildInputs = [
+    av
+    click
+    click-default-group
+    jinja2
+    lxml
+    numpy
+    opencv4
+    pillow
+    pydantic
+    pydantic-extra-types
+    python-pptx
+    qtpy
+    requests
+    rich
+    rtoml
+    tqdm
+
+    # avconv is a potential alternative
+    ffmpeg
+    # This could also be manimgl, but that is not (yet) packaged
+    manim
+  ] ++ (if ! withGui then [ ipython ] else [ ]);
+
+  pythonImportsCheck = [ "manim_slides" ];
+
+  meta = with lib; {
+    description = "Tool for live presentations using manim";
+    homepage = "https://github.com/jeertmans/manim-slides/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ soispha ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -31599,6 +31599,12 @@ with pkgs;
 
   manim = callPackage ../applications/video/manim { };
 
+  manim-slides = python3Packages.toPythonApplication (
+    python3Packages.manim-slides.override {
+      withGui = true;
+    }
+  );
+
   manuskript = libsForQt5.callPackage ../applications/editors/manuskript { };
 
   mindforger = libsForQt5.callPackage ../applications/editors/mindforger { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6997,6 +6997,8 @@ self: super: with self; {
     inherit (pkgs.darwin.apple_sdk.frameworks) AppKit;
   };
 
+  manim-slides = callPackage ../development/python-modules/manim-slides { };
+
   manifest-ml = callPackage ../development/python-modules/manifest-ml { };
 
   manifestoo = callPackage ../development/python-modules/manifestoo { };


### PR DESCRIPTION
## Description of changes

Another implementation fixing #251914 (edit: wrong issue linked earlier)

**NOTE**: Work in progress because ignoring some `manim` tests, and rather clumsily put together.

More done to explore deficiencies in #275577

## Things done

 - Fixed Manim
 - got manim-slides working with pdm
 - Tested it out: https://static.marimo.app/static/manim-example-rket
 with `nix-shell -p ffmpeg manim "python3.withPackages(ps: with ps; [ marimo manim-slides ])"`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
