### PR TITLE
Add Chirpstack packages

### DIFF
--- a/pkgs/by-name/ch/chirpstack-concentratord/package.nix
+++ b/pkgs/by-name/ch/chirpstack-concentratord/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  gitUpdater,
+  protobuf,
+  libloragw-2g4,
+  libloragw-sx1301,
+  libloragw-sx1302,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "chirpstack-concentratord";
+  version = "4.4.2";
+
+  src = fetchFromGitHub {
+    owner = "chirpstack";
+    repo = "chirpstack-concentratord";
+    rev = "v${version}";
+    hash = "sha256-UbUtNJuz8zfhHzyOiT/mRNtNRmdoNnuszrVSbLoVGK8=";
+  };
+
+  cargoHash = "sha256-JXIyrbBRGJR9mjvawU46mBfGYxZPpYl9aB9k3WBA/co=";
+
+  buildInputs = [
+    libloragw-2g4
+    libloragw-sx1301
+    libloragw-sx1302
+  ];
+
+  nativeBuildInputs = [
+    protobuf
+    rustPlatform.bindgenHook
+  ];
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
+  meta = {
+    description = "Concentrator HAL daemon for LoRa gateways";
+    homepage = "https://www.chirpstack.io/";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.stv0g ];
+    platforms = [ "aarch64-linux" ];
+    mainProgram = "chirpstack-concentratord";
+  };
+}

--- a/pkgs/by-name/ch/chirpstack-fuota-server/package.nix
+++ b/pkgs/by-name/ch/chirpstack-fuota-server/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule rec {
+  pname = "chirpstack-fuota-server";
+  version = "unstable-2024-04-02";
+
+  src = fetchFromGitHub {
+    owner = "chirpstack";
+    repo = "chirpstack-fuota-server";
+    rev = "6e014688cb4b2a5dc658bf7876df69a1cf3e2176";
+    hash = "sha256-ShpBUnDGaW8vbt5y1wZbedwFHPJaggPuij71l2p0a6o=";
+  };
+
+  vendorHash = "sha256-dTmHkauFelqMo5MpB/TyK5yVax5d4/+g9twjmsRG3e0=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  doCheck = false;
+
+  meta = {
+    description = "FUOTA server which can be used together with ChirpStack Application Server";
+    homepage = "https://www.chirpstack.io/";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.stv0g ];
+    mainProgram = "chirpstack-fuota-server";
+  };
+}

--- a/pkgs/by-name/ch/chirpstack-gateway-bridge/package.nix
+++ b/pkgs/by-name/ch/chirpstack-gateway-bridge/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  gitUpdater,
+}:
+buildGoModule rec {
+  pname = "chirpstack-gateway-bridge";
+  version = "4.0.11";
+
+  src = fetchFromGitHub {
+    owner = "chirpstack";
+    repo = "chirpstack-gateway-bridge";
+    rev = "v${version}";
+    hash = "sha256-nVrYyvoN6jayXAwivwxhijNeLEcGICTWJ4T9EBs5uaI=";
+  };
+
+  vendorHash = "sha256-PX5Jd8fUFEOOd38NNqbV15jbEIcDQRYGk0l1MhtLiTk=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=v${version}"
+  ];
+
+  doCheck = false;
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
+  meta = {
+    description = "ChirpStack Gateway Bridge abstracts Packet Forwarder protocols into Protobuf or JSON over MQTT";
+    homepage = "https://www.chirpstack.io/";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.stv0g ];
+    mainProgram = "chirpstack-gateway-bridge";
+  };
+}

