### PR TITLE
atasm: 1.09 -> 1.23, move to an active fork

### DIFF
--- a/pkgs/development/compilers/atasm/default.nix
+++ b/pkgs/development/compilers/atasm/default.nix
@@ -1,18 +1,21 @@
 { lib
 , stdenv
-, fetchurl
-, unzip
+, fetchFromGitHub
 , zlib
 }:
 
 stdenv.mkDerivation rec {
   pname = "atasm";
-  version = "1.09";
+  version = "1.23";
 
-  src = fetchurl {
-    url = "https://atari.miribilist.com/${pname}/${pname}${builtins.replaceStrings ["."] [""] version}.zip";
-    hash = "sha256-26shhw2r30GZIPz6S1rf6dOLKRpgpLwrqCRZX3+8PvA=";
+  src = fetchFromGitHub {
+    owner = "CycoPH";
+    repo = "atasm";
+    rev = "V${version}";
+    hash = "sha256-U1HNYTiXO6WZEQJl2icY0ZEVy82CsL1mKR7Xgj9OZ14=";
   };
+
+  makefile = "Makefile";
 
   patches = [
     # make install fails because atasm.txt was moved; report to upstream
@@ -22,10 +25,6 @@ stdenv.mkDerivation rec {
   ];
 
   dontConfigure = true;
-
-  nativeBuildInputs = [
-    unzip
-  ];
 
   buildInputs = [
     zlib
@@ -42,9 +41,10 @@ stdenv.mkDerivation rec {
   '';
 
   preInstall = ''
+    mkdir -p $out/bin/
     install -d $out/share/doc/${pname} $out/man/man1
     installFlagsArray+=(
-      DESTDIR=$out
+      DESTDIR=$out/bin/
       DOCDIR=$out/share/doc/${pname}
       MANDIR=$out/man/man1
     )
@@ -55,9 +55,10 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    homepage = "https://atari.miribilist.com/atasm/";
+    homepage = "https://github.com/CycoPH/atasm";
     description = "A commandline 6502 assembler compatible with Mac/65";
     license = licenses.gpl2Plus;
+    changelog = "https://github.com/CycoPH/atasm/releases/tag/V${version}";
     maintainers = with maintainers; [ AndersonTorres ];
     platforms = with platforms; unix;
   };


### PR DESCRIPTION
## Description of changes

It also fixes the build to have the binary and not only the doc/man page.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Result of `nixpkgs-review` run on x86_64-linux [1](https://github.com/Mic92/nixpkgs-review)
<details>
  <summary>1 package built:</summary>
  <ul>
    <li>atasm</li>
  </ul>
</details>

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
