### PR TITLE
python312Packages.exchangelib: 5.1.0 -> 5.2.0

### DIFF
--- a/pkgs/development/python-modules/exchangelib/default.nix
+++ b/pkgs/development/python-modules/exchangelib/default.nix
@@ -5,7 +5,6 @@
 , defusedxml
 , dnspython
 , fetchFromGitHub
-, fetchpatch
 , flake8
 , isodate
 , lxml
@@ -18,37 +17,34 @@
 , pyyaml
 , requests
 , requests-ntlm
+, requests-gssapi
 , requests-oauthlib
 , requests-kerberos
 , requests-mock
+, setuptools
 , tzdata
 , tzlocal
 }:
 
 buildPythonPackage rec {
   pname = "exchangelib";
-  version = "5.1.0";
-  format = "setuptools";
+  version = "5.2.0";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "ecederstrand";
-    repo = pname;
+    repo = "exchangelib";
     rev = "refs/tags/v${version}";
-    hash = "sha256-WKQgfmEbil55WO3tWVq4n9wiJNw0Op/jbI7xt5vtKpA=";
+    hash = "sha256-q45aYVyp75PUiqYSMSvSFMy3vaclv93QVkjKWVrxWc4=";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "tests-timezones-2.patch";
-      url = "https://github.com/ecederstrand/exchangelib/commit/419eafcd9261bfd0617823ee437204d5556a8271.diff";
-      excludes = [ "tests/test_ewsdatetime.py" ];
-      hash = "sha256-dSp6NkNT5dHOg8XgDi8sR3t3hq46sNtPjUXva2YfFSU=";
-    })
+  build-system = [
+    setuptools
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     cached-property
     defusedxml
     dnspython
@@ -65,6 +61,19 @@ buildPythonPackage rec {
   ] ++ lib.optionals (pythonOlder "3.9") [
     backports-zoneinfo
   ];
+
+  passthru.optional-dependencies = {
+    complete = [
+      requests-gssapi
+      # requests-negotiate-sspi
+    ];
+    kerberos = [
+      requests-gssapi
+    ];
+    # sspi = [
+    #   requests-negotiate-sspi
+    # ];
+  };
 
   nativeCheckInputs = [
     flake8


### PR DESCRIPTION
Diff: https://github.com/ecederstrand/exchangelib/compare/refs/tags/v5.1.0...v5.2.0

Changelog: https://github.com/ecederstrand/exchangelib/blob/v5.2.0/CHANGELOG.md

## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