--- a/pkgs/by-name/ch/chirpstack-mqtt-forwarder/package.nix
+++ b/pkgs/by-name/ch/chirpstack-mqtt-forwarder/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  darwin,
+  rustPlatform,
+  fetchFromGitHub,
+  gitUpdater,
+  protobuf,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "chirpstack-mqtt-forwarder";
+  version = "4.3.1";
+
+  src = fetchFromGitHub {
+    owner = "chirpstack";
+    repo = "chirpstack-mqtt-forwarder";
+    rev = "v${version}";
+    hash = "sha256-jbu8O1Wag6KpN49VyXsYO8os95ctZjzuxKXoDMLyiKU=";
+  };
+
+  cargoHash = "sha256-1tAZjsjoVKUkrF0WAqxs9d+1w8/AqFGDfpFGAHvf+D0=";
+
+  nativeBuildInputs = [ protobuf ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.CoreFoundation
+    darwin.apple_sdk.frameworks.Security
+  ];
+
+  doCheck = false;
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
+  meta = {
+    description = "ChirpStack MQTT Forwarder is a forwarder which can be installed on the gateway to forward LoRa data over MQTT";
+    homepage = "https://www.chirpstack.io/";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.stv0g ];
+    mainProgram = "chirpstack-mqtt-forwarder";
+  };
+}

--- a/pkgs/by-name/ch/chirpstack-rest-api/package.nix
+++ b/pkgs/by-name/ch/chirpstack-rest-api/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  gitUpdater,
+}:
+buildGoModule rec {
+  pname = "chirpstack-rest-api";
+  version = "4.9.0";
+
+  src = fetchFromGitHub {
+    owner = "chirpstack";
+    repo = "chirpstack-rest-api";
+    rev = "v${version}";
+    hash = "sha256-mL0p5gRSnCoQlYF0DyOt9FHW/jtNnl5hI+o8oJvJsT8=";
+  };
+
+  vendorHash = "sha256-thEoNN5j9frdb0KODZUkfQXGsrYwUCRcN74jwuXufU8=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=v${version}"
+  ];
+
+  doCheck = false;
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
+  meta = {
+    description = "ChirpStack gRPC API to REST proxy";
+    homepage = "https://www.chirpstack.io/";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.stv0g ];
+    mainProgram = "chirpstack-rest-api";
+  };
+}

--- a/pkgs/by-name/ch/chirpstack-udp-forwarder/package.nix
+++ b/pkgs/by-name/ch/chirpstack-udp-forwarder/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  darwin,
+  rustPlatform,
+  fetchFromGitHub,
+  gitUpdater,
+  protobuf,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "chirpstack-udp-forwarder";
+  version = "4.1.8";
+
+  src = fetchFromGitHub {
+    owner = "chirpstack";
+    repo = "chirpstack-udp-forwarder";
+    rev = "v${version}";
+    hash = "sha256-Snj5nKyFsq8WJJNw1d8O/YX/dZ/tCTVBw5R8kXJvsa4=";
+  };
+
+  cargoHash = "sha256-7ugrIVT4SYrqPqF0CrLU+/Ep/p9H7/on3hkZ5JzY9AE=";
+
+  nativeBuildInputs = [ protobuf ];
+
+  buildInputs = lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.CoreFoundation
+    darwin.apple_sdk.frameworks.Security
+  ];
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
+  meta = {
+    description = "UDP packet-forwarder for the ChirpStack Concentratord";
+    homepage = "https://www.chirpstack.io/";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.stv0g ];
+    mainProgram = "chirpstack-udp-forwarder";
+  };
+}

