### PR TITLE
python39Packages.hypothesis: disable failing tests

### DIFF
--- a/pkgs/development/python-modules/hypothesis/default.nix
+++ b/pkgs/development/python-modules/hypothesis/default.nix
@@ -79,6 +79,14 @@ buildPythonPackage rec {
     "tests/cover"
   ];
 
+  disabledTests = if (pythonOlder "3.10") then [
+    # not sure why these tests fail with only 3.9
+    # FileNotFoundError: [Errno 2] No such file or directory: 'git'
+    "test_observability"
+    "test_assume_has_status_reason"
+    "test_observability_captures_stateful_reprs"
+  ] else null;
+
   pythonImportsCheck = [
     "hypothesis"
   ];


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I'm not sure why these tests fail with only `python39`.
It's observed in #298085 

<details>
<summary>error log</summary>

```
hypothesis> ______________________________ test_observability ______________________________
hypothesis> [gw4] linux -- Python 3.9.18 /nix/store/00ckk33d1pb4vzxw11bj2mzg2vjcbs3a-python3-3.9.18/bin/python3.9
hypothesis> Traceback (most recent call last):
hypothesis>   File "/nix/store/q8zgv7nf9qq0crhmjbw24dpn33w1l62l-python3.9-hypothesis-6.98.17/lib/python3.9/site-packages/hypothesis/core.py", line 1020, in _execute_once_for_engine
hypothesis>     result = self.execute_once(data)
hypothesis>   File "/nix/store/q8zgv7nf9qq0crhmjbw24dpn33w1l62l-python3.9-hypothesis-6.98.17/lib/python3.9/site-packages/hypothesis/core.py", line 943, in execute_once
hypothesis>     result = self.test_runner(data, run)
hypothesis>   File "/nix/store/q8zgv7nf9qq0crhmjbw24dpn33w1l62l-python3.9-hypothesis-6.98.17/lib/python3.9/site-packages/hypothesis/core.py", line 734, in default_executor
hypothesis>     return function(data)
hypothesis>   File "/nix/store/q8zgv7nf9qq0crhmjbw24dpn33w1l62l-python3.9-hypothesis-6.98.17/lib/python3.9/site-packages/hypothesis/core.py", line 922, in run
hypothesis>     return test(*args, **kwargs)
hypothesis>   File "/build/source/hypothesis-python/tests/cover/test_observability.py", line 46, in do_it_all
hypothesis>     @example(a=0, x=4, data=None)
hypothesis>   File "/nix/store/q8zgv7nf9qq0crhmjbw24dpn33w1l62l-python3.9-hypothesis-6.98.17/lib/python3.9/site-packages/hypothesis/core.py", line 832, in test
hypothesis>     result = self.test(*args, **kwargs)
hypothesis>   File "/build/source/hypothesis-python/tests/cover/test_observability.py", line 52, in do_it_all
hypothesis>     assume(a % 9)
hypothesis>   File "/nix/store/q8zgv7nf9qq0crhmjbw24dpn33w1l62l-python3.9-hypothesis-6.98.17/lib/python3.9/site-packages/hypothesis/control.py", line 70, in assume
hypothesis>     raise UnsatisfiedAssumption(f"failed to satisfy {where}")
hypothesis> hypothesis.errors.UnsatisfiedAssumption: failed to satisfy assume() in do_it_all (line 52)
hypothesis> 
hypothesis> During handling of the above exception, another exception occurred:
hypothesis> 
hypothesis> Traceback (most recent call last):
hypothesis>   File "/nix/store/q8zgv7nf9qq0crhmjbw24dpn33w1l62l-python3.9-hypothesis-6.98.17/lib/python3.9/site-packages/hypothesis/core.py", line 1037, in _execute_once_for_engine
hypothesis>     data.mark_invalid(e.reason)
hypothesis>   File "/nix/store/q8zgv7nf9qq0crhmjbw24dpn33w1l62l-python3.9-hypothesis-6.98.17/lib/python3.9/site-packages/hypothesis/internal/conjecture/data.py", line 2028, in mark_invalid
hypothesis>     self.conclude_test(Status.INVALID)
hypothesis>   File "/nix/store/q8zgv7nf9qq0crhmjbw24dpn33w1l62l-python3.9-hypothesis-6.98.17/lib/python3.9/site-packages/hypothesis/internal/conjecture/data.py", line 2018, in conclude_test
hypothesis>     raise StopTest(self.testcounter)
hypothesis> hypothesis.errors.StopTest: 18073
hypothesis> 
hypothesis> During handling of the above exception, another exception occurred:
hypothesis> 
hypothesis> Traceback (most recent call last):
hypothesis>   File "/nix/store/q8zgv7nf9qq0crhmjbw24dpn33w1l62l-python3.9-hypothesis-6.98.17/lib/python3.9/site-packages/hypothesis/internal/scrutineer.py", line 203, in _get_git_repo_root
hypothesis>     where = subprocess.run(
hypothesis>   File "/nix/store/00ckk33d1pb4vzxw11bj2mzg2vjcbs3a-python3-3.9.18/lib/python3.9/subprocess.py", line 505, in run
hypothesis>     with Popen(*popenargs, **kwargs) as process:
hypothesis>   File "/nix/store/00ckk33d1pb4vzxw11bj2mzg2vjcbs3a-python3-3.9.18/lib/python3.9/subprocess.py", line 951, in __init__
hypothesis>     self._execute_child(args, executable, preexec_fn, close_fds,
hypothesis>   File "/nix/store/00ckk33d1pb4vzxw11bj2mzg2vjcbs3a-python3-3.9.18/lib/python3.9/subprocess.py", line 1837, in _execute_child
hypothesis>     raise child_exception_type(errno_num, err_msg, err_filename)
hypothesis> FileNotFoundError: [Errno 2] No such file or directory: 'git'
hypothesis> 
hypothesis> During handling of the above exception, another exception occurred:
hypothesis> 
hypothesis> Traceback (most recent call last):
hypothesis>   File "/nix/store/0h4xzbxkqhpyyl0fp43gy3rvcly7xzdk-python3.9-pytest-8.0.2/lib/python3.9/site-packages/_pytest/runner.py", line 342, in from_call
hypothesis>     result: Optional[TResult] = func()
hypothesis>   File "/nix/store/0h4xzbxkqhpyyl0fp43gy3rvcly7xzdk-python3.9-pytest-8.0.2/lib/python3.9/site-packages/_pytest/runner.py", line 263, in <lambda>
hypothesis>     lambda: ihook(item=item, **kwds), when=when, reraise=reraise
hypothesis>   File "/nix/store/kmh0p7vx6sgxwpfk7n0498byg0falfkj-python3.9-pluggy-1.4.0/lib/python3.9/site-packages/pluggy/_hooks.py", line 501, in __call__
hypothesis>     return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
hypothesis>   File "/nix/store/kmh0p7vx6sgxwpfk7n0498byg0falfkj-python3.9-pluggy-1.4.0/lib/python3.9/site-packages/pluggy/_manager.py", line 119, in _hookexec
hypothesis>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
hypothesis>   File "/nix/store/kmh0p7vx6sgxwpfk7n0498byg0falfkj-python3.9-pluggy-1.4.0/lib/python3.9/site-packages/pluggy/_callers.py", line 181, in _multicall
hypothesis>     return outcome.get_result()
hypothesis>   File "/nix/store/kmh0p7vx6sgxwpfk7n0498byg0falfkj-python3.9-pluggy-1.4.0/lib/python3.9/site-packages/pluggy/_result.py", line 99, in get_result
hypothesis>     raise exc.with_traceback(exc.__traceback__)
hypothesis>   File "/nix/store/kmh0p7vx6sgxwpfk7n0498byg0falfkj-python3.9-pluggy-1.4.0/lib/python3.9/site-packages/pluggy/_callers.py", line 166, in _multicall
hypothesis>     teardown.throw(outcome._exception)
hypothesis>   File "/nix/store/0h4xzbxkqhpyyl0fp43gy3rvcly7xzdk-python3.9-pytest-8.0.2/lib/python3.9/site-packages/_pytest/threadexception.py", line 87, in pytest_runtest_call
hypothesis>     yield from thread_exception_runtest_hook()
hypothesis>   File "/nix/store/0h4xzbxkqhpyyl0fp43gy3rvcly7xzdk-python3.9-pytest-8.0.2/lib/python3.9/site-packages/_pytest/threadexception.py", line 63, in thread_exception_runtest_hook
hypothesis>     yield
hypothesis>   File "/nix/store/kmh0p7vx6sgxwpfk7n0498byg0falfkj-python3.9-pluggy-1.4.0/lib/python3.9/site-packages/pluggy/_callers.py", line 166, in _multicall
hypothesis>     teardown.throw(outcome._exception)
hypothesis>   File "/nix/store/0h4xzbxkqhpyyl0fp43gy3rvcly7xzdk-python3.9-pytest-8.0.2/lib/python3.9/site-packages/_pytest/unraisableexception.py", line 90, in pytest_runtest_call
hypothesis>     yield from unraisable_exception_runtest_hook()
hypothesis>   File "/nix/store/0h4xzbxkqhpyyl0fp43gy3rvcly7xzdk-python3.9-pytest-8.0.2/lib/python3.9/site-packages/_pytest/unraisableexception.py", line 65, in unraisable_exception_runtest_hook
hypothesis>     yield
hypothesis>   File "/nix/store/kmh0p7vx6sgxwpfk7n0498byg0falfkj-python3.9-pluggy-1.4.0/lib/python3.9/site-packages/pluggy/_callers.py", line 166, in _multicall
hypothesis>     teardown.throw(outcome._exception)
hypothesis>   File "/nix/store/0h4xzbxkqhpyyl0fp43gy3rvcly7xzdk-python3.9-pytest-8.0.2/lib/python3.9/site-packages/_pytest/logging.py", line 839, in pytest_runtest_call
hypothesis>     yield from self._runtest_for(item, "call")
hypothesis>   File "/nix/store/0h4xzbxkqhpyyl0fp43gy3rvcly7xzdk-python3.9-pytest-8.0.2/lib/python3.9/site-packages/_pytest/logging.py", line 822, in _runtest_for
hypothesis>     yield
hypothesis>   File "/nix/store/kmh0p7vx6sgxwpfk7n0498byg0falfkj-python3.9-pluggy-1.4.0/lib/python3.9/site-packages/pluggy/_callers.py", line 166, in _multicall
hypothesis>     teardown.throw(outcome._exception)
hypothesis>   File "/nix/store/0h4xzbxkqhpyyl0fp43gy3rvcly7xzdk-python3.9-pytest-8.0.2/lib/python3.9/site-packages/_pytest/capture.py", line 882, in pytest_runtest_call
hypothesis>     return (yield)
hypothesis>   File "/nix/store/kmh0p7vx6sgxwpfk7n0498byg0falfkj-python3.9-pluggy-1.4.0/lib/python3.9/site-packages/pluggy/_callers.py", line 166, in _multicall
hypothesis>     teardown.throw(outcome._exception)
hypothesis>   File "/nix/store/0h4xzbxkqhpyyl0fp43gy3rvcly7xzdk-python3.9-pytest-8.0.2/lib/python3.9/site-packages/_pytest/skipping.py", line 256, in pytest_runtest_call
hypothesis>     return (yield)
hypothesis>   File "/nix/store/kmh0p7vx6sgxwpfk7n0498byg0falfkj-python3.9-pluggy-1.4.0/lib/python3.9/site-packages/pluggy/_callers.py", line 102, in _multicall
hypothesis>     res = hook_impl.function(*args)
hypothesis>   File "/nix/store/0h4xzbxkqhpyyl0fp43gy3rvcly7xzdk-python3.9-pytest-8.0.2/lib/python3.9/site-packages/_pytest/runner.py", line 178, in pytest_runtest_call
hypothesis>     raise e
hypothesis>   File "/nix/store/0h4xzbxkqhpyyl0fp43gy3rvcly7xzdk-python3.9-pytest-8.0.2/lib/python3.9/site-packages/_pytest/runner.py", line 170, in pytest_runtest_call
hypothesis>     item.runtest()
hypothesis>   File "/nix/store/0h4xzbxkqhpyyl0fp43gy3rvcly7xzdk-python3.9-pytest-8.0.2/lib/python3.9/site-packages/_pytest/python.py", line 1831, in runtest
hypothesis>     self.ihook.pytest_pyfunc_call(pyfuncitem=self)
hypothesis>   File "/nix/store/kmh0p7vx6sgxwpfk7n0498byg0falfkj-python3.9-pluggy-1.4.0/lib/python3.9/site-packages/pluggy/_hooks.py", line 501, in __call__
hypothesis>     return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
hypothesis>   File "/nix/store/kmh0p7vx6sgxwpfk7n0498byg0falfkj-python3.9-pluggy-1.4.0/lib/python3.9/site-packages/pluggy/_manager.py", line 119, in _hookexec
hypothesis>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
hypothesis>   File "/nix/store/kmh0p7vx6sgxwpfk7n0498byg0falfkj-python3.9-pluggy-1.4.0/lib/python3.9/site-packages/pluggy/_callers.py", line 138, in _multicall
hypothesis>     raise exception.with_traceback(exception.__traceback__)
hypothesis>   File "/nix/store/kmh0p7vx6sgxwpfk7n0498byg0falfkj-python3.9-pluggy-1.4.0/lib/python3.9/site-packages/pluggy/_callers.py", line 102, in _multicall
hypothesis>     res = hook_impl.function(*args)
hypothesis>   File "/nix/store/0h4xzbxkqhpyyl0fp43gy3rvcly7xzdk-python3.9-pytest-8.0.2/lib/python3.9/site-packages/_pytest/python.py", line 194, in pytest_pyfunc_call
hypothesis>     result = testfunction(**testargs)
hypothesis>   File "/build/source/hypothesis-python/tests/cover/test_observability.py", line 61, in test_observability
hypothesis>     do_it_all()
hypothesis>   File "/build/source/hypothesis-python/tests/cover/test_observability.py", line 46, in do_it_all
hypothesis>     @example(a=0, x=4, data=None)
hypothesis>   File "/nix/store/q8zgv7nf9qq0crhmjbw24dpn33w1l62l-python3.9-hypothesis-6.98.17/lib/python3.9/site-packages/hypothesis/core.py", line 1631, in wrapped_test
hypothesis>     raise the_error_hypothesis_found
hypothesis>   File "/nix/store/00ckk33d1pb4vzxw11bj2mzg2vjcbs3a-python3-3.9.18/lib/python3.9/pathlib.py", line 645, in __getitem__
hypothesis>     raise IndexError(idx)
hypothesis> IndexError: -1
```
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
