### PR TITLE
[release-23.11] rustPackages_1_76.{cargo,rustc}: init at 1.76.0

### DIFF
--- a/pkgs/development/compilers/rust/1_76.nix
+++ b/pkgs/development/compilers/rust/1_76.nix
@@ -1,0 +1,60 @@
+# New rust versions should first go to staging.
+# Things to check after updating:
+# 1. Rustc should produce rust binaries on x86_64-linux, aarch64-linux and x86_64-darwin:
+#    i.e. nix-shell -p fd or @GrahamcOfBorg build fd on github
+#    This testing can be also done by other volunteers as part of the pull
+#    request review, in case platforms cannot be covered.
+# 2. The LLVM version used for building should match with rust upstream.
+#    Check the version number in the src/llvm-project git submodule in:
+#    https://github.com/rust-lang/rust/blob/<version-tag>/.gitmodules
+# 3. Firefox and Thunderbird should still build on x86_64-linux.
+
+{ stdenv, lib
+, buildPackages
+, targetPackages
+, newScope, callPackage
+, CoreFoundation, Security, SystemConfiguration
+, pkgsBuildTarget, pkgsBuildBuild, pkgsBuildHost
+, makeRustPlatform
+, llvmPackages_17, llvm_17
+} @ args:
+
+import ./default.nix {
+  rustcVersion = "1.76.0";
+  rustcSha256 = "sha256-nlz/Azp/DSJmgYmCrZDk0+Tvj47hcVd2xuJQc6E2wCE=";
+
+  llvmSharedForBuild = pkgsBuildBuild.llvmPackages_17.libllvm.override { enableSharedLibraries = true; };
+  llvmSharedForHost = pkgsBuildHost.llvmPackages_17.libllvm.override { enableSharedLibraries = true; };
+  llvmSharedForTarget = pkgsBuildTarget.llvmPackages_17.libllvm.override { enableSharedLibraries = true; };
+
+  # For use at runtime
+  llvmShared = llvm_17.override { enableSharedLibraries = true; };
+
+  # Expose llvmPackages used for rustc from rustc via passthru for LTO in Firefox
+  llvmPackages = llvmPackages_17;
+
+  # Note: the version MUST be one version prior to the version we're
+  # building
+  bootstrapVersion = "1.75.0";
+
+  # fetch hashes by running `print-hashes.sh ${bootstrapVersion}`
+  bootstrapHashes = {
+    i686-unknown-linux-gnu = "107b8d8825deab338f338b15f047829da6225bb34644790847e96f0957c6678f";
+    x86_64-unknown-linux-gnu = "473978b6f8ff216389f9e89315211c6b683cf95a966196e7914b46e8cf0d74f6";
+    x86_64-unknown-linux-musl = "cc6ef41aa811ab34f946fe2b4338d1107daf08642125fd566386bf45563597de";
+    arm-unknown-linux-gnueabihf = "985454b6c385cb461cc8a39d2d7d55dcf6c50495033fe5d28edcc717729d8ae9";
+    armv7-unknown-linux-gnueabihf = "bd876a75f72040d96be2fb882770b16b482ac0ab15d7e3ad24e6d25b7c74bcf7";
+    aarch64-unknown-linux-gnu = "30828cd904fcfb47f1ac43627c7033c903889ea4aca538f53dcafbb3744a9a73";
+    aarch64-unknown-linux-musl = "26b5989525b7cf623f3868a37549736e0efe1142a08f191a97e29758cc640ac4";
+    x86_64-apple-darwin = "ad066e4dec7ae5948c4e7afe68e250c336a5ab3d655570bb119b3eba9cf22851";
+    aarch64-apple-darwin = "878ecf81e059507dd2ab256f59629a4fb00171035d2a2f5638cb582d999373b1";
+    powerpc64le-unknown-linux-gnu = "2599cdfea5860b4efbceb7bca69845a96ac1c96aa50cf8261151e82280b397a0";
+    riscv64gc-unknown-linux-gnu = "7f7b73d8924d7dd24dcb2ef0da257eb48d9aed658b00fe68e8f1ade0b1ce4511";
+  };
+
+  selectRustPackage = pkgs: pkgs.rust_1_76;
+
+  rustcPatches = [ ];
+}
+
+(builtins.removeAttrs args [ "pkgsBuildTarget" "pkgsBuildHost" "llvmPackages_17" "llvm_17"])

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -145,6 +145,8 @@ in stdenv.mkDerivation (finalAttrs: {
   ] ++ optionals (stdenv.isDarwin && stdenv.isx86_64) [
     # https://github.com/rust-lang/rust/issues/92173
     "--set rust.jemalloc"
+  ] ++ optionals (lib.versionAtLeast version "1.74.0") [
+    "--sysconfdir=${placeholder "out"}/etc"
   ];
 
   # if we already have a rust compiler for build just compile the target std
@@ -181,7 +183,7 @@ in stdenv.mkDerivation (finalAttrs: {
   # The bootstrap.py will generated a Makefile that then executes the build.
   # The BOOTSTRAP_ARGS used by this Makefile must include all flags to pass
   # to the bootstrap builder.
-  postConfigure = ''
+  postConfigure = lib.optionalString (lib.versionOlder version "1.74.0") ''
     substituteInPlace Makefile \
       --replace 'BOOTSTRAP_ARGS :=' 'BOOTSTRAP_ARGS := --jobs $(NIX_BUILD_CORES)'
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -16941,6 +16941,10 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
     llvm_16 = llvmPackages_16.libllvm;
   };
+  rust_1_76 = callPackage ../development/compilers/rust/1_76.nix {
+    inherit (darwin.apple_sdk.frameworks) CoreFoundation Security SystemConfiguration;
+    llvm_17 = llvmPackages_17.libllvm;
+  };
   rust = rust_1_73;
 
   mrustc = callPackage ../development/compilers/mrustc { };
@@ -16950,6 +16954,7 @@ with pkgs;
   };
 
   rustPackages_1_73 = rust_1_73.packages.stable;
+  rustPackages_1_76 = rust_1_76.packages.stable;
   rustPackages = rustPackages_1_73;
 
   inherit (rustPackages) cargo cargo-auditable cargo-auditable-cargo-wrapper clippy rustc rustPlatform;


### PR DESCRIPTION
## Description of changes

This is a manual backport/cherry-pick of 866d117d42d3c4e0426810bb6432c07c256376fc (#289940) and e9ca6038eb5f4398fc57feb4084b7df4afaa6d7d (#268075).

We need a newer version than `1.73` to build the latest chromium stable backport (`123.0.6312.58`).
The same thing has been done for Firefox multiple times in the past.

Closes #292779.
Needed for #297543 and #297891

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).