### PR TITLE
eapmd5pass: init at 1.5

### DIFF
--- a/pkgs/by-name/ea/eapmd5pass/package.nix
+++ b/pkgs/by-name/ea/eapmd5pass/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  openssl_1_1,
+  libpcap,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "eapmd5pass";
+  version = "1.5";
+
+  src = fetchFromGitHub {
+    owner = "joswr1ght";
+    repo = "eapmd5pass";
+    rev = "v${version}";
+    hash = "sha256-DYoily2dX/mbDFpQivGZZ/JMTIblooMzeoMw19w1Ky4=";
+  };
+
+  nativeBuildInputs = [
+    openssl_1_1
+    libpcap
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp eapmd5pass $out/bin
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Brute force password selection for EAP-MD5 authentication exchanges";
+    homepage = "https://github.com/joswr1ght/eapmd5pass";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ pinpox ];
+    mainProgram = "eapmd5pass";
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/by-name/ea/eapmd5pass/package.nix
+++ b/pkgs/by-name/ea/eapmd5pass/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-DYoily2dX/mbDFpQivGZZ/JMTIblooMzeoMw19w1Ky4=";
   };
 
-  nativeBuildInputs = [
+  buildInputs = [
     openssl_1_1
     libpcap
   ];


### PR DESCRIPTION
## Description of changes


Added package for eapmd5pass and tested compilation and exectution. 
It is a bit old, but still useful and [shipped with kali](https://www.kali.org/tools/eapmd5pass/)

Part of: https://t4ccer.com/arewehackersyet/
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
