### PR TITLE
gmsh: 4.11.1 -> 4.12.2

### DIFF
--- a/pkgs/applications/science/math/gmsh/default.nix
+++ b/pkgs/applications/science/math/gmsh/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, fetchpatch, cmake, blas, lapack, gfortran, gmm, fltk, libjpeg
+{ lib, stdenv, fetchurl, cmake, blas, lapack, gfortran, gmm, fltk, libjpeg
 , zlib, libGL, libGLU, xorg, opencascade-occt
 , python ? null, enablePython ? false }:
 
@@ -7,11 +7,11 @@ assert enablePython -> (python != null);
 
 stdenv.mkDerivation rec {
   pname = "gmsh";
-  version = "4.11.1";
+  version = "4.12.2";
 
   src = fetchurl {
     url = "https://gmsh.info/src/gmsh-${version}-source.tgz";
-    sha256 = "sha256-xf4bfL1AOIioFJKfL9D11p4nYAIioYx4bbW3boAFs2U=";
+    hash = "sha256-E+CdnKgQLlxAFx1u4VDGaHQrmMOmylf4N/e2Th4q9I8=";
   };
 
   buildInputs = [
@@ -26,19 +26,6 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./fix-python.patch
-
-    # Pull upstream fix git gcc-13:
-    #   https://gitlab.onelab.info/gmsh/gmsh/-/issues/2416
-    (fetchpatch {
-      name = "gcc-13-p1.patch";
-      url = "https://gitlab.onelab.info/gmsh/gmsh/-/commit/fb81a9c9026700e078de947b4522cb39e543a86b.patch";
-      hash = "sha256-1GInFqQZvOgflC3eQTjmZ9uBGFASRNCpCwDACN3yTQ4=";
-    })
-    (fetchpatch {
-      name = "gcc-13-p2.patch";
-      url = "https://gitlab.onelab.info/gmsh/gmsh/-/commit/aceb09c807b78ea26555f99fcb16c4f87c31fb5a.patch";
-      hash = "sha256-6FI0hIvj8hglCvxoKV0GzT2/F/Wz+ddkxV/TLzzJBLU=";
-    })
   ];
 
   postPatch = ''

--- a/pkgs/applications/science/math/gmsh/fix-python.patch
+++ b/pkgs/applications/science/math/gmsh/fix-python.patch
@@ -1,50 +1,13 @@
 diff --git a/api/gmsh.py b/api/gmsh.py
-index 747acb203..02004da5d 100644
+index f525284..a225c85 100644
 --- a/api/gmsh.py
 +++ b/api/gmsh.py
-@@ -44,44 +44,7 @@ moduledir = os.path.dirname(os.path.realpath(__file__))
- parentdir1 = os.path.dirname(moduledir)
- parentdir2 = os.path.dirname(parentdir1)
+@@ -78,6 +78,8 @@ if not libpath:
+     else:
+         libpath = find_library("gmsh")
  
--if platform.system() == "Windows":
--    libname = "gmsh-4.11.dll"
--elif platform.system() == "Darwin":
--    libname = "libgmsh.4.11.dylib"
--else:
--    libname = "libgmsh.so.4.11"
--
--# check if the library is in the same directory as the module...
--libpath = os.path.join(moduledir, libname)
--
--# ... or in the parent directory or its lib or Lib subdirectory
--if not os.path.exists(libpath):
--    libpath = os.path.join(parentdir1, libname)
--if not os.path.exists(libpath):
--    libpath = os.path.join(parentdir1, "lib", libname)
--if not os.path.exists(libpath):
--    libpath = os.path.join(parentdir1, "Lib", libname)
--
--# ... or in the parent of the parent directory or its lib or Lib subdirectory
--if not os.path.exists(libpath):
--    libpath = os.path.join(parentdir2, libname)
--if not os.path.exists(libpath):
--    libpath = os.path.join(parentdir2, "lib", libname)
--if not os.path.exists(libpath):
--    libpath = os.path.join(parentdir2, "Lib", libname)
--
--# if we couldn't find it, use ctype's find_library utility...
--if not os.path.exists(libpath):
--    if platform.system() == "Windows":
--        libpath = find_library("gmsh-4.11")
--        if not libpath:
--            libpath = find_library("gmsh")
--    else:
--        libpath = find_library("gmsh")
--
--# ... and print a warning if everything failed
--if not os.path.exists(libpath):
--    print("Warning: could not find Gmsh shared library " + libname)
 +libpath = "@LIBPATH@"
- 
- lib = CDLL(libpath)
- 
++
+ # ... and print a warning if everything failed
+ if not libpath:
+     print("Warning: could not find Gmsh shared library " + libname +


### PR DESCRIPTION
## Description of changes

https://gitlab.onelab.info/gmsh/gmsh/blob/master/CHANGELOG.txt

Closes #286536.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
