### PR TITLE
home-assistant-custom-components.homematicip_local: init at 1.58.0

### DIFF
--- a/pkgs/development/python-modules/hahomematic/default.nix
+++ b/pkgs/development/python-modules/hahomematic/default.nix
@@ -66,6 +66,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/danielperna84/hahomematic";
     changelog = "https://github.com/danielperna84/hahomematic/releases/tag/${version}";
     license = with licenses; [ mit ];
-    maintainers = with maintainers; [ fab ];
+    maintainers = with maintainers; [ dotlambda fab ];
   };
 }

--- a/pkgs/servers/home-assistant/custom-components/README.md
+++ b/pkgs/servers/home-assistant/custom-components/README.md
@@ -11,7 +11,7 @@ Python runtime dependencies can be directly consumed as unqualified
 function arguments. Pass them into `propagatedBuildInputs`, for them to
 be available to Home Assistant.
 
-Out-of-tree components need to use python packages from
+Out-of-tree components need to use Python packages from
 `home-assistant.python.pkgs` as to not introduce conflicting package
 versions into the Python environment.
 
@@ -58,7 +58,7 @@ domain in the `manifest.json` as well as the module name are
 
 The `pname` attribute is a composition of both `owner` and `domain`.
 
-Don't set `pname`, set `owner and `domain` instead.
+Don't set `pname`, set `owner` and `domain` instead.
 
 Exposing the `domain` attribute separately allows checking for
 conflicting components at eval time.

--- a/pkgs/servers/home-assistant/custom-components/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/default.nix
@@ -18,6 +18,8 @@
 
   gpio = callPackage ./gpio {};
 
+  homematicip_local = callPackage ./homematicip_local { };
+
   localtuya = callPackage ./localtuya {};
 
   miele = callPackage ./miele {};

--- a/pkgs/servers/home-assistant/custom-components/homematicip_local/default.nix
+++ b/pkgs/servers/home-assistant/custom-components/homematicip_local/default.nix
@@ -1,0 +1,30 @@
+{ lib
+, buildHomeAssistantComponent
+, fetchFromGitHub
+, hahomematic
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "danielperna84";
+  domain = "homematicip_local";
+  version = "1.58.0";
+
+  src = fetchFromGitHub {
+    owner = "danielperna84";
+    repo = "custom_homematic";
+    rev = "refs/tags/${version}";
+    hash = "sha256-ianM29eF2MN2THS3CTg4tBkd+8pV/m1fg8VvMDhhadg=";
+  };
+
+  dependencies = [
+    hahomematic
+  ];
+
+  meta = {
+    changelog = "https://github.com/danielperna84/custom_homematic/blob/${version}/changelog.md";
+    description = "Custom Home Assistant Component for HomeMatic";
+    homepage = "https://github.com/danielperna84/custom_homematic";
+    maintainers = with lib.maintainers; [ dotlambda ];
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
## Description of changes
According to https://github.com/danielperna84/hahomematic/blob/devel/README.md#hahomematic it looks like this will eventually replace the official homematic integration.
<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
