### PR TITLE
Fix qt6 quick projects by also linking missing metatypes jsons

### DIFF
--- a/pkgs/development/libraries/qt-6/qt-env.nix
+++ b/pkgs/development/libraries/qt-6/qt-env.nix
@@ -4,7 +4,7 @@ buildEnv {
   inherit name;
   paths = [ qtbase ] ++ paths;
 
-  pathsToLink = [ "/bin" "/mkspecs" "/include" "/lib" "/share" "/libexec" ];
+  pathsToLink = [ "/metatypes" "/bin" "/mkspecs" "/include" "/lib" "/share" "/libexec" ];
   extraOutputsToInstall = [ "out" "dev" ];
 
   postBuild = ''


### PR DESCRIPTION
## Description of changes

Added the metatypes directory as a link. Before this, when compiling a quick project in qtcreator you would get the following error:
It used to work in previous versions, but more recent changes to the core cmake macro files take advantage of these metatypes files.

```
-- Configuring done
CMake Error at /nix/store/jpwi0aqbzf6km4fkh5fx2f3lrk7wcxd0-qt-full-6.5.2/lib/cmake/Qt6Core/Qt6CoreMacros.cmake:588 (add_executable):
  Cannot find source file:

    /nix/store/jpwi0aqbzf6km4fkh5fx2f3lrk7wcxd0-qt-full-6.5.2/metatypes/qt6core_release_metatypes.json

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .mpp .m .M .mm .ixx .cppm .h
  .hh .h++ .hm .hpp .hxx .in .txx .f .F .for .f77 .f90 .f95 .f03 .hip .ispc
```

The error happened because the folder was only available in nix store under qt6base.

### Easy way to test this:

First make sure you delete old qt creator project cache: `rm -rf ~/.config/QtProject*`

Create the following flake.nix:

```
{
  inputs.nixpkgs.url = "<path to your nixpkgs containing this change>";

  outputs = { self, nixpkgs }:
  let
    pkgs = nixpkgs.legacyPackages.x86_64-linux;
  in {
    devShells.x86_64-linux.default = pkgs.mkShell {
      buildInputs = with pkgs; [
        cmake
        gdb
        qt6.qtbase
        qt6.full
        qtcreator

        # this is for the shellhook portion
        qt6.wrapQtAppsHook
        makeWrapper
        bashInteractive
      ];
      # set the environment variables that Qt apps expect
      shellHook = ''
        export QT_QPA_PLATFORM=wayland
        bashdir=$(mktemp -d)
        makeWrapper "$(type -p bash)" "$bashdir/bash" "''${qtWrapperArgs[@]}"
        exec "$bashdir/bash"
      '';
    };
  };
}
```

With `nix develop` run `qtcreator`, create a qt6 quick project using the available template; When configuring the kits, make sure you use the wrapped gcc/g++ variants for the compiler. Everything should run as expected.

Nix flake file credit: https://galowicz.de/2023/01/16/cpp-qt-qml-nix-setup/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