--- a/pkgs/by-name/li/libloragw-2g4/package.nix
+++ b/pkgs/by-name/li/libloragw-2g4/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation {
+  pname = "libloragw-2g4";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "Lora-net";
+    repo = "gateway_2g4_hal";
+    rev = "f14f5cf2e4caf3789bc32159fba5c10363166591";
+    hash = "sha256-EvsYCkZ55nEdZXhxp7AjCw954+uUIoi2Fc3xhaIjZys=";
+  };
+
+  makeFlags = [
+    "-e"
+    "-C"
+    "libloragw"
+  ];
+
+  preBuild = ''
+    make -C libtools
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{lib,include/libloragw-2g4}
+    cp libloragw/libloragw.a $out/lib/libloragw-2g4.a
+    cp libloragw/inc/* $out/include/libloragw-2g4
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "LoRa 2.4Ghz Gateway - Linux host Hardware Abstraction Layer, and tools (Packet Forwarder...)";
+    license = [
+      lib.licenses.bsd3
+      lib.licenses.mit
+    ];
+    maintainers = [ lib.maintainers.stv0g ];
+    platforms = [ "aarch64-linux" ];
+  };
+}

--- a/pkgs/by-name/li/libloragw-sx1301/package.nix
+++ b/pkgs/by-name/li/libloragw-sx1301/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation {
+  pname = "libloragw-sx1301";
+  version = "5.0.1r2";
+
+  src = fetchFromGitHub {
+    owner = "brocaar";
+    repo = "lora_gateway";
+    rev = "59381129a07858a2a91aeffe21cd6a728219cf23";
+    hash = "sha256-K+GCE3eJq/9CgjIPTCBx3dSbDP0QbTiv0QMAbbLZM7s=";
+  };
+
+  makeFlags = [
+    "-e"
+    "-C"
+    "libloragw"
+  ];
+
+  installPhase = ''
+    mkdir -p $out/{lib,include/libloragw-sx1301}
+    cp libloragw/libloragw.a $out/lib/libloragw-sx1301.a
+    cp libloragw/inc/* $out/include/libloragw-sx1301
+  '';
+
+  meta = {
+    description = "Driver/HAL to build a gateway using a concentrator board based on Semtech SX1301 multi-channel modem and SX1257/SX1255 RF transceivers";
+    license = [
+      lib.licenses.bsd3
+      lib.licenses.mit
+    ];
+    maintainers = [ lib.maintainers.stv0g ];
+    platforms = [ "aarch64-linux" ];
+  };
+}

--- a/pkgs/by-name/li/libloragw-sx1302/package.nix
+++ b/pkgs/by-name/li/libloragw-sx1302/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation {
+  pname = "libloragw-sx1302";
+  version = "2.1.0r7";
+
+  src = fetchFromGitHub {
+    owner = "brocaar";
+    repo = "sx1302_hal";
+    rev = "c3d99009556fdfe273c3a53306082ef181333c7a";
+    hash = "sha256-Ue3C7XbaCv/d0NIMclPSE+qcQpxw70DVhXlnpFACzhY=";
+  };
+
+  makeFlags = [
+    "-e"
+    "-C"
+    "libloragw"
+  ];
+
+  preBuild = ''
+    make -C libtools
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{lib,include/libloragw-sx1302}
+    cp libloragw/libloragw.a $out/lib/libloragw-sx1302.a
+    cp libloragw/inc/* $out/include/libloragw-sx1302
+    cp libtools/*.a $out/lib/
+    cp libtools/inc/* $out/include/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "SX1302 Hardware Abstraction Layer and Tools (packet forwarder...)";
+    license = [
+      lib.licenses.bsd3
+      lib.licenses.mit
+    ];
+    maintainers = [ lib.maintainers.stv0g ];
+    platforms = [ "aarch64-linux" ];
+  };
+}


### PR DESCRIPTION
## Description of changes

This PR adds the following packages from the [Chirpstack](https://www.chirpstack.io/) project:

- chirpstack-concentratord
- chirpstack-udp-forwarder
- chirpstack-mqtt-forwarder
- chirpstack-gateway-bridge
- chirpstack-rest-api
- chirpstack-fuota-server

> ChirpStack is an open-source LoRaWAN Network Server which can be used to setup LoRaWAN networks. ChirpStack provides a web-interface for the management of gateways, devices and tenants as well to setup data integrations with the major cloud providers, databases and services commonly used for handling device data. ChirpStack provides a gRPC based API that can be used to integrate or extend ChirpStack.

These are most of the packages of the Chirpstack project with exception of the main LoraWAN server itself. It is sufficient to run a Nix-powered LoraWAN gateway on an embedded device like a Raspberry Pi.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc