### PR TITLE
rocmPackages: extend ISA compatibility

### DIFF
--- a/pkgs/development/rocm-modules/6/clr/default.nix
+++ b/pkgs/development/rocm-modules/6/clr/default.nix
@@ -111,6 +111,8 @@ in stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/ROCm/clr/commit/77c581a3ebd47b5e2908973b70adea66891159ee.patch";
       hash = "sha256-auBedbd7rghlKav7A9V6l64J7VmtE9GizIdi5gWj+fs=";
     })
+    ./0001-Improve-hipamd-compat-check.patch
+    ./0001-improve-rocclr-isa-compatibility-check.patch
   ];
 
   postPatch = ''
@@ -124,6 +126,10 @@ in stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace hipamd/src/hip_embed_pch.sh \
       --replace "\''$LLVM_DIR/bin/clang" "${clang}/bin/clang"
+
+    # https://lists.debian.org/debian-ai/2024/02/msg00178.html
+    substituteInPlace rocclr/utils/flags.hpp \
+      --replace-fail "HIP_USE_RUNTIME_UNBUNDLER, false" "HIP_USE_RUNTIME_UNBUNDLER, true"
   '';
 
   postInstall = ''

--- a/pkgs/development/rocm-modules/6/clr/default.nix
+++ b/pkgs/development/rocm-modules/6/clr/default.nix
@@ -111,8 +111,16 @@ in stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/ROCm/clr/commit/77c581a3ebd47b5e2908973b70adea66891159ee.patch";
       hash = "sha256-auBedbd7rghlKav7A9V6l64J7VmtE9GizIdi5gWj+fs=";
     })
-    ./0001-Improve-hipamd-compat-check.patch
-    ./0001-improve-rocclr-isa-compatibility-check.patch
+    (fetchpatch {
+      name = "Improve-hipamd-compat-check.patch";
+      url = "https://github.com/GZGavinZhao/clr/commit/f52172a0767f88bf386dc615a3354156d023bdb8.patch";
+      hash = "sha256-kbEeJsQgAxbNfBCPB2Jny4z526UAnIxHNQLGsD2iFvg=";
+    })
+    (fetchpatch {
+      name = "improve-rocclr-isa-compatibility-check.patch";
+      url = "https://github.com/GZGavinZhao/clr/commit/2783c57b0f225ad8bc553e2d244837d57d8375bc.patch";
+      hash = "sha256-uQMex3gT/LqgQeMETbldpVODWorGLD/YMgjdwHlhd+M=";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/development/rocm-modules/6/clr/default.nix
+++ b/pkgs/development/rocm-modules/6/clr/default.nix
@@ -112,14 +112,14 @@ in stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-auBedbd7rghlKav7A9V6l64J7VmtE9GizIdi5gWj+fs=";
     })
     (fetchpatch {
-      name = "Improve-hipamd-compat-check.patch";
-      url = "https://github.com/GZGavinZhao/clr/commit/f52172a0767f88bf386dc615a3354156d023bdb8.patch";
-      hash = "sha256-kbEeJsQgAxbNfBCPB2Jny4z526UAnIxHNQLGsD2iFvg=";
+      name = "extend-hip-isa-compatibility-check.patch";
+      url = "https://salsa.debian.org/rocm-team/rocm-hipamd/-/raw/d6d20142c37e1dff820950b16ff8f0523241d935/debian/patches/0026-extend-hip-isa-compatibility-check.patch";
+      hash = "sha256-eG0ALZZQLRzD7zJueJFhi2emontmYy6xx8Rsm346nQI=";
     })
     (fetchpatch {
       name = "improve-rocclr-isa-compatibility-check.patch";
-      url = "https://github.com/GZGavinZhao/clr/commit/2783c57b0f225ad8bc553e2d244837d57d8375bc.patch";
-      hash = "sha256-uQMex3gT/LqgQeMETbldpVODWorGLD/YMgjdwHlhd+M=";
+      url = "https://salsa.debian.org/rocm-team/rocm-hipamd/-/raw/d6d20142c37e1dff820950b16ff8f0523241d935/debian/patches/0025-improve-rocclr-isa-compatibility-check.patch";
+      hash = "sha256-8eowuRiOAdd9ucKv4Eg9FPU7c6367H3eP3fRAGfXc6Y=";
     })
   ];
 

--- a/pkgs/development/rocm-modules/6/default.nix
+++ b/pkgs/development/rocm-modules/6/default.nix
@@ -194,7 +194,7 @@ in rec {
   };
 
   rocblas = callPackage ./rocblas {
-    inherit rocblas rocmUpdateScript rocm-cmake clr tensile;
+    inherit rocmUpdateScript rocm-cmake clr tensile;
     inherit (llvm) openmp;
     stdenv = llvm.rocmClangStdenv;
   };

--- a/pkgs/development/rocm-modules/6/miopen/default.nix
+++ b/pkgs/development/rocm-modules/6/miopen/default.nix
@@ -116,6 +116,11 @@ in stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/ROCm/MIOpen/commit/3413d2daaeb44b7d6eadcc03033a5954a118491e.patch";
       hash = "sha256-ST4snUcTmmSI1Ogx815KEX9GdMnmubsavDzXCGJkiKs=";
     })
+    (fetchpatch {
+      name = "Extend-MIOpen-ISA-compatibility.patch";
+      url = "https://github.com/GZGavinZhao/MIOpen/commit/416088b534618bd669a765afce59cfc7197064c1.patch";
+      hash = "sha256-OwONCA68y8s2GqtQj+OtotXwUXQ5jM8tpeM92iaD4MU=";
+    })
   ];
 
   outputs = [

--- a/pkgs/development/rocm-modules/6/rccl/default.nix
+++ b/pkgs/development/rocm-modules/6/rccl/default.nix
@@ -65,7 +65,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Really strange behavior, `#!/usr/bin/env perl` should work...
     substituteInPlace CMakeLists.txt \
-      --replace "\''$ \''${hipify-perl_executable}" "${perl}/bin/perl ${hipify}/bin/hipify-perl"
+      --replace "\''$ \''${hipify-perl_executable}" "${perl}/bin/perl ${hipify}/bin/hipify-perl" \
+      --replace-warn "-parallel-jobs=12" "-parallel-jobs=1" \
+      --replace-warn "-parallel-jobs=16" "-parallel-jobs=1"
   '';
 
   postInstall = lib.optionalString buildTests ''

--- a/pkgs/development/rocm-modules/6/rocblas/default.nix
+++ b/pkgs/development/rocm-modules/6/rocblas/default.nix
@@ -1,5 +1,4 @@
-{ rocblas
-, lib
+{ lib
 , stdenv
 , fetchFromGitHub
 , fetchpatch
@@ -56,6 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     rocm-cmake
     clr
+  ] ++ lib.optionals buildTensile [
     tensile
   ];
 

--- a/pkgs/development/rocm-modules/6/rocblas/default.nix
+++ b/pkgs/development/rocm-modules/6/rocblas/default.nix
@@ -86,6 +86,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "ROCBLAS_TENSILE_LIBRARY_DIR" "lib/rocblas")
     (lib.cmakeBool "BUILD_CLIENTS_TESTS" buildTests)
     (lib.cmakeBool "BUILD_CLIENTS_BENCHMARKS" buildBenchmarks)
+    # rocblas header files are not installed unless we set this
+    (lib.cmakeFeature "CMAKE_INSTALL_INCLUDEDIR" "include")
   ] ++ lib.optionals buildTensile [
     (lib.cmakeBool "BUILD_WITH_PIP" false)
     (lib.cmakeFeature "Tensile_LOGIC" tensileLogic)

--- a/pkgs/development/rocm-modules/6/rocblas/default.nix
+++ b/pkgs/development/rocm-modules/6/rocblas/default.nix
@@ -29,6 +29,14 @@
 , tensileSepArch ? false
 , tensileLazyLib ? false
 , tensileLibFormat ? "msgpack"
+# `gfx940`, `gfx941` are not present in this list because they are early
+# engineering samples, and all final MI300 hardware are `gfx942`:
+# https://github.com/NixOS/nixpkgs/pull/298388#issuecomment-2032791130
+#
+# `gfx1012` is not present in this list because the ISA compatibility patches
+# would force all `gfx101*` GPUs to run as `gfx1010`, so `gfx101*` GPUs will
+# always try to use `gfx1010` code objects, hence building for `gfx1012` is
+# useless: https://github.com/NixOS/nixpkgs/pull/298388#issuecomment-2076327152
 , gpuTargets ? [ "gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack+;gfx90a:xnack-;gfx942;gfx1010;gfx1030;gfx1100;gfx1101;gfx1102" ]
 }:
 

--- a/pkgs/development/rocm-modules/6/rocblas/default.nix
+++ b/pkgs/development/rocm-modules/6/rocblas/default.nix
@@ -29,7 +29,7 @@
 , tensileSepArch ? false
 , tensileLazyLib ? false
 , tensileLibFormat ? "msgpack"
-, gpuTargets ? [ "all" ]
+, gpuTargets ? [ "gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack+;gfx90a:xnack-;gfx942;gfx1010;gfx1030;gfx1100;gfx1101;gfx1102" ]
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/development/rocm-modules/6/rocblas/default.nix
+++ b/pkgs/development/rocm-modules/6/rocblas/default.nix
@@ -33,51 +33,7 @@
 , gpuTargets ? [ "all" ]
 }:
 
-let
-  # NOTE: Update the default GPU targets on every update
-  gfx80 = (rocblas.override {
-    gpuTargets = [
-      "gfx803"
-    ];
-  }).overrideAttrs { pname = "rocblas-tensile-gfx80"; };
-
-  gfx90 = (rocblas.override {
-    gpuTargets = [
-      "gfx900"
-      "gfx906:xnack-"
-      "gfx908:xnack-"
-      "gfx90a:xnack+"
-      "gfx90a:xnack-"
-    ];
-  }).overrideAttrs { pname = "rocblas-tensile-gfx90"; };
-
-  gfx94 = (rocblas.override {
-    gpuTargets = [
-      "gfx940"
-      "gfx941"
-      "gfx942"
-    ];
-  }).overrideAttrs { pname = "rocblas-tensile-gfx94"; };
-
-  gfx10 = (rocblas.override {
-    gpuTargets = [
-      "gfx1010"
-      "gfx1012"
-      "gfx1030"
-    ];
-  }).overrideAttrs { pname = "rocblas-tensile-gfx10"; };
-
-  gfx11 = (rocblas.override {
-    gpuTargets = [
-      "gfx1100"
-      "gfx1101"
-      "gfx1102"
-    ];
-  }).overrideAttrs { pname = "rocblas-tensile-gfx11"; };
-
-  # Unfortunately, we have to do two full builds, otherwise we get overlapping _fallback.dat files
-  fallbacks = rocblas.overrideAttrs { pname = "rocblas-tensile-fallbacks"; };
-in stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rocblas";
   version = "6.0.2";
 
@@ -100,6 +56,7 @@ in stdenv.mkDerivation (finalAttrs: {
     cmake
     rocm-cmake
     clr
+    tensile
   ];
 
   buildInputs = [
@@ -126,17 +83,11 @@ in stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "AMDGPU_TARGETS" (lib.concatStringsSep ";" gpuTargets))
     (lib.cmakeBool "BUILD_WITH_TENSILE" buildTensile)
     (lib.cmakeBool "ROCM_SYMLINK_LIBS" false)
-    # # Manually define CMAKE_INSTALL_<DIR>
-    # # See: https://github.com/NixOS/nixpkgs/pull/197838
-    # "-DCMAKE_INSTALL_BINDIR=bin"
-    # "-DCMAKE_INSTALL_LIBDIR=lib"
-    # "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    (lib.cmakeFeature "ROCBLAS_TENSILE_LIBRARY_DIR" "lib/rocblas")
     (lib.cmakeBool "BUILD_CLIENTS_TESTS" buildTests)
     (lib.cmakeBool "BUILD_CLIENTS_BENCHMARKS" buildBenchmarks)
   ] ++ lib.optionals buildTensile [
-    (lib.cmakeFeature "VIRTUALENV_HOME_DIR" "/build/source/tensile")
-    (lib.cmakeFeature "Tensile_TEST_LOCAL_PATH" "/build/source/tensile")
-    (lib.cmakeFeature "Tensile_ROOT" "/build/source/tensile/${python3.sitePackages}/Tensile")
+    (lib.cmakeBool "BUILD_WITH_PIP" false)
     (lib.cmakeFeature "Tensile_LOGIC" tensileLogic)
     (lib.cmakeFeature "Tensile_CODE_OBJECT_VERSION" tensileCOVersion)
     (lib.cmakeBool "Tensile_SEPARATE_ARCHITECTURES" tensileSepArch)
@@ -155,56 +106,10 @@ in stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
+  # Pass $NIX_BUILD_CORES to Tensile
   postPatch = ''
     substituteInPlace cmake/build-options.cmake \
       --replace-fail 'Tensile_CPU_THREADS ""' 'Tensile_CPU_THREADS "$ENV{NIX_BUILD_CORES}"'
-  '' + lib.optionalString (finalAttrs.pname != "rocblas") ''
-    # Return early and install tensile files manually
-    substituteInPlace library/src/CMakeLists.txt \
-      --replace "set_target_properties( TensileHost PROPERTIES OUTPUT_NAME" "return()''\nset_target_properties( TensileHost PROPERTIES OUTPUT_NAME"
-  '' + lib.optionalString (buildTensile && finalAttrs.pname == "rocblas") ''
-    # Link the prebuilt Tensile files
-    mkdir -p build/Tensile/library
-
-    for path in ${gfx80} ${gfx90} ${gfx94} ${gfx10} ${gfx11} ${fallbacks}; do
-      ln -s $path/lib/rocblas/library/* build/Tensile/library
-    done
-
-    unlink build/Tensile/library/TensileManifest.txt
-  '' + lib.optionalString buildTensile ''
-    # Tensile REALLY wants to write to the nix directory if we include it normally
-    cp -a ${tensile} tensile
-    chmod +w -R tensile
-
-    # Rewrap Tensile
-    substituteInPlace tensile/bin/{.t*,.T*,*} \
-      --replace "${tensile}" "/build/source/tensile"
-
-    substituteInPlace CMakeLists.txt \
-      --replace "include(virtualenv)" "" \
-      --replace "virtualenv_install(\''${Tensile_TEST_LOCAL_PATH})" ""
-  '';
-
-  postInstall = lib.optionalString (finalAttrs.pname == "rocblas") ''
-    ln -sf ${fallbacks}/lib/rocblas/library/TensileManifest.txt $out/lib/rocblas/library
-  '' + lib.optionalString (finalAttrs.pname != "rocblas") ''
-    mkdir -p $out/lib/rocblas/library
-    rm -rf $out/share
-  '' + lib.optionalString (finalAttrs.pname != "rocblas" && finalAttrs.pname != "rocblas-tensile-fallbacks") ''
-    rm Tensile/library/{TensileManifest.txt,*_fallback.dat}
-    mv Tensile/library/* $out/lib/rocblas/library
-  '' + lib.optionalString (finalAttrs.pname == "rocblas-tensile-fallbacks") ''
-    mv Tensile/library/{TensileManifest.txt,*_fallback.dat} $out/lib/rocblas/library
-  '' + lib.optionalString buildTests ''
-    mkdir -p $test/bin
-    cp -a $out/bin/* $test/bin
-    rm $test/bin/*-bench || true
-  '' + lib.optionalString buildBenchmarks ''
-    mkdir -p $benchmark/bin
-    cp -a $out/bin/* $benchmark/bin
-    rm $benchmark/bin/*-test || true
-  '' + lib.optionalString (buildTests || buildBenchmarks ) ''
-    rm -rf $out/bin
   '';
 
   passthru.updateScript = rocmUpdateScript {

--- a/pkgs/development/rocm-modules/6/rocm-runtime/default.nix
+++ b/pkgs/development/rocm-modules/6/rocm-runtime/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , rocmUpdateScript
 , pkg-config
 , cmake
@@ -40,6 +41,15 @@ stdenv.mkDerivation (finalAttrs: {
     numactl
     valgrind
     libxml2
+  ];
+
+  patches = [
+    (fetchpatch {
+      name = "extend-isa-compatibility-check.patch";
+      url = "https://salsa.debian.org/rocm-team/rocr-runtime/-/raw/076026d43bbee7f816b81fea72f984213a9ff961/debian/patches/0004-extend-isa-compatibility-check.patch";
+      hash = "sha256-cC030zVGS4kNXwaztv5cwfXfVwOldpLGV9iYgEfPEnY=";
+      stripLen = 1;
+    })
   ];
 
   postPatch = ''

--- a/pkgs/development/rocm-modules/6/rocprim/default.nix
+++ b/pkgs/development/rocm-modules/6/rocprim/default.nix
@@ -1,4 +1,5 @@
 { lib
+, fetchpatch
 , stdenv
 , fetchFromGitHub
 , rocmUpdateScript
@@ -30,6 +31,14 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "rocm-${finalAttrs.version}";
     hash = "sha256-nWvq26qRPZ6Au1rc5cR74TKArcdUFg7O9djFi8SvMeM=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "arch-conversion-marco.patch";
+      url = "https://salsa.debian.org/rocm-team/rocprim/-/raw/70c8aaee3cf545d92685f4ed9bf8f41e3d4d570c/debian/patches/arch-conversion-macro.patch";
+      hash = "sha256-oXdmbCArOB5bKE8ozDFrSh4opbO+c4VI6PNhljeUSms=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/development/rocm-modules/6/tensile/default.nix
+++ b/pkgs/development/rocm-modules/6/tensile/default.nix
@@ -41,6 +41,11 @@ buildPythonPackage rec {
       url = "https://github.com/GZGavinZhao/Tensile/commit/855cb15839849addb0816a6dde45772034a3e41f.patch";
       hash = "sha256-d+fVf/vz+sxGqJ96vuxe0jRMgbC5K6j5FQ5SJ1e3Sl8=";
     })
+    (fetchpatch {
+      name = "Don-t-copy-file-twice-in-copyStaticFiles.patch";
+      url = "https://github.com/GZGavinZhao/Tensile/commit/9e14d5a00a096bddac605910a0e4dfb4c35bb0d5.patch";
+      hash = "sha256-gOzjJyD1K056OFQ+hK5nbUeBhxLTIgQLoT+0K12SypI=";
+    })
   ];
 
   doCheck = false; # Too many errors, not sure how to set this up properly

--- a/pkgs/development/rocm-modules/6/tensile/default.nix
+++ b/pkgs/development/rocm-modules/6/tensile/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , rocmUpdateScript
 , buildPythonPackage
 , pytestCheckHook
@@ -34,6 +35,14 @@ buildPythonPackage rec {
     joblib
   ];
 
+  patches = [
+    (fetchpatch {
+      name = "Extend-Tensile-HIP-ISA-compatibility.patch";
+      url = "https://github.com/GZGavinZhao/Tensile/commit/855cb15839849addb0816a6dde45772034a3e41f.patch";
+      hash = "sha256-d+fVf/vz+sxGqJ96vuxe0jRMgbC5K6j5FQ5SJ1e3Sl8=";
+    })
+  ];
+
   doCheck = false; # Too many errors, not sure how to set this up properly
 
   nativeCheckInputs = [
@@ -42,9 +51,9 @@ buildPythonPackage rec {
     rocminfo
   ];
 
-  preCheck = ''
-    export ROCM_PATH=${rocminfo}
-  '';
+  env = {
+    ROCM_PATH = rocminfo;
+  };
 
   pythonImportsCheck = [ "Tensile" ];
 


### PR DESCRIPTION
- **rocmPackages: extend rocm-runtime ISA compatibility**
- **rocmPackages: extend clr ISA compatibility**
- **rocmPackages: extend tensile ISA compatibility**
- **rocmPackages: extend rocblas ISA compatibility**
- **rocmPackages: extend miopen ISA compatibility**

## Description of changes

This will eliminate the need for users to use `HSA_OVERRIDE_GFX_VERSION` to emulate their GPUs as a supported GPU model.

For more info, see [this](https://lists.debian.org/debian-ai/2024/02/msg00178.html) mailing thread.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
